### PR TITLE
IVR as messages

### DIFF
--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -2492,7 +2492,7 @@ class TwilioHandler(View):
 
                 if flow:
                     run = FlowRun.create(flow, contact, call=call)
-                    response = Flow.handle_call(call, request.POST)
+                    response = Flow.handle_call(call, request.POST, None)
                     return HttpResponse(unicode(response))
                 else:
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2257,7 +2257,10 @@ class RuleSet(models.Model):
         return False
 
     def find_matching_rule(self, step, run, msg):
-        orig_text = msg.text
+
+        orig_text = None
+        if msg:
+            orig_text = msg.text
 
         context = run.flow.build_message_context(run.contact, msg)
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1650,11 +1650,6 @@ class Flow(TembaModel, SmartModel):
         for msg in msgs:
             step.add_message(msg)
 
-        # create our ivr action
-        if call:
-            from temba.ivr.models import IVRAction
-            IVRAction.create_action(call, step)
-
         # update the activity for our run
         if not run.contact.is_test:
             self.update_activity(step, previous_step, rule_uuid=rule)
@@ -3077,10 +3072,6 @@ class FlowStep(models.Model):
         msg = self.messages.all().first()
         if msg:
             return msg.text
-
-        # IVR always has a decimal value and no text
-        elif self.ivr_actions_for_step.all():
-            return unicode(self.rule_value)
 
     def add_message(self, msg):
         self.messages.add(msg)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -445,6 +445,7 @@ class Flow(TembaModel, SmartModel):
                     run.set_completed()
                     return response
 
+                step.add_message(msg)
                 step.save_rule_match(rule, value)
                 ruleset.save_run_value(run, rule, value, recording=recording_url)
 
@@ -500,6 +501,9 @@ class Flow(TembaModel, SmartModel):
 
                 actionset = ActionSet.get(rule.destination)
                 step = flow.add_step(step.run, actionset, [], rule=rule.uuid, category=rule.category, call=call, previous_step=step)
+
+                if msg:
+                    step.add_message(msg)
 
         if actionset:
             run.voice_response = response
@@ -2646,7 +2650,6 @@ class FlowRun(models.Model):
             self.voice_response.say(text)
 
         # create a Msg object to track what happened
-        # TODO: these should mostly be free
         from temba.msgs.models import DELIVERED, IVR
         return Msg.create_outgoing(self.flow.org, self.flow.created_by, self.contact, text, channel=self.call.channel,
                                    response_to=response_to, recording_url=recording_url, status=DELIVERED, msg_type=IVR)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2532,7 +2532,7 @@ class FlowsTest(FlowFileTest):
         # should have one event scheduled for this contact
         self.assertTrue(EventFire.objects.filter(contact=self.contact))
 
-    def test_tanslations_rule_first(self):
+    def test_translations_rule_first(self):
 
         # import a rule first flow that already has language dicts
         # this rule first does not depend on @step.value for the first rule, so

--- a/temba/ivr/migrations/0003_auto_20150129_1725.py
+++ b/temba/ivr/migrations/0003_auto_20150129_1725.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0005_auto_20141210_0208'),
+        ('ivr', '0002_auto_20141126_2054'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ivrcall',
+            name='contact_urn',
+            field=models.ForeignKey(verbose_name='Contact URN', to='contacts.ContactURN', help_text='The URN this call is communicating with', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='ivrcall',
+            name='duration',
+            field=models.IntegerField(default=0, help_text='The length of this call in seconds', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/temba/ivr/migrations/0004_auto_20150129_1727.py
+++ b/temba/ivr/migrations/0004_auto_20150129_1727.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from temba.ivr.models import IVRCall
+from temba.ivr.models import ContactURN
+
+def populate_unknown_urns(apps, schema_editor):
+
+        # fix any Calls that remain with no contact URN (because their contact doesn't have one)
+        for call in IVRCall.objects.filter(contact_urn=None):
+            # find or create an unknown contact URN for this org
+            unknown = ContactURN.objects.filter(urn='tel:unknown', org=call.org).first()
+            if not unknown:
+                unknown = ContactURN.objects.create(org=call.org,
+                                                    scheme='tel',
+                                                    path='unknown',
+                                                    urn='tel:unknown',
+                                                    priority=50)
+            call.contact_urn = unknown
+            call.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ivr', '0003_auto_20150129_1725'),
+    ]
+
+    operations = [
+
+        # populate Call.contact_urn with the Call's contact's tel URN
+        migrations.RunSQL("""UPDATE ivr_ivrcall AS s SET contact_urn_id = cu.id FROM contacts_contacturn AS cu
+                  WHERE s.contact_id = cu.contact_id AND cu.scheme = 'tel'"""),
+
+        migrations.RunPython(populate_unknown_urns)
+    ]

--- a/temba/ivr/migrations/0005_auto_20150129_1759.py
+++ b/temba/ivr/migrations/0005_auto_20150129_1759.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ivr', '0004_auto_20150129_1727'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ivrcall',
+            name='contact_urn',
+            field=models.ForeignKey(verbose_name='Contact URN', to='contacts.ContactURN', help_text='The URN this call is communicating with'),
+            preserve_default=True,
+        ),
+    ]

--- a/temba/ivr/migrations/0006_auto_20150130_1709.py
+++ b/temba/ivr/migrations/0006_auto_20150130_1709.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ivr', '0005_auto_20150129_1759'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='ivraction',
+            name='call',
+        ),
+        migrations.RemoveField(
+            model_name='ivraction',
+            name='org',
+        ),
+        migrations.RemoveField(
+            model_name='ivraction',
+            name='step',
+        ),
+        migrations.RemoveField(
+            model_name='ivraction',
+            name='topup',
+        ),
+        migrations.DeleteModel(
+            name='IVRAction',
+        ),
+    ]

--- a/temba/ivr/migrations/0006_auto_20150203_0558.py
+++ b/temba/ivr/migrations/0006_auto_20150203_0558.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from temba.msgs.models import Msg, HANDLED, IVR
+from temba.orgs.models import Org
+from temba.flows.models import FlowStep, ActionSet, SayAction
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    def reverse(apps, schema_editor):
+        IVRAction = apps.get_model("ivr", "IVRAction")
+        #
+        for org in Org.objects.all():
+            channel = org.get_call_channel()
+            print "Processing %s" % org
+            if channel:
+                for ivr in IVRAction.objects.filter(org=org):
+                    step = FlowStep.objects.get(pk=ivr.step.pk)
+                    if step.rule_value:
+                        print "[%s] %s" % (ivr.call.contact_urn, step.rule_value)
+                        step.messages.all().delete()
+                        print step.messages.all().count()
+
+    def create_messages_for_ivr_actions(apps, schema_editor):
+
+        IVRAction = apps.get_model("ivr", "IVRAction")
+        # create a one-to-one mapping for any ivr actions as ivr messages
+        for org in Org.objects.all():
+            channel = org.get_call_channel()
+
+            # print "Processing %s" % org
+            if channel:
+                for ivr in IVRAction.objects.filter(org=org):
+                    step = FlowStep.objects.get(pk=ivr.step.pk)
+                    if step.rule_value:
+                        print "[%s] %s" % (ivr.call.contact_urn, step.rule_value)
+                        urn = ivr.call.contact_urn
+                        msg_dict = {}
+                        if step.rule_value[0:4] == 'http':
+                            msg_dict['recording_url'] = step.rule_value
+
+                        msg = Msg.create_incoming(channel, (urn.scheme, urn.path), step.rule_value,
+                                                  user=ivr.call.created_by, topup=ivr.topup, status=HANDLED,
+                                                  msg_type=IVR, date=ivr.created_on, org=org, **msg_dict)
+                        step.add_message(msg)
+
+
+    dependencies = [
+        ('ivr', '0005_auto_20150129_1759'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_messages_for_ivr_actions, reverse)
+    ]

--- a/temba/ivr/migrations/0007_auto_20150203_0743.py
+++ b/temba/ivr/migrations/0007_auto_20150203_0743.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('ivr', '0005_auto_20150129_1759'),
+        ('ivr', '0006_auto_20150203_0558'),
     ]
 
     operations = [

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -190,6 +190,7 @@ class IVRTests(TembaTest):
         self.assertEquals('Placing test call to +1 800-555-1212', ActionLog.objects.all().first().text)
 
         # now pretend we are a normal caller
+        ActionLog.objects.all().delete()
         eric.is_test = False
         eric.save()
         Contact.set_simulation(False)
@@ -239,6 +240,10 @@ class IVRTests(TembaTest):
 
         # simulation gets flipped off by middleware, and this unhandled message doesn't flip it back on
         self.assertFalse(Contact.get_simulation())
+
+        # also shouldn't have any ActionLogs for non-test users
+        self.assertEquals(0, ActionLog.objects.all().count())
+        self.assertEquals(1, flow.get_completed_runs())
 
         # test other our call status mappings with twilio
         def test_status_update(call_to_update, twilio_status, temba_status):

--- a/temba/msgs/migrations/0003_auto_20150129_0515.py
+++ b/temba/msgs/migrations/0003_auto_20150129_0515.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0002_broadcast_channel'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='msg',
+            name='recording_url',
+            field=models.URLField(help_text='The url for any recording associated with this message', max_length=255, null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='msg',
+            name='msg_type',
+            field=models.CharField(default='I', help_text='The type of this message', max_length=1, verbose_name='Message Type', choices=[('I', 'Inbox Message'), ('F', 'Flow Message'), ('V', 'IVR Message')]),
+            preserve_default=True,
+        ),
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1128,6 +1128,7 @@ class Msg(models.Model, OrgAssetMixin):
                         response_to=response_to,
                         msg_type=msg_type,
                         priority=priority,
+                        recording_url=recording_url,
                         has_template_error=has_template_error)
 
         if topup_id is not None:

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -937,7 +937,7 @@ class Msg(models.Model, OrgAssetMixin):
 
     @classmethod
     def create_incoming(cls, channel, urn, text, user=None, date=None, org=None,
-                        status=PENDING, recording_url=None, msg_type=INBOX):
+                        status=PENDING, recording_url=None, msg_type=INBOX, topup=None):
 
         from temba.api.models import WebHookEvent, SMS_RECEIVED
 
@@ -962,7 +962,9 @@ class Msg(models.Model, OrgAssetMixin):
 
         # costs 1 credit to receive a message
         topup_id = None
-        if not contact.is_test:
+        if topup:
+            topup_id = topup.pk
+        elif not contact.is_test:
             topup_id = org.decrement_credit()
 
         # we limit text messages to 640 characters
@@ -992,8 +994,8 @@ class Msg(models.Model, OrgAssetMixin):
         if status == PENDING:
             msg.handle()
 
-        # fire an event off for this message
-        WebHookEvent.trigger_sms_event(SMS_RECEIVED, msg, date)
+            # fire an event off for this message
+            WebHookEvent.trigger_sms_event(SMS_RECEIVED, msg, date)
 
         return msg
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -506,7 +506,7 @@ class OrgTest(TembaTest):
         create_msgs(contact, 10)
 
         # we should have 1000 minus 10 credits for this org
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             self.assertEquals(990, self.org.get_credits_remaining())  # from db
         with self.assertNumQueries(0):
             self.assertEquals(1000, self.org.get_credits_total())  # from cache
@@ -598,7 +598,7 @@ class OrgTest(TembaTest):
         # check our totals
         self.org.update_caches(OrgEvent.topup_updated, None)
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             self.assertEquals(31, self.org.get_credits_total())
             self.assertEquals(32, self.org.get_credits_used())
             self.assertEquals(-1, self.org.get_credits_remaining())

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -55,7 +55,7 @@
       .row
         .span9
           -for msg in all_messages
-            .message.span9
+            .message.span9{class:'type-{{msg.msg_type}}'}
               .avatar{class:'{% if msg.direction == "I" or msg.call_type == "mo_call" or msg.call_type == "mo_miss" %}I{%else%}O{%endif%}'}
                 -if msg.direction == "I" or msg.call_type == "mo_call" or msg.call_type == "mo_miss"
                   .glyph.icon-user
@@ -69,7 +69,10 @@
 
               .text{class:'{% if msg.direction == "I" or msg.call_type == "mo_call" or msg.call_type == "mo_miss" %}I{%else%}O{%endif%} {% if msg.visibility == "A" %}A{%endif%}'}
 
-                {{msg.text}}
+                -if msg.text != msg.recording_url
+                  {{msg.text}}
+                -else
+                  -trans "Recorded message from the contact"
 
                 -if msg.call_type == 'mo_call'
                   -blocktrans with duration=msg.duration
@@ -86,6 +89,17 @@
                   {{ msg.created_on|gmail_time }}
                   -if msg.visibility == 'A'
                     (Archived)
+                  -if msg.recording_url
+                    .recording{class:'direction-{{msg.direction}}', onClick:'playMessage("{{msg.pk}}");'}
+                      %audio{id:'message-{{msg.pk}}', type:"audio/wav", src:'{{msg.recording_url}}'}
+                      .play
+                        .icon-arrow-right-8
+                        .text
+                          -trans "Listen"
+                      .stop.hide
+                        .stop-icon
+                        .text
+                          -trans "Stop"
             .clearfix
         .span3
           .contact_fields
@@ -155,6 +169,80 @@
 
           .glyph {
             margin-right: 3px;
+          }
+        }
+
+
+        .sent-at {
+
+          .recording {
+
+            .stop {
+              .stop-icon {
+                width:7px;
+                height:7px;
+                background: @flat-white;
+                display:inline-block;
+                line-height:0px;
+                margin-top:-6px;
+                margin-right:1px;
+                margin-left:5px;
+              }
+              .text {
+                padding-top:7px;
+              }
+            }
+
+            &.direction-I{
+
+            }
+
+            padding:1px 6px;
+            padding-bottom:4px;
+            padding-left:1px;
+            .rounded-corners(6px);
+            height:12px;
+            background: @flat-white;
+            color:@flat-white - #333;
+            display:inline-block;
+            margin-right:5px;
+            line-height:0px;
+
+
+            .icon-arrow-right-8 {
+              display:inline-block;
+              font-size:16px;
+              margin-top:-1px;
+              margin-right:-3px;
+            }
+
+            .text {
+              display:inline-block;
+              padding-left:0px;
+            }
+
+            &:hover {
+              background: @color-links;
+              color: @flat-white;
+              cursor:pointer;
+            }
+
+            &.playing {
+              background: @flat-blue;
+              color: #fff;
+
+              &:hover {
+                color: #fff;
+              }
+
+              .stop {
+                display:block;
+              }
+
+              .play {
+                display:none;
+              }
+            }
           }
         }
 
@@ -268,7 +356,7 @@
               font-size:11px;
               font-style:normal;
               padding-bottom:5px;
-              margin-top:-3px;
+              margin-top:0px;
 
               .glyph {
                 margin-right:2px;
@@ -283,6 +371,28 @@
 
 -block extra-script
   {{ block.super }}
+
+  :javascript
+    function playMessage (messageId) {
+      var audio = $('audio#message-' + messageId)
+      var parent = audio.parent();
+      var player = audio[0];
+
+      if (!parent.hasClass('playing')) {
+        audio.bind('ended', function(){
+          parent.removeClass('playing');
+
+        });
+
+        parent.addClass('playing');
+        player.currentTime = 0;
+        player.play();
+
+      } else {
+        parent.removeClass('playing');
+        player.pause();
+      }
+    }
 
   %script
 

--- a/templates/flows/flow_results_contact.haml
+++ b/templates/flows/flow_results_contact.haml
@@ -1,5 +1,5 @@
 -extends "smartmin/read.html"
--load smartmin sms compress temba contacts
+-load smartmin sms compress temba contacts i18n
 
 -block post-header
   -include "flows/simulator.html"
@@ -31,6 +31,45 @@
   -compress css inline
     {% lessblock %}
       :plain
+
+        .to {
+          a {
+            color: @flat-white;
+          }
+        }
+        .recording {
+
+
+
+          padding:1px 6px;
+          padding-left:1px;
+          display:inline-block;
+          margin-right:5px;
+          line-height:0px;
+          font-size:11px;
+
+          .text {
+            display:inline-block;
+            padding-left:0px;
+          }
+
+          &:hover {
+            cursor:pointer;
+          }
+
+          &.playing {
+
+            .stop {
+              display:block;
+            }
+
+            .play {
+              display:none;
+            }
+          }
+        }
+
+
         .flow-name {
           font-size:18px;
           margin-top:-3px;
@@ -162,7 +201,29 @@
 
 -block extra-script
   {{block.super}}
+
   :javascript
+    function playMessage (messageId) {
+      var audio = $('audio#message-' + messageId)
+      var parent = audio.parent();
+      var player = audio[0];
+
+      if (!parent.hasClass('playing')) {
+        audio.bind('ended', function(){
+          parent.removeClass('playing');
+
+        });
+
+        parent.addClass('playing');
+        player.currentTime = 0;
+        player.play();
+
+      } else {
+        parent.removeClass('playing');
+        player.pause();
+      }
+    }
+
 
     $(window).scroll(function() {
       var top = $(this).scrollTop();
@@ -245,7 +306,7 @@
                   .glyph.icon-bubbles-2
 
                 .active
-                  -if run.is_active or run.pk == 12461
+                  -if run.is_active
                 .most-recent
                   .title
                     Last message sent {{last.created_on}}
@@ -263,17 +324,41 @@
 
           -for msg in messages
             -if msg.direction == 'O'
-              .imsg.from= msg.text
+              .imsg.from
+                {{msg.text}}
+                -if msg.recording_url
+                  .recording{class:'direction-{{msg.direction}}', onClick:'playMessage("{{msg.pk}}");'}
+                    %audio{id:'message-{{msg.pk}}', type:"audio/wav", src:'{{msg.recording_url}}'}
+                    .play
+                      %a{href:'javascript:void();'}
+                        listen
+                    .stop.hide
+                      %a{href:'javascript:void();'}
+                        stop
             -if msg.direction == 'I'
               -if msg.text == ''
                 .imsg.to.empty
                   Empty message
               -else
-                .imsg.to= msg.text
+                .imsg.to
+                  {{msg.text}}
+                  -if msg.recording_url
+                    .recording{class:'direction-{{msg.direction}}', onClick:'playMessage("{{msg.pk}}");'}
+                      %audio{id:'message-{{msg.pk}}', type:"audio/wav", src:'{{msg.recording_url}}'}
+                      .play
+                        %a{href:'javascript:void();'}
+                          listen
+                      .stop.hide
+                        %a{href:'javascript:void();'}
+                          stop
+
+
             -with msg.get_flow_step as step
               -if step and step.rule_category
                 .ilog.from
                   Categorized as {{step.rule_category}}
+
+
           -if not run.is_active
             .ilog.from
               -if run.expired_on

--- a/templates/flows/flow_results_contact.haml
+++ b/templates/flows/flow_results_contact.haml
@@ -242,18 +242,24 @@
         $('.run-summary').removeClass('selected');
         $(this).addClass('selected');
         var run = $(this).data('run');
-        var run = $('.run_' + run).clone();
-        $('.simulator-body').append(run.html());
-        var children = $('.simulator-body').children('.run-messages');
-        if (children.length > 1) {
-          $(children[0]).slideUp('fast', function(){
-            $(this).remove()
-          });
+        run = $('.run_' + run).clone();
+        if (run.length > 0){
+          $('.simulator-content').show();
+          $('.simulator-body').append(run.html());
+          var children = $('.simulator-body').children('.run-messages');
+          if (children.length > 1) {
+            $(children[0]).slideUp('fast', function(){
+              $(this).remove()
+            });
+          }
+          $('.simulator-body').scrollTop(0);
+        } else {
+          $('.simulator-content').hide();
         }
-        $('.simulator-body').scrollTop(0);
       });
 
       $('.run-summary:first').click();
+
     });
 
     {% if org_perms.flows.flow_update %}
@@ -287,84 +293,91 @@
     .span8
       .run-summaries
         -for run in runs
-          -with run.messages|last as last
 
-            -if run.messages|length > 0
-              .run-summary{data-run:'{{run.pk}}'}
-                - if org_perms.flows.flow_update
-                  .icon-cancel-circle.remove.hide{data-run:'{{run.pk}}'}
-                .started
-                  Started
+          -with run.messages|last as last_message
+            .run-summary{data-run:'{{run.pk}}'}
+              -if org_perms.flows.flow_update
+                .icon-cancel-circle.remove.hide{data-run:'{{run.pk}}'}
+              .started
+                Started
+                %span.attn
+                  {{run.created_on}}
+                -if last_message.created_on and last_message.created_on|date:"jS F Y H:i" != run.created_on|date:"jS F Y H:i"
+                  to
                   %span.attn
-                    {{run.created_on}}
-                  -if last.created_on|date:"jS F Y H:i" != run.created_on|date:"jS F Y H:i"
-                    to
-                    %span.attn
-                      {{ last.created_on }}
-                .messages
+                    {{ last_message.created_on }}
+              .messages
+                -if run.messages|length > 0
                   {{ run.messages|length }}
                   .glyph.icon-bubbles-2
 
-                .active
-                  -if run.is_active
-                .most-recent
-                  .title
-                    Last message sent {{last.created_on}}
-                  {{last}}
+              .active
+                -if run.is_active
+              .most-recent
+                .title
+                  -if last_message
+                    Last message sent {{last_message.created_on}}
+                -if last_message.text|length > 1 and last_message.text != last_message.recording_url
+                  {{last_message}}
 
 
   -for run in runs
-    -with run.messages as messages
-      .run.hide{class:'run_{{run.pk}}'}
-        .run-messages
-          .ilog.from
-            Started {{run.created_on}}
-            %br
-            {{messages|length}} message{{messages|pluralize:"s"}}
+    -if run.messages
+      -with run.messages as messages
 
-          -for msg in messages
-            -if msg.direction == 'O'
-              .imsg.from
-                {{msg.text}}
-                -if msg.recording_url
-                  .recording{class:'direction-{{msg.direction}}', onClick:'playMessage("{{msg.pk}}");'}
-                    %audio{id:'message-{{msg.pk}}', type:"audio/wav", src:'{{msg.recording_url}}'}
-                    .play
-                      %a{href:'javascript:void();'}
-                        listen
-                    .stop.hide
-                      %a{href:'javascript:void();'}
-                        stop
-            -if msg.direction == 'I'
-              -if msg.text == ''
-                .imsg.to.empty
-                  Empty message
-              -else
-                .imsg.to
-                  {{msg.text}}
-                  -if msg.recording_url
-                    .recording{class:'direction-{{msg.direction}}', onClick:'playMessage("{{msg.pk}}");'}
-                      %audio{id:'message-{{msg.pk}}', type:"audio/wav", src:'{{msg.recording_url}}'}
-                      .play
-                        %a{href:'javascript:void();'}
-                          listen
-                      .stop.hide
-                        %a{href:'javascript:void();'}
-                          stop
+        -if messages|length > 0
+          .run.hide{class:'run_{{run.pk}}'}
+            .run-messages
+              .ilog.from
+                Started {{run.created_on}}
+                %br
+                {{messages|length}} message{{messages|pluralize:"s"}}
+
+              -for msg in messages
+                -if msg.direction == 'O'
+                  .imsg.from
+                    -if msg.text != msg.recording_url
+                      {{msg.text}}
+                    -if msg.recording_url
+                      .recording{class:'direction-{{msg.direction}}', onClick:'playMessage("{{msg.pk}}");'}
+                        %audio{id:'message-{{msg.pk}}', type:"audio/wav", src:'{{msg.recording_url}}'}
+                        .play
+                          %a{href:'javascript:void();'}
+                            listen
+                        .stop.hide
+                          %a{href:'javascript:void();'}
+                            stop
+                -if msg.direction == 'I'
+                  -if msg.text == ''
+                    .imsg.to.empty
+                      Empty message
+                  -else
+                    .imsg.to
+                      -if msg.text != msg.recording_url
+                        {{msg.text}}
+                      -if msg.recording_url
+                        .recording{class:'direction-{{msg.direction}}', onClick:'playMessage("{{msg.pk}}");'}
+                          %audio{id:'message-{{msg.pk}}', type:"audio/wav", src:'{{msg.recording_url}}'}
+                          .play
+                            %a{href:'javascript:void();'}
+                              listen
+                          .stop.hide
+                            %a{href:'javascript:void();'}
+                              stop
 
 
-            -with msg.get_flow_step as step
-              -if step and step.rule_category
+                -with msg.get_flow_step as step
+                  -if step and step.rule_category
+                    .ilog.from
+                      Categorized as {{step.rule_category}}
+
+
+              -if not run.is_active
                 .ilog.from
-                  Categorized as {{step.rule_category}}
-
-
-          -if not run.is_active
-            .ilog.from
-              -if run.expired_on
-                This run expired {{ run.expired_on }}
-              -else
-                {{contact|name_or_urn:user_org}} exited from this flow
+                  -if run.expired_on
+                    This run expired {{ run.expired_on }}
+                  -else
+                    {{contact|name_or_urn:user_org}} exited from this flow
 
 
 -block post-fields


### PR DESCRIPTION
Create messages for all interactions during an IVR call

A few notes:
* Migration only creates incoming messages (we don't have enough information to create outgoing messages). It's better to have this migration than not, otherwise, the runs will appear empty for legacy IVR runs. While the end result isn't fantastic, It's the best we can do. 
![textit - visually build interactive sms applications 2015-02-02 23-45-58](https://cloud.githubusercontent.com/assets/211652/6016405/4f0f8f7c-ab36-11e4-88f2-74f099703b7f.png)

* With IVRAction gone, all incoming messages that were created above will take over the topup of the IVRAction it is replacing. This means that orgs will essentially be debited for historical IVR, but only for the incoming messages. The actions representing the outgoing messages are removed (and the topup ids attached to them). If a topup is recalculated, they will get these credits back, but if the topup has already been exhausted they may not. This seems reasonable.

* Messages aren't tied to calls (IVRAction was, so this is a bit of detail we are tossing out). FlowRuns have a call so we can still map it out through the intermediary.





