### PR TITLE
Auth tokens

### DIFF
--- a/temba/api/migrations/0005_apitoken_role.py
+++ b/temba/api/migrations/0005_apitoken_role.py
@@ -14,9 +14,8 @@ class Migration(migrations.Migration):
     def populate_token_roles(apps, schema_editor):
         for token in APIToken.objects.all():
             group = token.org.get_user_org_group(token.user)
-
             if group:
-                token.role = group.name[0:1]  # S, A, V, E
+                token.role = group
                 token.save()
             else:
                 print "Removing abandoned token for %s: %s (%s)" % (token.user, token.org, token.key)
@@ -26,14 +25,14 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='apitoken',
             name='role',
-            field=models.CharField(max_length=1, null=True),
+            field=models.ForeignKey(to='auth.Group', null=True),
             preserve_default=True,
         ),
         migrations.RunPython(populate_token_roles, populate_token_roles),
         migrations.AlterField(
             model_name='apitoken',
             name='role',
-            field=models.CharField(max_length=1),
+            field=models.ForeignKey(to='auth.Group'),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(

--- a/temba/api/migrations/0005_apitoken_role.py
+++ b/temba/api/migrations/0005_apitoken_role.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from temba.api.models import APIToken
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0004_webhookresult_request'),
+    ]
+
+    def populate_token_roles(apps, schema_editor):
+        for token in APIToken.objects.all():
+            group = token.org.get_user_org_group(token.user)
+
+            if group:
+                token.role = group.name[0:1]  # S, A, V, E
+                token.save()
+            else:
+                token.delete()
+                print "Removing abandoned token for %s: %s (%s)" % (token.user, token.org, token.key)
+
+    operations = [
+        migrations.AddField(
+            model_name='apitoken',
+            name='role',
+            field=models.CharField(max_length=1, null=True),
+            preserve_default=True,
+        ),
+        migrations.RunPython(populate_token_roles, populate_token_roles),
+        migrations.AlterField(
+            model_name='apitoken',
+            name='role',
+            field=models.CharField(max_length=1),
+            preserve_default=True,
+        ),
+        migrations.AlterUniqueTogether(
+            name='apitoken',
+            unique_together=set([('user', 'org', 'role')]),
+        ),
+    ]

--- a/temba/api/migrations/0005_apitoken_role.py
+++ b/temba/api/migrations/0005_apitoken_role.py
@@ -19,8 +19,8 @@ class Migration(migrations.Migration):
                 token.role = group.name[0:1]  # S, A, V, E
                 token.save()
             else:
-                token.delete()
                 print "Removing abandoned token for %s: %s (%s)" % (token.user, token.org, token.key)
+                token.delete()
 
     operations = [
         migrations.AddField(

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -479,6 +479,7 @@ class APIToken(models.Model):
     user = models.ForeignKey(User, related_name='api_tokens')
     org = models.ForeignKey(Org, related_name='api_tokens')
     created = models.DateTimeField(auto_now_add=True)
+    role = models.CharField(max_length=1, null=False)
 
     def save(self, *args, **kwargs):
         if not self.key:
@@ -493,7 +494,7 @@ class APIToken(models.Model):
         return self.key
 
     class Meta:
-        unique_together = ('user', 'org')
+        unique_together = ('user', 'org', 'role')
 
 
 def get_or_create_api_token(user):
@@ -507,19 +508,20 @@ def get_or_create_api_token(user):
     if not org:
         org = Org.get_org(user)
 
+    role = user.get_role()
     if org:
-        tokens = APIToken.objects.filter(user=user, org=org)
+        tokens = APIToken.objects.filter(user=user, org=org, role=role)
 
         if tokens:
             return str(tokens[0])
         else:
-            token = APIToken.objects.create(user=user, org=org)
+            token = APIToken.objects.create(user=user, org=org, role=role)
             return str(token)
     else:
         return None
 
 
-def api_token(user):
+def api_token(user, role):
     """
     Cached property access to a user's lazily-created API token
     """

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -509,6 +509,7 @@ def get_or_create_api_token(user):
         org = Org.get_org(user)
 
     role = user.get_role()
+
     if org:
         tokens = APIToken.objects.filter(user=user, org=org, role=role)
 
@@ -521,7 +522,7 @@ def get_or_create_api_token(user):
         return None
 
 
-def api_token(user, role):
+def api_token(user):
     """
     Cached property access to a user's lazily-created API token
     """

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -18,6 +18,7 @@ from django.utils.http import urlquote_plus
 from mock import patch
 from redis_cache import get_redis_connection
 from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
 from temba.campaigns.models import Campaign, CampaignEvent, MESSAGE_EVENT, FLOW_EVENT
 from temba.contacts.models import Contact, ContactField, ContactGroup, ContactURN, TEL_SCHEME, TWITTER_SCHEME
 from temba.orgs.models import Org, ACCOUNT_SID, ACCOUNT_TOKEN, APPLICATION_SID, NEXMO_KEY, NEXMO_SECRET
@@ -38,7 +39,7 @@ from twilio.util import RequestValidator
 from twython import TwythonError
 from urllib import urlencode
 from urlparse import parse_qs
-from .models import WebHookEvent, WebHookResult, SMS_RECEIVED
+from .models import WebHookEvent, WebHookResult, APIToken, SMS_RECEIVED
 from .serializers import DictionaryField, IntegerArrayField, StringArrayField, PhoneArrayField, ChannelField, FlowField
 
 
@@ -2136,6 +2137,63 @@ class APITest(TembaTest):
         response = self.fetchJSON(url, 'uuid=%s' % junk.uuid)
         self.assertResultCount(response, 1)
         self.assertContains(response, "Junk")
+
+    def test_api_authenticate(self):
+
+        url = reverse('api.authenticate')
+
+        # fetch our html docs
+        self.assertEqual(self.fetchHTML(url).status_code, 200)
+
+        # login an admin as an admin
+        admin = json.loads(self.client.post(url, dict(email='Administrator', password='Administrator', role='A')).content)
+        self.assertEqual(1, len(admin))
+        self.assertEqual('Temba', admin[0]['name'])
+        self.assertIsNotNone(APIToken.objects.filter(key=admin[0]['token'], role='A').first())
+
+        # login an admin as a surveyor
+        surveyor = json.loads(self.client.post(url, dict(email='Administrator', password='Administrator', role='S')).content)
+        self.assertEqual(1, len(surveyor))
+        self.assertEqual('Temba', surveyor[0]['name'])
+        self.assertIsNotNone(APIToken.objects.filter(key=surveyor[0]['token'], role='S').first())
+
+        # the keys should be different
+        self.assertNotEqual(admin[0]['token'], surveyor[0]['token'])
+
+        # don't do ssl auth check
+        settings.SESSION_COOKIE_SECURE = False
+
+        # configure our api client
+        client = APIClient()
+
+        admin_token = dict(HTTP_AUTHORIZATION='Token ' + admin[0]['token'])
+        surveyor_token = dict(HTTP_AUTHORIZATION='Token ' + surveyor[0]['token'])
+
+        # campaigns can be fetched by admin token
+        client.credentials(**admin_token)
+        self.assertEqual(200, client.get(reverse('api.campaigns') + '.json').status_code)
+
+        # but not by an admin's surveyor token
+        client.credentials(**surveyor_token)
+        self.assertEqual(403, client.get(reverse('api.campaigns') + '.json').status_code)
+
+        # but their surveyor token can get flows or contacts
+        self.assertEqual(200, client.get(reverse('api.flows') + '.json').status_code)
+        self.assertEqual(200, client.get(reverse('api.contacts') + '.json').status_code)
+
+        # our surveyor can't login with an admin role
+        response = json.loads(self.client.post(url, dict(email='Surveyor', password='Surveyor', role='A')).content)
+        self.assertEqual(0, len(response))
+
+        # but they can with a surveyor role
+        response = json.loads(self.client.post(url, dict(email='Surveyor', password='Surveyor', role='S')).content)
+        self.assertEqual(1, len(response))
+
+        # and can fetch flows and contacts, but not campaigns
+        client.credentials(HTTP_AUTHORIZATION='Token ' + response[0]['token'])
+        self.assertEqual(200, client.get(reverse('api.flows') + '.json').status_code)
+        self.assertEqual(200, client.get(reverse('api.contacts') + '.json').status_code)
+        self.assertEqual(403, client.get(reverse('api.campaigns') + '.json').status_code)
 
     def test_api_broadcasts(self):
         url = reverse('api.broadcasts')

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 
 from datetime import datetime, timedelta
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.utils import timezone
@@ -2146,17 +2147,20 @@ class APITest(TembaTest):
         # fetch our html docs
         self.assertEqual(self.fetchHTML(url).status_code, 200)
 
+        admin_group = Group.objects.get(name='Administrators')
+        surveyor_group = Group.objects.get(name='Surveyors')
+
         # login an admin as an admin
         admin = json.loads(self.client.post(url, dict(email='Administrator', password='Administrator', role='A')).content)
         self.assertEqual(1, len(admin))
         self.assertEqual('Temba', admin[0]['name'])
-        self.assertIsNotNone(APIToken.objects.filter(key=admin[0]['token'], role='A').first())
+        self.assertIsNotNone(APIToken.objects.filter(key=admin[0]['token'], role=admin_group).first())
 
         # login an admin as a surveyor
         surveyor = json.loads(self.client.post(url, dict(email='Administrator', password='Administrator', role='S')).content)
         self.assertEqual(1, len(surveyor))
         self.assertEqual('Temba', surveyor[0]['name'])
-        self.assertIsNotNone(APIToken.objects.filter(key=surveyor[0]['token'], role='S').first())
+        self.assertIsNotNone(APIToken.objects.filter(key=surveyor[0]['token'], role=surveyor_group).first())
 
         # the keys should be different
         self.assertNotEqual(admin[0]['token'], surveyor[0]['token'])

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -2194,11 +2194,13 @@ class APITest(TembaTest):
         response = json.loads(self.client.post(url, dict(email='Surveyor', password='Surveyor', role='S')).content)
         self.assertEqual(1, len(response))
 
-        # and can fetch flows and contacts, but not campaigns
+        # and can fetch flows, contacts, and fields, but not campaigns
         client.credentials(HTTP_AUTHORIZATION='Token ' + response[0]['token'])
         self.assertEqual(200, client.get(reverse('api.flows') + '.json').status_code)
         self.assertEqual(200, client.get(reverse('api.contacts') + '.json').status_code)
+        self.assertEqual(200, client.get(reverse('api.contactfields') + '.json').status_code)
         self.assertEqual(403, client.get(reverse('api.campaigns') + '.json').status_code)
+
 
     def test_api_broadcasts(self):
         url = reverse('api.broadcasts')

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1471,6 +1471,7 @@ class APITest(TembaTest):
 
         # page is implicit
         response = self.fetchJSON(url)
+        self.assertEqual(200, response.status_code)
         self.assertResultCount(response, 300)
         self.assertEqual(response.json['results'][0]['name'], "Minion 300")
 

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -72,12 +72,10 @@ def webhook_status_processor(request):
 
     return status
 
+
 class ApiPermission(BasePermission):
     def has_permission(self, request, view):
 
-        # TODO: Lookup group based on token in request.auth
-
-        # api_token = request.auth
         if getattr(view, 'permission', None):
 
             if request.user.is_anonymous():

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1346,7 +1346,7 @@ def set_role(obj, role):
 def get_role(obj):
 
     if not hasattr(obj, '_role'):
-        obj._role = obj.get_org_group().name[0:1]
+        obj._role = obj.get_org_group()
 
     return obj._role
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1339,6 +1339,10 @@ def get_org_group(obj):
     return org_group
 
 
+def set_role(obj, role):
+    obj._role = role
+
+
 def get_role(obj):
 
     if not hasattr(obj, '_role'):
@@ -1379,6 +1383,7 @@ User.get_settings = get_settings
 User.get_user_orgs = get_user_orgs
 User.get_org_group = get_org_group
 User.get_role = get_role
+User.set_role = set_role
 User.has_org_perm = _user_has_org_perm
 
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1339,6 +1339,15 @@ def get_org_group(obj):
     return org_group
 
 
+def get_role(obj):
+
+    if obj._role:
+        return obj._role
+
+    obj._role = obj.get_org_group().name[0:1]
+    return obj.role
+
+
 def _user_has_org_perm(user, org, permission):
     """
     Determines if a user has the given permission in this org
@@ -1370,12 +1379,14 @@ User.is_beta = is_beta_user
 User.get_settings = get_settings
 User.get_user_orgs = get_user_orgs
 User.get_org_group = get_org_group
+User.get_role = get_role
 User.has_org_perm = _user_has_org_perm
 
 
 USER_GROUPS = (('A', _("Administrator")),
                ('E', _("Editor")),
-               ('V', _("Viewer")))
+               ('V', _("Viewer")),
+               ('S', _("Surveyor")))
 
 
 def get_stripe_credentials():

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1341,11 +1341,10 @@ def get_org_group(obj):
 
 def get_role(obj):
 
-    if obj._role:
-        return obj._role
+    if not hasattr(obj, '_role'):
+        obj._role = obj.get_org_group().name[0:1]
 
-    obj._role = obj.get_org_group().name[0:1]
-    return obj.role
+    return obj._role
 
 
 def _user_has_org_perm(user, org, permission):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -514,6 +514,7 @@ GROUP_PERMISSIONS = {
         'orgs.org_surveyor',
         'orgs.org_api',
         'contacts.contact_api',
+        'contacts.contactfield_api',
         'locations.adminboundary_api',
         'flows.flow_api'
     ),


### PR DESCRIPTION
Add new property ```APIToken.role```. 

* Migrate current tokens to have role based on user group for org
* Apply role when generating new tokens
* Require role when authenticating against the api
* Take role into account with authenticating with token