### PR TITLE
Some more API v2 tweaks

### DIFF
--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -4,8 +4,9 @@ import logging
 
 from django.conf import settings
 from django.http import HttpResponseServerError
-from rest_framework import exceptions
+from rest_framework import exceptions, status
 from rest_framework.authentication import TokenAuthentication
+from rest_framework.exceptions import APIException
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import exception_handler
@@ -89,6 +90,13 @@ class DocumentationRenderer(BrowsableAPIRenderer):
         self.template = 'api/v%d/api_root.html' % api_version
 
         return super(DocumentationRenderer, self).render(data, accepted_media_type, renderer_context)
+
+
+class InvalidQueryError(APIException):
+    """
+    Exception class for invalid queries in list endpoints
+    """
+    status_code = status.HTTP_400_BAD_REQUEST
 
 
 def temba_exception_handler(exc, context):

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -68,7 +68,7 @@ class APITest(TembaTest):
 
         # 403 for JSON request too
         response = self.fetchJSON(url)
-        self.assertEqual(response.status_code, 403)
+        self.assertResponseError(response, None, "You do not have permission to perform this action.", status_code=403)
 
         # 200 for administrator
         self.login(self.admin)
@@ -84,16 +84,91 @@ class APITest(TembaTest):
         self.assertEqual([r['uuid'] for r in response.json['results']], [o.uuid for o in expected])
 
     def assertResponseError(self, response, field, expected_message, status_code=400):
-        self.assertEqual(status_code, response.status_code)
+        self.assertEqual(response.status_code, status_code)
         if field:
             self.assertIn(field, response.json)
             self.assertIsInstance(response.json[field], list)
             self.assertIn(expected_message, response.json[field])
         else:
-            self.assertIsInstance(response.json, list)
-            self.assertIn(expected_message, response.json)
+            self.assertIsInstance(response.json, dict)
+            self.assertIn('detail', response.json)
+            self.assertEqual(response.json['detail'], expected_message)
 
-    def test_api_contacts(self):
+    def test_authentication(self):
+        url = reverse('api.v2.contacts') + '.json'
+
+        # can't fetch endpoint with invalid token
+        response = self.client.get(url, content_type="application/json",
+                                   HTTP_X_FORWARDED_HTTPS='https', HTTP_AUTHORIZATION="Token 1234567890")
+        response.json = json.loads(response.content)
+
+        self.assertResponseError(response, None, "Invalid token", status_code=403)
+
+        # can fetch endpoint with valid token
+        response = self.client.get(url, content_type="application/json",
+                                   HTTP_X_FORWARDED_HTTPS='https', HTTP_AUTHORIZATION="Token %s" % self.admin.api_token)
+
+        self.assertEqual(response.status_code, 200)
+
+        # but not if user is inactive
+        self.admin.is_active = False
+        self.admin.save()
+
+        response = self.client.get(url, content_type="application/json",
+                                   HTTP_X_FORWARDED_HTTPS='https', HTTP_AUTHORIZATION="Token %s" % self.admin.api_token)
+        response.json = json.loads(response.content)
+
+        self.assertResponseError(response, None, "User inactive or deleted", status_code=403)
+
+    def test_root(self):
+        url = reverse('api.v2')
+
+        # browse as HTML anonymously (should still show docs)
+        response = self.fetchHTML(url)
+        self.assertContains(response, "This is the <strong>under-development</strong> API v2", status_code=403)
+
+        # try to browse as JSON anonymously
+        response = self.fetchJSON(url)
+        self.assertResponseError(response, None, "Authentication credentials were not provided.", status_code=403)
+
+        # login as administrator
+        self.login(self.admin)
+        token = self.admin.api_token  # generates token for the user
+        self.assertIsInstance(token, basestring)
+        self.assertEqual(len(token), 40)
+
+        with self.assertNumQueries(0):  # subsequent lookup of token comes from cache
+            self.assertEqual(self.admin.api_token, token)
+
+        # browse as HTML
+        response = self.fetchHTML(url)
+        self.assertContains(response, token, status_code=200)  # displays their API token
+
+        # browse as JSON
+        response = self.fetchJSON(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['runs'], 'https://testserver:80/api/v2/runs')  # endpoints are listed
+
+    def test_explorer(self):
+        url = reverse('api.v2.explorer')
+
+        response = self.fetchHTML(url)
+        self.assertEquals(200, response.status_code)
+        self.assertContains(response, "Log in to use the Explorer")
+
+        # login as non-org user
+        self.login(self.non_org_user)
+        response = self.fetchHTML(url)
+        self.assertEquals(200, response.status_code)
+        self.assertContains(response, "Log in to use the Explorer")
+
+        # login as administrator
+        self.login(self.admin)
+        response = self.fetchHTML(url)
+        self.assertEquals(200, response.status_code)
+        self.assertNotContains(response, "Log in to use the Explorer")
+
+    def test_contacts(self):
         url = reverse('api.v2.contacts')
 
         self.assertEndpointAccess(url)
@@ -152,7 +227,7 @@ class APITest(TembaTest):
         response = self.fetchJSON(url, 'group=invalid')
         self.assertResultsByUUID(response, [])
 
-    def test_api_messages(self):
+    def test_messages(self):
         url = reverse('api.v2.messages')
 
         self.assertEndpointAccess(url)
@@ -272,7 +347,7 @@ class APITest(TembaTest):
             response = self.fetchJSON(url, query)
             self.assertResponseError(response, None, "Can only specify one of folder, label or broadcast parameters")
 
-    def test_api_runs(self):
+    def test_runs(self):
         url = reverse('api.v2.runs')
 
         self.assertEndpointAccess(url)

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -350,7 +350,7 @@ class APITest(TembaTest):
                       'broadcast=12345&folder=inbox', 'broadcast=12345&label=Spam'):
             response = self.fetchJSON(url, query)
             self.assertResponseError(response, None,
-                                     "Can only specify one of contact, folder, label or broadcast parameters")
+                                     "You may only specify one of the contact, folder, label, broadcast parameters")
 
     def test_runs(self):
         url = reverse('api.v2.runs')
@@ -503,3 +503,8 @@ class APITest(TembaTest):
         # filter by invalid before
         response = self.fetchJSON(url, 'before=longago')
         self.assertResultsById(response, [])
+
+        # can't filter by both contact and flow together
+        response = self.fetchJSON(url, 'contact=%s&flow=%s' % (self.joe.uuid, flow1.uuid))
+        self.assertResponseError(response, None,
+                                 "You may only specify one of the contact, flow parameters")

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -253,6 +253,7 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
                 {'name': "uuid", 'required': False, 'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': "urn", 'required': False, 'help': "A contact URN to filter by. ex: tel:+250788123123"},
                 {'name': "group", 'required': False, 'help': "A group name or UUID to filter by. ex: Customers"},
+                {'name': "deleted", 'required': False, 'help': "Whether to return only deleted contacts. ex: false"},
                 {'name': 'before', 'required': False, 'help': "Only return contacts modified before this date, ex: 2015-01-28T18:00:00.000"},
                 {'name': 'after', 'required': False, 'help': "Only return contacts modified after this date, ex: 2015-01-28T18:00:00.000"}
             ]

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -17,6 +17,7 @@ from temba.orgs.models import Org
 from temba.utils import str_to_bool, json_date_to_datetime
 from .serializers import ContactReadSerializer, FlowRunReadSerializer, MsgReadSerializer
 from ..models import ApiPermission, SSLPermission
+from ..support import InvalidQueryError
 
 
 @api_view(['GET'])
@@ -325,7 +326,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
 
         # only allowed to filter by one of broadcast, filter or label
         if sum([1 for f in [folder, params.get('label'), params.get('broadcast')] if f]) > 1:
-            raise ValidationError("Can only specify one of folder, label or broadcast parameters")
+            raise InvalidQueryError("Can only specify one of folder, label or broadcast parameters")
 
         if folder:
             sys_label = self.FOLDER_FILTERS.get(folder.lower())


### PR DESCRIPTION
* Added convenient mechanism for list endpoints to enforce mutually exclusive params
* Don't allow combining contact with other filters on messages endpoint
* Don't allow both contact and flow on runs endpoint
* Fixed format of error response when exception thrown from get_queryset
* Don't return deleted messages from messages endpoint
* Added missing id params on read explorers
* Moar tests