### PR TITLE
Optimization for eventfire creation

### DIFF
--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -357,6 +357,11 @@ class EventFire(Model):
 
     @classmethod
     def update_events_for_event(cls, event):
+        from temba.campaigns.tasks import update_event_fires
+        update_event_fires.delay(event.pk)
+
+    @classmethod
+    def do_update_events_for_event(cls, event):
         # unschedule any fires
         EventFire.objects.filter(event=event, fired=None).delete()
 

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -356,12 +356,12 @@ class EventFire(Model):
             cls.update_campaign_events_for_contact(campaign, contact)
 
     @classmethod
-    def update_events_for_event(cls, event):
+    def update_eventfires_for_event(cls, event):
         from temba.campaigns.tasks import update_event_fires
         update_event_fires.delay(event.pk)
 
     @classmethod
-    def do_update_events_for_event(cls, event):
+    def do_update_eventfires_for_event(cls, event):
         # unschedule any fires
         EventFire.objects.filter(event=event, fired=None).delete()
 

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -269,14 +269,19 @@ class CampaignEvent(SmartModel):
 
         return offset
 
-    def calculate_scheduled_fire(self, contact):
+    def calculate_scheduled_fire_for_value(self, date_value, now):
+
+        date_value = self.campaign.org.parse_date(date_value)
+
+        # if we got a date, floor to the minute
+        if date_value:
+            date_value = date_value.replace(second=0, microsecond=0)
+
         if not self.relative_to.is_active: # pragma: no cover
             return None
 
         # try to parse it to a datetime
         try:
-            now = timezone.now()
-            date_value = EventFire.parse_relative_to_date(contact, self.relative_to.key)
             if date_value:
                 if self.unit == MINUTES:
                     delta = timedelta(minutes=self.offset)
@@ -299,6 +304,10 @@ class CampaignEvent(SmartModel):
             pass
 
         return None
+
+    def calculate_scheduled_fire(self, contact):
+        date_value = EventFire.parse_relative_to_date(contact, self.relative_to.key)
+        return self.calculate_scheduled_fire_for_value(date_value, timezone.now())
 
     def __unicode__(self):
         return "%s == %d -> %s" % (self.relative_to, self.offset, self.flow)
@@ -352,13 +361,25 @@ class EventFire(Model):
 
         # add new ones
         if event.is_active:
-            for contact in event.campaign.group.contacts.exclude(is_test=True):
-                # calculate our scheduled date
-                scheduled = event.calculate_scheduled_fire(contact)
+
+            from temba.values.models import Value
+            values = Value.objects.filter(contact__in=event.campaign.group.contacts.exclude(is_test=True),
+                                          contact_field__key__exact=event.relative_to.key).select_related('contact').distinct('contact')
+
+            now = timezone.now()
+            events = []
+
+            org = event.campaign.org
+            for value in values:
+                formatted_date = org.format_date(value.datetime_value)
+                scheduled = event.calculate_scheduled_fire_for_value(formatted_date, now)
 
                 # and if we have a date, then schedule it
                 if scheduled:
-                    EventFire.objects.create(event=event, contact=contact, scheduled=scheduled)
+                    events.append(EventFire(event=event, contact=value.contact, scheduled=scheduled))
+
+            # bulk create our event fires
+            EventFire.objects.bulk_create(events)
 
     @classmethod
     def update_field_events(cls, contact_field):
@@ -372,17 +393,27 @@ class EventFire(Model):
             # cancel existing events, we are going to recreate them all
             EventFire.objects.filter(event__relative_to=contact_field, fired=None).delete()
 
+            now = timezone.now()
+            from temba.values.models import Value
+
+            org = contact_field.org
             for event in CampaignEvent.objects.filter(relative_to=contact_field,
                                                       campaign__is_active=True, campaign__is_archived=False, is_active=True):
 
-                # for each contact
-                for contact in event.campaign.group.contacts.filter(is_active=True):
-                    # calculate our scheduled date
-                    scheduled = event.calculate_scheduled_fire(contact)
+                values = Value.objects.filter(contact__in=event.campaign.group.contacts.filter(is_active=True),
+                                              contact_field__key__exact=contact_field.key).select_related('contact').distinct('contact')
+
+                events = []
+                for value in values:
+                    formatted_date = org.format_date(value.datetime_value)
+                    scheduled = event.calculate_scheduled_fire_for_value(formatted_date, now)
 
                     # and if we have a date, then schedule it
                     if scheduled:
-                        EventFire.objects.create(event=event, contact=contact, scheduled=scheduled)
+                        events.append(EventFire(event=event, contact=value.contact, scheduled=scheduled))
+
+                # bulk create our event fires
+                EventFire.objects.bulk_create(events)
 
     @classmethod
     def update_events_for_contact(cls, contact):

--- a/temba/campaigns/tasks.py
+++ b/temba/campaigns/tasks.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from django.utils import timezone
 from djcelery_transactions import task
 from redis_cache import get_redis_connection
-from .models import Campaign, EventFire
+from temba.campaigns.models import CampaignEvent, EventFire
 from django.conf import settings
 import redis
 from temba.msgs.models import HANDLER_QUEUE, HANDLE_EVENT_TASK, FIRE_EVENT
@@ -32,3 +32,9 @@ def check_campaigns_task(sched_id=None):
 
                 except:  # pragma: no cover
                     logger.error("Error running campaign event: %s" % fire.pk, exc_info=True)
+
+@task(track_started=True, name='update_event_fires_task') # pragma: no cover
+def update_event_fires(event_id):
+    event = CampaignEvent.objects.filter(pk=event_id).first()
+    if event:
+        EventFire.do_update_events_for_event(event)

--- a/temba/campaigns/tasks.py
+++ b/temba/campaigns/tasks.py
@@ -37,4 +37,4 @@ def check_campaigns_task(sched_id=None):
 def update_event_fires(event_id):
     event = CampaignEvent.objects.filter(pk=event_id).first()
     if event:
-        EventFire.do_update_events_for_event(event)
+        EventFire.do_update_eventfires_for_event(event)

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -287,7 +287,7 @@ class CampaignEventCRUDL(SmartCRUDL):
             self.object.is_active = False
             self.object.save()
 
-            EventFire.update_events_for_event(self.object)
+            EventFire.update_eventfires_for_event(self.object)
 
             redirect_url = self.get_redirect_url()
             return HttpResponseRedirect(redirect_url)
@@ -326,7 +326,7 @@ class CampaignEventCRUDL(SmartCRUDL):
         def post_save(self, obj):
             obj = super(CampaignEventCRUDL.Update, self).post_save(obj)
             obj.update_flow_name()
-            EventFire.update_events_for_event(obj)
+            EventFire.update_eventfires_for_event(obj)
             return obj
 
         def pre_save(self, obj):
@@ -371,7 +371,7 @@ class CampaignEventCRUDL(SmartCRUDL):
         def post_save(self, obj):
             obj = super(CampaignEventCRUDL.Create, self).post_save(obj)
             obj.update_flow_name()
-            EventFire.update_events_for_event(obj)
+            EventFire.update_eventfires_for_event(obj)
             return obj
 
         def pre_save(self, obj):


### PR DESCRIPTION
Primary change is instead of looking up all contacts and then value for each of those contacts as separate queries we lookup all values for the list of contacts in a single query. Also creates the event fires as a bulk insert instead of individual creates.

Definitely noticed some goofiness where we turn dates into strings and then back into dates which is accounting for timezones. Didn't want to mess with that just yet, so its maintained here.