### PR TITLE
Various optimizations that make flow exports 10x faster

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -22,7 +22,7 @@ from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User, Group
 from django.db import models, transaction
-from django.db.models import Q, Count
+from django.db.models import Q, Count, Sum
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _, ungettext_lazy as _n
 from django.utils.html import escape
@@ -36,6 +36,7 @@ from temba.msgs.models import Broadcast, Msg, FLOW, INBOX, OUTGOING, STOP_WORDS,
 from temba.orgs.models import Org, Language, UNREAD_FLOW_MSGS, CURRENT_EXPORT_VERSION
 from temba.temba_email import send_temba_email
 from temba.utils import get_datetime_format, str_to_datetime, datetime_to_str, analytics
+from temba.utils.profiler import SegmentProfiler
 from temba.utils.cache import get_cacheable
 from temba.utils.models import TembaModel
 from temba.utils.queues import push_task
@@ -1170,24 +1171,9 @@ class Flow(TembaModel, SmartModel):
         return get_cacheable(cache_key, FLOW_PROP_CACHE_TTL, lambda: [rs.uuid for rs in self.rule_sets.all()])
 
     def get_columns(self):
-        runs = self.steps().filter(step_type=RULE_SET).exclude(rule_uuid=None).order_by('run').values('run').annotate(count=Count('run')).order_by('-count').first()
         node_order = []
-        existing = set()
-
-        if runs:
-            busiest_run = runs['run']
-            steps = self.steps().filter(run=busiest_run, step_type=RULE_SET).exclude(rule_uuid=None).order_by('arrived_on', 'pk')
-
-            for step in steps:
-                if step.step_uuid not in existing:
-                    existing.add(step.step_uuid)
-                    ruleset = RuleSet.get(step.run.flow, step.step_uuid)
-                    if ruleset:
-                        node_order.append(ruleset)
-
-        # add any nodes that weren't visited by this contact at the end
         for ruleset in RuleSet.objects.filter(flow=self).exclude(label=None).order_by('pk'):
-            if ruleset.uuid not in existing:
+            if ruleset.uuid:
                 node_order.append(ruleset)
 
         return node_order
@@ -3085,22 +3071,32 @@ class FlowRun(models.Model):
         return msg
 
 
-class MemorySavingQuerysetIterator(object):
+class FlowStepIterator(object):
     """
     Queryset wrapper to chunk queries and reduce in-memory footprint
     """
-    def __init__(self, queryset, max_obj_num=1000):
-        self._base_queryset = queryset
+    def __init__(self, ids, order_by=None, select_related=None, prefetch_related=None, max_obj_num=1000):
+        self._ids = ids
+        self._order_by = order_by
+        self._select_related = select_related
+        self._prefetch_related = prefetch_related
         self._generator = self._setup()
         self.max_obj_num = max_obj_num
 
     def _setup(self):
-        for i in xrange(0, self._base_queryset.count(), self.max_obj_num):
-            # By making a copy of of the queryset and using that to actually access
-            # the objects we ensure that there are only `max_obj_num` objects in
-            # memory at any given time
-            smaller_queryset = copy.deepcopy(self._base_queryset)[i:i+self.max_obj_num]
-            for obj in smaller_queryset.iterator():
+        for i in xrange(0, len(self._ids), self.max_obj_num):
+            chunk_queryset = FlowStep.objects.filter(id__in=self._ids[i:i+self.max_obj_num])
+
+            if self._order_by:
+                chunk_queryset = chunk_queryset.order_by(*self._order_by)
+
+            if self._select_related:
+                chunk_queryset = chunk_queryset.select_related(*self._select_related)
+
+            if self._prefetch_related:
+                chunk_queryset = chunk_queryset.prefetch_related(*self._prefetch_related)
+
+            for obj in chunk_queryset:
                 yield obj
 
     def __iter__(self):
@@ -3148,8 +3144,9 @@ class ExportFlowResultsTask(SmartModel):
         # merge the columns for all of our flows
         columns = []
         flows = self.flows.all()
-        for flow in flows:
-            columns += flow.get_columns()
+        with SegmentProfiler("get columns"):
+            for flow in flows:
+                columns += flow.get_columns()
 
         org = None
         if flows:
@@ -3171,51 +3168,53 @@ class ExportFlowResultsTask(SmartModel):
         # build a cache of rule uuid to category name, we want to use the most recent name the user set
         # if possible and back down to the cached rule_category only when necessary
         category_map = dict()
-        for ruleset in RuleSet.objects.filter(flow__in=flows).select_related('flow'):
-            for rule in ruleset.get_rules():
-                category_map[rule.uuid] = rule.get_category_name(ruleset.flow.base_language)
 
-        all_steps = FlowStep.objects.filter(run__flow__in=flows, step_type=RULE_SET)
-        all_steps = all_steps.order_by('contact', 'run', 'arrived_on', 'pk').select_related('run', 'contact').prefetch_related('messages')
+        with SegmentProfiler("rule uuid to category to name"):
+            for ruleset in RuleSet.objects.filter(flow__in=flows).select_related('flow'):
+                for rule in ruleset.get_rules():
+                    category_map[rule.uuid] = rule.get_category_name(ruleset.flow.base_language)
+
+        with SegmentProfiler("calculate all steps"):
+            all_steps = FlowStep.objects.filter(run__flow__in=flows, step_type=RULE_SET)\
+                                        .order_by('contact', 'run', 'arrived_on', 'pk')
 
         # count of unique flow runs
-        all_runs_count = all_steps.values('run').distinct().count()
+        with SegmentProfiler("# of runs"):
+            all_runs_count = all_steps.values('run').distinct().count()
 
         # count of unique contacts
-        contacts_count = all_steps.values('contact').distinct().count()
+        with SegmentProfiler("# of contacts"):
+            contacts_count = all_steps.values('contact').distinct().count()
 
-        # first add the needed sheets in order
-        # predicted by the counts we have
-        runs_sheets = []
-        total_all_runs_sheet_count = 0
+        # grab the ids for all our steps so we don't have to ever calculate them again
+        with SegmentProfiler("calculate step ids"):
+            all_steps = FlowStep.objects.filter(run__flow__in=flows)\
+                                        .order_by('contact', 'run', 'arrived_on', 'pk')\
+                                        .values('id')
+            step_ids = [s['id'] for s in all_steps]
+
+        # build our sheets
+        run_sheets = []
+        total_run_sheet_count = 0
 
         # the full sheets we need for runs
-        for i in range(all_runs_count / max_rows):
-            total_all_runs_sheet_count += 1
-            sheet = book.add_sheet("Runs (%d)" % total_all_runs_sheet_count, cell_overwrite_ok=True)
-            runs_sheets.append(sheet)
+        for i in range(all_runs_count / max_rows + 1):
+            total_run_sheet_count += 1
+            name = "Runs" if (i+1) <= 1 else "Runs (%d)" % (i+1)
+            sheet = book.add_sheet(name, cell_overwrite_ok=True)
+            run_sheets.append(sheet)
 
-        # some extra runs add an extra sheet for those
-        if all_runs_count % max_rows != 0 or all_runs_count == 0:
-            total_all_runs_sheet_count += 1
-            sheet = book.add_sheet("Runs (%d)" % total_all_runs_sheet_count, cell_overwrite_ok=True)
-            runs_sheets.append(sheet)
-
-        total_merged_runs_sheet_count = 0
+        total_merged_run_sheet_count = 0
 
         # the full sheets we need for contacts
-        for i in range(contacts_count / max_rows):
-            total_merged_runs_sheet_count += 1
-            sheet = book.add_sheet("Contacts (%d)" % total_merged_runs_sheet_count, cell_overwrite_ok=True)
-            runs_sheets.append(sheet)
+        for i in range(contacts_count / max_rows + 1):
+            total_merged_run_sheet_count += 1
+            name = "Contacts" if (i+1) <= 1 else "Contacts (%d)" % (i+1)
+            sheet = book.add_sheet(name, cell_overwrite_ok=True)
+            run_sheets.append(sheet)
 
-        # extra sheet if more contacts
-        if contacts_count % max_rows != 0 or contacts_count == 0:
-            total_merged_runs_sheet_count += 1
-            sheet = book.add_sheet("Contacts (%d)" % total_merged_runs_sheet_count, cell_overwrite_ok=True)
-            runs_sheets.append(sheet)
-
-        for sheet in runs_sheets:
+        # then populate their header columns
+        for sheet in run_sheets:
             # build up our header row
             sheet.write(0, 0, "Phone")
             sheet.write(0, 1, "Name")
@@ -3238,156 +3237,171 @@ class ExportFlowResultsTask(SmartModel):
                 sheet.col(5+col*3+1).width = 15 * 256
                 sheet.col(5+col*3+2).width = 15 * 256
 
-        row = 0
+        run_row = 0
         merged_row = 0
+        msg_row = 0
+
         latest = None
         earliest = None
 
         last_run = 0
         last_contact = None
 
-        # initial sheet to write to
-        # one for all runs and the
-        all_runs_sheet_index = 0
-        merged_runs_sheet_index = total_all_runs_sheet_count
+        # index of sheets that we are currently writing to
+        run_sheet_index = 0
+        merged_run_sheet_index = total_run_sheet_count
+        msg_sheet_index = 0
 
-        all_runs = book.get_sheet(all_runs_sheet_index)
-        merged_runs = book.get_sheet(merged_runs_sheet_index)
+        # get our initial runs and merged runs to write to
+        runs = book.get_sheet(run_sheet_index)
+        merged_runs = book.get_sheet(merged_run_sheet_index)
+        msgs = None
 
-        for run_step in MemorySavingQuerysetIterator(all_steps):
+        processed_steps = 0
+        total_steps = len(step_ids)
+        start = time.time()
+        flow_names = ", ".join([f['name'] for f in self.flows.values('name')])
+
+        for run_step in FlowStepIterator(step_ids,
+                                         order_by=['contact', 'run', 'arrived_on', 'pk'],
+                                         select_related=['run', 'contact'],
+                                         prefetch_related=['messages', 'messages__channel', 'contact__all_groups']):
+
+            processed_steps += 1
+            if processed_steps % 10000 == 0:
+                print "Export of %s - %d%% complete in %0.2fs" % \
+                      (flow_names, processed_steps * 100 / total_steps, time.time() - start)
+
             # skip over test contacts
             if run_step.contact.is_test:
                 continue
 
-            if last_contact != run_step.contact.pk:
-                if merged_row % 1000 == 0:
-                    merged_runs.flush_row_data()
-                merged_row += 1
+            # if this is a rule step, write out the value collected
+            if run_step.step_type == RULE_SET:
 
-                if merged_row > max_rows:
-                    # get the next sheet to use for Contacts
-                    merged_row = 1
-                    merged_runs_sheet_index += 1
-                    merged_runs = book.get_sheet(merged_runs_sheet_index)
+                if last_contact != run_step.contact.pk:
+                    if merged_row % 1000 == 0:
+                        merged_runs.flush_row_data()
 
-            # a new run
-            if last_run != run_step.run.pk:
-                earliest = None
-                latest = None
+                    merged_row += 1
 
-                if row % 1000 == 0:
-                    all_runs.flush_row_data()
+                    if merged_row > max_rows:
+                        # get the next sheet to use for Contacts
+                        merged_row = 1
+                        merged_run_sheet_index += 1
+                        merged_runs = book.get_sheet(merged_run_sheet_index)
 
-                row += 1
+                # a new run
+                if last_run != run_step.run.pk:
+                    earliest = None
+                    latest = None
 
-                if row > max_rows:
-                    # get the next sheet to use for Runs
-                    row = 1
-                    all_runs_sheet_index += 1
-                    all_runs = book.get_sheet(all_runs_sheet_index)
+                    if run_row % 1000 == 0:
+                        runs.flush_row_data()
 
-                all_runs.write(row, 0, run_step.contact.get_urn_display(org=org, scheme=TEL_SCHEME, full=True))
-                all_runs.write(row, 1, run_step.contact.name)
-                all_runs.write(row, 2, run_step.contact.groups_as_text())
+                    run_row += 1
 
-                merged_runs.write(merged_row, 0, run_step.contact.get_urn_display(org=org, scheme=TEL_SCHEME, full=True))
-                merged_runs.write(merged_row, 1, run_step.contact.name)
-                merged_runs.write(merged_row, 2, run_step.contact.groups_as_text())
+                    if run_row > max_rows:
+                        # get the next sheet to use for Runs
+                        run_row = 1
+                        run_sheet_index += 1
+                        runs = book.get_sheet(run_sheet_index)
 
-            if not latest or latest < run_step.arrived_on:
-                latest = run_step.arrived_on
+                    # build up our group names
+                    group_names = []
+                    for group in run_step.contact.all_groups.all():
+                        if group.group_type == ContactGroup.TYPE_USER_DEFINED:
+                            group_names.append(group.name)
 
-            if not earliest or earliest > run_step.arrived_on:
-                earliest = run_step.arrived_on
+                    group_names.sort()
+                    groups = ", ".join(group_names)
 
-            if earliest:
-                all_runs.write(row, 3, as_org_tz(earliest), date_format)
-                merged_runs.write(merged_row, 3, as_org_tz(earliest), date_format)
+                    runs.write(run_row, 0, run_step.contact.get_urn_display(org=org, scheme=TEL_SCHEME, full=True))
+                    runs.write(run_row, 1, run_step.contact.name)
+                    runs.write(run_row, 2, groups)
 
-            if latest:
-                all_runs.write(row, 4, as_org_tz(latest), date_format)
-                merged_runs.write(merged_row, 4, as_org_tz(latest), date_format)
+                    merged_runs.write(merged_row, 0, run_step.contact.get_urn_display(org=org, scheme=TEL_SCHEME, full=True))
+                    merged_runs.write(merged_row, 1, run_step.contact.name)
+                    merged_runs.write(merged_row, 2, groups)
 
-            # write the step data
-            col = column_map.get(run_step.step_uuid, 0)
-            if col:
-                category = category_map.get(run_step.rule_uuid, None)
-                if category:
-                    all_runs.write(row, col, category)
-                    merged_runs.write(merged_row, col, category)
-                elif run_step.rule_category:
-                    all_runs.write(row, col, run_step.rule_category)
-                    merged_runs.write(merged_row, col, run_step.rule_category)
+                if not latest or latest < run_step.arrived_on:
+                    latest = run_step.arrived_on
 
-                value = run_step.rule_value
-                if value:
-                    all_runs.write(row, col+1, value)
-                    merged_runs.write(merged_row, col+1, value)
+                if not earliest or earliest > run_step.arrived_on:
+                    earliest = run_step.arrived_on
 
-                text = run_step.get_text()
-                if text:
-                    all_runs.write(row, col+2, text)
-                    merged_runs.write(merged_row, col+2, text)
+                if earliest:
+                    runs.write(run_row, 3, as_org_tz(earliest), date_format)
+                    merged_runs.write(merged_row, 3, as_org_tz(earliest), date_format)
 
-            last_run = run_step.run.pk
-            last_contact = run_step.contact.pk
+                if latest:
+                    runs.write(run_row, 4, as_org_tz(latest), date_format)
+                    merged_runs.write(merged_row, 4, as_org_tz(latest), date_format)
 
-        row = 1
-        sheet_count = 0
+                # write the step data
+                col = column_map.get(run_step.step_uuid, 0)
+                if col:
+                    category = category_map.get(run_step.rule_uuid, None)
+                    if category:
+                        runs.write(run_row, col, category)
+                        merged_runs.write(merged_row, col, category)
+                    elif run_step.rule_category:
+                        runs.write(run_row, col, run_step.rule_category)
+                        merged_runs.write(merged_row, col, run_step.rule_category)
 
-        all_steps = FlowStep.objects.filter(run__flow__in=flows).order_by('run', 'arrived_on', 'pk')
-        all_steps = all_steps.select_related('run', 'contact').prefetch_related('messages')
+                    value = run_step.rule_value
+                    if value:
+                        runs.write(run_row, col+1, value)
+                        merged_runs.write(merged_row, col+1, value)
 
-        # now print out all the raw messages
-        all_messages = None
-        for step in MemorySavingQuerysetIterator(all_steps):
-            if step.contact.is_test:
-                continue
+                    text = run_step.get_text()
+                    if text:
+                        runs.write(run_row, col+2, text)
+                        merged_runs.write(merged_row, col+2, text)
 
-            # if the step has no message to display and no ivr action
-            if not step.get_text():
-                continue
+                last_run = run_step.run.pk
+                last_contact = run_step.contact.pk
 
-            if row > max_rows or not all_messages:
-                row = 1
-                sheet_count += 1
+            # write out any message associated with this step
+            if run_step.get_text():
+                msg_row += 1
 
-                name = "SMS"
-                if sheet_count > 1:
-                    name = "SMS (%d)" % sheet_count
+                if msg_row % 1000 == 0:
+                    msgs.flush_row_data()
 
-                all_messages = book.add_sheet(name)
+                if msg_row > max_rows or not msgs:
+                    msg_row = 1
+                    msg_sheet_index += 1
 
-                all_messages.write(0, 0, "Phone")
-                all_messages.write(0, 1, "Name")
-                all_messages.write(0, 2, "Date")
-                all_messages.write(0, 3, "Direction")
-                all_messages.write(0, 4, "Message")
-                all_messages.write(0, 5, "Channel")
+                    name = "Messages" if (msg_sheet_index+1) <= 1 else "Messages (%d)" % (msg_sheet_index+1)
+                    msgs = book.add_sheet(name)
 
-                all_messages.col(0).width = small_width
-                all_messages.col(1).width = medium_width
-                all_messages.col(2).width = medium_width
-                all_messages.col(3).width = small_width
-                all_messages.col(4).width = large_width
-                all_messages.col(5).width = small_width
+                    msgs.write(0, 0, "Phone")
+                    msgs.write(0, 1, "Name")
+                    msgs.write(0, 2, "Date")
+                    msgs.write(0, 3, "Direction")
+                    msgs.write(0, 4, "Message")
+                    msgs.write(0, 5, "Channel")
 
-            all_messages.write(row, 0, step.contact.get_urn_display(org=org, scheme=TEL_SCHEME, full=True))
-            all_messages.write(row, 1, step.contact.name)
-            arrived_on = as_org_tz(step.arrived_on)
+                    msgs.col(0).width = small_width
+                    msgs.col(1).width = medium_width
+                    msgs.col(2).width = medium_width
+                    msgs.col(3).width = small_width
+                    msgs.col(4).width = large_width
+                    msgs.col(5).width = small_width
 
-            all_messages.write(row, 2, arrived_on, date_format)
-            if step.step_type == RULE_SET:
-                all_messages.write(row, 3, "IN")
-            else:
-                all_messages.write(row, 3, "OUT")
+                msgs.write(msg_row, 0, run_step.contact.get_urn_display(org=org, scheme=TEL_SCHEME, full=True))
+                msgs.write(msg_row, 1, run_step.contact.name)
+                arrived_on = as_org_tz(run_step.arrived_on)
 
-            all_messages.write(row, 4, step.get_text())
-            all_messages.write(row, 5, step.get_channel_name())
-            row += 1
+                msgs.write(msg_row, 2, arrived_on, date_format)
+                if run_step.step_type == RULE_SET:
+                    msgs.write(msg_row, 3, "IN")
+                else:
+                    msgs.write(msg_row, 3, "OUT")
 
-            if row % 1000 == 0:
-                all_messages.flush_row_data()
+                msgs.write(msg_row, 4, run_step.get_text())
+                msgs.write(msg_row, 5, run_step.get_channel_name())
 
         temp = NamedTemporaryFile(delete=True)
         book.save(temp)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -145,6 +145,11 @@ class RuleTest(TembaTest):
         self.assertTrue('mutable' in response.context)
 
     def test_states(self):
+        # make sure to delete any old exports
+        from shutil import rmtree
+        export_dir = "%s/test_orgs/%d/results_exports/" % (settings.MEDIA_ROOT, self.org.pk)
+        rmtree(export_dir, ignore_errors=True)
+
         # set our flow
         self.flow.update(self.definition)
 

--- a/temba/perf_tests.py
+++ b/temba/perf_tests.py
@@ -178,21 +178,21 @@ class PerformanceTest(TembaTest):  # pragma: no cover
     def test_contact_create(self):
         num_contacts = 1000
 
-        with SegmentProfiler("Creating new contacts", self):
+        with SegmentProfiler("Creating new contacts", self, force_profile=True):
             self._create_contacts(num_contacts, ["Bobby"])
 
-        with SegmentProfiler("Updating existing contacts", self):
+        with SegmentProfiler("Updating existing contacts", self, force_profile=True):
             self._create_contacts(num_contacts, ["Jimmy"])
 
     def test_message_incoming(self):
         num_contacts = 300
 
-        with SegmentProfiler("Creating incoming messages from new contacts", self, False):
+        with SegmentProfiler("Creating incoming messages from new contacts", self, False, force_profile=True):
             for c in range(0, num_contacts):
                 scheme, path, channel = self.urn_generators[c % len(self.urn_generators)](c)
                 Msg.create_incoming(channel, (scheme, path), "Thanks #1", self.user)
 
-        with SegmentProfiler("Creating incoming messages from existing contacts", self, False):
+        with SegmentProfiler("Creating incoming messages from existing contacts", self, False, force_profile=True):
             for c in range(0, num_contacts):
                 scheme, path, channel = self.urn_generators[c % len(self.urn_generators)](c)
                 Msg.create_incoming(channel, (scheme, path), "Thanks #2", self.user)
@@ -209,7 +209,7 @@ class PerformanceTest(TembaTest):  # pragma: no cover
 
         broadcast = self._create_broadcast("Hello message #1", contacts)
 
-        with SegmentProfiler("Sending broadcast to new contacts", self, True):
+        with SegmentProfiler("Sending broadcast to new contacts", self, True, force_profile=True):
             broadcast.send()
 
         # give all contact URNs an assigned channel as if they've been used for incoming
@@ -225,12 +225,12 @@ class PerformanceTest(TembaTest):  # pragma: no cover
 
         broadcast = self._create_broadcast("Hello message #2", contacts)
 
-        with SegmentProfiler("Sending broadcast when urns have channels", self, True):
+        with SegmentProfiler("Sending broadcast when urns have channels", self, True, force_profile=True):
             broadcast.send()
 
         broadcast = self._create_broadcast("Hello =contact #3", contacts)
 
-        with SegmentProfiler("Sending broadcast with expression", self, True):
+        with SegmentProfiler("Sending broadcast with expression", self, True, force_profile=True):
             broadcast.send()
 
         # check messages for each channel
@@ -253,7 +253,7 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         task = ExportMessagesTask.objects.create(org=self.org, host='rapidpro.io',
                                                  created_by=self.user, modified_by=self.user)
 
-        with SegmentProfiler("Export messages", self, True):
+        with SegmentProfiler("Export messages", self, True, force_profile=True):
             task.do_export()
 
     def test_flow_start(self):
@@ -261,7 +261,7 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         groups = self._create_groups(10, ["Bobbys", "Jims", "Marys"], contacts)
         flow = self.create_flow()
 
-        with SegmentProfiler("Starting a flow", self, True):
+        with SegmentProfiler("Starting a flow", self, True, force_profile=True):
             flow.start(groups, [])
 
         self.assertEqual(10000, Msg.objects.all().count())
@@ -276,13 +276,13 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         self.clear_cache()
 
         with SegmentProfiler("Fetch first page of contacts from API", self,
-                             assert_queries=API_INITIAL_REQUEST_QUERIES+7, assert_tx=0):
+                             assert_queries=API_INITIAL_REQUEST_QUERIES+7, assert_tx=0, force_profile=True):
             self._fetch_json('%s.json' % reverse('api.contacts'))
 
         # query count now cached
 
         with SegmentProfiler("Fetch second page of contacts from API", self,
-                             assert_queries=API_REQUEST_QUERIES+6, assert_tx=0):
+                             assert_queries=API_REQUEST_QUERIES+6, assert_tx=0, force_profile=True):
             self._fetch_json('%s.json?page=2' % reverse('api.contacts'))
 
     def test_api_groups(self):
@@ -293,7 +293,7 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         self.clear_cache()
 
         with SegmentProfiler("Fetch first page of groups from API", self,
-                             assert_queries=API_INITIAL_REQUEST_QUERIES+2, assert_tx=0):
+                             assert_queries=API_INITIAL_REQUEST_QUERIES+2, assert_tx=0, force_profile=True):
             self._fetch_json('%s.json' % reverse('api.contactgroups'))
 
     def test_api_messages(self):
@@ -307,13 +307,13 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         self.clear_cache()
 
         with SegmentProfiler("Fetch first page of messages from API", self,
-                             assert_queries=API_INITIAL_REQUEST_QUERIES+3, assert_tx=0):
+                             assert_queries=API_INITIAL_REQUEST_QUERIES+3, assert_tx=0, force_profile=True):
             self._fetch_json('%s.json' % reverse('api.messages'))
 
         # query count now cached
 
         with SegmentProfiler("Fetch second page of messages from API", self,
-                             assert_queries=API_REQUEST_QUERIES+2, assert_tx=0):
+                             assert_queries=API_REQUEST_QUERIES+2, assert_tx=0, force_profile=True):
             self._fetch_json('%s.json?page=2' % reverse('api.messages'))
 
     def test_api_runs(self):
@@ -325,16 +325,16 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         self.clear_cache()
 
         with SegmentProfiler("Fetch first page of flow runs from API", self,
-                             assert_queries=API_INITIAL_REQUEST_QUERIES+7, assert_tx=0):
+                             assert_queries=API_INITIAL_REQUEST_QUERIES+7, assert_tx=0, force_profile=True):
             self._fetch_json('%s.json' % reverse('api.runs'))
 
         # query count, terminal nodes and category nodes for the flow all now cached
 
         with SegmentProfiler("Fetch second page of flow runs from API", self,
-                             assert_queries=API_REQUEST_QUERIES+4, assert_tx=0):
+                             assert_queries=API_REQUEST_QUERIES+4, assert_tx=0, force_profile=True):
             self._fetch_json('%s.json?page=2' % reverse('api.runs'))
 
-        with SegmentProfiler("Create new flow runs via API endpoint", self, assert_tx=1):
+        with SegmentProfiler("Create new flow runs via API endpoint", self, assert_tx=1, force_profile=True):
             data = {'flow': flow.pk, 'contact': [c.uuid for c in contacts]}
             self._post_json('%s.json' % reverse('api.runs'), data)
 
@@ -344,20 +344,20 @@ class PerformanceTest(TembaTest):  # pragma: no cover
 
         self.login(self.user)
 
-        with SegmentProfiler("Omnibox with telephone search", self):
+        with SegmentProfiler("Omnibox with telephone search", self, force_profile=True):
             self._fetch_json("%s?search=078" % reverse("contacts.contact_omnibox"))
 
     def test_contact_search(self):
         contacts = self._create_contacts(10000, ["Bobby", "Jimmy", "Mary"])
         self._create_values(contacts, self.field_nick, lambda c: c.name.lower().replace(' ', '_'))
 
-        with SegmentProfiler("Contact search with simple query", self):
+        with SegmentProfiler("Contact search with simple query", self, force_profile=True):
             qs, is_complex = Contact.search(self.org, 'bob')
 
         self.assertEqual(3334, qs.count())
         self.assertEqual(False, is_complex)
 
-        with SegmentProfiler("Contact search with complex query", self):
+        with SegmentProfiler("Contact search with complex query", self, force_profile=True):
             qs, is_complex = Contact.search(self.org, 'name = bob or tel has 078 or twitter = tweep_123 or nick is bob')
 
         self.assertEqual(3377, qs.count())
@@ -368,12 +368,12 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         contacts = self._create_contacts(num_contacts, ["Bobby", "Jimmy", "Mary"])
         groups = self._create_groups(10, ["Big Group"], contacts)
 
-        with SegmentProfiler("Contact group counts via regular queries", self):
+        with SegmentProfiler("Contact group counts via regular queries", self, force_profile=True):
             for group in groups:
                 self.assertEqual(group.contacts.count(), num_contacts)
                 self.assertEqual(group.contacts.count(), num_contacts)
 
-        with SegmentProfiler("Contact group counts with caching", self):
+        with SegmentProfiler("Contact group counts with caching", self, force_profile=True):
             for group in groups:
                 self.assertEqual(group.get_member_count(), num_contacts)
                 self.assertEqual(group.get_member_count(), num_contacts)
@@ -396,16 +396,16 @@ class PerformanceTest(TembaTest):  # pragma: no cover
 
         self.login(self.user)
 
-        with SegmentProfiler("Contact list page", self):
+        with SegmentProfiler("Contact list page", self, force_profile=True):
             self.client.get(reverse('contacts.contact_list'))
 
-        with SegmentProfiler("Contact list page (repeat)", self):
+        with SegmentProfiler("Contact list page (repeat)", self, force_profile=True):
             self.client.get(reverse('contacts.contact_list'))
 
-        with SegmentProfiler("Message inbox page", self):
+        with SegmentProfiler("Message inbox page", self, force_profile=True):
             self.client.get(reverse('msgs.msg_inbox'))
 
-        with SegmentProfiler("Message inbox page (repeat)", self):
+        with SegmentProfiler("Message inbox page (repeat)", self, force_profile=True):
             self.client.get(reverse('msgs.msg_inbox'))
 
     def test_channellog(self):
@@ -414,7 +414,7 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         msg = dict_to_struct('MockMsg', msg.as_task_json())
 
 
-        with SegmentProfiler("Channel Log inserts (10,000)", self):
+        with SegmentProfiler("Channel Log inserts (10,000)", self, force_profile=True):
             for i in range(10000):
                 ChannelLog.log_success(msg, "Sent Message", method="GET", url="http://foo",
                                        request="GET http://foo", response="Ok", response_status="201")

--- a/temba/utils/profiler.py
+++ b/temba/utils/profiler.py
@@ -1,0 +1,82 @@
+from django.conf import settings
+from django.db import connection, reset_queries
+from timeit import default_timer
+from temba.utils import truncate
+
+MAX_QUERIES_PRINT = 16
+API_INITIAL_REQUEST_QUERIES = 9  # num of required db hits for an initial API request
+API_REQUEST_QUERIES = 7  # num of required db hits for a subsequent API request
+
+class SegmentProfiler(object):  # pragma: no cover
+    """
+    Used in a with block to profile a segment of code
+    """
+    def __init__(self, name, test=None, db_profile=True, assert_queries=None, assert_tx=None):
+        self.name = name
+
+        self.test = test
+        if self.test:
+            self.test.segments.append(self)
+
+        self.db_profile = db_profile
+        self.assert_queries = assert_queries
+        self.assert_tx = assert_tx
+
+        self.old_debug = settings.DEBUG
+
+        self.time_total = 0.0
+        self.time_queries = 0.0
+        self.queries = []
+
+    def __enter__(self):
+        if self.db_profile:
+            settings.DEBUG = True
+            reset_queries()
+
+        self.start_time = default_timer()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.time_total = default_timer() - self.start_time
+
+        if self.db_profile:
+            settings.DEBUG = self.old_debug
+            self.queries = connection.queries
+            self.num_tx = len([q for q in self.queries if q['sql'].startswith('SAVEPOINT')])
+
+            reset_queries()
+
+            # assert number of queries if specified
+            if self.test and self.assert_queries is not None:
+                self.test.assertEqual(len(self.queries), self.assert_queries)
+
+            # assert number of transactions if specified
+            if self.test and self.assert_tx is not None:
+                self.test.assertEqual(self.num_tx, self.assert_tx)
+
+        if not self.test:
+            print unicode(self)
+
+    def __unicode__(self):
+        def format_query(q):
+            return "Query [%s] %.3f secs" % (truncate(q['sql'], 75), float(q['time']))
+
+        message = "Segment [%s] time: %.3f secs" % (self.name, self.time_total)
+        if self.db_profile:
+            num_queries = len(self.queries)
+            time_db = sum([float(q['time']) for q in self.queries])
+
+            message += ", %.3f secs db time, %d db queries, %d transaction(s)" % (time_db, num_queries, self.num_tx)
+
+            # if we have only have a few queries, include them all in order of execution
+            if len(self.queries) <= MAX_QUERIES_PRINT:
+                message += ":"
+                for query in self.queries:
+                    message += "\n\t%s" % format_query(query)
+            # if there are too many, only include slowest in order of duration
+            else:
+                message += ". %d slowest:" % MAX_QUERIES_PRINT
+                slowest = sorted(list(self.queries), key=lambda q: float(q['time']), reverse=True)[:MAX_QUERIES_PRINT]
+                for query in slowest:
+                    message += "\n\t%s" % format_query(query)
+
+        return message


### PR DESCRIPTION
Biggest wins were that the "MemorySavingQuerySet" was actually refiring the rather expensive query every 1000 records.. we now cache the ids and load 1,000 records at once which is a huge savings.

Also optimized the select_related and prefetch_related so that we only do two queries per batch of 1,000.

Sum results is we should be able to do 600k exports in ~30mins with much more friendly DB characteristics.