### PR TITLE
Let channel phone number take precendence for channel country

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1944,7 +1944,6 @@ class SyncEvent(SmartModel):
     @classmethod
     def create(cls, channel, cmd, incoming_commands):
         # update country, device and OS on our channel
-        country = cmd.get('cc', None)
         device = cmd.get('dev', None)
         os = cmd.get('os', None)
 

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -168,12 +168,12 @@ class Channel(SmartModel):
         return [t for t, config in RELAYER_TYPE_CONFIG.iteritems() if config['scheme'] == scheme]
 
     @classmethod
-    def derive_country_from_phone(cls, phone):
+    def derive_country_from_phone(cls, phone, country=None):
         """
         Given a phone number in E164 returns the two letter country code for it.  ex: +250788383383 -> RW
         """
         try:
-            parsed = phonenumbers.parse(phone, None)
+            parsed = phonenumbers.parse(phone, country)
             return phonenumbers.region_code_for_number(parsed)
         except:
             return None
@@ -1949,8 +1949,8 @@ class SyncEvent(SmartModel):
         os = cmd.get('os', None)
 
         # update our channel if anything is new
-        if channel.country != country or channel.device != device or channel.os != os:
-            Channel.objects.filter(pk=channel.pk).update(country=country, device=device, os=os)
+        if channel.device != device or channel.os != os:
+            Channel.objects.filter(pk=channel.pk).update(device=device, os=os)
 
         args = dict()
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1479,21 +1479,24 @@ class SyncEventTest(SmartminTest):
         self.user = self.create_user("tito")
         self.org = Org.objects.create(name="Temba", timezone="Africa/Kigali", created_by=self.user, modified_by=self.user)
         self.tel_channel = Channel.objects.create(name="Test Channel", address="0785551212", org=self.org,
-                                                  created_by=self.user, modified_by=self.user,
+                                                  created_by=self.user, modified_by=self.user, country='RW',
                                                   secret="12345", gcm_id="123")
 
     def test_sync_event_model(self):
-        self.sync_event = SyncEvent.create(self.tel_channel, dict(p_src="AC", p_sts="DIS", p_lvl=80, net="WIFI", pending=[1, 2], retry=[3, 4], cc='RW'), [1,2])
+        self.sync_event = SyncEvent.create(self.tel_channel, dict(p_src="AC", p_sts="DIS", p_lvl=80, net="WIFI",
+                                                                  pending=[1, 2], retry=[3, 4], cc='RW'), [1,2])
         self.assertEquals(SyncEvent.objects.all().count(), 1)
         self.assertEquals(self.sync_event.get_pending_messages(), [1, 2])
         self.assertEquals(self.sync_event.get_retry_messages(), [3, 4])
         self.assertEquals(self.sync_event.incoming_command_count, 0)
 
-        self.sync_event = SyncEvent.create(self.tel_channel, dict(p_src="AC", p_sts="DIS", p_lvl=80, net="WIFI", pending=[1, 2], retry=[3, 4], cc='US'), [1])
+        self.sync_event = SyncEvent.create(self.tel_channel, dict(p_src="AC", p_sts="DIS", p_lvl=80, net="WIFI",
+                                                                  pending=[1, 2], retry=[3, 4], cc='US'), [1])
         self.assertEquals(self.sync_event.incoming_command_count, 0)
         self.tel_channel = Channel.objects.get(pk=self.tel_channel.pk)
-        self.assertEquals('US', self.tel_channel.country)
 
+        # we shouldn't update country once the relayer is claimed
+        self.assertEquals('RW', self.tel_channel.country)
 
 class ChannelAlertTest(TembaTest):
 


### PR DESCRIPTION
Fixes the case that World Relief (DE) has been running into, that their device was reporting DE as a country but they were registering with a number in a different place. We now let the phone number of the channel take precedence when determining whether they are adding a channel in the same country as their other orgs.