### PR TITLE
Obtain locks for squashing counts to prevent deadlocks

### DIFF
--- a/temba/channels/migrations/0024_auto_20151002_1407.py
+++ b/temba/channels/migrations/0024_auto_20151002_1407.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+#language=SQL
+TRIGGER_SQL = """
+    CREATE OR REPLACE FUNCTION temba_maybe_squash_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE) RETURNS VOID AS $$
+      BEGIN
+        IF RANDOM() < .001 THEN
+          -- Obtain a lock on the channel so that two threads don't enter this update at once
+          PERFORM "id" FROM channels_channel WHERE "id" = _channel_id FOR UPDATE;
+
+          IF _count_day IS NULL THEN
+            WITH removed as (DELETE FROM channels_channelcount
+              WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" IS NULL
+              RETURNING "count")
+              INSERT INTO channels_channelcount("channel_id", "count_type", "count")
+              VALUES (_channel_id, _count_type, GREATEST(0, (SELECT SUM("count") FROM removed)));
+          ELSE
+            WITH removed as (DELETE FROM channels_channelcount
+              WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" = _count_day
+              RETURNING "count")
+              INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
+              VALUES (_channel_id, _count_type, _count_day, GREATEST(0, (SELECT SUM("count") FROM removed)));
+          END IF;
+        END IF;
+      END;
+    $$ LANGUAGE plpgsql;
+"""
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('channels', '0023_auto_20150916_2138'),
+    ]
+
+    operations = [
+        migrations.RunSQL(TRIGGER_SQL)
+    ]

--- a/temba/msgs/migrations/0032_auto_20151002_1411.py
+++ b/temba/msgs/migrations/0032_auto_20151002_1411.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# language=SQL
+TRIGGER_SQL = """
+----------------------------------------------------------------------------------
+-- Every 1000 inserts or so this will squash the label by gathering the counts
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_maybe_squash_systemlabel(_org_id INTEGER, _label_type CHAR(1))
+RETURNS VOID AS $$
+BEGIN
+  IF RANDOM() < .001 THEN
+    -- Acquire a lock on the org so we don't deadlock if another thread does this at the same time
+    PERFORM "id" from orgs_org where "id" = _org_id FOR UPDATE;
+
+    WITH deleted as (DELETE FROM msgs_systemlabel
+      WHERE "org_id" = _org_id AND "label_type" = _label_type
+      RETURNING "count")
+      INSERT INTO msgs_systemlabel("org_id", "label_type", "count")
+      VALUES (_org_id, _label_type, GREATEST(0, (SELECT SUM("count") FROM deleted)));
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0031_msg_contact_urn_optional'),
+    ]
+
+    operations = [
+        migrations.RunSQL(TRIGGER_SQL)
+    ]

--- a/temba/orgs/migrations/0010_auto_20151002_1417.py
+++ b/temba/orgs/migrations/0010_auto_20151002_1417.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# language=SQL
+TRIGGER_SQL = """
+----------------------------------------------------------------------------------
+-- Every 1,000 inserts or so this will squash the credits by gathering them
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_maybe_squash_topupcredits(_topup_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+  IF RANDOM() < .001 THEN
+    -- Acquire a lock on this topup so there is only one squash at a time
+    PERFORM "id" FROM orgs_topup WHERE "id" = _topup_id FOR UPDATE;
+
+    WITH deleted as (DELETE FROM orgs_topupcredits
+      WHERE "topup_id" = _topup_id
+      RETURNING "used")
+      INSERT INTO orgs_topupcredits("topup_id", "used")
+      VALUES (_topup_id, GREATEST(0, (SELECT SUM("used") FROM deleted)));
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0009_org_surveyors'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
This should avoid any possibility of deadlocks doing these counts. Have to love the #postgres channel.