### PR TITLE
Maintain expiration on import and copy

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -435,6 +435,7 @@ class RuleTest(TembaTest):
 
         # pick a really long name so we have to concatenate
         self.flow.name = "Color Flow is a long name to use for something like this"
+        self.flow.expires_after_minutes = 60
         self.flow.save()
 
         # make sure our metadata got saved
@@ -446,6 +447,9 @@ class RuleTest(TembaTest):
 
         metadata = json.loads(copy.metadata)
         self.assertEquals("Ryan Lewis", metadata['author'])
+
+        # expiration should be copied too
+        self.assertEquals(60, copy.expires_after_minutes)
 
         # should have a different id
         self.assertNotEqual(self.flow.pk, copy.pk)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1213,6 +1213,9 @@ class BulkExportTest(TembaTest):
 
         # let's update some stuff
         confirm_appointment = Flow.objects.get(name='Confirm Appointment')
+        confirm_appointment.expires_after_minutes = 60
+        confirm_appointment.save()
+
         action_set = confirm_appointment.action_sets.order_by('-y').first()
         actions = action_set.get_actions_dict()
         actions[0]['msg'] = 'Thanks for nothing'
@@ -1235,7 +1238,8 @@ class BulkExportTest(TembaTest):
         self.import_file('the-clinic')
 
         # our flow should get reset from the import
-        action_set = Flow.objects.get(pk=confirm_appointment.pk).action_sets.order_by('-y').first()
+        confirm_appointment = Flow.objects.get(pk=confirm_appointment.pk)
+        action_set = confirm_appointment.action_sets.order_by('-y').first()
         actions = action_set.get_actions_dict()
         self.assertEquals("Thanks, your appointment at The Clinic has been confirmed for @contact.next_appointment. See you then!", actions[0]['msg'])
 
@@ -1274,16 +1278,16 @@ class BulkExportTest(TembaTest):
                          campaigns=[c.pk for c in Campaign.objects.all()])
 
         response = self.client.post(reverse('orgs.org_export'), post_data)
-        response = json.loads(response.content)
-        self.assertEquals(4, response.get('version', 0))
-        self.assertEquals('http://rapidpro.io', response.get('site', None))
+        exported = json.loads(response.content)
+        self.assertEquals(4, exported.get('version', 0))
+        self.assertEquals('http://rapidpro.io', exported.get('site', None))
 
-        self.assertEquals(8, len(response.get('flows', [])))
-        self.assertEquals(4, len(response.get('triggers', [])))
-        self.assertEquals(1, len(response.get('campaigns', [])))
+        self.assertEquals(8, len(exported.get('flows', [])))
+        self.assertEquals(4, len(exported.get('triggers', [])))
+        self.assertEquals(1, len(exported.get('campaigns', [])))
 
         # finally let's try importing our exported file
-        self.org.import_app(response, self.admin, site='http://rapidpro.io')
+        self.org.import_app(exported, self.admin, site='http://rapidpro.io')
         assert_object_counts()
 
         # let's rename a flow and import our export again
@@ -1300,7 +1304,7 @@ class BulkExportTest(TembaTest):
         group.save()
 
         # it should fall back on ids and not create new objects even though the names changed
-        self.org.import_app(response, self.admin, site='http://rapidpro.io')
+        self.org.import_app(exported, self.admin, site='http://rapidpro.io')
         assert_object_counts()
 
         # and our objets should have the same names as before
@@ -1319,7 +1323,7 @@ class BulkExportTest(TembaTest):
         group.save()
 
         # now import the same import but pretend its from a different site
-        self.org.import_app(response, self.admin, site='http://temba.io')
+        self.org.import_app(exported, self.admin, site='http://temba.io')
 
         # the newly named objects won't get updated in this case and we'll create new ones instead
         self.assertEquals(9, Flow.objects.filter(org=self.org, is_archived=False, flow_type='F').count())
@@ -1338,5 +1342,13 @@ class BulkExportTest(TembaTest):
         # with the archived flag one, it should be there
         response = self.client.get("%s?archived=1" % reverse('orgs.org_export'))
         self.assertContains(response, 'Register Patient')
+
+        # delete our flow, and reimport
+        confirm_appointment.delete()
+        self.org.import_app(exported, self.admin, site='http://rapidpro.io')
+
+        # make sure we have the previously exported expiration
+        confirm_appointment = Flow.objects.get(name='Confirm Appointment')
+        self.assertEquals(60, confirm_appointment.expires_after_minutes)
 
 


### PR DESCRIPTION
Just like it says. We weren't carrying forward expiration settings on export/import or on flow copy.