### PR TITLE
Survey contact creation

### DIFF
--- a/static/less/flow_editor.less
+++ b/static/less/flow_editor.less
@@ -72,7 +72,7 @@
   height: 80px;
   padding: 20px;
 
-  .icon-phone, .icon-channel-android {
+  .icon-phone, .icon-mobile {
     margin-right:26px;
     color: @color-font-lightgrey;
   }

--- a/static/less/style.less
+++ b/static/less/style.less
@@ -2267,7 +2267,7 @@ input[type='radio'] {
             margin-top: -1px;
           }
 
-          .icon-channel-android {
+          .icon-mobile {
             color: @color-font-lightgrey;
             font-size:16px;
             margin-right: 5px;

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -158,6 +158,11 @@ class Flow(TembaModel):
     SAVED_BY = 'saved_by'
     VERSION = 'version'
 
+
+    CONCTACT_CREATION = 'contact_creation'
+    CONTACT_PER_RUN = 'run'
+    CONTACT_PER_LOGIN = 'login'
+
     SAVED_ON = 'saved_on'
     NAME = 'name'
     REVISION = 'revision'
@@ -1010,6 +1015,15 @@ class Flow(TembaModel):
         # now update with our remapped values
         self.update(flow_json)
         return self
+
+    def set_metadata_json(self, metadata):
+        self.metadata = json.dumps(metadata)
+
+    def get_metadata_json(self):
+        metadata = {}
+        if self.metadata:
+            metadata = json.loads(self.metadata)
+        return metadata
 
     def archive(self):
         self.is_archived = True

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -159,7 +159,7 @@ class Flow(TembaModel):
     VERSION = 'version'
 
 
-    CONCTACT_CREATION = 'contact_creation'
+    CONTACT_CREATION = 'contact_creation'
     CONTACT_PER_RUN = 'run'
     CONTACT_PER_LOGIN = 'login'
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -526,12 +526,12 @@ class FlowCRUDL(SmartCRUDL):
 
                 if self.instance.flow_type == Flow.SURVEY:
                     contact_creation = forms.ChoiceField(label=_('Create a contact '),
-                                                       initial=metadata.get('contact_creation', Flow.CONTACT_PER_RUN),
+                                                       initial=metadata.get(Flow.CONTACT_CREATION, Flow.CONTACT_PER_RUN),
                                                        help_text=_("Whether surveyor logins should be used as the contact for each run"),
                                                        choices=((Flow.CONTACT_PER_RUN, _('For each run')),
                                                                 (Flow.CONTACT_PER_LOGIN, _('For each login'))))
 
-                    self.fields['contact_creation'] = contact_creation
+                    self.fields[Flow.CONTACT_CREATION] = contact_creation
 
                 self.fields['keyword_triggers'].initial = ','.join([t.keyword for t in flow_triggers])
 
@@ -551,7 +551,7 @@ class FlowCRUDL(SmartCRUDL):
                 fields += ['base_language']
 
             if obj.flow_type == Flow.SURVEY:
-                fields.insert(len(fields) - 1, 'contact_creation')
+                fields.insert(len(fields) - 1, Flow.CONTACT_CREATION)
 
             return fields
 
@@ -564,8 +564,8 @@ class FlowCRUDL(SmartCRUDL):
             obj = super(FlowCRUDL.Update, self).pre_save(obj)
             metadata = obj.get_metadata_json()
 
-            if 'contact_creation' in self.form.cleaned_data:
-                metadata['contact_creation'] = self.form.cleaned_data['contact_creation']
+            if Flow.CONTACT_CREATION in self.form.cleaned_data:
+                metadata[Flow.CONTACT_CREATION] = self.form.cleaned_data[Flow.CONTACT_CREATION]
             obj.set_metadata_json(metadata)
             return obj
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -465,8 +465,6 @@ class FlowCRUDL(SmartCRUDL):
             user = self.request.user
             org = user.get_org()
 
-
-
             # create triggers for this flow only if there are keywords
             if len(self.form.cleaned_data['keyword_triggers']) > 0:
                 for keyword in self.form.cleaned_data['keyword_triggers'].split(','):
@@ -504,13 +502,19 @@ class FlowCRUDL(SmartCRUDL):
 
     class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
         class FlowUpdateForm(BaseFlowForm):
+
+
+
             keyword_triggers = forms.CharField(required=False, label=_("Global keyword triggers"),
                                                help_text=_("When a user sends any of these keywords they will begin this flow"))
+
+
 
             def __init__(self, user, *args, **kwargs):
                 super(FlowCRUDL.Update.FlowUpdateForm, self).__init__(*args, **kwargs)
                 self.user = user
 
+                metadata = self.instance.get_metadata_json()
                 flow_triggers = Trigger.objects.filter(org=self.instance.org, flow=self.instance, is_archived=False, groups=None,
                                                        trigger_type=Trigger.TYPE_KEYWORD).order_by('created_on')
 
@@ -519,6 +523,15 @@ class FlowCRUDL(SmartCRUDL):
                     choices = [('', 'No Preference')]
                     choices += [(lang.iso_code, lang.name) for lang in self.instance.org.languages.all().order_by('orgs', 'name')]
                     self.fields['base_language'] = forms.ChoiceField(label=_('Language'), choices=choices)
+
+                if self.instance.flow_type == Flow.SURVEY:
+                    contact_creation = forms.ChoiceField(label=_('Create a contact '),
+                                                       initial=metadata.get('contact_creation', Flow.CONTACT_PER_RUN),
+                                                       help_text=_("Whether surveyor logins should be used as the contact for each run"),
+                                                       choices=((Flow.CONTACT_PER_RUN, _('For each run')),
+                                                                (Flow.CONTACT_PER_LOGIN, _('For each login'))))
+
+                    self.fields['contact_creation'] = contact_creation
 
                 self.fields['keyword_triggers'].initial = ','.join([t.keyword for t in flow_triggers])
 
@@ -532,14 +545,29 @@ class FlowCRUDL(SmartCRUDL):
 
         def derive_fields(self):
             fields = [field for field in self.fields]
-            if not self.get_object().base_language and self.org.primary_language:
+
+            obj = self.get_object()
+            if not obj.base_language and self.org.primary_language:
                 fields += ['base_language']
+
+            if obj.flow_type == Flow.SURVEY:
+                fields.insert(len(fields) - 1, 'contact_creation')
+
             return fields
 
         def get_form_kwargs(self):
             kwargs = super(FlowCRUDL.Update, self).get_form_kwargs()
             kwargs['user'] = self.request.user
             return kwargs
+
+        def pre_save(self, obj):
+            obj = super(FlowCRUDL.Update, self).pre_save(obj)
+            metadata = obj.get_metadata_json()
+
+            if 'contact_creation' in self.form.cleaned_data:
+                metadata['contact_creation'] = self.form.cleaned_data['contact_creation']
+            obj.set_metadata_json(metadata)
+            return obj
 
         def post_save(self, obj):
             keywords = set()
@@ -567,6 +595,7 @@ class FlowCRUDL(SmartCRUDL):
                 else:
                     Trigger.objects.create(org=org, keyword=keyword, trigger_type=Trigger.TYPE_KEYWORD,
                                            flow=obj, created_by=user, modified_by=user)
+
 
             # run async task to update all runs
             from .tasks import update_run_expirations_task

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -206,7 +206,7 @@
         -if flow.flow_type == 'V'
           .icon-phone
         -elif flow.flow_type == 'S'
-          .icon-channel-android
+          .icon-mobile
         {{ flow.name }}
 
       #pending{ng-show:'pending == "S" || pending == "P"'}

--- a/templates/flows/flow_list.haml
+++ b/templates/flows/flow_list.haml
@@ -133,7 +133,7 @@
                           -if object.flow_type == 'V'
                             .icon-phone
                           -elif object.flow_type == 'S'
-                            .icon-channel-android
+                            .icon-mobile
 
                           {{ object.name }}
 

--- a/templates/flows/flow_update.haml
+++ b/templates/flows/flow_update.haml
@@ -19,9 +19,9 @@
 
       select2div('#id_expires_after_minutes', '520px');
       select2div('#id_flow_type', '520px');
+      select2div('#id_contact_creation', '520px');
 
       useFontCheckbox("#id_ignore_triggers");
-
 
       $('#id_labels').select2();
 
@@ -35,4 +35,5 @@
         placeholder: "Add a keyword to begin this flow (optional)",
         containerCssClass: "select2-temba-field"
       });
+
     });


### PR DESCRIPTION
Lets flow designers show how survey flows create contacts.

* Add form option for how contacts are created on Surveyor
* Switch icon marking surveys to be a smartphone instead of android

Add new optional entry in flow definition (without advancing version). Open to alternate naming here.
```
"metadata": {
  "contact_creation": ([run] | [login])
}
```