### PR TITLE
Make sure runs are removed from active sets when they are expired

### DIFF
--- a/temba/flows/migrations/0013_auto_20150306_1817.py
+++ b/temba/flows/migrations/0013_auto_20150306_1817.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from redis_cache import get_redis_connection
+from temba.flows.models import FlowRun
+
+
+def remove_expired_flows_from_active(apps, schema_editor):
+    r = get_redis_connection()
+    for key in r.keys('*:step_active_set:*'):
+        # make sure our flow run activity is removed
+        FlowRun.do_expire_runs(FlowRun.objects.filter(pk__in=r.smembers(key), is_active=False, contact__is_test=False))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0012_auto_20150302_1734'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_expired_flows_from_active, remove_expired_flows_from_active)
+    ]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2596,11 +2596,11 @@ class FlowRun(models.Model):
 
         for run in runs:
             if run['flow'] != last_flow:
-                expired_runs = []
                 if last_flow is not None:
                     flow = Flow.objects.filter(pk=last_flow).first()
                     if flow:
                         flow.remove_active_for_run_ids(expired_runs)
+                expired_runs = []
             expired_runs.append(run['pk'])
             last_flow = run['flow']
 
@@ -2610,8 +2610,8 @@ class FlowRun(models.Model):
             if flow:
                 flow.remove_active_for_run_ids(expired_runs)
 
-        # finally, update the columns in the databse with new expiration
-        runs.update(is_active=False, expired_on=timezone.now())
+        # finally, update the columns in the database with new expiration
+        runs.filter(is_active=True).update(is_active=False, expired_on=timezone.now())
 
     def release(self):
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2596,7 +2596,7 @@ class FlowRun(models.Model):
 
         for run in runs:
             if run['flow'] != last_flow:
-                if last_flow is not None:
+                if expired_runs:
                     flow = Flow.objects.filter(pk=last_flow).first()
                     if flow:
                         flow.remove_active_for_run_ids(expired_runs)


### PR DESCRIPTION
There was an optimization for expiring large batches of runs that wasn't being exercised in the test and (surprise!) had a bug. This makes the test more robust and fixes the big. Also includes a migration to update the active sets by removing any expired runs.