### PR TITLE
Fixes flow starts that span more than one contact and more than one flow

### DIFF
--- a/media/test_imports/flow-starts.json
+++ b/media/test_imports/flow-starts.json
@@ -1,0 +1,116 @@
+{
+  "campaigns": [], 
+  "version": 4, 
+  "site": "http://rapidpro.io", 
+  "flows": [
+    {
+      "definition": {
+        "base_language": "eng", 
+        "action_sets": [
+          {
+            "y": 0, 
+            "x": 100, 
+            "destination": null, 
+            "uuid": "f1eaf53b-27d8-4e93-818e-4c4808b21976", 
+            "actions": [
+              {
+                "field": "name", 
+                "type": "save", 
+                "value": "Greg", 
+                "label": "Contact Name"
+              }
+            ]
+          }
+        ], 
+        "last_saved": "2015-03-31T13:24:32.741812Z", 
+        "entry": "f1eaf53b-27d8-4e93-818e-4c4808b21976", 
+        "rule_sets": [], 
+        "metadata": {}
+      }, 
+      "id": 13968, 
+      "flow_type": "F", 
+      "name": "Child Flow"
+    }, 
+    {
+      "definition": {
+        "base_language": "eng", 
+        "action_sets": [
+          {
+            "y": 163, 
+            "x": 201, 
+            "destination": null, 
+            "uuid": "59fa8d6c-50fd-4686-a45f-d9a30f616b80", 
+            "actions": [
+              {
+                "type": "flow", 
+                "name": "Child Flow", 
+                "id": 13968
+              }
+            ]
+          }
+        ], 
+        "last_saved": "2015-03-31T13:27:02.568148Z", 
+        "entry": "f4eba3d0-3bfc-4564-a3ee-662cb0fac9f0", 
+        "rule_sets": [
+          {
+            "uuid": "f4eba3d0-3bfc-4564-a3ee-662cb0fac9f0", 
+            "webhook_action": "GET", 
+            "rules": [
+              {
+                "test": {
+                  "test": {
+                    "eng": "Foo"
+                  }, 
+                  "base": "Foo", 
+                  "type": "contains_any"
+                }, 
+                "category": {
+                  "base": "Foo", 
+                  "eng": "Foo"
+                }, 
+                "config": {
+                  "type": "contains_any", 
+                  "verbose_name": "has any of these words", 
+                  "name": "Contains any", 
+                  "localized": true, 
+                  "operands": 1
+                }, 
+                "uuid": "0265fb76-e6df-458f-8727-0b2d08f040ec"
+              }, 
+              {
+                "test": {
+                  "test": "true", 
+                  "type": "true"
+                }, 
+                "category": {
+                  "base": "All Responses", 
+                  "eng": "Other"
+                }, 
+                "destination": "59fa8d6c-50fd-4686-a45f-d9a30f616b80", 
+                "config": {
+                  "type": "true", 
+                  "verbose_name": "contains anything", 
+                  "name": "Other", 
+                  "operands": 0
+                }, 
+                "uuid": "e0d2f9fb-a300-4a21-b258-e594bd26030d"
+              }
+            ], 
+            "webhook": null, 
+            "label": "Response 1", 
+            "operand": "@contact.groups", 
+            "finished_key": null, 
+            "response_type": "C", 
+            "y": 0, 
+            "x": 129
+          }
+        ], 
+        "metadata": {}
+      }, 
+      "id": 13967, 
+      "flow_type": "F", 
+      "name": "Parent Flow"
+    }
+  ], 
+  "triggers": []
+}

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1475,7 +1475,7 @@ class Flow(TembaModel, SmartModel):
             return
 
         if self.flow_type == Flow.VOICE:
-            return self.start_call_flow(all_contacts, started_flows=started_flows, start_msg=start_msg,
+            return self.start_call_flow(all_contacts, start_msg=start_msg,
                                         extra=extra, flow_start=flow_start)
 
         else:
@@ -1483,12 +1483,8 @@ class Flow(TembaModel, SmartModel):
                                        started_flows=started_flows,
                                        start_msg=start_msg, extra=extra, flow_start=flow_start)
 
-    def start_call_flow(self, all_contacts, started_flows=None, start_msg=None, extra=None, flow_start=None):
+    def start_call_flow(self, all_contacts, start_msg=None, extra=None, flow_start=None):
         from temba.ivr.models import IVRCall
-
-        if started_flows is None:
-            started_flows = []
-
         runs = []
         channel = self.org.get_call_channel()
 
@@ -1669,11 +1665,15 @@ class Flow(TembaModel, SmartModel):
         optimize_sending_action = len(broadcasts) > 0
 
         for contact in batch_contacts:
+            # each contact maintain it's own list of started flows
+            started_flows_by_contact = list(started_flows)
+
             run = run_map[contact.id]
             run_msgs = message_map.get(contact.id, [])
 
             if entry_actions:
-                run_msgs += entry_actions.execute_actions(run, start_msg, started_flows, execute_reply_action=not optimize_sending_action)
+                run_msgs += entry_actions.execute_actions(run, start_msg, started_flows_by_contact,
+                                                          execute_reply_action=not optimize_sending_action)
 
                 step = self.add_step(run, entry_actions, run_msgs, is_start=True)
 
@@ -1690,13 +1690,13 @@ class Flow(TembaModel, SmartModel):
 
                 # if we have a start message, go and handle the rule
                 if start_msg:
-                    self.find_and_handle(start_msg, started_flows)
+                    self.find_and_handle(start_msg, started_flows_by_contact)
 
                 # otherwise, if this ruleset doesn't operate on a step, then evaluate it immediately
                 elif not entry_rules.requires_step():
                     # create an empty placeholder message
                     msg = Msg(contact=contact, text='', id=0)
-                    self.handle_ruleset(entry_rules, step, run, msg, started_flows)
+                    self.handle_ruleset(entry_rules, step, run, msg, started_flows_by_contact)
 
             if start_msg:
                 step.add_message(start_msg)
@@ -1721,7 +1721,9 @@ class Flow(TembaModel, SmartModel):
 
         return runs
 
-    def add_step(self, run, step, msgs=[], rule=None, category=None, call=None, is_start=False, previous_step=None):
+    def add_step(self, run, step, msgs=None, rule=None, category=None, call=None, is_start=False, previous_step=None):
+        if msgs is None:
+            msgs = []
 
         # if we were previously marked complete, activate again
         run.set_completed(False)


### PR DESCRIPTION
On flow starts, we were using a single list of the previously started flows to prevent loops from happening, instead of one list per contact.