### PR TITLE
Small fix for fetching messages by id in the API

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1098,6 +1098,11 @@ class APITest(TembaTest):
         self.assertEquals(self.admin.get_org(), sms.org)
         self.assertEquals(self.channel, sms.channel)
         self.assertEquals(broadcast, sms.broadcast)
+        
+        # fetch by message id
+        response = self.fetchJSON(url, "id=%d" % sms.pk)
+        self.assertResultCount(response, 1)
+        self.assertContains(response, "test1")
 
         response = self.fetchJSON(url, "status=Q&before=2030-01-01T00:00:00.000&after=2010-01-01T00:00:00.000&phone=%%2B250788123123&channel=%d" % self.channel.pk)
         self.assertEquals(200, response.status_code)

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -682,7 +682,7 @@ class MessagesEndpoint(generics.ListAPIView):
     def get_queryset(self):
         queryset = Msg.objects.filter(org=self.request.user.get_org()).order_by('-created_on')
 
-        ids = splitting_getlist(self.request, 'sms')
+        ids = splitting_getlist(self.request, 'id')
         if ids:
             queryset = queryset.filter(pk__in=ids)
 


### PR DESCRIPTION
API docs already claim you can search by `id`