### PR TITLE
Contact read page tweaks

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -47,7 +47,7 @@ ply==3.4
 uservoice==0.0.19
 nose-perfdump==1.5
 geojson==1.0.7
-pycountry==1.6
+pycountry==1.18
 stop-words==2014.5.26
 twython==3.1.2
 rapidpro-expressions==1.1

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -52,7 +52,7 @@ ply
 uservoice
 nose-perfdump
 geojson==1.0.7
-pycountry==1.6
+pycountry
 stop-words
 twython
 enum34

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -3,14 +3,15 @@ from __future__ import unicode_literals
 import pycountry
 
 from django import template
-from temba.contacts.models import Contact, ContactURN, FACEBOOK_SCHEME, TEL_SCHEME, TWITTER_SCHEME, TWILIO_SCHEME, URN_ANON_MASK
+from temba.contacts.models import Contact, ContactURN, FACEBOOK_SCHEME, TEL_SCHEME, TWITTER_SCHEME, TWILIO_SCHEME, EXTERNAL_SCHEME, URN_ANON_MASK
 
 register = template.Library()
 
 URN_SCHEME_ICONS = {TEL_SCHEME: 'icon-mobile-2',
                     TWITTER_SCHEME: 'icon-twitter',
                     TWILIO_SCHEME: 'icon-twilio_original',
-                    FACEBOOK_SCHEME: 'icon-facebook'}
+                    FACEBOOK_SCHEME: 'icon-facebook',
+                    EXTERNAL_SCHEME: 'icon-channel-external'}
 
 
 @register.filter

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import pycountry
+
 from django import template
 from temba.contacts.models import Contact, ContactURN, FACEBOOK_SCHEME, TEL_SCHEME, TWITTER_SCHEME, TWILIO_SCHEME, URN_ANON_MASK
 
@@ -10,6 +12,7 @@ URN_SCHEME_ICONS = {TEL_SCHEME: 'icon-mobile-2',
                     TWILIO_SCHEME: 'icon-twilio_original',
                     FACEBOOK_SCHEME: 'icon-facebook'}
 
+
 @register.filter
 def contact_field(contact, arg):
     value = contact.get_field_display(arg)
@@ -18,17 +21,21 @@ def contact_field(contact, arg):
     else:
         return '--'
 
+
 @register.filter
 def tel(contact, org):
     return contact.get_urn_display(org=org, scheme=TEL_SCHEME)
+
 
 @register.filter
 def short_name(contact, org):
     return contact.get_display(org, short=True)
 
+
 @register.filter
 def name_or_urn(contact, org):
     return contact.get_display(org)
+
 
 @register.filter
 def format_urn(urn_or_contact, org):
@@ -41,6 +48,17 @@ def format_urn(urn_or_contact, org):
     else:
         raise ValueError('Must be a URN or contact')
 
+
 @register.filter
 def urn_icon(urn):
     return URN_SCHEME_ICONS.get(urn.scheme, '')
+
+
+@register.filter
+def lang_name(code):
+    """
+    Returns the name of a language with the given code. Differs from Django's language_name tag in that it considers all
+    possible languages and not just those configured as translation languages.
+    """
+    lang = pycountry.languages.get(iso639_3_code=code)
+    return lang.name if lang else None

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -61,5 +61,9 @@ def lang_name(code):
     Returns the name of a language with the given code. Differs from Django's language_name tag in that it considers all
     possible languages and not just those configured as translation languages.
     """
-    lang = pycountry.languages.get(iso639_3_code=code)
-    return lang.name if lang else None
+    if code:
+        try:
+            return pycountry.languages.get(iso639_3_code=code).name
+        except KeyError:
+            pass
+    return None

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -112,20 +112,31 @@
 
             .clearfix
         .span3
-          .contact_fields
-            -if contact_fields
+          -if contact.language
+            .contact_fields
               .contact_fields_title
-                -trans "Contact Fields"
-            -for field in contact_fields
+                -trans "Details"
               .contact_field
                 .contact_field_label
-                  {{field.label|title}}
+                  -trans "Language"
                 .contact_field_value
-                  {{ object|contact_field:field.key }}
+                  {{contact.language|lang_name|default:"--"}}
               .clearfix
 
-          .contact_fields
-            -if contact_fields
+          -if contact_fields
+            .contact_fields
+              .contact_fields_title
+                -trans "Custom Fields"
+              -for field in contact_fields
+                .contact_field
+                  .contact_field_label
+                    {{field.label|title}}
+                  .contact_field_value
+                    {{ object|contact_field:field.key }}
+                .clearfix
+
+          -if upcoming_events
+            .contact_fields
               .contact_fields_title
                 -trans "Scheduled Messages"
 

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -112,16 +112,15 @@
 
             .clearfix
         .span3
-          -if contact.language
-            .contact_fields
-              .contact_fields_title
-                -trans "Details"
-              .contact_field
-                .contact_field_label
-                  -trans "Language"
-                .contact_field_value
-                  {{contact.language|lang_name|default:"--"}}
-              .clearfix
+          .contact_fields
+            .contact_fields_title
+              -trans "Details"
+            .contact_field
+              .contact_field_label
+                -trans "Language"
+              .contact_field_value
+                {{contact.language|lang_name|default:"--"}}
+            .clearfix
 
           -if contact_fields
             .contact_fields


### PR DESCRIPTION
* Add language display
* Rename "Contact Fields" to "Custom Fields"
* Add icon for external scheme URNs

Language display under new "Details" section. We add state and district here if/when they become properties of 'Contact':

<img width="369" alt="screen shot 2015-11-16 at 11 41 16" src="https://cloud.githubusercontent.com/assets/675558/11180186/5f4cad72-8c61-11e5-89a5-74510f0ba334.png">

Use external channel icon for external scheme URNs:

<img width="270" alt="screen shot 2015-11-16 at 11 40 54" src="https://cloud.githubusercontent.com/assets/675558/11180188/6288359c-8c61-11e5-9fba-b5ccea5b7e96.png">
