### PR TITLE
Show an error dialog when flow saves fail

### DIFF
--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -496,7 +496,7 @@ app.service "Flow", ['$rootScope', '$window', '$http', '$timeout', '$interval', 
               resolve:
                 type: -> "error"
                 title: -> "Error Saving"
-                body: -> "We're not quite sure why, but your latest changes could not be saved. Please click Reload and try again."
+                body: -> "Sorry, but we were unable to save your flow. Please reload the page and try again, this may clear your latest changes."
                 ok: -> 'Reload'
 
             modalInstance.result.then (reload) ->

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -486,8 +486,10 @@ app.service "Flow", ['$rootScope', '$window', '$http', '$timeout', '$interval', 
         $http.post('/flow/json/' + $rootScope.flowId + '/', utils.toJson($rootScope.flow)).error (data, statusCode) ->
 
           if statusCode == 400
-            $log.debug(data)
             $rootScope.saving = false
+            if UserVoice
+              UserVoice.push(['set', 'ticket_custom_fields', {'Error': data.description}]);
+
             modalInstance = $modal.open
               templateUrl: "/partials/modal?v=" + version
               controller: ModalController
@@ -495,7 +497,6 @@ app.service "Flow", ['$rootScope', '$window', '$http', '$timeout', '$interval', 
                 type: -> "error"
                 title: -> "Error Saving"
                 body: -> "We're not quite sure why, but your latest changes could not be saved. Please click Reload and try again."
-                helpBody: -> data.description
                 ok: -> 'Reload'
 
             modalInstance.result.then (reload) ->
@@ -1087,14 +1088,11 @@ app.service "Flow", ['$rootScope', '$window', '$http', '$timeout', '$interval', 
     @markDirty()
 ]
 
-ModalController = ($scope, $modalInstance, type, title, body, helpBody=null, ok=null) ->
+ModalController = ($scope, $modalInstance, type, title, body, ok=null) ->
   $scope.type = type
   $scope.title = title
   $scope.body = body
-
-  if helpBody
-    $scope.helpTitle = 'Support Information'
-    $scope.helpBody = helpBody
+  $scope.error = error
 
   if ok
     $scope.okButton = ok
@@ -1107,3 +1105,9 @@ ModalController = ($scope, $modalInstance, type, title, body, helpBody=null, ok=
 
   $scope.cancel = ->
     $modalInstance.dismiss "cancel"
+
+  $scope.showHelpWidget = ->
+    if UserVoice
+      UserVoice.push(['show', {
+        mode: 'contact'
+      }]);

--- a/static/less/flow_editor.less
+++ b/static/less/flow_editor.less
@@ -856,6 +856,35 @@
       }
     }
   }
+
+  .btn.show-help {
+    display: none;
+  }
+
+  .help {
+
+    display: none;
+    margin-top: 20px;
+    background: @flat-white + #050505;
+    .rounded-corners(5px);
+    padding: 12px;
+
+    .help-title {
+      font-size:14px;
+    }
+
+    .help-body {
+      font-size: 12px;;
+      line-height: 12px;
+      color: @flat-grey;
+      font-family: 'Courier New';
+      margin-top:2px;
+    }
+
+    &.show-help {
+      display:block;
+    }
+  }
 }
 
 .action-editor {

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1469,7 +1469,7 @@ class RuleTest(TembaTest):
 
         response = self.client.post(reverse('flows.flow_json', args=[flow.pk]), json.dumps(json_dict), content_type="application/json")
         self.assertEquals(400, response.status_code)
-        self.assertEquals('failed', json.loads(response.content)['status'])
+        self.assertEquals('failure', json.loads(response.content)['status'])
 
         # flow should still be there though
         flow = Flow.objects.get(pk=flow.pk)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1469,6 +1469,7 @@ class RuleTest(TembaTest):
 
         response = self.client.post(reverse('flows.flow_json', args=[flow.pk]), json.dumps(json_dict), content_type="application/json")
         self.assertEquals(400, response.status_code)
+        self.assertEquals('failed', json.loads(response.content)['status'])
 
         # flow should still be there though
         flow = Flow.objects.get(pk=flow.pk)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1467,9 +1467,8 @@ class RuleTest(TembaTest):
         json_dict['last_saved'] = datetime_to_str(timezone.now())
         json_dict['action_sets'][0]['destination'] = 'notthere'
 
-
-        with self.assertRaises(FlowException):
-            response = self.client.post(reverse('flows.flow_json', args=[flow.pk]), json.dumps(json_dict), content_type="application/json")
+        response = self.client.post(reverse('flows.flow_json', args=[flow.pk]), json.dumps(json_dict), content_type="application/json")
+        self.assertEquals(400, response.status_code)
 
         # flow should still be there though
         flow = Flow.objects.get(pk=flow.pk)

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1194,8 +1194,13 @@ class FlowCRUDL(SmartCRUDL):
             # try to save the our flow, if this fails, let's let that bubble up to our logger
             json_dict = json.loads(json_string)
             print json.dumps(json_dict, indent=2)
-            response_data = self.get_object(self.get_queryset()).update(json_dict, user=self.request.user)
-            return build_json_response(response_data, status=200)
+
+            from temba.flows.models import FlowException
+            try:
+                response_data = self.get_object(self.get_queryset()).update(json_dict, user=self.request.user)
+                return build_json_response(response_data, status=200)
+            except FlowException as e:
+                return build_json_response(dict(status="failure", description=str(e)), status=400)
 
     class Broadcast(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
         class BroadcastForm(forms.ModelForm):

--- a/templates/partials/modal.haml
+++ b/templates/partials/modal.haml
@@ -11,7 +11,17 @@
             [[title]]
       .modal-body
         [[body]]
+
+        .help{ng-class:'{"show-help":showHelp}'}
+          .help-title
+            -blocktrans
+              When <a href='javascript:void(0)' class='uv-send-message'>contacting support</a> include this message.
+          .help-body
+            [[helpBody]]
+
       .modal-footer
+        %button.pull-left{ng-show:'subtext', ng-class:'{"show-help":showHelp}', ng-click:"showHelp=true", class:"btn btn-secondary",ng-hide:"hideCancel"}
+          -trans "Help"
         %button{ng-click:"cancel()",class:"btn btn-secondary",ng-hide:"hideCancel"}
           -trans "Cancel"
         %button{ng-click:"ok()",class:"btn btn-primary"}

--- a/templates/partials/modal.haml
+++ b/templates/partials/modal.haml
@@ -11,16 +11,8 @@
             [[title]]
       .modal-body
         [[body]]
-
-        .help{ng-class:'{"show-help":showHelp}'}
-          .help-title
-            -blocktrans
-              When <a href='javascript:void(0)' class='uv-send-message'>contacting support</a> include this message.
-          .help-body
-            [[helpBody]]
-
       .modal-footer
-        %button.pull-left{ng-show:'subtext', ng-class:'{"show-help":showHelp}', ng-click:"showHelp=true", class:"btn btn-secondary",ng-hide:"hideCancel"}
+        %button.pull-left{ng-show:'subtext', ng-class:'{"show-help":showHelp}', ng-click:"showHelpWidget()", class:"btn btn-secondary",ng-hide:"hideCancel"}
           -trans "Help"
         %button{ng-click:"cancel()",class:"btn btn-secondary",ng-hide:"hideCancel"}
           -trans "Cancel"


### PR DESCRIPTION
While flows can no longer be saved with known invalid cycles (thanks to server side evaluation), that information was not presented to the user.

* View catches FlowException when saving flows and sends back json error
* Show error dialog when json error is received
* Embed error in the UserVoice widget so it is transparently provided to support team

We should be catching any errors before sending them to the server, but this is a far better experience if there are cases we miss (or are broken for one reason or another).