### PR TITLE
Allow configuring kannel channels to send messages using national format

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -65,6 +65,7 @@ PASSWORD = 'password'
 KEY = 'key'
 API_ID = 'api_id'
 VERIFY_SSL = 'verify_ssl'
+USE_NATIONAL = 'use_national'
 ENCODING = 'encoding'
 
 DEFAULT_ENCODING = 'D'  # we just pass the text down to the endpoint
@@ -887,6 +888,13 @@ class Channel(SmartModel):
         payload['to'] = msg.urn_path
         payload['dlr-url'] = dlr_url
         payload['dlr-mask'] = dlr_mask
+
+        # should our to actually be in national format?
+        use_national = channel.config.get(USE_NATIONAL, False)
+        if use_national:
+            # parse and remap our 'to' address
+            parsed = phonenumbers.parse(msg.urn_path)
+            payload['to'] = str(parsed.national_number)
 
         # figure out if we should send encoding or do any of our own substitution
         encoding = channel.config.get(ENCODING, DEFAULT_ENCODING)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -2814,11 +2814,12 @@ class KannelTest(TembaTest):
 
                 # assert verify was set to true
                 self.assertTrue(mock.call_args[1]['verify'])
+                self.assertEquals('+250788383383', mock.call_args[1]['params']['to'])
 
                 self.clear_cache()
 
             self.channel.config = json.dumps(dict(username='kannel-user', password='kannel-pass',
-                                                  encoding=SMART_ENCODING,
+                                                  encoding=SMART_ENCODING, use_national=True,
                                                   send_url='http://foo/', verify_ssl=False))
             self.channel.save()
 
@@ -2838,6 +2839,7 @@ class KannelTest(TembaTest):
 
                 # assert verify was set to true
                 self.assertEquals('No capital accented E!', mock.call_args[1]['params']['text'])
+                self.assertEquals('788383383', mock.call_args[1]['params']['to'])
                 self.assertFalse('coding' in mock.call_args[1]['params'])
                 self.clear_cache()
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -38,7 +38,7 @@ from .models import Channel, SyncEvent, Alert, ChannelLog, ChannelCount, M3TECH
 from .models import PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN, PLIVO, BLACKMYNA, SMSCENTRAL, VERIFY_SSL
 from .models import PASSWORD, RECEIVE, SEND, CALL, ANSWER, SEND_METHOD, SEND_URL, USERNAME, CLICKATELL, HIGH_CONNECTION
 from .models import ANDROID, EXTERNAL, HUB9, INFOBIP, KANNEL, NEXMO, TWILIO, TWITTER, VUMI, VERBOICE, SHAQODOON
-from .models import ENCODING, ENCODING_CHOICES, DEFAULT_ENCODING, YO
+from .models import ENCODING, ENCODING_CHOICES, DEFAULT_ENCODING, YO, USE_NATIONAL
 
 RELAYER_TYPE_ICONS = {ANDROID: "icon-channel-android",
                       EXTERNAL: "icon-channel-external",
@@ -967,15 +967,21 @@ class ChannelCRUDL(SmartCRUDL):
             country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
                                         help_text=_("The country this phone number is used in"))
             url = forms.URLField(max_length=1024, label=_("Send URL"),
-                                 help_text=_("The publicly accessible URL for your Kannel instance for sending. ex: https://kannel.macklemore.co/cgi-bin/sendsms"))
+                                 help_text=_("The publicly accessible URL for your Kannel instance for sending. "
+                                             "ex: https://kannel.macklemore.co/cgi-bin/sendsms"))
             username = forms.CharField(max_length=64, required=False,
-                                       help_text=_("The username to use to authenticate to Kannel, if left blank we will generate one for you"))
+                                       help_text=_("The username to use to authenticate to Kannel, if left blank we "
+                                                   "will generate one for you"))
             password = forms.CharField(max_length=64, required=False,
-                                       help_text=_("The password to use to authenticate to Kannel, if left blank we will generate one for you"))
+                                       help_text=_("The password to use to authenticate to Kannel, if left blank we "
+                                                   "will generate one for you"))
             encoding = forms.ChoiceField(ENCODING_CHOICES, label=_("Encoding"),
                                          help_text=_("What encoding to use for outgoing messages"))
             verify_ssl = forms.BooleanField(initial=True, required=False, label=_("Verify SSL"),
                                             help_text=_("Whether to verify the SSL connection (recommended)"))
+            use_national = forms.BooleanField(initial=False, required=False, label=_("Use National Numbers"),
+                                              help_text=_("Use only the national number (no country code) when "
+                                                          "sending (not recommended)"))
 
         title = _("Connect Kannel Service")
         success_url = "id@channels.channel_configuration"
@@ -990,7 +996,9 @@ class ChannelCRUDL(SmartCRUDL):
             number = data['number']
             role = SEND + RECEIVE
 
-            config = {SEND_URL: url, VERIFY_SSL: data.get('verify_ssl'),
+            config = {SEND_URL: url,
+                      VERIFY_SSL: data.get('verify_ssl', False),
+                      USE_NATIONAL: data.get('use_national', False),
                       USERNAME: data.get('username', None), PASSWORD: data.get('password', None),
                       ENCODING: data.get('encoding', DEFAULT_ENCODING)}
             self.object = Channel.add_config_external_channel(org, self.request.user, country, number, KANNEL,


### PR DESCRIPTION
Telcel SMSC in MX won't accept MT messages with a full international number.