### PR TITLE
Passing empty string for parent to label API endpoint should act same as not passing it

### DIFF
--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -293,6 +293,8 @@ class LabelWriteSerializer(WriteSerializer):
                 raise ValidationError("Message labels can only be nested one-level deep")
 
             attrs[source] = parent_obj
+        else:
+            attrs[source] = None
 
         return attrs
 

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1607,7 +1607,7 @@ class APITest(TembaTest):
         self.assertEqual(flagged.parent, screened)
 
         # update changing name and setting parent to null
-        response = self.postJSON(url, dict(uuid=flagged.uuid, name='Spam', parent=None))
+        response = self.postJSON(url, dict(uuid=flagged.uuid, name='Spam', parent=''))
         self.assertEquals(201, response.status_code)
 
         flagged = Label.objects.get(uuid=flagged.uuid)


### PR DESCRIPTION
For when users do https://app.getsentry.com/nyaruka/rapidpro/group/67345152/