### PR TITLE
Return emptry strings when Blackmyna delivers messages or status updates

### DIFF
--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -1,7 +1,7 @@
 -e git+https://github.com/nyaruka/smartmin.git#egg=smartmin
 Django==1.7.7
 coverage==3.5.1
-django-celery==3.1.9
+django-celery==3.1.16
 django-compressor==1.3
 django-debug-toolbar==1.2.2
 django-digest==1.13
@@ -14,7 +14,7 @@ gunicorn==18.0
 nose==1.3.0
 pisa==3.0.33
 raven==4.0.4
-celery-with-redis==3.0
+celery[redis]==3.1.18
 python-gcm
 pytz==2014.7
 hamlpy

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -3365,7 +3365,7 @@ class BlackmynaHandler(View):
                 sms.fail()
 
             sms.broadcast.update()
-            return HttpResponse(json.dumps(dict(msg="Status Updated")))
+            return HttpResponse("")
 
         # An MO message
         elif action == 'receive':
@@ -3381,7 +3381,7 @@ class BlackmynaHandler(View):
                 return HttpResponse("Invalid to number [%s], expecting [%s]" % (to_number, channel.address), status=400)
 
             msg = Msg.create_incoming(channel, (TEL_SCHEME, from_number), message)
-            return HttpResponse(json.dumps(dict(msg="Msg received", id=msg.id)))
+            return HttpResponse("")
 
         return HttpResponse("Unrecognized action: %s" % action, status=400)
 


### PR DESCRIPTION
This is due to them not being able to change their config to not send back responses with our responses. Doh.