### PR TITLE
Populate flowrun orgs and modified_on

### DIFF
--- a/temba/flows/migrations/0028_populate_flowrun_orgs.py
+++ b/temba/flows/migrations/0028_populate_flowrun_orgs.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0027_auto_20150820_2030'),
+    ]
+
+    def populate_flowrun_orgs(apps, schema_editor):
+        Org = apps.get_model('orgs', 'Org')
+        FlowRun = apps.get_model('flows', 'FlowRun')
+
+        for org in Org.objects.all():
+            FlowRun.objects.filter(flow__org=org).update(org_id=org.id)
+
+    operations = [
+        migrations.RunPython(populate_flowrun_orgs),
+    ]

--- a/temba/flows/migrations/0029_populate_run_modified_on.py
+++ b/temba/flows/migrations/0029_populate_run_modified_on.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.models import F
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0028_populate_flowrun_orgs'),
+    ]
+
+    def populate_flowrun_modified_on(apps, schema_editor):
+        FlowRun = apps.get_model('flows', 'FlowRun')
+
+        # update all flow runs that have already expired, their modified on is their expired on
+        FlowRun.objects.exclude(expired_on=None).update(modified_on=F('expired_on'))
+
+        # the rest will be determined based on their last step
+        updated = 0
+        for run in FlowRun.objects.filter(modified_on=None):
+            latest_step = run.steps.order_by('-arrived_on').first()
+            if latest_step:
+                run.modified_on = latest_step.arrived_on
+            else:
+                run.modified_on = run.created_on
+            run.save()
+
+            updated += 1
+            if updated % 1000:
+                print "  Updated %d runs" % updated
+
+    operations = [
+        migrations.RunPython(populate_flowrun_modified_on),
+    ]


### PR DESCRIPTION
These two rather long data migrations take care of populating both orgs on flow runs and modified_on.