### PR TITLE
Fixes for SetLanguageAction

### DIFF
--- a/karma/flows/test_controllers.coffee
+++ b/karma/flows/test_controllers.coffee
@@ -282,4 +282,32 @@ describe 'Controllers:', ->
         expect(added.id).toBe('a_new_field')
         expect(added.text).toBe('A New Field')
       $timeout.flush()
-      
+
+
+    it 'should give proper language choices', ->
+
+      # load a flow
+      flowService.fetch(flows.favorites.id)
+      flowService.contactFieldSearch = []
+      flowService.language = {iso_code:'base'}
+      $http.flush()
+
+      actionset = flowService.flow.action_sets[0]
+      action = actionset.actions[0]
+      action.type = 'lang'
+      action.name = 'Achinese'
+      action.lang = 'ace'
+
+      $scope.clickAction(actionset, action)
+
+      $scope.dialog.opened.then ->
+        modalScope = $modalStack.getTop().value.modalScope
+
+        # Achinese should be added as an option since it was previously
+        # set on the flow even though it is not an org language
+        expect(modalScope.languages[0]).toEqual({name:'Achinese', iso_code:'ace'})
+
+        # make sure 'Default' isn't added as an option
+        expect(modalScope.languages.length).toEqual(1)
+
+      $timeout.flush()

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -1338,13 +1338,6 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
 
   $scope.config = Flow.getActionConfig({type:$scope.action.type})
 
-  $scope.validLanguageFilter = (language) ->
-    if language.iso_code == "base"
-      return false
-    if language.name == "Default"
-      return false
-    return true
-
   # a simple function to filter out invalid actions
   $scope.validActionFilter = (action) ->
 

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -798,10 +798,12 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
   $scope.options = options
 
   $scope.contactFields = Flow.contactFieldSearch
-  $scope.languages = Flow.languages
   $scope.actionConfigs = Flow.actions
   $scope.rulesetConfigs = Flow.rulesets
   $scope.operatorConfigs = Flow.operators
+
+  # all org languages except default
+  $scope.languages = utils.clone(Flow.languages).filter (lang) -> lang.name isnt "Default"
 
   formData = {}
 
@@ -825,6 +827,23 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
 
     actionset = options.actionset
     action = options.action
+
+    # if its a language type, see if we need to add a missing lanugage to the list
+    if action.type == "lang"
+      found = false
+      for lang in $scope.languages
+        if lang.iso_code == action.lang
+          found = true
+          break
+
+      if not found
+        $scope.languages.push({name:action.name, iso_code:action.lang})
+        $scope.languages.sort (a, b) ->
+          if a.name < b.name
+            return -1
+          if a.name > b.name
+            return 1
+          return 0
 
     #our place holder ruleset if the flip
     ruleset =
@@ -1318,6 +1337,13 @@ NodeEditorController = ($rootScope, $scope, $modal, $modalInstance, $timeout, $l
     $scope.action.action = 'GET'
 
   $scope.config = Flow.getActionConfig({type:$scope.action.type})
+
+  $scope.validLanguageFilter = (language) ->
+    if language.iso_code == "base"
+      return false
+    if language.name == "Default"
+      return false
+    return true
 
   # a simple function to filter out invalid actions
   $scope.validActionFilter = (action) ->

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4470,7 +4470,12 @@ class SetLanguageAction(Action):
         return dict(type=SetLanguageAction.TYPE, lang=self.lang, name=self.name)
 
     def execute(self, run, actionset_uuid, msg, offline_on=None):
-        run.contact.language = self.lang
+
+        if len(self.lang) != 3:
+            run.contact.language = None
+        else:
+            run.contact.language = self.lang
+
         run.contact.save(update_fields=['language'])
         self.logger(run)
         return []

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2002,6 +2002,15 @@ class ActionTest(TembaTest):
         action.execute(run, None, None)
         self.assertEquals('kli', Contact.objects.get(pk=self.contact.pk).language)
 
+        # try setting the language to something thats not three characters
+        action_json['lang'] = 'base'
+        action_json['name'] = 'Default'
+        action = SetLanguageAction.from_json(self.org, action_json)
+        action.execute(run, None, None)
+
+        # should clear the contacts language
+        self.assertIsNone(Contact.objects.get(pk=self.contact.pk).language)
+
     def test_start_flow_action(self):
         orig_flow = self.create_flow()
         run = FlowRun.create(orig_flow, self.contact)

--- a/templates/partials/action_editor.haml
+++ b/templates/partials/action_editor.haml
@@ -53,7 +53,7 @@
         -blocktrans
           Set the preferred language for the contact.
 
-      %select{ng-model:"action.lang",style:"height:34px",name:"lang",ng-options:"lang.iso_code as lang.name for lang in languages",required:"",class:"language",select2:""}
+      %select{ng-model:"action.lang",style:"height:34px",name:"lang",ng-options:"lang.iso_code as lang.name for lang in languages", required:"", class:"language", select2:""}
       %button{ng-click:"saveLanguage(action_editor.lang)",class:"submit hide"}
         -trans "Ok"
 


### PR DESCRIPTION
 * Nullify contact language if attempting to set to invalid language (not three letter iso code)
 * Don't show "Default" as an option in the editor
 * Show current language in action if not an org language in the editor