### PR TITLE
Fix IVR prompt uploads

### DIFF
--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -275,6 +275,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
             actions: [
               type: if window.ivr then 'say' else 'reply'
               msg: msg
+              uuid: uuid()
             ]
 
           $scope.clickAction(actionset, actionset.actions[0])


### PR DESCRIPTION
Newly created actions weren't getting uuids which resulted in mismatched audio recordings if uploads where made before the flow was reloaded.

This is a fix for rapidpro/rapidpro#123