### PR TITLE
Allow updating of contacts on anon orgs by uuid

### DIFF
--- a/temba/api/tests/test_v1.py
+++ b/temba/api/tests/test_v1.py
@@ -1352,11 +1352,11 @@ class APITest(TembaTest):
 
             # but can't update phone
             response = self.postJSON(url, dict(name="Anon", uuid=contact.uuid, phone='+250788123456'))
-            self.assertResponseError(response, 'non_field_errors', "Cannot update URNs on anonymous organizations")
+            self.assertResponseError(response, 'non_field_errors', "Cannot update contact URNs on anonymous organizations")
 
             # or URNs
             response = self.postJSON(url, dict(name="Anon", uuid=contact.uuid, urns=['tel:+250788123456']))
-            self.assertResponseError(response, 'non_field_errors', "Cannot update URNs on anonymous organizations")
+            self.assertResponseError(response, 'non_field_errors', "Cannot update contact URNs on anonymous organizations")
 
         # finally try clearing our language
         response = self.postJSON(url, dict(phone='+250788123456', language=None))

--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -480,8 +480,8 @@ class ContactWriteSerializer(WriteSerializer):
         if data.get('group_uuids') is not None and data.get('groups') is not None:
             raise serializers.ValidationError("Parameter groups is deprecated and can't be used together with group_uuids")
 
-        if self.org.is_anon and self.instance:
-            raise serializers.ValidationError("Cannot update contacts on anonymous organizations, can only create")
+        if self.org.is_anon and self.instance and self.urn_tuples is not None:
+            raise serializers.ValidationError("Cannot update contact URNs on anonymous organizations")
 
         if self.urn_tuples is not None:
             # look up these URNs, keeping track of the contacts that are connected to them


### PR DESCRIPTION
Users should still be able to update contacts on anon orgs by uuid.

@rowanseymour plz review