### PR TITLE
Quicker flow saves

### DIFF
--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -2,7 +2,7 @@ app = angular.module('temba.services', [])
 
 version = new Date().getTime()
 
-quietPeriod = 5000
+quietPeriod = 1000
 errorRetries = 5
 
 app.service "utils", ->

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -2,7 +2,7 @@ app = angular.module('temba.services', [])
 
 version = new Date().getTime()
 
-quietPeriod = 1000
+quietPeriod = 500
 errorRetries = 5
 
 app.service "utils", ->

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2101,7 +2101,6 @@ class Flow(TembaModel, SmartModel):
                     self.entry_uuid = None
                     self.entry_type = None
 
-
             # if we have a base language, set that, but never overwrite an existing language
             json_language = json_dict.get('base_language', None)
             if not self.base_language and json_language:
@@ -2121,6 +2120,10 @@ class Flow(TembaModel, SmartModel):
             if user is None:
                 user = self.created_by
 
+            # remove any versions that were created in the last minute
+            versions = self.versions.filter(created_on__gt=timezone.now() - timedelta(seconds=60)).delete()
+
+            # create a new version
             self.versions.create(definition=json.dumps(json_dict), created_by=user, modified_by=user)
 
             return dict(status="success", description="Flow Saved", saved_on=datetime_to_str(self.saved_on))

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -134,6 +134,14 @@
       }, 100)
     });
 
+    $(window).bind('beforeunload', function(e) {
+      scope = $('html').scope();
+      if (scope && scope.saving) {
+        return "Your flow is still saving, are you sure you want to leave?"
+      }
+    });
+
+
 -block page-top
 
 -block page-container


### PR DESCRIPTION
* Reduce quiet period from 5s to 0.5s
* Remove revisions occurring in the last minute when creating revisions
* Don't post messages in the simulator until outstanding saves are complete
* Warn user if they try to leave before the flow is done saving
