### PR TITLE
handle malformed single message flows during migration

### DIFF
--- a/media/test_flows/malformed_single_message.json
+++ b/media/test_flows/malformed_single_message.json
@@ -1,0 +1,31 @@
+{
+  "campaigns": [],
+  "triggers": [],
+  "version": 3,
+  "site": "http://rapidpro.io",
+  "flows": [
+    {
+      "name": "Single Message Flow",
+      "id": -1,
+      "uuid": "f467561a-3b95-4a4a-94bc-97bc6b4268c0",
+      "definition": {
+        "entry": "2d702ba6-461e-442c-96bc-2b8a87c9ceca",
+        "action_sets": [
+          {
+            "x": 0,
+            "y": 0,
+            "uuid": "2d702ba6-461e-442c-96bc-2b8a87c9ceca",
+            "destination": null,
+            "actions":[
+              {
+                "msg": "Single message text",
+                "type": "reply"
+              }
+            ]
+          }
+        ],
+        "rulesets": []
+      }
+    }
+  ]
+}

--- a/temba/flows/flow_migrations.py
+++ b/temba/flows/flow_migrations.py
@@ -28,6 +28,10 @@ def migrate_to_version_7(json_flow):
             metadata['revision'] = revision
         metadata['saved_on'] = json_flow.get('last_saved')
 
+        # single message flows incorrectly created an empty rulesets
+        # element which should be rule_sets instead
+        definition.pop('rulesets')
+
         return definition
 
     return json_flow
@@ -52,7 +56,7 @@ def migrate_to_version_6(json_flow):
     if 'base_language' not in definition:
         definition['base_language'] = base_language
 
-        for ruleset in definition.get('rule_sets'):
+        for ruleset in definition.get('rule_sets', []):
             for rule in ruleset.get('rules'):
 
                 # betweens haven't always required a category name, create one
@@ -93,7 +97,7 @@ def migrate_to_version_5(json_flow):
 
     definition = json_flow.get('definition')
 
-    for ruleset in definition.get('rule_sets'):
+    for ruleset in definition.get('rule_sets', []):
 
         response_type = ruleset.pop('response_type', None)
         ruleset_type = ruleset.get('ruleset_type', None)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1094,7 +1094,7 @@ class Flow(TembaModel, SmartModel):
 
         uuid = str(uuid4())
         action_sets = [dict(x=100, y=0,  uuid=uuid, actions=[dict(type='reply', msg=dict(base=message))])]
-        self.update(dict(entry=uuid, rulesets=[], action_sets=action_sets, base_language='base'))
+        self.update(dict(entry=uuid, rule_sets=[], action_sets=action_sets, base_language='base'))
 
     def steps(self):
         return FlowStep.objects.filter(run__flow=self)


### PR DESCRIPTION
Fix for issue migrating single message flows:
https://app.getsentry.com/nyaruka/textit/group/87968947/

These were created with 'rulesets' instead of 'rule_sets' (although they were always empty). We now tolerate it in all previous migrations and fix it in version 7.