### PR TITLE
Fix celery analytics by hooking into worker_ready signal

### DIFF
--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import logging
 
-from celery.signals import celeryd_init
 from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
@@ -185,11 +184,6 @@ def check_messages_task():
                 print "** Found %d unhandled messages" % unhandled_count
                 for msg in unhandled_messages[:100]:
                     msg.handle()
-
-
-@celeryd_init.connect
-def configure_workers(sender=None, conf=None, **kwargs):
-    init_analytics()
 
 
 @task(track_started=True, name='export_sms_task')

--- a/temba/urls.py
+++ b/temba/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import patterns, include, url
 from django.contrib.auth.models import User, AnonymousUser
 from django.conf import settings
 from temba.channels.views import register, sync
+from celery.signals import worker_ready
 
 import logging
 
@@ -55,8 +56,13 @@ def init_analytics():
     if librato_user and librato_token:
         init_librato(librato_user, librato_token)
 
-# and initialize them (in celery, the above will have to be called manually)
+# initialize our analytics (the signal below will initialize each worker)
 init_analytics()
+
+
+@worker_ready.connect
+def configure_workers(sender=None, **kwargs):
+    init_analytics()
 
 
 def track_user(self):  # pragma: no cover


### PR DESCRIPTION
This makes sure librato is initialized before our workers boot up.