### PR TITLE
Up twitter DM limit to 10k chars

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -4119,7 +4119,10 @@ class TwitterTest(TembaTest):
         joe = self.create_contact("Joe", number="+250788383383", twitter="joe1981")
         testers = self.create_group("Testers", [joe])
 
-        bcast = joe.send("Test message", self.admin, trigger_send=False)
+        bcast = joe.send("This is a long message, longer than just 160 characters, it spans what was before "
+                         "more than one message but which is now but one, solitary message, going off into the "
+                         "Twitterverse to tweet away.",
+                         self.admin, trigger_send=False)
 
         # our outgoing message
         msg = bcast.get_messages()[0]
@@ -4132,6 +4135,9 @@ class TwitterTest(TembaTest):
 
                 # manually send it off
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
+
+                # assert we were only called once
+                self.assertEquals(1, mock.call_count)
 
                 # check the status of the message is now sent
                 msg = bcast.get_messages()[0]

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -105,7 +105,7 @@ RELAYER_TYPE_CONFIG = {
     VUMI: dict(scheme='tel', max_length=1600),
     KANNEL: dict(scheme='tel', max_length=1600),
     HUB9: dict(scheme='tel', max_length=1600),
-    TWITTER: dict(scheme='twitter', max_length=140),
+    TWITTER: dict(scheme='twitter', max_length=10000),
     SHAQODOON: dict(scheme='tel', max_length=1600),
     CLICKATELL: dict(scheme='tel', max_length=420),
     PLIVO: dict(scheme='tel', max_length=1600),


### PR DESCRIPTION
This might help with being throttled by Twitter since we'll be sending half the # of messages.