### PR TITLE
Cache active topups

### DIFF
--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -596,6 +596,7 @@ class OrgTest(TembaTest):
         yesterday = timezone.now() - relativedelta(days=1)
         mega_topup.expires_on = yesterday
         mega_topup.save(update_fields=['expires_on'])
+        self.org.update_caches(OrgEvent.topup_updated, None)
 
         # new incoming messages should not be assigned a topup
         msg = self.create_msg(contact=contact, direction='I', text="Test")


### PR DESCRIPTION
Prevents us having to sum all the credit_used rows for every credit assignment.