### PR TITLE
Fix ensure_current_version

### DIFF
--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -1071,6 +1071,13 @@ class FlowDefinitionWriteSerializer(WriteSerializer):
 
         return attrs
 
+    def validate_definition(self, attrs, source):
+        definition = attrs.get(source, None)
+        version = attrs.get('version')
+        if version < 7 and not definition:
+            attrs['definition'] = dict(action_sets=[], rule_sets=[])
+        return attrs
+
     def restore_object(self, flow_json, instance=None):
         """
         Update our flow

--- a/temba/flows/flow_migrations.py
+++ b/temba/flows/flow_migrations.py
@@ -10,23 +10,27 @@ def migrate_to_version_7(json_flow):
     """
     Adds flow details to metadata section
     """
-    definition = json_flow.get('definition', dict())
-    definition['flow_type'] = json_flow.get('flow_type', 'F')
+    definition = json_flow.get('definition', None)
 
-    metadata = definition.get('metadata', None)
-    if not metadata:
-        metadata = dict()
-        definition['metadata'] = metadata
+    # don't attempt if there isn't a nested definition block
+    if definition:
+        definition['flow_type'] = json_flow.get('flow_type', 'F')
+        metadata = definition.get('metadata', None)
+        if not metadata:
+            metadata = dict()
+            definition['metadata'] = metadata
 
-    metadata['name'] = json_flow.get('name')
-    metadata['id'] = json_flow.get('id', None)
-    metadata['uuid'] = json_flow.get('uuid', None)
-    revision = json_flow.get('revision', None)
-    if revision:
-        metadata['revision'] = revision
-    metadata['saved_on'] = json_flow.get('last_saved')
+        metadata['name'] = json_flow.get('name')
+        metadata['id'] = json_flow.get('id', None)
+        metadata['uuid'] = json_flow.get('uuid', None)
+        revision = json_flow.get('revision', None)
+        if revision:
+            metadata['revision'] = revision
+        metadata['saved_on'] = json_flow.get('last_saved')
 
-    return definition
+        return definition
+
+    return json_flow
 
 
 def migrate_to_version_6(json_flow):

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2010,7 +2010,13 @@ class Flow(TembaModel, SmartModel):
         """
         if self.version_number < CURRENT_EXPORT_VERSION:
             with self.lock_on(FlowLock.definition):
-                json_flow = FlowVersion.migrate_definition(self.as_json(), self.version_number, CURRENT_EXPORT_VERSION)
+                version = self.versions.all().order_by('-version').all().first()
+                if version:
+                    version_number = version.version
+                    json_flow = version.get_definition_json()
+                else:
+                    json_flow = self.as_json()
+
                 self.update(json_flow)
                 # TODO: After Django 1.8 consider doing a self.refresh_from_db() here
 
@@ -2685,12 +2691,10 @@ class FlowVersion(SmartModel):
 
     @classmethod
     def migrate_definition(cls, json_flow, version, to_version=None):
-
-
         if not to_version:
             to_version = CURRENT_EXPORT_VERSION
         from temba.flows import flow_migrations
-        while (version < to_version):
+        while (version < to_version and version < CURRENT_EXPORT_VERSION):
             migrate_fn = getattr(flow_migrations, 'migrate_to_version_%d' % (version + 1), None)
             if migrate_fn:
                 json_flow = migrate_fn(json_flow)
@@ -2707,7 +2711,7 @@ class FlowVersion(SmartModel):
         if self.spec_version <= 6:
             definition = dict(definition=definition, flow_type=self.flow.flow_type,
                               expires=self.flow.expires_after_minutes, id=self.flow.pk,
-                              revision=self.version)
+                              revision=self.version, uuid=self.flow.uuid)
 
         # migrate our definition if necessary
         if self.spec_version < CURRENT_EXPORT_VERSION:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2012,7 +2012,6 @@ class Flow(TembaModel, SmartModel):
             with self.lock_on(FlowLock.definition):
                 version = self.versions.all().order_by('-version').all().first()
                 if version:
-                    version_number = version.version
                     json_flow = version.get_definition_json()
                 else:
                     json_flow = self.as_json()

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2010,7 +2010,7 @@ class Flow(TembaModel, SmartModel):
         """
         if self.version_number < CURRENT_EXPORT_VERSION:
             with self.lock_on(FlowLock.definition):
-                json_flow = FlowVersion.migrate_definition(self.as_json(), self.version_number, self)
+                json_flow = FlowVersion.migrate_definition(self.as_json(), self.version_number, CURRENT_EXPORT_VERSION)
                 self.update(json_flow)
                 # TODO: After Django 1.8 consider doing a self.refresh_from_db() here
 
@@ -2685,6 +2685,7 @@ class FlowVersion(SmartModel):
 
     @classmethod
     def migrate_definition(cls, json_flow, version, to_version=None):
+
 
         if not to_version:
             to_version = CURRENT_EXPORT_VERSION

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3550,6 +3550,29 @@ class FlowMigrationTest(FlowFileTest):
         flow.update(flow_json)
         return Flow.objects.get(pk=flow.pk)
 
+    def test_ensure_current_version(self):
+        flow_json = self.get_flow_json('call-me-maybe')['definition']
+        flow = Flow.create_instance(dict(name='Call Me Maybe', org=self.org,
+                                         created_by=self.admin, modified_by=self.admin,
+                                         saved_by=self.admin, version_number=3))
+
+        FlowVersion.create_instance(dict(flow=flow, definition=json.dumps(flow_json),
+                                         spec_version=3, version=1,
+                                         created_by=self.admin, modified_by=self.admin))
+
+        # now make sure we are on the latest version
+        flow.ensure_current_version()
+
+        # and that the format looks correct
+        flow_json = flow.as_json()
+        self.assertEquals(flow_json['metadata']['name'], 'Call Me Maybe')
+        self.assertEquals(flow_json['metadata']['revision'], 2)
+        self.assertEquals(flow_json['metadata']['id'], 1)
+        self.assertEquals(flow_json['metadata']['expires'], 720)
+        self.assertEquals(flow_json['base_language'], 'base')
+        self.assertEquals(5, len(flow_json['action_sets']))
+        self.assertEquals(1, len(flow_json['rule_sets']))
+
     def test_migrate_to_7(self):
 
         flow_json = self.get_flow_json('call-me-maybe')

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3591,7 +3591,6 @@ class FlowMigrationTest(FlowFileTest):
         flow_json = flow.as_json()
         self.assertEquals(flow_json['metadata']['name'], 'Call Me Maybe')
         self.assertEquals(flow_json['metadata']['revision'], 2)
-        self.assertEquals(flow_json['metadata']['id'], 1)
         self.assertEquals(flow_json['metadata']['expires'], 720)
         self.assertEquals(flow_json['base_language'], 'base')
         self.assertEquals(5, len(flow_json['action_sets']))


### PR DESCRIPTION
Fix ensure_current_version to pass the proper to_version number. Also don't migrate forward for version 7 if there is no definition in the block.

