### PR TITLE
Detect non-gsm7 messages and send as unicode on nexmo

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -3039,6 +3039,35 @@ class NexmoTest(TembaTest):
                 end = time.time()
                 self.assertTrue(1.5 > end - start > 1, "Sending of six messages took: %f" % (end - start))
 
+                self.clear_cache()
+
+            with patch('requests.get') as mock:
+                mock.return_value = MockResponse(200, json.dumps(dict(messages=[{'status':0, 'message-id':12}])), method='POST')
+
+                sms.text = u"Unicode ☺"
+                sms.save()
+
+                # manually send it off
+                Channel.send_message(dict_to_struct('MsgStruct', sms.as_task_json()))
+
+                # check the status of the message is now sent
+                msg = bcast.get_messages()[0]
+                self.assertEquals(SENT, msg.status)
+                self.assertTrue(msg.sent_on)
+                self.assertEquals('12', msg.external_id)
+
+                # assert that we were called with unicode
+                mock.assert_called_once_with('https://rest.nexmo.com/sms/json',
+                                             params={'from': u'250785551212',
+                                                     'api_secret': u'1234',
+                                                     'status-report-req': 1,
+                                                     'to': u'250788383383',
+                                                     'text': u'Unicode \u263a',
+                                                     'api_key': u'1234',
+                                                     'type': 'unicode'})
+
+                self.clear_cache()
+
             with patch('requests.get') as mock:
                 mock.return_value = MockResponse(400, "Error", method='POST')
 

--- a/temba/nexmo.py
+++ b/temba/nexmo.py
@@ -2,7 +2,7 @@ from urllib import urlencode
 from urlparse import urljoin
 from django.utils.translation import ugettext_lazy as _
 import requests
-
+from temba.utils.gsm7 import is_gsm7
 
 class NexmoClient(object):
     """
@@ -66,6 +66,10 @@ class NexmoClient(object):
         params['to'] = to_number.strip('+')
         params['text'] = text
         params['status-report-req'] = 1
+
+        # if this isn't going to work as plaintext, send as unicode instead
+        if not is_gsm7(text):
+            params['type'] = 'unicode'
 
         response = requests.get(NexmoClient.SEND_URL, params=params)
         response_json = response.json()

--- a/temba/utils/gsm7.py
+++ b/temba/utils/gsm7.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+# All valid GSM7 characters, table format
+VALID_GSM7 = u"@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>" \
+             u"?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ`¿abcdefghijklmnopqrstuvwxyzäöñüà" \
+             u"````````````````````^```````````````````{}`````\\````````````[~]`" \
+             u"|````````````````````````````````````€``````````````````````````"
+
+# Valid GSM7 chars as a set
+GSM7_CHARS = {c for c in VALID_GSM7}
+
+
+def is_gsm7(text):
+    """
+    Returns whether the passed in text can be represented in GSM7 character set
+    """
+    for c in text:
+        if c not in GSM7_CHARS:
+            return False
+
+    return True

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -20,6 +20,7 @@ from . import format_decimal, slugify_with, str_to_datetime, str_to_time, trunca
 from . import PageableQuery, json_to_dict, dict_to_struct, datetime_to_ms, ms_to_datetime, dict_to_json, str_to_bool
 from . import percentage, datetime_to_json_date, json_date_to_datetime, timezone_to_country_code, non_atomic_gets
 from temba.utils.exporter import TableExporter
+from temba.utils.gsm7 import is_gsm7
 from xlrd import open_workbook
 
 
@@ -833,6 +834,14 @@ class PercentageTest(TembaTest):
         self.assertEquals(75, percentage(75, 100))
         self.assertEquals(76, percentage(759, 1000))
 
+
+class GSM7Test(TembaTest):
+
+    def test_is_gsm7(self):
+        self.assertTrue(is_gsm7("Hello World! {} <>"))
+        self.assertFalse(is_gsm7("No capital accented È!"))
+        self.assertFalse(is_gsm7("No unicode. ☺"))
+        
 
 class TableExporterTest(TembaTest):
 


### PR DESCRIPTION
Nexmo doesn't detect this on our own, so we have to.