### PR TITLE
Update event fires properly on campaign group changes

### DIFF
--- a/media/test_imports/farmers.csv
+++ b/media/test_imports/farmers.csv
@@ -1,0 +1,1 @@
+phone,name,planting_date250788111111,Rob Jasper,10-08-2020 12:30:10250788222222,Mike Gordon,15-08-2020 12:30:10

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -349,6 +349,7 @@ class CampaignEvent(SmartModel):
     def __unicode__(self):
         return "%s == %d -> %s" % (self.relative_to, self.offset, self.flow)
 
+
 class EventFire(Model):
     event = models.ForeignKey('campaigns.CampaignEvent', related_name="event_fires",
                               help_text="The event that will be fired")
@@ -388,6 +389,11 @@ class EventFire(Model):
         Updates all the scheduled events for each user for the passed in campaign.
         Should be called anytime a campaign changes.
         """
+        from temba.campaigns.tasks import update_event_fires_for_campaign
+        update_event_fires_for_campaign.delay(campaign.pk)
+
+    @classmethod
+    def do_update_campaign_events(cls, campaign):
         for contact in campaign.group.contacts.exclude(is_test=True):
             cls.update_campaign_events_for_contact(campaign, contact)
 

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -256,6 +256,90 @@ class ScheduleTest(TembaTest):
         response = self.client.get(reverse('campaigns.campaign_read', args=[campaign.pk]))
         self.assertNotContains(response, "Color Flow")
 
+    def test_deleting_reimport_contact_groups(self):
+        campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
+
+        # create a reminder for our first planting event
+        planting_reminder = CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
+                                                            offset=3, unit='D', flow=self.reminder_flow)
+
+        self.assertEquals(0, EventFire.objects.all().count())
+        self.farmer1.set_field('planting_date', "10-05-2020 12:30:10")
+        self.farmer2.set_field('planting_date', "15-05-2020 12:30:10")
+
+        # now we have event fires accordingly
+        self.assertEquals(2, EventFire.objects.all().count())
+
+        # farmer one fire
+        scheduled = EventFire.objects.get(contact=self.farmer1, event=planting_reminder).scheduled
+        self.assertEquals("13-5-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+
+        # farmer two fire
+        scheduled = EventFire.objects.get(contact=self.farmer2, event=planting_reminder).scheduled
+        self.assertEquals("18-5-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+
+        # delete our farmers group
+        self.farmers.release()
+
+        # this should have removed all the event fires for that group
+        self.assertEquals(0, EventFire.objects.filter(event=planting_reminder).count())
+
+        # and our group is no longer active
+        self.assertFalse(campaign.group.is_active)
+
+        # now import the group again
+        filename = 'farmers.csv'
+        extra_fields = [dict(key='planting_date', header='planting_date', label='Planting Date', type='D')]
+        import_params = dict(org_id=self.org.id, timezone=self.org.timezone, extra_fields=extra_fields, original_filename=filename)
+
+        from temba.contacts.models import ImportTask, Contact
+        import json
+        task = ImportTask.objects.create(
+            created_by=self.admin, modified_by=self.admin,
+            csv_file='test_imports/' + filename,
+            model_class="Contact", import_params=json.dumps(import_params), import_log="", task_id="A")
+        Contact.import_csv(task, log=None)
+
+        # check that we have new planting dates
+        self.farmer1 = Contact.objects.get(pk=self.farmer1.pk)
+        self.farmer2 = Contact.objects.get(pk=self.farmer2.pk)
+
+        planting = self.farmer1.get_field('planting_date').datetime_value
+        self.assertEquals("10-8-2020", "%s-%s-%s" % (planting.day, planting.month, planting.year))
+
+        planting = self.farmer2.get_field('planting_date').datetime_value
+        self.assertEquals("15-8-2020", "%s-%s-%s" % (planting.day, planting.month, planting.year))
+
+        # now update the campaign
+        from temba.contacts.models import ContactGroup
+        self.farmers = ContactGroup.user_groups.get(name='Farmers', is_active=True)
+        self.login(self.admin)
+        post_data = dict(name="Planting Reminders", group=self.farmers.pk)
+        self.client.post(reverse('campaigns.campaign_update', args=[campaign.pk]), post_data)
+
+        # should have two fresh new fires
+        self.assertEquals(2, EventFire.objects.all().count())
+
+        # check their new planting dates
+        scheduled = EventFire.objects.get(contact=self.farmer1, event=planting_reminder).scheduled
+        self.assertEquals("13-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+
+        # farmer two fire
+        scheduled = EventFire.objects.get(contact=self.farmer2, event=planting_reminder).scheduled
+        self.assertEquals("18-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+
+        # give our non farmer a planting date
+        self.nonfarmer.set_field('planting_date', "20-05-2020 12:30:10")
+
+        # now update to the non-farmer group
+        self.nonfarmers = self.create_group("Not Farmers", [self.nonfarmer])
+        post_data = dict(name="Planting Reminders", group=self.nonfarmers.pk)
+        self.client.post(reverse('campaigns.campaign_update', args=[campaign.pk]), post_data)
+
+        # only one fire for the non-farmer the previous two should be deleted by the group change
+        self.assertEquals(1, EventFire.objects.all().count())
+        self.assertEquals(1, EventFire.objects.filter(contact=self.nonfarmer).count())
+
     def test_scheduling(self):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1541,6 +1541,10 @@ class ContactGroup(TembaModel, SmartModel):
         self.save()
         self.contacts.clear()
 
+        # delete any event fires related to our group
+        from temba.campaigns.models import EventFire
+        EventFire.objects.filter(event__campaign__group=self, fired=None).delete()
+
         Value.invalidate_cache(group=self)
 
     @property

--- a/templates/campaigns/campaign_read.haml
+++ b/templates/campaigns/campaign_read.haml
@@ -11,9 +11,12 @@
       {{title}}
     %h5
       .icon-users-2
-      Events for the
-      %a{href:"{% url 'contacts.contact_filter' object.group.pk %}"}= object.group.name
-      group
+      -if object.group.is_active
+        Events for the
+        %a{href:"{% url 'contacts.contact_filter' object.group.pk %}"}= object.group.name
+        group
+      -else
+        -trans "No group assigned to this campaign"
 
 -block content
   -if not object.events.all
@@ -21,7 +24,7 @@
       %body
         %tr.empty_list
           %td
-            No events in this campaign yet.
+            -trans "No events in this campaign yet."
 
   -else
     %table.events


### PR DESCRIPTION
* Check when updating a campaign if the group changes, if so update it's fires
* Remove any unfired fires when deleting a group
* Run update fires for campaign in celery
* Don't show inactive groups on campaign read page