### PR TITLE
Update expressions dependency to 1.1.5

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -48,7 +48,7 @@ geojson==1.0.7
 pycountry==1.18
 stop-words==2015.2.23.1
 twython==3.1.2
-rapidpro-expressions==1.1.4
+rapidpro-expressions==1.1.5
 ## The following requirements were added by pip --freeze:
 Django-Select2==4.2.2
 Jinja2==2.7.3


### PR DESCRIPTION
Adds fix for float values in the context. Previously it was assumed that every float value was a Decimal instance, but `@extra` can end up with floats.