### PR TITLE
Add release() method to Flow, call when deleting

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -560,6 +560,17 @@ class APITest(TembaTest):
         response = self.fetchJSON(url, 'flow=%s' % flow1.uuid)
         self.assertResultsById(response, [frank_run2, frank_run1, joe_run2, joe_run1])
 
+        # doesn't work if flow is inactive
+        flow1.is_active = False
+        flow1.save()
+
+        response = self.fetchJSON(url, 'flow=%s' % flow1.uuid)
+        self.assertResultsById(response, [])
+
+        # restore to active
+        flow1.is_active = True
+        flow1.save()
+
         # filter by invalid flow
         response = self.fetchJSON(url, 'flow=invalid')
         self.assertResultsById(response, [])

--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -1056,7 +1056,7 @@ class FlowWriteSerializer(WriteSerializer):
                     raise serializers.ValidationError("Name is missing from metadata")
 
                 uuid = metadata.get('uuid', None)
-                if uuid and not Flow.objects.filter(org=self.org, uuid=uuid).exists():
+                if uuid and not Flow.objects.filter(org=self.org, is_active=True, uuid=uuid).exists():
                     raise serializers.ValidationError("No such flow with UUID: %s" % uuid)
             else:
                 raise serializers.ValidationError("Metadata field is required for version %s" % version)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -673,7 +673,7 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
         # filter by flow (optional)
         flow_uuid = params.get('flow')
         if flow_uuid:
-            flow = Flow.objects.filter(org=org, uuid=flow_uuid).first()
+            flow = Flow.objects.filter(org=org, uuid=flow_uuid, is_active=True).first()
             if flow:
                 queryset = queryset.filter(flow=flow)
             else:

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -347,6 +347,17 @@ class CampaignEvent(SmartModel):
 
         return None
 
+    def release(self):
+        """
+        Removes this event.. also takes care of removing any event fires that were scheduled and unfired
+        """
+        # mark ourselves inactive
+        self.is_active = False
+        self.save()
+
+        # delete any pending event fires
+        EventFire.update_eventfires_for_event(self)
+
     def calculate_scheduled_fire(self, contact):
         date_value = EventFire.parse_relative_to_date(contact, self.relative_to.key)
         return self.calculate_scheduled_fire_for_value(date_value, timezone.now())

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -126,7 +126,7 @@ class Campaign(SmartModel):
                                                                    event_spec['delivery_hour'])
                         event.update_flow_name()
                     else:
-                        flow = Flow.objects.filter(org=org, id=event_spec['flow']['id']).first()
+                        flow = Flow.objects.filter(org=org, is_active=True, id=event_spec['flow']['id']).first()
                         if flow:
                             CampaignEvent.create_flow_event(org, user, campaign, relative_to,
                                                             event_spec['offset'],

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -38,14 +38,14 @@ class CampaignTest(TembaTest):
         self.admin.groups.add(Group.objects.get(name="Beta"))
 
     def test_get_unique_name(self):
-        flow1 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
-        self.assertEqual(flow1.name, "Reminders")
+        campaign1 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
+        self.assertEqual(campaign1.name, "Reminders")
 
-        flow2 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
-        self.assertEqual(flow2.name, "Reminders 2")
+        campaign2 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
+        self.assertEqual(campaign2.name, "Reminders 2")
 
-        flow3 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
-        self.assertEqual(flow3.name, "Reminders 3")
+        campaign3 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
+        self.assertEqual(campaign3.name, "Reminders 3")
 
         self.create_secondary_org()
         self.assertEqual(Campaign.get_unique_name(self.org2, "Reminders"), "Reminders")  # different org

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -312,10 +312,7 @@ class CampaignEventCRUDL(SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             self.object = self.get_object()
-            self.object.is_active = False
-            self.object.save()
-
-            EventFire.update_eventfires_for_event(self.object)
+            self.object.release()
 
             redirect_url = self.get_redirect_url()
             return HttpResponseRedirect(redirect_url)

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -254,7 +254,8 @@ class EventForm(forms.ModelForm):
         relative_to.queryset = ContactField.objects.filter(org=self.user.get_org(), is_active=True).order_by('label')
 
         flow = self.fields['flow_to_start']
-        flow.queryset = Flow.objects.filter(org=self.user.get_org(), flow_type__in=[Flow.FLOW, Flow.VOICE], is_active=True, is_archived=False).order_by('name')
+        flow.queryset = Flow.objects.filter(org=self.user.get_org(), flow_type__in=[Flow.FLOW, Flow.VOICE],
+                                            is_active=True, is_archived=False).order_by('name')
 
     class Meta:
         model = CampaignEvent

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -881,7 +881,7 @@ class Channel(TembaModel):
             if not org.get_schemes(CALL):
                 # archive any IVR flows
                 from temba.flows.models import Flow
-                for flow in Flow.objects.filter(org=org, flow_type=Flow.VOICE):
+                for flow in Flow.objects.filter(org=org, is_active=True, flow_type=Flow.VOICE):
                     flow.archive()
 
         # if we just lost answering capabilities, archive our inbound call trigger

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3674,8 +3674,6 @@ class FlowsTest(FlowFileTest):
         response = self.client.post(reverse('flows.flow_delete', args=[flow.pk]))
         self.assertRedirect(response, reverse('flows.flow_list'))
 
-        flow.delete()
-
         # flow should no longer be active
         flow.refresh_from_db()
         self.assertFalse(flow.is_active)

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -488,7 +488,7 @@ class OrgCRUDL(SmartCRUDL):
             from temba.flows.models import Flow
             from temba.campaigns.models import Campaign
 
-            flows = set(Flow.objects.filter(id__in=self.request.REQUEST.getlist('flows'), org=self.get_object()))
+            flows = set(Flow.objects.filter(id__in=self.request.REQUEST.getlist('flows'), org=self.get_object(), is_active=True))
             campaigns = Campaign.objects.filter(id__in=self.request.REQUEST.getlist('campaigns'), org=self.get_object())
 
             # add in all the flows our campaign depends on

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -319,6 +319,13 @@ class Trigger(SmartModel):
 
         return [each_trigger.pk for each_trigger in triggers]
 
+    def release(self):
+        """
+        Releases this Trigger, use this instead of delete
+        """
+        self.is_active = False
+        self.save()
+
     def fire(self):
         if self.is_archived or not self.is_active:
             return None

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -116,7 +116,7 @@ class Trigger(SmartModel):
 
                     groups.append(group)
 
-                flow = Flow.objects.get(org=org, pk=trigger_spec['flow']['id'])
+                flow = Flow.objects.get(org=org, pk=trigger_spec['flow']['id'], is_active=True)
 
                 # see if that trigger already exists
                 trigger = Trigger.objects.filter(org=org, trigger_type=trigger_spec['trigger_type'])

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -66,7 +66,7 @@ class DefaultTriggerForm(BaseTriggerForm):
     Default trigger form which only allows selection of a non-message based flow
     """
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.objects.filter(is_archived=False, org=user.get_org(), flow_type__in=[Flow.FLOW, Flow.VOICE])
+        flows = Flow.objects.filter(org=user.get_org(), is_active=True, is_archived=False, flow_type__in=[Flow.FLOW, Flow.VOICE])
         super(DefaultTriggerForm, self).__init__(user, flows,  *args, **kwargs)
 
 
@@ -111,7 +111,7 @@ class CatchAllTriggerForm(GroupBasedTriggerForm):
     For for catchall triggers
     """
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.objects.filter(is_archived=False, org=user.get_org(), flow_type__in=[Flow.FLOW, Flow.VOICE])
+        flows = Flow.objects.filter(org=user.get_org(), is_active=True, is_archived=False, flow_type__in=[Flow.FLOW, Flow.VOICE])
         super(CatchAllTriggerForm, self).__init__(user, flows, *args, **kwargs)
 
     def get_existing_triggers(self, cleaned_data):
@@ -137,7 +137,7 @@ class KeywordTriggerForm(GroupBasedTriggerForm):
                               help_text=_("The first word of the message text"))
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.objects.filter(is_archived=False, org=user.get_org(), flow_type__in=[Flow.FLOW, Flow.VOICE])
+        flows = Flow.objects.filter(org=user.get_org(), is_active=True, is_archived=False, flow_type__in=[Flow.FLOW, Flow.VOICE])
         super(KeywordTriggerForm, self).__init__(user, flows, *args, **kwargs)
 
     def get_existing_triggers(self, cleaned_data):
@@ -190,7 +190,7 @@ class RegisterTriggerForm(BaseTriggerForm):
                                help_text=_("The message to send in response after they join the group (optional)"))
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.objects.filter(is_archived=False, org=user.get_org(), flow_type__in=[Flow.FLOW, Flow.VOICE])
+        flows = Flow.objects.filter(org=user.get_org(), is_active=True, is_archived=False, flow_type__in=[Flow.FLOW, Flow.VOICE])
 
         super(RegisterTriggerForm, self).__init__(user, flows, *args, **kwargs)
 
@@ -216,7 +216,7 @@ class ScheduleTriggerForm(BaseScheduleForm, forms.ModelForm):
         super(ScheduleTriggerForm, self).__init__(*args, **kwargs)
         self.user = user
         self.fields['omnibox'].set_user(user)
-        self.fields['flow'].queryset = Flow.objects.filter(is_archived=False, org=self.user.get_org()).exclude(flow_type=Flow.MESSAGE)
+        self.fields['flow'].queryset = Flow.objects.filter(org=self.user.get_org(), is_active=True, is_archived=False).exclude(flow_type=Flow.MESSAGE)
 
     def clean(self):
         data = super(ScheduleTriggerForm, self).clean()
@@ -234,7 +234,7 @@ class ScheduleTriggerForm(BaseScheduleForm, forms.ModelForm):
 class InboundCallTriggerForm(GroupBasedTriggerForm):
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.objects.filter(is_archived=False, org=user.get_org(), flow_type=Flow.VOICE)
+        flows = Flow.objects.filter(org=user.get_org(), is_active=True, is_archived=False, flow_type=Flow.VOICE)
         super(InboundCallTriggerForm, self).__init__(user, flows, *args, **kwargs)
 
     def get_existing_triggers(self, cleaned_data):
@@ -250,7 +250,7 @@ class FollowTriggerForm(BaseTriggerForm):
     channel = forms.ModelChoiceField(Channel.objects.filter(pk__lt=0), label=_("Channel"), required=True)
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.objects.filter(is_archived=False, org=user.get_org(), flow_type__in=[Flow.FLOW, Flow.VOICE])
+        flows = Flow.objects.filter(org=user.get_org(), is_active=True, is_archived=False, flow_type__in=[Flow.FLOW, Flow.VOICE])
         super(FollowTriggerForm, self).__init__(user, flows, *args, **kwargs)
 
         self.fields['channel'].queryset = Channel.objects.filter(is_active=True, org=self.user.get_org(),

--- a/temba/values/models.py
+++ b/temba/values/models.py
@@ -49,7 +49,7 @@ class Value(models.Model):
     ruleset = models.ForeignKey('flows.RuleSet', null=True, on_delete=models.SET_NULL,
                                 help_text="The RuleSet this value is for, if any")
 
-    run = models.ForeignKey('flows.FlowRun', null=True, on_delete=models.SET_NULL, related_name='values',
+    run = models.ForeignKey('flows.FlowRun', null=True, related_name='values', on_delete=models.SET_NULL,
                             help_text="The FlowRun this value is for, if any")
 
     rule_uuid = models.CharField(max_length=255, null=True, db_index=True,

--- a/templates/flows/ruleset_analytics.haml
+++ b/templates/flows/ruleset_analytics.haml
@@ -78,9 +78,9 @@
             -trans "Most Active"
           .flow{ng-repeat:'flow in flows | orderBy:"-stats.contacts" | limitTo:4 '}
             .message-count{ ng-click: 'addFlowFields(flow)' }
-              [[flow.stats.contacts]]
+              [[flow.stats.runs]]
               .message-label
-                <ng-pluralize count="flow.stats.contacts" when="{'0': '{% trans "contacts" %}', 'one': '{% trans "contact" %}', 'other': '{% trans "contacts" %}' }">
+                <ng-pluralize count="flow.stats.runs" when="{'0': '{% trans "runs" %}', 'one': '{% trans "run" %}', 'other': '{% trans "runs" %}' }">
                 </ng-pluralize>
 
             .flow-name{ ng-click: 'addFlowFields(flow)' }
@@ -97,9 +97,9 @@
             -trans "Most Recent"
           .flow{ng-repeat:'flow in flows | orderBy:"-stats.created_on" | limitTo:4 ', data:'[[flow.id]]'}
             .message-count{ ng-click: 'addFlowFields(flow)' }
-              [[flow.stats.contacts]]
+              [[flow.stats.runs]]
               .message-label
-                <ng-pluralize count="flow.stats.contacts" when="{'0': '{% trans "contacts" %}', 'one': '{% trans "contact" %}', 'other': '{% trans "contacts" %}' }">
+                <ng-pluralize count="flow.stats.runs" when="{'0': '{% trans "runs" %}', 'one': '{% trans "run" %}', 'other': '{% trans "runs" %}' }">
                 </ng-pluralize>
 
             .flow-name{ ng-click: 'addFlowFields(flow)' }


### PR DESCRIPTION
We currently allow users to delete flows from the editor page. Right now this does a full delete, removing all flows, revisions, starts, etc.. due to cascading deletes. (ironically not Values even though they are rendered unreachable)

This tends to time out on flows with lots of runs as it is done in the web request.

This adds a new ```release()``` method to Flow, that does the following:
 * sets ```is_active``` to False

Then starts a celery task to:
 * remove all flow steps
 * remove all value objects
 * clears caches in redis
 * this does NOT clear out runs, because I think those are worth keeping around for auditing purposes.. it also keeps flow revisions and flow starts for the same reasons

