### PR TITLE
Fix order of upcoming events on contact history

### DIFF
--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -572,7 +572,7 @@ class ContactCRUDL(SmartCRUDL):
             context['contact_groups'] = contact.user_groups.extra(select={'lower_name': 'lower(name)'}).order_by('lower_name')
 
             # upcoming scheduled events
-            context['upcoming_events'] = contact.fire_events.filter(scheduled__gte=timezone.now()).order_by('scheduled')[:3].reverse()
+            context['upcoming_events'] = list(reversed(contact.fire_events.filter(scheduled__gte=timezone.now()).order_by('scheduled')[:3]))
 
             # divide contact's URNs into those we can send to, and those we can't
             from temba.channels.models import SEND


### PR DESCRIPTION
Event sorting was wrong for upcoming events, reverse() on querysets is of course not the same as reversed(). Now we slice from the queryset first and run that through reversed().