### PR TITLE
Missed call channels

### DIFF
--- a/media/test_flows/call-channel-split.json
+++ b/media/test_flows/call-channel-split.json
@@ -1,0 +1,103 @@
+{
+  "version": 8, 
+  "flows": [
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 76, 
+          "x": 380, 
+          "destination": null, 
+          "uuid": "0557a725-7193-4179-899a-67bcfba9ab2d", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "Got @channel.tel_e164"
+              }, 
+              "type": "reply"
+            }
+          ]
+        }, 
+        {
+          "y": 169, 
+          "x": 58, 
+          "destination": null, 
+          "uuid": "fcf4977a-221b-4a42-b39c-2c113220c8d6", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "Matched @channel.tel_e164"
+              }, 
+              "type": "reply"
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "F", 
+      "entry": "fc529add-714c-47c4-bd5c-3b84f6c38e0b", 
+      "rule_sets": [
+        {
+          "uuid": "fc529add-714c-47c4-bd5c-3b84f6c38e0b", 
+          "webhook_action": null, 
+          "rules": [
+            {
+              "test": {
+                "test": {
+                  "eng": "250785551212"
+                }, 
+                "type": "contains_any"
+              }, 
+              "category": {
+                "eng": "250785551212"
+              }, 
+              "destination": "fcf4977a-221b-4a42-b39c-2c113220c8d6", 
+              "uuid": "a422d7dc-84bc-442c-acad-2b168d3f707a", 
+              "destination_type": "A"
+            }, 
+            {
+              "test": {
+                "test": "true", 
+                "type": "true"
+              }, 
+              "category": {
+                "eng": "Other"
+              }, 
+              "destination": "0557a725-7193-4179-899a-67bcfba9ab2d", 
+              "uuid": "f8f09497-5664-4713-95d5-1f7869cd6288", 
+              "destination_type": "A"
+            }
+          ], 
+          "webhook": null, 
+          "ruleset_type": "expression", 
+          "label": "Device", 
+          "operand": "@channel.tel_e164", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 0, 
+          "x": 100, 
+          "config": {}
+        }
+      ], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 7, 
+        "id": 40799, 
+        "name": "Call Channel Split", 
+        "saved_on": "2015-10-29T15:08:50.974404Z"
+      }
+    }
+  ], 
+  "triggers": [
+    {
+      "trigger_type": "M", 
+      "flow": {
+        "name": "Call Channel Split", 
+        "id": 40799
+      }, 
+      "groups": [], 
+      "keyword": null, 
+      "channel": null
+    }
+  ]
+}

--- a/temba/api/channels.py
+++ b/temba/api/channels.py
@@ -18,7 +18,7 @@ from temba.contacts.models import Contact, ContactURN, TEL_SCHEME
 from temba.flows.models import Flow, FlowRun
 from temba.orgs.models import get_stripe_credentials, NEXMO_UUID
 from temba.msgs.models import Msg, HANDLE_EVENT_TASK, HANDLER_QUEUE, MSG_EVENT
-from temba.triggers.models import Trigger, MISSED_CALL_TRIGGER
+from temba.triggers.models import Trigger
 from temba.utils import analytics, JsonResponse
 from temba.utils.middleware import disable_middleware
 from temba.utils.queues import push_task
@@ -96,7 +96,7 @@ class TwilioHandler(View):
                     response.hangup()
 
                     # if they have a missed call trigger, fire that off
-                    Trigger.catch_triggers(contact, MISSED_CALL_TRIGGER)
+                    Trigger.catch_triggers(contact, Trigger.TYPE_MISSED_CALL)
 
                     # either way, we need to hangup now
                     return HttpResponse(unicode(response))

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -17,7 +17,7 @@ from smartmin.models import SmartModel
 from temba.contacts.models import TEL_SCHEME
 from temba.orgs.models import Org
 from temba.channels.models import Channel, TEMBA_HEADERS
-from temba.msgs.models import CALL_OUT, CALL_OUT_MISSED, CALL_IN, CALL_IN_MISSED
+from temba.msgs.models import Call
 from temba.utils import datetime_to_str, prepped_request_to_str
 from temba.utils.cache import get_cacheable_attr
 from urllib import urlencode
@@ -45,10 +45,10 @@ CATEGORIZE = 'categorize'
 EVENT_CHOICES = ((SMS_RECEIVED, "Incoming SMS Message"),
                  (SMS_SENT, "Outgoing SMS Sent"),
                  (SMS_DELIVERED, "Outgoing SMS Delivered to Recipient"),
-                 (CALL_OUT, "Outgoing Call"),
-                 (CALL_OUT_MISSED, "Missed Outgoing Call"),
-                 (CALL_IN, "Incoming Call"),
-                 (CALL_IN_MISSED, "Missed Incoming Call"),
+                 (Call.TYPE_OUT, "Outgoing Call"),
+                 (Call.TYPE_OUT_MISSED, "Missed Outgoing Call"),
+                 (Call.TYPE_IN, "Incoming Call"),
+                 (Call.TYPE_IN_MISSED, "Missed Incoming Call"),
                  (RELAYER_ALARM, "Channel Alarm"),
                  (FLOW, "Flow Step Reached"),
                  (CATEGORIZE, "Flow Categorization"))

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -30,11 +30,11 @@ from temba.channels.models import Channel, ChannelLog, SyncEvent, SEND_URL, SEND
 from temba.channels.models import PLIVO, PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, PLIVO_APP_ID, TEMBA_HEADERS
 from temba.channels.models import API_ID, USERNAME, PASSWORD, CLICKATELL, SHAQODOON, M3TECH, YO
 from temba.flows.models import Flow, FlowLabel, FlowRun, RuleSet
-from temba.msgs.models import Broadcast, Call, Msg, WIRED, FAILED, SENT, DELIVERED, ERRORED, INCOMING, CALL_IN_MISSED
+from temba.msgs.models import Broadcast, Call, Msg, WIRED, FAILED, SENT, DELIVERED, ERRORED, INCOMING
 from temba.msgs.models import MSG_SENT_KEY, Label, SystemLabel, VISIBLE, ARCHIVED, DELETED
 from temba.orgs.models import Language
 from temba.tests import MockResponse, TembaTest, AnonymousOrg
-from temba.triggers.models import Trigger, FOLLOW_TRIGGER
+from temba.triggers.models import Trigger
 from temba.utils import dict_to_struct, datetime_to_json_date
 from temba.values.models import Value, DATETIME
 from twilio.util import RequestValidator
@@ -5039,8 +5039,8 @@ class MageHandlerTest(TembaTest):
 
         channel = Channel.create(self.org, self.user, None, 'TT', "Twitter Channel", address="billy_bob")
 
-        Trigger.objects.create(created_by=self.user, modified_by=self.user, org=self.org, trigger_type=FOLLOW_TRIGGER,
-                               flow=flow, channel=channel)
+        Trigger.objects.create(created_by=self.user, modified_by=self.user, org=self.org,
+                               trigger_type=Trigger.TYPE_FOLLOW, flow=flow, channel=channel)
 
         contact = self.create_contact("Mary Jo", twitter='mary_jo')
         urn = contact.get_urn(TWITTER_SCHEME)
@@ -5097,7 +5097,7 @@ class WebHookTest(TembaTest):
         call = Call.objects.create(org=self.org,
                                    channel=self.channel,
                                    contact=self.joe,
-                                   call_type=CALL_IN_MISSED,
+                                   call_type=Call.TYPE_IN_MISSED,
                                    time=now,
                                    created_by=self.admin,
                                    modified_by=self.admin)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -827,8 +827,8 @@ class Channel(SmartModel):
         # if we just lost answering capabilities, archive our inbound call trigger
         if ANSWER in self.role:
             if not org.get_schemes(ANSWER):
-                from temba.triggers.models import Trigger, INBOUND_CALL_TRIGGER
-                Trigger.objects.filter(trigger_type=INBOUND_CALL_TRIGGER, org=org, is_archived=False).update(is_archived=True)
+                from temba.triggers.models import Trigger
+                Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL, org=org, is_archived=False).update(is_archived=True)
 
         from temba.triggers.models import Trigger
         Trigger.objects.filter(channel=self, org=org).update(is_active=False)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -967,7 +967,7 @@ class ContactTest(TembaTest):
         self.assertEquals(5, len(response.context['all_messages']))
 
         # lets create an incoming call from this contact
-        Call.create_call(self.channel, self.joe.get_urn(TEL_SCHEME).path, timezone.now(), 5, "CALL_IN")
+        Call.create_call(self.channel, self.joe.get_urn(TEL_SCHEME).path, timezone.now(), 5, Call.TYPE_IN)
 
         response = self.fetch_protected(read_url, self.admin)
         self.assertEquals(6, len(response.context['all_messages']))
@@ -981,7 +981,7 @@ class ContactTest(TembaTest):
         self.assertTrue(isinstance(response.context['all_messages'][0], Msg))
 
         # lets create an outgoing call from this contact
-        Call.create_call(self.channel, self.joe.get_urn(TEL_SCHEME).path, timezone.now(), 5, "CALL_OUT_MISSED")
+        Call.create_call(self.channel, self.joe.get_urn(TEL_SCHEME).path, timezone.now(), 5, Call.TYPE_OUT_MISSED)
 
         # visit a contact detail page as an admin with the organization
         response = self.fetch_protected(read_url, self.admin)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1215,7 +1215,6 @@ class Flow(TembaModel, SmartModel):
             # where the message was sent to
             elif msg.channel:
                 channel_context = msg.channel.build_message_context()
-
         elif contact:
             message_context = dict(__default__='', contact=contact_context)
         else:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -664,8 +664,7 @@ class Flow(TembaModel, SmartModel):
         msgs = actionset.execute_actions(run, msg, started_flows)
 
         for msg in msgs:
-            if msg:
-                step.add_message(msg)
+            step.add_message(msg)
 
         # and onto the destination
         destination = Flow.get_node(actionset.flow, actionset.destination, actionset.destination_type)
@@ -1373,7 +1372,7 @@ class Flow(TembaModel, SmartModel):
         if not self.entry_uuid:
             return
 
-        if start_msg:
+        if start_msg and start_msg.id:
             start_msg.msg_type = FLOW
             start_msg.save(update_fields=['msg_type'])
 
@@ -3575,6 +3574,10 @@ class FlowStep(models.Model):
             return msg.channel.name
 
     def add_message(self, msg):
+        # no-op for no msg or mock msgs
+        if not msg or not msg.id:
+            return
+
         self.messages.add(msg)
 
         # incoming non-IVR messages won't have a type yet so update that

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1110,7 +1110,7 @@ class FlowTest(TembaTest):
                                trigger_type=Trigger.TYPE_INBOUND_CALL, flow=flow_with_keywords)
 
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
-                               trigger_type=Trigger.SCHEDULE, flow=flow_with_keywords)
+                               trigger_type=Trigger.TYPE_SCHEDULE, flow=flow_with_keywords)
 
         self.assertEquals(flow_with_keywords.triggers.filter(is_archived=False).count(), 8)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -21,11 +21,10 @@ from temba.api.models import WebHookEvent
 from temba.channels.models import Channel
 from temba.contacts.models import Contact, ContactGroup, ContactField, ContactURN, TEL_SCHEME, TWITTER_SCHEME
 from temba.msgs.models import Broadcast, Label, Msg, INCOMING, SMS_NORMAL_PRIORITY, SMS_HIGH_PRIORITY, PENDING, FLOW
-from temba.msgs.models import OUTGOING
+from temba.msgs.models import OUTGOING, Call
 from temba.orgs.models import Org, Language, CURRENT_EXPORT_VERSION
 from temba.tests import TembaTest, MockResponse, FlowFileTest, uuid
-from temba.triggers.models import Trigger, FOLLOW_TRIGGER, CATCH_ALL_TRIGGER, MISSED_CALL_TRIGGER, INBOUND_CALL_TRIGGER
-from temba.triggers.models import SCHEDULE_TRIGGER, KEYWORD_TRIGGER
+from temba.triggers.models import Trigger
 from temba.utils import datetime_to_str, str_to_datetime
 from temba.values.models import Value
 from uuid import uuid4
@@ -1099,19 +1098,19 @@ class FlowTest(TembaTest):
 
         # add triggers of other types
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
-                               trigger_type=FOLLOW_TRIGGER, flow=flow_with_keywords, channel=self.channel)
+                               trigger_type=Trigger.TYPE_FOLLOW, flow=flow_with_keywords, channel=self.channel)
 
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
-                               trigger_type=CATCH_ALL_TRIGGER, flow=flow_with_keywords)
+                               trigger_type=Trigger.TYPE_CATCH_ALL, flow=flow_with_keywords)
 
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
-                               trigger_type=MISSED_CALL_TRIGGER, flow=flow_with_keywords)
+                               trigger_type=Trigger.TYPE_MISSED_CALL, flow=flow_with_keywords)
 
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
-                               trigger_type=INBOUND_CALL_TRIGGER, flow=flow_with_keywords)
+                               trigger_type=Trigger.TYPE_INBOUND_CALL, flow=flow_with_keywords)
 
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
-                               trigger_type=SCHEDULE_TRIGGER, flow=flow_with_keywords)
+                               trigger_type=Trigger.SCHEDULE, flow=flow_with_keywords)
 
         self.assertEquals(flow_with_keywords.triggers.filter(is_archived=False).count(), 8)
 
@@ -1128,16 +1127,18 @@ class FlowTest(TembaTest):
         self.assertTrue(flow_with_keywords in response.context['object_list'].all())
         self.assertEquals(flow_with_keywords.triggers.count(), 9)
         self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True).count(), 2)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True, trigger_type=KEYWORD_TRIGGER).count(), 2)
+        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True,
+                                                             trigger_type=Trigger.TYPE_KEYWORD).count(), 2)
         self.assertEquals(flow_with_keywords.triggers.filter(is_archived=False).count(), 7)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True, trigger_type=KEYWORD_TRIGGER).count(), 2)
+        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True,
+                                                             trigger_type=Trigger.TYPE_KEYWORD).count(), 2)
 
         # only keyword triggers got archived, other are stil active
-        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=FOLLOW_TRIGGER))
-        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=CATCH_ALL_TRIGGER))
-        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=SCHEDULE_TRIGGER))
-        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=MISSED_CALL_TRIGGER))
-        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=INBOUND_CALL_TRIGGER))
+        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=Trigger.TYPE_FOLLOW))
+        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL))
+        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=Trigger.TYPE_SCHEDULE))
+        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL))
+        self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=Trigger.TYPE_INBOUND_CALL))
 
     def test_views(self):
         self.create_secondary_org()
@@ -3944,6 +3945,22 @@ class WebhookLoopTest(FlowFileTest):
         with patch('requests.get') as mock:
             mock.return_value = MockResponse(200, '{ "text": "second message" }')
             self.assertEquals("second message", self.send_message(flow, "second"))
+
+
+class MissedCallChannelTest(FlowFileTest):
+
+    def test_missed_call_channel(self):
+        flow = self.get_flow('call-channel-split')
+
+        # trigger a missed call on our channel
+        call = Call.create_call(self.channel, '+250788111222', timezone.now(), 0, Call.TYPE_IN_MISSED)
+
+        # should have triggered our flow
+        FlowRun.objects.get(flow=flow)
+
+        # should have sent a message to the user
+        msg = Msg.objects.get(contact=call.contact, channel=self.channel)
+        self.assertEquals(msg.text, "Matched +250785551212")
 
 
 class GhostActionNodeTest(FlowFileTest):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -13,7 +13,7 @@ from temba.channels.models import Channel, KANNEL
 from temba.contacts.models import ContactField, ContactURN, TEL_SCHEME
 from temba.msgs.models import Msg, Contact, ContactGroup, ExportMessagesTask, RESENT, FAILED, OUTGOING, PENDING, WIRED
 from temba.msgs.models import Broadcast, Label, Call, SystemLabel, UnreachableException, SMS_BULK_PRIORITY
-from temba.msgs.models import VISIBLE, ARCHIVED, DELETED, HANDLED, QUEUED, SENT, CALL_IN
+from temba.msgs.models import VISIBLE, ARCHIVED, DELETED, HANDLED, QUEUED, SENT
 from temba.orgs.models import Org, Language
 from temba.schedules.models import Schedule
 from temba.tests import TembaTest, AnonymousOrg
@@ -1658,7 +1658,7 @@ class SystemLabelTest(TembaTest):
         msg2 = Msg.create_incoming(self.channel, (TEL_SCHEME, "0783835001"), text="Message 2")
         msg3 = Msg.create_incoming(self.channel, (TEL_SCHEME, "0783835001"), text="Message 3")
         msg4 = Msg.create_incoming(self.channel, (TEL_SCHEME, "0783835001"), text="Message 4")
-        call1 = Call.create_call(self.channel, "0783835001", timezone.now(), 10, CALL_IN)
+        call1 = Call.create_call(self.channel, "0783835001", timezone.now(), 10, Call.TYPE_IN)
         bcast1 = Broadcast.create(self.org, self.user, "Broadcast 1", [contact1, contact2])
         bcast2 = Broadcast.create(self.org, self.user, "Broadcast 2", [contact1, contact2],
                                   schedule=Schedule.create_schedule(timezone.now(), 'D', self.user))
@@ -1671,7 +1671,7 @@ class SystemLabelTest(TembaTest):
         msg3.archive()
         bcast1.send(status=QUEUED)
         msg5, msg6 = tuple(Msg.objects.filter(broadcast=bcast1))
-        Call.create_call(self.channel, "0783835002", timezone.now(), 10, CALL_IN)
+        Call.create_call(self.channel, "0783835002", timezone.now(), 10, Call.TYPE_IN)
         Broadcast.create(self.org, self.user, "Broadcast 3", [contact1],
                          schedule=Schedule.create_schedule(timezone.now(), 'W', self.user))
 

--- a/temba/triggers/handlers.py
+++ b/temba/triggers/handlers.py
@@ -16,4 +16,4 @@ class CatchAllHandler(MessageHandler):
         super(CatchAllHandler, self).__init__('triggers')
 
     def handle(self, msg):
-        return Trigger.catch_triggers(msg, Trigger.TRIGGER_CATCH_ALL)
+        return Trigger.catch_triggers(msg, Trigger.TYPE_CATCH_ALL)

--- a/temba/triggers/handlers.py
+++ b/temba/triggers/handlers.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
 
 from temba.msgs.handler import MessageHandler
-from .models import Trigger, CATCH_ALL_TRIGGER
-
+from .models import Trigger
 
 class TriggerHandler(MessageHandler):
     def __init__(self):
@@ -17,4 +16,4 @@ class CatchAllHandler(MessageHandler):
         super(CatchAllHandler, self).__init__('triggers')
 
     def handle(self, msg):
-        return Trigger.catch_triggers(msg, CATCH_ALL_TRIGGER)
+        return Trigger.catch_triggers(msg, Trigger.TRIGGER_CATCH_ALL)

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -159,7 +159,7 @@ class Trigger(SmartModel):
             start_msg = entity
         elif isinstance(entity, Call) or isinstance(entity, IVRCall):
             contact = entity.contact
-            start_msg = None
+            start_msg = Msg(contact=contact, channel=entity.channel, created_on=timezone.now(), id=0)
         elif isinstance(entity, Contact):
             contact = entity
             start_msg = None

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -13,27 +13,24 @@ from temba.flows.models import Flow, FlowRun
 from temba.msgs.models import Msg, Call
 from temba.ivr.models import IVRCall
 
-KEYWORD_TRIGGER = 'K'
-SCHEDULE_TRIGGER = 'S'
-MISSED_CALL_TRIGGER = 'M'
-CATCH_ALL_TRIGGER = 'C'
-FOLLOW_TRIGGER = 'F'
-INBOUND_CALL_TRIGGER = 'V'
-
-TRIGGER_TYPES = ((KEYWORD_TRIGGER, _("Keyword Trigger")),
-                 (SCHEDULE_TRIGGER, _("Schedule Trigger")),
-                 (INBOUND_CALL_TRIGGER, _("Inbound Call Trigger")),
-                 (MISSED_CALL_TRIGGER, _("Missed Call Trigger")),
-                 (CATCH_ALL_TRIGGER, _("Catch All Trigger")),
-                 (FOLLOW_TRIGGER, _("Follow Account Trigger")))
-
-
 class Trigger(SmartModel):
-
     """
     A Trigger is used to start a user in a flow based on an event. For example, triggers might fire
     for missed calls, inboud sms messages starting with a keyword, or on a repeating schedule.
     """
+    TYPE_KEYWORD = 'K'
+    TYPE_SCHEDULE = 'S'
+    TYPE_MISSED_CALL = 'M'
+    TYPE_INBOUND_CALL = 'V'
+    TYPE_CATCH_ALL = 'C'
+    TYPE_FOLLOW = 'F'
+
+    TRIGGER_TYPES = ((TYPE_KEYWORD, _("Keyword Trigger")),
+                     (TYPE_SCHEDULE, _("Schedule Trigger")),
+                     (TYPE_INBOUND_CALL, _("Inbound Call Trigger")),
+                     (TYPE_MISSED_CALL, _("Missed Call Trigger")),
+                     (TYPE_CATCH_ALL, _("Catch All Trigger")),
+                     (TYPE_FOLLOW, _("Follow Account Trigger")))
 
     org = models.ForeignKey(Org, verbose_name=_("Org"), help_text=_("The organization this trigger belongs to"))
 
@@ -62,13 +59,13 @@ class Trigger(SmartModel):
                                     null=True, blank=True, related_name='trigger',
                                     help_text=_('Our recurring schedule'))
 
-    trigger_type = models.CharField(max_length=1, choices=TRIGGER_TYPES, default=KEYWORD_TRIGGER, verbose_name=_("Trigger Type"),
-                                    help_text=_('The type of this trigger'))
+    trigger_type = models.CharField(max_length=1, choices=TRIGGER_TYPES, default=TYPE_KEYWORD,
+                                    verbose_name=_("Trigger Type"), help_text=_('The type of this trigger'))
 
     channel = models.OneToOneField(Channel, verbose_name=_("Channel"), null=True, help_text=_("The associated channel"))
 
     def __unicode__(self):
-        if self.trigger_type == KEYWORD_TRIGGER:
+        if self.trigger_type == Trigger.TYPE_KEYWORD:
             return self.keyword
         return self.get_trigger_type_display()
 
@@ -232,13 +229,17 @@ class Trigger(SmartModel):
         groups_ids = contact.user_groups.values_list('pk', flat=True)
 
         # Check first if we have a trigger for the contact groups
-        matching = Trigger.objects.filter(is_archived=False, is_active=True, org=contact.org, trigger_type=INBOUND_CALL_TRIGGER,
-                                          flow__is_archived=False, flow__is_active=True, groups__in=groups_ids).order_by('groups__name').prefetch_related('groups', 'groups__contacts')
+        matching = Trigger.objects.filter(is_archived=False, is_active=True, org=contact.org,
+                                          trigger_type=Trigger.TYPE_INBOUND_CALL, flow__is_archived=False,
+                                          flow__is_active=True, groups__in=groups_ids).order_by('groups__name')\
+                                  .prefetch_related('groups', 'groups__contacts')
 
         # If no trigger for contact groups find there is a no group trigger
         if not matching:
-            matching = Trigger.objects.filter(is_archived=False, is_active=True, org=contact.org, trigger_type=INBOUND_CALL_TRIGGER,
-                                              flow__is_archived=False, flow__is_active=True, groups=None).prefetch_related('groups', 'groups__contacts')
+            matching = Trigger.objects.filter(is_archived=False, is_active=True, org=contact.org,
+                                              trigger_type=Trigger.TYPE_INBOUND_CALL, flow__is_archived=False,
+                                              flow__is_active=True, groups=None)\
+                                      .prefetch_related('groups', 'groups__contacts')
 
         if not matching:
             return None
@@ -257,8 +258,8 @@ class Trigger(SmartModel):
 
     @classmethod
     def apply_action_restore(cls, triggers):
-        m_last_triggered = triggers.filter(trigger_type=MISSED_CALL_TRIGGER).order_by('-last_triggered', '-modified_on')
-        c_last_triggered = triggers.filter(trigger_type=CATCH_ALL_TRIGGER).order_by('-last_triggered', '-modified_on')
+        m_last_triggered = triggers.filter(trigger_type=Trigger.TYPE_MISSED_CALL).order_by('-last_triggered', '-modified_on')
+        c_last_triggered = triggers.filter(trigger_type=Trigger.TYPE_CATCH_ALL).order_by('-last_triggered', '-modified_on')
 
         remaining_triggers = triggers.exclude(pk__in=m_last_triggered).exclude(pk__in=c_last_triggered)
 
@@ -266,7 +267,7 @@ class Trigger(SmartModel):
 
             if trigger.keyword:
                 same_keyword_triggers = Trigger.objects.filter(org=trigger.org, keyword=trigger.keyword, is_archived=False, is_active=True,
-                                                               trigger_type=KEYWORD_TRIGGER)
+                                                               trigger_type=Trigger.TYPE_KEYWORD)
                 if same_keyword_triggers:
                     same_keyword_triggers.update(is_archived=True)
 
@@ -276,7 +277,7 @@ class Trigger(SmartModel):
         if m_last_triggered:
             # first archive all our missed call triggers and unarchive the last triggered in the selected
             Trigger.objects.filter(org=m_last_triggered[0].org,
-                                   trigger_type=MISSED_CALL_TRIGGER,
+                                   trigger_type=Trigger.TYPE_MISSED_CALL,
                                    is_active=True).update(is_archived=True)
             m_last_triggered[0].is_archived = False
             m_last_triggered[0].save()
@@ -284,7 +285,7 @@ class Trigger(SmartModel):
         if c_last_triggered:
             # first archive all our catch all message triggers and unarchive the last triggered in the selected
             Trigger.objects.filter(org=c_last_triggered[0].org,
-                                   trigger_type=CATCH_ALL_TRIGGER,
+                                   trigger_type=Trigger.TYPE_CATCH_ALL,
                                    is_active=True).update(is_archived=True)
             c_last_triggered[0].is_archived = False
             c_last_triggered[0].save()

--- a/temba/triggers/tasks.py
+++ b/temba/triggers/tasks.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from djcelery_transactions import task
 from temba.contacts.models import ContactURN
-from temba.triggers.models import Trigger, FOLLOW_TRIGGER
+from temba.triggers.models import Trigger
 from temba.utils.mage import mage_handle_new_contact
 
 
@@ -20,4 +20,4 @@ def fire_follow_triggers(channel_id, contact_urn_id, new_mage_contact=False):
     if new_mage_contact:
         mage_handle_new_contact(contact.org, contact)
 
-    Trigger.catch_triggers(contact, FOLLOW_TRIGGER, channel_id=channel_id)
+    Trigger.catch_triggers(contact, Trigger.TYPE_FOLLOW, channel_id=channel_id)

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -11,10 +11,10 @@ from temba.orgs.models import Language
 from temba.contacts.models import TEL_SCHEME
 from temba.flows.models import Flow, ActionSet, FlowRun
 from temba.schedules.models import Schedule
-from temba.msgs.models import Msg, INCOMING, Call, CALL_IN_MISSED
+from temba.msgs.models import Msg, INCOMING, Call
 from temba.channels.models import SEND, CALL, ANSWER, RECEIVE
 from temba.tests import TembaTest
-from .models import Trigger, MISSED_CALL_TRIGGER, CATCH_ALL_TRIGGER, INBOUND_CALL_TRIGGER
+from .models import Trigger
 from temba.triggers.views import DefaultTriggerForm, RegisterTriggerForm
 
 
@@ -172,7 +172,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict(flow=guitarist_flow.pk)
         response = self.client.post(reverse('triggers.trigger_inbound_call'), post_data)
-        trigger = Trigger.objects.filter(trigger_type=INBOUND_CALL_TRIGGER).first()
+        trigger = Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL).first()
         self.assertIsNotNone(trigger)
 
         # pretend we are getting a call from somebody
@@ -190,7 +190,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict(flow=bassist_flow.pk, groups=[bassists.pk])
         response = self.client.post(reverse('triggers.trigger_inbound_call'), post_data)
-        self.assertEquals(2, Trigger.objects.filter(trigger_type=INBOUND_CALL_TRIGGER).count())
+        self.assertEquals(2, Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL).count())
 
         self.assertEquals(bassist_flow.pk, Trigger.find_flow_for_inbound_call(mike).pk)
         self.assertEquals(guitarist_flow.pk, Trigger.find_flow_for_inbound_call(trey).pk)
@@ -200,7 +200,7 @@ class TriggerTest(TembaTest):
 
         # we no longer have voice flows or inbound call triggers that arent archived
         self.assertEquals(0, Flow.objects.filter(flow_type=Flow.VOICE, is_archived=False).count())
-        self.assertEquals(0, Trigger.objects.filter(trigger_type=INBOUND_CALL_TRIGGER, is_archived=False).count())
+        self.assertEquals(0, Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL, is_archived=False).count())
 
     def test_trigger_schedule(self):
         self.login(self.admin)
@@ -490,13 +490,13 @@ class TriggerTest(TembaTest):
 
     def test_missed_call_trigger(self):
         self.login(self.admin)
-        missed_call_trigger = Trigger.get_triggers_of_type(self.org, MISSED_CALL_TRIGGER).first()
+        missed_call_trigger = Trigger.get_triggers_of_type(self.org, Trigger.TYPE_MISSED_CALL).first()
         flow = self.create_flow()
         contact = self.create_contact("Ali", "250788739305")
 
         self.assertFalse(missed_call_trigger)
 
-        Call.create_call(self.channel, contact.get_urn(TEL_SCHEME).path, timezone.now(), 0, CALL_IN_MISSED)
+        Call.create_call(self.channel, contact.get_urn(TEL_SCHEME).path, timezone.now(), 0, Call.TYPE_IN_MISSED)
         self.assertEquals(1, Call.objects.all().count())
         self.assertEquals(0, flow.runs.all().count())
 
@@ -510,14 +510,14 @@ class TriggerTest(TembaTest):
         response = self.client.post(trigger_url, post_data)
         trigger =  Trigger.objects.all().order_by('-pk')[0]
 
-        self.assertEquals(trigger.trigger_type, MISSED_CALL_TRIGGER)
+        self.assertEquals(trigger.trigger_type, Trigger.TYPE_MISSED_CALL)
         self.assertEquals(trigger.flow.pk, flow.pk)
 
-        missed_call_trigger = Trigger.get_triggers_of_type(self.org, MISSED_CALL_TRIGGER).first()
+        missed_call_trigger = Trigger.get_triggers_of_type(self.org, Trigger.TYPE_MISSED_CALL).first()
 
         self.assertEquals(missed_call_trigger.pk, trigger.pk)
 
-        Call.create_call(self.channel, contact.get_urn(TEL_SCHEME).path, timezone.now(), 0, CALL_IN_MISSED)
+        Call.create_call(self.channel, contact.get_urn(TEL_SCHEME).path, timezone.now(), 0, Call.TYPE_IN_MISSED)
         self.assertEquals(2, Call.objects.all().count())
         self.assertEquals(1, flow.runs.all().count())
         self.assertEquals(flow.runs.all()[0].contact.pk, contact.pk)
@@ -538,23 +538,23 @@ class TriggerTest(TembaTest):
 
             response = self.client.post(trigger_url, post_data)
             self.assertEquals(i+2, Trigger.objects.all().count())
-            self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=MISSED_CALL_TRIGGER).count())
+            self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL).count())
 
         # even unarchiving we only have one acive trigger at a time
-        triggers = Trigger.objects.filter(trigger_type=MISSED_CALL_TRIGGER, is_archived=True)
-        active_trigger = Trigger.objects.get(trigger_type=MISSED_CALL_TRIGGER, is_archived=False)
+        triggers = Trigger.objects.filter(trigger_type=Trigger.TYPE_MISSED_CALL, is_archived=True)
+        active_trigger = Trigger.objects.get(trigger_type=Trigger.TYPE_MISSED_CALL, is_archived=False)
 
         post_data = dict()
         post_data['action'] = 'restore'
         post_data['objects'] = [_.pk for _ in triggers]
 
         response = self.client.post(reverse("triggers.trigger_archived"), post_data)
-        self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=MISSED_CALL_TRIGGER).count())
-        self.assertFalse(active_trigger.pk == Trigger.objects.filter(is_archived=False, trigger_type=MISSED_CALL_TRIGGER)[0].pk)
+        self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL).count())
+        self.assertFalse(active_trigger.pk == Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL)[0].pk)
 
     def test_catch_all_trigger(self):
         self.login(self.admin)
-        catch_all_trigger = Trigger.get_triggers_of_type(self.org, CATCH_ALL_TRIGGER).first()
+        catch_all_trigger = Trigger.get_triggers_of_type(self.org, Trigger.TYPE_CATCH_ALL).first()
         flow = self.create_flow()
 
         contact = self.create_contact("Ali", "250788739305")
@@ -582,10 +582,10 @@ class TriggerTest(TembaTest):
         response = self.client.post(trigger_url, post_data)
         trigger = Trigger.objects.all().order_by('-pk')[0]
 
-        self.assertEquals(trigger.trigger_type, CATCH_ALL_TRIGGER)
+        self.assertEquals(trigger.trigger_type, Trigger.TYPE_CATCH_ALL)
         self.assertEquals(trigger.flow.pk, flow.pk)
 
-        catch_all_trigger = Trigger.get_triggers_of_type(self.org, CATCH_ALL_TRIGGER).first()
+        catch_all_trigger = Trigger.get_triggers_of_type(self.org, Trigger.TYPE_CATCH_ALL).first()
 
         self.assertEquals(catch_all_trigger.pk, trigger.pk)
 
@@ -610,19 +610,19 @@ class TriggerTest(TembaTest):
             post_data = dict(flow=flow.pk)
             response = self.client.post(trigger_url, post_data)
             self.assertEquals(i+2, Trigger.objects.all().count())
-            self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=CATCH_ALL_TRIGGER).count())
+            self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL).count())
 
         # even unarchiving we only have one acive trigger at a time
-        triggers = Trigger.objects.filter(trigger_type=CATCH_ALL_TRIGGER, is_archived=True)
-        active_trigger = Trigger.objects.get(trigger_type=CATCH_ALL_TRIGGER, is_archived=False)
+        triggers = Trigger.objects.filter(trigger_type=Trigger.TYPE_CATCH_ALL, is_archived=True)
+        active_trigger = Trigger.objects.get(trigger_type=Trigger.TYPE_CATCH_ALL, is_archived=False)
 
         post_data = dict()
         post_data['action'] = 'restore'
         post_data['objects'] = [_.pk for _ in triggers]
 
         response = self.client.post(reverse("triggers.trigger_archived"), post_data)
-        self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=CATCH_ALL_TRIGGER).count())
-        self.assertFalse(active_trigger.pk == Trigger.objects.filter(is_archived=False, trigger_type=CATCH_ALL_TRIGGER)[0].pk)
+        self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL).count())
+        self.assertFalse(active_trigger.pk == Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL)[0].pk)
 
     def test_update(self):
 


### PR DESCRIPTION
We weren't passing any kind of message to flows triggers by missed calls, which makes it impossible to split your behavior based on the channel passed in. A bigger refactor might be needed later to change to passing in channel AND msg to flows, but in the meantime I created a mock Msg wrapper that contains that information. (which we do elsewhere)

Touched some pieces in Trigger and Call and decided to move the various TYPE constants into the Classes themselves.

+unit test.