### PR TITLE
Fixes asynchronous Vumi failures not retrying

### DIFF
--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -43,7 +43,7 @@ from temba.utils.middleware import disable_middleware
 from urlparse import parse_qs
 from temba.utils.queues import push_task
 from twilio import twiml
-
+from redis_cache import get_redis_connection
 
 def webhook_status_processor(request):
     status = dict()
@@ -3153,14 +3153,13 @@ class VumiHandler(View):
             elif status == 'delivery_report':
                 sms = sms.first()
                 if sms:
-
                     delivery_status = body.get('delivery_status', 'success')
                     if delivery_status == 'failed':
 
                         # we can get multiple reports from vumi if they multi-part the message for us
                         if sms.status in (WIRED, DELIVERED):
                             print "!! [%d] marking %s message as error" % (sms.pk, sms.get_status_display())
-                            Msg.mark_error(sms)
+                            Msg.mark_error(get_redis_connection(), sms)
                     else:
 
                         # we should only mark it as delivered if it's in a wired state, we want to hold on to our

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -17,7 +17,7 @@ from temba.msgs.models import VISIBLE, ARCHIVED, HANDLED, SENT
 from temba.tests import TembaTest
 from temba.utils import dict_to_struct
 from temba.values.models import DATETIME, DECIMAL
-
+from redis_cache import get_redis_connection
 
 class MsgTest(TembaTest):
 
@@ -38,39 +38,40 @@ class MsgTest(TembaTest):
     def test_erroring(self):
         # test with real message
         msg = Msg.create_outgoing(self.org, self.admin, self.joe, "Test 1")
+        r = get_redis_connection()
 
-        Msg.mark_error(msg)
+        Msg.mark_error(r, msg)
         msg = Msg.objects.get(pk=msg.id)
         self.assertEqual(msg.status, 'E')
         self.assertEqual(msg.error_count, 1)
         self.assertIsNotNone(msg.next_attempt)
 
-        Msg.mark_error(msg)
+        Msg.mark_error(r, msg)
         msg = Msg.objects.get(pk=msg.id)
         self.assertEqual(msg.status, 'E')
         self.assertEqual(msg.error_count, 2)
         self.assertIsNotNone(msg.next_attempt)
 
-        Msg.mark_error(msg)
+        Msg.mark_error(r, msg)
         msg = Msg.objects.get(pk=msg.id)
         self.assertEqual(msg.status, 'F')
 
         # test with mock message
         msg = dict_to_struct('MsgStruct', Msg.create_outgoing(self.org, self.admin, self.joe, "Test 2").as_task_json())
 
-        Msg.mark_error(msg)
+        Msg.mark_error(r, msg)
         msg = Msg.objects.get(pk=msg.id)
         self.assertEqual(msg.status, 'E')
         self.assertEqual(msg.error_count, 1)
         self.assertIsNotNone(msg.next_attempt)
 
-        Msg.mark_error(msg)
+        Msg.mark_error(r, msg)
         msg = Msg.objects.get(pk=msg.id)
         self.assertEqual(msg.status, 'E')
         self.assertEqual(msg.error_count, 2)
         self.assertIsNotNone(msg.next_attempt)
 
-        Msg.mark_error(msg)
+        Msg.mark_error(r, msg)
         msg = Msg.objects.get(pk=msg.id)
         self.assertEqual(msg.status, 'F')
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -718,6 +718,8 @@ class OrgTest(TembaTest):
             self.assertEqual(dict(contacts_all=3, contacts_failed=0, contacts_blocked=0), get_all_counts(self.org))
 
     def test_message_folder_counts(self):
+        r = get_redis_connection()
+
         folders = (OrgFolder.msgs_inbox, OrgFolder.msgs_archived, OrgFolder.msgs_outbox, OrgFolder.broadcasts_outbox,
                    OrgFolder.calls_all, OrgFolder.msgs_flows, OrgFolder.broadcasts_scheduled, OrgFolder.msgs_failed)
         get_all_counts = lambda org: {key.name: org.get_folder_count(key) for key in folders}
@@ -776,10 +778,10 @@ class OrgTest(TembaTest):
             self.assertEqual(dict(msgs_inbox=2, msgs_archived=0, msgs_outbox=2, broadcasts_outbox=1, calls_all=2,
                                   msgs_flows=0, broadcasts_scheduled=2, msgs_failed=1), get_all_counts(self.org))
 
-        Msg.mark_error(msg6)
-        Msg.mark_error(msg6)
-        Msg.mark_error(msg6)
-        Msg.mark_error(msg6)
+        Msg.mark_error(r, msg6)
+        Msg.mark_error(r, msg6)
+        Msg.mark_error(r, msg6)
+        Msg.mark_error(r, msg6)
 
         with self.assertNumQueries(0):
             self.assertEqual(dict(msgs_inbox=2, msgs_archived=0, msgs_outbox=2, broadcasts_outbox=1, calls_all=2,


### PR DESCRIPTION
Fixes the case that we weren't clearing our failsafe double send redis key when vumi came back with an error sending. (ie, when the downstream smsc fails)