### PR TITLE
Broadcasts api fix

### DIFF
--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -1010,7 +1010,6 @@ class BroadcastReadSerializer(serializers.ModelSerializer):
     contacts = serializers.SerializerMethodField('get_contacts')
     groups = serializers.SerializerMethodField('get_groups')
     text = serializers.Field(source='text')
-    messages = serializers.SerializerMethodField('get_messages')
     created_on = serializers.Field(source='created_on')
     status = serializers.Field(source='status')
 
@@ -1023,15 +1022,9 @@ class BroadcastReadSerializer(serializers.ModelSerializer):
     def get_groups(self, obj):
         return [group.uuid for group in obj.groups.all()]
 
-    def get_messages(self, obj):
-        if obj.status == INITIALIZING:
-            return []
-        else:
-            return [msg.id for msg in obj.get_messages()]
-
     class Meta:
         model = Broadcast
-        fields = ('id', 'urns', 'contacts', 'groups', 'text', 'messages', 'created_on', 'status')
+        fields = ('id', 'urns', 'contacts', 'groups', 'text', 'created_on', 'status')
 
 
 class BroadcastCreateSerializer(serializers.Serializer):

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1055,6 +1055,11 @@ class APITest(TembaTest):
         self.assertEquals(200, response.status_code)
         self.assertResultCount(response, 0)
 
+        # search by broadcast id
+        response = self.fetchJSON(url, "broadcast=%d" % broadcast.pk)
+        self.assertEquals(200, response.status_code)
+        self.assertResultCount(response, 1)
+
         # check anon org case
         with AnonymousOrg(self.org):
             response = self.fetchJSON(url, "status=Q&before=2030-01-01T00:00:00.000&after=2010-01-01T00:00:00.000&phone=%%2B250788123123&channel=%d" % self.channel.pk)
@@ -1156,7 +1161,6 @@ class APITest(TembaTest):
         self.assertEqual(response.json['urns'], [])
         self.assertEqual(sorted(response.json['contacts']), sorted([self.joe.uuid, frank.uuid]))
         self.assertEqual(response.json['groups'], [])
-        self.assertEqual(response.json['messages'], [])
 
         # message will have been sent in celery task
         broadcast1 = Broadcast.objects.get(pk=response.json['id'])


### PR DESCRIPTION
Removes messages from serialized broadcasts as this will get too large on big broadcasts. As an alternative, added filtering by broadcast id to messages endpoint