### PR TITLE
Removed reverse param to messages endpoint

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1788,10 +1788,6 @@ class APITest(TembaTest):
         response = self.fetchJSON(url, "")
         self.assertEqual([m['id'] for m in response.json['results']], [msg5.pk, msg4.pk, msg3.pk, msg2.pk, msg1.pk])
 
-        # test reversing ordering
-        response = self.fetchJSON(url, "reverse=1")
-        self.assertEqual([m['id'] for m in response.json['results']], [msg1.pk, msg2.pk, msg3.pk, msg4.pk, msg5.pk])
-
         # check archived status
         msg2.visibility = ARCHIVED
         msg2.save()

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -902,11 +902,8 @@ class MessageEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
         else:
             queryset = queryset.exclude(visibility=DELETED)
 
-        reverse_order = self.request.QUERY_PARAMS.get('reverse', None)
-        order = 'created_on' if reverse_order and str_to_bool(reverse_order) else '-created_on'
-
         queryset = queryset.select_related('org', 'contact', 'contact_urn').prefetch_related('labels')
-        return queryset.order_by(order).distinct()
+        return queryset.order_by('-created_on').distinct()
 
     @classmethod
     def get_read_explorer(cls):


### PR DESCRIPTION
File under: Terrible ideas

Can't find evidence of anyone using this besides CasePro (which no longer does): https://logentries.com/app/d6f114f1#/logs?f=1440840240000&t=1443432240000&log_q=where(api%20AND%20messages%20AND%20reverse%20NOT%20casepro)