### PR TITLE
Cache a user's API token to avoid repeat DB hits

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -18,7 +18,7 @@ from temba.orgs.models import Org
 from temba.channels.models import Channel, TEMBA_HEADERS
 from temba.msgs.models import CALL_OUT, CALL_OUT_MISSED, CALL_IN, CALL_IN_MISSED
 from temba.utils import datetime_to_str, prepped_request_to_str
-from temba.utils.cache import get_obj_cacheable
+from temba.utils.cache import get_cacheable_attr
 from urllib import urlencode
 
 PENDING = 'P'
@@ -523,7 +523,7 @@ def api_token(user):
     """
     Cached property access to a user's lazily-created API token
     """
-    return get_obj_cacheable(user, '__api_token', lambda: get_or_create_api_token(user))
+    return get_cacheable_attr(user, '__api_token', lambda: get_or_create_api_token(user))
 
 
 User.api_token = property(api_token)

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -193,7 +193,9 @@ class APITest(TembaTest):
 
         # login as administrator
         self.login(self.admin)
-        token = self.admin.api_token()  # generates token for the user
+        token = self.admin.api_token  # generates token for the user
+        self.assertIsInstance(token, basestring)
+        self.assertEqual(len(token), 40)
 
         # browse as HTML
         response = self.fetchHTML(url)
@@ -271,13 +273,13 @@ class APITest(TembaTest):
         self.login(self.admin)
 
         # test that this user has a token
-        self.assertTrue(self.admin.api_token())
+        self.assertTrue(self.admin.api_token)
 
         # blow it away
         Token.objects.all().delete()
 
         # should create one lazily
-        self.assertTrue(self.admin.api_token())
+        self.assertTrue(self.admin.api_token)
 
         # browse endpoint as HTML docs
         response = self.fetchHTML(url)

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -197,6 +197,9 @@ class APITest(TembaTest):
         self.assertIsInstance(token, basestring)
         self.assertEqual(len(token), 40)
 
+        with self.assertNumQueries(0):  # subsequent lookup of token comes from cache
+            self.assertEqual(self.admin.api_token, token)
+
         # browse as HTML
         response = self.fetchHTML(url)
         self.assertContains(response, token, status_code=200)  # displays their API token

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -894,7 +894,7 @@ class OrgCRUDLTest(TembaTest):
         self.assertTrue(user.check_password("HelloWorld1"))
 
         # user should be able to get a token
-        self.assertTrue(user.api_token())
+        self.assertTrue(user.api_token)
 
         # should have an org
         org = Org.objects.get(name="Relieves World")

--- a/temba/utils/cache.py
+++ b/temba/utils/cache.py
@@ -30,7 +30,7 @@ def get_cacheable_result(cache_key, cache_ttl, callable, r=None, force_dirty=Fal
     return int(get_cacheable(cache_key, cache_ttl, callable, r=r, force_dirty=force_dirty))
 
 
-def get_obj_cacheable(obj, attr_name, calculate):
+def get_cacheable_attr(obj, attr_name, calculate):
     """
     Gets the result of a method call, using the given object and attribute name
     as a cache

--- a/temba/utils/cache.py
+++ b/temba/utils/cache.py
@@ -30,6 +30,20 @@ def get_cacheable_result(cache_key, cache_ttl, callable, r=None, force_dirty=Fal
     return int(get_cacheable(cache_key, cache_ttl, callable, r=r, force_dirty=force_dirty))
 
 
+def get_obj_cacheable(obj, attr_name, calculate):
+    """
+    Gets the result of a method call, using the given object and attribute name
+    as a cache
+    """
+    if hasattr(obj, attr_name):
+        return getattr(obj, attr_name)
+
+    calculated = calculate()
+    setattr(obj, attr_name, calculated)
+
+    return calculated
+
+
 def incrby_existing(key, delta, r=None):
     """
     Update a existing integer value in the cache. If value doesn't exist, nothing happens. If value has a TTL, then that

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -12,7 +12,7 @@ from mock import patch
 from redis_cache import get_redis_connection
 from temba.contacts.models import Contact
 from temba.tests import TembaTest
-from .cache import get_cacheable_result, get_obj_cacheable, incrby_existing
+from .cache import get_cacheable_result, get_cacheable_attr, incrby_existing
 from .queues import pop_task, push_task, HIGH_PRIORITY, LOW_PRIORITY
 from .parser import EvaluationError, EvaluationContext, evaluate_template, evaluate_expression, set_evaluation_context, get_function_listing
 from .parser_functions import *
@@ -173,13 +173,13 @@ class CacheTest(TembaTest):
         with self.assertNumQueries(0):
             self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 2)  # from cache
 
-    def test_get_obj_cacheable(self):
+    def test_get_cacheable_attr(self):
         def calculate():
             return "CALCULATED"
 
-        self.assertEqual(get_obj_cacheable(self, '_test_value', calculate), "CALCULATED")
+        self.assertEqual(get_cacheable_attr(self, '_test_value', calculate), "CALCULATED")
         self._test_value = "CACHED"
-        self.assertEqual(get_obj_cacheable(self, '_test_value', calculate), "CACHED")
+        self.assertEqual(get_cacheable_attr(self, '_test_value', calculate), "CACHED")
 
     def test_incrby_existing(self):
         r = get_redis_connection()

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -12,7 +12,7 @@ from mock import patch
 from redis_cache import get_redis_connection
 from temba.contacts.models import Contact
 from temba.tests import TembaTest
-from .cache import get_cacheable_result, incrby_existing
+from .cache import get_cacheable_result, get_obj_cacheable, incrby_existing
 from .queues import pop_task, push_task, HIGH_PRIORITY, LOW_PRIORITY
 from .parser import EvaluationError, EvaluationContext, evaluate_template, evaluate_expression, set_evaluation_context, get_function_listing
 from .parser_functions import *
@@ -147,6 +147,7 @@ class InitTest(TembaTest):
         # any invalid timezones should return ""
         self.assertEqual('', timezone_to_country_code('Nyamirambo'))
 
+
 class CacheTest(TembaTest):
 
     def test_get_cacheable_result(self):
@@ -171,6 +172,14 @@ class CacheTest(TembaTest):
             self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 2)  # from db
         with self.assertNumQueries(0):
             self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 2)  # from cache
+
+    def test_get_obj_cacheable(self):
+        def calculate():
+            return "CALCULATED"
+
+        self.assertEqual(get_obj_cacheable(self, '_test_value', calculate), "CALCULATED")
+        self._test_value = "CACHED"
+        self.assertEqual(get_obj_cacheable(self, '_test_value', calculate), "CACHED")
 
     def test_incrby_existing(self):
         r = get_redis_connection()


### PR DESCRIPTION
Removes ~50 db hits from the API explorer page where it is repeatedly referenced in the template.