### PR TITLE
Unnose

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,23 @@
+# .coveragerc to control coverage.py
+[run]
+source = ./temba
+
 [report]
+ignore_errors = True
+precision = 0
+show_missing = True
+
+
 omit =
     */migrations/*
+    */tests*,
+    *__init__*,
+    *settings*,
+    *management/commands*
     temba/perf_tests.py
+
+[html]
+directory = coverage_html_report
+
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ before_script:
 - ln -s $TRAVIS_BUILD_DIR/temba/settings.py.dev $TRAVIS_BUILD_DIR/temba/settings.py
 script:
 - node_modules/karma/bin/karma start karma.conf.coffee --single-run --browsers PhantomJS
-- coverage run --source="./temba" manage.py test --noinput --verbosity=2
+- coverage run manage.py test --noinput --verbosity=2
 after_success:
-- coverage report -m --omit="*/migrations/*,*/tests*,*__init__*,*settings*,*management/commands*" -i
+- coverage report -i
 - coveralls
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,9 @@ before_script:
 - ln -s $TRAVIS_BUILD_DIR/temba/settings.py.dev $TRAVIS_BUILD_DIR/temba/settings.py
 script:
 - node_modules/karma/bin/karma start karma.conf.coffee --single-run --browsers PhantomJS
-- coverage run --source="." manage.py test temba/api temba/assets temba/campaigns
-  temba/channels temba/contacts temba/flows temba/ivr temba/locations temba/msgs temba/orgs
-  temba/public temba/reports temba/schedules temba/triggers temba/utils temba/values
-  --verbosity=2 --noinput
+- coverage run --source="./temba" manage.py test --noinput --verbosity=2
 after_success:
-- coverage report -m --include="temba/api/*,temba/assets/*,temba/campaigns/*,temba/channels/*,temba/contacts/*,temba/flows/*,temba/ivr/*,temba/locations/*,temba/msgs/*,temba/orgs/*,temba/public/*,temba/reports/*,temba/schedules/*,temba/triggers/*,temba/utils/*,temba/values/*"
-  --omit="*/migrations/*,*/tests" -i
+- coverage report -m --omit="*/migrations/*,*/tests*,*__init__*,*settings*,*management/commands*" -i
 - coveralls
 notifications:
   slack:

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -7,10 +7,8 @@ django-debug-toolbar==1.2.2
 django-digest==1.13
 django-guardian==1.3.1
 -e git+http://github.com/nyaruka/django-modeltranslation.git@dffebc9363297d77d91c99d46e8e53b32dc05e61#egg=django_modeltranslation-master
-django-nose==1.4.2
 django-rosetta==0.6.2
 gunicorn==19.3.0
-nose==1.3.0
 pisa==3.0.33
 raven==4.0.4
 celery[redis]==3.1.18

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/nyaruka/smartmin.git@e14f017c1e208a13aa7a844a30379d97e8ce57ea#egg=smartmin
 Django==1.8.5
-coverage==3.5.1
+coverage==4.0.3
 django-celery==3.1.16
 django-compressor==1.5
 django-debug-toolbar==1.2.2

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/nyaruka/smartmin.git#egg=smartmin
 Django==1.8.5
-coverage==3.5.1
+coverage==4.0.3
 django-celery==3.1.16
 django-compressor==1.5
 django-debug-toolbar==1.2.2

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -8,11 +8,9 @@ django-digest==1.13
 django-extensions
 django-guardian
 -e git+http://github.com/nyaruka/django-modeltranslation.git#egg=django_modeltranslation-dev
-django-nose==1.4.2
 -e git+http://github.com/nyaruka/django-quickblocks.git#egg=django-quickblocks-dev
 django-rosetta==0.6.2
 gunicorn==19.3.0
-nose==1.3.0
 pisa==3.0.33
 raven==4.0.4
 celery[redis]==3.1.18

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -56,9 +56,9 @@ DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
 INTERNAL_IPS = ('127.0.0.1',)
 
 #-----------------------------------------------------------------------------------
-# Load nose in development
+# Load development apps
 #-----------------------------------------------------------------------------------
-INSTALLED_APPS = INSTALLED_APPS + ('django_nose', 'storages')
+INSTALLED_APPS = INSTALLED_APPS + ('storages',)
 # INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar', )
 
 #-----------------------------------------------------------------------------------

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -17,16 +17,6 @@ if TESTING:
     DEBUG = False
     TEMPLATE_DEBUG = False
 
-    # if nose's failfast is used, also skip migrations
-    if '--failfast' in sys.argv:
-        class DisableMigrations(object):
-            def __contains__(self, item):
-                return True
-            
-            def __getitem__(self, item):
-                return "notmigrations"
-        MIGRATION_MODULES = DisableMigrations()
-
 ADMINS = (
     ('RapidPro', 'code@yourdomain.io'),
 )
@@ -855,9 +845,10 @@ ANONYMOUS_USER_ID = -1
 BROKER_BACKEND = 'memory'
 
 #-----------------------------------------------------------------------------------
-# Django-Nose config
+# Our test runner is standard but with ability to exclude apps
 #-----------------------------------------------------------------------------------
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+TEST_RUNNER = 'temba.tests.ExcludeTestRunner'
+TEST_EXCLUDE = ('smartmin',)
 
 #-----------------------------------------------------------------------------------
 # Debug Toolbar

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -49,14 +49,6 @@ class ExcludeTestRunner(DiscoverRunner):
                 if pkg not in excluded:
                     tests.append(case)
             suite._tests = tests
-
-        packages = set()
-        for case in suite._tests:
-            pkg = case.__class__.__module__.split('.')[0]
-            packages.add(pkg)
-
-        for pkg in packages:
-            print pkg
         return suite
 
 

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -6,7 +6,6 @@ import redis
 import shutil
 import string
 import time
-import logging
 
 from datetime import datetime
 from django.conf import settings
@@ -29,14 +28,10 @@ from xlrd import xldate_as_tuple
 from xlrd.sheet import XL_CELL_DATE
 
 
-
-
 class ExcludeTestRunner(DiscoverRunner):
     def __init__(self, *args, **kwargs):
         from django.conf import settings
         settings.TESTING = True
-        south_log = logging.getLogger("south")
-        south_log.setLevel(logging.WARNING)
         super(ExcludeTestRunner, self).__init__(*args, **kwargs)
 
     def build_suite(self, *args, **kwargs):


### PR DESCRIPTION
Remove the nose test runner so we can use standard runner switches (--keepdb, etc). Also gives saner discovery now. 

Switch to using .coveragerc for source and report omission. 

This also fixes our omission for tests, so reported coverage will drop about 3% but actual coverage is the same. 


