### PR TITLE
Bug fixes

### DIFF
--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -1169,21 +1169,6 @@ ActionEditorController = ($scope, $rootScope, $modalInstance, $timeout, $log, Fl
 
     $scope.action.type = type
     Flow.saveAction(actionset, $scope.action)
-
-    # link us up if necessary, we need to do this after our element is created
-    if $scope.actionset.from
-      for ruleset in $scope.flow.rule_sets
-        for rule in ruleset.rules
-          if rule.uuid == $scope.actionset.from
-            rule.destination = $scope.actionset.uuid
-            break
-
-      $timeout ->
-        Plumb.connect($scope.actionset.from, $scope.actionset.uuid, 'actions')
-        $scope.actionset.from = null
-      ,10
-
-
     $modalInstance.close()
 
   # Saving an SMS to somebody else

--- a/static/coffee/flows/directives.coffee
+++ b/static/coffee/flows/directives.coffee
@@ -277,7 +277,8 @@ app.directive "source", [ 'Plumb', '$log', (Plumb, $log) ->
       if scope.action_set
         scope.$watch (->scope.action_set.destination), (destination) ->
           scope.$evalAsync ->
-            Plumb.setSourceEnabled(element, !destination?)
+            if !scope.action_set._terminal
+              Plumb.setSourceEnabled(element, !destination?)
 
       else if scope.category
         scope.$watch (->scope.category.target), (target) ->

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -218,9 +218,16 @@ app.service "Plumb", ["$timeout", "$rootScope", "$log", ($timeout, $rootScope, $
 
 
   disconnectAllConnections: (id) ->
+
+    # reenable any sources connecting to us
+    jsPlumb.select({target:id}).each (connection) ->
+      jsPlumb.setSourceEnabled($('#' + connection.sourceId), true)
+
+    # now disconnect the existing connections
     jsPlumb.detachAllConnections(id)
 
     $('#' + id + ' .source').each ->
+      jsPlumb.setSourceEnabled($(this), true)
       jsPlumb.detachAllConnections($(this))
 
   disconnectOutboundConnections: (id) ->

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -820,6 +820,20 @@ app.service "Flow", ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
   saveAction: (actionset, action) ->
 
+    # link us up if necessary, we need to do this after our element is created
+    if actionset.from
+      for ruleset in $rootScope.flow.rule_sets
+        for rule in ruleset.rules
+          if rule.uuid == actionset.from
+            rule.destination = actionset.uuid
+            break
+
+      $timeout ->
+        Plumb.connect(actionset.from, actionset.uuid, 'actions')
+        actionset.from = null
+      ,10
+
+
     found = false
     for previous, idx in actionset.actions
       if previous.uuid == action.uuid

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -401,6 +401,7 @@ class Flow(TembaModel, SmartModel):
         # by default we look for pressed keys
         text = user_response.get('Digits', None)
         msg = None
+
         if text:
             msg = Msg.create_incoming(call.channel, (call.contact_urn.scheme, call.contact_urn.path),
                                       text, status=HANDLED, msg_type=IVR)
@@ -527,8 +528,6 @@ class Flow(TembaModel, SmartModel):
             else:
                 run.voice_response = response
                 action_msgs += actionset.execute_actions(run, msg, [])
-                step.left_on = timezone.now()
-                step.save(update_fields=['left_on'])
 
                 # log it for our test contacts
                 if is_test_contact:

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from mock import patch
 import mock
-from temba.flows.models import Flow, FAILED, FlowRun, ActionLog
+from temba.flows.models import Flow, FAILED, FlowRun, ActionLog, FlowStep
 from temba.ivr.models import IVRCall, OUTGOING, IN_PROGRESS, QUEUED, COMPLETED, BUSY, CANCELED, RINGING, NO_ANSWER
 from temba.ivr.clients import TwilioClient
 from temba.msgs.models import Msg
@@ -272,6 +272,13 @@ class IVRTests(TembaTest):
         # also shouldn't have any ActionLogs for non-test users
         self.assertEquals(0, ActionLog.objects.all().count())
         self.assertEquals(1, flow.get_completed_runs())
+
+        # should still have one active run
+        self.assertEquals(1, FlowRun.objects.filter(is_active=True).count())
+
+        # and we haven't left our final step
+        step = FlowStep.objects.all().order_by('-pk').first()
+        self.assertIsNone(step.left_on)
 
         # test other our call status mappings with twilio
         def test_status_update(call_to_update, twilio_status, temba_status):


### PR DESCRIPTION
* When removing the last action, the source for the node pointing to it is enabled
* Make sure we create connections when new non-message actions are created
* Don't enable sources for terminal action sets 
* Fix for IVR where left_on was erroneously set for terminal action sets