### PR TITLE
Use redis to keep track of unread msgs and incoming flow msgs

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -472,7 +472,7 @@ class Flow(TembaModel, SmartModel):
 
         # if we handled it, increment our unread count
         if handled and not call.contact.is_test:
-            self.increment_unread_responses()
+            run.flow.increment_unread_responses()
 
         # if we didn't handle it, this is a good time to hangup
         if not handled or hangup:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -33,7 +33,7 @@ from string import maketrans, punctuation
 from temba.contacts.models import Contact, ContactGroup, ContactField, ContactURN, TEL_SCHEME, NEW_CONTACT_VARIABLE
 from temba.locations.models import AdminBoundary
 from temba.msgs.models import Broadcast, Msg, FLOW, INBOX, OUTGOING, STOP_WORDS, QUEUED, INITIALIZING, Label
-from temba.orgs.models import Org, Language
+from temba.orgs.models import Org, Language, UNREAD_FLOW_MSGS
 from temba.temba_email import send_temba_email
 from temba.utils import get_datetime_format, str_to_datetime, datetime_to_str, analytics
 from temba.utils.cache import get_cacheable

--- a/temba/flows/templatetags/__init__.py
+++ b/temba/flows/templatetags/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'nicp'

--- a/temba/flows/templatetags/rules.py
+++ b/temba/flows/templatetags/rules.py
@@ -1,7 +1,0 @@
-from django import template
-
-register = template.Library()
-
-@register.filter
-def flow_responses_since(flow, time):
-    return flow.get_responses_since(time)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3186,62 +3186,6 @@ class FlowsTest(FlowFileTest):
         self.assertEquals('Bleck', response['messages'][1]['text'])
 
 
-class UnreadCountTest(FlowFileTest):
-
-    def test_unread_count_test(self):
-        flow = self.get_flow('favorites')
-
-        # create a trigger for 'favs'
-        Trigger.objects.create(org=self.org, flow=flow, keyword='favs', created_by=self.admin, modified_by=self.admin)
-
-        # start our flow by firing an incoming message
-        contact = self.create_contact('Anakin Skywalker', '+12067791212')
-        msg = self.create_msg(contact=contact, text="favs")
-
-        # process it
-        Msg.process_message(msg)
-
-        # at this point our flow should have started.. go to our trigger list page to see if our context is correct
-        self.login(self.admin)
-        trigger_list = reverse('triggers.trigger_list')
-        response = self.client.get(trigger_list)
-
-        self.assertEquals(0, response.context['msgs_unread_count'])
-        self.assertEquals(1, response.context['flows_unread_count'])
-
-        # answer another question in the flow
-        msg = self.create_msg(contact=contact, text="red")
-        Msg.process_message(msg)
-
-        response = self.client.get(trigger_list)
-        self.assertEquals(0, response.context['msgs_unread_count'])
-        self.assertEquals(2, response.context['flows_unread_count'])
-
-        # finish the flow and send a message outside it
-        msg = self.create_msg(contact=contact, text="primus")
-        Msg.process_message(msg)
-
-        msg = self.create_msg(contact=contact, text="nic")
-        Msg.process_message(msg)
-
-        msg = self.create_msg(contact=contact, text="Hello?")
-        Msg.process_message(msg)
-
-        response = self.client.get(trigger_list)
-        self.assertEquals(4, response.context['flows_unread_count'])
-        self.assertEquals(1, response.context['msgs_unread_count'])
-
-        # visit the msg pane
-        response = self.client.get(reverse('msgs.msg_inbox'))
-        self.assertEquals(4, response.context['flows_unread_count'])
-        self.assertEquals(0, response.context['msgs_unread_count'])
-
-        # now the flow list pane
-        response = self.client.get(reverse('flows.flow_list'))
-        self.assertEquals(0, response.context['flows_unread_count'])
-        self.assertEquals(0, response.context['msgs_unread_count'])
-
-
 class DuplicateValueTest(FlowFileTest):
 
     def test_duplicate_value_test(self):
@@ -3261,6 +3205,7 @@ class DuplicateValueTest(FlowFileTest):
         # we should now still have only one value, but the category should be Red now
         value = Value.objects.get(run=run)
         self.assertEquals("Red", value.category)
+
 
 class WebhookLoopTest(FlowFileTest):
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -37,34 +37,6 @@ from temba.utils import analytics, build_json_response, percentage, datetime_to_
 from temba.values.models import Value, STATE, DISTRICT
 from .models import FlowStep, RuleSet, ActionLog, ExportFlowResultsTask, FlowLabel, COMPLETE, FAILED, FlowStart
 
-def flow_unread_response_count_processor(request):
-    """
-    Context processor to calculate the number of unread responses on flows so we can
-    display that in the menu.
-    """
-    context = dict()
-    user = request.user
-
-    if user.is_superuser or user.is_anonymous():
-        return context
-
-    org = user.get_org()
-
-    if org:
-        flows_last_viewed = org.flows_last_viewed
-        unread_response_count = Flow.get_org_responses_since(org, flows_last_viewed)
-
-        if request.path.find("/flow/") == 0:
-            org.flows_last_viewed = timezone.now()
-            org.save()
-            unread_response_count = 0
-
-        context['flows_last_viewed'] = flows_last_viewed
-        context['flows_unread_count'] = unread_response_count
-
-    return context
-
-
 class BaseFlowForm(forms.ModelForm):
     expires_after_minutes = forms.ChoiceField(label=_('Expire inactive contacts'),
                                               help_text=_("When inactive contacts should be removed from the flow"),

--- a/temba/locations/models.py
+++ b/temba/locations/models.py
@@ -51,7 +51,7 @@ class AdminBoundary(models.Model):
 
     def get_geojson_feature(self):
         return geojson.Feature(properties=dict(name=self.name, osm_id=self.osm_id, id=self.pk, level=self.level),
-                               geometry=geojson.loads(self.simplified_geometry.geojson))
+                               geometry=None if not self.simplified_geometry else geojson.loads(self.simplified_geometry.geojson))
 
     def get_geojson(self):
         return AdminBoundary.get_geojson_dump([self.get_geojson_feature()])

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -69,8 +69,8 @@ class Locationtest(TembaTest):
         response_json = json.loads(response.content)
 
         # now have kigs as an alias
-        self.assertEquals("Kigali", response_json[1]['name'])
-        self.assertEquals(['kigs', 'kig'], response_json[1]['aliases'])
+        self.assertEquals("Kigali City", response_json[1]['name'])
+        self.assertEquals('kig\nkigs', response_json[1]['aliases'])
 
 
 

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -1,3 +1,79 @@
-from django.test import TestCase
+import json
+from django.core.urlresolvers import reverse
+from temba.tests import TembaTest
 
-# Create your tests here.
+class Locationtest(TembaTest):
+
+    def test_boundaries(self):
+        self.login(self.admin)
+
+        # clear our country on our org
+        self.org.country = None
+        self.org.save()
+
+        # get the aliases for our user org
+        response = self.client.get(reverse('locations.adminboundary_alias'))
+
+        # should be a redirect to our org home
+        self.assertRedirect(response, reverse('orgs.org_home'))
+
+        # now set it to rwanda
+        self.org.country = self.country
+        self.org.save()
+
+        # our country is set to rwanda, we should get it as the main object
+        response = self.client.get(reverse('locations.adminboundary_alias'))
+        self.assertEquals(self.country, response.context['object'])
+
+        # ok, now get the geometry for rwanda
+        response = self.client.get(reverse('locations.adminboundary_geometry', args=[self.country.osm_id]))
+
+        # should be json
+        response_json = json.loads(response.content)
+
+        # should have features in it
+        self.assertTrue('features' in response_json)
+
+        # should have our two top level states
+        self.assertEquals(2, len(response_json['features']))
+
+        # now get it for one of the sub areas
+        response = self.client.get(reverse('locations.adminboundary_geometry', args=[self.district1.osm_id]))
+        response_json = json.loads(response.content)
+
+        # should have features in it
+        self.assertTrue('features' in response_json)
+
+        # should have our single district in it
+        self.assertEquals(1, len(response_json['features']))
+
+        # now grab our aliases
+        response = self.client.get(reverse('locations.adminboundary_boundaries', args=[self.country.osm_id]))
+        response_json = json.loads(response.content)
+
+        # should just be kigali, without any aliases
+        self.assertEquals(2, len(response_json))
+        self.assertEquals("Eastern Province", response_json[0]['name'])
+        self.assertEquals("Kigali City", response_json[1]['name'])
+        self.assertEquals('', response_json[1]['aliases'])
+
+        # update our alias for kigali
+        response = self.client.post(reverse('locations.adminboundary_boundaries', args=[self.country.osm_id]),
+                                    json.dumps([dict(osm_id=self.state1.osm_id, aliases="kigs\nkig")]),
+                                    content_type='application/json')
+
+        self.assertEquals(200, response.status_code)
+
+        # fetch our aliases again
+        response = self.client.get(reverse('locations.adminboundary_boundaries', args=[self.country.osm_id]))
+        response_json = json.loads(response.content)
+
+        # now have kigs as an alias
+        self.assertEquals("Kigali", response_json[1]['name'])
+        self.assertEquals(['kigs', 'kig'], response_json[1]['aliases'])
+
+
+
+
+
+

--- a/temba/msgs/migrations/0014_labels_to_folders.py
+++ b/temba/msgs/migrations/0014_labels_to_folders.py
@@ -52,10 +52,6 @@ def migrate_label_hierarchies(apps, schema_editor):
             else:
                 parent.delete()
 
-    print
-    print "Renamed %d labels with non-unique names" % rename_count
-    print "Converted %d parent labels to folders" % folder_count
-
 
 class Migration(migrations.Migration):
 

--- a/temba/msgs/migrations/0017_install_label_triggers.py
+++ b/temba/msgs/migrations/0017_install_label_triggers.py
@@ -14,9 +14,6 @@ def populate_label_counts(apps, schema_editor):
         label.visible_count = label.msgs.filter(visibility='V', contact__is_test=False).count()
         label.save(update_fields=('visible_count',))
 
-    print
-    print "Pre-calculated counts for %d labels" % len(user_labels)
-
 
 class Migration(migrations.Migration):
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -20,7 +20,7 @@ from django.utils.translation import ugettext, ugettext_lazy as _
 from smartmin.models import SmartModel
 from temba.contacts.models import Contact, ContactGroup, ContactURN, TEL_SCHEME
 from temba.channels.models import Channel, ANDROID, SEND, CALL
-from temba.orgs.models import Org, OrgModelMixin, OrgEvent, TopUp, Language
+from temba.orgs.models import Org, OrgModelMixin, OrgEvent, TopUp, Language, UNREAD_FLOW_MSGS, UNREAD_INBOX_MSGS
 from temba.schedules.models import Schedule
 from temba.temba_email import send_temba_email
 from temba.utils import get_datetime_format, datetime_to_str, analytics
@@ -637,6 +637,12 @@ class Msg(models.Model, OrgModelMixin):
                     logger.exception("Error in message handling: %s" % e)
 
         cls.mark_handled(msg)
+
+        # if this isn't a flow message, increment our unread inbox count
+        if msg.msg_type == INBOX:
+            msg.org.increment_unread_msg_count(UNREAD_INBOX_MSGS)
+        elif msg.msg_type == FLOW:
+            msg.org.increment_unread_msg_count(UNREAD_FLOW_MSGS)
 
         # record our handling latency for this object
         if msg.queued_on:

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -638,11 +638,9 @@ class Msg(models.Model, OrgModelMixin):
 
         cls.mark_handled(msg)
 
-        # if this isn't a flow message, increment our unread inbox count
+        # if this is an inbox message, increment our unread inbox count
         if msg.msg_type == INBOX:
             msg.org.increment_unread_msg_count(UNREAD_INBOX_MSGS)
-        elif msg.msg_type == FLOW:
-            msg.org.increment_unread_msg_count(UNREAD_FLOW_MSGS)
 
         # record our handling latency for this object
         if msg.queued_on:

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -53,31 +53,6 @@ def send_message_auto_complete_processor(request):
     return dict(completions=json.dumps(completions))
 
 
-def unread_msg_count_processor(request):
-    ctxt_data = dict()
-    user = request.user
-
-    if user.is_superuser or user.is_anonymous():
-        return ctxt_data
-
-    org = user.get_org()
-    if org:
-        msg_last_viewed = org.msg_last_viewed
-        unread_msg_count = Msg.get_unread_msg_count(user)
-
-        if request.path == reverse('msgs.msg_inbox'):
-            org.msg_last_viewed = timezone.now()
-            org.save()
-
-            unread_msg_count = 0
-            ctxt_data['msg_last_viewed'] = msg_last_viewed
-
-        if unread_msg_count:
-            ctxt_data['unread_msg_count'] = unread_msg_count
-
-    return ctxt_data
-
-
 class SendMessageForm(Form):
     omnibox = OmniboxField()
     text = forms.CharField(widget=forms.Textarea, max_length=640)

--- a/temba/orgs/context_processors.py
+++ b/temba/orgs/context_processors.py
@@ -1,4 +1,5 @@
-from .models import get_stripe_credentials
+from .models import get_stripe_credentials, UNREAD_INBOX_MSGS, UNREAD_FLOW_MSGS
+from django.utils import timezone
 
 class defaultdict(dict):
   def __missing__(self, key):
@@ -71,4 +72,43 @@ def settings_includer(request):
     Includes a few settings that we always want in our context
     """
     context = dict(STRIPE_PUBLIC_KEY=get_stripe_credentials()[0])
+    return context
+
+def unread_count_processor(request):
+    """
+    Context processor to calculate the number of unread messages in the inbox and on flow tabs
+    """
+    context = dict()
+    user = request.user
+
+    if user.is_superuser or user.is_anonymous():
+        return context
+
+    org = user.get_org()
+
+    if org:
+        # calculate and populate our unread counts on flows
+        flows_unread_count = org.get_unread_msg_count(UNREAD_FLOW_MSGS)
+
+        if request.path.find('/flow/') == 0:
+            org.clear_unread_msg_count(UNREAD_FLOW_MSGS)
+            org.flows_last_viewed = timezone.now()
+            org.save(update_fields=['flows_last_viewed'])
+            flows_unread_count = 0
+
+        context['flows_last_viewed'] = org.flows_last_viewed
+        context['flows_unread_count'] = flows_unread_count
+
+        # calculate and populate our unread counts on inbox msgs
+        msgs_unread_count = org.get_unread_msg_count(UNREAD_INBOX_MSGS)
+
+        if request.path.find('/msg/') == 0:
+            org.clear_unread_msg_count(UNREAD_INBOX_MSGS)
+            org.msg_last_viewed = timezone.now()
+            org.save(update_fields=['msg_last_viewed'])
+            msgs_unread_count = 0
+
+        context['msgs_last_viewed'] = org.msg_last_viewed
+        context['msgs_unread_count'] = msgs_unread_count
+
     return context

--- a/temba/orgs/context_processors.py
+++ b/temba/orgs/context_processors.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from .models import get_stripe_credentials, UNREAD_INBOX_MSGS, UNREAD_FLOW_MSGS
 from django.utils import timezone
 
@@ -90,7 +91,7 @@ def unread_count_processor(request):
         # calculate and populate our unread counts on flows
         flows_unread_count = org.get_unread_msg_count(UNREAD_FLOW_MSGS)
 
-        if request.path.find('/flow/') == 0:
+        if request.path.find(reverse('flows.flow_list')) == 0:
             org.clear_unread_msg_count(UNREAD_FLOW_MSGS)
             org.flows_last_viewed = timezone.now()
             org.save(update_fields=['flows_last_viewed'])
@@ -102,7 +103,7 @@ def unread_count_processor(request):
         # calculate and populate our unread counts on inbox msgs
         msgs_unread_count = org.get_unread_msg_count(UNREAD_INBOX_MSGS)
 
-        if request.path.find('/msg/') == 0:
+        if request.path.find(reverse('msgs.msg_inbox')) == 0:
             org.clear_unread_msg_count(UNREAD_INBOX_MSGS)
             org.msg_last_viewed = timezone.now()
             org.save(update_fields=['msg_last_viewed'])

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -36,6 +36,9 @@ from twilio.rest import TwilioRestClient
 from uuid import uuid4
 from .bundles import BUNDLE_MAP, WELCOME_TOPUP_SIZE
 
+UNREAD_INBOX_MSGS = 'unread_inbox_msgs'
+UNREAD_FLOW_MSGS = 'unread_flow_msgs'
+
 CURRENT_EXPORT_VERSION = 4
 EARLIEST_IMPORT_VERSION = 3
 
@@ -1323,6 +1326,30 @@ class Org(SmartModel):
 
         return recommended
 
+    def increment_unread_msg_count(self, type):
+        """
+        Increments our redis cache of how many unread messages exist for this org and type.
+        @param type: either UNREAD_INBOX_MSGS or UNREAD_FLOW_MSGS
+        """
+        r = get_redis_connection()
+        r.hincrby(type, self.id, 1)
+
+    def get_unread_msg_count(self, msg_type):
+        """
+        Gets the value of our redis cache of how many unread messages exist for this org and type.
+        @param msg_type: either UNREAD_INBOX_MSGS or UNREAD_FLOW_MSGS
+        """
+        r = get_redis_connection()
+        count = r.hget(msg_type, self.id)
+        return 0 if count is None else int(count)
+
+    def clear_unread_msg_count(self, msg_type):
+        """
+        Clears our redis cache of how many unread messages exist for this org and type.
+        @param msg_type: either UNREAD_INBOX_MSGS or UNREAD_FLOW_MSGS
+        """
+        r = get_redis_connection()
+        r.hdel(msg_type, self.id)
 
     def initialize(self, brand=None, topup_size=WELCOME_TOPUP_SIZE):
         """

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1462,10 +1462,9 @@ class UnreadCountTest(FlowFileTest):
         self.assertEquals(0, response.context['msgs_unread_count'])
 
         # make sure a test contact doesn't update our counts
-        contact.is_test = True
-        contact.save()
+        test_contact = self.create_contact("Test Contact", "+12065551214", is_test=True)
 
-        msg = self.create_msg(contact=contact, text="favs")
+        msg = self.create_msg(contact=test_contact, text="favs")
         Msg.process_message(msg)
 
         # assert our counts weren't updated

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1421,6 +1421,12 @@ class UnreadCountTest(FlowFileTest):
         # process it
         Msg.process_message(msg)
 
+        # our flow unread count should have gone up
+        self.assertEquals(1, flow.get_and_clear_unread_responses())
+
+        # cleared by the first call
+        self.assertEquals(0, flow.get_and_clear_unread_responses())
+
         # at this point our flow should have started.. go to our trigger list page to see if our context is correct
         self.login(self.admin)
         trigger_list = reverse('triggers.trigger_list')
@@ -1463,12 +1469,6 @@ class UnreadCountTest(FlowFileTest):
 
         # make sure a test contact doesn't update our counts
         test_contact = self.create_contact("Test Contact", "+12065551214", is_test=True)
-
-        # our flow unread count should have gone up as well
-        self.assertEquals(4, flow.get_and_clear_unread_responses())
-
-        # cleared by the first call
-        self.assertEquals(0, flow.get_and_clear_unread_responses())
 
         msg = self.create_msg(contact=test_contact, text="favs")
         Msg.process_message(msg)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1464,9 +1464,18 @@ class UnreadCountTest(FlowFileTest):
         # make sure a test contact doesn't update our counts
         test_contact = self.create_contact("Test Contact", "+12065551214", is_test=True)
 
+        # our flow unread count should have gone up as well
+        self.assertEquals(4, flow.get_and_clear_unread_responses())
+
+        # cleared by the first call
+        self.assertEquals(0, flow.get_and_clear_unread_responses())
+
         msg = self.create_msg(contact=test_contact, text="favs")
         Msg.process_message(msg)
 
         # assert our counts weren't updated
         self.assertEquals(0, self.org.get_unread_msg_count(UNREAD_INBOX_MSGS))
         self.assertEquals(0, self.org.get_unread_msg_count(UNREAD_FLOW_MSGS))
+
+        # wasn't counted for the individual flow
+        self.assertEquals(0, flow.get_and_clear_unread_responses())

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -33,7 +33,7 @@ from temba.utils import analytics, build_json_response
 from timezones.forms import TimeZoneField
 from twilio.rest import TwilioRestClient
 from .bundles import WELCOME_TOPUP_SIZE
-from .models import Org, OrgCache, OrgEvent, TopUp, Invitation, UserSettings
+from .models import Org, OrgCache, OrgEvent, TopUp, Invitation, UserSettings, UNREAD_FLOW_MSGS, UNREAD_INBOX_MSGS
 from .models import MT_SMS_EVENTS, MO_SMS_EVENTS, MT_CALL_EVENTS, MO_CALL_EVENTS, ALARM_EVENTS
 
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -135,11 +135,10 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.request',
     'temba.context_processors.branding',
     'temba.orgs.context_processors.user_group_perms_processor',
+    'temba.orgs.context_processors.unread_count_processor',
     'temba.channels.views.channel_status_processor',
-    'temba.msgs.views.unread_msg_count_processor',
     'temba.msgs.views.send_message_auto_complete_processor',
     'temba.api.views.webhook_status_processor',
-    'temba.flows.views.flow_unread_response_count_processor',
     'temba.orgs.context_processors.settings_includer',
 )
 

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -48,12 +48,12 @@ class TembaTest(SmartminTest):
 
         # setup admin boundaries for Rwanda
         self.country = AdminBoundary.objects.create(osm_id='171496', name='Rwanda', level=0)
-        state1 = AdminBoundary.objects.create(osm_id='1708283', name='Kigali City', level=1, parent=self.country)
-        state2 = AdminBoundary.objects.create(osm_id='171591', name='Eastern Province', level=1, parent=self.country)
-        AdminBoundary.objects.create(osm_id='1711131', name='Gatsibo', level=2, parent=state2)
-        AdminBoundary.objects.create(osm_id='1711163', name='Kayonza', level=2, parent=state2)
-        AdminBoundary.objects.create(osm_id='60485579', name='Kigali', level=2, parent=state1)
-        AdminBoundary.objects.create(osm_id='1711142', name='Rwamagana', level=2, parent=state2)
+        self.state1 = AdminBoundary.objects.create(osm_id='1708283', name='Kigali City', level=1, parent=self.country)
+        self.state2 = AdminBoundary.objects.create(osm_id='171591', name='Eastern Province', level=1, parent=self.country)
+        self.district1 = AdminBoundary.objects.create(osm_id='1711131', name='Gatsibo', level=2, parent=self.state2)
+        self.district2 = AdminBoundary.objects.create(osm_id='1711163', name='Kayonza', level=2, parent=self.state2)
+        self.district3 = AdminBoundary.objects.create(osm_id='60485579', name='Kigali', level=2, parent=self.state1)
+        self.district4 = AdminBoundary.objects.create(osm_id='1711142', name='Rwamagana', level=2, parent=self.state2)
 
         self.org = Org.objects.create(name="Temba", timezone="Africa/Kigali", country=self.country,
                                       created_by=self.user, modified_by=self.user)

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -207,7 +207,6 @@ class TembaTest(SmartminTest):
         ruleset.save()
 
 
-
 class FlowFileTest(TembaTest):
 
     def setUp(self):

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -114,7 +114,7 @@ class TembaTest(SmartminTest):
 
         self.org2.initialize()
 
-    def create_contact(self, name=None, number=None, twitter=None):
+    def create_contact(self, name=None, number=None, twitter=None, is_test=False):
         """
         Create a contact in the master test org
         """
@@ -127,7 +127,7 @@ class TembaTest(SmartminTest):
         if not name and not urns:  # pragma: no cover
             raise ValueError("Need a name or URN to create a contact")
 
-        return Contact.get_or_create(self.org, self.user, name, urns=urns)
+        return Contact.get_or_create(self.org, self.user, name, urns=urns, is_test=is_test)
 
     def create_group(self, name, contacts):
         group = ContactGroup.create(self.org, self.user, name)

--- a/templates/campaigns/campaign_list.haml
+++ b/templates/campaigns/campaign_list.haml
@@ -1,5 +1,5 @@
 -extends "smartmin/list.html"
--load smartmin rules sms temba compress i18n
+-load smartmin sms temba compress i18n
 
 -block title-icon
   .title-icon

--- a/templates/campaigns/campaign_read.haml
+++ b/templates/campaigns/campaign_read.haml
@@ -1,5 +1,5 @@
 -extends "smartmin/read.html"
--load smartmin rules sms temba compress humanize i18n
+-load smartmin sms temba compress humanize i18n
 
 -block title-icon
   .title-icon

--- a/templates/campaigns/campaignevent_read.haml
+++ b/templates/campaigns/campaignevent_read.haml
@@ -1,5 +1,5 @@
 -extends "smartmin/read.html"
--load smartmin rules sms temba compress humanize contacts
+-load smartmin sms temba compress humanize contacts
 
 -block title-icon
   .title-icon

--- a/templates/flows/flow_filter.haml
+++ b/templates/flows/flow_filter.haml
@@ -1,5 +1,5 @@
 -extends "flows/flow_list.haml"
--load smartmin rules sms temba compress
+-load smartmin sms temba compress
 -load i18n
 
 -block title-icon

--- a/templates/flows/flow_list.haml
+++ b/templates/flows/flow_list.haml
@@ -1,5 +1,5 @@
 -extends "smartmin/list.html"
--load smartmin rules sms temba compress
+-load smartmin sms temba compress
 -load i18n humanize
 
 -block title-icon
@@ -123,7 +123,7 @@
               %table.list-table.flow-list.object-list.table.table-condensed{style: '{% if not org_perms.flows.flow_update %}margin-top:10px{% endif %}'}
                 %tbody
                   -for object in object_list
-                    -with object|flow_responses_since:flows_last_viewed as new_contacts
+                    -with object.get_and_clear_unread_responses as new_responses
                       %tr.flow.object-row.select-row{ data-object-id: "{{ object.id }}" }
                         %td.flow.checkbox.object-row-checkbox
                           -if object.flow_type != 'V' or object.org.supports_ivr
@@ -138,9 +138,9 @@
                           -if not object.is_archived
                             .value-labels
                               %nobr
-                                -if new_contacts
+                                -if new_responses
                                   %span.label.label-info.label-responses
-                                    - blocktrans count counter=new_contacts
+                                    - blocktrans count counter=new_responses
                                       1 New Response
                                       - plural
                                       ={counter} New Responses

--- a/templates/flows/flow_versions.haml
+++ b/templates/flows/flow_versions.haml
@@ -1,3 +1,3 @@
 -extends "smartmin/list.html"
--load smartmin rules sms temba compress
+-load smartmin sms temba compress
 -load i18n humanize

--- a/templates/includes/nav.haml
+++ b/templates/includes/nav.haml
@@ -7,9 +7,9 @@
       %a.icon-nav-messages{href:"{% url 'msgs.msg_inbox' %}", class:"{% active request 'inbox|outbox|broadcast|call|sms/filter|sms/flow|sms/archived|failed' %}"}
         .title
           -trans "messages"
-      -if unread_msg_count
+      -if msgs_unread_count
         .notification
-          {{unread_msg_count}}
+          {{ msgs_unread_count }}
 
   -if org_perms.contacts.contact_list and not request.user.is_superuser
     %li.nav-contacts

--- a/templates/triggers/trigger_list.haml
+++ b/templates/triggers/trigger_list.haml
@@ -1,5 +1,5 @@
 -extends "smartmin/list.html"
--load smartmin rules sms temba compress
+-load smartmin sms temba compress
 -load i18n
 
 -block title-icon


### PR DESCRIPTION
Instead of doing the rather expensive query of figuring out if there are new inbox or flow messages since the user last visited the org, we now use a redis to increment a count as those things occur.

Redis is good for this because none of these matter so much, these are just hints to the user.