### PR TITLE
Fix timezone for clickatell, tweaks to event firing

### DIFF
--- a/temba/api/channels.py
+++ b/temba/api/channels.py
@@ -1085,9 +1085,9 @@ class ClickatellHandler(View):
                 # return 200 as clickatell pings our endpoint during configuration
                 return HttpResponse("Missing one of 'from', 'text', 'moMsgId' or 'timestamp' in request parameters.", status=200)
 
-            # dates come in the format "2014-04-18 03:54:20" GMT
+            # dates come in the format "2014-04-18 03:54:20" GMT+2
             sms_date = datetime.strptime(request.REQUEST['timestamp'], '%Y-%m-%d %H:%M:%S')
-            gmt_date = pytz.timezone('GMT').localize(sms_date)
+            gmt_date = pytz.timezone('Europe/Berlin').localize(sms_date)
             text = request.REQUEST['text']
 
             # clickatell will sometimes send us UTF-16BE encoded data which is double encoded, we need to turn

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -3747,6 +3747,9 @@ class ClickatellTest(TembaTest):
         self.assertEquals(self.channel, msg1.channel)
         self.assertEquals("Hello World", msg1.text)
         self.assertEquals(2012, msg1.created_on.year)
+
+        # times are sent as GMT+2
+        self.assertEquals(8, msg1.created_on.hour)
         self.assertEquals('id1234', msg1.external_id)
 
     def test_status(self):

--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -32,18 +32,19 @@ def process_message_task(msg_id, from_mage=False, new_contact=False):
 
     # get a lock on this contact, we process messages one by one to prevent odd behavior in flow processing
     key = 'pcm_%d' % msg.contact_id
-    with r.lock(key, timeout=60):
-        print "[%09d] Processing - %s" % (msg.id, msg.text)
-        start = time.time()
+    if not r.get(key):
+        with r.lock(key, timeout=120):
+            print "M[%09d] Processing - %s" % (msg.id, msg.text)
+            start = time.time()
 
-        # if message was created in Mage...
-        if from_mage:
-            mage_handle_new_message(msg.org, msg)
-            if new_contact:
-                mage_handle_new_contact(msg.org, msg.contact)
+            # if message was created in Mage...
+            if from_mage:
+                mage_handle_new_message(msg.org, msg)
+                if new_contact:
+                    mage_handle_new_contact(msg.org, msg.contact)
 
-        Msg.process_message(msg)
-        print "[%09d] %08.3f s - %s" % (msg.id, time.time() - start, msg.text)
+            Msg.process_message(msg)
+            print "M[%09d] %08.3f s - %s" % (msg.id, time.time() - start, msg.text)
 
 @task(track_started=True, name='send_broadcast')
 def send_broadcast_task(broadcast_id):
@@ -224,10 +225,16 @@ def handle_event_task():
 
     elif event_task['type'] == FIRE_EVENT:
         # use a lock to make sure we don't do two at once somehow
-        with r.lock('fire_campaign_%s' % event_task['id'], timeout=120):
-            event = EventFire.objects.filter(pk=event_task['id'], fired=None).first()
-            if event:
-                event.fire()
+        key = 'fire_campaign_%s' % event_task['id']
+        if not r.get(key):
+            with r.lock(key, timeout=120):
+                event = EventFire.objects.filter(pk=event_task['id'], fired=None)\
+                                         .select_related('event', 'event__campaign', 'event__campaign__org').first()
+                if event:
+                    print "E[%09d] Firing for org: %s" % (event.id, event.event.campaign.org.name)
+                    start = time.time()
+                    event.fire()
+                    print "E[%09d] %08.3f s" % (event.id, time.time() - start)
 
     else:
         raise Exception("Unexpected event type: %s" % event_task)


### PR DESCRIPTION
Turns out clickatell sends their timezone-less timestamps as GMT+2.. ya, that makes sense.

Also wedged in some tweaks to the tasks for handling trigger events and messages, that we weren't checking for the lock was causing our workers to stack up when things went sideways. (like when redis runs out of room as it did earlier)