### PR TITLE
Fix reserved words matching prefixes of field names

### DIFF
--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -110,10 +110,7 @@ def contact_search_complex(org, query, base_queryset):
     search_lexer.base_queryset = base_queryset
 
     # combining results from multiple joins can lead to duplicates
-    parsed = search_parser.parse(query, lexer=search_lexer)
-
-    return parsed.distinct()
-
+    return search_parser.parse(query, lexer=search_lexer).distinct()
 
 def generate_queryset(lexer, identifier, comparator, value):
     """

--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -99,7 +99,6 @@ def contact_search_simple(org, query, base_queryset):
 
     return base_queryset.filter(q).distinct()
 
-
 def contact_search_complex(org, query, base_queryset):
     """
     Performs a complex query based search, e.g. 'name = "Bob" AND age > 18'
@@ -111,7 +110,9 @@ def contact_search_complex(org, query, base_queryset):
     search_lexer.base_queryset = base_queryset
 
     # combining results from multiple joins can lead to duplicates
-    return search_parser.parse(query, lexer=search_lexer).distinct()
+    parsed = search_parser.parse(query, lexer=search_lexer)
+
+    return parsed.distinct()
 
 
 def generate_queryset(lexer, identifier, comparator, value):
@@ -230,16 +231,20 @@ tokens = ('BINOP', 'COMPARATOR', 'TEXT', 'STRING')
 
 literals = '()'
 
+# treat reserved words specially
+# http://www.dabeaz.com/ply/ply.html#ply_nn4
+reserved = {
+   'or': 'BINOP',
+   'and': 'BINOP',
+   'has': 'COMPARATOR',
+   'is': 'COMPARATOR',
+}
+
 t_ignore = ' \t'  # ignore tabs and spaces
 
 
-def t_BINOP(t):
-    r"""(?i)OR|AND"""
-    return t
-
-
 def t_COMPARATOR(t):
-    r"""(?i)~|has|is|=|[<>]=?|~~?"""
+    r"""(?i)~|=|[<>]=?|~~?"""
     return t
 
 
@@ -251,6 +256,7 @@ def t_STRING(t):
 
 def t_TEXT(t):
     r"""[\w_\.\+\-\/]+"""
+    t.type = reserved.get(t.value.lower(), 'TEXT')
     return t
 
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -785,6 +785,8 @@ class ContactTest(TembaTest):
         ContactField.get_or_create(self.org, 'join_date', "Join Date", value_type='D')
         ContactField.get_or_create(self.org, 'home', "Home District", value_type='I')
         state_field = ContactField.get_or_create(self.org, 'state', "Home State", value_type='S')
+        ContactField.get_or_create(self.org, 'isureporter', "Is UReporter", value_type='T')
+        ContactField.get_or_create(self.org, 'hasbirth', "Has Birth", value_type='T')
 
         africa = AdminBoundary.objects.create(osm_id='R001', name='Africa', level=0)
         rwanda = AdminBoundary.objects.create(osm_id='R002', name='Rwanda', level=1, parent=africa)
@@ -814,6 +816,9 @@ class ContactTest(TembaTest):
                 mock_parse_location.return_value = locations_boundaries[index]
                 contact.set_field('home', locations[index])
 
+        contact.set_field('isureporter', 'yes')
+        contact.set_field('hasbirth', 'no')
+
         q = lambda query: Contact.search(self.org, query)[0].count()
 
         # non-complex queries
@@ -822,6 +827,15 @@ class ContactTest(TembaTest):
         self.assertEquals(22, q('  paige  '))
         self.assertEquals(22, q('fish'))
         self.assertEquals(1, q('0788382011'))  # does a contains
+
+        # test prefixes with 'is' or 'has'
+        self.assertEqual(q('isureporter = "yes"'), 1)
+        self.assertEqual(q('isureporter = yes'), 1)
+        self.assertEqual(q('isureporter = no'), 0)
+
+        self.assertEqual(q('hasbirth = "no"'), 1)
+        self.assertEqual(q('hasbirth = no'), 1)
+        self.assertEqual(q('hasbirth = yes'), 0)
 
         # name as property
         self.assertEquals(23, q('name is "trey"'))


### PR DESCRIPTION
We weren't defining the lexer quite right for reserved words..

See "specification of tokens" here:
  http://www.dabeaz.com/ply/ply.html#ply_nn4