### PR TITLE
Contact History Tweaks

### DIFF
--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -1,6 +1,10 @@
 from __future__ import unicode_literals
 
+from datetime import datetime
+
+import pytz
 from django import template
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 from temba.contacts.models import Contact, ContactURN, FACEBOOK_SCHEME, TEL_SCHEME, TWITTER_SCHEME, TWILIO_SCHEME, URN_ANON_MASK
 from django.utils.translation import ugettext_lazy as _

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -980,6 +980,7 @@ class ContactTest(TembaTest):
 
         # create an event from the past
         from temba.campaigns.models import EventFire
+
         scheduled = timezone.now() - timedelta(days=5)
         EventFire.objects.create(event=self.planting_reminder, contact=self.joe, scheduled=scheduled, fired=scheduled)
 
@@ -1000,13 +1001,7 @@ class ContactTest(TembaTest):
         self.assertFalse(response.context['more'])
 
         # six remaining messages
-        self.assertEquals(6, len(activity))
-
-        # create an earlier message to capture our event
-        self.create_msg(direction='I', contact=self.joe, text="Older message", created_on=scheduled - timedelta(days=1))
-        response = self.fetch_protected('%s?page=2' % reverse('contacts.contact_history', args=[self.joe.uuid]), self.admin)
-        activity = response.context['activity']
-        self.assertEquals(8, len(activity))
+        self.assertEquals(7, len(activity))
         self.assertTrue(isinstance(activity[6], EventFire))
 
         # most recent thing is a message followed by a flow run
@@ -1024,8 +1019,6 @@ class ContactTest(TembaTest):
         self.assertEquals('Newer message', activity[0].text)
         self.assertTrue(isinstance(activity[0], Msg))
         self.assertTrue(isinstance(activity[1], Call))
-
-
 
     def test_event_times(self):
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import json
 import pytz
+import time
 
 from datetime import datetime, date, timedelta
 from django.core.urlresolvers import reverse
@@ -991,8 +992,11 @@ class ContactTest(TembaTest):
         response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]), self.admin)
         activity = response.context['activity']
 
-        # 100 messages and one FlowRun, no event or call since they happened earlier
-        self.assertEquals(101, len(activity))
+        # even though there are no messages after it, should still see the recent call
+        self.assertTrue(isinstance(activity[0], Call))
+
+        # 100 messages, a call, and a flow run
+        self.assertEquals(102, len(activity))
         self.assertTrue(response.context['more'])
 
         # fetch page 2
@@ -1007,10 +1011,10 @@ class ContactTest(TembaTest):
         # most recent thing is a message followed by a flow run
         response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]), self.admin)
         activity = response.context['activity']
-        self.assertTrue(isinstance(activity[0], Msg))
-        self.assertTrue(isinstance(activity[1], FlowRun))
+        self.assertTrue(isinstance(activity[1], Msg))
+        self.assertTrue(isinstance(activity[2], FlowRun))
 
-        # but if a new message comes in
+        # if a new message comes in
         self.create_msg(direction='I', contact=self.joe, text="Newer message")
         response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]), self.admin)
         activity = response.context['activity']
@@ -1020,7 +1024,28 @@ class ContactTest(TembaTest):
         self.assertTrue(isinstance(activity[0], Msg))
         self.assertTrue(isinstance(activity[1], Call))
 
+        # remove 50 messages
+        for i in range(50):
+            msgs[i].delete()
+
+        # add five more messages from eight days ago
+        for i in range(5):
+            self.create_msg(direction='I', contact=self.joe, text="Old Message", created_on=timezone.now() - timedelta(days=8))
+
+        # number of items on the first page should be 65 now
+        response = self.fetch_protected((reverse('contacts.contact_history', args=[self.joe.uuid])), self.admin)
+        activity = response.context['activity']
+        self.assertEquals(65, len(activity))
+
+        recent_seconds = int(time.mktime((timezone.now() - timedelta(days=7)).timetuple()))
+        response = self.fetch_protected("%s?r=true&rs=%s" % (reverse('contacts.contact_history', args=[self.joe.uuid]), recent_seconds), self.admin)
+        activity = response.context['activity']
+
+        # with our recent flag on, should not see the 5 older messages
+        self.assertEquals(60, len(activity))
+
     def test_event_times(self):
+
 
         self.create_campaign()
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -969,9 +969,9 @@ class ContactTest(TembaTest):
         self.create_campaign()
 
         # create some messages
-        i = 0
+        msgs = []
         for i in range(5):
-            self.create_msg(direction='I', contact=self.joe, text="Inbound message %d" % i)
+            msgs.append(self.create_msg(direction='I', contact=self.joe, text="Inbound message %d" % i))
             i += 1
 
         # start a joe flow
@@ -981,7 +981,7 @@ class ContactTest(TembaTest):
         # create an event from the past
         from temba.campaigns.models import EventFire
         scheduled = timezone.now() - timedelta(days=5)
-        event = EventFire.objects.create(event=self.planting_reminder, contact=self.joe, scheduled=scheduled, fired=scheduled)
+        EventFire.objects.create(event=self.planting_reminder, contact=self.joe, scheduled=scheduled, fired=scheduled)
 
         # create a missed call
         Call.create_call(self.channel, self.joe.get_urn(TEL_SCHEME).path, timezone.now(), 5, Call.TYPE_OUT_MISSED)
@@ -989,21 +989,38 @@ class ContactTest(TembaTest):
         # fetch our contact history
         response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]), self.admin)
         activity = response.context['activity']
+
+        # we won't see our event because it happened before the last message in the list which determines our window
+        self.assertEquals(7, len(activity))
+
+        # but if a message arrived before the event..'
+        self.create_msg(direction='I', contact=self.joe, text="Older message", created_on=scheduled - timedelta(days=1))
+
+        # then it'll be included
+        response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]), self.admin)
+        activity = response.context['activity']
         self.assertEquals(9, len(activity))
 
-        # most recent thing is our missed call
-        self.assertTrue(isinstance(activity[0], Call))
+        # most recent thing is a message followed by a flow run
+        self.assertTrue(isinstance(activity[0], Msg))
+        self.assertTrue(isinstance(activity[1], FlowRun))
 
-        # order should be most recent first
-        self.assertEquals('What is your favorite color?', activity[1].text)
-        self.assertTrue(isinstance(activity[2], FlowRun))
+        # but if a new message comes in
+        self.create_msg(direction='I', contact=self.joe, text="Newer message")
+        response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]), self.admin)
+        activity = response.context['activity']
+
+        # now we'll see the message that just came in first, followed by the Call event
+        self.assertEquals('Newer message', activity[0].text)
+        self.assertTrue(isinstance(activity[0], Msg))
+        self.assertTrue(isinstance(activity[1], Call))
 
         # then our five messages
-        for i in range (5):
-            self.assertEquals('Inbound message %d' % (4-i), activity[3 + i].text)
+        for i in range(5):
+            self.assertEquals('Inbound message %d' % (4-i), activity[4 + i].text)
 
         # then lastly is our event that happened 5 days ago
-        self.assertTrue(isinstance(activity[8], EventFire))
+        self.assertTrue(isinstance(activity[9], EventFire))
 
     def test_event_times(self):
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -4,9 +4,10 @@ import json
 import pycountry
 import regex
 import pytz
+import time
 
 from collections import OrderedDict
-from datetime import timedelta
+from datetime import timedelta, datetime
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -608,7 +609,7 @@ class ContactCRUDL(SmartCRUDL):
                     contact_fields.append(dict(label='Language', value=lang, featured=True))
 
             context['contact_fields'] = sorted(contact_fields, key=lambda f: f['label'])
-
+            context['recent_seconds'] = int(time.mktime((timezone.now() - timedelta(days=7)).timetuple()))
             return context
 
         def post(self, request, *args, **kwargs):
@@ -673,7 +674,7 @@ class ContactCRUDL(SmartCRUDL):
             from temba.flows.models import FlowRun, Flow
             from temba.campaigns.models import EventFire
 
-            def contact_cmp(a, b):
+            def activity_cmp(a, b):
 
                 if not hasattr(a, 'created_on') and hasattr(a, 'fired'):
                     a.created_on = a.fired
@@ -692,38 +693,51 @@ class ContactCRUDL(SmartCRUDL):
 
             # determine our start and end time based on the page
             page = int(self.request.REQUEST.get('page', 1))
-
             msgs_per_page = 100
-            start_message = (page - 1) * msgs_per_page
-            end_message = page * msgs_per_page
+            start_time = None
 
-            # fetch the next 100 messages, grab one extra to see if we should show link for more
-            text_messages = Msg.objects.filter(contact=contact.id, visibility__in=(VISIBLE, ARCHIVED)).order_by('-created_on')[start_message:end_message + 1]
+            # if we are just grabbing recent history use that window
+
+            recent_seconds = int(self.request.REQUEST.get('rs', 0))
+            recent = self.request.REQUEST.get('r', False)
+            context['recent_date'] = datetime.utcfromtimestamp(recent_seconds).replace(tzinfo=pytz.utc)
+
+            text_messages = Msg.objects.filter(contact=contact.id, visibility__in=(VISIBLE, ARCHIVED)).order_by('-created_on')
+            if recent:
+                start_time = context['recent_date']
+                text_messages = text_messages.filter(created_on__gt=start_time)
+                context['recent'] = True
+
+            # other wise, just grab 100 messages within our page (and an extra marker, for determining more)
+            else:
+                start_message = (page - 1) * msgs_per_page
+                end_message = page * msgs_per_page
+                text_messages = text_messages[start_message:end_message+1]
 
             # ignore our lead message past the first page
             count = len(text_messages)
             first_message = 0
-            start_time = None
 
             # if we got an extra one at the end too, trim it off
             context['more'] = False
-            if count > msgs_per_page:
+            if count > msgs_per_page and not recent:
                 context['more'] = True
                 start_time = text_messages[count - 1].created_on
                 count -= 1
 
             # grab up to 100 messages from our first message
-            text_messages = text_messages[first_message:first_message+100]
+            if not recent_seconds:
+                text_messages = text_messages[first_message:first_message+100]
 
             activity = []
 
             if count > 0:
-                # if we dont know our start time, go back to the beginning
+                # if we don't know our start time, go back to the beginning
                 if not start_time:
                     start_time = timezone.datetime(2013, 1, 1, tzinfo=pytz.utc)
 
                 # if we don't know our stop time yet, assume the first message
-                if page == 0:
+                if page == 1:
                     end_time = timezone.now()
                 else:
                     end_time = text_messages[0].created_on
@@ -738,11 +752,9 @@ class ContactCRUDL(SmartCRUDL):
                 calls = Call.objects.filter(contact=contact, created_on__lt=end_time, created_on__gt=start_time)
 
                 # now chain them all together in the same list and sort by time
-                activity = chain(text_messages, runs, fired, calls)
-                activity = sorted(activity, cmp=contact_cmp, reverse=True)
+                activity = sorted(chain(text_messages, runs, fired, calls), cmp=activity_cmp, reverse=True)
 
             context['activity'] = activity
-
             return context
 
     class List(ContactActionMixin, ContactListView):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -703,6 +703,7 @@ class ContactCRUDL(SmartCRUDL):
             count = len(text_messages)
 
             # if we got an extra one, trim it off
+            context['more'] = False
             if count > msgs_per_page:
                 context['more'] = True
                 text_messages = text_messages[0:100]

--- a/templates/contacts/contact_history.haml
+++ b/templates/contacts/contact_history.haml
@@ -88,10 +88,7 @@
 
 %tr.since
   %td{colspan:3}
-
-    %span.date
-      Activity since {{start_time}}
-    %p
-      -if more
-        %a.btn.btn-tiny.btn-secondary.load-more
-          Load More
+    %span.loading
+    -if more
+      %a.btn.btn-tiny.btn-secondary.load-more
+        Load More

--- a/templates/contacts/contact_history.haml
+++ b/templates/contacts/contact_history.haml
@@ -92,5 +92,6 @@
     %span.date
       Activity since {{start_time}}
     %p
-      %a.btn.btn-tiny.btn-secondary.load-more
-        Load More
+      -if more
+        %a.btn.btn-tiny.btn-secondary.load-more
+          Load More

--- a/templates/contacts/contact_history.haml
+++ b/templates/contacts/contact_history.haml
@@ -2,7 +2,7 @@
 
 -for item in activity
 
-  %tr.item{class:'msg_{{item.msg_type}} {% if item.direction or item.recipient_count%}msg{%else%}non-msg{%endif%}'}
+  %tr.item{class:'msg_{{item.msg_type}} {% if item.created_on > recent_date%}recent{%endif%} {% if item.direction or item.recipient_count%}msg{%else%}non-msg{%endif%}'}
 
     %td.icon
 
@@ -85,10 +85,10 @@
         %span.long.hide
           {{item.created_on}}
 
-
-%tr.since
-  %td{colspan:3}
-    %span.loading
-    -if more
-      %a.btn.btn-tiny.btn-secondary.load-more
-        Load More
+-if not recent
+  %tr.since
+    %td{colspan:3}
+      %span.loading
+      -if more
+        %a.btn.btn-tiny.btn-secondary.load-more
+          Load More

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -94,7 +94,7 @@
                 Start
                 %a.href{ href: "{% url 'flows.flow_editor' evt.event.flow.pk %}" }= evt.event.flow.name
           %td.created_on
-            {{evt.scheduled|gmail_time}}
+            {{evt.scheduled}}
 
   .header
     Message History

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -101,7 +101,7 @@
   %table.activity.history
     %tr.since
       %td{colspan:3}
-        %span.date
+        %span.loading
           One moment..
 
 
@@ -458,7 +458,7 @@
       // when they click to load more, fetch more history
       $('.load-more').live('click', function() {
         $(this).css('visibility', 'hidden');
-        $('.since .date').text('One moment..');
+        $('.since .loading').text('One moment..');
 
         page++
         $.get('/contact/history/{{contact.uuid}}/?page=' + page, function(data){

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -23,7 +23,7 @@
       .contact-urn
         .{class:"glyph {{urn|urn_icon}}"}
         -if not user_org.is_anon
-          %a.contact-urn-path{href:"javascript:showComposeInitialized(\"u={{ urn.id }}\")"}><
+          %a.contact-urn-path{href:"javascript:showComposeInitialized(\"u={{ urn.id }}\", null, fetchRecentMessages)"}><
             {{urn|format_urn:user_org}}
         -else
           %span.contact-urn-path
@@ -439,7 +439,10 @@
 
   :javascript
 
-    var page = 1
+    var page = 1;
+    var refreshSeconds = 30;
+    var scheduledRefresh = null;
+
     $(document).ready(function() {
 
       $('.time').live('mouseover', function() {
@@ -450,7 +453,7 @@
         $(this).children('.long').hide();
       });
       // fetch our first chunk of history
-      $.get('/contact/history/{{contact.uuid}}/', function(data){
+      $.get('/contact/history/{{contact.uuid}}/?rs={{recent_seconds}}', function(data){
         $('.history tr:last').remove();
         $('.history').append(data);
       });
@@ -461,7 +464,7 @@
         $('.since .loading').text('One moment..');
 
         page++
-        $.get('/contact/history/{{contact.uuid}}/?page=' + page, function(data){
+        $.get('/contact/history/{{contact.uuid}}/?rs={{recent_seconds}}&page=' + page, function(data){
           $('.history tr:last').remove();
           $('.history').append(data);
         });
@@ -488,7 +491,19 @@
           $('.normal').css('display', 'inline-block').show();
         }
       })
+
+      // update messages every 30s
+      scheduledReresh = setTimeout(fetchRecentMessages, refreshSeconds * 1000)
     });
+
+    function fetchRecentMessages(){
+      clearTimeout(scheduledRefresh);
+      $.get('/contact/history/{{contact.uuid}}/?r=true&rs={{recent_seconds}}', function(data){
+          $('.history tr.recent').remove();
+          $('.history').prepend(data);
+          scheduledRefresh = setTimeout(fetchRecentMessages, refreshSeconds * 1000)
+      });
+    }
 
     // plays the audio recording for a message
     function playMessage (messageId) {
@@ -569,7 +584,7 @@
     $(".contact-send-button").on('click', function() {
       {% if contact_sendable_urns %}
       $(".gear-menu").removeClass("open");
-      showComposeInitialized("c={{object.id}}");
+      showComposeInitialized("c={{object.id}}", null, fetchRecentMessages);
       {% else %}
       modal = new Modal('{% trans "Error" %}', '{% trans "This contact does not have any number which you can send to. Please edit the contact first or add a new phone." %}');
       modal.addClass('alert');

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -99,6 +99,10 @@
   .header
     Message History
   %table.activity.history
+    %tr.since
+      %td{colspan:3}
+        %span.date
+          One moment..
 
 
 -block post-content
@@ -447,6 +451,7 @@
       });
       // fetch our first chunk of history
       $.get('/contact/history/{{contact.uuid}}/', function(data){
+        $('.history tr:last').remove();
         $('.history').append(data);
       });
 

--- a/templates/msgs/msg_send_modal.haml
+++ b/templates/msgs/msg_send_modal.haml
@@ -69,8 +69,8 @@
     };
 
     // show the compose dialog with some contacts prepopulated
-    function showComposeInitialized(queryString, url) {
-      showCompose(true, url);
+    function showComposeInitialized(queryString, url, onComplete) {
+      showCompose(true, url, onComplete);
       $.get("{% url 'contacts.contact_omnibox' %}?" + queryString, function(data, textStatus){
         initializeOmnibox(data.results);
         $('.select2-input').attr('tabindex', 2);
@@ -78,7 +78,7 @@
     }
 
     
-    function showCompose(loading, url) {
+    function showCompose(loading, url, onComplete) {
       // make sure any previous errors are removed
       $("#send-message .error").remove();
 
@@ -123,9 +123,11 @@
       // store our post location in the form
       $('#send-form').attr("action", url);
 
-      $("#send-message .ok").unbind('click').unbind('keypress').click(function(e) {sendMessage(e) }).keypress(function(e) {
+      $("#send-message .ok").unbind('click').unbind('keypress').click(function(e) {
+        sendMessage(e, null, onComplete)
+      }).keypress(function(e) {
         if(e.which == 13){
-          sendMessage(e);
+          sendMessage(e, null, onComplete);
         }
       });
 
@@ -145,7 +147,7 @@
       sendMessage(this, true);
     });
 
-    function sendMessage(e, scheduled) {
+    function sendMessage(e, scheduled, onComplete) {
       if ($("#send-message .ok").hasClass("disabled")) {
         e.preventDefault();
         return;
@@ -189,6 +191,10 @@
           hideCompose();
         }
         fetchPJAXContent(".", "#pjax", { forceReload:true });
+
+        if (onComplete) {
+          onComplete();
+        }
 
 
       }).fail(function(data, textStatus) {


### PR DESCRIPTION
Some tweaks to the contact history:
* Use the last 100 messages to determine the window for events. 
* Give feedback on initial load.
* Don't show more button if there aren't any more messages

One unfortunate side effect is that this will hide any events that occurred before the first message and will also not surface events that have occurred since the last message.

The bonus is that its a far nicer user experience for the vast majority of cases.
