### PR TITLE
Little fixes

### DIFF
--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -2738,7 +2738,7 @@ class FlowDefinitionEndpoint(BaseAPIView, CreateAPIMixin):
     or updating of existing flows. This endpoint has only alpha-level support and is subject
     to modification or removal.
 
-    ## Getting a flow defintion
+    ## Getting a flow definition
 
     Returns the flow definition for the given flow.
 
@@ -2746,7 +2746,7 @@ class FlowDefinitionEndpoint(BaseAPIView, CreateAPIMixin):
 
     Example:
 
-        GET /api/v1/flow_definition.json
+        GET /api/v1/flow_definition.json?uuid=f14e4ff0-724d-43fe-a953-1d16aefd1c00
 
     Response is a flow definition
         {

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -127,7 +127,7 @@ class ContactField(models.Model):
             else:
                 # we need to create a new contact field, use our key with invalid chars removed
                 if not label:
-                    label = regex.sub(r'([A-Za-z0-9\- ]+)', ' ', key, regex.V0).title()
+                    label = regex.sub(r'([^A-Za-z0-9\- ]+)', ' ', key, regex.V0).title()
 
                 if not value_type:
                     value_type = TEXT

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1970,6 +1970,22 @@ class ContactFieldTest(TembaTest):
         self.contactfield_2 = ContactField.get_or_create(self.org, "second", "Second")
         self.contactfield_3 = ContactField.get_or_create(self.org, "third", "Third")
 
+    def test_get_or_create(self):
+        join_date = ContactField.get_or_create(self.org, "join_date")
+        self.assertEqual(join_date.key, "join_date")
+        self.assertEqual(join_date.label, "Join Date")
+        self.assertEqual(join_date.value_type, TEXT)
+
+        another = ContactField.get_or_create(self.org, "another", "My Label", value_type=DECIMAL)
+        self.assertEqual(another.key, "another")
+        self.assertEqual(another.label, "My Label")
+        self.assertEqual(another.value_type, DECIMAL)
+
+        another = ContactField.get_or_create(self.org, "another", "Updated Label", value_type=DATETIME)
+        self.assertEqual(another.key, "another")
+        self.assertEqual(another.label, "Updated Label")
+        self.assertEqual(another.value_type, DATETIME)
+
     def test_contact_templatetag(self):
         self.joe.set_field('First', 'Starter')
         self.assertEquals(contact_field(self.joe, 'First'), 'Starter')


### PR DESCRIPTION
 * Fixed `ContactField.get_or_create` when label is not specified 
 * Flow definition API endpoint docs tweak