### PR TITLE
Remove base turds

### DIFF
--- a/karma/flows/test_services.coffee
+++ b/karma/flows/test_services.coffee
@@ -139,6 +139,11 @@ describe 'Services:', ->
 
       flowService.deriveCategories(ruleset, 'eng')
 
+      console.log(ruleset._categories[0])
+      console.log(ruleset._categories[1])
+      console.log(ruleset._categories[2])
+      console.log(ruleset._categories[3])
+
       # we create a UI version of our rules
       expect(ruleset._categories).not.toBe(undefined)
 

--- a/karma/flows/test_services.coffee
+++ b/karma/flows/test_services.coffee
@@ -139,11 +139,6 @@ describe 'Services:', ->
 
       flowService.deriveCategories(ruleset, 'eng')
 
-      console.log(ruleset._categories[0])
-      console.log(ruleset._categories[1])
-      console.log(ruleset._categories[2])
-      console.log(ruleset._categories[3])
-
       # we create a UI version of our rules
       expect(ruleset._categories).not.toBe(undefined)
 

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -855,7 +855,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
 
     # localized category name
     if Flow.flow.base_language
-      ruleset.rules[0].category = { base:'All Responses' }
+      ruleset.rules[0].category = { _base:'All Responses' }
       ruleset.rules[0].category[Flow.flow.base_language] = 'All Responses'
 
   formData.rulesetConfig = Flow.getRulesetConfig({type:ruleset.ruleset_type})
@@ -950,23 +950,23 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
     if rule.test.type in ['date_before', 'date_after', 'date_equal']
       # relative dates formatted as: @date.today|time_delta:'n'
       # lets rip out the delta parameter and use it as our test instead
-      rule.test.base = rule.test.test.slice(24, -1)
+      rule.test._base = rule.test.test.slice(24, -1)
 
     # set the operands
     else if rule.test.type != "between"
 
       if flow.base_language and rule.test.test and rule._config.localized
-        rule.test.base = rule.test.test[flow.base_language]
+        rule.test._base = rule.test.test[flow.base_language]
       else
         rule.test =
-          base: rule.test.test
+          _base: rule.test.test
 
     # and finally the category name
     if flow.base_language
-      rule.category.base = rule.category[flow.base_language]
+      rule.category._base = rule.category[flow.base_language]
     else
       rule.category =
-        base: rule.category
+        _base: rule.category
 
   if window.ivr
     # prep our menu
@@ -977,7 +977,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
 
     for rule in $scope.ruleset.rules
 
-      num = parseInt(rule.test.base)
+      num = parseInt(rule.test._base)
       if num >= 0 and num <= 9
 
         # zero comes last on our keypad
@@ -1015,10 +1015,10 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
     categoryName = $scope.getDefaultCategory(rule)
 
     if rule.category
-      rule.category.base = categoryName
+      rule.category._base = categoryName
     else
       rule.category =
-        base: categoryName
+        _base: categoryName
 
   $scope.isVisibleOperator = (operator) ->
     if $scope.formData.rulesetConfig.type == 'wait_digits'
@@ -1048,8 +1048,8 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
   $scope.getDefaultCategory = (rule) ->
 
     categoryName = ''
-    if rule.test and rule.test.base
-      categoryName = rule.test.base.strip()
+    if rule.test and rule.test._base
+      categoryName = rule.test._base.strip()
 
     op = rule._config.type
     if op in ["between"]
@@ -1114,15 +1114,15 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
     complete = true
     for rule in $scope.ruleset.rules
       if not rule._config.operands == 0
-        if not rule.category or not rule.category.base
+        if not rule.category or not rule.category._base
           complete = false
           break
       else if rule._config.operands == 1
-        if not rule.category or not rule.category.base or not rule.test.base
+        if not rule.category or not rule.category._base or not rule.test._base
           complete = false
           break
       else if rule._config.operands == 2
-        if not rule.category or not rule.category.base or not rule.test.min or not rule.test.min
+        if not rule.category or not rule.category._base or not rule.test.min or not rule.test.min
           complete = false
           break
 
@@ -1134,7 +1134,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
           type: if window.ivr then "starts" else "contains_any"
         category:
           _autoName: true
-          base: ''
+          _base: ''
         _config: if window.ivr then Flow.getOperatorConfig('starts') else Flow.getOperatorConfig('contains_any')
   , true
 
@@ -1146,7 +1146,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
     # create rules off of an IVR menu configuration
     if ruleset.ruleset_type == 'wait_digit'
       for option in $scope.numbers
-        if option.category and option.category.base
+        if option.category and option.category._base
           if flow.base_language
             rule =
               uuid: option.uuid
@@ -1156,12 +1156,12 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
                 type: 'eq'
                 test: option.number
 
-            rule.category[flow.base_language] = option.category.base
+            rule.category[flow.base_language] = option.category._base
           else
             rule =
               uuid: option.uuid
               destination: option.destination
-              category: option.category.base
+              category: option.category._base
               test:
                 type: 'eq'
                 test: option.number
@@ -1177,31 +1177,31 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
           continue
 
         # between categories are not required, populate their category name
-        if (not rule.category or not rule.category.base) and rule._config.type == 'between' and rule.test.min and rule.test.max
+        if (not rule.category or not rule.category._base) and rule._config.type == 'between' and rule.test.min and rule.test.max
             rule.category =
-              base: rule.test.min + " - " + rule.test.max
+              _base: rule.test.min + " - " + rule.test.max
 
         # we'll always have an empty rule for new rule creation on the form
-        if not rule.category or rule.category.base.strip().length == 0
+        if not rule.category or (rule.category._base.strip().length == 0)
           continue
 
         rule.test.type = rule._config.type
 
         # add our time delta filter for our date operators
         if rule._config.type in ["date_before", "date_after", "date_equal"]
-          rule.test.test = "@date.today|time_delta:'" + rule.test.base + "'"
+          rule.test.test = "@date.today|time_delta:'" + rule.test._base + "'"
         else
           if flow.base_language and rule._config.localized
             if not rule.test.test
               rule.test.test = {}
-            rule.test.test[flow.base_language] = rule.test.base
+            rule.test.test[flow.base_language] = rule.test._base
           else
-            rule.test.test = rule.test.base
+            rule.test.test = rule.test._base
 
         if flow.base_language
-          rule.category[flow.base_language] = rule.category.base
+          rule.category[flow.base_language] = rule.category._base
         else
-          rule.category = rule.category.base
+          rule.category = rule.category._base
         if rule.category
           rules.push(rule)
 
@@ -1234,7 +1234,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
 
     # finally add it to the end of our rule list
     rules.push
-      config: Flow.getOperatorConfig("true")
+      _config: Flow.getOperatorConfig("true")
       test:
         test: "true"
         type: "true"
@@ -1247,78 +1247,80 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
   $scope.okRules = ->
 
     # close our dialog
-    $modalInstance.close ""
     stopWatching()
+    $modalInstance.close ""
 
-    # changes from the user
-    ruleset = $scope.ruleset
-    rulesetConfig = $scope.formData.rulesetConfig
-    contactField = $scope.formData.contactField
-    flowField = $scope.formData.flowField
+    $timeout ->
+      # changes from the user
+      ruleset = $scope.ruleset
+      rulesetConfig = $scope.formData.rulesetConfig
+      contactField = $scope.formData.contactField
+      flowField = $scope.formData.flowField
 
-    # save whatever ruleset type they are setting us to
-    ruleset.ruleset_type = rulesetConfig.type
+      # save whatever ruleset type they are setting us to
+      ruleset.ruleset_type = rulesetConfig.type
 
-    # settings for a message form
-    if rulesetConfig.type == 'form_field'
-      ruleset.operand = '@flow.' + flowField.id
-      ruleset.config =
-        field_index: $scope.formData.fieldIndex.id
-        field_delimiter: $scope.formData.fieldDelimiter.id
+      # settings for a message form
+      if rulesetConfig.type == 'form_field'
+        ruleset.operand = '@flow.' + flowField.id
+        ruleset.config =
+          field_index: $scope.formData.fieldIndex.id
+          field_delimiter: $scope.formData.fieldDelimiter.id
 
-    # update our operand if they selected a contact field explicitly
-    else if ruleset.ruleset_type == 'contact_field'
-      ruleset.operand = '@contact.' + contactField.id
+      # update our operand if they selected a contact field explicitly
+      else if ruleset.ruleset_type == 'contact_field'
+        ruleset.operand = '@contact.' + contactField.id
 
-    # or if they picked a flow field
-    else if ruleset.ruleset_type == 'flow_field'
-      ruleset.operand = '@flow.' + flowField.id
+      # or if they picked a flow field
+      else if ruleset.ruleset_type == 'flow_field'
+        ruleset.operand = '@flow.' + flowField.id
 
-    # or just want to evaluate against a message
-    else if ruleset.ruleset_type == 'wait_message'
-      ruleset.operand = '@step.value'
+      # or just want to evaluate against a message
+      else if ruleset.ruleset_type == 'wait_message'
+        ruleset.operand = '@step.value'
 
-    # clear our webhook if we aren't the right type
-    # TODO: this should live in a json config blog
-    if ruleset.ruleset_type != 'webhook'
-      ruleset.webhook = null
-      ruleset.webhook_action = null
+      # clear our webhook if we aren't the right type
+      # TODO: this should live in a json config blob
+      if ruleset.ruleset_type != 'webhook'
+        ruleset.webhook = null
+        ruleset.webhook_action = null
 
-    # update our rules accordingly
-    $scope.updateRules(ruleset, rulesetConfig)
+      # update our rules accordingly
+      $scope.updateRules(ruleset, rulesetConfig)
 
-    # unplumb any rules that were explicity removed
-    Plumb.disconnectRules($scope.removed)
+      # unplumb any rules that were explicity removed
+      Plumb.disconnectRules($scope.removed)
 
-    # switching from an actionset means removing it and hijacking its connections
-    connections = Plumb.getConnectionMap({ target: actionset.uuid })
-    if $scope.ruleset._switchedFromAction
-      Flow.removeActionSet($scope.actionset)
+      # switching from an actionset means removing it and hijacking its connections
+      connections = Plumb.getConnectionMap({ target: actionset.uuid })
+      if ruleset._switchedFromAction
+        Flow.removeActionSet($scope.actionset)
 
-    # save our new ruleset
-    Flow.replaceRuleset(ruleset, false)
+      # save our new ruleset
+      Flow.replaceRuleset(ruleset, false)
 
-    # remove any connections that shouldn't be allowed
-    for rule in $scope.ruleset.rules
-      if rule.destination and not Flow.isConnectionAllowed(ruleset.uuid + '_' + rule.uuid, rule.destination)
-        Flow.updateDestination($scope.ruleset.uuid + '_' + rule.uuid, null)
+      # remove any connections that shouldn't be allowed
+      for rule in ruleset.rules
+        if rule.destination and not Flow.isConnectionAllowed(ruleset.uuid + '_' + rule.uuid, rule.destination)
+          Flow.updateDestination($scope.ruleset.uuid + '_' + rule.uuid, null)
 
-    # steal the old connections if we are replacing an actionset with ourselves
-    if ruleset._switchedFromAction
-      $timeout ->
-        ruleset_uuid = ruleset.uuid
-        for source of connections
-          if Flow.isConnectionAllowed(source, ruleset_uuid)
-            Flow.updateDestination(source, ruleset_uuid)
-      ,0
+      # steal the old connections if we are replacing an actionset with ourselves
+      if ruleset._switchedFromAction
+        $timeout ->
+          ruleset_uuid = ruleset.uuid
+          for source of connections
+            if Flow.isConnectionAllowed(source, ruleset_uuid)
+              Flow.updateDestination(source, ruleset_uuid)
+        ,0
 
-    # link us up if necessary, we need to do this after our element is created
-    if $scope.options.dragSource
-      if Flow.isConnectionAllowed($scope.options.dragSource, ruleset.uuid)
-        Flow.updateDestination($scope.options.dragSource, ruleset.uuid)
+      # link us up if necessary, we need to do this after our element is created
+      if $scope.options.dragSource
+        if Flow.isConnectionAllowed($scope.options.dragSource, ruleset.uuid)
+          Flow.updateDestination($scope.options.dragSource, ruleset.uuid)
 
-    # finally, make sure we get saved
-    Flow.markDirty()
+      # finally, make sure we get saved
+      Flow.markDirty()
+    ,0
 
   $scope.cancel = ->
     stopWatching()

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -746,7 +746,6 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
     deriveCategories: (ruleset, base_language) ->
 
       categories = []
-
       for rule in ruleset.rules
 
         if not rule.uuid

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2724,7 +2724,7 @@ class FlowVersion(SmartModel):
 
         while (version != CURRENT_EXPORT_VERSION):
 
-            # Move from version 4 to version 5
+            # Move to Version 5, passive rulesets
             if version == 4:
 
                 def requires_step(operand):

--- a/templates/partials/split_editor.haml
+++ b/templates/partials/split_editor.haml
@@ -75,7 +75,7 @@
             .
 
         .help-text
-           -blocktrans
+          -blocktrans
             This step will be identified as [[ruleset.uuid]]
 
         %p{class:"description response"}
@@ -103,7 +103,7 @@
         .option{class:'option-[[option.number]]', ng-repeat:"option in numbers"}
           .number
             [[option.number]]
-          %input{ng-model:"option.category.base",type:"text"}
+          %input{ng-model:"option.category._base",type:"text"}
 
     // RULE EDITOR
     %form{name:'ruleForm'}
@@ -116,23 +116,23 @@
 
               // between is the only one with two operands
               .operation{ng-if:"rule._config.operands == 2"}
-                %input{ng-model:"rule.test.min",name:"min",number:"",ng-required:"rule.test.min.length > 0 || rule.test.max.length > 0 || rule.category.base.length > 0",ng-change:"updateCategory(rule)",lower-than:"[[rule.test.max]]",type:"text",class:"operand-small"}
+                %input{ng-model:"rule.test.min",name:"min",number:"",ng-required:"rule.test.min.length > 0 || rule.test.max.length > 0 || rule.category._base.length > 0",ng-change:"updateCategory(rule)",lower-than:"[[rule.test.max]]",type:"text",class:"operand-small"}
                 -trans "and"
-                %input{ng-model:"rule.test.max", name:"max",number:"",ng-required:"rule.test.min.length > 0 || rule.test.max.length > 0 || rule.category.base.length > 0",ng-change:"updateCategory(rule)",type:"text",class:"operand-small"}
+                %input{ng-model:"rule.test.max", name:"max",number:"",ng-required:"rule.test.min.length > 0 || rule.test.max.length > 0 || rule.category._base.length > 0",ng-change:"updateCategory(rule)",type:"text",class:"operand-small"}
 
               // single operand based rules that aren't dates
               .operation{ng-if:'rule._config.operands == 1 && rule._config.validate !="date"'}
-                %input{ng-model:"rule.test.base",name:"operand",placeholder:"[[rule._config.placeholder]]",auto-complete:"rule._config.auto_complete",flow:"[[flowId]]",ng-required:"rule.category.base",ng-change:"updateCategory(rule)",type:"text",class:"operand",validate-type:"[[rule._config.type]]",uuid:"[[ruleset.uuid]]"}
+                %input{ng-model:"rule.test._base",name:"operand",placeholder:"[[rule._config.placeholder]]",auto-complete:"rule._config.auto_complete",flow:"[[flowId]]",ng-required:"rule.category._base",ng-change:"updateCategory(rule)",type:"text",class:"operand",validate-type:"[[rule._config.type]]",uuid:"[[ruleset.uuid]]"}
 
               // single operand rules with relative dates
               .operation{ng-if:'rule._config.operands == 1 && rule._config.validate =="date"'}
                 -trans "today +"
-                %input{ng-model:"rule.test.base",name:"days",number:"",ng-required:"rule.category.base",type:"text",class:"operand-small"}
+                %input{ng-model:"rule.test._base",name:"days",number:"",ng-required:"rule.category._base",type:"text",class:"operand-small"}
                 -trans "days"
               .operation{ng-if:"rule._config.operands == 0"}
               .categorize
                 -trans "categorize as"
-                %input{ng-model:"rule.category.base",name:"category",ng-required:"rule._config.operands==0 || (rule._config.operands==1 && rule.test.base) || (rule._config.operands==2 && (rule.test.test.min || rule.test.test.max))",ng-change:"rule.category._autoName = false",type:"text",class:"category"}
+                %input{ng-model:"rule.category._base",name:"category",ng-required:"rule._config.operands==0 || (rule._config.operands==1 && rule.test._base) || (rule._config.operands==2 && (rule.test.test.min || rule.test.test.max))",ng-change:"rule.category._autoName = false",type:"text",class:"category"}
               .icon.icon-close{ng-click:"remove(rule)"}
               .error{ng-show:"inner.min.$error.lowerThan"}
                 -blocktrans


### PR DESCRIPTION
Remove "base" properties in flow definitions in preparation for removing non-localized flow format. Also fixes flash of errors in rule editor when closing the dialog.