### PR TITLE
Fix slugging to replace all bad characters

### DIFF
--- a/karma/flows/test_services.coffee
+++ b/karma/flows/test_services.coffee
@@ -51,6 +51,10 @@ describe 'Services:', ->
       $timeout = _$timeout_
     )
 
+    it 'should slugify properly', ->
+      expect(flowService.slugify('This Response Slugged')).toBe('this_response_slugged')
+      expect(flowService.slugify('This RESPONSE$@slugGed')).toBe('this_response_slugged')
+      expect(flowService.slugify('this    response %slugged')).toBe('this_response_slugged')
 
     it 'should set flow definition after fetching', ->
       flowService.fetch(flows.rules_first.id).then (response) ->

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -662,7 +662,8 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
     # translates a string into a slug
     slugify: (label) ->
       label = label.toString().toLowerCase().replace(/([^a-z0-9]+)/, ' ')
-      return label.replace(/([^a-z0-9]+)/, '_')
+      label = label.replace(/([^a-z0-9]+)/g, '_')
+      return label
 
     # Get an array of current flow fields as:
     # [ { id: 'label_name', name: 'Label Name' } ]

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -661,8 +661,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
     # translates a string into a slug
     slugify: (label) ->
-      label = label.toString().toLowerCase().replace(/([^a-z0-9]+)/, ' ')
-      return label.replace(/([^a-z0-9]+)/g, '_')
+      return label.toString().toLowerCase().replace(/([^a-z0-9]+)/g, '_')
 
     # Get an array of current flow fields as:
     # [ { id: 'label_name', name: 'Label Name' } ]

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -662,8 +662,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
     # translates a string into a slug
     slugify: (label) ->
       label = label.toString().toLowerCase().replace(/([^a-z0-9]+)/, ' ')
-      label = label.replace(/([^a-z0-9]+)/g, '_')
-      return label
+      return label.replace(/([^a-z0-9]+)/g, '_')
 
     # Get an array of current flow fields as:
     # [ { id: 'label_name', name: 'Label Name' } ]


### PR DESCRIPTION
Fixes issue with form_field ruleset type not getting a proper operand when created by the editor. Issue is due to client side slugging only replacing once.