### PR TITLE
Handle large flow restarts

### DIFF
--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -1241,8 +1241,8 @@ class FlowRunWriteSerializer(WriteSerializer):
                                      flow=self.flow_obj, created_on=started).order_by('-modified_on').first()
 
         if not run:
-            run = FlowRun.create(self.flow_obj, self.contact_obj, created_on=started)
-            self.flow_obj.update_start_counts([self.contact_obj])
+            run = FlowRun.create(self.flow_obj, self.contact_obj.pk, created_on=started)
+            self.flow_obj.update_start_counts([self.contact_obj.pk])
 
         step_objs = []
         previous_rule = None

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -82,7 +82,7 @@ class TwilioHandler(View):
                 call.save()
 
                 if flow:
-                    FlowRun.create(flow, contact, call=call)
+                    FlowRun.create(flow, contact.pk, call=call)
                     response = Flow.handle_call(call, {})
                     return HttpResponse(unicode(response))
                 else:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1404,7 +1404,7 @@ class Flow(TembaModel):
 
         if not restart_participants:
             # exclude anybody who has already participated in the flow
-            already_started = [c['contact_id'] for c in self.runs.all().values('contact_id')]
+            already_started = {c['contact_id'] for c in self.runs.all().values('contact_id')}
             all_contact_ids = [contact_id for contact_id in all_contact_ids if contact_id not in already_started]
 
         else:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1399,12 +1399,11 @@ class Flow(TembaModel):
             start_msg.save(update_fields=['msg_type'])
 
         all_contact_ids = Contact.all().filter(Q(all_groups__in=group_qs) | Q(pk__in=contact_qs))
-        all_contact_ids = all_contact_ids.only('is_test').order_by('pk').values('pk').distinct('pk')
-        all_contact_ids = [c['pk'] for c in all_contact_ids]
+        all_contact_ids = all_contact_ids.only('is_test').order_by('pk').values_list('pk', flat=True).distinct('pk')
 
         if not restart_participants:
             # exclude anybody who has already participated in the flow
-            already_started = {c['contact_id'] for c in self.runs.all().values('contact_id')}
+            already_started = set(self.runs.all().values_list('contact_id', flat=True))
             all_contact_ids = [contact_id for contact_id in all_contact_ids if contact_id not in already_started]
 
         else:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -948,23 +948,26 @@ class Flow(TembaModel):
         r = get_redis_connection()
         return r.scard(self.get_stats_cache_key(FlowStatsCache.contacts_started_set))
 
-    def update_start_counts(self, contacts, simulation=False):
+    def update_start_counts(self, contact_ids, simulation=False):
         """
         Track who and how many people just started our flow
         """
 
-        simulation = len(contacts) == 1 and contacts[0].is_test
+        if len(contact_ids) == 1:
+            contact = Contact.objects.filter(pk=contact_ids[0]).first()
+            if contact:
+                simulation = contact.is_test
 
         if not simulation:
             r = get_redis_connection()
-            contact_count = len(contacts)
+            contact_count = len(contact_ids)
 
             # total number of runs as an int
             r.incrby(self.get_stats_cache_key(FlowStatsCache.runs_started_count), contact_count)
 
             # distinct participants as a set
             if contact_count:
-                r.sadd(self.get_stats_cache_key(FlowStatsCache.contacts_started_set), *[c.pk for c in contacts])
+                r.sadd(self.get_stats_cache_key(FlowStatsCache.contacts_started_set), *contact_ids)
 
     def get_base_text(self, language_dict, default=''):
         if not isinstance(language_dict, dict):
@@ -1395,41 +1398,48 @@ class Flow(TembaModel):
             start_msg.msg_type = FLOW
             start_msg.save(update_fields=['msg_type'])
 
-        all_contacts = Contact.all().filter(Q(all_groups__in=group_qs) | Q(pk__in=contact_qs))
-        all_contacts = all_contacts.only('is_test').order_by('pk').distinct('pk')
+        all_contact_ids = Contact.all().filter(Q(all_groups__in=group_qs) | Q(pk__in=contact_qs))
+        all_contact_ids = all_contact_ids.only('is_test').order_by('pk').values('pk').distinct('pk')
+        all_contact_ids = [c['pk'] for c in all_contact_ids]
 
         if not restart_participants:
             # exclude anybody who has already participated in the flow
-            all_contacts = all_contacts.exclude(pk__in=[r['contact'] for r in self.runs.all().values('contact')])
+            already_started = [c['contact_id'] for c in self.runs.all().values('contact_id')]
+            all_contact_ids = [contact_id for contact_id in all_contact_ids if contact_id not in already_started]
+
         else:
             # stop any runs still active for these contacts
-            previous_runs = self.runs.filter(is_active=True, contact__in=all_contacts)
+            previous_runs = self.runs.filter(is_active=True, contact__pk__in=all_contact_ids)
             FlowRun.bulk_exit(previous_runs, FlowRun.EXIT_TYPE_INTERRUPTED)
+
+        contact_count = len(all_contact_ids)
 
         # update our total flow count on our flow start so we can keep track of when it is finished
         if flow_start:
-            flow_start.contact_count = all_contacts.count()
+            flow_start.contact_count = contact_count
             flow_start.save(update_fields=['contact_count'])
 
         # if there are no contacts to start this flow, then update our status and exit this flow
-        if all_contacts.count() == 0:
-            if flow_start: flow_start.update_status()
+        if contact_count == 0:
+            if flow_start:
+                flow_start.update_status()
             return
 
         # single contact starting from a trigger? increment our unread count
-        if start_msg and all_contacts.count() == 1 and not all_contacts.first().is_test:
-            self.increment_unread_responses()
+        if start_msg and contact_count == 1:
+            if Contact.objects.filter(pk=all_contact_ids[0], org=self.org, is_test=False).first():
+                self.increment_unread_responses()
 
         if self.flow_type == Flow.VOICE:
-            return self.start_call_flow(all_contacts, start_msg=start_msg,
+            return self.start_call_flow(all_contact_ids, start_msg=start_msg,
                                         extra=extra, flow_start=flow_start)
 
         else:
-            return self.start_msg_flow(all_contacts,
+            return self.start_msg_flow(all_contact_ids,
                                        started_flows=started_flows,
                                        start_msg=start_msg, extra=extra, flow_start=flow_start)
 
-    def start_call_flow(self, all_contacts, start_msg=None, extra=None, flow_start=None):
+    def start_call_flow(self, all_contact_ids, start_msg=None, extra=None, flow_start=None):
         from temba.ivr.models import IVRCall
         runs = []
         channel = self.org.get_call_channel()
@@ -1445,16 +1455,16 @@ class Flow(TembaModel):
         elif self.entry_type == Flow.RULES_ENTRY:
             entry_rules = RuleSet.objects.filter(uuid=self.entry_uuid).first()
 
-        for contact in all_contacts:
-            run = FlowRun.create(self, contact, start=flow_start)
+        for contact_id in all_contact_ids:
+            run = FlowRun.create(self, contact_id, start=flow_start)
             if extra:
                 run.update_fields(extra)
 
             # keep track of all runs we are starting in redis for faster calcs later
-            self.update_start_counts([contact])
+            self.update_start_counts([contact_id])
 
             # create our call objects
-            call = IVRCall.create_outgoing(channel, contact, self, self.created_by)
+            call = IVRCall.create_outgoing(channel, contact_id, self, self.created_by)
 
             # save away our created call
             run.call = call
@@ -1470,7 +1480,7 @@ class Flow(TembaModel):
 
         return runs
 
-    def start_msg_flow(self, all_contacts, started_flows=None, start_msg=None, extra=None, flow_start=None):
+    def start_msg_flow(self, all_contact_ids, started_flows=None, start_msg=None, extra=None, flow_start=None):
         start_msg_id = start_msg.id if start_msg else None
         flow_start_id = flow_start.id if flow_start else None
 
@@ -1479,9 +1489,6 @@ class Flow(TembaModel):
 
         # create the broadcast for this flow
         send_actions = self.get_entry_send_actions()
-
-        # convert to contact ids
-        all_contact_ids = [c['id'] for c in all_contacts.values('id')]
 
         # for each send action, we need to create a broadcast, we'll group our created messages under these
         broadcasts = []
@@ -1507,7 +1514,7 @@ class Flow(TembaModel):
 
         # if there are fewer contacts than our batch size, do it immediately
         if len(all_contact_ids) < START_FLOW_BATCH_SIZE:
-            return self.start_msg_flow_batch(all_contacts, broadcasts=broadcasts, started_flows=started_flows,
+            return self.start_msg_flow_batch(all_contact_ids, broadcasts=broadcasts, started_flows=started_flows,
                                              start_msg=start_msg, extra=extra, flow_start=flow_start)
 
         # otherwise, create batches instead
@@ -1532,15 +1539,19 @@ class Flow(TembaModel):
 
             return []
 
-    def start_msg_flow_batch(self, batch_contacts, broadcasts=None, started_flows=None, start_msg=None,
+    def start_msg_flow_batch(self, batch_contact_ids, broadcasts=None, started_flows=None, start_msg=None,
                              extra=None, flow_start=None):
-        batch_contact_ids = [c.id for c in batch_contacts]
 
         if started_flows is None:
             started_flows = []
 
         if broadcasts is None:
             broadcasts = []
+
+        simulation = False
+        if len(batch_contact_ids) == 1:
+            if Contact.objects.filter(pk=batch_contact_ids[0], org=self.org, is_test=True).first():
+                simulation = True
 
         # these fields are the initial state for our flow run
         run_fields = None
@@ -1551,13 +1562,14 @@ class Flow(TembaModel):
         # create all our flow runs for this set of contacts at once
         batch = []
         now = timezone.now()
-        for contact in batch_contacts:
-            run = FlowRun.create(self, contact, fields=run_fields, start=flow_start, created_on=now, db_insert=False)
+
+        for contact_id in batch_contact_ids:
+            run = FlowRun.create(self, contact_id, fields=run_fields, start=flow_start, created_on=now, db_insert=False)
             batch.append(run)
         FlowRun.objects.bulk_create(batch)
 
         # keep track of all runs we are starting in redis for faster calcs later
-        self.update_start_counts(batch_contacts)
+        self.update_start_counts(batch_contact_ids)
 
         # build a map of contact to flow run
         run_map = dict()
@@ -1586,7 +1598,7 @@ class Flow(TembaModel):
                 message_context.update(message_context_base)
 
                 # provide the broadcast with a partial recipient list
-                partial_recipients = list(), batch_contacts
+                partial_recipients = list(), Contact.objects.filter(org=self.org, pk__in=batch_contact_ids)
 
                 # create the sms messages
                 created_on = timezone.now()
@@ -1614,12 +1626,12 @@ class Flow(TembaModel):
         msgs = []
         optimize_sending_action = len(broadcasts) > 0
 
-        for contact in batch_contacts:
-            # each contact maintain it's own list of started flows
+        for contact_id in batch_contact_ids:
+            # each contact maintains its own list of started flows
             started_flows_by_contact = list(started_flows)
 
-            run = run_map[contact.id]
-            run_msgs = message_map.get(contact.id, [])
+            run = run_map[contact_id]
+            run_msgs = message_map.get(contact_id, [])
             arrived_on = timezone.now()
 
             if entry_actions:
@@ -1636,9 +1648,9 @@ class Flow(TembaModel):
 
                     next_step = self.add_step(run, destination, previous_step=step, arrived_on=timezone.now())
 
-                    msg = Msg(org=self.org, contact=contact, text='', id=0)
+                    msg = Msg(org=self.org, contact_id=contact_id, text='', id=0)
                     Flow.handle_destination(destination, next_step, run, msg, started_flows_by_contact,
-                                            is_test_contact=contact.is_test)
+                                            is_test_contact=simulation)
 
                 else:
                     run.set_completed(final_step=step)
@@ -1653,7 +1665,7 @@ class Flow(TembaModel):
                 # if we didn't get an incoming message, see if we need to evaluate it passively
                 elif not entry_rules.is_pause():
                     # create an empty placeholder message
-                    msg = Msg(org=self.org, contact=contact, text='', id=0)
+                    msg = Msg(org=self.org, contact_id=contact_id, text='', id=0)
                     Flow.handle_destination(entry_rules, step, run, msg, started_flows_by_contact)
 
             if start_msg:
@@ -2807,8 +2819,8 @@ class FlowRun(models.Model):
                               help_text=_("The FlowStart objects that started this run"))
 
     @classmethod
-    def create(cls, flow, contact, start=None, call=None, fields=None, created_on=None, db_insert=True):
-        args = dict(org=flow.org, flow=flow, contact=contact, start=start, call=call, fields=fields)
+    def create(cls, flow, contact_id, start=None, call=None, fields=None, created_on=None, db_insert=True):
+        args = dict(org=flow.org, flow=flow, contact_id=contact_id, start=start, call=call, fields=fields)
 
         if created_on:
             args['created_on'] = created_on

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -75,7 +75,6 @@ def start_msg_flow_batch_task():
 
     # instantiate all the objects we need that were serialized as JSON
     flow = Flow.objects.get(pk=task['flow'])
-    batch_contacts = list(Contact.objects.filter(pk__in=task['contacts']))
     broadcasts = [] if not task['broadcasts'] else Broadcast.objects.filter(pk__in=task['broadcasts'])
     started_flows = [] if not task['started_flows'] else task['started_flows']
     start_msg = None if not task['start_msg'] else Msg.all_messages.filter(pk=task['start_msg']).first()
@@ -83,7 +82,7 @@ def start_msg_flow_batch_task():
     flow_start = None if not task['flow_start'] else FlowStart.objects.filter(pk=task['flow_start']).first()
 
     # and go do our work
-    flow.start_msg_flow_batch(batch_contacts, broadcasts=broadcasts,
+    flow.start_msg_flow_batch(task['contacts'], broadcasts=broadcasts,
                               started_flows=started_flows, start_msg=start_msg,
                               extra=extra, flow_start=flow_start)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -804,7 +804,7 @@ class FlowTest(TembaTest):
         if runs:
             run = runs[0]
         else:
-            run = FlowRun.create(self.flow, self.contact)
+            run = FlowRun.create(self.flow, self.contact.pk)
 
         # clear any extra on this run
         run.fields = ""
@@ -1947,7 +1947,7 @@ class ActionTest(TembaTest):
 
     def test_reply_action(self):
         msg = self.create_msg(direction=INCOMING, contact=self.contact, text="Green is my favorite")
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         action = ReplyAction(dict(base="We love green too!"))
         action.execute(run, None, msg)
@@ -1971,7 +1971,7 @@ class ActionTest(TembaTest):
 
         self.contact.set_field('state', "WA", label="State")
         self.contact2.set_field('state', "GA", label="State")
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         action = SendAction(dict(base=msg_body),
                             [], [self.contact2], [])
@@ -2001,7 +2001,7 @@ class ActionTest(TembaTest):
         self.other_group.update_contacts([self.contact2], True)
 
         action = SendAction(dict(base=msg_body), [self.other_group], [self.contact], [])
-        run = FlowRun.create(self.flow, test_contact)
+        run = FlowRun.create(self.flow, test_contact.pk)
         action.execute(run, None, None)
 
         # check the action description
@@ -2018,7 +2018,7 @@ class ActionTest(TembaTest):
     @override_settings(SEND_EMAILS=True)
     def test_email_action(self):
         msg = self.create_msg(direction=INCOMING, contact=self.contact, text="Green is my favorite")
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         action = EmailAction(["steve@apple.com"], "Subject", "Body")
 
@@ -2056,7 +2056,7 @@ class ActionTest(TembaTest):
 
         # check simulator reports invalid addresses
         test_contact = Contact.get_test_contact(self.user)
-        test_run = FlowRun.create(self.flow, test_contact)
+        test_run = FlowRun.create(self.flow, test_contact.pk)
 
         action.execute(test_run, None, msg)
 
@@ -2078,7 +2078,7 @@ class ActionTest(TembaTest):
     def test_save_to_contact_action(self):
         sms = self.create_msg(direction=INCOMING, contact=self.contact, text="batman")
         test = SaveToContactAction.from_json(self.org, dict(type='save', label="Superhero Name", value='@step'))
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         field = ContactField.objects.get(org=self.org, key="superhero_name")
         self.assertEquals("Superhero Name", field.label)
@@ -2190,7 +2190,7 @@ class ActionTest(TembaTest):
         # try the same with a simulator contact
         test_contact = Contact.get_test_contact(self.admin)
         test_contact_urn = test_contact.urns.all().first()
-        run = FlowRun.create(self.flow, test_contact)
+        run = FlowRun.create(self.flow, test_contact.pk)
         test.execute(run, None, sms)
 
         # URN should be unchanged on the simulator contact
@@ -2213,7 +2213,7 @@ class ActionTest(TembaTest):
         self.assertEqual('Klingon', action.name)
 
         # execute our action and check we are Klingon now, eeektorp shnockahltip.
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
         action.execute(run, None, None)
         self.assertEquals('kli', Contact.objects.get(pk=self.contact.pk).language)
 
@@ -2248,7 +2248,7 @@ class ActionTest(TembaTest):
 
     def test_group_actions(self):
         sms = self.create_msg(direction=INCOMING, contact=self.contact, text="Green is my favorite")
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         group = self.create_group("Flow Group", [])
 
@@ -2306,7 +2306,7 @@ class ActionTest(TembaTest):
     def test_add_label_action(self):
         flow = self.flow
         msg = self.create_msg(direction=INCOMING, contact=self.contact, text="Green is my favorite")
-        run = FlowRun.create(flow, self.contact)
+        run = FlowRun.create(flow, self.contact.pk)
 
         label = Label.get_or_create(self.org, self.user, "green label")
 
@@ -2358,7 +2358,7 @@ class ActionTest(TembaTest):
 
         self.assertEqual(action.webhook, 'http://example.com/callback.php')
 
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         # test with no incoming message
         action.execute(run, None, None)
@@ -2404,7 +2404,7 @@ class ActionTest(TembaTest):
         # check simulator warns of webhook URL errors
         action = WebhookAction('http://example.com/callback.php?@contact.xyz')
         test_contact = Contact.get_test_contact(self.user)
-        test_run = FlowRun.create(self.flow, test_contact)
+        test_run = FlowRun.create(self.flow, test_contact.pk)
 
         action.execute(test_run, None, None)
 
@@ -2458,7 +2458,7 @@ class FlowRunTest(TembaTest):
         self.assertEquals(fields, normalized)
 
     def test_update_fields(self):
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         # set our fields from an empty state
         new_values = dict(field1="value1", field2="value2")
@@ -2585,7 +2585,7 @@ class WebhookTest(TembaTest):
         self.flow = self.create_flow()
         self.contact = self.create_contact("Ben Haggerty", '+250788383383')
 
-        run = FlowRun.create(self.flow, self.contact)
+        run = FlowRun.create(self.flow, self.contact.pk)
 
         # webhook ruleset comes first
         webhook = RuleSet.objects.create(flow=self.flow, uuid=uuid(100), x=0, y=0, ruleset_type=RuleSet.TYPE_WEBHOOK)
@@ -3401,7 +3401,7 @@ class FlowsTest(FlowFileTest):
         self.contact.name = "Ben Haggerty"
         self.contact.save()
 
-        runs = flow.start_msg_flow(Contact.objects.filter(id=self.contact.id))
+        runs = flow.start_msg_flow([self.contact.id])
         self.assertEquals(1, len(runs))
         self.assertEquals(1, self.contact.msgs.all().count())
         self.assertEquals('Hi Ben Haggerty, what is your phone number?', self.contact.msgs.all()[0].text)
@@ -3723,7 +3723,7 @@ class FlowsTest(FlowFileTest):
 
         # start our flow without a message (simulating it being fired by a trigger or the simulator)
         # this will evaluate requires_step() to make sure it handles localized flows
-        runs = flow.start_msg_flow(Contact.objects.filter(id=self.contact.id))
+        runs = flow.start_msg_flow([self.contact.id])
         self.assertEquals(1, len(runs))
         self.assertEquals(1, self.contact.msgs.all().count())
         self.assertEquals('You are not in the enrolled group.', self.contact.msgs.all()[0].text)
@@ -3731,7 +3731,7 @@ class FlowsTest(FlowFileTest):
         enrolled_group = ContactGroup.create(self.org, self.user, "Enrolled")
         enrolled_group.update_contacts([self.contact], True)
 
-        runs_started = flow.start_msg_flow(Contact.objects.filter(id=self.contact.id))
+        runs_started = flow.start_msg_flow([self.contact.id])
         self.assertEquals(1, len(runs_started))
         self.assertEquals(2, self.contact.msgs.all().count())
         self.assertEquals('You are in the enrolled group.', self.contact.msgs.all().order_by('-pk')[0].text)

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -122,27 +122,13 @@ class IVRCall(SmartModel):
                 print "Hanging up %s for %s" % (self.external_id, self.get_status_display())
                 client.calls.hangup(self.external_id)
 
-    def do_update_call(self, qs=None):
-        client = self.channel.get_ivr_client()
-        if client:
-            try:
-                url = "http://%s%s" % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[self.pk]))
-                if qs:
-                    url = "%s?%s" % (url, qs)
-                client.calls.update(self.external_id, url=url)
-            except Exception as e: # pragma: no cover
-                import traceback
-                traceback.print_exc()
-                self.status = FAILED
-                self.save()
-
     def do_start_call(self, qs=None):
         client = self.channel.get_ivr_client()
         from temba.ivr.clients import IVRException
         if client:
             try:
                 url = "https://%s%s" % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[self.pk]))
-                if qs:
+                if qs:  # pragma: no cover
                     url = "%s?%s" % (url, qs)
 
                 tel = None

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -75,7 +75,12 @@ class IVRCall(SmartModel):
 
 
     @classmethod
-    def create_outgoing(cls, channel, contact, flow, user, call_type=FLOW):
+    def create_outgoing(cls, channel, contact_id, flow, user, call_type=FLOW):
+        contact = Contact.objects.filter(pk=contact_id, org=channel.org).first()
+
+        if not contact:
+            raise ValueError("Invalid contact, cannot initiate call")
+
         contact_urn = contact.get_urn(TEL_SCHEME)
         if not contact_urn:
             raise ValueError("Can't call contact with no tel URN")

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -230,6 +230,8 @@ class IVRTests(FlowFileTest):
     @mock.patch('twilio.util.RequestValidator', MockRequestValidator)
     def test_ivr_flow(self):
 
+
+
         # should be able to create an ivr flow
         self.assertTrue(self.org.supports_ivr())
         self.assertTrue(self.admin.groups.filter(name="Beta"))
@@ -383,6 +385,32 @@ class IVRTests(FlowFileTest):
 
         # the next step shouldn't have any messages yet since they haven't pressed anything
         self.assertEquals(0, steps[1].messages.all().count())
+
+        # test invalid contact id
+        with self.assertRaises(ValueError):
+            IVRCall.create_outgoing(call.channel, 999, flow, self.admin)
+
+        # test no valid urn
+        with self.assertRaises(ValueError):
+            call.contact.urns.all().delete()
+            IVRCall.create_outgoing(call.channel, call.contact.pk, flow, self.admin)
+
+        # try updating our status to completed for a test contact
+        Contact.set_simulation(True)
+        flow.start([], [test_contact])
+        call = IVRCall.objects.filter(direction=OUTGOING).order_by('-pk').first()
+        call.update_status('completed', 30)
+        call.save()
+        call.refresh_from_db()
+
+        self.assertEqual(ActionLog.objects.all().order_by('-pk').first().text, 'Call ended.')
+        self.assertEqual(call.duration, 30)
+
+        # now look at implied duration
+        call.update_status('in-progress', None)
+        call.save()
+        call.refresh_from_db()
+        self.assertIsNotNone(call.get_duration())
 
     @mock.patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
     @mock.patch('temba.ivr.clients.TwilioClient', MockTwilioClient)

--- a/temba/perf_tests.py
+++ b/temba/perf_tests.py
@@ -154,7 +154,7 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         runs = []
         for c in range(0, count):
             contact = contacts[c % len(contacts)]
-            runs.append(FlowRun.create(flow, contact, db_insert=False))
+            runs.append(FlowRun.create(flow, contact.pk, db_insert=False))
         FlowRun.objects.bulk_create(runs)
 
         # add a step to each run

--- a/temba/values/tests.py
+++ b/temba/values/tests.py
@@ -95,9 +95,9 @@ class ResultTest(FlowFileTest):
         self.assertNotEqual(new_value.string_value, original_value.string_value)
 
     def run_color_gender_flow(self, contact, color, gender, age):
-        self.assertEquals("What is your gender?", self.send_message(self.flow, color, contact=contact, restart_participants=True))
-        self.assertEquals("What is your age?", self.send_message(self.flow, gender, contact=contact))
-        self.assertEquals("Thanks.", self.send_message(self.flow, age, contact=contact))
+        self.assertEqual(self.send_message(self.flow, color, contact=contact, restart_participants=True), "What is your gender?")
+        self.assertEqual(self.send_message(self.flow, gender, contact=contact), "What is your age?")
+        self.assertEqual(self.send_message(self.flow, age, contact=contact), "Thanks.")
 
     def setup_color_gender_flow(self):
         self.flow = self.get_flow('color_gender_age')


### PR DESCRIPTION
When users start a large group into a flow that was mostly already started, determining the remaining contacts caused the flow start to fail. This switches to the use of contact_ids throughout flow start and eliminates a large exclusion query.