### PR TITLE
Speed up test failure cycle

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -2,15 +2,30 @@ import sys, os
 from hamlpy import templatize
 
 #-----------------------------------------------------------------------------------
-# Sets TESTING to True if this configuration is read during a unit test
-#-----------------------------------------------------------------------------------
-TESTING = sys.argv[1:2] == ['test']
-
-#-----------------------------------------------------------------------------------
 # Default to debugging
 #-----------------------------------------------------------------------------------
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
+
+#-----------------------------------------------------------------------------------
+# Sets TESTING to True if this configuration is read during a unit test
+#-----------------------------------------------------------------------------------
+TESTING = sys.argv[1:2] == ['test']
+
+if TESTING:
+    PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+    DEBUG = False
+    TEMPLATE_DEBUG = False
+
+    # if nose's failfast is used, also skip migrations
+    if '--failfast' in sys.argv:
+        class DisableMigrations(object):
+            def __contains__(self, item):
+                return True
+
+            def __getitem__(self, item):
+                return "notmigrations"
+        MIGRATION_MODULES = DisableMigrations()
 
 ADMINS = (
     ('RapidPro', 'code@yourdomain.io'),
@@ -234,6 +249,9 @@ INSTALLED_APPS = (
     'temba.locations',
     'temba.values',
 )
+
+# the last installed app that uses smartmin permissions
+PERMISSIONS_APP = 'temba.values'
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Two changes here:

1) Add our PERMISSIONS_APP for smartmin. Not sure how this wasn't there before, but this will speed up the permission check 10-fold.

2) Allow local test runs to skip the migrations (instead relying on current model state of the world like old syncdb used to). The test suite still runs all migrations. Since this is only needed until Django 1.8, I just piggy-backed on the --failfast command for nose.

With both of these changes, my single test run went from 3:30 to 0:14, so ~16x faster.