### PR TITLE
fix to show ivr runs on contact flow results page

### DIFF
--- a/templates/flows/flow_results.haml
+++ b/templates/flows/flow_results.haml
@@ -1,5 +1,6 @@
 -extends "smartmin/read.html"
 -load smartmin sms compress temba contacts
+-load i18n
 
 -block page-top
   .row
@@ -15,8 +16,10 @@
 
     .span3
       .pull-right
-        %a.btn.btn-success{ href: "{% url 'flows.flow_export_results' %}?ids={{ object.id }}" } Download Results
-        %a.btn{ href: "{% url 'flows.flow_editor' object.pk %}" } View
+        %a.btn.btn-success{ href: "{% url 'flows.flow_export_results' %}?ids={{ object.id }}" }
+          -trans "Download Results"
+        %a.btn{ href: "{% url 'flows.flow_editor' object.pk %}" }
+          -trans "View"
 
 -block buttons
 
@@ -122,19 +125,19 @@
           });
 
   %button#more-link.btn.btn-tiny
-    More Charts
+    -trans "More Charts"
 
   %table#data.dataTable
     %thead
       %tr
         %th
-          Date
+          -trans "Date"
         %th
-          Phone
+          -trans "Phone"
         %th
-          Name
+          -trans "Name"
         %th
-          Runs
+          -trans "Runs"
 
         -for col in counts
           %th
@@ -147,37 +150,37 @@
   #table-gutter
 
     %h5.table-options
-      Table Options
+      -trans "Table Options"
 
     #column-options.hide
       #contact-columns
         .column-header
-          Contact Data
+          -trans "Contact Data"
         .option
           %div{class:'col_0 view_toggle', data-col:'0'}
             .glyph.notif-checkbox
           .col
-            Date
+            -trans "Date"
         .option
           %div{class:'col_1 view_toggle', data-col:'1'}
             .glyph.notif-checkbox
           .col
-            Phone
+            -trans "Phone"
         .option
           %div{class:'col_2 view_toggle', data-col:'2'}
             .glyph.notif-checkbox
           .col
-            Name
+            -trans "Name"
         .option
           %div{class:'col_3 view_toggle', data-col:'3'}
             .glyph.notif-checkbox
           .col
-            Runs
+            -trans "Runs"
 
       -if counts|length > 0
         #flow-columns
           .column-header
-            Flow Data
+            -trans "Flow Data"
 
           -for col in counts
             .option
@@ -333,7 +336,7 @@
 
       // remove the search label
       $('.dataTables_filter label').replaceWith($('.dataTables_filter input'));
-      $('.dataTables_filter input').attr('placeholder', 'Search for name or number');
+      $('.dataTables_filter input').attr('placeholder', '{% trans "Search for name or number" %}');
 
       var charts = $('.inline-chart').length
       if (charts == 0) {
@@ -345,10 +348,10 @@
         $('#more-link').on('click', function() {
           if ($('#top-charts').css('height') == '240px') {
             $('#top-charts').css('height', '100%');
-            $(this).text('Less Charts');
+            $(this).text('{% trans "Less Charts" %}');
           } else {
             $('#top-charts').css('height', '240px');
-            $(this).text('More Charts');
+            $(this).text('{% trans "More Charts" %}');
           }
 
           $(this).blur();

--- a/templates/flows/flow_results_contact.haml
+++ b/templates/flows/flow_results_contact.haml
@@ -120,10 +120,11 @@
               display:inline-block;
             }
 
-            .messages {
+            .messages, .ivr-actions {
               display:inline-block;
               float:right;
               margin-top:-6px;
+              margin-left: 10px;
             }
 
             .active {
@@ -226,9 +227,9 @@
     .span8
       .run-summaries
         -for run in runs
-          -with run.messages|last as last
+          -with last=run.interactions|last
 
-            -if run.messages|length > 0
+            -if run.interactions|length > 0
               .run-summary{data-run:'{{run.pk}}'}
                 - if org_perms.flows.flow_update
                   .icon-cancel-circle.remove.hide{data-run:'{{run.pk}}'}
@@ -240,40 +241,66 @@
                     to
                     %span.attn
                       {{ last.created_on }}
-                .messages
-                  {{ run.messages|length }}
-                  .glyph.icon-bubbles-2
+                  -elif last.call
+                    for
+                    %span.attn
+                      {{ last.call.duration }} seconds
+
+                -if run.messages_interactions
+                  .messages
+                    {{ run.messages_interactions|length }}
+                    .glyph.icon-bubbles-2
+                -if run.ivr_interactions
+                  .ivr-actions
+                    {{ run.ivr_interactions|length }}
+                    .glyph.icon-phone2
 
                 .active
                   -if run.is_active or run.pk == 12461
                 .most-recent
                   .title
                     Last message sent {{last.created_on}}
-                  {{last}}
+                  -if last.call
+                    IVR call action
+                  -else
+                    {{last}}
 
 
   -for run in runs
-    -with run.messages as messages
+    -with interactions=run.interactions messages=run.messages_interactions call_interactions=run.ivr_interactions
       .run.hide{class:'run_{{run.pk}}'}
         .run-messages
           .ilog.from
             Started {{run.created_on}}
             %br
             {{messages|length}} message{{messages|pluralize:"s"}}
+            %br
+            Call with {{ call_interactions|length }} action{{call_interactions|pluralize:"s"}}
 
-          -for msg in messages
-            -if msg.direction == 'O'
-              .imsg.from= msg.text
-            -if msg.direction == 'I'
-              -if msg.text == ''
+          -for interaction in interactions
+            -if interaction.call
+              .ilog.from
+                IVR call action
+            -elif interaction.direction == 'O'
+              .imsg.from= interaction.text
+            -elif interaction.direction == 'I'
+              -if interaction.text == ''
                 .imsg.to.empty
                   Empty message
               -else
-                .imsg.to= msg.text
-            -with msg.get_flow_step as step
-              -if step and step.rule_category
-                .ilog.from
-                  Categorized as {{step.rule_category}}
+                .imsg.to= interaction.text
+
+            -if interaction.call
+              -with interaction.step as step
+                -if step and step.rule_category
+                  .ilog.from
+                    Categorized as {{step.rule_category}}
+            -else
+              -with interaction.get_flow_step as step
+                -if step and step.rule_category
+                  .ilog.from
+                    Categorized as {{step.rule_category}}
+
           -if not run.is_active
             .ilog.from
               -if run.expired_on

--- a/templates/flows/flow_results_contact.haml
+++ b/templates/flows/flow_results_contact.haml
@@ -1,5 +1,6 @@
 -extends "smartmin/read.html"
 -load smartmin sms compress temba contacts
+-load i18n
 
 -block post-header
   -include "flows/simulator.html"
@@ -17,8 +18,10 @@
 
     .span4
       .pull-right
-        %a.btn.btn-success{ href: "{% url 'flows.flow_export_results' %}?ids={{ object.id }}" } Export Flow Results
-        %a.btn{ href: "{% url 'flows.flow_editor' object.pk %}" } View Flow
+        %a.btn.btn-success{ href: "{% url 'flows.flow_export_results' %}?ids={{ object.id }}" }
+          -trans "Export Flow Results"
+        %a.btn{ href: "{% url 'flows.flow_editor' object.pk %}" }
+          -trans "View Flow"
 
 -block buttons
 
@@ -213,7 +216,7 @@
           });
         }}, false);
 
-        modal.setPrimaryButton('Remove');
+        modal.setPrimaryButton('{% trans "Remove" %}');
         modal.show();
       });
     {% endif %}
@@ -234,17 +237,18 @@
                 - if org_perms.flows.flow_update
                   .icon-cancel-circle.remove.hide{data-run:'{{run.pk}}'}
                 .started
-                  Started
+                  -trans "Started"
                   %span.attn
                     {{run.created_on}}
                   -if last.created_on|date:"jS F Y H:i" != run.created_on|date:"jS F Y H:i"
-                    to
+                    -trans "to"
                     %span.attn
                       {{ last.created_on }}
                   -elif last.call
-                    for
+                    -trans "for"
                     %span.attn
-                      {{ last.call.duration }} seconds
+                      -blocktrans
+                        {{ last.call.duration }} seconds
 
                 -if run.messages_interactions
                   .messages
@@ -259,9 +263,10 @@
                   -if run.is_active or run.pk == 12461
                 .most-recent
                   .title
-                    Last message sent {{last.created_on}}
+                    -blocktrans
+                      Last message sent {{last.created_on}}
                   -if last.call
-                    IVR call action
+                    -trans "IVR call action"
                   -else
                     {{last}}
 
@@ -271,22 +276,25 @@
       .run.hide{class:'run_{{run.pk}}'}
         .run-messages
           .ilog.from
-            Started {{run.created_on}}
+            -blocktrans
+              Started {{run.created_on}}
             %br
-            {{messages|length}} message{{messages|pluralize:"s"}}
+            -blocktrans
+              {{messages|length}} message{{messages|pluralize:"s"}}
             %br
-            Call with {{ call_interactions|length }} action{{call_interactions|pluralize:"s"}}
+            -blocktrans
+              Call with {{ call_interactions|length }} action{{call_interactions|pluralize:"s"}}
 
           -for interaction in interactions
             -if interaction.call
               .ilog.from
-                IVR call action
+                -trans "IVR call action"
             -elif interaction.direction == 'O'
               .imsg.from= interaction.text
             -elif interaction.direction == 'I'
               -if interaction.text == ''
                 .imsg.to.empty
-                  Empty message
+                  -trans "Empty message"
               -else
                 .imsg.to= interaction.text
 
@@ -294,28 +302,33 @@
               -with interaction.step as step
                 -if step and step.rule_category
                   .ilog.from
-                    Categorized as {{step.rule_category}}
+                    -blocktrans
+                      Categorized as {{step.rule_category}}
             -else
               -with interaction.get_flow_step as step
                 -if step and step.rule_category
                   .ilog.from
-                    Categorized as {{step.rule_category}}
+                    -blocktrans
+                      Categorized as {{step.rule_category}}
 
           -if not run.is_active
             .ilog.from
               -if run.expired_on
-                This run expired {{ run.expired_on }}
+                -blocktrans
+                  This run expired {{ run.expired_on }}
               -else
-                {{contact|name_or_urn:user_org}} exited from this flow
+                -blocktrans
+                  {{contact|name_or_urn:user_org}} exited from this flow
 
 
 -block post-fields
   - if org_perms.flows.flow_update
     .deletion.hide
       .title
-        Remove Contact Results
+        -trans "Remove Contact Results"
 
       .body
-        %p Are you sure you want to remove the results for this contact?
+        %p
+          -trans "Are you sure you want to remove the results for this contact?"
 
       %a#delete-form.posterize{}


### PR DESCRIPTION
this allow users to remove ivr runs in the same way as other runs

https://trello.com/c/llcZq2i0/1598-no-way-to-remove-flow-results-for-ivr-runs

please review @ericnewcomer 