### PR TITLE
Use the same path when expiring single flow runs and batch expirations

### DIFF
--- a/temba/flows/migrations/0005_auto_20141216_0629.py
+++ b/temba/flows/migrations/0005_auto_20141216_0629.py
@@ -30,7 +30,7 @@ def populate_redis_activity(apps, schema_editor):
             print "%d%% flows built" % pct
         last_pct = pct
 
-    print "Total time: %ss" % (time.time() - start)
+    # print "Total time: %ss" % (time.time() - start)
 
 class Migration(migrations.Migration):
 

--- a/temba/flows/migrations/0007_auto_20150115_1926.py
+++ b/temba/flows/migrations/0007_auto_20150115_1926.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+
+def rebuild_flow_stats(apps, schema_editor):
+
+    # kinda breaking migration rules here to not duplicate code, should be asking
+    # for raw model from apps.get_model('flows', 'Flow'). This means this migration
+    # can only run as long as the methods we are calling here exist.
+    from temba.flows.models import FlowRun
+    from django.utils import timezone
+    from datetime import timedelta
+
+    forty_five_days_ago = timezone.now() - timedelta(days=45)
+    runs = FlowRun.objects.filter(expired_on__gte=forty_five_days_ago).exclude(flow__flow_type='M').distinct('flow')
+
+    for run in runs:
+        # request a longer lock during our migration
+        print "Rebuilding flow stats for %s.." % run.flow
+        run.flow.do_calculate_flow_stats(lock_ttl=600)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0006_remove_flowrun_uuid'),
+    ]
+
+    operations = [
+        migrations.RunPython(rebuild_flow_stats)
+    ]

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -32,8 +32,8 @@ def check_flows_task():
     """
     See if any flow runs need to be expired
     """
-    now = timezone.now()
-    FlowRun.objects.filter(is_active=True, expires_on__lte=now).update(is_active=False, expired_on=now)
+    runs = FlowRun.objects.filter(is_active=True, expires_on__lte=timezone.now()).order_by('flow')
+    FlowRun.do_expire_runs(runs)
 
 
 @task(track_started=True, name='export_flow_results_task')

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -32,8 +32,7 @@ def check_flows_task():
     """
     See if any flow runs need to be expired
     """
-    runs = FlowRun.objects.filter(is_active=True, expires_on__lte=timezone.now()).order_by('flow')
-    FlowRun.do_expire_runs(runs)
+    FlowRun.do_expire_runs(FlowRun.objects.filter(is_active=True, expires_on__lte=timezone.now()))
 
 
 @task(track_started=True, name='export_flow_results_task')


### PR DESCRIPTION
We weren't using the same expiration path when expiring flow runs from the cron. This change uses a shared method for the cron and for an individual run.expire(). The expiration for activity here is a bit more complex than before in order to be considerate of large batches of expirations occurring at once.