### PR TITLE
re-encode back to utf-8 when receiving from clickatell latin-1

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -1061,7 +1061,7 @@ class ClickatellHandler(View):
                 # now encode back into utf-8
                 text = text_bytes.decode('utf-16be').encode('utf-8')
             elif charset == 'ISO-8859-1':
-                text = text.encode('iso-8859-1', 'ignore')
+                text = text.encode('iso-8859-1', 'ignore').decode('iso-8859-1').encode('utf-8')
 
             sms = Msg.create_incoming(channel,
                                       (TEL_SCHEME, request.REQUEST['from']),

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -4332,6 +4332,46 @@ class ClickatellTest(TembaTest):
         self.assertEquals(2012, msg1.created_on.year)
         self.assertEquals('id1234', msg1.external_id)
 
+        Msg.all_messages.all().delete()
+
+        encoded_message = urlencode(data)
+        encoded_message += "&text=a%3F+%A3irvine+stinta%3F%A5.++"
+        encoded_message += "&charset=ISO-8859-1"
+        receive_url = reverse('handlers.clickatell_handler', args=['receive', self.channel.uuid]) + '?' + encoded_message
+
+        response = self.client.get(receive_url)
+
+        self.assertEquals(200, response.status_code)
+        # and we should have a new message
+        msg1 = Msg.all_messages.get()
+        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEquals(INCOMING, msg1.direction)
+        self.assertEquals(self.org, msg1.org)
+        self.assertEquals(self.channel, msg1.channel)
+        self.assertEquals(u'a? \xa3irvine stinta?\xa5.  ', msg1.text)
+        self.assertEquals(2012, msg1.created_on.year)
+        self.assertEquals('id1234', msg1.external_id)
+
+        Msg.all_messages.all().delete()
+
+        data['text'] = 'when? or What? is this '
+
+        encoded_message = urlencode(data)
+        encoded_message += "&charset=ISO-8859-1"
+        receive_url = reverse('handlers.clickatell_handler', args=['receive', self.channel.uuid]) + '?' + encoded_message
+
+        response = self.client.get(receive_url)
+
+        self.assertEquals(200, response.status_code)
+        # and we should have a new message
+        msg1 = Msg.all_messages.get()
+        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEquals(INCOMING, msg1.direction)
+        self.assertEquals(self.org, msg1.org)
+        self.assertEquals(self.channel, msg1.channel)
+        self.assertEquals(u'when? or What? is this ', msg1.text)
+        self.assertEquals(2012, msg1.created_on.year)
+        self.assertEquals('id1234', msg1.external_id)
 
     def test_receive(self):
         self.channel.org.config = json.dumps({API_ID:'12345', USERNAME:'uname', PASSWORD:'pword'})

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -4312,6 +4312,27 @@ class ClickatellTest(TembaTest):
         self.assertEquals(2012, msg1.created_on.year)
         self.assertEquals('id1234', msg1.external_id)
 
+        Msg.all_messages.all().delete()
+
+        encoded_message = urlencode(data)
+        encoded_message += "&text=Artwell+S%ECbbnda"
+        encoded_message += "&charset=ISO-8859-1"
+        receive_url = reverse('handlers.clickatell_handler', args=['receive', self.channel.uuid]) + '?' + encoded_message
+
+        response = self.client.get(receive_url)
+
+        self.assertEquals(200, response.status_code)
+        # and we should have a new message
+        msg1 = Msg.all_messages.get()
+        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEquals(INCOMING, msg1.direction)
+        self.assertEquals(self.org, msg1.org)
+        self.assertEquals(self.channel, msg1.channel)
+        self.assertEquals(u'Artwell S\xecbbnda', msg1.text)
+        self.assertEquals(2012, msg1.created_on.year)
+        self.assertEquals('id1234', msg1.external_id)
+
+
     def test_receive(self):
         self.channel.org.config = json.dumps({API_ID:'12345', USERNAME:'uname', PASSWORD:'pword'})
         self.channel.org.save()

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -4328,7 +4328,7 @@ class ClickatellTest(TembaTest):
         self.assertEquals(INCOMING, msg1.direction)
         self.assertEquals(self.org, msg1.org)
         self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals(u'Artwell S\xecbbnda', msg1.text)
+        self.assertEquals("Artwell Sìbbnda", msg1.text)
         self.assertEquals(2012, msg1.created_on.year)
         self.assertEquals('id1234', msg1.external_id)
 
@@ -4348,7 +4348,7 @@ class ClickatellTest(TembaTest):
         self.assertEquals(INCOMING, msg1.direction)
         self.assertEquals(self.org, msg1.org)
         self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals(u'a? \xa3irvine stinta?\xa5.  ', msg1.text)
+        self.assertEquals("a? £irvine stinta?¥.  ", msg1.text)
         self.assertEquals(2012, msg1.created_on.year)
         self.assertEquals('id1234', msg1.external_id)
 
@@ -4369,7 +4369,7 @@ class ClickatellTest(TembaTest):
         self.assertEquals(INCOMING, msg1.direction)
         self.assertEquals(self.org, msg1.org)
         self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals(u'when? or What? is this ', msg1.text)
+        self.assertEquals("when? or What? is this ", msg1.text)
         self.assertEquals(2012, msg1.created_on.year)
         self.assertEquals('id1234', msg1.external_id)
 


### PR DESCRIPTION
follow up  #525 to properly handle receiving from Clickatell 

When receiving from Clickatell with encoding ISO-8859-1,
we decode that ignoring missing characters and we encode to utf-8 before saving

FIxes https://app.getsentry.com/nyaruka/rapidpro/issues/109283753/