### PR TITLE
Fix for scheduled messages near day boundaries

### DIFF
--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -67,8 +67,9 @@ class Schedule(SmartModel):
         """
         Get the next point in the future when our schedule should expire again
         """
+
         hour_of_day = self.repeat_hour_of_day if self.repeat_hour_of_day else trigger_date.hour
-        trigger_date = datetime(trigger_date.year, trigger_date.month, trigger_date.day, hour_of_day).replace(tzinfo=self.get_org_timezone())
+        trigger_date = trigger_date.replace(hour=hour_of_day, minute=0, second=0, microsecond=0)
 
         if self.repeat_period == "O":
             return trigger_date
@@ -95,19 +96,15 @@ class Schedule(SmartModel):
                     if bitmask & self.repeat_days == bitmask:
                         return trigger_date + timedelta(days=i + 1)
         if self.repeat_period == "D":
-            trigger_date += timedelta(days=1)
-            return datetime(trigger_date.year, trigger_date.month,
-                            trigger_date.day, hour=self.repeat_hour_of_day).replace(tzinfo=self.get_org_timezone())
+            return trigger_date + timedelta(days=1)
 
     def update_schedule(self, now=None):
         """
         Updates our schedule for the next date, returns true if it was expired
         """
+
         if not now:
             now = timezone.now()
-
-        # convert to local timezone so hours are correct
-        now = now.astimezone(self.get_org_timezone())
 
         if self.is_expired() and now:
             self.next_fire = self.get_next_fire(now)

--- a/temba/schedules/views.py
+++ b/temba/schedules/views.py
@@ -115,7 +115,6 @@ class ScheduleCRUDL(SmartCRUDL):
 
                 # create our recurrence
                 if form.is_recurring():
-                    days = None
                     if 'repeat_days' in form.cleaned_data:
                         days = form.cleaned_data['repeat_days']
                     schedule.repeat_days = days

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -857,7 +857,7 @@ BROKER_BACKEND = 'memory'
 #-----------------------------------------------------------------------------------
 # Django-Nose config
 #-----------------------------------------------------------------------------------
-# TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 #-----------------------------------------------------------------------------------
 # Debug Toolbar


### PR DESCRIPTION
Simplify date math on calculating next fire to not impose timezone, instead deferring to timezone aware datetime. Add more unit tests on date calculation across day boundaries.