### PR TITLE
Restrictions on archiving and labelling messages

### DIFF
--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -13,7 +13,7 @@ from temba.channels.models import Channel
 from temba.contacts.models import Contact, ContactField, ContactGroup, ContactURN, TEL_SCHEME
 from temba.flows.models import Flow, FlowRun
 from temba.locations.models import AdminBoundary
-from temba.msgs.models import Msg, Call, Broadcast, Label, ARCHIVED
+from temba.msgs.models import Msg, Call, Broadcast, Label, ARCHIVED, INCOMING
 from temba.values.models import VALUE_TYPE_CHOICES
 
 
@@ -228,7 +228,7 @@ class MsgBulkActionSerializer(WriteSerializer):
         msg_ids = attrs['messages']
         action = attrs['action']
 
-        msgs = Msg.objects.filter(org=self.org, pk__in=msg_ids)
+        msgs = Msg.objects.filter(org=self.org, direction=INCOMING, pk__in=msg_ids)
 
         if action == 'label':
             attrs['label'].toggle_label(msgs, add=True)

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1251,7 +1251,8 @@ class Msg(models.Model, OrgModelMixin):
         """
         Releases (i.e. deletes) this message, provided it is not currently deleted
         """
-        self.archive()  # handle VISIBLE > ARCHIVED state change first if necessary
+        # handle VISIBLE > ARCHIVED state change first if necessary
+        self._update_state(dict(visibility=VISIBLE), dict(visibility=ARCHIVED), OrgEvent.msg_archived)
 
         if self._update_state(dict(visibility=ARCHIVED), dict(visibility=DELETED, text=""), OrgEvent.msg_deleted):
             for label in self.labels.all():

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1251,9 +1251,6 @@ class Msg(models.Model, OrgModelMixin):
         """
         Releases (i.e. deletes) this message, provided it is not currently deleted
         """
-        if self.direction != INCOMING:
-            raise ValueError("Can only delete incoming messages")
-
         self.archive()  # handle VISIBLE > ARCHIVED state change first if necessary
 
         if self._update_state(dict(visibility=ARCHIVED), dict(visibility=DELETED, text=""), OrgEvent.msg_deleted):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -37,7 +37,6 @@ class MsgTest(TembaTest):
 
     def test_archive_and_release(self):
         msg1 = Msg.create_incoming(self.channel, (TEL_SCHEME, '123'), "Incoming")
-        msg2 = Msg.create_outgoing(self.org, self.admin, self.joe, "Outgoing")
         label = Label.get_or_create(self.org, self.admin, "Spam")
         label.toggle_label([msg1], add=True)
 
@@ -58,9 +57,9 @@ class MsgTest(TembaTest):
         self.assertEqual(msg1.visibility, DELETED)
         self.assertEqual(set(msg1.labels.all()), set())  # do remove labels
 
-        # can't archive, restore or delete outgoing messages
+        # can't archive outgoing messages
+        msg2 = Msg.create_outgoing(self.org, self.admin, self.joe, "Outgoing")
         self.assertRaises(ValueError, msg2.archive)
-        self.assertRaises(ValueError, msg2.release)
 
     def test_erroring(self):
         # test with real message
@@ -633,37 +632,14 @@ class MsgTest(TembaTest):
         response = self.fetch_protected(failed_url, self.admin)
 
         self.assertEquals(response.context['object_list'].count(), 3)
-        self.assertEquals(response.context['actions'], ['archive', 'resend'])
-
-        # let's archive some messages
-        post_data = dict()
-        post_data['action'] = 'archive'
-        post_data['objects'] = msg1.pk
-
-        response = self.client.post(failed_url, post_data, follow=True)
-
-        # now one msg is archived
-        self.assertEquals(Msg.objects.filter(visibility=ARCHIVED).count(), 1)
-        self.assertEquals(Msg.objects.filter(visibility=VISIBLE).count(), 2)
-        self.assertEquals(Msg.objects.filter(visibility=ARCHIVED)[0].pk, msg1.pk)
+        self.assertEquals(response.context['actions'], ['resend'])
 
         # let's resend some messages
-        post_data['action'] = 'resend'
-        post_data['objects'] = msg2.pk
+        self.client.post(failed_url, dict(action='resend', objects=msg2.pk), follow=True)
 
-        response = self.client.post(failed_url, post_data, follow=True)
-
-        # the archived message
-        self.assertEquals(msg1.pk, Msg.objects.filter(visibility=ARCHIVED, status=FAILED)[0].pk)
-
-        # the resent message
-        self.assertEquals(msg2.pk, Msg.objects.filter(visibility=ARCHIVED, status=RESENT)[0].pk)
-
-        # the one we didn't do anything to
-        self.assertEquals(msg3.pk, Msg.objects.filter(visibility=VISIBLE, status=FAILED)[0].pk)
-
-        # the message created to resent
-        self.assertEquals(Msg.objects.filter(visibility=VISIBLE, status=PENDING).count(), 1)
+        # check for the resent message and the new one being resent
+        self.assertEqual(set(Msg.objects.filter(status=RESENT)), {msg2})
+        self.assertEqual(Msg.objects.filter(status=PENDING).count(), 1)
 
         # make sure there was a new outgoing message created that got attached to our broadcast
         self.assertEquals(1, broadcast.get_messages().count())
@@ -1276,9 +1252,9 @@ class LabelTest(TembaTest):
 
     def test_message_count(self):
         label = Label.get_or_create(self.org, self.user, "Spam")
-        msg1 = self.create_msg(text="Message 1", contact=self.joe)
-        msg2 = self.create_msg(text="Message 2", contact=self.joe)
-        msg3 = self.create_msg(text="Message 3", contact=self.joe)
+        msg1 = self.create_msg(text="Message 1", contact=self.joe, direction='I')
+        msg2 = self.create_msg(text="Message 2", contact=self.joe, direction='I')
+        msg3 = self.create_msg(text="Message 3", contact=self.joe, direction='I')
 
         with self.assertNumQueries(1):  # from db
             self.assertEqual(label.get_message_count(), 0)
@@ -1322,9 +1298,9 @@ class LabelTest(TembaTest):
         label2 = Label.get_or_create(self.org, self.user, "Social", folder1)
         label3 = Label.get_or_create(self.org, self.user, "Other")
 
-        msg1 = self.create_msg(text="Message 1", contact=self.joe)
-        msg2 = self.create_msg(text="Message 2", contact=self.joe)
-        msg3 = self.create_msg(text="Message 3", contact=self.joe)
+        msg1 = self.create_msg(text="Message 1", contact=self.joe, direction='I')
+        msg2 = self.create_msg(text="Message 2", contact=self.joe, direction='I')
+        msg3 = self.create_msg(text="Message 3", contact=self.joe, direction='I')
 
         label1.toggle_label([msg1, msg2], add=True)
         label2.toggle_label([msg2, msg3], add=True)
@@ -1347,9 +1323,9 @@ class LabelTest(TembaTest):
         label2 = Label.get_or_create(self.org, self.user, "Social", folder1)
         label3 = Label.get_or_create(self.org, self.user, "Other")
 
-        msg1 = self.create_msg(text="Message 1", contact=self.joe)
-        msg2 = self.create_msg(text="Message 2", contact=self.joe)
-        msg3 = self.create_msg(text="Message 3", contact=self.joe)
+        msg1 = self.create_msg(text="Message 1", contact=self.joe, direction='I')
+        msg2 = self.create_msg(text="Message 2", contact=self.joe, direction='I')
+        msg3 = self.create_msg(text="Message 3", contact=self.joe, direction='I')
 
         label1.toggle_label([msg1, msg2], add=True)
         label2.toggle_label([msg1], add=True)

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -751,7 +751,7 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_context_data(self, *args, **kwargs):
             context = super(MsgCRUDL.Failed, self).get_context_data(*args, **kwargs)
-            context['actions'] = ['archive', 'resend']
+            context['actions'] = ['resend']
             return context
 
     class Filter(MsgActionMixin, FolderListView):


### PR DESCRIPTION
* Bulk actions endpoint will ignore ids of outgoing messages
* Removed archive as an action from Failed messages view
* Reworked unit tests that were labelling outgoing messages