### PR TITLE
Fix add to group action to strip group name before trying to look up

### DIFF
--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -582,7 +582,7 @@ class ContactBulkActionSerializer(WriteSerializer):
 
     def validate_group(self, value):
         if value:
-            self.group_obj = ContactGroup.user_groups.filter(org=self.org, name=value, is_active=True).first()
+            self.group_obj = ContactGroup.get_user_group(org=self.org, name=value)
             if not self.group_obj:
                 raise serializers.ValidationError("No such group: %s" % value)
         return value

--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -582,7 +582,7 @@ class ContactBulkActionSerializer(WriteSerializer):
 
     def validate_group(self, value):
         if value:
-            self.group_obj = ContactGroup.get_user_group(org=self.org, name=value)
+            self.group_obj = ContactGroup.get_user_group(self.org, value)
             if not self.group_obj:
                 raise serializers.ValidationError("No such group: %s" % value)
         return value

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -48,7 +48,7 @@ class WebHookEventMixin(OrgPermsMixin):
 class WebHookEventListView(WebHookEventMixin, SmartListView):
     model = WebHookEvent
     fields = ('event', 'status', 'channel', 'tries', 'created_on')
-    title = "Recent WebHook Events"
+    title = _("Recent WebHook Events")
     template_name = 'api/webhookevent_list.html'
     default_order = ('-created_on',)
     permission = 'api.webhookevent_list'
@@ -64,19 +64,19 @@ class WebHookEventReadView(WebHookEventMixin, SmartReadView):
     fields = ('event', 'status', 'channel', 'tries', 'next_attempt')
     template_name = 'api/webhookevent_read.html'
     permission = 'api.webhookevent_read'
-    field_config = { 'next_attempt': dict(label="Next Delivery"), 'tries': dict(label="Attempts") }
+    field_config = {'next_attempt': dict(label=_("Next Delivery")), 'tries': dict(label=_("Attempts"))}
 
     def get_next_attempt(self, obj): # pragma: no cover
         if obj.next_attempt:
-            return "Around %s" % obj.next_attempt
+            return _("Around %s") % obj.next_attempt
         else:
             if obj.try_count == 3:
-                return "Never, three attempts errored, failed permanently"
+                return _("Never, three attempts errored, failed permanently")
             else:
                 if obj.status == 'C':
-                    return "Never, event delivered successfully"
+                    return _("Never, event delivered successfully")
                 else:
-                    return "Never, event deliverey failed permanently"
+                    return _("Never, event delivery failed permanently")
 
     def get_context_data(self, *args, **kwargs):
         context = super(WebHookEventReadView, self).get_context_data(*args, **kwargs)
@@ -91,7 +91,7 @@ class WebHookTunnelView(View):
     def post(self, request):
         try:
             if not 'url' in request.POST or not 'data' in request.POST:
-                return HttpResponse("Must include both 'url' and 'data' parameters.", status=400)
+                return HttpResponse(_("Must include both 'url' and 'data' parameters."), status=400)
 
             url = request.POST['url']
             data = request.POST['data']

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -10,7 +10,7 @@ from django.views.generic import View
 from smartmin.views import SmartTemplateView, SmartReadView, SmartListView
 from temba.api.models import WebHookEvent, WebHookResult
 from temba.orgs.views import OrgPermsMixin
-
+from django.utils.translation import ugettext, ugettext_lazy as _
 
 def webhook_status_processor(request):
     status = dict()

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -87,7 +87,7 @@ class Campaign(SmartModel):
 
                 # fall back to lookups by name
                 if not group:
-                    group = ContactGroup.user_groups.filter(name=campaign_spec['group']['name'], org=org).first()
+                    group = ContactGroup.get_user_group(org=org, name=campaign_spec['group']['name'])
 
                 if not campaign:
                     campaign = Campaign.objects.filter(org=org, name=name).first()

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -87,7 +87,7 @@ class Campaign(SmartModel):
 
                 # fall back to lookups by name
                 if not group:
-                    group = ContactGroup.get_user_group(org=org, name=campaign_spec['group']['name'])
+                    group = ContactGroup.get_user_group(org, campaign_spec['group']['name'])
 
                 if not campaign:
                     campaign = Campaign.objects.filter(org=org, name=name).first()

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1535,7 +1535,7 @@ class ContactGroup(TembaModel):
         """
         Returns a normalized name for the passed in group name
         """
-        return None if not name else name.strip()[:cls.MAX_NAME_LEN]
+        return None if name is None else name.strip()[:cls.MAX_NAME_LEN]
 
     @classmethod
     def is_valid_name(cls, name):

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3941,7 +3941,7 @@ class AddToGroupAction(Action):
                 else:
                     group = ContactGroup.get_user_group(org, g)
                     if group:
-                        groups.append(group[0])
+                        groups.append(group)
                     else:
                         groups.append(ContactGroup.create(org, org.get_user(), g))
         return groups

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3928,8 +3928,8 @@ class AddToGroupAction(Action):
                     if not group.is_active:
                         group.is_active = True
                         group.save(update_fields=['is_active'])
-                elif ContactGroup.user_groups.filter(org=org, name=group_name, is_active=True).first():
-                    group = ContactGroup.user_groups.filter(org=org, name=group_name, is_active=True).first()
+                elif ContactGroup.get_user_group(org, group_name):
+                    group = ContactGroup.get_user_group(org, group_name)
                 else:
                     group = ContactGroup.create(org, org.created_by, group_name)
 
@@ -3939,7 +3939,7 @@ class AddToGroupAction(Action):
                 if g and g[0] == '@':
                     groups.append(g)
                 else:
-                    group = ContactGroup.user_groups.filter(org=org, name=g, is_active=True)
+                    group = ContactGroup.get_user_group(org, g)
                     if group:
                         groups.append(group[0])
                     else:
@@ -3966,15 +3966,15 @@ class AddToGroupAction(Action):
         if contact:
             for group in self.groups:
                 if not isinstance(group, ContactGroup):
+
                     contact = run.contact
                     message_context = run.flow.build_message_context(contact, msg)
                     (value, errors) = Msg.substitute_variables(group, contact, message_context, org=run.flow.org)
                     group = None
 
                     if not errors:
-                        try:
-                            group = ContactGroup.user_groups.get(org=contact.org, name=value, is_active=True)
-                        except ContactGroup.DoesNotExist:
+                        group = ContactGroup.get_user_group(contact.org, value)
+                        if not group:
                             user = get_flow_user()
                             try:
                                 group = ContactGroup.create(contact.org, user, name=value)
@@ -4266,8 +4266,8 @@ class VariableContactAction(Action):
 
             if group_id and ContactGroup.user_groups.filter(org=org, id=group_id, is_active=True):
                 group = ContactGroup.user_groups.get(org=org, id=group_id, is_active=True)
-            elif ContactGroup.user_groups.filter(org=org, name=group_name, is_active=True):
-                group = ContactGroup.user_groups.get(org=org, name=group_name, is_active=True)
+            elif ContactGroup.get_user_group(org, group_name):
+                group = ContactGroup.get_user_group(org, group_name)
             else:
                 group = ContactGroup.create(org, org.get_user(), group_name)
 
@@ -4326,7 +4326,7 @@ class VariableContactAction(Action):
                 (variable, errors) = Msg.substitute_variables(variable, contact=run.contact,
                                                               message_context=message_context, org=run.flow.org)
 
-                variable_group = ContactGroup.user_groups.filter(org=run.flow.org, is_active=True, name=variable).first()
+                variable_group = ContactGroup.get_user_group(run.flow.org, name=variable)
                 if variable_group:
                     groups.append(variable_group)
                 else:

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2261,18 +2261,18 @@ class ActionTest(TembaTest):
 
         # user should now be in the group
         self.assertTrue(group.contacts.filter(id=self.contact.pk))
-        self.assertEquals(1, group.contacts.all().count())
+        self.assertEqual(1, group.contacts.all().count())
 
         # we should have created a group with the name of the contact
         replace_group = ContactGroup.user_groups.get(name=self.contact.name)
         self.assertTrue(replace_group.contacts.filter(id=self.contact.pk))
-        self.assertEquals(1, replace_group.contacts.all().count())
+        self.assertEqual(1, replace_group.contacts.all().count())
 
         # passing through twice doesn't change anything
         action.execute(run, None, sms)
 
         self.assertTrue(group.contacts.filter(id=self.contact.pk))
-        self.assertEquals(group.contacts.all().count(), 1)
+        self.assertEqual(group.contacts.all().count(), 1)
         self.assertEqual(self.contact.user_groups.all().count(), 2)
 
         # having the group name containing a space doesn't change anything
@@ -2294,14 +2294,14 @@ class ActionTest(TembaTest):
 
         # user should be gone now
         self.assertFalse(group.contacts.filter(id=self.contact.pk))
-        self.assertEquals(0, group.contacts.all().count())
+        self.assertEqual(0, group.contacts.all().count())
         self.assertFalse(replace_group.contacts.filter(id=self.contact.pk))
-        self.assertEquals(0, replace_group.contacts.all().count())
+        self.assertEqual(0, replace_group.contacts.all().count())
 
         action.execute(run, None, sms)
 
         self.assertFalse(group.contacts.filter(id=self.contact.pk))
-        self.assertEquals(0, group.contacts.all().count())
+        self.assertEqual(0, group.contacts.all().count())
 
     def test_add_label_action(self):
         flow = self.flow

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2263,7 +2263,7 @@ class ActionTest(TembaTest):
         self.assertTrue(group.contacts.filter(id=self.contact.pk))
         self.assertEquals(1, group.contacts.all().count())
 
-        # we should have acreated a group with the name of the contact
+        # we should have created a group with the name of the contact
         replace_group = ContactGroup.user_groups.get(name=self.contact.name)
         self.assertTrue(replace_group.contacts.filter(id=self.contact.pk))
         self.assertEquals(1, replace_group.contacts.all().count())
@@ -2272,7 +2272,19 @@ class ActionTest(TembaTest):
         action.execute(run, None, sms)
 
         self.assertTrue(group.contacts.filter(id=self.contact.pk))
-        self.assertEquals(1, group.contacts.all().count())
+        self.assertEquals(group.contacts.all().count(), 1)
+        self.assertEqual(self.contact.user_groups.all().count(), 2)
+
+        # having the group name containing a space doesn't change anything
+        self.contact.name += " "
+        self.contact.save()
+        run.contact = self.contact
+
+        action.execute(run, None, sms)
+
+        self.assertTrue(group.contacts.filter(id=self.contact.pk))
+        self.assertEqual(group.contacts.all().count(), 1)
+        self.assertEqual(self.contact.user_groups.all().count(), 2)
 
         action = DeleteFromGroupAction([group, "@step.contact"])
         action_json = action.as_json()

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -105,7 +105,7 @@ class Trigger(SmartModel):
                         group = ContactGroup.user_groups.filter(org=org, pk=group_spec['id']).first()
 
                     if not group:
-                        group = ContactGroup.user_groups.filter(org=org, name=group_spec['name']).first()
+                        group = ContactGroup.get_user_group(org, group_spec['name'])
 
                     if not group:
                         group = ContactGroup.create(org, user, group_spec['name'])

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -173,10 +173,8 @@ class RegisterTriggerForm(BaseTriggerForm):
                 value = value[7:]
 
                 # we must get groups for this org only
-                groups = ContactGroup.user_groups.filter(name=value, org=self.user.get_org())
-                if groups:
-                    group = groups[0]
-                else:
+                group = ContactGroup.get_user_group(self.user.get_org(), value)
+                if not group:
                     group = ContactGroup.create(self.user.get_org(), self.user, name=value)
                 return group
 


### PR DESCRIPTION
Fixes a bug where someone was using a webhook result with a trailing space "Lahora ", and we were failing the lookup, but then creating a new group every time.

This adds a few methods to normalize names and normalize the looking up a group by name.