### PR TITLE
ISO639-v2

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -77,6 +77,7 @@ gnureadline==6.3.3
 google==1.07
 httplib2==0.9
 ipython==2.2.0
+iso639==0.1.1
 kombu==3.0.16
 nodeenv==0.9.4
 oauthlib==0.6.1

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -41,6 +41,7 @@ django-timezones
 -e git+http://github.com/nyaruka/django-hstore.git#egg=django-hstore
 colorama
 isoweek==1.2.0
+iso639==0.1.1
 twilio
 pycrypto
 numpy

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -4,6 +4,7 @@ import json
 import pycountry
 import regex
 
+
 from collections import OrderedDict
 from datetime import timedelta
 from django import forms
@@ -29,7 +30,7 @@ from temba.orgs.views import OrgPermsMixin, OrgObjPermsMixin, ModalMixin
 from temba.msgs.models import Broadcast, Call, Msg, VISIBLE, ARCHIVED
 from temba.msgs.views import SendMessageForm, BaseActionForm
 from temba.values.models import VALUE_TYPE_CHOICES, TEXT, DISTRICT
-from temba.utils import analytics, slugify_with, build_json_response
+from temba.utils import analytics, slugify_with, languages
 from .omnibox import omnibox_query, omnibox_results_to_dict
 
 
@@ -598,16 +599,12 @@ class ContactCRUDL(SmartCRUDL):
 
             # stuff in the contact's language in the fields as well
             if contact.language:
-                try:
-                  lang = pycountry.languages.get(iso639_3_code=contact.language).name
-                except KeyError:
+                lang = languages.get_language_name(contact.language)
+                if not lang:
                     lang = contact.language
-
-                if lang:
-                    contact_fields.append(dict(label='Language', value=lang, featured=True))
+                contact_fields.append(dict(label='Language', value=lang, featured=True))
 
             context['contact_fields'] = sorted(contact_fields, key=lambda f: f['label'])
-
             return context
 
         def post(self, request, *args, **kwargs):

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -20,6 +20,7 @@ from temba.channels.models import Channel, RECEIVE, SEND, TWILIO, TWITTER, PLIVO
 from temba.flows.models import Flow, ActionSet
 from temba.msgs.models import Label, Msg, INCOMING
 from temba.utils.email import link_components
+from temba.utils import languages
 from temba.tests import TembaTest, MockResponse, MockTwilioClient, MockRequestValidator, FlowFileTest
 from temba.triggers.models import Trigger
 from .models import Org, OrgEvent, TopUp, Invitation, Language, DAYFIRST, MONTHFIRST, CURRENT_EXPORT_VERSION
@@ -1272,6 +1273,25 @@ class OrgCRUDLTest(TembaTest):
 
 
 class LanguageTest(TembaTest):
+
+    def test_language_codes(self):
+        self.assertEquals('French', languages.get_language_name('fre'))
+        self.assertEquals('Creoles and pidgins, English based', languages.get_language_name('cpe'))
+
+        # should strip off anything after an open paren or semicolon
+        self.assertEquals('Official Aramaic', languages.get_language_name('arc'))
+        self.assertEquals('Haitian', languages.get_language_name('hat'))
+
+        # check that search returns results and in the proper order
+        matches = languages.search_language_names('Fre')
+        self.assertEquals(4, len(matches))
+        self.assertEquals('Creoles and pidgins, French-based', matches[0]['text'])
+        self.assertEquals('French', matches[1]['text'])
+        self.assertEquals('French, Middle (ca.1400-1600)', matches[2]['text'])
+        self.assertEquals('French, Old (842-ca.1400)', matches[3]['text'])
+
+        # try a language that doesn't exist
+        self.assertEquals(None, languages.get_language_name('klingon'))
 
     def test_get_localized_text(self):
         text_translations = dict(eng="Hello", esp="Hola")

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1274,6 +1274,29 @@ class OrgCRUDLTest(TembaTest):
 
 class LanguageTest(TembaTest):
 
+    def test_setting_language(self):
+        self.login(self.admin)
+
+        # update our org with some language settings
+        post_data = dict(primary_lang='fre', languages='hat,arc')
+        response = self.client.post(reverse('orgs.org_languages'), post_data)
+        self.assertEquals(302, response.status_code)
+        self.org.refresh_from_db()
+
+        self.assertEquals('French', self.org.primary_language.name)
+        self.assertIsNotNone(self.org.languages.filter(name='French'))
+
+        # everything after the paren should be stripped for aramaic
+        self.assertIsNotNone(self.org.languages.filter(name='Official Aramaic'))
+
+        # everything after the semi should be stripped for haitian
+        self.assertIsNotNone(self.org.languages.filter(name='Haitian'))
+
+        # check that the last load shows our new languages
+        response = self.client.get(reverse('orgs.org_languages'))
+        self.assertContains(response, 'fre')
+        self.assertContains(response, 'hat,arc')
+
     def test_language_codes(self):
         self.assertEquals('French', languages.get_language_name('fre'))
         self.assertEquals('Creoles and pidgins, English based', languages.get_language_name('cpe'))

--- a/temba/utils/languages.py
+++ b/temba/utils/languages.py
@@ -32,7 +32,7 @@ def search_language_names(query):
         query: Substring of a language name, 'Frenc'
 
     Returns:
-        A list of dicts showing the matches [{id:'fre', text='French'}]
+        A list of dicts showing the matches [{id:'fre', text:'French'}]
     """
     matches = []
     for lang in iso639.data:

--- a/temba/utils/languages.py
+++ b/temba/utils/languages.py
@@ -1,0 +1,42 @@
+import re
+import iso639
+from iso639 import NonExistentLanguageError
+
+iso_codes = {}
+
+
+def get_language_name(iso_code):
+    """
+    Gets a language name for a given ISO639-2 code.
+
+    Args:
+        iso_code: three character iso_code
+    """
+    if iso_code not in iso_codes:
+        try:
+            lang = iso639.to_name(iso_code)
+        except NonExistentLanguageError:
+            return None
+
+        # we only show up to the first semi
+        lang = re.split(';|\(', lang)[0].strip()
+        iso_codes[iso_code] = lang
+
+    return iso_codes[iso_code]
+
+
+def search_language_names(query):
+    """
+    Searches language names in ISO639-2
+    Args:
+        query: Substring of a language name, 'Frenc'
+
+    Returns:
+        A list of dicts showing the matches [{id:'fre', text='French'}]
+    """
+    matches = []
+    for lang in iso639.data:
+        query = query.lower()
+        if query in lang['name'].lower():
+            matches.append(dict(id=lang['iso639_2_b'], text=lang['name'].strip()))
+    return matches

--- a/temba/utils/languages.py
+++ b/temba/utils/languages.py
@@ -18,7 +18,7 @@ def get_language_name(iso_code):
         except NonExistentLanguageError:
             return None
 
-        # we only show up to the first semi
+        # we only show up to the first semi or paren
         lang = re.split(';|\(', lang)[0].strip()
         iso_codes[iso_code] = lang
 


### PR DESCRIPTION
Use new iso639 library instead of pycountry for determining valid iso codes. This will ensure as pycountry moves forward we stick with iso639-v2 codes.