### PR TITLE
Simplify queries on main analytics page to speed it up

### DIFF
--- a/static/coffee/analytics.coffee
+++ b/static/coffee/analytics.coffee
@@ -82,11 +82,7 @@ $ ->
             text += "<div class='field-count'>" + gettext("Add all ") + obj.rules.length + gettext(" fields") + "</div>"
           return text
 
-        text = "<div class='field-rule'>" + obj.text + "</div><div class='field-contacts'>("
-        text += obj.stats.contacts + gettext(" contact")
-        if obj.stats.contacts.length != 1
-          text += "s"
-        text += ")</div>"
+        text = "<div class='field-rule'>" + obj.text + "</div>"
 
       escapeMarkup: (m) -> m
       matcher: (term, text, opt) ->
@@ -331,7 +327,7 @@ FieldController = ($scope, $http) ->
 
             data.total = total
             data.chartType = chartType
-            data.isVisible = data.categories.length > 1
+            data.isVisible = true
             if visible?
               data.isVisible = visible
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1384,7 +1384,7 @@ class ContactGroup(TembaModel, SmartModel):
 
     def analytics_json(self):
         if self.contacts.exists():
-            return dict(name=self.name, id=self.pk, count=self.contacts.all().count())
+            return dict(name=self.name, id=self.pk, count=self.get_member_count())
 
     def __unicode__(self):
         return self.name

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -775,7 +775,7 @@ class Flow(TembaModel, SmartModel):
         if hasattr(kind, 'name'):
             name = kind.name
 
-        cache_key = FLOW_STAT_CACHE_KEY % (self.org.pk, self.pk, name)
+        cache_key = FLOW_STAT_CACHE_KEY % (self.org_id, self.pk, name)
         if item:
             cache_key += (':%s' % item)
         return cache_key
@@ -2403,6 +2403,9 @@ class RuleSet(models.Model):
 
     def get_rules(self):
         return Rule.from_json_array(self.flow.org, json.loads(self.rules))
+
+    def get_rule_uuids(self):
+        return [rule['uuid'] for rule in json.loads(self.rules)]
 
     def set_rules_dict(self, json_dict):
         self.rules = json.dumps(json_dict)

--- a/templates/flows/ruleset_analytics.haml
+++ b/templates/flows/ruleset_analytics.haml
@@ -78,9 +78,9 @@
             -trans "Most Active"
           .flow{ng-repeat:'flow in flows | orderBy:"-stats.messages" | limitTo:4 '}
             .message-count{ ng-click: 'addFlowFields(flow)' }
-              [[flow.stats.messages]]
+              [[flow.stats.contacts]]
               .message-label
-                <ng-pluralize count="flow.stats.messages" when="{'0': '{% trans "msgs" %}', 'one': '{% trans "msg" %}', 'other': '{% trans "msgs" %}' }">
+                <ng-pluralize count="flow.stats.contacts" when="{'0': '{% trans "contacts" %}', 'one': '{% trans "contact" %}', 'other': '{% trans "contacts" %}' }">
                 </ng-pluralize>
 
             .flow-name{ ng-click: 'addFlowFields(flow)' }
@@ -89,18 +89,17 @@
               <ng-pluralize count="flow.rules.length" when="{'0': '{% trans "No fields." %}', 'one': '{% trans "1 field" %}', 'other': '{% trans "{} fields" %}' }">
               </ng-pluralize>
             .last-message
-              <ng-pluralize count="flow.stats.messages" when="{'0': '{% trans "No messages yet" %}', 'one': '{% trans "Last message on" %}', 'other': '{% trans "Last message on" %}' }">
-              </ng-pluralize>
-              [[ flow.stats.last_message | date:'mediumDate']]
+              {% trans "Created on" %}
+              [[ flow.stats.created_on | date:'mediumDate']]
 
         .samples.by-recency{ng-model:"flows"}
           %h2
             -trans "Most Recent"
-          .flow{ng-repeat:'flow in flows | orderBy:"-stats.last_message" | limitTo:4 ', data:'[[flow.id]]'}
+          .flow{ng-repeat:'flow in flows | orderBy:"-stats.created_on" | limitTo:4 ', data:'[[flow.id]]'}
             .message-count{ ng-click: 'addFlowFields(flow)' }
-              [[flow.stats.messages]]
+              [[flow.stats.contacts]]
               .message-label
-                <ng-pluralize count="flow.stats.messages" when="{'0': '{% trans "msgs" %}', 'one': '{% trans "msg" %}', 'other': '{% trans "msgs" %}' }">
+                <ng-pluralize count="flow.stats.contacts" when="{'0': '{% trans "contacts" %}', 'one': '{% trans "contact" %}', 'other': '{% trans "contacts" %}' }">
                 </ng-pluralize>
 
             .flow-name{ ng-click: 'addFlowFields(flow)' }
@@ -109,9 +108,8 @@
               <ng-pluralize count="flow.rules.length" when="{'0': '{% trans "No fields." %}', 'one': '{% trans "1 field" %}', 'other': '{% trans "{} fields" %}' }">
               </ng-pluralize>
             .last-message
-              <ng-pluralize count="flow.stats.messages" when="{'0': '{% trans "No messages yet" %}', 'one': '{% trans "Last message on" %}', 'other': '{% trans "Last message on" %}' }">
-              </ng-pluralize>
-              [[ flow.stats.last_message | date:'mediumDate']]
+              {% trans "Created on" %}
+              [[ flow.stats.created_on | date:'mediumDate']]
 
       - if org_perms.reports.report_create
         %h2.current-report-title{ ng-show:"currentReport"}

--- a/templates/flows/ruleset_analytics.haml
+++ b/templates/flows/ruleset_analytics.haml
@@ -76,7 +76,7 @@
         .samples.by-responses{ng-model:"flows"}
           %h2
             -trans "Most Active"
-          .flow{ng-repeat:'flow in flows | orderBy:"-stats.messages" | limitTo:4 '}
+          .flow{ng-repeat:'flow in flows | orderBy:"-stats.contacts" | limitTo:4 '}
             .message-count{ ng-click: 'addFlowFields(flow)' }
               [[flow.stats.contacts]]
               .message-label


### PR DESCRIPTION
The main index page for analytics was doing a ton of super expensive queries, just to show the lists of rulesets in various orders.

This removes those and just shows the most recent and active flows, along with a simple list of all the categories.

Also a few other optimizations on queries and not using caches.