### PR TITLE
Use our optimized value summary call for choropleth

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1383,7 +1383,7 @@ class ContactGroup(TembaModel, SmartModel):
         return self.query is not None
 
     def analytics_json(self):
-        if self.contacts.exists():
+        if self.get_member_count() > 0:
             return dict(name=self.name, id=self.pk, count=self.get_member_count())
 
     def __unicode__(self):

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -148,6 +148,14 @@ def build_json_response(json_dict, status=200):
     """
     return HttpResponse(json.dumps(json_dict), status=status, content_type='application/json')
 
+def percentage(numerator, denominator):
+    """
+    Returns an integer percentage as an integer for the passed in numerator and denominator.
+    """
+    if not denominator or not numerator:
+        return 0
+
+    return int(100.0 * numerator / denominator + .5)
 
 def format_decimal(val):
     """

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -16,7 +16,8 @@ from .cache import get_cacheable_result, incrby_existing
 from .queues import pop_task, push_task, HIGH_PRIORITY, LOW_PRIORITY
 from .parser import EvaluationError, EvaluationContext, evaluate_template, evaluate_expression, set_evaluation_context, get_function_listing
 from .parser_functions import *
-from . import format_decimal, slugify_with, str_to_datetime, str_to_time, truncate, random_string, non_atomic_when_eager
+from . import format_decimal, slugify_with, str_to_datetime, str_to_time, truncate, random_string, non_atomic_when_eager, \
+    percentage
 from . import PageableQuery, json_to_dict, dict_to_struct, datetime_to_ms, ms_to_datetime, dict_to_json
 from . import datetime_to_json_date, json_date_to_datetime, timezone_to_country_code
 
@@ -776,3 +777,13 @@ class PageableQueryTest(TembaTest):
         paginator = Paginator(query, 2)
         assertPage(["Billy Joel", "Joe Blow"], True, paginator.page(1))
         assertPage(["Mary Jo"], False, paginator.page(2))
+
+
+class PercentageTest(TembaTest):
+
+    def test_percentage(self):
+        self.assertEquals(0, percentage(0, 100))
+        self.assertEquals(0, percentage(0, 0))
+        self.assertEquals(0, percentage(100, 0))
+        self.assertEquals(75, percentage(75, 100))
+        self.assertEquals(76, percentage(759, 1000))


### PR DESCRIPTION
Uses our much faster (and cached) Value summary method to calculating Choropleth results in analytics. Now it is basically just reformatting those results in the view instead of doing slow calculations.

Also fixes us going to the db for each group to calculate whether there are contacts in it by using the cache instead.