### PR TITLE
Speed up our analytics around total msg counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ docs/_build/
 
 # PyBuilder
 target/
+textit

--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -93,39 +93,39 @@ def collect_message_metrics_task():
             context = dict(source=settings.HOSTNAME)
 
             # total # of delivered messages
-            count = Msg.objects.filter(direction=OUTGOING, status=DELIVERED, contact__is_test=False).exclude(channel=None).exclude(topup=None).count()
+            count = Msg.objects.filter(direction=OUTGOING, status=DELIVERED).exclude(channel=None).exclude(topup=None).count()
             analytics.track('System', 'temba.total_outgoing_delivered', properties=dict(value=count), context=context)
 
             # total # of sent messages (this includes delivered and wired)
-            #count = Msg.objects.filter(direction=OUTGOING, status__in=[DELIVERED, SENT, WIRED], contact__is_test=False).exclude(channel=None).exclude(topup=None).count()
-            #analytics.track('System', 'temba.total_outgoing_sent', properties=dict(value=count), context=context)
+            count = Msg.objects.filter(direction=OUTGOING, status__in=[DELIVERED, SENT, WIRED]).exclude(channel=None).exclude(topup=None).count()
+            analytics.track('System', 'temba.total_outgoing_sent', properties=dict(value=count), context=context)
 
             # total # of failed messages
-            count = Msg.objects.filter(direction=OUTGOING, status=FAILED, contact__is_test=False).exclude(channel=None).exclude(topup=None).count()
+            count = Msg.objects.filter(direction=OUTGOING, status=FAILED).exclude(channel=None).exclude(topup=None).count()
             analytics.track('System', 'temba.total_outgoing_failed', properties=dict(value=count), context=context)
 
             # current # of queued messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=QUEUED, contact__is_test=False).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
+            count = Msg.objects.filter(direction=OUTGOING, status=QUEUED).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
             analytics.track('System', 'temba.current_outgoing_queued', properties=dict(value=count), context=context)
 
             # current # of initializing messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=INITIALIZING, contact__is_test=False).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
+            count = Msg.objects.filter(direction=OUTGOING, status=INITIALIZING).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
             analytics.track('System', 'temba.current_outgoing_initializing', properties=dict(value=count), context=context)
 
             # current # of pending messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=PENDING, contact__is_test=False).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
+            count = Msg.objects.filter(direction=OUTGOING, status=PENDING).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
             analytics.track('System', 'temba.current_outgoing_pending', properties=dict(value=count), context=context)
 
             # current # of errored messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=ERRORED, contact__is_test=False).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
+            count = Msg.objects.filter(direction=OUTGOING, status=ERRORED).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
             analytics.track('System', 'temba.current_outgoing_errored', properties=dict(value=count), context=context)
 
             # current # of android outgoing messages waiting to be sent
-            count = Msg.objects.filter(direction=OUTGOING, status__in=[PENDING, QUEUED], contact__is_test=False, channel__channel_type='A').exclude(channel=None).exclude(topup=None).count()
+            count = Msg.objects.filter(direction=OUTGOING, status__in=[PENDING, QUEUED], channel__channel_type='A').exclude(channel=None).exclude(topup=None).count()
             analytics.track('System', 'temba.current_outgoing_android', properties=dict(value=count), context=context)
 
             # current # of pending incoming messages that haven't yet been handled
-            count = Msg.objects.filter(direction=INCOMING, status=PENDING, contact__is_test=False).exclude(channel=None).count()
+            count = Msg.objects.filter(direction=INCOMING, status=PENDING).exclude(channel=None).count()
             analytics.track('System', 'temba.current_incoming_pending', properties=dict(value=count), context=context)
 
             # stuff into redis when we last run, we do this as a canary as to whether our tasks are falling behind or not running


### PR DESCRIPTION
This removes our big join of `is_test` on Contact which was getting crazy expensive given the size of things.

This should still give us 'good enough' analytics on current state of the world because `topup=None` is actually a pretty good proxy to whether a msg is a simulator message.
