### PR TITLE
Language fixes

### DIFF
--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -40,6 +40,9 @@ module.exports = (config) ->
       'karma/flows/test_directives.coffee',
       'karma/flows/test_controllers.coffee',
 
+      # paritals templates to be loaded by ng-html2js
+      'templates/partials/*.haml'
+
     ]
 
     # list of files to exclude
@@ -50,12 +53,20 @@ module.exports = (config) ->
     # preprocess matching files before serving them to the browser
     # available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'karma/**/*.coffee': ['coffee']
+      'templates/partials/*.haml': ["ng-html2js"],
+      'karma/**/*.coffee': ['coffee'],
       'static/**/*.coffee': ['coverage']
     }
 
+    ngHtml2JsPreprocessor: {
+      # the name of the Angular module to create
+      moduleName: "partials"
+      cacheIdFromPath: (filepath) ->
+        return filepath.replace('templates', '').replace('.haml', '')
+    }
+
     # this makes sure that we get coffeescript line numbers instead
-    # of the line number from the transpiled 
+    # of the line number from the transpiled
     coffeePreprocessor:
       options:
         bare: true
@@ -102,4 +113,3 @@ module.exports = (config) ->
     # Continuous Integration mode
     # if true, Karma captures browsers, runs the tests and exits
     singleRun: false
-

--- a/karma/flows/test_controllers.coffee
+++ b/karma/flows/test_controllers.coffee
@@ -3,6 +3,7 @@ describe 'Controllers:', ->
   beforeEach ->
     # initialize our angular app
     module 'app'
+    module 'partials'
 
   $rootScope = null
   $compile = null
@@ -11,18 +12,52 @@ describe 'Controllers:', ->
   $log = null
   window.mutable = true
 
+  $http = null
+  flows = null
+
+  beforeEach inject((_$httpBackend_) ->
+
+
+
+    $http = _$httpBackend_
+
+    # wire up our mock flows
+    flows = {
+      'favorites': { id: 1, languages:[] },
+      'rules_first': { id: 2, languages:[] },
+      'loop_detection': { id: 3, languages:[] },
+      'webhook_rule_first': { id: 4, languages:[] },
+    }
+
+    $http.whenGET('/contactfield/json/').respond([])
+    $http.whenGET('/label/').respond([])
+
+    for file, config of flows
+
+      $http.whenPOST('/flow/json/' + config.id + '/').respond()
+      $http.whenGET('/flow/json/' + config.id + '/').respond(
+        {
+          flow: getJSONFixture(file + '.json').flows[0].definition,
+          languages: config.languages
+        }
+      )
+
+      $http.whenGET('/flow/versions/' + config.id + '/').respond(
+        [],  {'content-type':'application/json'}
+      )
+
+      $http.whenGET('/flow/completion/?flow=' + config.id).respond([])
+  )
 
   beforeEach inject((_$rootScope_, _$compile_, _$log_, _$modal_) ->
       $rootScope = _$rootScope_.$new()
       $scope = $rootScope.$new()
       $modal = _$modal_
+
+      $rootScope.ghost =
+        hide: ->
+
       $scope.$parent = $rootScope
-
-      $scope.$parent.flow =
-        base_language: 'eng'
-
-      $scope.$parent.language = { iso_code: 'eng' }
-
       $compile = _$compile_
       $log = _$log_
     )
@@ -32,16 +67,28 @@ describe 'Controllers:', ->
   describe 'FlowController', ->
 
     flowController = null
+    flowService = null
 
-    beforeEach inject(($controller) ->
+    beforeEach inject(($controller, _Flow_) ->
+
+      flowService = _Flow_
       flowController = $controller 'FlowController',
         $scope: $scope
         $rootScope: $rootScope
         $log: $log
+        Flow: flowService
     )
 
+    it 'should show warning when attempting an infinite loop', ->
 
+      flowService.fetch(flows.webhook_rule_first.id).then ->
+        $scope.flow = flowService.flow
+        connection =
+          sourceId: 'c81d60ec-9a74-48d6-a55f-e70a5d7195d3'
+          targetId: '9b3b6b7d-13ec-46ea-8918-a83a4099be33'
 
+        expect($scope.dialog).toBe(undefined)
+        $scope.onBeforeConnectorDrop(connection)
+        expect($scope.dialog).not.toBe(undefined)
 
-
-
+      $http.flush()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "karma-jasmine" : "0.3.5",
     "karma-mocha" : "0.1.10",
     "karma-phantomjs-launcher" : "0.1.4",
-    "karma-ng-html2js-preprocessor", "0.1.2",
+    "karma-ng-html2js-preprocessor" : "0.1.2",
     "mocha" : "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "karma-jasmine" : "0.3.5",
     "karma-mocha" : "0.1.10",
     "karma-phantomjs-launcher" : "0.1.4",
+    "karma-ng-html2js-preprocessor", "0.1.2",
     "mocha" : "2.1.0"
   }
 }

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -109,20 +109,23 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
   $rootScope.activityInterval = 5000
 
   # fetch our flow to get started
-  Flow.fetch window.flowId, ->
-    $scope.updateActivity()
-    $scope.flow = Flow.flow
+  $scope.init = ->
+    Flow.fetch window.flowId, ->
+      $scope.updateActivity()
+      $scope.flow = Flow.flow
 
   showDialog = (title, body, okButton='Okay', hideCancel=true) ->
 
-    return $modal.open
-      templateUrl: "/partials/modal?v=" + version
+    $scope.dialog = $modal.open
+      templateUrl: "/partials/modal"
       controller: SimpleMessageController
       resolve:
         title: -> title
         body: -> body
         okButton: -> okButton
         hideCancel: -> hideCancel
+
+    return $scope.dialog
 
   $scope.getAcceptedScopes = (nodeType) ->
     return 'actions rules'
@@ -278,9 +281,11 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
     return category.sources[0]
 
   $scope.onBeforeConnectorDrop = (props) ->
+
     if not Flow.isConnectionAllowed(props.sourceId, props.targetId)
       $rootScope.ghost.hide()
       $rootScope.ghost = null
+      showDialog('Infinite Loop', 'Connecting these steps together would create an infinite loop in your flow. To connect these steps you need to pass through a step that waits for the user to respond.')
       return false
     return true
 
@@ -424,7 +429,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
 
     if Flow.language and Flow.flow.base_language and Flow.flow.base_language != Flow.language.iso_code
       $modal.open
-        templateUrl: "/partials/translate_rules?v=" + version
+        templateUrl: "/partials/translate_rules"
         controller: TranslateRulesController
         resolve:
           languages: ->
@@ -435,7 +440,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
 
       if window.ivr
         $modal.open
-          templateUrl: "/partials/node_editor?v=" + version
+          templateUrl: "/partials/node_editor"
           controller: NodeEditorController
           resolve:
             options: ->
@@ -446,7 +451,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
 
       else
         $modal.open
-          templateUrl: "/partials/node_editor?v=" + version
+          templateUrl: "/partials/node_editor"
           controller: NodeEditorController
           resolve:
             options: ->
@@ -516,7 +521,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
   $scope.clickActionSource = (actionset) ->
     if actionset._terminal
       $modal.open
-        templateUrl: "/partials/modal?v=" + version
+        templateUrl: "/partials/modal"
         controller: TerminalWarningController
         resolve:
           actionset: -> actionset
@@ -552,7 +557,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
       return
 
     $modal.open
-      templateUrl: "/partials/node_editor?v=" + version
+      templateUrl: "/partials/node_editor"
       controller: NodeEditorController
       resolve:
         options: ->
@@ -615,7 +620,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
         fromText = action.msg[Flow.flow.base_language]
 
         modalInstance = $modal.open(
-          templateUrl: "/partials/translation_modal?v=" + version
+          templateUrl: "/partials/translation_modal"
           controller: TranslationController
           resolve:
             languages: ->
@@ -641,7 +646,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
     else
 
       $modal.open
-        templateUrl: "/partials/node_editor?v=" + version
+        templateUrl: "/partials/node_editor"
         controller: NodeEditorController
         resolve:
           options: ->
@@ -893,7 +898,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
   $scope.updateWebhook = () ->
 
     $modal.open
-      templateUrl: "/partials/rule_webhook?v=" + version
+      templateUrl: "/partials/rule_webhook"
       controller: RuleOptionsController
       resolve:
         methods: ->
@@ -975,7 +980,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
   $scope.updateSplitVariable = ->
 
     $modal.open
-      templateUrl: "/partials/split_variable?v=" + version
+      templateUrl: "/partials/split_variable"
       controller: RuleOptionsController
       resolve:
         methods: -> []

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -619,7 +619,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
 
         fromText = action.msg[Flow.flow.base_language]
 
-        modalInstance = $modal.open(
+        $scope.dialog = $modal.open(
           templateUrl: "/partials/translation_modal"
           controller: TranslationController
           resolve:
@@ -631,10 +631,10 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
               to: action.msg[Flow.language.iso_code]
         )
 
-        modalInstance.opened.then ->
+        $scope.dialog.opened.then ->
           $('textarea').focus()
 
-        modalInstance.result.then (translation) ->
+        $scope.dialog.result.then (translation) ->
           action = utils.clone(action)
           if translation and translation.strip().length > 0
              action.msg[Flow.language.iso_code] = translation
@@ -645,7 +645,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
 
     else
 
-      $modal.open
+      $scope.dialog = $modal.open
         templateUrl: "/partials/node_editor"
         controller: NodeEditorController
         resolve:

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -402,8 +402,8 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
   # this is necessary to style the bottom of the action set node container accordingly
   $scope.lastActionMissingTranslation = (actionset) ->
     lastAction = actionset.actions[actionset.actions.length - 1]
-    if $scope.flow.base_language
-      if $scope.flow.base_language != Flow.language.iso_code
+    if Flow.language
+      if Flow.language.iso_code != Flow.flow.base_language
         if lastAction.msg and lastAction.type in ['reply', 'send', 'send', 'say'] and not lastAction.msg[Flow.language.iso_code]
           return true
 
@@ -422,7 +422,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
 
     DragHelper.hide()
 
-    if Flow.flow.base_language and Flow.flow.base_language != Flow.language.iso_code
+    if Flow.language and Flow.flow.base_language and Flow.flow.base_language != Flow.language.iso_code
       $modal.open
         templateUrl: "/partials/translate_rules?v=" + version
         controller: TranslateRulesController
@@ -608,7 +608,7 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$modal',
     DragHelper.hide()
 
     # if its the base language, don't show the from text
-    if Flow.flow.base_language and Flow.flow.base_language != Flow.language.iso_code
+    if Flow.language and Flow.flow.base_language and Flow.flow.base_language != Flow.language.iso_code
 
       if action.type in ["send", "reply", "say"]
 
@@ -727,12 +727,12 @@ TranslateRulesController = ($scope, $modalInstance, Flow, utils, languages, rule
 
     if rule.category
       rule._translation = {category:{}, test:{}}
-      rule._translation.category['from'] = rule.category[$scope.$parent.flow.base_language]
-      rule._translation.category['to'] = rule.category[$scope.$parent.language.iso_code]
+      rule._translation.category['from'] = rule.category[Flow.flow.base_language]
+      rule._translation.category['to'] = rule.category[Flow.language.iso_code]
 
       if typeof(rule.test.test) == "object"
-        rule._translation.test['from'] = rule.test.test[$scope.$parent.flow.base_language]
-        rule._translation.test['to'] = rule.test.test[$scope.$parent.language.iso_code]
+        rule._translation.test['from'] = rule.test.test[Flow.flow.base_language]
+        rule._translation.test['to'] = rule.test.test[Flow.language.iso_code]
 
   $scope.ruleset = ruleset
   $scope.languages = languages

--- a/static/coffee/flows/directives.coffee
+++ b/static/coffee/flows/directives.coffee
@@ -150,12 +150,17 @@ app.directive "action", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
       # grab the appropriate translated version
 
       if Flow.flow.base_language
+
+        iso_code = Flow.flow.base_language
+        if currentLanguage
+          iso_code = currentLanguage.iso_code
+
         if action.type in ['send', 'reply', 'say']
-          action._translation = action.msg[currentLanguage.iso_code]
+          action._translation = action.msg[iso_code]
 
           # translated recording for IVR
           if action.recording
-            action._translation_recording = action.recording[currentLanguage.iso_code]
+            action._translation_recording = action.recording[iso_code]
             if action._translation_recording
               action._translation_recording = window.recordingURL + action._translation_recording
 
@@ -247,12 +252,18 @@ app.directive "ruleset", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
     Flow.replaceRuleset(scope.ruleset, false)
 
     scope.updateTranslationStatus = (ruleset, baseLanguage, currentLanguage) ->
+
+
+      iso_code = baseLanguage
+      if currentLanguage
+        iso_code = currentLanguage.iso_code
+
       for category in ruleset._categories
 
         category._missingTranslation = false
         if category.name
-          if Flow.flow.base_language
-            category._translation = category.name[currentLanguage.iso_code]
+          if baseLanguage
+            category._translation = category.name[iso_code]
 
             if category._translation is undefined
               category._translation = category.name[baseLanguage]
@@ -263,8 +274,8 @@ app.directive "ruleset", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
           else
             category._translation = category.name
 
-      Flow.updateTranslationStats()
-      Plumb.repaint(element)
+        Flow.updateTranslationStats()
+        Plumb.repaint(element)
 
     scope.$watch (->scope.ruleset), ->
       scope.updateTranslationStatus(scope.ruleset, Flow.flow.base_language, Flow.language)

--- a/static/coffee/flows/directives.coffee
+++ b/static/coffee/flows/directives.coffee
@@ -274,8 +274,8 @@ app.directive "ruleset", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
           else
             category._translation = category.name
 
-        Flow.updateTranslationStats()
-        Plumb.repaint(element)
+      Flow.updateTranslationStats()
+      Plumb.repaint(element)
 
     scope.$watch (->scope.ruleset), ->
       scope.updateTranslationStatus(scope.ruleset, Flow.flow.base_language, Flow.language)

--- a/static/coffee/flows/widgets.coffee
+++ b/static/coffee/flows/widgets.coffee
@@ -26,8 +26,8 @@ app.directive "sms", [ "$log", "Flow", ($log, Flow) ->
     # determine the initial message based on the current language
     scope.message = scope.sms
 
-    if Flow.language and scope.sms
-      localized = scope.sms[Flow.language.iso_code]
+    if Flow.flow.base_language and scope.sms
+      localized = scope.sms[Flow.flow.base_language]
       if localized?
         scope.message = localized
 

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -194,7 +194,7 @@
           [[version.user.email]]
 
 
-  #ctlr{ng-controller:'FlowController', ng-show:'flow', ng-mousemove:'mouseMove($event)', ng-cloak:''}
+  #ctlr{ng-controller:'FlowController', ng-show:'flow', ng-mousemove:'mouseMove($event)', ng-cloak:'', ng-init:"init()"}
     -include "flows/simulator.html"
 
     #toolbar


### PR DESCRIPTION
* Allow localized flows to be viewed in orgs without a primary language set
* Remove explicit cache avoidance for partials
* Add FlowController testing
* Use ng-html2js in karma to hack in loading of partials to test modals