### PR TITLE
Don't require actionsets to send messages to be extended

### DIFF
--- a/karma/flows/test_services.coffee
+++ b/karma/flows/test_services.coffee
@@ -171,6 +171,36 @@ describe 'Services:', ->
       flowService.deriveCategories(ruleset, 'eng')
       expect(ruleOther.destination).toBe(null)
 
+    describe 'checkTerminal', ->
+
+      actionset = null
+      beforeEach ->
+        actionset =
+          "y": 0, "x": 0
+          "destination": null
+          "uuid": "dcd9541a-0263-474e-b3f1-03a28993f95a"
+          "actions": [{ "msg": "I don't know that color. Try again.", "type": "reply"}]
+
+      it 'should detect terminal actionsets', ->
+
+        # we haven't determined our terminal status yet
+        expect(actionset._terminal).toBe(undefined)
+
+        # we aren't terminal
+        flowService.checkTerminal(actionset)
+        expect(actionset._terminal).toBe(false)
+
+      # this should be removed once r2r ivr is implemented
+      it 'should make sure IVR flows require a message', ->
+
+        window.ivr = true
+        flowService.checkTerminal(actionset)
+        expect(actionset._terminal).toBe(true)
+
+        # make it a say and try again
+        actionset.actions[0].type = "say"
+        flowService.checkTerminal(actionset)
+        expect(actionset._terminal).toBe(false)
 
     describe 'isConnectionAllowed()', ->
 

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -1002,14 +1002,14 @@ app.service "Flow", ['$rootScope', '$window', '$http', '$timeout', '$interval', 
       if window.ivr and action.type == 'say'
         hasMessage = true
 
-      if not window.ivr and action.type == 'reply'
-        hasMessage = true
-
       if action.type == 'flow'
         startsFlow = true
 
     # if they start another flow or doesn't have a message it's terminal
-    terminal = startsFlow or not hasMessage
+    if window.ivr
+      terminal = startsFlow or not hasMessage
+    else
+      terminal = startsFlow
 
     if actionset._terminal != terminal
       actionset._terminal = terminal


### PR DESCRIPTION
This lets you extend actionsets which don't send messages.