### PR TITLE
When Twitter returns 403/404, contact should be failed permanently 

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -2827,6 +2827,7 @@ class VumiTest(TembaTest):
         self.channel.save()
 
         joe = self.create_contact("Joe", "+250788383383")
+        reporters = self.create_group("Reporters", [joe])
         bcast = joe.send("Test message", self.admin, trigger_send=False)
 
         # our outgoing sms
@@ -2905,9 +2906,10 @@ class VumiTest(TembaTest):
                 self.assertTrue(msg.next_attempt < timezone.now())
                 self.assertEquals(1, mock.call_count)
 
-                # could should now be failed as well
+                # could should now be failed as well and in no groups
                 joe = Contact.objects.get(id=joe.id)
                 self.assertTrue(joe.is_failed)
+                self.assertFalse(ContactGroup.user_groups.filter(contacts=joe))
 
         finally:
             settings.SEND_MESSAGES = False

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -4006,6 +4006,8 @@ class TwitterTest(TembaTest):
         self.channel.save()
 
         joe = self.create_contact("Joe", number="+250788383383", twitter="joe1981")
+        testers = self.create_group("Testers", [joe])
+
         bcast = joe.send("Test message", self.admin, trigger_send=False)
 
         # our outgoing message
@@ -4059,6 +4061,11 @@ class TwitterTest(TembaTest):
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
+                # should not fail the contact
+                contact = Contact.objects.get(pk=joe.pk)
+                self.assertFalse(contact.is_failed)
+                self.assertEqual(contact.user_groups.count(), 1)
+
                 # should record the right error
                 self.assertTrue(ChannelLog.objects.get(msg=msg).description.find("Different 403 error") >= 0)
 
@@ -4069,19 +4076,43 @@ class TwitterTest(TembaTest):
                 # manually send it off
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
-                # fail the message
+                # should fail the message
                 msg = bcast.get_messages()[0]
                 self.assertEquals(FAILED, msg.status)
                 self.assertEquals(2, msg.error_count)
 
-                # contact should be failed
+                # should fail the contact permanently (i.e. removed from groups)
                 contact = Contact.objects.get(pk=joe.pk)
                 self.assertTrue(contact.is_failed)
+                self.assertEqual(contact.user_groups.count(), 0)
+
+                self.clear_cache()
+
+            joe.is_failed = False
+            joe.save()
+            testers.update_contacts([joe], add=True)
+
+            with patch('twython.Twython.send_direct_message') as mock:
+                mock.side_effect = TwythonError("Sorry, that page does not exist.", error_code=404)
+
+                # manually send it off
+                Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
+
+                # should fail the message
+                msg = bcast.get_messages()[0]
+                self.assertEqual(msg.status, FAILED)
+                self.assertEqual(msg.error_count, 2)
+
+                # should fail the contact permanently (i.e. removed from groups)
+                contact = Contact.objects.get(pk=joe.pk)
+                self.assertTrue(contact.is_failed)
+                self.assertEqual(contact.user_groups.count(), 0)
 
                 self.clear_cache()
 
         finally:
             settings.SEND_MESSAGES = False
+
 
 class MageHandlerTest(TembaTest):
 

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1156,7 +1156,7 @@ class Channel(SmartModel):
 
             # if this is fatal due to the user opting out, fail this contact permanently
             if response.text and response.text.find('has opted out'):
-                Contact.objects.get(id=msg.contact).fail()
+                Contact.objects.get(id=msg.contact).fail(permanently=True)
 
             raise SendException("Got non-200 response [%d] from API" % response.status_code,
                                 method='PUT',

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1496,11 +1496,10 @@ class Channel(SmartModel):
             error_code = getattr(e, 'error_code', 400)
             fatal = False
 
-            # this handle doesn't exist anymore or we can't send to them, fail them
-            if error_code == 404 or \
-              (error_code == 403 and str(e).find('users who are not following you') >= 0):
+            # this handle doesn't exist anymore or we can't send to them, fail them permanently
+            if error_code == 404 or (error_code == 403 and str(e).find('users who are not following you') >= 0):
                 fatal = True
-                Contact.objects.get(id=msg.contact).fail()
+                Contact.objects.get(id=msg.contact).fail(permanently=True)
 
             raise SendException(str(e),
                                 'https://api.twitter.com/1.1/direct_messages/new.json',

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -852,15 +852,19 @@ class Contact(TembaModel, SmartModel):
         self.is_blocked = False
         self.save(update_fields=['is_blocked'])
 
-    def fail(self):
+    def fail(self, permanently=False):
         """
-        Fails this contact, provided it is currently normal
+        Fails this contact. If permanently then contact is removed from all groups.
         """
         if self.is_test:
             raise ValueError("Can't fail a test contact")
 
         self.is_failed = True
         self.save(update_fields=['is_failed'])
+
+        if permanently:
+            for group in self.user_groups.all():
+                group.update_contacts([self], False)
 
     def unfail(self):
         """


### PR DESCRIPTION
and removed from groups