### PR TITLE
Squash credits and channel counts every 1,000 inserts

### DIFF
--- a/temba/channels/migrations/0022_update_maybe_squash.py
+++ b/temba/channels/migrations/0022_update_maybe_squash.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations, connection
+
+#language=SQL
+TRIGGER_SQL = """
+    CREATE OR REPLACE FUNCTION temba_maybe_squash_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE) RETURNS VOID AS $$
+      BEGIN
+        IF RANDOM() < .001 THEN
+          IF _count_day IS NULL THEN
+            WITH removed as (DELETE FROM channels_channelcount
+              WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" IS NULL
+              RETURNING "count")
+              INSERT INTO channels_channelcount("channel_id", "count_type", "count")
+              VALUES (_channel_id, _count_type, GREATEST(0, (SELECT SUM("count") FROM removed)));
+          ELSE
+            WITH removed as (DELETE FROM channels_channelcount
+              WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" = _count_day
+              RETURNING "count")
+              INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
+              VALUES (_channel_id, _count_type, _count_day, GREATEST(0, (SELECT SUM("count") FROM removed)));
+          END IF;
+        END IF;
+      END;
+    $$ LANGUAGE plpgsql;
+"""
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('channels', '0021_auto_20150803_1857'),
+    ]
+
+    operations = [
+        migrations.RunSQL(TRIGGER_SQL),
+    ]

--- a/temba/orgs/migrations/0008_update_maybe_squash.py
+++ b/temba/orgs/migrations/0008_update_maybe_squash.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# language=SQL
+TRIGGER_SQL = """
+----------------------------------------------------------------------------------
+-- Every 1,000 inserts or so this will squash the credits by gathering them
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_maybe_squash_topupcredits(_topup_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+  IF RANDOM() < .001 THEN
+    WITH deleted as (DELETE FROM orgs_topupcredits
+      WHERE "topup_id" = _topup_id
+      RETURNING "used")
+      INSERT INTO orgs_topupcredits("topup_id", "used")
+      VALUES (_topup_id, GREATEST(0, (SELECT SUM("used") FROM deleted)));
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0007_remove_topup_used'),
+    ]
+
+    operations = [
+        migrations.RunSQL(TRIGGER_SQL),
+    ]


### PR DESCRIPTION
Our every 100 inserts squash was too often and causing contention during blasts.

This is probably a temporary fix, I need to figure out how we can do a database lock of some sort during the squash to make this absolutely foolproof but should help in the meantime.