### PR TITLE
Optimizations for the runs endpoint

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -570,10 +570,17 @@ class APITest(TembaTest):
         response = self.postJSON(url, dict(flow_uuid=flow.uuid, contact=contact.uuid))
         self.assertEquals(201, response.status_code)
 
-        # now fetch them instead...
+        # now test fetching them instead.....
+
+        # no filtering
         response = self.fetchJSON(url)
         self.assertEquals(200, response.status_code)
         self.assertResultCount(response, 9)  # all the runs
+
+        flow.start([], [Contact.get_test_contact(self.user)])  # create a run for a test contact
+
+        response = self.fetchJSON(url)
+        self.assertResultCount(response, 9)  # test contact's run not included
 
         # filter by run id
         response = self.fetchJSON(url, "run=%d" % run.pk)

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -2184,11 +2184,15 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
 
         steps_prefetch = Prefetch('steps', queryset=FlowStep.objects.order_by('arrived_on'))
 
+        msgs_prefetch = Prefetch('steps__messages')
+
         rulesets_prefetch = Prefetch('flow__rule_sets',
                                      queryset=RuleSet.objects.exclude(label=None).order_by('pk'),
                                      to_attr='ruleset_prefetch')
 
-        return queryset.select_related('contact', 'flow').prefetch_related(steps_prefetch, rulesets_prefetch).order_by('-created_on')
+        queryset = queryset.select_related('contact', 'flow')
+        queryset = queryset.prefetch_related(steps_prefetch, msgs_prefetch, rulesets_prefetch)
+        return queryset.order_by('-pk')
 
     @classmethod
     def get_read_explorer(cls):

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -2134,19 +2134,45 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
                         status=status.HTTP_400_BAD_REQUEST)
 
     def get_queryset(self):
-        queryset = self.model.objects.filter(flow__org=self.request.user.get_org(), contact__is_test=False)
+        org = self.request.user.get_org()
+        queryset = self.model.objects.all()
+
+        contact_uuids = splitting_getlist(self.request, 'contact')
+        contact_phones = splitting_getlist(self.request, 'phone')  # deprecated
+
+        # subquery on contacts to avoid join - if we're querying for specific contacts
+        if contact_uuids or contact_phones:
+            include_contacts = Contact.objects.filter(org=org, is_test=False, is_active=True)
+
+            if contact_uuids:
+                include_contacts = include_contacts.filter(uuid__in=contact_uuids)
+
+            if contact_phones:
+                include_contacts = include_contacts.filter(urns__path__in=contact_phones)
+
+            queryset = queryset.filter(contact__in=include_contacts)
+        else:
+            test_contacts = Contact.objects.filter(org=org, is_test=True)
+            queryset = queryset.exclude(contact__in=test_contacts)
+
+        # subquery on flows to avoid join
+        include_flows = Flow.objects.filter(org=org, is_active=True)
+
+        flow_ids = splitting_getlist(self.request, 'flow')  # deprecated, use flow_uuid
+        if flow_ids:
+            include_flows = include_flows.filter(pk__in=flow_ids)
+
+        flow_uuids = splitting_getlist(self.request, 'flow_uuid')
+        if flow_uuids:
+            include_flows = include_flows.filter(uuid__in=flow_uuids)
+
+        queryset = queryset.filter(flow__in=include_flows)
+
+        # other queries on the runs themselves...
 
         runs = splitting_getlist(self.request, 'run')
         if runs:
             queryset = queryset.filter(pk__in=runs)
-
-        flows = splitting_getlist(self.request, 'flow')  # deprecated, use flow_uuid
-        if flows:
-            queryset = queryset.filter(flow__pk__in=flows)
-
-        flow_uuids = splitting_getlist(self.request, 'flow_uuid')
-        if flow_uuids:
-            queryset = queryset.filter(flow__uuid__in=flow_uuids)
 
         before = self.request.QUERY_PARAMS.get('before', None)
         if before:
@@ -2164,9 +2190,7 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
             except:
                 queryset = queryset.filter(pk=-1)
 
-        phones = splitting_getlist(self.request, 'phone')  # deprecated
-        if phones:
-            queryset = queryset.filter(contact__urns__path__in=phones)
+        # it's faster to filter by contact group using a join than a subquery - especially for larger groups
 
         groups = splitting_getlist(self.request, 'group')  # deprecated, use group_uuids
         if groups:
@@ -2178,20 +2202,15 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
             queryset = queryset.filter(contact__all_groups__uuid__in=group_uuids,
                                        contact__all_groups__group_type=ContactGroup.TYPE_USER_DEFINED)
 
-        contacts = splitting_getlist(self.request, 'contact')
-        if contacts:
-            queryset = queryset.filter(contact__uuid__in=contacts)
-
         steps_prefetch = Prefetch('steps', queryset=FlowStep.objects.order_by('arrived_on'))
-
-        msgs_prefetch = Prefetch('steps__messages')
 
         rulesets_prefetch = Prefetch('flow__rule_sets',
                                      queryset=RuleSet.objects.exclude(label=None).order_by('pk'),
                                      to_attr='ruleset_prefetch')
 
-        queryset = queryset.select_related('contact', 'flow')
-        queryset = queryset.prefetch_related(steps_prefetch, msgs_prefetch, rulesets_prefetch)
+        # use prefetch rather than select_related for foreign keys flow/contact to avoid joins
+        queryset = queryset.prefetch_related('flow', rulesets_prefetch, steps_prefetch, 'steps__messages', 'contact')
+
         return queryset.order_by('-pk')
 
     @classmethod

--- a/temba/perf_tests.py
+++ b/temba/perf_tests.py
@@ -161,6 +161,13 @@ class PerformanceTest(TembaTest):  # pragma: no cover
             contact = contacts[c % len(contacts)]
             runs.append(FlowRun.create(flow, contact, db_insert=False))
         FlowRun.objects.bulk_create(runs)
+
+        # add a step to each run
+        steps = []
+        for run in FlowRun.objects.all():
+            steps.append(FlowStep(run=run, contact=run.contact, step_type='R', step_uuid=flow.entry_uuid, arrived_on=timezone.now()))
+        FlowStep.objects.bulk_create(steps)
+
         return runs
 
     def _fetch_json(self, url):


### PR DESCRIPTION
* Prefetch step messages to avoid repeat fetches
* Use subqueries to filter by flow and contact where possible to avoid large joins