### PR TITLE
Reroute surveyor users to download page

### DIFF
--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -415,7 +415,7 @@ class OrgCRUDL(SmartCRUDL):
     actions = ('signup', 'home', 'webhook', 'edit', 'join', 'grant', 'create_login', 'choose',
                'manage_accounts', 'manage', 'update', 'country', 'languages', 'clear_cache', 'download',
                'twilio_connect', 'twilio_account', 'nexmo_account', 'nexmo_connect', 'export', 'import',
-               'plivo_connect', 'service')
+               'plivo_connect', 'service', 'surveyor')
 
     model = Org
 
@@ -964,7 +964,6 @@ class OrgCRUDL(SmartCRUDL):
             else:
                 return reverse('orgs.org_home')
 
-
     class Service(SmartFormView):
         class ServiceForm(forms.Form):
             organization = forms.ModelChoiceField(queryset=Org.objects.all(), empty_label=None)
@@ -983,7 +982,6 @@ class OrgCRUDL(SmartCRUDL):
         def form_invalid(self, form):
             self.request.session['org_id'] = None
             return HttpResponseRedirect(reverse('orgs.org_manage'))
-
 
     class Choose(SmartFormView):
         class ChooseForm(forms.Form):
@@ -1004,6 +1002,9 @@ class OrgCRUDL(SmartCRUDL):
                 elif user_orgs.count() == 1:
                     org = user_orgs[0]
                     self.request.session['org_id'] = org.pk
+                    if org.get_org_surveyors().filter(username=self.request.user.username):
+                        return HttpResponseRedirect(reverse('orgs.org_surveyor'))
+
                     return HttpResponseRedirect(self.get_success_url())
 
             return None
@@ -1030,6 +1031,10 @@ class OrgCRUDL(SmartCRUDL):
                 self.request.session['org_id'] = org.pk
             else:
                 return HttpResponseRedirect(reverse('orgs.org_choose'))
+
+            if org.get_org_surveyors().filter(username=self.request.user.username):
+                print reverse('orgs.org_surveyor')
+                return HttpResponseRedirect(reverse('orgs.org_surveyor'))
 
             return HttpResponseRedirect(self.get_success_url())
 
@@ -1062,25 +1067,30 @@ class OrgCRUDL(SmartCRUDL):
             user.last_name = self.form.cleaned_data['last_name']
             user.save()
 
-            invitation = self.get_invitation()
+            self.invitation = self.get_invitation()
 
             # log the user in
             user = authenticate(username=user.username, password=self.form.cleaned_data['password'])
             login(self.request, user)
-            if invitation.user_group == 'A':
+            if self.invitation.user_group == 'A':
                 obj.administrators.add(user)
-            elif invitation.user_group == 'E':
+            elif self.invitation.user_group == 'E':
                 obj.editors.add(user)
-            elif invitation.user_group == 'S':
+            elif self.invitation.user_group == 'S':
                 obj.surveyors.add(user)
             else:
                 obj.viewers.add(user)
 
             # make the invitation inactive
-            invitation.is_active = False
-            invitation.save()
+            self.invitation.is_active = False
+            self.invitation.save()
 
             return obj
+
+        def get_success_url(self):
+            if self.invitation.user_group == 'S':
+                return reverse('orgs.org_surveyor')
+            return super(OrgCRUDL.CreateLogin, self).get_success_url()
 
         @classmethod
         def derive_url_pattern(cls, path, action):
@@ -1162,6 +1172,12 @@ class OrgCRUDL(SmartCRUDL):
                 self.request.user.set_org(org)
                 self.request.session['org_id'] = org.pk
 
+        def get_success_url(self):
+            if self.get_invitation().user_group == 'S':
+                return reverse('orgs.org_surveyor')
+
+            return super(OrgCRUDL.Join, self).get_success_url()
+
         @classmethod
         def derive_url_pattern(cls, path, action):
             return r'^%s/%s/(?P<secret>\w+)/$' % (path, action)
@@ -1185,6 +1201,11 @@ class OrgCRUDL(SmartCRUDL):
 
             context['org'] = self.get_object()
             return context
+
+    class Surveyor(InferOrgMixin, OrgPermsMixin, SmartReadView):
+        def derive_title(self):
+            return _('Welcome!')
+
 
     class Grant(SmartCreateView):
         title = _("Create Organization Account")

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1153,27 +1153,27 @@ class OrgCRUDL(SmartCRUDL):
 
         def save(self, org):
             org = self.get_object()
-            invitation = self.get_invitation()
+            self.invitation = self.get_invitation()
             if org:
-                if invitation.user_group == 'A':
+                if self.invitation.user_group == 'A':
                     org.administrators.add(self.request.user)
-                elif invitation.user_group == 'E':
+                elif self.invitation.user_group == 'E':
                     org.editors.add(self.request.user)
-                elif invitation.user_group == 'S':
+                elif self.invitation.user_group == 'S':
                     org.surveyors.add(self.request.user)
                 else:
                     org.viewers.add(self.request.user)
 
                 # make the invitation inactive
-                invitation.is_active = False
-                invitation.save()
+                self.invitation.is_active = False
+                self.invitation.save()
 
                 # set the active org on this user
                 self.request.user.set_org(org)
                 self.request.session['org_id'] = org.pk
 
         def get_success_url(self):
-            if self.get_invitation().user_group == 'S':
+            if self.invitation.user_group == 'S':
                 return reverse('orgs.org_surveyor')
 
             return super(OrgCRUDL.Join, self).get_success_url()

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -394,6 +394,7 @@ PERMISSIONS = {
                  'profile',
                  'service',
                  'signup',
+                 'surveyor',
                  'trial',
                  'twilio_account',
                  'twilio_connect',
@@ -510,6 +511,7 @@ GROUP_PERMISSIONS = {
     "Beta": (
     ),
     "Surveyors": (
+        'orgs.org_surveyor',
         'orgs.org_api',
         'contacts.contact_api',
         'locations.adminboundary_api',

--- a/templates/orgs/org_surveyor.haml
+++ b/templates/orgs/org_surveyor.haml
@@ -1,0 +1,16 @@
+-extends "frame.html"
+
+-load i18n
+
+-block content
+
+  %p
+    -blocktrans with org.name as org and brand.name as brandname
+      To get started submitting surveys for {{ org }}, download the {{ brandname }} Surveyor app from
+      Google Play. After you install the Surveyor app on your Android phone, simply login with the same
+      account you use to login to {{ brandname }}.
+
+    %br
+    %br
+    %a{href:"https://play.google.com/store/apps/details?id={{brand.android_package}}.surveyor"}
+      %img{alt:"{{brand.name}} Surveyor on Google Play", src:"https://developer.android.com/images/brand/en_app_rgb_wo_45.png"}


### PR DESCRIPTION
Adds a placeholder for users that are invited as surveyors. This page is shown if they accept an invite as a surveyor or login for an org for which they are a surveyor.

![Surveyor](https://monosnap.com/file/f3GFph4FcJVAWVPtDAchqoCgn4NgQm.png)