### PR TITLE
Allow use of shared shortcodes on AfricasTalking

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -339,9 +339,8 @@ class Channel(SmartModel):
                                       org=org, created_by=user, modified_by=user, role=SEND+RECEIVE+CALL+ANSWER)
 
     @classmethod
-    def add_africas_talking_channel(cls, org, user, phone, username, api_key):
-        config = dict(username=username,
-                      api_key=api_key)
+    def add_africas_talking_channel(cls, org, user, phone, username, api_key, is_shared=False):
+        config = dict(username=username, api_key=api_key, is_shared=is_shared)
 
         return Channel.objects.create(channel_type=AFRICAS_TALKING, country='KE',
                                       name="Africa's Talking: %s" % phone, address=phone, uuid=str(uuid4()),
@@ -1411,7 +1410,10 @@ class Channel(SmartModel):
         payload = dict(username=channel.config['username'],
                        to=msg.urn_path,
                        message=text)
-        payload['from'] = channel.address
+
+        # if this isn't a shared shortcode, send the from address
+        if not channel.config.get('is_shared', False):
+            payload['from'] = channel.address
 
         headers = dict(Accept='application/json', apikey=channel.config['api_key'])
         headers.update(TEMBA_HEADERS)

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1301,18 +1301,19 @@ class ChannelCRUDL(SmartCRUDL):
 
             return super(ChannelCRUDL.ClaimAuthenticatedExternal, self).form_valid(form)
 
-
     class ClaimAfricasTalking(OrgPermsMixin, SmartFormView):
         class ATClaimForm(forms.Form):
             shortcode = forms.CharField(max_length=6, min_length=1,
                                         help_text=_("Your short code on Africa's Talking"))
+            is_shared = forms.BooleanField(initial=False, required=False,
+                                           help_text=_("Whether this short code is shared with others"))
             username = forms.CharField(max_length=32,
                                        help_text=_("Your username on Africa's Talking"))
             api_key = forms.CharField(max_length=64,
                                       help_text=_("Your api key, should be 64 characters"))
 
         title = _("Connect Africa's Talking Account")
-        fields = ('shortcode', 'username', 'api_key')
+        fields = ('shortcode', 'is_shared', 'username', 'api_key')
         form_class = ATClaimForm
         success_url = "id@channels.channel_configuration"
 
@@ -1324,7 +1325,8 @@ class ChannelCRUDL(SmartCRUDL):
 
             data = form.cleaned_data
             self.object = Channel.add_africas_talking_channel(org, self.request.user,
-                                                              phone=data['shortcode'], username=data['username'], api_key=data['api_key'])
+                                                              phone=data['shortcode'], username=data['username'],
+                                                              api_key=data['api_key'], is_shared=data['is_shared'])
 
             # make sure all contacts added before the channel are normalized
             self.object.ensure_normalized_contacts()


### PR DESCRIPTION
Lets users use one of the Africa's Talking shared shortcodes.. this basically is just a flag set when connecting that then changes our send format a bit.