### PR TITLE
Naked contacts

### DIFF
--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -533,11 +533,9 @@ class ContactWriteSerializer(WriteSerializer):
 
         if uuid:
             contact = Contact.objects.get(uuid=uuid, org=self.org, is_active=True)
-
-            # user didn't specify either urns or phone, stick to what already exists
-            if urns is None and phone is None:
-                urns = [(u.scheme, u.path) for u in contact.urns.all()]
-            contact.update_urns(urns)
+            
+            if urns:
+                contact.update_urns(urns)
 
         else:
             contact = Contact.get_or_create(self.org, self.user, urns=urns, uuid=uuid)

--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -380,8 +380,8 @@ class ContactWriteSerializer(WriteSerializer):
         phone = attrs.get('phone', None)
         uuid = attrs.get('uuid', None)
 
-        if (not urns and not phone and not uuid) or (urns and phone):
-            raise ValidationError("Must provide either urns, phone or uuid but only one of each")
+        if urns and phone:
+            raise ValidationError("Cannot provide both urns and phone parameters together")
 
         if attrs.get('group_uuids', []) and attrs.get('groups', []):
             raise ValidationError("Parameter groups is deprecated and can't be used together with group_uuids")

--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -523,23 +523,22 @@ class ContactWriteSerializer(WriteSerializer):
         if self.org.is_anon:
             raise ValidationError("Cannot update contacts on anonymous organizations")
 
-        uuid = attrs.get('uuid', None)
-        if uuid:
-            contact = Contact.objects.get(uuid=uuid, org=self.org, is_active=True)
-
         urns = attrs.get('urns', None)
         phone = attrs.get('phone', None)
-
-        # user didn't specify either urns or phone, stick to what already exists
-        if urns is None and phone is None:
-            urns = [(u.scheme, u.path) for u in contact.urns.all()]
+        uuid = attrs.get('uuid', None)
 
         # user only specified phone, build our urns from it
         if phone:
-            urns = [(TEL_SCHEME, attrs['phone'])]
+            urns = [(TEL_SCHEME, phone)]
 
         if uuid:
+            contact = Contact.objects.get(uuid=uuid, org=self.org, is_active=True)
+
+            # user didn't specify either urns or phone, stick to what already exists
+            if urns is None and phone is None:
+                urns = [(u.scheme, u.path) for u in contact.urns.all()]
             contact.update_urns(urns)
+
         else:
             contact = Contact.get_or_create(self.org, self.user, urns=urns, uuid=uuid)
 

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1356,6 +1356,11 @@ class APITest(TembaTest):
         self.assertFalse(Contact.objects.get(pk=shinonda.pk).is_active)
         self.assertFalse(Contact.objects.get(pk=chad.pk).is_active)
 
+        # add a naked contact
+        response = self.postJSON(url, dict())
+        self.assertIsNotNone(json.loads(response.content)['uuid'])
+        self.assertEquals(201, response.status_code)
+
     def test_api_contacts_with_multiple_pages(self):
         url = reverse('api.contacts')
 


### PR DESCRIPTION
Allow the creation of empty contacts via the api. This is necessary for surveyor which will potentially later fill the contact out with actions inside a flow allowing us to remove the screen asking for name and phone number before launching a flow.

@rowanseymour 