### PR TITLE
Only allow one export per type per org at a time so people don't melt us

### DIFF
--- a/temba/contacts/migrations/0020_exportcontactstask_is_finished.py
+++ b/temba/contacts/migrations/0020_exportcontactstask_is_finished.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0019_unblock_unfail_test_contacts'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='exportcontactstask',
+            name='is_finished',
+            field=models.BooleanField(default=False, help_text='Whether this export has completed'),
+            preserve_default=True,
+        ),
+        migrations.RunSQL("UPDATE contacts_exportcontactstask SET is_finished=TRUE;"),
+    ]

--- a/temba/contacts/tasks.py
+++ b/temba/contacts/tasks.py
@@ -9,7 +9,6 @@ def export_contacts_task(id):
     """
     Export contacts to a file and e-mail a link to the user
     """
-    tasks = ExportContactsTask.objects.filter(pk=id)
-    if tasks:
-        task = tasks[0]
-        task.do_export()
+    export_task = ExportContactsTask.objects.filter(pk=id).first()
+    if export_task:
+        export_task.start_export()

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1853,8 +1853,19 @@ class ContactFieldTest(TembaTest):
 
         Contact.get_test_contact(self.user)  # create test contact to ensure they aren't included in the export
 
+        # create a dummy export task so that we won't be able to export
+        blocking_export = ExportContactsTask.objects.create(org=self.org, host='test',
+                                                            created_by=self.admin, modified_by=self.admin)
+
+        response = self.client.get(reverse('contacts.contact_export'), dict(), follow=True)
+        self.assertContains(response, "already an export in progress")
+
+        # ok, mark that one as finished and try again
+        blocking_export.is_finished = True
+        blocking_export.save()
+
         self.client.get(reverse('contacts.contact_export'), dict())
-        task = ExportContactsTask.objects.get()
+        task = ExportContactsTask.objects.all().order_by('-id').first()
 
         filename = "%s/test_orgs/%d/contact_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
         workbook = open_workbook(filename, 'rb')

--- a/temba/flows/migrations/0022_exportflowresultstask_is_finished.py
+++ b/temba/flows/migrations/0022_exportflowresultstask_is_finished.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0021_actionset_destination_uuid'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='exportflowresultstask',
+            name='is_finished',
+            field=models.BooleanField(default=False, help_text='Whether this export is complete'),
+            preserve_default=True,
+        ),
+        migrations.RunSQL("UPDATE flows_exportflowresultstask SET is_finished=TRUE;"),
+    ]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2912,6 +2912,22 @@ class ExportFlowResultsTask(SmartModel):
     flows = models.ManyToManyField(Flow, related_name='exports', help_text=_("The flows to export"))
     host = models.CharField(max_length=32, help_text=_("The host this export task was created on"))
     task_id = models.CharField(null=True, max_length=64)
+    is_finished = models.BooleanField(default=False,
+                                      help_text=_("Whether this export is complete"))
+
+    def start_export(self):
+        """
+        Starts our export, wrapping it in a try block to make sure we mark it as finished when complete.
+        """
+        try:
+            start = time.time()
+            self.do_export()
+        finally:
+            elapsed = time.time() - start
+            analytics.track(self.created_by.username, 'temba.flowresult_export_latency', properties=dict(value=elapsed))
+
+            self.is_finished = True
+            self.save(update_fields=['is_finished'])
 
     def do_export(self):
         from xlwt import Workbook

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -40,10 +40,9 @@ def export_flow_results_task(id):
     """
     Export a flow to a file and e-mail a link to the user
     """
-    tasks = ExportFlowResultsTask.objects.filter(pk=id)
-    if tasks:
-        task = tasks[0]
-        task.do_export()
+    export_task = ExportFlowResultsTask.objects.filter(pk=id).first()
+    if export_task:
+        export_task.start_export()
 
 
 @task(track_started=True, name='start_flow_task')

--- a/temba/msgs/migrations/0021_exportmessagestask_is_finished.py
+++ b/temba/msgs/migrations/0021_exportmessagestask_is_finished.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0020_update_label_triggers'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='exportmessagestask',
+            name='is_finished',
+            field=models.BooleanField(default=False, help_text='Whether this export is finished running'),
+            preserve_default=True,
+        ),
+        migrations.RunSQL("UPDATE msgs_exportmessagestask SET is_finished=TRUE;"),
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1544,6 +1544,22 @@ class ExportMessagesTask(SmartModel):
     end_date = models.DateField(null=True, blank=True, help_text=_("The date for the newest message to export"))
     host = models.CharField(max_length=32, help_text=_("The host this export task was created on"))
     task_id = models.CharField(null=True, max_length=64)
+    is_finished = models.BooleanField(default=False,
+                                      help_text=_("Whether this export is finished running"))
+
+    def start_export(self):
+        """
+        Starts our export, wrapping it in a try block to make sure we mark it as finished when complete.
+        """
+        try:
+            start = time.time()
+            self.do_export()
+        finally:
+            elapsed = time.time() - start
+            analytics.track(self.created_by.username, 'temba.msg_export_latency', properties=dict(value=elapsed))
+
+            self.is_finished = True
+            self.save(update_fields=['is_finished'])
 
     def do_export(self):
         from xlwt import Workbook, XFStyle

--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -195,10 +195,9 @@ def export_sms_task(id):
     """
     Export messages to a file and e-mail a link to the user
     """
-    tasks = ExportMessagesTask.objects.filter(pk=id)
-    if tasks:
-        export_task = tasks[0]
-        export_task.do_export()
+    export_task = ExportMessagesTask.objects.filter(pk=id).first()
+    if export_task:
+        export_task.start_export()
 
 @task(track_started=True, name="handle_event_task", time_limit=90, soft_time_limit=60)
 def handle_event_task():


### PR DESCRIPTION
Adds ```is_finished``` on all export tasks and tracks when they are complete. Also disallows the creation of new exports until the previous exports are actually complete. 