### PR TITLE
Better contact related errors

### DIFF
--- a/temba/api/__init__.py
+++ b/temba/api/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.conf import settings
 from django.http import HttpResponseServerError
 from rest_framework.views import exception_handler
 
@@ -10,7 +11,7 @@ def temba_exception_handler(exc):
     """
     response = exception_handler(exc)
 
-    if response:
+    if response or not getattr(settings, 'REST_HANDLE_EXCEPTIONS', False):
         return response
     else:
         return HttpResponseServerError("Server Error. Site administrators have been notified.")

--- a/temba/api/__init__.py
+++ b/temba/api/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.http import HttpResponseServerError
+from rest_framework.views import exception_handler
+
+
+def temba_exception_handler(exc):
+    """
+    Custom exception handler which prevents responding to API requests that error with an HTML error page
+    """
+    response = exception_handler(exc)
+
+    if response:
+        return response
+    else:
+        return HttpResponseServerError("Server Error. Site administrators have been notified.")

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1296,6 +1296,15 @@ class APITest(TembaTest):
         response = self.postJSON(url, dict(phone='+250788123456', groups=[artists.name], group_uuids=[artists.uuid]))
         self.assertEquals(400, response.status_code)
 
+        # can't add a contact to a group if they're blocked
+        contact.block()
+        response = self.postJSON(url, dict(phone='+250788123456', groups=["Dancers"]))
+        self.assertEqual(response.status_code, 400)
+        self.assertResponseError(response, 'non_field_errors', "Cannot add blocked contact to groups")
+
+        contact.unblock()
+        artists.contacts.add(contact)
+
         # try updating a non-existent field
         response = self.postJSON(url, dict(phone='+250788123456', fields={"real_name": "Andy"}))
         self.assertEquals(400, response.status_code)

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -266,6 +266,16 @@ class APITest(TembaTest):
         self.channel.save()
         self.assertRaises(ValidationError, channel_field.from_native, self.channel.pk)
 
+    @patch('temba.api.views.FieldEndpoint.get_queryset')
+    def test_api_error_handling(self, mock_get_queryset):
+        mock_get_queryset.side_effect = ValueError("DOH!")
+
+        self.login(self.admin)
+
+        response = self.client.get(reverse('api.contactfields') + '.json', content_type="application/json", HTTP_X_FORWARDED_HTTPS='https')
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.content, "Server Error. Site administrators have been notified.")
+
     def test_api_org(self):
         url = reverse('api.org')
 

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1275,7 +1275,7 @@ class APITest(TembaTest):
         self.assertEquals(201, response.status_code)
         self.assertEquals("Music Artists", artists.name)
         self.assertEqual(1, artists.contacts.count())
-        self.assertEqual(1, artists.get_member_count())  # check cached value
+        self.assertEqual(1, artists.get_member_count())  # check trigger-based count
 
         # remove contact from a group by name
         response = self.postJSON(url, dict(phone='+250788123456', groups=[]))
@@ -1610,9 +1610,10 @@ class APITest(TembaTest):
         contact1 = self.create_contact("Ann", '+250788000001')
         contact2 = self.create_contact("Bob", '+250788000002')
         contact3 = self.create_contact("Cat", '+250788000003')
-        contact4 = self.create_contact("Don", '+250788000004')
+        contact4 = self.create_contact("Don", '+250788000004')  # a blocked contact
+        contact5 = self.create_contact("Eve", '+250788000005')  # a deleted contact
         contact4.block()
-        contact4.release()
+        contact5.release()
         test_contact = Contact.get_test_contact(self.user)
 
         group = ContactGroup.get_or_create(self.org, self.admin, "Testers")
@@ -1622,11 +1623,27 @@ class APITest(TembaTest):
         flow.start([], [contact1, contact2, contact3])
         runs = FlowRun.objects.filter(flow=flow)
 
-        # add contacts to the group by name
-        response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid, contact4.uuid, test_contact.uuid],
+        # try adding all contacts to a group
+        response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid,
+                                                     contact5.uuid, test_contact.uuid],
+                                           action='add', group="Testers"))
+
+        # error reporting that the deleted and test contacts are invalid
+        self.assertResponseError(response, 'contacts',
+                                 "Some contacts are invalid: %s, %s" % (contact5.uuid, test_contact.uuid))
+
+        # try adding a blocked contact to a group
+        response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid],
+                                           action='add', group="Testers"))
+
+        # error reporting that the deleted and test contacts are invalid
+        self.assertResponseError(response, 'non_field_errors', "Blocked cannot be added to groups: %s" % contact4.uuid)
+
+        # add valid contacts to the group by name
+        response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid],
                                            action='add', group="Testers"))
         self.assertEquals(204, response.status_code)
-        self.assertEqual(set(group.contacts.all()), {contact1, contact2})  # not 4 (it's deleted) or the test contact
+        self.assertEqual(set(group.contacts.all()), {contact1, contact2})
 
         # try to add to a non-existent group
         response = self.postJSON(url, dict(contacts=[contact1.uuid], action='add', group='Spammers'))
@@ -1653,23 +1670,23 @@ class APITest(TembaTest):
         response = self.postJSON(url, dict(contacts=[contact1.uuid], action='add', group=''))
         self.assertResponseError(response, 'non_field_errors', "For action add you should also specify group or group_uuid")
 
-        # block all contacts
-        response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid, test_contact.uuid],
+        # try to block all contacts
+        response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid,
+                                                     contact5.uuid, test_contact.uuid],
+                                           action='block'))
+        self.assertResponseError(response, 'contacts',
+                                 "Some contacts are invalid: %s, %s" % (contact5.uuid, test_contact.uuid))
+
+        # block all valid contacts
+        response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid],
                                            action='block'))
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(set(Contact.objects.filter(is_blocked=False)), {test_contact})
         self.assertEqual(set(Contact.objects.filter(is_blocked=True)), {contact1, contact2, contact3, contact4})
 
         # unblock contact 1
         response = self.postJSON(url, dict(contacts=[contact1.uuid], action='unblock'))
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(set(Contact.objects.filter(is_blocked=False)), {contact1, test_contact})
-        self.assertEqual(set(Contact.objects.filter(is_blocked=True)), {contact2, contact3, contact4})
-
-        # can't unblock a deleted contact
-        response = self.postJSON(url, dict(contacts=[contact4.uuid], action='unblock'))
-        self.assertEqual(response.status_code, 204)
-        self.assertEqual(set(Contact.objects.filter(is_blocked=False)), {contact1, test_contact})
+        self.assertEqual(set(Contact.objects.filter(is_blocked=False)), {contact1, contact5, test_contact})
         self.assertEqual(set(Contact.objects.filter(is_blocked=True)), {contact2, contact3, contact4})
 
         # expire contacts 1 and 2 from any active runs
@@ -1681,15 +1698,15 @@ class APITest(TembaTest):
         # delete contacts 1 and 2
         response = self.postJSON(url, dict(contacts=[contact1.uuid, contact2.uuid], action='delete'))
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(set(Contact.objects.filter(is_active=False)), {contact1, contact2, contact4})
-        self.assertEqual(set(Contact.objects.filter(is_active=True)), {contact3, test_contact})
+        self.assertEqual(set(Contact.objects.filter(is_active=False)), {contact1, contact2, contact5})
+        self.assertEqual(set(Contact.objects.filter(is_active=True)), {contact3, contact4, test_contact})
 
         # try to provide a group for a non-group action
-        response = self.postJSON(url, dict(contacts=[contact1.uuid], action='block', group='Testers'))
+        response = self.postJSON(url, dict(contacts=[contact3.uuid], action='block', group='Testers'))
         self.assertResponseError(response, 'non_field_errors', "For action block you should not specify group or group_uuid")
 
         # try to invoke an invalid action
-        response = self.postJSON(url, dict(contacts=[contact1.uuid], action='like'))
+        response = self.postJSON(url, dict(contacts=[contact3.uuid], action='like'))
         self.assertResponseError(response, 'action', "Invalid action name: like")
 
     def test_api_messages(self):

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -270,11 +270,15 @@ class APITest(TembaTest):
     def test_api_error_handling(self, mock_get_queryset):
         mock_get_queryset.side_effect = ValueError("DOH!")
 
+        settings.REST_FRAMEWORK['EXCEPTION_HANDLER'] = 'temba.api.temba_exception_handler'
+
         self.login(self.admin)
 
         response = self.client.get(reverse('api.contactfields') + '.json', content_type="application/json", HTTP_X_FORWARDED_HTTPS='https')
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.content, "Server Error. Site administrators have been notified.")
+
+        del settings.REST_FRAMEWORK['EXCEPTION_HANDLER']
 
     def test_api_org(self):
         url = reverse('api.org')

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import json
-from django.contrib.auth.models import Group
 import requests
 import urllib
 
@@ -40,7 +39,6 @@ from temba.contacts.models import Contact, ContactField, ContactGroup, TEL_SCHEM
 from temba.flows.models import Flow, FlowRun, FlowStep, RuleSet
 from temba.locations.models import AdminBoundary
 from temba.orgs.views import OrgPermsMixin
-from temba.orgs.models import Org
 from temba.msgs.models import Broadcast, Msg, Call, Label, ARCHIVED, VISIBLE, DELETED
 from temba.utils import JsonResponse, json_date_to_datetime, splitting_getlist, str_to_bool, non_atomic_gets
 from temba.values.models import Value
@@ -2841,7 +2839,7 @@ class FlowDefinitionEndpoint(BaseAPIView, CreateAPIMixin):
 
     * **metadata** - contains the name and uuid (optional) for the flow
     * **version** - the flow spec version for the definition being submitted
-    * **base_language** - the default language code to us for the flow
+    * **base_language** - the default language code to use for the flow
     * **flow_type** - the type of the flow (F)low, (V)oice, (S)urvey
     * **action_sets** - the actions in the flow
     * **rule_sets** - the rules in the flow

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1449,7 +1449,7 @@ class ContactGroup(TembaModel, SmartModel):
         group_contacts = self.contacts.all()
 
         for contact in contacts:
-            if add and contact.is_blocked or not contact.is_active:
+            if add and (contact.is_blocked or not contact.is_active):
                 raise ValueError("Blocked or deleted contacts can't be added to groups")
 
             contact_changed = False

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -865,28 +865,26 @@ class Contact(TembaModel, SmartModel):
         """
         Releases (i.e. deletes) this contact, provided it is currently not deleted
         """
-        # perform everything in an org level lock to prevent conflicts with get_or_create or update_urns
-        with self.org.lock_on(OrgLock.contacts):
-            self.is_active = False
-            self.save(update_fields=['is_active'])
+        self.is_active = False
+        self.save(update_fields=['is_active'])
 
-            # detach all contact's URNs
-            self.update_urns([])
+        # detach all contact's URNs
+        self.update_urns([])
 
-            # remove contact from all groups
-            self.update_groups([])
+        # remove contact from all groups
+        self.update_groups([])
 
-            # release all messages with this contact
-            for msg in self.msgs.all():
-                msg.release()
+        # release all messages with this contact
+        for msg in self.msgs.all():
+            msg.release()
 
-            # release all calls with this contact
-            for call in self.calls.all():
-                call.release()
+        # release all calls with this contact
+        for call in self.calls.all():
+            call.release()
 
-            # remove all flow runs and steps
-            for run in self.runs.all():
-                run.release()
+        # remove all flow runs and steps
+        for run in self.runs.all():
+            run.release()
 
     @classmethod
     def bulk_cache_initialize(cls, org, contacts, for_show_only=False):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -588,26 +588,21 @@ class ContactTest(TembaTest):
         testers = self.create_group("Testers", [])
 
         self.joe.update_groups([spammers, testers])
-
         self.assertEqual(self.joe.user_groups.all(), {spammers, testers})
 
         self.joe.update_groups([testers])
-
         self.assertEqual(self.joe.user_groups.all(), {testers})
 
         self.joe.update_groups([])
-
         self.assertEqual(self.joe.user_groups.all(), {})
 
+        # can't add blocked contacts to a group
         self.joe.block()
-
-        # can't add to group if blocked
         self.assertRaises(ValueError, self.joe.update_groups, [spammers])
 
+        # can't add deleted contacts to a group
         self.joe.unblock()
         self.joe.release()
-
-        # or deleted
         self.assertRaises(ValueError, self.joe.update_groups, [spammers])
 
     def test_contact_display(self):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -7,15 +7,13 @@ import pytz
 from datetime import datetime, date
 from django.utils import timezone
 
-from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from mock import patch
 from smartmin.tests import _CRUDLTest
 from smartmin.csv_imports.models import ImportTask
-from temba.contacts.models import Contact, ContactGroup, ContactField, ContactURN, TEL_SCHEME, TWITTER_SCHEME, \
-    URN_SCHEME_CHOICES
-from temba.contacts.models import ExportContactsTask
+from temba.contacts.models import Contact, ContactGroup, ContactField, ContactURN, ExportContactsTask
+from temba.contacts.models import TEL_SCHEME, TWITTER_SCHEME, URN_SCHEME_CHOICES
 from temba.contacts.templatetags.contacts import contact_field
 from temba.locations.models import AdminBoundary
 from temba.orgs.models import Org
@@ -382,7 +380,7 @@ class ContactGroupTest(TembaTest):
 
 class ContactTest(TembaTest):
     def setUp(self):
-        TembaTest.setUp(self)
+        super(ContactTest, self).setUp()
 
         self.user1 = self.create_user("nash")
         self.manager1 = self.create_user("mike")
@@ -584,6 +582,33 @@ class ContactTest(TembaTest):
         test_contact = Contact.get_test_contact(self.user)
         self.assertRaises(ValueError, test_contact.block)
         self.assertRaises(ValueError, test_contact.fail)
+
+    def test_update_groups(self):
+        spammers = self.create_group("Spammers", [])
+        testers = self.create_group("Testers", [])
+
+        self.joe.update_groups([spammers, testers])
+
+        self.assertEqual(self.joe.user_groups.all(), {spammers, testers})
+
+        self.joe.update_groups([testers])
+
+        self.assertEqual(self.joe.user_groups.all(), {testers})
+
+        self.joe.update_groups([])
+
+        self.assertEqual(self.joe.user_groups.all(), {})
+
+        self.joe.block()
+
+        # can't add to group if blocked
+        self.assertRaises(ValueError, self.joe.update_groups, [spammers])
+
+        self.joe.unblock()
+        self.joe.release()
+
+        # or deleted
+        self.assertRaises(ValueError, self.joe.update_groups, [spammers])
 
     def test_contact_display(self):
         mr_long_name = self.create_contact(name="Wolfeschlegelsteinhausenbergerdorff", number="8877")

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -588,13 +588,13 @@ class ContactTest(TembaTest):
         testers = self.create_group("Testers", [])
 
         self.joe.update_groups([spammers, testers])
-        self.assertEqual(self.joe.user_groups.all(), {spammers, testers})
+        self.assertEqual(set(self.joe.user_groups.all()), {spammers, testers})
 
         self.joe.update_groups([testers])
-        self.assertEqual(self.joe.user_groups.all(), {testers})
+        self.assertEqual(set(self.joe.user_groups.all()), {testers})
 
         self.joe.update_groups([])
-        self.assertEqual(self.joe.user_groups.all(), {})
+        self.assertEqual(set(self.joe.user_groups.all()), set())
 
         # can't add blocked contacts to a group
         self.joe.block()

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -982,7 +982,8 @@ REST_FRAMEWORK = {
         'temba.api.renderers.DocumentationRenderer',
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.XMLRenderer',
-    )
+    ),
+    'EXCEPTION_HANDLER': 'temba.api.temba_exception_handler'
 }
 
 #-----------------------------------------------------------------------------------

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -982,11 +982,10 @@ REST_FRAMEWORK = {
         'temba.api.renderers.DocumentationRenderer',
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.XMLRenderer',
-    )
+    ),
+    'EXCEPTION_HANDLER': 'temba.api.temba_exception_handler'
 }
-
-if not TESTING:
-    REST_FRAMEWORK['EXCEPTION_HANDLER'] = 'temba.api.temba_exception_handler'
+REST_HANDLE_EXCEPTIONS = not TESTING
 
 #-----------------------------------------------------------------------------------
 # Aggregator settings

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -982,9 +982,11 @@ REST_FRAMEWORK = {
         'temba.api.renderers.DocumentationRenderer',
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.XMLRenderer',
-    ),
-    'EXCEPTION_HANDLER': 'temba.api.temba_exception_handler'
+    )
 }
+
+if not TESTING:
+    REST_FRAMEWORK['EXCEPTION_HANDLER'] = 'temba.api.temba_exception_handler'
 
 #-----------------------------------------------------------------------------------
 # Aggregator settings


### PR DESCRIPTION
* ContactGroup.update_contacts now prevents adding of blocked contacts to groups
* Contact bulk actions endpoint errors if any passed UUIDs are invalid (or test contacts)
* Contact write endpoint validates that a blocked contact isn't being added to a group
* Added REST framework exception handler so that API calls don't return the html error page
* Simplified `Contact.release()`