### PR TITLE
Transaction handling

### DIFF
--- a/media/test_flows/exception.json
+++ b/media/test_flows/exception.json
@@ -1,0 +1,61 @@
+{
+  "version": 5, 
+  "flows": [
+    {
+      "definition": {
+        "base_language": "eng", 
+        "action_sets": [
+          {
+            "y": 0, 
+            "x": 100, 
+            "destination": null, 
+            "uuid": "b83f6247-379c-4a73-a28a-c11530acf1bc", 
+            "actions": [
+              {
+                "msg": {
+                  "eng": "You are now part of the group!"
+                }, 
+                "type": "reply"
+              }, 
+              {
+                "type": "add_group", 
+                "groups": [
+                  {
+                    "name": "Exceptions", 
+                    "id": 40746
+                  }
+                ]
+              }, 
+              {
+                "field": "name", 
+                "type": "save", 
+                "value": "Exception!", 
+                "label": "Contact Name"
+              }
+            ]
+          }
+        ], 
+        "last_saved": "2015-08-20T15:41:46.225385Z", 
+        "entry": "b83f6247-379c-4a73-a28a-c11530acf1bc", 
+        "rule_sets": [], 
+        "metadata": {}
+      }, 
+      "expires": 10080, 
+      "id": 35389, 
+      "flow_type": "F", 
+      "name": "Exception Flow"
+    }
+  ], 
+  "triggers": [
+    {
+      "trigger_type": "K", 
+      "flow": {
+        "name": "Exception Flow", 
+        "id": 35389
+      }, 
+      "groups": [], 
+      "keyword": "exception", 
+      "channel": null
+    }
+  ]
+}

--- a/media/test_flows/exception.json
+++ b/media/test_flows/exception.json
@@ -27,10 +27,10 @@
                 ]
               }, 
               {
-                "field": "name", 
+                "field": "nickname",
                 "type": "save", 
                 "value": "Exception!", 
-                "label": "Contact Name"
+                "label": "Contact Nickname"
               }
             ]
           }

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3569,7 +3569,8 @@ class HandlingExceptionTest(FlowFileTest):
                 # and that our message is scheduled to be queued in the future
                 self.assertTrue(msg1.queued_on > timezone.now())
 
-    test_handling_exception.active = True
+                # and that there is no outgoing mesage
+                self.assertFalse(Msg.objects.filter(direction=OUTGOING))
 
 class WebhookLoopTest(FlowFileTest):
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3513,6 +3513,25 @@ class DuplicateValueTest(FlowFileTest):
         value = Value.objects.get(run=run)
         self.assertEquals("Red", value.category)
 
+class HandlingExceptionTest(FlowFileTest):
+
+    def test_handling_exception(self):
+        # this flow has three main actions:
+        # 1) sends a message
+        # 2) adds the contact to a group
+        # 3) updates the contact's name
+        flow = self.get_flow('exception')
+
+        # we want to make sure that none of those take place if the third action blows up
+
+        # patch contact update_value to blow up
+        with patch('requests.get') as mock:
+
+        msg1 = Msg.create_incoming(self.channel, self.contact.get_urn(), "exception")
+
+
+    test_handling_exception.active = True
+
 
 class WebhookLoopTest(FlowFileTest):
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -891,7 +891,7 @@ class Msg(models.Model):
 
         return handled
 
-    def handle(self, delay=0):
+    def handle(self):
         if self.direction == OUTGOING:
             raise ValueError(ugettext("Cannot process an outgoing message."))
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -875,7 +875,7 @@ class Msg(models.Model):
 
         return handled
 
-    def handle(self):
+    def handle(self, delay=0):
         if self.direction == OUTGOING:
             raise ValueError(ugettext("Cannot process an outgoing message."))
 


### PR DESCRIPTION
Runs our incoming message handling within an atomic transaction, so that in the case of error everything gets rolled back and we can try again later.

This change also will cause those errors in message handling to appear in sentry as they are no longer trapped by process_message.