### PR TITLE
Send proper finish key attribute on gather

### DIFF
--- a/media/test_imports/call-me-maybe.json
+++ b/media/test_imports/call-me-maybe.json
@@ -52,7 +52,7 @@
             "webhook": null, 
             "label": "Call Me", 
             "operand": "@step.value", 
-            "finished_key": null, 
+            "finished_key": null,
             "y": 165, 
             "x": 204
           }

--- a/media/test_imports/gather-digits.json
+++ b/media/test_imports/gather-digits.json
@@ -1,0 +1,81 @@
+{
+  "version": 4, 
+  "flows": [
+    {
+      "definition": {
+        "base_language": "eng", 
+        "action_sets": [
+          {
+            "y": 0, 
+            "x": 100, 
+            "destination": "7cc4d533-5683-457c-81c0-1a03e2cfbef7", 
+            "uuid": "56e82b72-d1f6-4b1d-8000-8af5655dadd0", 
+            "actions": [
+              {
+                "recording": {
+                  "eng": null
+                }, 
+                "msg": {
+                  "eng": "Enter your phone number followed by the pound sign."
+                }, 
+                "type": "say", 
+                "uuid": "8af6fd9a-43c4-4b64-a3d5-374921d12b0c"
+              }
+            ]
+          }, 
+          {
+            "y": 267, 
+            "x": 100, 
+            "destination": null, 
+            "uuid": "bfd145fd-39f2-4b5c-b709-bb652b4aceb7", 
+            "actions": [
+              {
+                "recording": {
+                  "eng": null
+                }, 
+                "msg": {
+                  "eng": "Thank you for the recording, I have recorded your number as @flow.phone"
+                }, 
+                "type": "say", 
+                "uuid": "bcef13b7-ccff-4ae8-98e4-95de6d082805"
+              }
+            ]
+          }
+        ], 
+        "last_saved": "2015-02-05T04:50:59.366437Z", 
+        "entry": "56e82b72-d1f6-4b1d-8000-8af5655dadd0", 
+        "rule_sets": [
+          {
+            "uuid": "7cc4d533-5683-457c-81c0-1a03e2cfbef7", 
+            "webhook_action": null, 
+            "rules": [
+              {
+                "test": {
+                  "type": "true"
+                }, 
+                "category": {
+                  "base": "All Responses", 
+                  "eng": "All Responses"
+                }, 
+                "destination": "bfd145fd-39f2-4b5c-b709-bb652b4aceb7", 
+                "uuid": "1aa6478b-738e-4821-b077-69af368b9757"
+              }
+            ], 
+            "webhook": null, 
+            "label": "Phone", 
+            "operand": "@step.value", 
+            "finished_key": "#", 
+            "response_type": "K", 
+            "y": 145, 
+            "x": 85
+          }
+        ], 
+        "metadata": {}
+      }, 
+      "id": 24887, 
+      "flow_type": "V", 
+      "name": "Gather Digits"
+    }
+  ], 
+  "triggers": []
+}

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2248,7 +2248,7 @@ class RuleSet(models.Model):
         if self.response_type == RECORDING:
             return run.voice_response
         elif self.response_type == KEYPAD:
-            return run.voice_response.gather(finished_key=self.finished_key, timeout=60, action=action)
+            return run.voice_response.gather(finishOnKey=self.finished_key, timeout=60, action=action)
         else:
             # otherwise we assume it's single digit entry
             return run.voice_response.gather(numDigits=1, timeout=60, action=action)

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -79,7 +79,7 @@ class IVRTests(TembaTest):
     @mock.patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
     @mock.patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @mock.patch('twilio.util.RequestValidator', MockRequestValidator)
-    def test_ivr_hangup(self):
+    def test_ivr_recording(self):
 
         # create our ivr setup
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN")
@@ -128,11 +128,53 @@ class IVRTests(TembaTest):
         self.assertEquals(COMPLETED, call.status)
         self.assertEquals(15, call.duration)
 
+        messages = Msg.objects.filter(msg_type=IVR).order_by('pk')
+        self.assertEquals(3, messages.count())
+        self.assertEquals(3, self.org.get_credits_used())
+
+        from temba.flows.models import FlowStep
+        steps = FlowStep.objects.all()
+        self.assertEquals(3, steps.count())
+
+        # each of our steps should have exactly one message
+        for step in steps:
+            self.assertEquals(1, step.messages.all().count(), msg="Step '%s' does not have excatly one message" % step)
+
+        # each message should have exactly one step
+        for msg in messages:
+            self.assertEquals(1, msg.steps.all().count(), msg="Message '%s' is not attached to exaclty one step" % msg.text)
 
     @mock.patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
     @mock.patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @mock.patch('twilio.util.RequestValidator', MockRequestValidator)
-    def test_ivr_options(self):
+    def test_ivr_digit_gather(self):
+
+        self.org.connect_twilio("TEST_SID", "TEST_TOKEN")
+        self.org.save()
+
+        # import an ivr flow
+        self.import_file('gather-digits')
+
+        # make sure our flow is there as expected
+        flow = Flow.objects.filter(name='Gather Digits').first()
+
+        # start our flow
+        eric = self.create_contact('Eric Newcomer', number='+13603621737')
+        flow.start([], [eric])
+        call = IVRCall.objects.filter(direction=OUTGOING).first()
+
+        # after a call is picked up, twilio will call back to our server
+        post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
+        response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)
+
+        # make sure we send the finishOnKey attribute to twilio
+        self.assertContains(response, 'finishOnKey="#"')
+
+
+    @mock.patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
+    @mock.patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
+    @mock.patch('twilio.util.RequestValidator', MockRequestValidator)
+    def test_ivr_flow(self):
 
         # should be able to create an ivr flow
         self.assertTrue(self.org.supports_ivr())
@@ -180,6 +222,7 @@ class IVRTests(TembaTest):
         # after a call is picked up, twilio will call back to our server
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)
+
         self.assertContains(response, '<Say>Would you like me to call you? Press one for yes, two for no, or three for maybe.</Say>')
 
         # updated our status and duration accordingly


### PR DESCRIPTION
When gathering multi-digit keypad entry we are sending a bogus attribute to twilio. The end result is the same since we only allow sending the default today, but customers get warnings in their Twilio logs.