### PR TITLE
Fix phone number updates

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -540,7 +540,6 @@ class Contact(TembaModel, SmartModel):
 
             test_contact = Contact.get_or_create(org, user, "Test Contact", [(TEL_SCHEME, '+%s' % test_urn_path)],
                                                  is_test=True)
-
         return test_contact
 
     @classmethod

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4496,7 +4496,13 @@ class SaveToContactAction(Action):
 
         elif self.field == 'tel_e164':
             new_value = value[:128]
-            contact.update_urns([('tel', new_value)])
+
+            # all previous urns minus phone numbers
+            urns = [(urn.scheme, urn.path) for urn in contact.urns.all().exclude(scheme='tel')]
+
+            # add in our new phone number
+            urns += [('tel', new_value)]
+            contact.update_urns(urns)
 
         else:
             new_value = value[:640]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3434,6 +3434,9 @@ class FlowStep(models.Model):
 
         steps = FlowStep.objects.filter(run__is_active=True, run__flow__is_active=True, run__contact=contact, left_on=None)
 
+        # don't consider voice steps, those are interactive
+        steps = steps.exclude(run__flow__is_active=Flow.VOICE)
+
         # real contacts don't deal with archived flows
         if not contact.is_test:
             steps = steps.filter(run__flow__is_archived=False)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -588,6 +588,7 @@ class Flow(TembaModel, SmartModel):
     @classmethod
     def handle_destination(cls, destination, step, run, msg,
                            started_flows=None, is_test_contact=False, user_input=False):
+
         if started_flows is None:
             started_flows = []
 
@@ -3431,8 +3432,7 @@ class FlowStep(models.Model):
     @classmethod
     def get_active_steps_for_contact(cls, contact, step_type=None):
 
-        steps = FlowStep.objects.filter(run__is_active=True, run__flow__is_active=True, run__contact=contact,
-                                        run__flow__flow_type=Flow.FLOW, left_on=None)
+        steps = FlowStep.objects.filter(run__is_active=True, run__flow__is_active=True, run__contact=contact, left_on=None)
 
         # real contacts don't deal with archived flows
         if not contact.is_test:
@@ -4383,6 +4383,9 @@ class SetLanguageAction(Action):
     def get_description(self):
         print "Set language to %s" % self.name
 
+class SetPhoneAction(Action):
+    pass
+
 
 class StartFlowAction(Action):
     """
@@ -4456,9 +4459,11 @@ class SaveToContactAction(Action):
 
         # make sure this field exists
         if field == 'name':
-            label = "Contact Name"
+            label = 'Contact Name'
         elif field == 'first_name':
-            label = "First Name"
+            label = 'First Name'
+        elif field == 'tel_e164':
+            label = 'Phone Number'
         else:
             contact_field = ContactField.objects.filter(org=org, key=field).first()
             if contact_field:
@@ -4488,6 +4493,11 @@ class SaveToContactAction(Action):
             new_value = value[:128]
             contact.set_first_name(new_value)
             contact.save(update_fields=['name'])
+
+        elif self.field == 'tel_e164':
+            new_value = value[:128]
+            contact.update_urns([('tel', new_value)])
+
         else:
             new_value = value[:640]
             contact.set_field(self.field, new_value)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4383,9 +4383,6 @@ class SetLanguageAction(Action):
     def get_description(self):
         print "Set language to %s" % self.name
 
-class SetPhoneAction(Action):
-    pass
-
 
 class StartFlowAction(Action):
     """

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4553,8 +4553,8 @@ class SaveToContactAction(Action):
         elif self.field == 'tel_e164':
             new_value = value[:128]
 
-            # all previous urns minus phone numbers
-            urns = [(urn.scheme, urn.path) for urn in contact.urns.all().exclude(scheme='tel')]
+            # all previous urns minus the current phone urn if we are on one
+            urns = [(urn.scheme, urn.path) for urn in contact.urns.all().exclude(scheme=TEL_SCHEME, pk=msg.contact_urn.pk)]
 
             # add in our new phone number
             urns += [('tel', new_value)]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3435,7 +3435,7 @@ class FlowStep(models.Model):
         steps = FlowStep.objects.filter(run__is_active=True, run__flow__is_active=True, run__contact=contact, left_on=None)
 
         # don't consider voice steps, those are interactive
-        steps = steps.exclude(run__flow__is_active=Flow.VOICE)
+        steps = steps.exclude(run__flow__flow_type=Flow.VOICE)
 
         # real contacts don't deal with archived flows
         if not contact.is_test:

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1226,6 +1226,20 @@ class RuleTest(TembaTest):
         contact = Contact.objects.get(id=self.contact.pk)
         self.assertEquals(test.value, contact.get_field('last_message').string_value)
 
+        # test saving a contact's phone number
+        test = SaveToContactAction.from_json(self.org, dict(type='save', label='Phone Number', field='tel_e164', value='@step'))
+        print contact.urns.all()
+        sms = self.create_msg(direction=INCOMING, contact=self.contact, text="+12065551212")
+        test.execute(run, None, sms)
+
+        # updating Phone Number should not create a contact field
+        self.assertIsNone(ContactField.objects.filter(org=self.org, key='tel_e164').first())
+
+        # instead it should update the tel urn for our contact
+        contact = Contact.objects.get(id=self.contact.pk)
+        self.assertEquals(1, contact.urns.all().count())
+        self.assertIsNotNone(contact.urns.filter(path='+12065551212').first())
+
     test_save_to_contact_action.active = True
 
     def test_language_action(self):

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1228,7 +1228,6 @@ class RuleTest(TembaTest):
 
         # test saving a contact's phone number
         test = SaveToContactAction.from_json(self.org, dict(type='save', label='Phone Number', field='tel_e164', value='@step'))
-        print contact.urns.all()
         sms = self.create_msg(direction=INCOMING, contact=self.contact, text="+12065551212")
         test.execute(run, None, sms)
 


### PR DESCRIPTION
SaveToContact action was doing the wrong thing when users select Phone Number as the field. It used to create a contact field instead of updating the urns accordingly.