### PR TITLE
Email URNs

### DIFF
--- a/temba/api/tests/test_v1.py
+++ b/temba/api/tests/test_v1.py
@@ -1478,7 +1478,7 @@ class APITest(TembaTest):
         self.assertEqual(len(response.json['results']), 2)
 
         self.assertEqual(response.json['results'][1]['name'], "Dr Dre")
-        self.assertEqual(response.json['results'][1]['urns'], ['twitter:drdre', 'tel:+250788123456'])
+        self.assertEqual(response.json['results'][1]['urns'], ['tel:+250788123456', 'twitter:drdre'])
         self.assertEqual(response.json['results'][1]['fields'], {'real_name': "Andre", 'registration_date': None})
         self.assertEqual(response.json['results'][1]['group_uuids'], [artists.uuid])
         self.assertEqual(response.json['results'][1]['groups'], ["Music Artists"])

--- a/temba/api/tests/test_v1.py
+++ b/temba/api/tests/test_v1.py
@@ -19,7 +19,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 from temba.campaigns.models import Campaign, CampaignEvent, MESSAGE_EVENT, FLOW_EVENT
 from temba.channels.models import Channel, SyncEvent
-from temba.contacts.models import Contact, ContactField, ContactGroup, TEL_SCHEME, TWITTER_SCHEME
+from temba.contacts.models import Contact, ContactField, ContactGroup, TEL_SCHEME, TWITTER_SCHEME, EMAIL_SCHEME
 from temba.flows.models import Flow, FlowLabel, FlowRun, RuleSet, ActionSet, RULE_SET
 from temba.msgs.models import Broadcast, Call, Msg, Label, FAILED, ERRORED, VISIBLE, ARCHIVED, DELETED
 from temba.orgs.models import Org, Language
@@ -1631,6 +1631,20 @@ class APITest(TembaTest):
         response = self.postJSON(url, dict())
         self.assertIsNotNone(json.loads(response.content)['uuid'])
         self.assertEquals(201, response.status_code)
+
+        # create a contact with an email urn
+        response = self.postJSON(url, dict(name='Snoop Dogg', urns=['mailto:snoop@foshizzle.com']))
+        self.assertEquals(201, response.status_code)
+
+        # lookup that contact from an urn
+        contact = Contact.from_urn(self.org, EMAIL_SCHEME, 'snoop@foshizzle.com')
+        self.assertEquals('Snoop', contact.first_name(self.org))
+
+        # find it via the api
+        response = self.fetchJSON(url, 'urns=%s' % (urlquote_plus("mailto:snoop@foshizzle.com")))
+        self.assertResultCount(response, 1)
+        results = json.loads(response.content)['results']
+        self.assertEquals('Snoop Dogg', results[0]['name'])
 
     def test_api_contacts_with_multiple_pages(self):
         url = reverse('api.v1.contacts')

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -289,9 +289,11 @@ class CampaignTest(TembaTest):
         # but if we add him back in, should be updated
         post_data = dict(name=self.farmer1.name,
                          groups=[self.farmers.id],
-                         __urn__tel=self.farmer1.get_urn('tel').path,
-                         __field__planting_date=['4/8/2020'])
-        response = self.client.post(reverse('contacts.contact_update', args=[self.farmer1.id]), post_data)
+                         __urn__tel=self.farmer1.get_urn('tel').path)
+
+        self.client.post(reverse('contacts.contact_update', args=[self.farmer1.id]), post_data)
+        response = self.client.post(reverse('contacts.contact_update_fields', args=[self.farmer1.id]),
+                                    dict(__field__planting_date=['4/8/2020']))
         self.assertRedirect(response, reverse('contacts.contact_read', args=[self.farmer1.uuid]))
 
         fires = EventFire.objects.all()

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -506,6 +506,7 @@ class Contact(TembaModel):
             existing_orphan_urns = dict()
             urns_to_create = dict()
             for scheme, path in urns:
+
                 if not scheme or not path:
                     raise ValueError(_("URN cannot have empty scheme or path"))
 
@@ -679,7 +680,7 @@ class Contact(TembaModel):
                 # excel formatting that field as numeric.. try to parse it into an int instead
                 try:
                     value = str(int(float(value)))
-                except ValueError:
+                except ValueError:  # pragma: no cover
                     # oh well, neither of those, stick to the plan, maybe we can make sense of it below
                     pass
 
@@ -1208,8 +1209,6 @@ class Contact(TembaModel):
         tel = self.get_urn(TEL_SCHEME)
         if tel:
             return tel.path
-        else:
-            return None
 
     def send(self, text, user, trigger_send=True, response_to=None, message_context=None):
         from temba.msgs.models import Broadcast
@@ -1440,12 +1439,12 @@ class ContactURN(models.Model):
                 if self.path and self.path[0] == '+':
                     return phonenumbers.format_number(phonenumbers.parse(self.path, None),
                                                       phonenumbers.PhoneNumberFormat.NATIONAL)
-            except Exception: # pragma: no cover
+            except Exception:  # pragma: no cover
                 pass
 
         return self.path
 
-    def __unicode__(self):
+    def __unicode__(self):  # pragma: no cover
         return self.urn
 
     class Meta:
@@ -1562,9 +1561,6 @@ class ContactGroup(TembaModel):
 
             # if we are adding the contact to the group, and this contact is not in this group
             if add:
-                if contact.is_blocked:
-                    raise ValueError("Can't add or remove groups on blocked contact")
-
                 if not group_contacts.filter(id=contact.id):
                     self.contacts.add(contact)
                     contact_changed = True

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -40,6 +40,7 @@ EXTERNAL_SCHEME = 'ext'
 
 # schemes that we actually support
 URN_SCHEME_CHOICES = ((TEL_SCHEME, _("Phone number")),
+                      (EMAIL_SCHEME, _("Email address")),
                       (TWITTER_SCHEME, _("Twitter handle")),
                       (EXTERNAL_SCHEME, _("External identifier")))
 
@@ -1336,6 +1337,14 @@ class ContactURN(models.Model):
         # validate twitter URNs look like handles
         elif scheme == TWITTER_SCHEME:
             return regex.match(r'^[a-zA-Z0-9_]{1,15}$', path, regex.V0)
+
+        elif scheme == EMAIL_SCHEME:
+            from django.core.validators import validate_email
+            try:
+                validate_email(path)
+                return True
+            except Exception:
+                return False
 
         # anything goes for external schemes
         elif scheme == EXTERNAL_SCHEME:

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1118,7 +1118,8 @@ class Contact(TembaModel):
 
     def update_urns(self, urns):
         """
-        Updates the URNs on this contact to match the provided list, i.e. detaches any existing not included
+        Updates the URNs on this contact to match the provided list, i.e. detaches any existing not included.
+        The URNs are supplied in order of priority, most preferred URN first.
         """
         country = self.org.get_country_code()
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1548,7 +1548,7 @@ class ContactGroup(TembaModel):
         """
         Adds or removes contacts from this group. Returns array of contact ids of contacts whose membership changed
         """
-        if self.group_type != self.TYPE_USER_DEFINED:
+        if self.group_type != self.TYPE_USER_DEFINED:  # pragma: no cover
             raise ValueError("Can't add or remove test contacts from system groups")
 
         changed = set()
@@ -1626,7 +1626,7 @@ class ContactGroup(TembaModel):
 
     @classmethod
     def get_system_group_queryset(cls, org, group_type):
-        if group_type == cls.TYPE_USER_DEFINED:
+        if group_type == cls.TYPE_USER_DEFINED:  # pragma: no cover
             raise ValueError("Can only get system group querysets")
 
         return cls.all_groups.get(org=org, group_type=group_type).contacts.all()
@@ -1807,7 +1807,7 @@ class ExportContactsTask(SmartModel):
                     current_contact += 1
 
                     # output some status information every 10,000 contacts
-                    if current_contact % 10000 == 0:
+                    if current_contact % 10000 == 0:  # pragma: no cover
                         elapsed = time.time() - start
                         predicted = int(elapsed / (current_contact / (len(contact_ids) * 1.0)))
 

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -6,7 +6,7 @@ import pytz
 from django import template
 from django.utils import timezone
 from django.utils.safestring import mark_safe
-from temba.contacts.models import Contact, ContactURN, FACEBOOK_SCHEME, TEL_SCHEME, TWITTER_SCHEME, TWILIO_SCHEME, URN_ANON_MASK
+from temba.contacts.models import Contact, ContactURN, EMAIL_SCHEME, EXTERNAL_SCHEME, FACEBOOK_SCHEME, TEL_SCHEME, TWITTER_SCHEME, TWILIO_SCHEME, URN_ANON_MASK
 from django.utils.translation import ugettext_lazy as _
 
 register = template.Library()
@@ -14,7 +14,9 @@ register = template.Library()
 URN_SCHEME_ICONS = {TEL_SCHEME: 'icon-mobile-2',
                     TWITTER_SCHEME: 'icon-twitter',
                     TWILIO_SCHEME: 'icon-twilio_original',
-                    FACEBOOK_SCHEME: 'icon-facebook'}
+                    EMAIL_SCHEME: 'icon-envelop',
+                    FACEBOOK_SCHEME: 'icon-facebook',
+                    EXTERNAL_SCHEME: 'icon-channel-external'}
 
 ACTIVITY_ICONS = {
     'EventFire': 'icon-clock',

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -564,7 +564,7 @@ class ContactCRUDL(SmartCRUDL):
                     if groups:
                         context['group'] = groups[0]
 
-                    elif not task.status() in ['PENDING', 'RUNNING', 'STARTED']:
+                    elif not task.status() in ['PENDING', 'RUNNING', 'STARTED']:  # pragma: no cover
                         context['show_form'] = True
 
             return context
@@ -573,7 +573,7 @@ class ContactCRUDL(SmartCRUDL):
             task_id = self.request.REQUEST.get('task', None)
             if task_id:
                 tasks = ImportTask.objects.filter(pk=task_id, created_by=self.request.user)
-                if tasks and tasks[0].status() in ['PENDING', 'RUNNING', 'STARTED']:
+                if tasks and tasks[0].status() in ['PENDING', 'RUNNING', 'STARTED']:  # pragma: no cover
                     return 3000
             return 0
 
@@ -769,7 +769,7 @@ class ContactCRUDL(SmartCRUDL):
                 if not hasattr(b, 'created_on') and hasattr(b, 'fired'):
                     b.created_on = b.fired
 
-                if a.created_on == b.created_on:
+                if a.created_on == b.created_on:  # pragma: no cover
                     return 0
                 elif a.created_on < b.created_on:
                     return -1
@@ -1039,23 +1039,6 @@ class ContactCRUDL(SmartCRUDL):
 
                 obj.update_urns(urns)
 
-            fields_to_save_later = dict()
-            for field_key, value in self.form.cleaned_data.iteritems():
-                if field_key.startswith('__field__'):
-                    key = field_key[9:]
-                    contact_field = ContactField.objects.filter(org=self.org, key=key).first()
-                    contact_field_type = contact_field.value_type
-
-                    # district values are saved last to validate the states
-                    if contact_field_type == DISTRICT:
-                        fields_to_save_later[key] = value
-                    else:
-                        obj.set_field(key, value)
-
-            # now save our district fields
-            for key, value in fields_to_save_later.iteritems():
-                obj.set_field(key, value)
-
             return obj
 
     class UpdateFields(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
@@ -1086,6 +1069,10 @@ class ContactCRUDL(SmartCRUDL):
                         fields_to_save_later[key] = value
                     else:
                         obj.set_field(key, value)
+
+            # now save our district fields
+            for key, value in fields_to_save_later.iteritems():
+                obj.set_field(key, value)
 
             return obj
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -335,7 +335,7 @@ class ContactCRUDL(SmartCRUDL):
                                                            group=group, host=host)
                 export_contacts_task.delay(export.pk)
 
-                if not getattr(settings, 'CELERY_ALWAYS_EAGER', False):
+                if not getattr(settings, 'CELERY_ALWAYS_EAGER', False):  # pragma: no cover
                     messages.info(self.request,
                                   _("We are preparing your export. We will e-mail you at %s when it is ready.")
                                   % self.request.user.username)
@@ -638,8 +638,6 @@ class ContactCRUDL(SmartCRUDL):
             context = super(ContactCRUDL.Read, self).get_context_data(**kwargs)
 
             contact = self.object
-            if not contact.is_active:
-                raise Http404("No active contact with that id")
 
             # the users group membership
             context['contact_groups'] = contact.user_groups.extra(select={'lower_name': 'lower(name)'}).order_by('lower_name')

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -219,6 +219,11 @@ class ContactForm(forms.ModelForm):
             idx = 0
 
             last_urn = None
+
+            if not urns:
+                urn = ContactURN()
+                urn.scheme = 'tel'
+                urns = [urn]
             for urn in urns:
 
                 first_urn = last_urn is None or urn.scheme != last_urn.scheme
@@ -682,8 +687,6 @@ class ContactCRUDL(SmartCRUDL):
 
             context['contact_urns'] = urns
 
-            print urns
-
             # load our contacts values
             Contact.bulk_cache_initialize(contact.org, [contact])
 
@@ -1038,12 +1041,12 @@ class ContactCRUDL(SmartCRUDL):
             if not self.org.is_anon:
                 urns = []
 
-                print self.form.data
                 for field_key, value in self.form.data.iteritems():
                     if field_key.startswith('urn__') and value:
                         parts = field_key.split('__')
                         scheme = parts[1]
-                        order = int(self.form.data.get('order__' + field_key))
+
+                        order = int(self.form.data.get('order__' + field_key, "0"))
                         urns.append((order, (scheme, value)))
 
                 new_scheme = self.form.cleaned_data.get('new_scheme', None)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1345,7 +1345,7 @@ class OrgCRUDLTest(TembaTest):
 
         # create a new contact
         response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty',
-                                                                                  __urn__tel__0='0788123123'))
+                                                                                  urn__tel__0='0788123123'))
         self.assertNoFormErrors(response)
 
         # make sure that contact's created on is our cs rep

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -351,6 +351,7 @@ PERMISSIONS = {
                          'import',
                          'omnibox',
                          'unblock',
+                         'update_fields'
                          ),
 
     'contacts.contactfield': ('api',
@@ -554,6 +555,7 @@ GROUP_PERMISSIONS = {
         'contacts.contact_read',
         'contacts.contact_unblock',
         'contacts.contact_update',
+        'contacts.contact_update_fields',
         'contacts.contactfield.*',
         'contacts.contactgroup.*',
 
@@ -676,6 +678,7 @@ GROUP_PERMISSIONS = {
         'contacts.contact_read',
         'contacts.contact_unblock',
         'contacts.contact_update',
+        'contacts.contact_update_fields',
         'contacts.contactfield.*',
         'contacts.contactgroup.*',
 

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -33,7 +33,14 @@
       .contact-urn
         .{class:"glyph {{urn|urn_icon}}"}
         %i.contact-urn-path
-          {{urn|format_urn:user_org}}
+          -if urn.scheme == 'mailto'
+            %a{href:"{{urn}}"}
+              {{urn|format_urn:user_org}}
+          -elif urn.scheme == 'twitter'
+            %a{href:'http://twitter.com/{{urn.path}}'}
+              {{urn|format_urn:user_org}}
+          -else
+            {{urn|format_urn:user_org}}
 
   -block contact-groups
     %div.header-margin
@@ -345,12 +352,6 @@
           display: inline-block;
           margin-right: 10px;
 
-          &:first-of-type {
-            .contact-urn-path {
-              font-weight: bold;
-            }
-          }
-
           .glyph {
             margin-right: 3px;
           }
@@ -554,6 +555,13 @@
     {% if org_perms.contacts.contact_update %}
     $(".update-contact").live('click', function(){
       var modal = new Modax('{% trans "Update Contact" %}','{% url "contacts.contact_update" object.pk %}');
+      modal.setIcon('icon-user');
+      modal.setRedirectOnSuccess(true);
+      modal.show();
+    });
+
+    $(".update-contact-fields").live('click', function(){
+      var modal = new Modax('{% trans "Custom Fields" %}','{% url "contacts.contact_update_fields" object.pk %}');
       modal.setIcon('icon-user');
       modal.setRedirectOnSuccess(true);
       modal.show();

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -19,12 +19,24 @@
         .glyph.icon-vcard
         {{contact.anon_identifier}}
 
-    -for urn in contact_sendable_urns
+    -for urn in contact_urns
       .contact-urn
         .{class:"glyph {{urn|urn_icon}}"}
         -if not user_org.is_anon
-          %a.contact-urn-path{href:"javascript:showComposeInitialized(\"u={{ urn.id }}\", null, fetchRecentMessages)"}><
-            {{urn|format_urn:user_org}}
+          -if urn.sendable
+            %a.contact-urn-path{href:"javascript:showComposeInitialized(\"u={{ urn.id }}\", null, fetchRecentMessages)"}><
+              {{urn|format_urn:user_org}}
+          -else
+            %i.contact-urn-path
+              -if urn.scheme == 'mailto'
+                %a{href:"{{urn}}"}
+                  {{urn|format_urn:user_org}}
+              -elif urn.scheme == 'twitter'
+                %a{href:'http://twitter.com/{{urn.path}}'}
+                  {{urn|format_urn:user_org}}
+              -else
+                {{urn|format_urn:user_org}}
+
         -else
           %span.contact-urn-path
             {{urn|format_urn:user_org}}

--- a/templates/contacts/contact_update.haml
+++ b/templates/contacts/contact_update.haml
@@ -14,9 +14,66 @@
       $('#id-urn-scheme').select2({width:'150px', minimumResultsForSearch: -1})
 
       select2div('#id_language', '520px', 'No preference')
+      createMoveLinks();
+
     });
 
+    function createMoveLinks() {
+      $('.order-helper').remove();
+
+      // :not(:first)
+      var idx = 0;
+      var first = true;
+      $(".control-group input[id^=id_urn__]").each(function() {
+        var input = $('#' + this.id);
+        var parts = this.id.split('__');
+
+        // store a hidden value to track our order
+        $(this).after('<input class="order-helper" type=hidden name="order__' + this.name + '" value="' + idx + '"/>')
+
+        // add a link to increase the priority
+        if (!first) {
+          var link = 'javascript:moveUp("' + this.id + '");';
+          link = "<div style='float:right' title='Increase priority' class='order-helper icon-arrow-down' onclick='" + link + "'></div>"
+          $(this).parents('.control-group').prepend(link)
+        }
+
+
+        idx++;
+        first = false;
+
+
+      });
+    }
+
+    function moveUp(link) {
+      var group = $('#' + link).parents('.control-group');
+      var previous = group.prev();
+      previous.before(group);
+      createMoveLinks();
+    }
+
+
+
 -block extra-fields
+  :css
+    .icon-arrow-down {
+      -ms-transform: rotate(180deg);
+      -moz-transform: rotate(180deg);
+      -webkit-transform: rotate(180deg);
+      -o-transform: rotate(180deg);
+
+      margin-top:10px;
+      font-size:14px;
+      cursor: pointer;
+      color: #ccc;
+    }
+
+
+  //-for urn in object.get_urns
+    {{urn.scheme}}
+    %input{value:'{{urn.path}}'}
+
 
   // Manual option to add a new URN for this contact
   <div class="control-group {% if form.errors.new_path %}error{%endif%}">

--- a/templates/contacts/contact_update.haml
+++ b/templates/contacts/contact_update.haml
@@ -1,5 +1,6 @@
 -extends 'smartmin/update.html'
 
+
 -block modal-script
   {{block.super}}
 
@@ -10,8 +11,35 @@
         containerCssClass: "select2-temba-field"
       });
 
+      $('#id-urn-scheme').select2({width:'150px', minimumResultsForSearch: -1})
+
       select2div('#id_language', '520px', 'No preference')
     });
 
+-block extra-fields
+
+  // Manual option to add a new URN for this contact
+  <div class="control-group {% if form.errors.new_path %}error{%endif%}">
+    %label.control-label
+      Add Connection
+    .controls
+
+
+      %select#id-urn-scheme{name:'new_scheme', float:'left'}
+        -for key, value in schemes
+          <option value='{{key}}' {% if form.data.new_scheme == key %}selected{%endif%}>{{value}}</option>
+      %input{name:'new_path', type:'text', style:'margin-left:5px;width:347px', value:'{{form.data.new_path}}'}
+
+      %p.help-block
+        Add a new way connect with this contact
+      -if form.errors.new_path
+        %p.help-block.field-errors
+          {{form.errors.new_path}}
+
+  </div>
+
+
+
 -block summary
   {{ contact }}
+


### PR DESCRIPTION
First step in allowing "user as contact" in Surveyor.

* Add mailto scheme support for ContactURN
* Allow creation of URNs when editing contacts
* Move contact field editing to its own dialog
* Show email urns (linked with mailto)
* Link twitter urns to twitter profile
* Add coverage for contacts/views.py and contacts/models.py

Relevant screen shots:

<img src="http://take.ms/xeCAF" width=150>

<img src="http://take.ms/FBY74" width=550>

<img src="http://take.ms/4x3xX" width=350>
