### PR TITLE
Ensure exceptions from API requests still go to Sentry

### DIFF
--- a/temba/api/__init__.py
+++ b/temba/api/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+import logging
+
 from django.conf import settings
 from django.http import HttpResponseServerError
 from rest_framework.views import exception_handler
+
+logger = logging.getLogger(__name__)
 
 
 def temba_exception_handler(exc):
@@ -14,4 +18,8 @@ def temba_exception_handler(exc):
     if response or not getattr(settings, 'REST_HANDLE_EXCEPTIONS', False):
         return response
     else:
+        # ensure exception still goes to Sentry
+        logger.error('Exception in API request', exc_info=True)
+
+        # respond with simple message
         return HttpResponseServerError("Server Error. Site administrators have been notified.")


### PR DESCRIPTION
Fixes previous change which captures exceptions during API requests so that we don't return an HTML page.