### PR TITLE
Force webhook execution at the beginning of flows

### DIFF
--- a/media/test_flows/non_blocking_rule_first.json
+++ b/media/test_flows/non_blocking_rule_first.json
@@ -1,0 +1,58 @@
+{
+  "rule_sets": [
+    {
+      "uuid": "e02c6b80-e1bc-4d5d-a060-9e0a17ccfcd4",
+      "response_type": "C",
+      "rules": [
+        {
+          "test": {
+            "test": "Eminem",
+            "type": "contains_any"
+          },
+          "category": "Eminem",
+          "destination": "2a9b17b9-7c46-4b24-9e46-53a8fe060781",
+          "uuid": "a806788f-ebfc-4515-a849-164fc9245d5d"
+        },
+        {
+          "test": {
+            "test": "Tupac",
+            "type": "contains_any"
+          },
+          "category": "Tupac",
+          "destination": "2a9b17b9-7c46-4b24-9e46-53a8fe060781",
+          "uuid": "95ef3d80-90ad-43c6-93ee-84fe0539e2f4"
+        },
+        {
+          "test": {
+            "test": "true",
+            "type": "true"
+          },
+          "category": "Other",
+          "destination": "6548a40d-5cd7-436b-82c1-e93ea8991ffa",
+          "uuid": "608ba565-2477-49ff-84b8-45eab0bcc2c8"
+        }
+      ],
+      "label": "Name",
+      "operand": "@contact.name",
+      "y": 0,
+      "x": 260
+    }
+  ],
+  "action_sets": [
+    {
+      "y": 161,
+      "x": 114,
+      "destination": null,
+      "uuid": "2a9b17b9-7c46-4b24-9e46-53a8fe060781",
+      "actions": [
+        {
+          "msg": "Hi there @contact.first_name",
+          "type": "reply"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "notes": []
+  }
+}

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -655,7 +655,8 @@ class Flow(TembaModel, SmartModel):
 
     @classmethod
     def handle_destination(cls, destination, step, run, msg,
-                           started_flows=None, is_test_contact=False, user_input=False):
+                           started_flows=None, is_test_contact=False, user_input=False,
+                           force_execute_webhook=False):
 
         def add_to_path(path, uuid):
             if uuid in path:
@@ -677,7 +678,7 @@ class Flow(TembaModel, SmartModel):
                 requires_input = False
 
                 # if we are a ruleset against @step or we have a webhook we wait
-                if destination.webhook_url or destination.requires_step():
+                if (destination.webhook_url and not force_execute_webhook) or destination.requires_step():
                     requires_input = True
 
                 if user_input or not requires_input:
@@ -1716,7 +1717,8 @@ class Flow(TembaModel, SmartModel):
                 elif not entry_rules.requires_step():
                     # create an empty placeholder message
                     msg = Msg(contact=contact, text='', id=0)
-                    Flow.handle_destination(entry_rules, step, run, msg, started_flows_by_contact)
+                    Flow.handle_destination(entry_rules, step, run, msg, started_flows_by_contact,
+                                            force_execute_webhook=True)
 
             if start_msg:
                 step.add_message(start_msg)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2617,6 +2617,25 @@ class FlowsTest(FlowFileTest):
         self.assertEquals(Flow.RULES_ENTRY, flow.entry_type)
         self.assertEquals("You've got to be kitten me", self.send_message(flow, "cats"))
 
+    def test_non_blocking_rule_first(self):
+
+        flow = self.get_flow('non_blocking_rule_first')
+
+        eminem = self.create_contact('Eminem', '+12345')
+        flow.start(groups=[], contacts=[eminem])
+        msg = Msg.objects.filter(direction='O', contact=eminem).first()
+        self.assertEquals('Hi there Eminem', msg.text)
+
+        # put a webhook on the rule first and make sure it executes
+        ruleset = RuleSet.objects.get(uuid=flow.entry_uuid)
+        ruleset.webhook_url = 'http://localhost'
+        ruleset.save()
+
+        tupac = self.create_contact('Tupac', '+15432')
+        flow.start(groups=[], contacts=[tupac])
+        msg = Msg.objects.filter(direction='O', contact=tupac).first()
+        self.assertEquals('Hi there Tupac', msg.text)
+
     def test_substitution(self):
         flow = self.get_flow('substitution')
 


### PR DESCRIPTION
This is the maintain behavior where flows starting with non-blocking rulesets with webhooks would still have their webhooks triggered.

