### PR TITLE
UTF-16

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -2880,6 +2880,38 @@ class TwilioTest(TembaTest):
 
 class ClickatellTest(TembaTest):
 
+    def test_receive_utf16(self):
+        self.channel.channel_type = CLICKATELL
+        self.channel.uuid = uuid.uuid4()
+        self.channel.save()
+
+        self.channel.org.config = json.dumps({API_ID:'12345', USERNAME:'uname', PASSWORD:'pword'})
+        self.channel.org.save()
+
+        data = {'to': self.channel.address,
+                'from': '250788383383',
+                'timestamp': '2012-10-10 10:10:10',
+                'moMsgId': 'id1234'}
+
+        encoded_message = urlencode(data)
+        encoded_message += "&text=%00m%00e%00x%00i%00c%00o%00+%00k%00+%00m%00i%00s%00+%00p%00a%00p%00a%00s%00+%00n%00o%00+%00t%00e%00n%00%ED%00a%00+%00d%00i%00n%00e%00r%00o%00+%00p%00a%00r%00a%00+%00c%00o%00m%00p%00r%00a%00r%00n%00o%00s%00+%00l%00o%00+%00q%00+%00q%00u%00e%00r%00%ED%00a%00m%00o%00s%00.%00."
+        encoded_message += "&charset=UTF-16BE"
+        receive_url = reverse('api.clickatell_handler', args=['receive', self.channel.uuid]) + '?' + encoded_message
+
+        response = self.client.get(receive_url)
+
+        self.assertEquals(200, response.status_code)
+
+        # and we should have a new message
+        msg1 = Msg.objects.get()
+        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEquals(INCOMING, msg1.direction)
+        self.assertEquals(self.org, msg1.org)
+        self.assertEquals(self.channel, msg1.channel)
+        self.assertEquals(u"mexico k mis papas no ten\xeda dinero para comprarnos lo q quer\xedamos..", msg1.text)
+        self.assertEquals(2012, msg1.created_on.year)
+        self.assertEquals('id1234', msg1.external_id)
+
     def test_receive(self):
         # change our channel to a clickatell channel
         self.channel.channel_type = CLICKATELL

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -3664,10 +3664,21 @@ class ClickatellHandler(View):
             # dates come in the format "2014-04-18 03:54:20" GMT
             sms_date = datetime.strptime(request.REQUEST['timestamp'], '%Y-%m-%d %H:%M:%S')
             gmt_date = pytz.timezone('GMT').localize(sms_date)
+            text = request.REQUEST['text']
+
+            # clickatell will sometimes send us UTF-16BE encoded data which is double encoded, we need to turn
+            # this into utf-8 through the insane process below, Python is retarded about encodings
+            if request.REQUEST.get('charset', 'utf-8') == 'UTF-16BE':
+                text_bytes = bytearray()
+                for text_byte in text:
+                    text_bytes.append(ord(text_byte))
+
+                # now encode back into utf-8
+                text = text_bytes.decode('utf-16be').encode('utf-8')
 
             sms = Msg.create_incoming(channel,
                                       (TEL_SCHEME, request.REQUEST['from']),
-                                      request.REQUEST['text'],
+                                      text,
                                       date=gmt_date)
 
             Msg.objects.filter(pk=sms.id).update(external_id=request.REQUEST['moMsgId'])

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1003,7 +1003,6 @@ class ContactTest(TembaTest):
         blocked_url = reverse('contacts.contact_blocked')
 
         # archived contact are not on the list page
-        # Now Let's unblock Joe
         post_data = dict()
         post_data['action'] = 'unblock'
         post_data['objects'] = self.joe.id


### PR DESCRIPTION
Handles the case where Clickatell sends us UTF-16 encoded text. We convert it to UTF-8 so it saves properly to Postgres.

plz review @ericnewcomer @norkans7 @rowanseymour 