### PR TITLE
Fix join trigger flow

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -271,7 +271,9 @@ class Flow(TembaModel):
             actions += [dict(type='flow', id=start_flow.pk, name=start_flow.name)]
 
         action_sets = [dict(x=100, y=0, uuid=uuid, actions=actions)]
-        flow.update(dict(entry=uuid, rulesets=[], action_sets=action_sets))
+        flow.update(dict(entry=uuid, base_language=base_language,
+                         rulesets=[], action_sets=action_sets))
+
         return flow
 
     @classmethod

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2058,9 +2058,6 @@ class Flow(TembaModel):
         Updates a definition for a flow.
         """
 
-        # validate the definition before saving
-        FlowRevision.validate_flow_definition(json_dict)
-
         def get_step_type(dest, rulesets, actionsets):
             if dest:
                 if rulesets.get(dest, None):

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -262,7 +262,7 @@ class Flow(TembaModel):
 
         uuid = unicode(uuid4())
         actions = [dict(type='add_group', group=dict(id=group.pk, name=group.name)),
-                   dict(type='save', field='name', label='Contact Name', value='@step.value|remove_first_word|title_case')]
+                   dict(type='save', field='name', label='Contact Name', value='@(PROPER(REMOVE_FIRST_WORD(step.value)))')]
 
         if response:
             actions += [dict(type='reply', msg={base_language:response})]
@@ -272,7 +272,7 @@ class Flow(TembaModel):
 
         action_sets = [dict(x=100, y=0, uuid=uuid, actions=actions)]
         flow.update(dict(entry=uuid, base_language=base_language,
-                         rulesets=[], action_sets=action_sets))
+                         rule_sets=[], action_sets=action_sets))
 
         return flow
 
@@ -2058,6 +2058,9 @@ class Flow(TembaModel):
         Updates a definition for a flow.
         """
 
+        # validate the definition before saving
+        FlowRevision.validate_flow_definition(json_dict)
+
         def get_step_type(dest, rulesets, actionsets):
             if dest:
                 if rulesets.get(dest, None):
@@ -2710,7 +2713,7 @@ class FlowRevision(SmartModel):
 
         non_localized_error = _('Malformed flow, encountered non-localized definition')
 
-        # should always have a base_language after migration
+        # should always have a base_language
         if 'base_language' not in flow_spec or not flow_spec['base_language']:
             raise ValueError(non_localized_error)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -156,6 +156,19 @@ class FlowTest(TembaTest):
         self.assertEquals(CURRENT_EXPORT_VERSION, revisions[0].as_json()['version'])
         self.assertEquals('base', revisions[0].get_definition_json()['base_language'])
 
+        # now make one revision invalid
+        revision = revisions[1]
+        definition = revision.get_definition_json()
+        del definition['base_language']
+        revision.definition = json.dumps(definition)
+        revision.save()
+
+        # should be back to one valid flow
+        self.login(self.admin)
+        response = self.client.get(reverse('flows.flow_revisions', args=[self.flow.pk]))
+        revisions = json.loads(response.content)
+        self.assertEquals(1, len(revisions))
+
     def test_get_localized_text(self):
 
         text_translations = dict(eng="Hello", esp="Hola", fre="Salut")
@@ -1809,6 +1822,17 @@ class FlowTest(TembaTest):
 
         self.assertEquals(400, response.status_code)
         self.assertEquals('Invalid label name: @badlabel', json.loads(response.content)['description'])
+
+        # try submitting a flow def without a language
+        json_dict = flow.as_json()
+        del json_dict['base_language']
+        response = self.client.post(reverse('flows.flow_json', args=[flow.pk]),
+                                    json.dumps(json_dict),
+                                    content_type="application/json")
+
+        self.assertEquals(400, response.status_code)
+        self.assertEquals('Malformed flow, encountered non-localized definition', json.loads(response.content)['description'])
+
 
     def test_flow_start_with_start_msg(self):
         # set our flow
@@ -4146,16 +4170,16 @@ class FlowMigrationTest(FlowFileTest):
         # make sure it is localized
         poll = self.org.flows.filter(name='Sample Flow - Simple Poll').first()
         self.assertTrue('base' in poll.action_sets.all().order_by('y').first().get_actions()[0].msg)
-        self.assertEquals('base', poll.base_language)
+        self.assertEqual('base', poll.base_language)
 
         # check replacement
         order_checker = self.org.flows.filter(name='Sample Flow - Order Status Checker').first()
         ruleset = order_checker.rule_sets.filter(y=298).first()
-        self.assertEquals('https://app.rapidpro.io/demo/status/', ruleset.webhook_url)
+        self.assertEqual('https://app.rapidpro.io/demo/status/', ruleset.webhook_url)
 
         # our test user doesn't use an email address, check for Administrator for the email
         actionset = order_checker.action_sets.filter(y=991).first()
-        self.assertEquals('Administrator', actionset.get_actions()[1].emails[0])
+        self.assertEqual('Administrator', actionset.get_actions()[1].emails[0])
 
 
     def test_flow_results(self):

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1823,17 +1823,6 @@ class FlowTest(TembaTest):
         self.assertEquals(400, response.status_code)
         self.assertEquals('Invalid label name: @badlabel', json.loads(response.content)['description'])
 
-        # try submitting a flow def without a language
-        json_dict = flow.as_json()
-        del json_dict['base_language']
-        response = self.client.post(reverse('flows.flow_json', args=[flow.pk]),
-                                    json.dumps(json_dict),
-                                    content_type="application/json")
-
-        self.assertEquals(400, response.status_code)
-        self.assertEquals('Malformed flow, encountered non-localized definition', json.loads(response.content)['description'])
-
-
     def test_flow_start_with_start_msg(self):
         # set our flow
         self.flow.update(self.definition)

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -371,7 +371,15 @@ class FlowCRUDL(SmartCRUDL):
                 revision = FlowRevision.objects.get(flow=flow, pk=revision_id)
                 return build_json_response(revision.get_definition_json())
             else:
-                revisions = [revision.as_json() for revision in flow.revisions.all().order_by('-created_on')[:25]]
+                revisions = []
+                for revision in flow.revisions.all().order_by('-created_on')[:25]:
+                    # validate the flow defintion before presenting it to the user
+                    try:
+                        FlowRevision.validate_flow_definition(revision.get_definition_json())
+                        revisions.append(revision.as_json())
+                    except ValueError as e:
+                        pass
+
                 return build_json_response(revisions)
 
     class OrgQuerysetMixin(object):

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -383,14 +383,17 @@ class TriggerTest(TembaTest):
         self.assertEqual(flow.base_language, 'base')
 
         # now let's try it out
-        contact = self.create_contact('Ben', '+250788382382')
-        msg = self.create_msg(direction=INCOMING, contact=contact, text="join")
+        contact = self.create_contact('macklemore', '+250788382382')
+        msg = self.create_msg(direction=INCOMING, contact=contact, text="join ben haggerty")
         self.assertIsNone(msg.msg_type)
 
         self.assertTrue(Trigger.find_and_handle(msg))
 
         self.assertEqual(msg.msg_type, 'F')
         self.assertEqual(Trigger.objects.get(pk=trigger.pk).trigger_count, 1)
+
+        contact.refresh_from_db()
+        self.assertEqual('Ben Haggerty', contact.name)
 
         # we should be in the group now
         self.assertEqual({group}, set(contact.user_groups.all()))


### PR DESCRIPTION
Fix definition for join trigger flows to be:
* Properly localized
* Use rule_sets instead of rulesets
* Use new expression syntax instead of filters

Old revisions that don't pass validate_flow_defintiion are hidden from the user so they cannot be restored. Existing broken flows patched by hand, no migration.