### PR TITLE
Fix case where test contact's URN was reassigned

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -360,6 +360,10 @@ class Contact(TembaModel, SmartModel, OrgModelMixin):
         if incoming_channel and (not urns or len(urns) > 1):
             raise ValueError("Only one URN may be specified when calling from channel event")
 
+        # deal with None being passed into urns
+        if urns is None:
+            urns = ()
+
         # no channel? try to get one from our org
         country = None
         if incoming_channel:
@@ -492,13 +496,21 @@ class Contact(TembaModel, SmartModel, OrgModelMixin):
         org = user.get_org()
         test_contact = Contact.objects.filter(is_test=True, org=org, created_by=user).first()
 
-        if not test_contact:
+        # double check that our test contact has a valid URN, it may have been reassigned
+        if test_contact:
+            test_urn = test_contact.get_urn(TEL_SCHEME)
 
+            # no URN, let's start over
+            if not test_urn:
+                test_contact.release()
+                test_contact = None
+
+        if not test_contact:
             test_urn_path = START_TEST_CONTACT_PATH
             existing_urn = ContactURN.get_existing_urn(org, TEL_SCHEME, '+%s' % test_urn_path)
             while existing_urn and test_urn_path < END_TEST_CONTACT_PATH:
-                existing_urn = ContactURN.get_existing_urn(org, TEL_SCHEME, '+%s' % test_urn_path)
                 test_urn_path += 1
+                existing_urn = ContactURN.get_existing_urn(org, TEL_SCHEME, '+%s' % test_urn_path)
 
             test_contact = Contact.get_or_create(org, user, "Test Contact", [(TEL_SCHEME, '+%s' % test_urn_path)],
                                                  is_test=True)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -354,6 +354,16 @@ class ContactTest(TembaTest):
         self.assertEquals(test_contact_user2.created_by, self.user)
         self.assertTrue(test_contact_user2 == test_contact_user)
 
+        # assign this URN to another contact
+        other_contact = Contact.get_or_create(self.org, self.admin)
+        test_urn = test_contact_user2.get_urn(TEL_SCHEME)
+        test_urn.contact = other_contact
+        test_urn.save()
+
+        # fetching the test contact again should get us a new URN
+        new_test_contact = Contact.get_test_contact(self.user)
+        self.assertNotEqual(new_test_contact.get_urn(TEL_SCHEME), test_urn)
+
     def test_contact_create(self):
         self.login(self.admin)
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -544,7 +544,6 @@ class Flow(TembaModel, SmartModel):
 
     @classmethod
     def find_and_handle(cls, msg, started_flows=None, voice_response=None):
-
         if started_flows is None:
             started_flows = []
 


### PR DESCRIPTION
This fixes a problem where it was possible for a test contact to lose its URN and then no longer work properly. That was caused by the bug in get_test_contact(), but we now also make sure test contacts always have a unique URN before we hand them back.