### PR TITLE
Added .distinct() to messages api endpoint 

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1156,10 +1156,12 @@ class APITest(TembaTest):
         self.assertEquals(200, response.status_code)
         self.assertResultCount(response, 0)
 
-        label = Label.create_unique(self.org, self.user, "Goo")
-        label.toggle_label([msg1], add=True)
+        label1 = Label.create_unique(self.org, self.user, "Goo")
+        label1.toggle_label([msg1], add=True)
+        label2 = Label.create_unique(self.org, self.user, "Boo")
+        label2.toggle_label([msg1], add=True)
 
-        response = self.fetchJSON(url, "label=Goo")
+        response = self.fetchJSON(url, "label=Goo&label=Boo")
         self.assertEquals(200, response.status_code)
         self.assertResultCount(response, 1)
 

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -773,7 +773,7 @@ class MessagesEndpoint(generics.ListAPIView):
         reverse_order = self.request.QUERY_PARAMS.get('reverse', None)
         order = 'created_on' if reverse_order and str_to_bool(reverse_order) else '-created_on'
 
-        return queryset.order_by(order).prefetch_related('labels')
+        return queryset.order_by(order).prefetch_related('labels').distinct()
 
     @classmethod
     def get_read_explorer(cls):


### PR DESCRIPTION
Removes duplicates when querying with multiple labels