### PR TITLE
Add ability to segment results by contact field

### DIFF
--- a/media/test_flows/color_gender_age.json
+++ b/media/test_flows/color_gender_age.json
@@ -171,6 +171,12 @@
       "uuid": "5ad1b145-58ba-4b65-8cb5-84d98172b221", 
       "actions": [
         {
+          "type": "save",
+          "field": "gender",
+          "label": "Gender",
+          "value": "@flow.gender"
+        },
+        {
           "msg": "What is your age?", 
           "type": "reply"
         }

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -15,7 +15,6 @@ from django.core.urlresolvers import reverse
 from django.db import connection
 from django.utils import timezone
 from django.utils.http import urlquote_plus
-from djorm_hstore.models import register_hstore_handler
 from mock import patch
 from redis_cache import get_redis_connection
 from rest_framework.authtoken.models import Token
@@ -43,7 +42,6 @@ class APITest(TembaTest):
 
     def setUp(self):
         super(APITest, self).setUp()
-        register_hstore_handler(connection)
 
         self.joe = self.create_contact("Joe Blow", "0788123123")
 

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -3175,7 +3175,8 @@ class InfobipHandler(View):
                         'REJECTED', 'INVALID_MESSAGE_FORMAT']:
             sms.fail()
 
-        sms.broadcast.update()
+        if sms.broadcast:
+            sms.broadcast.update()
 
         return HttpResponse("SMS Status Updated")
 

--- a/temba/contacts/migrations/0001_initial.py
+++ b/temba/contacts/migrations/0001_initial.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 from django.conf import settings
 import temba.orgs.models
-import django_hstore.fields
-
 
 class Migration(migrations.Migration):
 
@@ -26,7 +24,7 @@ class Migration(migrations.Migration):
                 ('is_archived', models.BooleanField(default=False, help_text='Whether this contacts has been archived', verbose_name='Is Archived')),
                 ('is_test', models.BooleanField(default=False, help_text='Whether this contact is for simulation', verbose_name='Is Test')),
                 ('status', models.CharField(default='N', max_length=2, verbose_name='Contact Status')),
-                ('fields', django_hstore.fields.DictionaryField(db_index=True)),
+                ('fields', models.CharField(null=True, max_length=128)),
                 ('language', models.CharField(help_text='The preferred language for this contact', max_length=3, null=True, verbose_name='Language', blank=True)),
             ],
             options={

--- a/temba/contacts/migrations/0017_remove_contact_fields.py
+++ b/temba/contacts/migrations/0017_remove_contact_fields.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0016_remove_exportcontactstask_filename'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='contact',
+            name='fields',
+        ),
+    ]

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -13,8 +13,6 @@ from django.core.files.temp import NamedTemporaryFile
 from django.db import models
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
-from django_hstore import hstore
-from django_hstore.fields import DictionaryField
 from smartmin.models import SmartModel
 from smartmin.csv_imports.models import ImportTask
 from temba.channels.models import Channel
@@ -35,9 +33,7 @@ GROUP_MEMBER_COUNT_CACHE_KEY = 'org:%d:cache:group_member_count:%d'
 
 class ContactField(models.Model, OrgModelMixin):
     """
-    Represents a type of field that can be put on Contacts.  We store uuids as the keys in our HSTORE
-    field so that we don't have to worry about renaming fields with the user.  This takes care of that
-    mapping for us.
+    Represents a type of field that can be put on Contacts.
     """
     org = models.ForeignKey(Org, verbose_name=_("Org"), related_name="contactfields")
 
@@ -159,12 +155,8 @@ class Contact(TembaModel, SmartModel, OrgModelMixin):
     is_failed = models.BooleanField(verbose_name=_("Is Failed"), default=False,
                                     help_text=_("Whether we cannot send messages to this contact"))
 
-    fields = DictionaryField(db_index=True)
-
     language = models.CharField(max_length=3, verbose_name=_("Language"), null=True, blank=True,
                                 help_text=_("The preferred language for this contact"))
-
-    objects = hstore.HStoreManager()
 
     simulation = False
 
@@ -310,9 +302,6 @@ class Contact(TembaModel, SmartModel, OrgModelMixin):
 
         # cache
         setattr(self, '__field__%s' % key, existing)
-
-        # persist to db
-        self.save(update_fields=['fields'])
 
         # update any groups or campaigns for this contact
         self.handle_update(field=field)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6,7 +6,6 @@ import pytz
 from datetime import datetime, date
 from django.utils import timezone
 
-from django_hstore.apps import register_hstore_handler
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -219,8 +218,6 @@ class ContactGroupTest(TembaTest):
     def setUp(self):
         super(ContactGroupTest, self).setUp()
 
-        register_hstore_handler(connection)
-
         self.joe = Contact.get_or_create(self.org, self.admin, name="Joe Blow", urns=[(TEL_SCHEME, "123")])
         self.frank = Contact.get_or_create(self.org, self.admin, name="Frank Smith", urns=[(TEL_SCHEME, "1234")])
         self.mary = Contact.get_or_create(self.org, self.admin, name="Mary Mo", urns=[(TEL_SCHEME, "345")])
@@ -323,8 +320,6 @@ class ContactGroupTest(TembaTest):
 class ContactTest(TembaTest):
     def setUp(self):
         TembaTest.setUp(self)
-
-        register_hstore_handler(connection)
 
         self.user1 = self.create_user("nash")
         self.manager1 = self.create_user("mike")
@@ -1581,8 +1576,6 @@ class ContactURNTest(TembaTest):
 
 class ContactFieldTest(TembaTest):
     def setUp(self):
-        register_hstore_handler(connection)
-
         self.user = self.create_user("tito")
         self.manager1 = self.create_user("mike")
         self.admin = self.create_user("ben")

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -7,7 +7,6 @@ from xlrd import xldate_as_tuple
 from temba.tests import MockResponse, FlowFileTest
 from django.core import mail
 from django.core.urlresolvers import reverse
-from djorm_hstore.models import register_hstore_handler
 from smartmin.tests import SmartminTest
 
 
@@ -29,8 +28,6 @@ class RuleTest(TembaTest):
 
     def setUp(self):
         super(RuleTest, self).setUp()
-
-        register_hstore_handler(connection)
 
         self.contact = self.create_contact('Eric', '+250788382382')
         self.contact2 = self.create_contact('Nic', '+250788383383')

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -179,8 +179,6 @@ INSTALLED_APPS = (
     'django.contrib.humanize',
     'django.contrib.gis',
 
-    'django_hstore',
-
     # django sitemaps
     'django.contrib.sitemaps',
 

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -14,7 +14,6 @@ from django.core.urlresolvers import reverse
 from django.db import connection
 from django.test import LiveServerTestCase
 from django.utils import timezone
-from djorm_hstore.models import register_hstore_handler
 from smartmin.tests import SmartminTest
 from temba.contacts.models import Contact, ContactGroup, TEL_SCHEME, TWITTER_SCHEME
 from temba.orgs.models import Org
@@ -186,7 +185,6 @@ class FlowFileTest(TembaTest):
     def setUp(self):
         super(FlowFileTest, self).setUp()
         self.contact = self.create_contact('Ben Haggerty', '+12065552020')
-        register_hstore_handler(connection)
 
     def assertLastResponse(self, message):
         response = Msg.objects.filter(contact=self.contact).order_by('-created_on', '-pk').first()

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -424,3 +424,4 @@ def splitting_getlist(request, name, default=None):
         return vals[0].split(',')
     else:
         return vals
+

--- a/temba/values/models.py
+++ b/temba/values/models.py
@@ -176,7 +176,7 @@ class Value(models.Model):
                                                values__location_value__osm_id__in=boundaries)
 
                 # we are filtering by a contact field
-                elif 'contact_field' in filter:
+                elif 'contact_field' in contact_filter:
                     contact_query = Q()
 
                     # we can't use __in as we want case insensitive matching

--- a/temba/values/tests.py
+++ b/temba/values/tests.py
@@ -221,6 +221,18 @@ class ResultTest(FlowFileTest):
         self.assertResult(female_result, 1, "Blue", 1)
         self.assertResult(female_result, 2, "Green", 0)
 
+        # segment by gender again, but use the contact field to do so
+        result = Value.get_value_summary(ruleset=color, filters=[], segment=dict(contact_field="Gender", values=["MALE", "Female"]))
+        male_result = result[0]
+        self.assertResult(male_result, 0, "Red", 0)
+        self.assertResult(male_result, 1, "Blue", 1)
+        self.assertResult(male_result, 2, "Green", 1)
+
+        female_result = result[1]
+        self.assertResult(female_result, 0, "Red", 1)
+        self.assertResult(female_result, 1, "Blue", 1)
+        self.assertResult(female_result, 2, "Green", 0)
+
         # add in a filter at the same time
         result = Value.get_value_summary(ruleset=color, filters=[dict(ruleset=color.pk, categories=["Blue"])],
                                          segment=dict(ruleset=gender.pk, categories=["Male", "Female"]))


### PR DESCRIPTION
Adds the ability to segment results by a contact field by passing in the values you want to segment by. (this addresses my primary concern on performance as it is now no worse than ruleset segmenting)

Also get rid of HSTORE and ```fields``` field on Contact as these were unused.