### PR TITLE
Save recordings when speaker hangs up immediately afterwards

### DIFF
--- a/media/test_imports/capture-recording.json
+++ b/media/test_imports/capture-recording.json
@@ -1,0 +1,84 @@
+{
+  "version": 4,
+  "flows": [
+    {
+      "definition": {
+        "base_language": "eng",
+        "action_sets": [
+          {
+            "y": 0,
+            "x": 100,
+            "destination": "6425c5fb-3da0-49ce-b3ab-39f27af00734",
+            "uuid": "e923eedd-f165-4034-8588-562f677cdc5a",
+            "actions": [
+              {
+                "recording": null,
+                "msg": {
+                  "eng": "Please make a recording after the tone."
+                },
+                "type": "say",
+                "uuid": "5f59e92c-77ad-40bf-8fcd-bbc48da5a9ab"
+              }
+            ]
+          },
+          {
+            "y": 267,
+            "x": 100,
+            "destination": null,
+            "uuid": "ebb433fe-aa4b-48e5-a036-627f1ecc106b",
+            "actions": [
+              {
+                "recording": null,
+                "msg": {
+                  "eng": "Thank you for the recording."
+                },
+                "type": "say",
+                "uuid": "3a64b44f-02c2-4a7b-89d6-96862ec71bd7"
+              }
+            ]
+          }
+        ],
+        "last_saved": "2015-01-28T18:30:25.175217Z",
+        "entry": "e923eedd-f165-4034-8588-562f677cdc5a",
+        "rule_sets": [
+          {
+            "uuid": "6425c5fb-3da0-49ce-b3ab-39f27af00734",
+            "webhook_action": null,
+            "rules": [
+              {
+                "test": {
+                  "test": "true",
+                  "type": "true"
+                },
+                "category": {
+                  "base": "All Responses",
+                  "eng": "All Responses"
+                },
+                "destination": "ebb433fe-aa4b-48e5-a036-627f1ecc106b",
+                "config": {
+                  "type": "true",
+                  "verbose_name": "contains anything",
+                  "name": "Other",
+                  "operands": 0
+                },
+                "uuid": "288da1b3-3e63-4776-8845-39f398eb5b55"
+              }
+            ],
+            "webhook": null,
+            "label": "Recording",
+            "operand": "@step.value",
+            "finished_key": null,
+            "response_type": "R",
+            "y": 145,
+            "x": 85
+          }
+        ],
+        "metadata": {}
+      },
+      "id": 18973,
+      "flow_type": "V",
+      "name": "Capture Recording"
+    }
+  ],
+  "triggers": []
+}

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -66,7 +66,7 @@ class IVRCall(SmartModel):
     call_type = models.CharField(max_length=1, choices=TYPE_CHOICES, default=FLOW,
                                  help_text="What sort of call is this")
     duration = models.IntegerField(default=0, null=True,
-                                   help_text="The length of this call")
+                                   help_text="The length of this call in seconds")
 
 
     @classmethod

--- a/temba/ivr/views.py
+++ b/temba/ivr/views.py
@@ -54,7 +54,8 @@ class CallHandler(View):
                                request.POST.get('CallDuration', None))
             call.save()
 
-            if call.status == IN_PROGRESS:
+            hung_up = 'hangup' == request.POST.get('Digits', None)
+            if call.status == IN_PROGRESS or hung_up:
                 if call.is_flow():
                     response = Flow.handle_call(call, request.POST)
                     return HttpResponse(unicode(response))

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -395,6 +395,7 @@ class MockResponse(object):
 
     def __init__(self, status_code, text, method='GET', url='http://foo.com/'):
         self.text = text
+        self.content = text
         self.status_code = status_code
 
         # mock up a request object on our response as well


### PR DESCRIPTION
Handle case when speaker hangs the phone up immediately after making their recording. This is probably a pretty common scenario for recordings (such as in the case of leaving a voicemail).