### PR TITLE
Allow nexmo channels to set their address

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -996,7 +996,21 @@ class ChannelTest(TembaTest):
                 self.assertRedirects(response, reverse('public.public_welcome') + "?success")
 
                 # make sure it is actually connected
-                Channel.objects.get(channel_type='NX', org=self.org)
+                channel = Channel.objects.get(channel_type='NX', org=self.org)
+
+                # test the update page for nexmo
+                update_url = reverse('channels.channel_update', args=[channel.pk])
+                response = self.client.get(update_url)
+
+                # try changing our address
+                updated = response.context['form'].initial
+                updated['address'] = 'MTN'
+                updated['alert_email'] = 'foo@bar.com'
+
+                response = self.client.post(update_url, updated)
+                channel = Channel.objects.get(pk=channel.id)
+
+                self.assertEquals('MTN', channel.address)
 
     def test_claim_plivo(self):
         self.login(self.admin)

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -463,9 +463,14 @@ class UpdateChannelForm(forms.ModelForm):
         model = Channel
         fields = 'name', 'address', 'country', 'alert_email'
         config_fields = []
-        readonly = 'address', 'country'
-        labels = {'address': _('Number')}
-        helps = {'address': _('Phone number of this service')}
+        readonly = ('address', 'country',)
+        labels = {'address': _('Address')}
+        helps = {'address': _('The number or address of this channel')}
+
+
+class UpdateNexmoForm(UpdateChannelForm):
+    class Meta(UpdateChannelForm.Meta):
+        readonly = ('country',)
 
 
 class UpdateAndroidForm(UpdateChannelForm):
@@ -475,7 +480,6 @@ class UpdateAndroidForm(UpdateChannelForm):
 
 
 class UpdateTwitterForm(UpdateChannelForm):
-
     class Meta(UpdateChannelForm.Meta):
         fields = 'name', 'address', 'alert_email'
         readonly = ('address',)
@@ -767,6 +771,8 @@ class ChannelCRUDL(SmartCRUDL):
 
             if channel_type == ANDROID:
                 return UpdateAndroidForm
+            elif channel_type == NEXMO:
+                return UpdateNexmoForm
             elif scheme == TWITTER_SCHEME:
                 return UpdateTwitterForm
             else:


### PR DESCRIPTION
Allows users to edit the address for a Nexmo channel after they have added it.

This lets people change the "from" for Nexmo channels to a alphanumeric string instead of always enforcing strings. Obviously that only works in some countries, but is still useful.