### PR TITLE
Fix flow_type and version for FlowCRUDL.Json

### DIFF
--- a/karma/flows/helpers.coffee
+++ b/karma/flows/helpers.coffee
@@ -2,11 +2,11 @@ gettext = (text) ->
   return text
 
 getNode = (flow, uuid) ->
-  for actionset in flow.action_sets
+  for actionset in flow.definition.action_sets
     if actionset.uuid == uuid
       return actionset
 
-  for ruleset in flow.rule_sets
+  for ruleset in flow.definition.rule_sets
     if ruleset.uuid == uuid
       return ruleset
 

--- a/karma/flows/test_controllers.coffee
+++ b/karma/flows/test_controllers.coffee
@@ -35,7 +35,9 @@ describe 'Controllers:', ->
       $http.whenPOST('/flow/json/' + config.id + '/').respond()
       $http.whenGET('/flow/json/' + config.id + '/').respond(
         {
-          flow: getJSONFixture(file + '.json').flows[0].definition,
+          flow:
+            definition: getJSONFixture(file + '.json').flows[0].definition
+            flow_type: getJSONFixture(file + '.json').flows[0].flow_type
           languages: config.languages
         }
       )
@@ -169,6 +171,8 @@ describe 'Controllers:', ->
       $scope.dialog.opened.then ->
         modalScope = $modalStack.getTop().value.modalScope
 
+
+
         expect(modalScope.isVisibleRulesetType(getRuleConfig('wait_message'))).toBe(true)
         expect(modalScope.isVisibleRulesetType(getRuleConfig('webhook'))).toBe(true)
 
@@ -178,13 +182,13 @@ describe 'Controllers:', ->
         expect(modalScope.isVisibleRulesetType(getRuleConfig('wait_recording'))).toBe(false)
 
         # now pretend we are a voice flow
-        flowService.flow.type = 'V'
+        flowService.flow.flow_type = 'V'
         expect(modalScope.isVisibleRulesetType(getRuleConfig('wait_digits'))).toBe(true)
         expect(modalScope.isVisibleRulesetType(getRuleConfig('wait_digit'))).toBe(true)
         expect(modalScope.isVisibleRulesetType(getRuleConfig('wait_recording'))).toBe(true)
 
         # and now a survey flow
-        flowService.flow.type = 'S'
+        flowService.flow.flow_type = 'S'
         expect(modalScope.isVisibleRulesetType(getRuleConfig('wait_message'))).toBe(true)
         expect(modalScope.isVisibleRulesetType(getRuleConfig('wait_digits'))).toBe(false)
         expect(modalScope.isVisibleRulesetType(getRuleConfig('webhook'))).toBe(false)
@@ -219,14 +223,14 @@ describe 'Controllers:', ->
         expect(modalScope.validActionFilter(getAction('api'))).toBe(true)
 
         # pretend we are a voice flow
-        flowService.flow.type = 'V'
+        flowService.flow.flow_type = 'V'
         expect(modalScope.validActionFilter(getAction('reply'))).toBe(true)
         expect(modalScope.validActionFilter(getAction('say'))).toBe(true)
         expect(modalScope.validActionFilter(getAction('play'))).toBe(true)
         expect(modalScope.validActionFilter(getAction('api'))).toBe(true)
 
         # now try a survey
-        flowService.flow.type = 'S'
+        flowService.flow.flow_type = 'S'
         expect(modalScope.validActionFilter(getAction('reply'))).toBe(true)
         expect(modalScope.validActionFilter(getAction('say'))).toBe(false)
         expect(modalScope.validActionFilter(getAction('play'))).toBe(false)

--- a/karma/flows/test_controllers.coffee
+++ b/karma/flows/test_controllers.coffee
@@ -107,7 +107,7 @@ describe 'Controllers:', ->
       flowService.contactFieldSearch = []
 
       flowService.fetch(flows.webhook_rule_first.id).then ->
-        actionset = flowService.flow.action_sets[0]
+        actionset = flowService.flow.definition.action_sets[0]
         $scope.clickAction(actionset, actionset.actions[0])
         expect($scope.dialog).not.toBe(undefined)
 
@@ -122,14 +122,14 @@ describe 'Controllers:', ->
 
       $http.flush()
 
-    it 'should ruleset category translation', ->
+    it 'should peform ruleset category translation', ->
 
       # go grab our flow
       flowService.fetch(flows.webhook_rule_first.id)
       flowService.contactFieldSearch = []
       $http.flush()
 
-      ruleset = flowService.flow.rule_sets[0]
+      ruleset = flowService.flow.definition.rule_sets[0]
       $scope.clickRuleset(ruleset)
       $scope.dialog.opened.then ->
         modalScope = $modalStack.getTop().value.modalScope
@@ -166,7 +166,7 @@ describe 'Controllers:', ->
           if ruleset.type == type
             return ruleset
 
-      ruleset = flowService.flow.rule_sets[0]
+      ruleset = flowService.flow.definition.rule_sets[0]
       $scope.clickRuleset(ruleset)
       $scope.dialog.opened.then ->
         modalScope = $modalStack.getTop().value.modalScope
@@ -208,7 +208,7 @@ describe 'Controllers:', ->
           if action.type == type
             return action
 
-      actionset = flowService.flow.action_sets[0]
+      actionset = flowService.flow.definition.action_sets[0]
       action = actionset.actions[0]
       $scope.clickAction(actionset, action)
 

--- a/karma/flows/test_directives.coffee
+++ b/karma/flows/test_directives.coffee
@@ -21,12 +21,16 @@ describe 'Directives:', ->
       # TODO: directives should not depend on root scope
       #       hack it in until we clean that up
 
-      Flow.flow = getJSONFixture('favorites.json').flows[0].definition
+
+      Flow.flow =
+        definition: getJSONFixture('favorites.json').flows[0].definition
+        flow_type: getJSONFixture('favorites.json').flows[0].flow_type
+
       scope = $rootScope.$new()
       scope.$root = $rootScope
 
       # pick our first action to build some html for
-      scope.action = Flow.flow.action_sets[0].actions[0]
+      scope.action = Flow.flow.definition.action_sets[0].actions[0]
 
       # our action translation hasn't been inspected yet
       expect(scope.action._missingTranslation).toBeUndefined()

--- a/karma/flows/test_services.coffee
+++ b/karma/flows/test_services.coffee
@@ -67,13 +67,13 @@ describe 'Services:', ->
         flow = flowService.flow
 
         # our entry should already be set from reading in the file
-        expect(flow.entry).toBe('127f3736-77ce-4006-9ab0-0c07cea88956')
+        expect(flow.definition.entry).toBe('127f3736-77ce-4006-9ab0-0c07cea88956')
 
         # now determine the start point
         flowService.determineFlowStart()
 
         # it shouldn't have changed from what we had
-        expect(flow.entry).toBe('127f3736-77ce-4006-9ab0-0c07cea88956')
+        expect(flow.definition.entry).toBe('127f3736-77ce-4006-9ab0-0c07cea88956')
 
         # now let's move our entry node down
         entry = getNode(flow, '127f3736-77ce-4006-9ab0-0c07cea88956')
@@ -81,7 +81,7 @@ describe 'Services:', ->
         flowService.determineFlowStart()
 
         # our 'other' action set is now the top
-        expect(flow.entry).toBe('f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f')
+        expect(flow.definition.entry).toBe('f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f')
 
       $http.flush()
 
@@ -198,7 +198,7 @@ describe 'Services:', ->
         flowService.fetch(flows.loop_detection.id).then ->
           # derive all our categories
           flow = flowService.flow
-          for ruleset in flow.rule_sets
+          for ruleset in flow.definition.rule_sets
             flowService.deriveCategories(ruleset, 'eng')
         $http.flush()
 
@@ -243,7 +243,7 @@ describe 'Services:', ->
         expect(allowed).toBe(true, "Failed to allow legitimately branched connection")
 
       it 'should detect arbitrary expression pause', ->
-        for ruleset in flow.rule_sets
+        for ruleset in flow.definition.rule_sets
           if ruleset.uuid == messageSplitA
             ruleset.operand = '=(step.value= contact.last_four_digit)'
             ruleset.ruleset_type = 'wait_message'
@@ -326,7 +326,7 @@ describe 'Services:', ->
         flowService.fetch(flows.favorites.id).then ->
           # derive all our categories
           flow = flowService.flow
-          for ruleset in flow.rule_sets
+          for ruleset in flow.definition.rule_sets
             flowService.deriveCategories(ruleset, 'base')
         $http.flush()
 
@@ -377,6 +377,7 @@ describe 'Services:', ->
 
         # check we have the right number of categories to start
         colors = getNode(flow, colorRulesId)
+        expect(colors._categories).not.toBe(undefined)
         expect(colors._categories.length).toBe(4, 'categories were not derived properly')
 
         # now set the green category name to the same as red

--- a/karma/flows/test_services.coffee
+++ b/karma/flows/test_services.coffee
@@ -23,7 +23,9 @@ describe 'Services:', ->
 
       $http.whenGET('/flow/json/' + config.id + '/').respond(
         {
-          flow: getJSONFixture(file + '.json').flows[0].definition,
+          flow:
+            definition: getJSONFixture(file + '.json').flows[0].definition
+            flow_type: getJSONFixture(file + '.json').flows[0].flow_type
           languages: config.languages
         }
       )

--- a/media/test_flows/favorites.json
+++ b/media/test_flows/favorites.json
@@ -3,7 +3,6 @@
   "flows": [
     {
       "definition": {
-        "type": "F",
         "base_language": "base", 
         "action_sets": [
           {

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -1017,7 +1017,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
     return true
 
   $scope.isVisibleRulesetType = (rulesetConfig) ->
-    valid = flow.type in rulesetConfig.filter
+    valid = flow.flow_type in rulesetConfig.filter
 
     if (rulesetConfig.type == 'flow_field' or rulesetConfig.type == 'form_field') and $scope.flowFields.length == 0
       return false
@@ -1322,7 +1322,7 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
 
     valid = false
     if action.filter
-      valid = flow.type in action.filter
+      valid = flow.flow_type in action.filter
 
     if startsFlow and action.type == 'flow'
       return false

--- a/static/coffee/flows/directives.coffee
+++ b/static/coffee/flows/directives.coffee
@@ -149,7 +149,7 @@ app.directive "action", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
       action._missingTranslation = false
       # grab the appropriate translated version
 
-      iso_code = Flow.flow.base_language
+      iso_code = Flow.flow.definition.base_language
       if currentLanguage
         iso_code = currentLanguage.iso_code
 
@@ -178,13 +178,13 @@ app.directive "action", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
     scope.$watch (->scope.action.dirty), (current) ->
       if current
         scope.action.dirty = false
-        scope.updateTranslationStatus(scope.action, Flow.flow.base_language, Flow.language)
+        scope.updateTranslationStatus(scope.action, Flow.flow.definition.base_language, Flow.language)
 
     scope.$watch (->scope.action), ->
-        scope.updateTranslationStatus(scope.action, Flow.flow.base_language, Flow.language)
+        scope.updateTranslationStatus(scope.action, Flow.flow.definition.base_language, Flow.language)
 
     scope.$watch (->Flow.language), ->
-      scope.updateTranslationStatus(scope.action, Flow.flow.base_language, Flow.language)
+      scope.updateTranslationStatus(scope.action, Flow.flow.definition.base_language, Flow.language)
 
 
   return {
@@ -268,11 +268,11 @@ app.directive "ruleset", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
       Plumb.repaint(element)
 
     scope.$watch (->scope.ruleset), ->
-      scope.updateTranslationStatus(scope.ruleset, Flow.flow.base_language, Flow.language)
+      scope.updateTranslationStatus(scope.ruleset, Flow.flow.definition.base_language, Flow.language)
       Plumb.updateConnections(scope.ruleset)
 
     scope.$watch (->Flow.language), ->
-      scope.updateTranslationStatus(scope.ruleset, Flow.flow.base_language, Flow.language)
+      scope.updateTranslationStatus(scope.ruleset, Flow.flow.definition.base_language, Flow.language)
 
 
 

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -871,9 +871,8 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
       Flow = @
       $http.get('/flow/json/' + flowId + '/').success (data) ->
 
-        flow = data.flow
-
-        flow.type = window.flow_type
+        flow = data.flow.definition
+        flow.flow_type = data.flow.flow_type
 
         # add uuids for the individual actions, need this for the UI
         for actionset in flow.action_sets

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -489,13 +489,13 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
             topNode = node
 
       # check each node to see if they are the top
-      for actionset in @flow.action_sets
+      for actionset in @flow.definition.action_sets
         checkTop(actionset)
-      for ruleset in @flow.rule_sets
+      for ruleset in @flow.definition.rule_sets
         checkTop(ruleset)
 
       if topNode
-        @flow.entry = topNode.uuid
+        @flow.definition.entry = topNode.uuid
 
     Flow = @
     $rootScope.$watch (->Flow.dirty), (current, prev) ->
@@ -530,7 +530,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
           $log.debug("Saving.")
 
           if $rootScope.saved_on
-            Flow.flow['last_saved'] = $rootScope.saved_on
+            Flow.flow['saved_on'] = $rootScope.saved_on
 
           $http.post('/flow/json/' + Flow.flowId + '/', utils.toJson(Flow.flow)).error (data, statusCode) ->
 
@@ -599,11 +599,11 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
 
     getNode: (uuid) ->
-      for actionset in @flow.action_sets
+      for actionset in @flow.definition.action_sets
         if actionset.uuid == uuid
           return actionset
 
-      for ruleset in @flow.rule_sets
+      for ruleset in @flow.definition.rule_sets
         if ruleset.uuid == uuid
           return ruleset
 
@@ -670,8 +670,8 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
       # find our unique set of keys
       flowFields = {}
-      if @flow
-        for ruleset in @flow.rule_sets
+      if @flow.definition
+        for ruleset in @flow.definition.rule_sets
           if ruleset.uuid != excludeRuleset?.uuid
             flowFields[@slugify(ruleset.label)] = ruleset.label
 
@@ -815,7 +815,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
       # its a rule source
       if source.length > 1
-        for ruleset in Flow.flow.rule_sets
+        for ruleset in Flow.flow.definition.rule_sets
           if ruleset.uuid == source[0]
 
             # find the category we are updating
@@ -838,7 +838,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
       # its an action source
       else
         # keep our destination up to date
-        for actionset in Flow.flow.action_sets
+        for actionset in Flow.flow.definition.action_sets
           if actionset.uuid == source[0]
             actionset.destination = target
             Plumb.updateConnection(actionset)
@@ -871,11 +871,10 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
       Flow = @
       $http.get('/flow/json/' + flowId + '/').success (data) ->
 
-        flow = data.flow.definition
-        flow.flow_type = data.flow.flow_type
+        flow = data.flow
 
         # add uuids for the individual actions, need this for the UI
-        for actionset in flow.action_sets
+        for actionset in flow.definition.action_sets
           for action in actionset.actions
             action.uuid = uuid()
 
@@ -883,24 +882,24 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
         # show our base language first
         for lang in data.languages
-          if lang.iso_code == flow.base_language
+          if lang.iso_code == flow.definition.base_language
             languages.push(lang)
             Flow.language = lang
 
         for lang in data.languages
-          if lang.iso_code != flow.base_language
+          if lang.iso_code != flow.definition.base_language
             languages.push(lang)
 
         # if they don't have our base language in the org, force ourselves as the default
-        if not Flow.language and flow.base_language
+        if not Flow.language and flow.definition.base_language
           Flow.language =
-            iso_code: flow.base_language
+            iso_code: flow.definition.base_language
 
         # if we have language choices, make sure our base language is one of them
         if languages
-          if flow.base_language not in (lang.iso_code for lang in languages)
+          if flow.definition.base_language not in (lang.iso_code for lang in languages)
             languages.unshift
-              iso_code:flow.base_language
+              iso_code:flow.definition.base_language
               name: gettext('Default')
 
         Flow.languages = languages
@@ -951,13 +950,13 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
       if not ruleset.operand
         ruleset.operand = '@step.value'
 
-      for previous, idx in Flow.flow.rule_sets
+      for previous, idx in Flow.flow.definition.rule_sets
         if ruleset.uuid == previous.uuid
 
           # group our rules by category and update the master ruleset
-          @deriveCategories(ruleset, Flow.flow.base_language)
+          @deriveCategories(ruleset, Flow.flow.definition.base_language)
 
-          Flow.flow.rule_sets.splice(idx, 1, ruleset)
+          Flow.flow.definition.rule_sets.splice(idx, 1, ruleset)
           found = true
 
           if markDirty
@@ -965,7 +964,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
           break
 
       if not found
-        Flow.flow.rule_sets.push(ruleset)
+        Flow.flow.definition.rule_sets.push(ruleset)
         if markDirty
           @markDirty()
 
@@ -979,16 +978,17 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
       if @language
         # look at all translatable bits in our flow and check for completeness
         flow = @flow
+
         items = 0
         missing = 0
-        for actionset in flow.action_sets
+        for actionset in flow.definition.action_sets
           for action in actionset.actions
             if action.type in ['send', 'reply', 'say']
               items++
               if action._missingTranslation
                 missing++
 
-        for ruleset in flow.rule_sets
+        for ruleset in flow.definition.rule_sets
           for category in ruleset._categories
               items++
               if category._missingTranslation
@@ -998,7 +998,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
         flow._pctTranslated = (Math.floor(((items - missing) / items) * 100))
         flow._missingTranslation = items > 0
 
-        if flow._pctTranslated == 100 and flow.base_language != @language.iso_code
+        if flow._pctTranslated == 100 and flow.definition.base_language != @language.iso_code
           $rootScope.gearLinks = [
             {
               title: 'Default Language'
@@ -1023,7 +1023,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
       DragHelper.hide()
 
-      flow = Flow.flow
+      definition = Flow.flow.definition
 
       Flow = @
       # disconnect all of our connections to and from the node
@@ -1035,9 +1035,9 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
           Flow.updateDestination(source, null)
 
         # then remove us
-        for rs, idx in flow.rule_sets
+        for rs, idx in definition.rule_sets
           if rs.uuid == ruleset.uuid
-            flow.rule_sets.splice(idx, 1)
+            definition.rule_sets.splice(idx, 1)
             break
       ,0
 
@@ -1045,18 +1045,18 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
     addNote: (x, y) ->
 
-      if not Flow.flow.metadata.notes
-        Flow.flow.metadata.notes = []
+      if not Flow.flow.definition.metadata.notes
+        Flow.flow.definition.metadata.notes = []
 
-      Flow.flow.metadata.notes.push
+      Flow.flow.definition.metadata.notes.push
         x: x
         y: y
         title: 'New Note'
         body: '...'
 
     removeNote: (note) ->
-      idx = Flow.flow.metadata.notes.indexOf(note)
-      Flow.flow.metadata.notes.splice(idx, 1)
+      idx = Flow.flow.definition.metadata.notes.indexOf(note)
+      Flow.flow.definition.metadata.notes.splice(idx, 1)
       @markDirty()
 
     moveActionUp: (actionset, action) ->
@@ -1067,7 +1067,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
 
     removeActionSet: (actionset) ->
-      flow = Flow.flow
+      definition = Flow.flow.definition
 
       service = @
       # disconnect all of our connections to and from action node
@@ -1080,9 +1080,9 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
         # disconnect our connections, then remove it from the flow
         # Plumb.disconnectAllConnections(actionset.uuid)
-        for as, idx in flow.action_sets
+        for as, idx in definition.action_sets
           if as.uuid == actionset.uuid
-            flow.action_sets.splice(idx, 1)
+            definition.action_sets.splice(idx, 1)
             break
       ,0
 
@@ -1165,17 +1165,17 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
       # finally see if our actionset exists or if it needs to be added
       found = false
-      for as in Flow.flow.action_sets
+      for as in Flow.flow.definition.action_sets
         if as.uuid == actionset.uuid
           found = true
           break
 
       if not found
-        Flow.flow.action_sets.push(actionset)
+        Flow.flow.definition.action_sets.push(actionset)
 
-      if Flow.flow.action_sets.length == 1
+      if Flow.flow.definition.action_sets.length == 1
         $timeout ->
-          DragHelper.showSaveResponse($('#' + Flow.flow.action_sets[0].uuid + ' .source'))
+          DragHelper.showSaveResponse($('#' + Flow.flow.definition.action_sets[0].uuid + ' .source'))
         ,0
 
       @checkTerminal(actionset)

--- a/static/coffee/flows/widgets.coffee
+++ b/static/coffee/flows/widgets.coffee
@@ -27,7 +27,7 @@ app.directive "sms", [ "$log", "Flow", ($log, Flow) ->
     scope.message = scope.sms
 
     if scope.sms
-      localized = scope.sms[Flow.flow.base_language]
+      localized = scope.sms[Flow.flow.definition.base_language]
       if localized?
         scope.message = localized
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -158,7 +158,7 @@ class Flow(TembaModel, SmartModel):
     RULESET_TYPE = 'ruleset_type'
     OPERAND = 'operand'
     METADATA = 'metadata'
-    LAST_SAVED = 'last_saved'
+    SAVED_ON = 'saved_on'
     BASE_LANGUAGE = 'base_language'
     SAVED_BY = 'saved_by'
     VERSION = 'version'
@@ -1913,8 +1913,6 @@ class Flow(TembaModel, SmartModel):
         else:
             flow[Flow.METADATA] = json.loads(self.metadata)
 
-        flow[Flow.LAST_SAVED] = datetime_to_str(self.saved_on)
-
         if self.base_language:
             flow[Flow.BASE_LANGUAGE] = self.base_language
 
@@ -2001,7 +1999,7 @@ class Flow(TembaModel, SmartModel):
                 self.update(json_flow)
                 # TODO: After Django 1.8 consider doing a self.refresh_from_db() here
 
-    def update(self, json_dict, user=None, force=False):
+    def update(self, json_dict, user=None, force=False, saved_on=None):
         """
         Updates a definition for a flow.
         """
@@ -2021,11 +2019,7 @@ class Flow(TembaModel, SmartModel):
         try:
             # check whether the flow has changed since this flow was last saved
             if user and not force:
-                saved_on = json_dict.get(Flow.LAST_SAVED, None)
-                org = user.get_org()
-                tz = org.get_tzinfo()
-
-                if not saved_on or str_to_datetime(saved_on, tz) < self.saved_on:
+                if saved_on and saved_on < self.saved_on:
                     saver = ""
                     if self.saved_by.first_name:
                         saver += "%s " % self.saved_by.first_name

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1190,7 +1190,9 @@ class FlowCRUDL(SmartCRUDL):
 
             # all the translation languages for our org
             languages = [lang.as_json() for lang in flow.org.languages.all().order_by('orgs')]
-            return build_json_response(dict(flow=flow.as_json(expand_contacts=True), languages=languages))
+
+            flow_json = dict(name=flow.name, flow_type=flow.flow_type, definition=flow.as_json(expand_contacts=True))
+            return build_json_response(dict(flow=flow_json, languages=languages))
 
         def post(self, request, *args, **kwargs):
 

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -205,21 +205,21 @@
       %h2
         -if flow.flow_type == 'V'
           .icon-phone
-        {{ flow.name }}
+        [[ flow.name ]]
 
       #pending{ng-show:'pending == "S" || pending == "P"'}
         %div{class:"alert alert-info"}
           -blocktrans
             This flow is in the process of being sent, this message will disappear once all contacts have been added to the flow.
 
-      .languages{ng-show:'languages.length > 1 && flow.base_language && (flow.action_sets.length + flow.rule_sets.length) > 0'}
+      .languages{ng-show:'languages.length > 1 && flow.definition.base_language && (flow.definition.action_sets.length + flow.definition.rule_sets.length) > 0'}
         <span ng-repeat="lang in languages">
           <a href="javascript:void(0);" class='language' ng-class='{active:lang.iso_code == language.iso_code}' ng-click="setLanguage(lang)">[[lang.name]]</a>
           <span ng-hide='$last'>|</span>
         </span>
 
         .translated
-          %span.pct{ng-show:'flow.base_language != language.iso_code'}
+          %span.pct{ng-show:'flow.definition.base_language != language.iso_code'}
             [[flow._pctTranslated]]% translated
 
     #status.hide
@@ -235,7 +235,7 @@
 
       #flow{ class:'{% if not mutable %}readonly{%endif%}'}
 
-        .empty{ng-show:'flow.action_sets.length + flow.rule_sets.length == 0'}
+        .empty{ng-show:'flow.definition.action_sets.length + flow.definition.rule_sets.length == 0'}
 
           .option
             %h4
@@ -296,14 +296,14 @@
                 .category
                   All Responses
 
-        .node{ng-repeat:'action_set in flow.action_sets', drop-scope:'[[getAcceptedScopes("actionset")]]', node:'action_set', ng-dblclick:'$event.stopPropagation()',
+        .node{ng-repeat:'action_set in flow.definition.action_sets', drop-scope:'[[getAcceptedScopes("actionset")]]', node:'action_set', ng-dblclick:'$event.stopPropagation()',
                ng-attr-id:'[[action_set.uuid]]', class:'action-node', ng-class:'{recents:action_set._showMessages, translate:lastActionMissingTranslation(action_set)}',
                ng-style:"{left:action_set.x, top:action_set.y}"}
 
           .active{ng-show:'action_set._active > 0', ng-click:'broadcastToStep(action_set.uuid)'}
             [[action_set._active|number]]
 
-          .flow-start{ng-show:'action_set.uuid == flow.entry'}
+          .flow-start{ng-show:'action_set.uuid == flow.definition.entry'}
             -trans "Flow Start"
 
           .actions{ actionset:'action_set', ng-animate:'"animate"'}
@@ -425,7 +425,7 @@
               [[action_set._visited|number]]
 
 
-        .node{ng-repeat:'ruleset in flow.rule_sets track by ruleset.uuid',
+        .node{ng-repeat:'ruleset in flow.definition.rule_sets track by ruleset.uuid',
               node:'ruleset', drop-scope:'[[getAcceptedScopes("ruleset")]]', ng-dblclick:'$event.stopPropagation()',
               class:'rule-node', ng-attr-id:'[[ruleset.uuid]]',
               ng-class:"{recents:ruleset._showMessages}",
@@ -434,7 +434,7 @@
           .active{ng-show:'ruleset._active > 0', ng-click:'broadcastToStep(ruleset.uuid)'}
             [[ruleset._active|number]]
 
-          .flow-start{ng-show:'ruleset.uuid == flow.entry'}
+          .flow-start{ng-show:'ruleset.uuid == flow.definition.entry'}
             -trans "Flow Start"
 
 
@@ -496,10 +496,7 @@
                   .count{ng-mouseover:'showRecentMessages()', ng-mouseleave:'hideRecentMessages();'}
                     [[category._visited|number]]
 
-
-
-
-        .note{ng-dblclick:'$event.stopPropagation();', ng-repeat:'note in flow.metadata.notes', note:'note'}
+        .note{ng-dblclick:'$event.stopPropagation();', ng-repeat:'note in flow.definition.metadata.notes', note:'note'}
           %a.close{ng-click:'removeNote(note);'}
             .glyph.icon-close
           %textarea.msd-elastic.title.note-input{ng-model:'note.title'}


### PR DESCRIPTION
This is a refactor to make the Json view for FlowCRUDL match other flow definitions whereby the definition is nested under a property and other metadata lives above it. This gives us a tidy place for version information and the flow_type. This also affords us moving the last_saved out of the definition since it never really belonged there.

As a follow-on, it might make sense to remove the saved_on date checking for just passing the version number for the revision it was loaded with (which this PR adds).

This PR also fixes the broken JS tests on master.