### PR TITLE
fix drifting minutes on schedules

### DIFF
--- a/temba/schedules/migrations/0002_schedule_repeat_minute_of_hour.py
+++ b/temba/schedules/migrations/0002_schedule_repeat_minute_of_hour.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('schedules', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='schedule',
+            name='repeat_minute_of_hour',
+            field=models.IntegerField(help_text='The minute of the hour', null=True),
+        ),
+    ]

--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -24,6 +24,7 @@ class Schedule(SmartModel):
 
     status = models.CharField(default='U', choices=status_choices, max_length=1)
     repeat_hour_of_day = models.IntegerField(help_text="The hour of the day", null=True)
+    repeat_minute_of_hour = models.IntegerField(help_text="The minute of the hour", null=True)
     repeat_day_of_month = models.IntegerField(null=True, help_text="The day of the month to repeat on")
     repeat_period = models.CharField(max_length=1, null=True, help_text="When this schedule repeats", choices=repeat_choices)
     repeat_days = models.IntegerField(default=0, null=True, blank=True, help_text="bit mask of days of the week")
@@ -34,7 +35,7 @@ class Schedule(SmartModel):
     def create_schedule(cls, start_date, repeat_period, user, repeat_days=None, status='S'):
         return Schedule.objects.create(repeat_period=repeat_period, repeat_days=repeat_days,
                                        created_by=user, modified_by=user, repeat_day_of_month=start_date.day,
-                                       repeat_hour_of_day=start_date.hour,
+                                       repeat_hour_of_day=start_date.hour, repeat_minute_of_hour=start_date.minute,
                                        next_fire=start_date, status=status)
 
     def reset(self):
@@ -67,17 +68,19 @@ class Schedule(SmartModel):
         """
         Get the next point in the future when our schedule should expire again
         """
+        hour = self.repeat_hour_of_day if self.repeat_hour_of_day is not None else trigger_date.hour
+        minute = self.repeat_minute_of_hour if self.repeat_minute_of_hour is not None else 0
 
-        hour_of_day = self.repeat_hour_of_day if self.repeat_hour_of_day else trigger_date.hour
-        trigger_date = trigger_date.replace(hour=hour_of_day, minute=0, second=0, microsecond=0)
+        trigger_date = trigger_date.replace(hour=hour, minute=minute, second=0, microsecond=0)
 
         if self.repeat_period == "O":
             return trigger_date
+
         if self.repeat_period == "M":
             (weekday, days) = calendar.monthrange(trigger_date.year, trigger_date.month)
             day_of_month = min(days, self.repeat_day_of_month)
-            next_date = datetime(trigger_date.year, trigger_date.month,
-                                 day=day_of_month, hour=self.repeat_hour_of_day).replace(tzinfo=self.get_org_timezone())
+            next_date = datetime(trigger_date.year, trigger_date.month, day=day_of_month,
+                                 hour=hour, minute=minute, second=0, microsecond=0).replace(tzinfo=self.get_org_timezone())
             if trigger_date.day >= self.repeat_day_of_month:
                 next_date += relativedelta(months=1)
             return next_date
@@ -95,6 +98,7 @@ class Schedule(SmartModel):
                     bitmask = pow(2, day_idx + 1)
                     if bitmask & self.repeat_days == bitmask:
                         return trigger_date + timedelta(days=i + 1)
+
         if self.repeat_period == "D":
             return trigger_date + timedelta(days=1)
 

--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -162,5 +162,6 @@ class Schedule(SmartModel):
         return days
 
     def __unicode__(self):  # pragma: no cover
-        return "[%s] %s %s %s" % (str(self.next_fire), self.repeat_period, self.repeat_day_of_month, self.repeat_hour_of_day)
+        return "[%s] %s %s %s:%s" % (str(self.next_fire), self.repeat_period, self.repeat_day_of_month,
+                                     self.repeat_hour_of_day, self.repeat_minute_of_hour)
 

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -28,7 +28,7 @@ class ScheduleTest(TembaTest):
 
         if not start_date:
             # Test date is 10am on a Thursday, Jan 3rd
-            start_date = datetime(2013, 1, 3, hour=10).replace(tzinfo=pytz.utc)
+            start_date = datetime(2013, 1, 3, hour=10, minute=0).replace(tzinfo=pytz.utc)
 
         # create a our bitmask from repeat_days
         bitmask = 0
@@ -227,10 +227,10 @@ class ScheduleTest(TembaTest):
         self.org.save()
 
         tz = self.org.get_tzinfo()
-        eleven_pm_est = datetime(2013, 1, 3, hour=23, minute=0, second=0, microsecond=0).replace(tzinfo=tz)
+        eleven_fifteen_est = datetime(2013, 1, 3, hour=23, minute=15, second=0, microsecond=0).replace(tzinfo=tz)
 
-        # Test date is 10am on a Thursday, Jan 3rd
-        schedule = self.create_schedule('D', start_date=eleven_pm_est)
+        # Test date is 10:15am on a Thursday, Jan 3rd
+        schedule = self.create_schedule('D', start_date=eleven_fifteen_est)
         schedule.save()
 
         Broadcast.create(self.org, self.admin, 'Message', [], schedule=schedule)
@@ -239,7 +239,7 @@ class ScheduleTest(TembaTest):
         # when is the next fire once our first one passes
         sched_date = datetime(2013, 1, 3, hour=23, minute=30, second=0, microsecond=0).replace(tzinfo=tz)
         schedule.update_schedule(sched_date)
-        self.assertEquals('2013-01-04 23:00:00-05:00', unicode(schedule.next_fire))
+        self.assertEquals('2013-01-04 23:15:00-05:00', unicode(schedule.next_fire))
 
     def test_update_near_day_boundary(self):
 
@@ -270,7 +270,7 @@ class ScheduleTest(TembaTest):
         self.assertEquals('2050-01-04 04:00:00+00:00', unicode(sched.next_fire))
 
         # a time in the past
-        start_date = datetime(2010, 1, 3, 23, 0, 0, 0, tzinfo=tz)
+        start_date = datetime(2010, 1, 3, 23, 45, 0, 0, tzinfo=tz)
         start_date = pytz.utc.normalize(start_date.astimezone(pytz.utc))
 
         post_data = dict()
@@ -280,7 +280,7 @@ class ScheduleTest(TembaTest):
         self.client.post(update_url, post_data)
         sched = Schedule.objects.get(pk=sched.pk)
 
-        # next fire should fall at the same hour
-        self.assertIn('04:00:00+00:00', unicode(sched.next_fire))
+        # next fire should fall at the right hour and minute
+        self.assertIn('04:45:00+00:00', unicode(sched.next_fire))
 
 

--- a/temba/schedules/views.py
+++ b/temba/schedules/views.py
@@ -119,6 +119,7 @@ class ScheduleCRUDL(SmartCRUDL):
                         days = form.cleaned_data['repeat_days']
                     schedule.repeat_days = days
                     schedule.repeat_hour_of_day = schedule.next_fire.hour
+                    schedule.repeat_minute_of_hour = schedule.next_fire.minute
                     schedule.repeat_day_of_month = schedule.next_fire.day
                 schedule.save()
 

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -403,6 +403,7 @@ class TriggerCRUDL(SmartCRUDL):
                             days = form.cleaned_data['repeat_days']
                         schedule.repeat_days = days
                         schedule.repeat_hour_of_day = schedule.next_fire.hour
+                        schedule.repeat_minute_of_hour = schedule.next_fire.minute
                         schedule.repeat_day_of_month = schedule.next_fire.day
                     schedule.save()
 
@@ -578,6 +579,7 @@ class TriggerCRUDL(SmartCRUDL):
                         days = form.cleaned_data['repeat_days']
                     schedule.repeat_days = days
                     schedule.repeat_hour_of_day = schedule.next_fire.hour
+                    schedule.repeat_minute_of_hour = schedule.repeat_minute_of_hour
                     schedule.repeat_day_of_month = schedule.next_fire.day
                 schedule.save()
 


### PR DESCRIPTION
Adds repeat minute field on schedules, which is pulled out when creating schedules and used going forward.

Existing schedules will continue to work as they have (resetting minute to 0) but any set minutes going forward will do the right thing. (this only affected repeating schedules after the first fire) 