### PR TITLE
Add timeouts for redis connections in celery

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -907,6 +907,10 @@ REDIS_PORT = 6379
 REDIS_DB = 10 if TESTING else 15
 
 BROKER_URL = 'redis://%s:%d/%d' % (REDIS_HOST, REDIS_PORT, REDIS_DB)
+
+# by default, celery doesn't have any timeout on our redis connections, this fixes that
+BROKER_TRANSPORT_OPTIONS = {'socket_timeout': 5}
+
 CELERY_RESULT_BACKEND = BROKER_URL
 
 IS_PROD = False


### PR DESCRIPTION
See: https://github.com/celery/celery/issues/2741

Did some digging and pretty sure the occasional celery hang is due to our redis connections having a hiccup and celery not recovering. Looks like this timeout should fix that.