### PR TITLE
Fixed webhook URLs

### DIFF
--- a/temba/api/v1/views.py
+++ b/temba/api/v1/views.py
@@ -172,8 +172,8 @@ def api(request, format=None):
     ## Web Hook
 
     Your application can be notified when new messages are received, sent or delivered.  You can
-    configure a URL for those events to be delivered to.  Visit the [Web Hook Documentation](/api/v1/webhook/) and
-    [Simulator](/api/v1/webhook/simulator/) for more details.
+    configure a URL for those events to be delivered to.  Visit the [Web Hook Documentation](/webhooks/webhook/) and
+    [Simulator](/webhooks/webhook/simulator/) for more details.
 
     ## Verbs
 

--- a/templates/partials/action_editor.haml
+++ b/templates/partials/action_editor.haml
@@ -117,7 +117,7 @@
         -blocktrans
           We'll include the message text along with data specified
           in the
-          %a{href:"/api/v1/webhook/#flow"}<
+          %a{href:"/webhooks/webhook/#flow"}<
             Webhook Flow Event API
           .
 

--- a/templates/partials/split_editor.haml
+++ b/templates/partials/split_editor.haml
@@ -70,7 +70,7 @@
           -blocktrans
             We'll include the message text along with data specified in
             the
-            %a{href:"/api/v1/webhook/#flow"}<
+            %a{href:"/webhooks/webhook/#flow"}<
               Webhook Flow Event API
             .
 


### PR DESCRIPTION
Always arriving at the page you expect when you click on a link is a premium feature... so this a feature change rather than bug fix. That code was certified.