### PR TITLE
API Requests should return 403 if no org rather than throw exception

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -317,6 +317,10 @@ class APITest(TembaTest):
         # can't access, get 403
         self.assert403(url)
 
+        # login as non-org user
+        self.login(self.non_org_user)
+        self.assert403(url)
+
         # login as plain user
         self.login(self.user)
         self.assert403(url)

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -87,7 +87,7 @@ class ApiPermission(BasePermission):
             # otherwise lean on the logged in user
             else:
                 org = request.user.get_org()
-                group = org.get_user_org_group(request.user)
+                group = org.get_user_org_group(request.user) if org else None
 
             # if we have a group, check its permissions
             if group:


### PR DESCRIPTION
Fixes https://app.getsentry.com/nyaruka/textit/group/89200237/