### PR TITLE
Faster channel read

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -1,20 +1,19 @@
 -e git+https://github.com/nyaruka/smartmin.git@ee5d66be64079359714d913d5635e8de8e96885b#egg=smartmin
 Django==1.7.7
 coverage==3.5.1
-django-celery==3.1.9
+django-celery==3.1.16
 django-compressor==1.4
 django-debug-toolbar==1.2.2
 django-digest==1.13
 django-guardian==1.2.4
 -e git+http://github.com/nyaruka/django-modeltranslation.git@dffebc9363297d77d91c99d46e8e53b32dc05e61#egg=django_modeltranslation-master
 django-nose==1.2
--e git+http://github.com/nyaruka/django-quickblocks.git@054acd14c665ecaaf93a573cf7d35b8ab9f867d6#egg=django_quickblocks-master
 django-rosetta==0.6.2
 gunicorn==18.0
 nose==1.3.0
 pisa==3.0.33
 raven==4.0.4
-celery-with-redis==3.0
+celery[redis]==3.1.18
 python-gcm==0.1.5
 hamlpy==0.82.2
 django-redis==3.1.5
@@ -66,7 +65,6 @@ anyjson==0.3.3
 argparse==1.2.1
 backports.ssl-match-hostname==3.4.0.2
 billiard==3.3.0.17
-celery==3.1.11
 certifi==14.05.14
 django-appconf==0.6
 django-picklefield==0.3.0

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -3145,8 +3145,25 @@ class TwilioTest(TembaTest):
                 self.assertEquals(ERRORED, msg.status)
                 self.assertEquals(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
+
+            # check that our channel log works as well
+            self.login(self.admin)
+
+            response = self.client.get(reverse('channels.channellog_list') + "?channel=%d" % (self.channel.pk))
+
+            # there should be two log items for the two times we sent
+            self.assertEquals(2, len(response.context['channellog_list']))
+
+            # view the detailed information for one of them
+            response = self.client.get(reverse('channels.channellog_read', args=[ChannelLog.objects.all()[1].pk]))
+
+            # check that it contains the log of our exception
+            self.assertContains(response, "Failed to send message")
+
         finally:
             settings.SEND_MESSAGES = False
+
+    test_send.active = True
 
 
 class ClickatellTest(TembaTest):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -680,8 +680,7 @@ class ChannelCRUDL(SmartCRUDL):
                     return 0
 
             summary_months = 12
-            if is_jumbo:
-                summary_months = 3
+            if is_jumbo: summary_months = 3
 
             for i in range(summary_months):
                 if month_end_time > channel_added_on:

--- a/temba/formax.py
+++ b/temba/formax.py
@@ -34,17 +34,19 @@ class Formax(object):
         self.request.META['HTTP_X_FORMAX'] = 1
         self.request.META['HTTP_X_PJAX'] = 1
 
+        start = time.time()
+
         open = self.request.REQUEST.get('open', None)
         if open == name:
             action = 'open'
 
-        start = time.time()
         response = resolver.func(self.request, *resolver.args, **resolver.kwargs)
-        if settings.DEBUG:
-            print "%s took: %f" % (url, time.time() - start)
 
         # redirects don't do us any good
         if not isinstance(response, HttpResponseRedirect):
             response.render()
             self.sections.append(dict(name=name, url=url, response=response.content,
                                       icon=icon, action=action, button=button))
+
+        if settings.DEBUG:
+            print "%s took: %f" % (url, time.time() - start)


### PR DESCRIPTION
This makes a few concessions for accounts that have a huge # of messages so that we can display them in a reasonable amount of time. Namely, we don't display IVR counts for accounts with over 1M messages and we use a rough estimate of total messages instead of doing a real count.

Both of these should be removed when we start using triggers as they can both be tracked that way then. 