### PR TITLE
REST framework should encode unicode chars in JSON

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -1963,11 +1963,16 @@ class APITest(TembaTest):
         # add some incoming messages and a flow message
         msg2 = Msg.create_incoming(self.channel, (TEL_SCHEME, '0788123123'), "test2")
         msg3 = Msg.create_incoming(self.channel, (TEL_SCHEME, '0788123123'), "test3")
-        msg4 = Msg.create_incoming(self.channel, (TEL_SCHEME, '0788123123'), "test4")
+        msg4 = Msg.create_incoming(self.channel, (TEL_SCHEME, '0788123123'), "test4 (سلم)")
 
         flow = self.create_flow()
         flow.start([], [contact])
         msg5 = Msg.objects.get(msg_type='F')
+
+        # check encoding
+        response = self.fetchJSON(url, "id=%d" % msg4.pk)
+        self.assertIn('\\u0633\\u0644\\u0645', response.content)
+        self.assertEqual(response.json['results'][0]['text'], "test4 (\u0633\u0644\u0645)")
 
         # search by type
         response = self.fetchJSON(url, "type=F")

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -977,7 +977,8 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
         'rest_framework_xml.renderers.XMLRenderer',
     ),
-    'EXCEPTION_HANDLER': 'temba.api.temba_exception_handler'
+    'EXCEPTION_HANDLER': 'temba.api.temba_exception_handler',
+    'UNICODE_JSON': False
 }
 REST_HANDLE_EXCEPTIONS = not TESTING
 


### PR DESCRIPTION
REST framework 3 by default puts unicode chars in responses as they are, e.g. "x سلم" where as v2 would encode them, e.g. "x \u0633\u0644\u0645". This change restores the old behaviour.