### PR TITLE
Allow admins to remove themselves from orgs

### DIFF
--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -313,6 +313,25 @@ class OrgTest(TembaTest):
         self.assertEquals(3, Invitation.objects.all().count())
         self.assertEquals(4, len(mail.outbox))
 
+        # upgrade one of our users to an admin
+        self.org.editors.remove(self.user)
+        self.org.administrators.add(self.user)
+
+        # now remove ourselves as an admin
+        post_data = {
+            'administrators_%d' % self.user.pk: 'on',
+            'editors_%d' % self.editor.pk: 'on',
+            'user_group': 'E'
+        }
+
+        response = self.client.post(manage_accounts_url, post_data)
+
+        # should be redirected to chooser page
+        self.assertRedirect(response, reverse('orgs.org_choose'))
+
+        # and should no longer be an admin
+        self.assertFalse(self.admin in self.org.administrators.all())
+
     @patch('temba.temba_email.send_multipart_email')
     def test_join(self, mock_send_multipart_email):
         editor_invitation = Invitation.objects.create(org=self.org,

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -818,7 +818,6 @@ class OrgCRUDL(SmartCRUDL):
                 model = Invitation
                 fields = ('emails', 'user_group')
 
-
         form_class = InviteForm
         success_url = "@orgs.org_home"
         success_message = ""
@@ -909,10 +908,7 @@ class OrgCRUDL(SmartCRUDL):
 
             # remove all the org users
             for user in self.get_object().get_org_admins():
-                if user != self.request.user:
-                    self.get_object().administrators.remove(user)
-                else:
-                    self.get_object().administrators.add(user)
+                self.get_object().administrators.remove(user)
             for user in self.get_object().get_org_editors():
                 self.get_object().editors.remove(user)
             for user in self.get_object().get_org_viewers():
@@ -947,6 +943,16 @@ class OrgCRUDL(SmartCRUDL):
             context['invites'] = Invitation.objects.filter(org=org, is_active=True)
 
             return context
+
+        def get_success_url(self):
+            # if we are no longer part of this form, redirect to the chooser
+            if self.request.user not in self.org_users:
+                return reverse('orgs.org_choose')
+
+            # otherwise, back to our home page
+            else:
+                return reverse('orgs.org_home')
+
 
     class Service(SmartFormView):
         class ServiceForm(forms.Form):
@@ -1388,7 +1394,7 @@ class OrgCRUDL(SmartCRUDL):
 
             # only pro orgs get multiple users
             if self.has_org_perm("orgs.org_manage_accounts") and org.is_pro():
-                formax.add_section('manageaccount', reverse('orgs.org_manage_accounts'), icon='icon-users')
+                formax.add_section('manageaccount', reverse('orgs.org_manage_accounts'), icon='icon-users', action='redirect')
 
     class Edit(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
 


### PR DESCRIPTION
We weren't allowing admins from removing themselves from orgs if there was more than one admin on it. This fixes that.