### PR TITLE
Redirect asset downloads

### DIFF
--- a/static/coffee/flows/app.coffee
+++ b/static/coffee/flows/app.coffee
@@ -14,6 +14,7 @@ app.config [ '$httpProvider', '$sceDelegateProvider', ($httpProvider, $sceDelega
     'self',
     'http://*.s3.amazonaws.com/**',
     'https://*.s3.amazonaws.com/**',
+    'http://textit.ngrok.com/**',
   ])
 ]
 

--- a/static/coffee/flows/app.coffee
+++ b/static/coffee/flows/app.coffee
@@ -12,9 +12,8 @@ app.config [ '$httpProvider', '$sceDelegateProvider', ($httpProvider, $sceDelega
   # we need to whitelist our urls to reference our recordings
   $sceDelegateProvider.resourceUrlWhitelist([
     'self',
-    'http://dl.textit.in/**',
-    'http://dl.rapidpro.io/**',
-    'http://textit.ngrok.com/**',
+    'http://*.s3.amazonaws.com/**',
+    'https://*.s3.amazonaws.com/**',
   ])
 ]
 

--- a/temba/assets/models.py
+++ b/temba/assets/models.py
@@ -56,6 +56,9 @@ class BaseAssetStore(object):
         if not user.has_org_perm(asset.org, self.permission):
             raise AssetAccessDenied()
 
+        if not asset.uuid:
+            raise AssetFileNotFound()
+
         path = self.derive_path(asset.org, asset.uuid)
 
         if not default_storage.exists(path):

--- a/temba/assets/tests.py
+++ b/temba/assets/tests.py
@@ -18,31 +18,31 @@ class AssetTest(TembaTest):
                                                                 created_by=self.admin, modified_by=self.admin)
 
         response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', identifier=message_export_task.pk)))
+                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
         self.assertLoginRedirect(response)
 
         self.login(self.admin)
 
         # asset doesn't exist yet
         response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', identifier=message_export_task.pk)))
+                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
         self.assertContains(response, "File not found", status_code=200)
 
         # specify wrong asset type so db object won't exist
         response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='contact_export', identifier=message_export_task.pk)))
+                                           kwargs=dict(type='contact_export', pk=message_export_task.pk)))
         self.assertContains(response, "File not found", status_code=200)
 
         # create asset and request again with correct type
         message_export_task.do_export()
 
         response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', identifier=message_export_task.pk)))
+                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # check direct download stream
         response = self.client.get(reverse('assets.stream',
-                                           kwargs=dict(type='message_export', identifier=message_export_task.pk)))
+                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
         self.assertEqual(response.status_code, 200)
 
         # create contact export and check that we can access it
@@ -51,7 +51,7 @@ class AssetTest(TembaTest):
         contact_export_task.do_export()
 
         response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='contact_export', identifier=contact_export_task.pk)))
+                                           kwargs=dict(type='contact_export', pk=contact_export_task.pk)))
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # create flow results export and check that we can access it
@@ -62,7 +62,7 @@ class AssetTest(TembaTest):
         results_export_task.do_export()
 
         response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='results_export', identifier=results_export_task.pk)))
+                                           kwargs=dict(type='results_export', pk=results_export_task.pk)))
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # add our admin to another org
@@ -76,7 +76,7 @@ class AssetTest(TembaTest):
 
         # as this asset belongs to org #1, request will have that context
         response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', identifier=message_export_task.pk)))
+                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
         self.assertEquals(200, response.status_code)
         user = response.context_data['view'].request.user
         self.assertEquals(user, self.admin)

--- a/temba/assets/urls.py
+++ b/temba/assets/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import patterns, url
 from .views import AssetDownloadView, AssetStreamView
 
 
-urlpatterns = patterns('', url(r'download/(?P<type>\w+)/(?P<identifier>\d+)/$', AssetDownloadView.as_view(),
+urlpatterns = patterns('', url(r'download/(?P<type>\w+)/(?P<pk>\d+)/$', AssetDownloadView.as_view(),
                                name='assets.download'))
-urlpatterns += patterns('', url(r'stream/(?P<type>\w+)/(?P<identifier>\d+)/$', AssetStreamView.as_view(),
+urlpatterns += patterns('', url(r'stream/(?P<type>\w+)/(?P<pk>\d+)/$', AssetStreamView.as_view(),
                                 name='assets.stream'))

--- a/temba/assets/views.py
+++ b/temba/assets/views.py
@@ -4,7 +4,7 @@ import mimetypes
 import urllib2
 
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, HttpResponseNotFound, HttpResponseForbidden
+from django.http import HttpResponse, HttpResponseNotFound, HttpResponseForbidden, HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View
 from smartmin.views import SmartTemplateView
@@ -25,12 +25,13 @@ def handle_asset_request(user, asset_type, identifier):
         asset_type = mimetypes.guess_type(filename)[0]
 
         if location.startswith('http'):
-            asset_file = urllib2.urlopen(location)
+            # return an HTTP Redirect to the source
+            response = HttpResponseRedirect(location)
         else:
             asset_file = open('.' + location, 'rb')
+            response = HttpResponse(asset_file, content_type=asset_type)
+            response['Content-Disposition'] = 'attachment; filename=%s' % filename
 
-        response = HttpResponse(asset_file, content_type=asset_type)
-        response['Content-Disposition'] = 'attachment; filename=%s' % filename
         return response
     except AssetEntityNotFound:
         return HttpResponseNotFound("No such object in database")

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -226,7 +226,7 @@ class Channel(SmartModel):
         client = plivo.RestAPI(auth_id, auth_token)
 
         message_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('api.plivo_handler', args=['receive', plivo_uuid])
-        answer_url = "https://" + settings.AWS_STORAGE_BUCKET_NAME + "/plivo_voice_unavailable.xml"
+        answer_url = "https://" + settings.AWS_BUCKET_DOMAIN + "/plivo_voice_unavailable.xml"
 
         plivo_response_status, plivo_response = client.create_application(params=dict(app_name=app_name,
                                                                                       answer_url=answer_url,

--- a/temba/contacts/migrations/0024_exportcontactstask_uuid.py
+++ b/temba/contacts/migrations/0024_exportcontactstask_uuid.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0023_remove_test_contacts_from_sys_groups'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='exportcontactstask',
+            name='uuid',
+            field=models.CharField(help_text='The uuid used to name the resulting export file', max_length=36, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1672,11 +1672,11 @@ class ExportContactsTask(SmartModel):
         self.save(update_fields=['uuid'])
 
         store = AssetType.contact_export.store
-        store.save(self.uuid, File(table_file), 'csv' if exporter.is_csv else 'xls')
+        store.save(self.pk, File(table_file), 'csv' if exporter.is_csv else 'xls')
 
         subject = "Your contacts export is ready"
         template = 'contacts/email/contacts_export_download'
-        download_url = 'https://%s/%s' % (settings.TEMBA_HOST, get_asset_url(AssetType.contact_export, self.uuid))
+        download_url = 'https://%s/%s' % (settings.TEMBA_HOST, get_asset_url(AssetType.contact_export, self.pk))
 
         from temba.middleware import BrandingMiddleware
         branding = BrandingMiddleware.get_branding_for_host(self.host)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -2048,7 +2048,7 @@ class ContactFieldTest(TembaTest):
         self.client.get(reverse('contacts.contact_export'), dict())
         task = ExportContactsTask.objects.all().order_by('-id').first()
 
-        filename = "%s/test_orgs/%d/contact_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
+        filename = "%s/test_orgs/%d/contact_exports/%s.xls" % (settings.MEDIA_ROOT, self.org.pk, task.uuid)
         workbook = open_workbook(filename, 'rb')
         sheet = workbook.sheets()[0]
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -309,7 +309,7 @@ class ContactCRUDL(SmartCRUDL):
 
                 else:
                     export = ExportContactsTask.objects.get(id=export.pk)
-                    dl_url = reverse('assets.download', kwargs=dict(type='contact_export', identifier=export.pk))
+                    dl_url = reverse('assets.download', kwargs=dict(type='contact_export', pk=export.pk))
                     messages.info(self.request,
                                   _("Export complete, you can find it here: %s (production users will get an email)")
                                   % dl_url)

--- a/temba/flows/migrations/0036_auto_20151014_1703.py
+++ b/temba/flows/migrations/0036_auto_20151014_1703.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0035_auto_20151001_1831'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='exportflowresultstask',
+            name='uuid',
+            field=models.CharField(help_text='The uuid used to name the resulting export file', max_length=36, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3319,14 +3319,14 @@ class ExportFlowResultsTask(SmartModel):
         from temba.assets.views import get_asset_url
 
         store = AssetType.results_export.store
-        store.save(self.uuid, File(temp), 'xls')
+        store.save(self.pk, File(temp), 'xls')
 
         from temba.middleware import BrandingMiddleware
         branding = BrandingMiddleware.get_branding_for_host(self.host)
 
         subject = "Your export is ready"
         template = 'flows/email/flow_export_download'
-        download_url = 'https://%s/%s' % (settings.TEMBA_HOST, get_asset_url(AssetType.results_export, self.uuid))
+        download_url = 'https://%s/%s' % (settings.TEMBA_HOST, get_asset_url(AssetType.results_export, self.pk))
 
         # force a gc
         import gc

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -457,7 +457,7 @@ class Flow(TembaModel, SmartModel):
         # if we've been sent a recording, go grab it
         if recording_url:
             url = Flow.download_recording(call, recording_url, recording_id)
-            recording_url = "http://%s/%s" % (settings.AWS_BUCKET_DOMAIN, url)
+            recording_url = "https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, url)
 
         # create a message to hold our inbound message
         from temba.msgs.models import HANDLED, IVR
@@ -1025,7 +1025,7 @@ class Flow(TembaModel, SmartModel):
                 return None
 
             try:
-                url = "http://%s/%s" % (settings.AWS_BUCKET_DOMAIN, url)
+                url = "https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, url)
                 temp = NamedTemporaryFile(delete=True)
                 temp.write(urllib2.urlopen(url).read())
                 temp.flush()
@@ -4153,7 +4153,7 @@ class SayAction(Action):
 
             # if we have a localized recording, create the url
             if recording:
-                recording_url = "http://%s/%s" % (settings.AWS_BUCKET_DOMAIN, recording)
+                recording_url = "https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, recording)
 
         # localize the text for our message, need this either way for logging
         message = run.flow.get_localized_text(self.msg, run.contact)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -457,7 +457,7 @@ class Flow(TembaModel, SmartModel):
         # if we've been sent a recording, go grab it
         if recording_url:
             url = Flow.download_recording(call, recording_url, recording_id)
-            recording_url = "http://%s/%s" % (settings.AWS_STORAGE_BUCKET_NAME, url)
+            recording_url = "http://%s/%s" % (settings.AWS_BUCKET_DOMAIN, url)
 
         # create a message to hold our inbound message
         from temba.msgs.models import HANDLED, IVR
@@ -1025,7 +1025,7 @@ class Flow(TembaModel, SmartModel):
                 return None
 
             try:
-                url = "http://%s/%s" % (settings.AWS_STORAGE_BUCKET_NAME, url)
+                url = "http://%s/%s" % (settings.AWS_BUCKET_DOMAIN, url)
                 temp = NamedTemporaryFile(delete=True)
                 temp.write(urllib2.urlopen(url).read())
                 temp.flush()
@@ -4153,7 +4153,7 @@ class SayAction(Action):
 
             # if we have a localized recording, create the url
             if recording:
-                recording_url = "http://%s/%s" % (settings.AWS_STORAGE_BUCKET_NAME, recording)
+                recording_url = "http://%s/%s" % (settings.AWS_BUCKET_DOMAIN, recording)
 
         # localize the text for our message, need this either way for logging
         message = run.flow.get_localized_text(self.msg, run.contact)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -361,7 +361,7 @@ class RuleTest(TembaTest):
 
         # read it back in, check values
         from xlrd import open_workbook
-        filename = "%s/test_orgs/%d/results_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
+        filename = "%s/test_orgs/%d/results_exports/%s.xls" % (settings.MEDIA_ROOT, self.org.pk, task.uuid)
         workbook = open_workbook(os.path.join(settings.MEDIA_ROOT, filename), 'rb')
 
         self.assertEquals(3, len(workbook.sheets()))
@@ -438,7 +438,7 @@ class RuleTest(TembaTest):
         task = ExportFlowResultsTask.objects.all()[0]
 
         from xlrd import open_workbook
-        filename = "%s/test_orgs/%d/results_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
+        filename = "%s/test_orgs/%d/results_exports/%s.xls" % (settings.MEDIA_ROOT, self.org.pk, task.uuid)
         workbook = open_workbook(os.path.join(settings.MEDIA_ROOT, filename), 'rb')
 
         self.assertEquals(2, len(workbook.sheets()))
@@ -3095,7 +3095,7 @@ class FlowsTest(FlowFileTest):
 
         # read it back in, check values
         from xlrd import open_workbook
-        filename = "%s/test_orgs/%d/results_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
+        filename = "%s/test_orgs/%d/results_exports/%s.xls" % (settings.MEDIA_ROOT, self.org.pk, task.uuid)
         workbook = open_workbook(os.path.join(settings.MEDIA_ROOT, filename), 'rb')
 
         self.assertEquals(3, len(workbook.sheets()))

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -806,7 +806,7 @@ class FlowCRUDL(SmartCRUDL):
         def get_context_data(self, *args, **kwargs):
             context = super(FlowCRUDL.Read, self).get_context_data(*args, **kwargs)
 
-            context['recording_url'] = 'http://%s/' % settings.AWS_BUCKET_DOMAIN
+            context['recording_url'] = 'https://%s/' % settings.AWS_BUCKET_DOMAIN
 
             # are there pending starts?
             starting = False

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -875,7 +875,7 @@ class FlowCRUDL(SmartCRUDL):
 
                 else:
                     export = ExportFlowResultsTask.objects.get(id=export.pk)
-                    dl_url = reverse('assets.download', kwargs=dict(type='results_export', identifier=export.pk))
+                    dl_url = reverse('assets.download', kwargs=dict(type='results_export', pk=export.pk))
                     messages.info(self.request,
                                   _("Export complete, you can find it here: %s (production users will get an email)")
                                   % dl_url)

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -806,7 +806,7 @@ class FlowCRUDL(SmartCRUDL):
         def get_context_data(self, *args, **kwargs):
             context = super(FlowCRUDL.Read, self).get_context_data(*args, **kwargs)
 
-            context['recording_url'] = 'http://%s/' % settings.AWS_STORAGE_BUCKET_NAME
+            context['recording_url'] = 'http://%s/' % settings.AWS_BUCKET_DOMAIN
 
             # are there pending starts?
             starting = False

--- a/temba/msgs/migrations/0033_exportmessagestask_uuid.py
+++ b/temba/msgs/migrations/0033_exportmessagestask_uuid.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0032_auto_20151002_1411'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='exportmessagestask',
+            name='uuid',
+            field=models.CharField(help_text='The uuid used to name the resulting export file', max_length=36, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/temba/msgs/migrations/0034_move_recording_domains.py
+++ b/temba/msgs/migrations/0034_move_recording_domains.py
@@ -17,17 +17,18 @@ class Migration(migrations.Migration):
         bucket_name = settings.AWS_STORAGE_BUCKET_NAME
 
         # our old bucket name had periods instead of dashes
-        old_bucket_domain = bucket_name.replace('-', '.')
+        old_bucket_domain = 'http://' + bucket_name.replace('-', '.')
 
         # our new domain is more specific
-        new_bucket_domain = settings.AWS_BUCKET_DOMAIN
+        new_bucket_domain = 'https://' + settings.AWS_BUCKET_DOMAIN
 
         for msg in Msg.objects.filter(msg_type='V').exclude(recording_url=None):
             # if our recording URL is on our old bucket
             if msg.recording_url.find(old_bucket_domain) > 0:
                 # rename it to our new bucket
                 old_recording_url = msg.recording_url
-                msg.recording_url = msg.recording_url.replace(old_bucket_domain, new_bucket_domain)
+                msg.recording_url = msg.recording_url.replace(old_bucket_domain,
+                                                              new_bucket_domain)
                 print "[%d] %s to %s" % (msg.id, old_recording_url, msg.recording_url)
                 msg.save(update_fields=['recording_url'])
 

--- a/temba/msgs/migrations/0034_move_recording_domains.py
+++ b/temba/msgs/migrations/0034_move_recording_domains.py
@@ -17,13 +17,18 @@ class Migration(migrations.Migration):
         bucket_name = settings.AWS_STORAGE_BUCKET_NAME
 
         # our old bucket name had periods instead of dashes
-        old_bucket_name = bucket_name.replace('-', '.')
+        old_bucket_domain = bucket_name.replace('-', '.')
 
-        for msg in Msg.objects.filter(msg_type='I').exclude(recording_url=None):
+        # our new domain is more specific
+        new_bucket_domain = settings.AWS_BUCKET_DOMAIN
+
+        for msg in Msg.objects.filter(msg_type='V').exclude(recording_url=None):
             # if our recording URL is on our old bucket
-            if msg.recording_url.find(old_bucket_name):
+            if msg.recording_url.find(old_bucket_domain) > 0:
                 # rename it to our new bucket
-                msg.recording_url = msg.recording_url.replace(old_bucket_name, bucket_name)
+                old_recording_url = msg.recording_url
+                msg.recording_url = msg.recording_url.replace(old_bucket_domain, new_bucket_domain)
+                print "[%d] %s to %s" % (msg.id, old_recording_url, msg.recording_url)
                 msg.save(update_fields=['recording_url'])
 
     operations = [

--- a/temba/msgs/migrations/0034_move_recording_domains.py
+++ b/temba/msgs/migrations/0034_move_recording_domains.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0033_exportmessagestask_uuid'),
+    ]
+
+    def move_recording_domains(apps, schema_editor):
+        Msg = apps.get_model('msgs', 'Msg')
+
+        # this is our new bucket name
+        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+
+        # our old bucket name had periods instead of dashes
+        old_bucket_name = bucket_name.replace('-', '.')
+
+        for msg in Msg.objects.filter(msg_type='I').exclude(recording_url=None):
+            # if our recording URL is on our old bucket
+            if msg.recording_url.find(old_bucket_name):
+                # rename it to our new bucket
+                msg.recording_url = msg.recording_url.replace(old_bucket_name, bucket_name)
+                msg.save(update_fields=['recording_url'])
+
+    operations = [
+        migrations.RunPython(move_recording_domains)
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1757,14 +1757,14 @@ class ExportMessagesTask(SmartModel):
         from temba.assets.views import get_asset_url
 
         store = AssetType.message_export.store
-        store.save(self.uuid, File(temp), 'xls')
+        store.save(self.pk, File(temp), 'xls')
 
         from temba.middleware import BrandingMiddleware
         branding = BrandingMiddleware.get_branding_for_host(self.host)
 
         subject = "Your messages export is ready"
         template = 'msgs/email/msg_export_download'
-        download_url = branding['link'] + get_asset_url(AssetType.message_export, self.uuid)
+        download_url = branding['link'] + get_asset_url(AssetType.message_export, self.pk)
 
         # force a gc
         import gc

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -28,6 +28,7 @@ from temba.utils import get_datetime_format, datetime_to_str, analytics, chunk_l
 from temba.utils.models import TembaModel
 from temba.utils.parser import evaluate_template, EvaluationContext
 from temba.utils.queues import DEFAULT_PRIORITY, push_task, LOW_PRIORITY, HIGH_PRIORITY
+from uuid import uuid4
 from .handler import MessageHandler
 
 logger = logging.getLogger(__name__)
@@ -1653,6 +1654,8 @@ class ExportMessagesTask(SmartModel):
     task_id = models.CharField(null=True, max_length=64)
     is_finished = models.BooleanField(default=False,
                                       help_text=_("Whether this export is finished running"))
+    uuid = models.CharField(max_length=36, null=True,
+                            help_text=_("The uuid used to name the resulting export file"))
 
     def start_export(self):
         """
@@ -1746,19 +1749,22 @@ class ExportMessagesTask(SmartModel):
         book.save(temp)
         temp.flush()
 
+        self.uuid = str(uuid4())
+        self.save(update_fields=['uuid'])
+
         # save as file asset associated with this task
         from temba.assets.models import AssetType
         from temba.assets.views import get_asset_url
 
         store = AssetType.message_export.store
-        store.save(self.pk, File(temp), 'xls')
+        store.save(self.uuid, File(temp), 'xls')
 
         from temba.middleware import BrandingMiddleware
         branding = BrandingMiddleware.get_branding_for_host(self.host)
 
         subject = "Your messages export is ready"
         template = 'msgs/email/msg_export_download'
-        download_url = branding['link'] + get_asset_url(AssetType.message_export, self.pk)
+        download_url = branding['link'] + get_asset_url(AssetType.message_export, self.uuid)
 
         # force a gc
         import gc

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -579,7 +579,7 @@ class MsgTest(TembaTest):
         self.client.post(reverse('msgs.msg_export'))
         task = ExportMessagesTask.objects.all().order_by('-id').first()
 
-        filename = "%s/test_orgs/%d/message_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
+        filename = "%s/test_orgs/%d/message_exports/%s.xls" % (settings.MEDIA_ROOT, self.org.pk, task.uuid)
         workbook = open_workbook(filename, 'rb')
         sheet = workbook.sheets()[0]
 
@@ -614,7 +614,7 @@ class MsgTest(TembaTest):
         self.client.post("%s?label=%s" % (reverse('msgs.msg_export'), label.pk))
         task = ExportMessagesTask.objects.get()
 
-        filename = "%s/test_orgs/%d/message_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
+        filename = "%s/test_orgs/%d/message_exports/%s.xls" % (settings.MEDIA_ROOT, self.org.pk, task.uuid)
         workbook = open_workbook(filename, 'rb')
         sheet = workbook.sheets()[0]
 
@@ -633,7 +633,7 @@ class MsgTest(TembaTest):
             self.client.post(reverse('msgs.msg_export'))
             task = ExportMessagesTask.objects.get()
 
-            filename = "%s/test_orgs/%d/message_exports/%d.xls" % (settings.MEDIA_ROOT, self.org.pk, task.pk)
+            filename = "%s/test_orgs/%d/message_exports/%s.xls" % (settings.MEDIA_ROOT, self.org.pk, task.uuid)
             workbook = open_workbook(filename, 'rb')
             sheet = workbook.sheets()[0]
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -587,7 +587,7 @@ class MsgCRUDL(SmartCRUDL):
 
                 else:
                     export = ExportMessagesTask.objects.get(id=export.pk)
-                    dl_url = reverse('assets.download', kwargs=dict(type='message_export', identifier=export.pk))
+                    dl_url = reverse('assets.download', kwargs=dict(type='message_export', pk=export.pk))
                     messages.info(self.request, _("Export complete, you can find it here: %s (production users will get an email)") % dl_url)
 
             try:

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -498,7 +498,7 @@ class Org(SmartModel):
             app_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('api.twilio_handler')
 
             # the the twiml to run when the voice app fails
-            fallback_url = "https://" + settings.AWS_STORAGE_BUCKET_NAME + "/voice_unavailable.xml"
+            fallback_url = "https://" + settings.AWS_BUCKET_DOMAIN + "/voice_unavailable.xml"
 
             temba_app = client.applications.create(friendly_name=app_name,
                                                    voice_url=app_url,

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1621,7 +1621,7 @@ class OrgCRUDL(SmartCRUDL):
             asset_type = types_to_assets[task_type]
             identifier = self.kwargs.get('pk')
             return HttpResponseRedirect(reverse('assets.download',
-                                                kwargs=dict(type=asset_type.name, identifier=identifier)))
+                                                kwargs=dict(type=asset_type.name, pk=identifier)))
 
 
 class TopUpCRUDL(SmartCRUDL):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -46,7 +46,8 @@ EMAIL_HOST_PASSWORD = 'mypassword'
 EMAIL_USE_TLS = True
 
 # where recordings and exports are stored
-AWS_STORAGE_BUCKET_NAME = 'dl.temba.io'
+AWS_STORAGE_BUCKET_NAME = 'dl-temba-io'
+AWS_BUCKET_DOMAIN = AWS_STORAGE_BUCKET_NAME + '.s3.amazonaws.com'
 STORAGE_ROOT_DIR = 'test_orgs' if TESTING else 'orgs'
 
 #-----------------------------------------------------------------------------------


### PR DESCRIPTION
This moves to naming files with UUIDs for exports as well as using 301 redirects for downloads so we don't time out trying to download large files before serving to nginx.

