### PR TITLE
Allow writing to flows API endpoint

### DIFF
--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -818,7 +818,7 @@ class FlowWriteSerializer(serializers.Serializer):
             flow = Flow.create(org, self.user, name, flow_type)
 
         if definition:
-            flow.import_definition(definition)
+            flow.update(definition, self.user, force=True)
 
         return flow
 

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -26,7 +26,7 @@ from temba.api.serializers import BoundarySerializer, BroadcastReadSerializer, C
 from temba.api.serializers import CampaignWriteSerializer, CampaignEventSerializer, CampaignEventWriteSerializer
 from temba.api.serializers import ContactGroupReadSerializer, ContactReadSerializer, ContactWriteSerializer
 from temba.api.serializers import ContactFieldReadSerializer, ContactFieldWriteSerializer, BroadcastCreateSerializer
-from temba.api.serializers import FlowReadSerializer, FlowRunReadSerializer, FlowRunStartSerializer
+from temba.api.serializers import FlowReadSerializer, FlowRunReadSerializer, FlowRunStartSerializer, FlowWriteSerializer
 from temba.api.serializers import MsgCreateSerializer, MsgCreateResultSerializer, MsgReadSerializer
 from temba.api.serializers import ChannelClaimSerializer, ChannelReadSerializer, ResultSerializer
 from temba.campaigns.models import Campaign, CampaignEvent
@@ -2358,6 +2358,17 @@ class FlowEndpoint(generics.ListAPIView):
     model = Flow
     permission_classes = (SSLPermission, ApiPermission)
     serializer_class = FlowReadSerializer
+    form_serializer_class = FlowWriteSerializer
+
+    def post(self, request, format=None):
+        user = request.user
+        serializer = FlowWriteSerializer(user=user, data=request.DATA)
+        if serializer.is_valid():
+            serializer.save()
+            response_serializer = FlowReadSerializer(instance=serializer.object)
+            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def get_queryset(self):
         queryset = Flow.objects.filter(org=self.request.user.get_org(), is_active=True).order_by('-created_on')

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1953,14 +1953,13 @@ class Flow(TembaModel, SmartModel):
 
         return flow
 
-    def update(self, json_dict, user=None):
+    def update(self, json_dict, user=None, force=False):
         """
         Updates a definition for a flow.
         """
         try:
-
             # check whether the flow has changed since this flow was last saved
-            if user:
+            if user and not force:
                 saved_on = json_dict.get(Flow.LAST_SAVED, None)
                 org = user.get_org()
                 tz = org.get_tzinfo()
@@ -2166,7 +2165,7 @@ class Flow(TembaModel, SmartModel):
                 user = self.created_by
 
             # remove any versions that were created in the last minute
-            versions = self.versions.filter(created_on__gt=timezone.now() - timedelta(seconds=60)).delete()
+            self.versions.filter(created_on__gt=timezone.now() - timedelta(seconds=60)).delete()
 
             # create a new version
             self.versions.create(definition=json.dumps(json_dict), created_by=user, modified_by=user)


### PR DESCRIPTION
Flow definition is provided via optional definition field. Being optional you can update a flow's properties without providing the full JSON definition. For example to update an existing flow...

```json
{
  "uuid": "56811758-C8EE-494C-B3CC-FD92A85E49CA",
  "name": "Test Flow",
  "flow_type": "F",
  "definition": { "action_sets": ... }
}
```

Writing is not included in user facing documentation for now.