### PR TITLE
Move ChannelCount triggers to using an insert/delete approach

### DIFF
--- a/temba/channels/migrations/0021_auto_20150803_1857.py
+++ b/temba/channels/migrations/0021_auto_20150803_1857.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations, connection
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('channels', '0020_auto_20150714_0258'),
+    ]
+
+    def install_updated_increment(apps, schema_editor):
+        #language=SQL
+        update_trigger = """
+            CREATE OR REPLACE FUNCTION temba_decrement_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE) RETURNS VOID AS $$
+              BEGIN
+                INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
+                  VALUES(_channel_id, _count_type, _count_day, -1);
+                PERFORM temba_maybe_squash_channelcount(_channel_id, _count_type, _count_day);
+              END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE OR REPLACE FUNCTION temba_increment_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE) RETURNS VOID AS $$
+              BEGIN
+                INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
+                  VALUES(_channel_id, _count_type, _count_day, 1);
+                PERFORM temba_maybe_squash_channelcount(_channel_id, _count_type, _count_day);
+              END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE OR REPLACE FUNCTION temba_maybe_squash_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE) RETURNS VOID AS $$
+              DECLARE
+               current_count INT;
+              BEGIN
+                IF RANDOM() < .01 THEN
+                  IF _count_day IS NULL THEN
+                    WITH D as (DELETE FROM channels_channelcount
+                      WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" IS NULL
+                      RETURNING "count")
+                      INSERT INTO channels_channelcount("channel_id", "count_type", "count")
+                      VALUES (_channel_id, _count_type, GREATEST(0, (SELECT SUM("count") FROM D)));
+                  ELSE
+                    WITH D as (DELETE FROM channels_channelcount
+                      WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" = _count_day
+                      RETURNING "count")
+                      INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
+                      VALUES (_channel_id, _count_type, _count_day, GREATEST(0, (SELECT SUM("count") FROM D)));
+                  END IF;
+                END IF;
+              END;
+            $$ LANGUAGE plpgsql;
+        """
+        cursor = connection.cursor()
+        cursor.execute(update_trigger)
+
+    operations = [
+        migrations.AlterUniqueTogether(
+           name='channelcount',
+           unique_together=set([]),
+        ),
+        migrations.AlterIndexTogether(
+           name='channelcount',
+           index_together=set([('channel', 'count_type', 'day')]),
+        ),
+        migrations.RunPython(
+           install_updated_increment,
+        ),
+    ]

--- a/temba/channels/migrations/0021_auto_20150803_1857.py
+++ b/temba/channels/migrations/0021_auto_20150803_1857.py
@@ -29,22 +29,20 @@ class Migration(migrations.Migration):
             $$ LANGUAGE plpgsql;
 
             CREATE OR REPLACE FUNCTION temba_maybe_squash_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE) RETURNS VOID AS $$
-              DECLARE
-               current_count INT;
               BEGIN
-                IF RANDOM() < .01 THEN
+                IF RANDOM() < .005 THEN
                   IF _count_day IS NULL THEN
-                    WITH D as (DELETE FROM channels_channelcount
+                    WITH removed as (DELETE FROM channels_channelcount
                       WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" IS NULL
                       RETURNING "count")
                       INSERT INTO channels_channelcount("channel_id", "count_type", "count")
-                      VALUES (_channel_id, _count_type, GREATEST(0, (SELECT SUM("count") FROM D)));
+                      VALUES (_channel_id, _count_type, GREATEST(0, (SELECT SUM("count") FROM removed)));
                   ELSE
-                    WITH D as (DELETE FROM channels_channelcount
+                    WITH removed as (DELETE FROM channels_channelcount
                       WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" = _count_day
                       RETURNING "count")
                       INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
-                      VALUES (_channel_id, _count_type, _count_day, GREATEST(0, (SELECT SUM("count") FROM D)));
+                      VALUES (_channel_id, _count_type, _count_day, GREATEST(0, (SELECT SUM("count") FROM removed)));
                   END IF;
                 END IF;
               END;

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1842,9 +1842,18 @@ class ChannelCount(models.Model):
     count = models.IntegerField(default=0,
                                 help_text=_("The count of messages on this day and type"))
 
-    class Meta:
-        unique_together = ('channel', 'day', 'count_type')
+    @classmethod
+    def get_day_count(cls, channel, count_type, day):
+        count = ChannelCount.objects.filter(channel=channel, count_type=count_type, day=day).\
+          order_by('day', 'count_type').aggregate(count_sum=Sum('count'))
 
+        return 0 if not count else count['count_sum']
+
+    def __unicode__(self):
+        return "ChannelCount(%d) %s %s count: %d" % (self.channel_id, self.count_type, self.day, self.count)
+
+    class Meta:
+        index_together = ['channel', 'count_type', 'day']
 
 class SendException(Exception):
 


### PR DESCRIPTION
Switches to using INSERT and DELETE operations and squashing counts every ~100 inserts or so.