### PR TITLE
Email fixes

### DIFF
--- a/temba/temba_email.py
+++ b/temba/temba_email.py
@@ -15,11 +15,6 @@ def send_temba_email(to_email, subject, template, context, branding):
     :param context: The dictionary of context variables
     :param branding: The branding of the host
     """
-    # skip if we aren't meant to send emails
-    if not settings.SEND_EMAILS:
-        print "!! Skipping sending email, SEND_EMAILS to set False"
-        return
-
     from_email = getattr(settings, 'DEFAULT_FROM_EMAIL', 'website@rapidpro.io')
 
     html_template = loader.get_template(template + ".html")
@@ -31,6 +26,19 @@ def send_temba_email(to_email, subject, template, context, branding):
     html = html_template.render(Context(context))
     text = text_template.render(Context(context))
 
-    message = EmailMultiAlternatives(subject, text, from_email, [to_email])
-    message.attach_alternative(html, "text/html")
-    message.send()
+    send_multipart_email(subject, text, html, from_email, to_email)
+
+
+def send_multipart_email(subject, text, html, from_email, to_email):
+    """
+    Sends a multipart email. Having this as separate function makes testing emails easier
+    """
+    if settings.SEND_EMAILS:
+        message = EmailMultiAlternatives(subject, text, from_email, [to_email])
+        message.attach_alternative(html, "text/html")
+        message.send()
+    else:
+        # just print to console if we aren't meant to send emails
+        print "----------- Skipping sending email, SEND_EMAILS to set False -----------"
+        print text
+        print "------------------------------------------------------------------------"

--- a/templates/orgs/email/invitation_email.html
+++ b/templates/orgs/email/invitation_email.html
@@ -5,10 +5,10 @@
 {% block body %}
 
 <p>
-  {% blocktrans with org=org.name host=branding.host brand=branding.name secret=invitation.secret %}
+  {% blocktrans with org=org.name link=branding.link brand=branding.name secret=invitation.secret %}
       You've been invited to join {{ brand }} as a member of {{ org }}.
       <br/>
-      To accept the invitation, <a href='https://{{host}}/org/join/{{secret}}/'>click here</a>.
+      To accept the invitation, <a href='{{link}}/org/join/{{secret}}/'>click here</a>.
   {% endblocktrans %}
 </p>
 

--- a/templates/orgs/email/invitation_email.txt
+++ b/templates/orgs/email/invitation_email.txt
@@ -1,7 +1,9 @@
 {% load i18n %}
 
-{% trans "You've been invited to join {{org.name}} on {{ branding.name }}." %}
+{% blocktrans with org=org.name brand=branding.name %}
+You've been invited to join {{ org }} on {{ brand }}
+{% endblocktrans %}
 
 {% trans "Click this link to join" %}
-{{org.name}}
-      https://{{ branding.host }}/org/join/{{invitation.secret}}/
+{{ org.name }}
+      {{ branding.link }}/org/join/{{invitation.secret}}/


### PR DESCRIPTION
* Fixed text version of org invitation email
* Switch invitation emails to use branding.link so that they use correct URL on staging server
* Made it easier to test emails by extracting a send_multipart_email function