### PR TITLE
Allow Kannel connections to not verify SSL certificates

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -59,6 +59,7 @@ USERNAME = 'username'
 PASSWORD = 'password'
 KEY = 'key'
 API_ID = 'api_id'
+VERIFY_SSL = 'verify_ssl'
 
 SEND = 'S'
 RECEIVE = 'R'
@@ -831,7 +832,10 @@ class Channel(SmartModel):
         start = time.time()
 
         try:
-            response = requests.get(channel.config[SEND_URL], params=payload, timeout=15)
+            if channel.config.get(VERIFY_SSL, True):
+                response = requests.get(channel.config[SEND_URL], verify=True, params=payload, timeout=15)
+            else:
+                response = requests.get(channel.config[SEND_URL], verify=False, params=payload, timeout=15)
         except Exception as e:
             payload['password'] = 'x' * len(payload['password'])
             raise SendException(unicode(e),

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1718,6 +1718,7 @@ class ChannelAlertTest(TembaTest):
         post_data['number'] = '3071'
         post_data['country'] = 'RW'
         post_data['url'] = 'http://kannel.temba.com/cgi-bin/sendsms'
+        post_data['verify_ssl'] = False
 
         response = self.client.post(reverse('channels.channel_claim_kannel'), post_data)
 
@@ -1727,6 +1728,7 @@ class ChannelAlertTest(TembaTest):
         self.assertTrue(channel.uuid)
         self.assertEquals(post_data['number'], channel.address)
         self.assertEquals(post_data['url'], channel.config_json()['send_url'])
+        self.assertEquals(False, channel.config_json()['verify_ssl'])
 
         # make sure we generated a username and password
         self.assertTrue(channel.config_json()['username'])

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -35,7 +35,7 @@ from twilio import TwilioRestException
 from twython import Twython
 from uuid import uuid4
 from .models import Channel, SyncEvent, Alert, ChannelLog, ChannelCount
-from .models import PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, PLIVO, BLACKMYNA, SMSCENTRAL
+from .models import PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, PLIVO, BLACKMYNA, SMSCENTRAL, VERIFY_SSL
 from .models import PASSWORD, RECEIVE, SEND, CALL, ANSWER, SEND_METHOD, SEND_URL, USERNAME, CLICKATELL, HIGH_CONNECTION
 from .models import ANDROID, EXTERNAL, HUB9, INFOBIP, KANNEL, NEXMO, TWILIO, TWITTER, VUMI, VERBOICE, SHAQODOON
 
@@ -955,6 +955,8 @@ class ChannelCRUDL(SmartCRUDL):
                                        help_text=_("The username to use to authenticate to Kannel, if left blank we will generate one for you"))
             password = forms.CharField(max_length=64, required=False,
                                        help_text=_("The password to use to authenticate to Kannel, if left blank we will generate one for you"))
+            verify_ssl = forms.BooleanField(initial=True, required=False, label=_("Verify SSL"),
+                                            help_text=_("Whether to verify the SSL connection (recommended)"))
 
         title = _("Connect Kannel Service")
         success_url = "id@channels.channel_configuration"
@@ -969,7 +971,8 @@ class ChannelCRUDL(SmartCRUDL):
             number = data['number']
             role = SEND + RECEIVE
 
-            config = {SEND_URL: url, USERNAME: data.get('username', None), PASSWORD: data.get('password', None)}
+            config = {SEND_URL: url, VERIFY_SSL: data.get('verify_ssl'),
+                      USERNAME: data.get('username', None), PASSWORD: data.get('password', None)}
             self.object = Channel.add_config_external_channel(org, self.request.user, country, number, KANNEL,
                                                               config, role=role, parent=None)
 


### PR DESCRIPTION
Since a lot of aggregators use Kannel and a lot of aggregators aren't terribly good at configuring SSL, give the option of ignoring verification on SSL certs.