### PR TITLE
Fetch test contacts in separate query when filtering messages and runs on API v2 endpoints

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -430,7 +430,7 @@ class APITest(TembaTest):
         joe_msg3.refresh_from_db(fields=['modified_on'])
 
         # filter by inbox
-        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
+        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 7):
             response = self.fetchJSON(url, 'folder=INBOX')
 
         self.assertEqual(response.status_code, 200)
@@ -439,7 +439,7 @@ class APITest(TembaTest):
         self.assertMsgEqual(response.json['results'][0], frank_msg1, msg_type='inbox', msg_status='queued', msg_visibility='visible')
 
         # filter by incoming, should get deleted messages too
-        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
+        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 7):
             response = self.fetchJSON(url, 'folder=incoming')
 
         self.assertEqual(response.status_code, 200)
@@ -572,7 +572,7 @@ class APITest(TembaTest):
         frank_run1.refresh_from_db()
 
         # no filtering
-        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 5):
+        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
             response = self.fetchJSON(url)
 
         self.assertEqual(response.status_code, 200)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -663,8 +663,8 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
                 queryset = queryset.filter(pk=-1)
         else:
             # otherwise filter out test contact runs
-            test_contacts = list(Contact.objects.filter(org=org, is_test=True))
-            queryset = queryset.exclude(contact__in=test_contacts)
+            test_contact_ids = list(Contact.objects.filter(org=org, is_test=True).values_list('pk', flat=True))
+            queryset = queryset.exclude(contact__pk__in=test_contact_ids)
 
         # filter by label name/uuid (optional)
         label_ref = params.get('label')
@@ -863,8 +863,8 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
                 queryset = queryset.filter(pk=-1)
         else:
             # otherwise filter out test contact runs
-            test_contacts = list(Contact.objects.filter(org=org, is_test=True))
-            queryset = queryset.exclude(contact__in=test_contacts)
+            test_contact_ids = list(Contact.objects.filter(org=org, is_test=True).values_list('pk', flat=True))
+            queryset = queryset.exclude(contact__pk__in=test_contact_ids)
 
         # limit to responded runs (optional)
         if str_to_bool(params.get('responded')):

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -93,6 +93,7 @@ class MsgCursorPagination(pagination.CursorPagination):
         else:
             return ['-created_on']
 
+
 class BaseAPIView(generics.GenericAPIView):
     """
     Base class of all our API endpoints
@@ -662,7 +663,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
                 queryset = queryset.filter(pk=-1)
         else:
             # otherwise filter out test contact runs
-            test_contacts = Contact.objects.filter(org=org, is_test=True)
+            test_contacts = list(Contact.objects.filter(org=org, is_test=True))
             queryset = queryset.exclude(contact__in=test_contacts)
 
         # filter by label name/uuid (optional)
@@ -862,7 +863,7 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
                 queryset = queryset.filter(pk=-1)
         else:
             # otherwise filter out test contact runs
-            test_contacts = Contact.objects.filter(org=org, is_test=True)
+            test_contacts = list(Contact.objects.filter(org=org, is_test=True))
             queryset = queryset.exclude(contact__in=test_contacts)
 
         # limit to responded runs (optional)


### PR DESCRIPTION
Avoids slow queries... possibly from weird query planning on Postgres's part

The queryset for fetching a "page" of messages by a label is essentially...

```python
test_contacts = Contact.objects.filter(org=org, is_test=True)
Msg.all_messages.filter(org=org, labels=law).exclude(visibility='D').exclude(msg_type=None).exclude(contact__in=test_contacts).order_by('-created_on')[:251]
```

Which becomes...

```sql
SELECT "msgs_msg".* FROM "msgs_msg" 
INNER JOIN "msgs_msg_labels" ON ( "msgs_msg"."id" = "msgs_msg_labels"."msg_id" ) 
WHERE (
    "msgs_msg"."org_id" = 289 
    AND "msgs_msg_labels"."label_id" = 268 
    AND NOT ("msgs_msg"."visibility" = 'D') 
    AND NOT ("msgs_msg"."msg_type" IS NULL) 
    AND NOT ("msgs_msg"."contact_id" IN (SELECT U0."id" FROM "contacts_contact" U0 WHERE (U0."is_test" = True AND U0."org_id" = 289)))
) ORDER BY "msgs_msg"."created_on" DESC LIMIT 251;
```

But unfortunately sometimes that is really slow. The EXPLAIN as run on that label is...

```
Limit  (cost=584287.92..584287.93 rows=3 width=374)
  ->  Sort  (cost=584287.92..584287.93 rows=3 width=374)
        Sort Key: msgs_msg.created_on
        ->  Hash Join  (cost=575858.53..584287.90 rows=3 width=374)
              Hash Cond: (msgs_msg_labels.msg_id = msgs_msg.id)
              ->  Seq Scan on msgs_msg_labels  (cost=0.00..8362.89 rows=5907 width=4)
                    Filter: (label_id = 268)
              ->  Hash  (cost=574380.93..574380.93 rows=118208 width=374)
                    ->  Index Scan using msgs_msg_org_id on msgs_msg  (cost=142.11..574380.93 rows=118208 width=374)
                          Index Cond: (org_id = 289)
                          Filter: ((msg_type IS NOT NULL) AND ((visibility)::text <> 'D'::text) AND (NOT (hashed SubPlan 1)))
                          SubPlan 1
                            ->  Index Scan using org_test_contacts on contacts_contact u0  (cost=0.27..141.44 rows=41 width=4)
                                  Index Cond: (org_id = 289)
```

However we convert `test_contacts` to a list...

```python
test_contacts = list(Contact.objects.filter(org=org, is_test=True))
Msg.all_messages.filter(org=org, labels=law).exclude(visibility='D').exclude(msg_type=None).exclude(contact__in=test_contacts).order_by('-created_on')[:251]
```

Then it's evaluated separately...

```sql
SELECT "msgs_msg".* FROM "msgs_msg" 
INNER JOIN "msgs_msg_labels" ON ( "msgs_msg"."id" = "msgs_msg_labels"."msg_id" ) 
WHERE (
    "msgs_msg"."org_id" = 289 
    AND "msgs_msg_labels"."label_id" = 268 
    AND NOT ("msgs_msg"."visibility" = 'D') 
    AND NOT ("msgs_msg"."msg_type" IS NULL) 
    AND NOT ("msgs_msg"."contact_id" IN (1861837, 2377502, 3001871, 3097377, 3154264, 3145837, 3110880))
) ORDER BY "msgs_msg"."created_on" DESC LIMIT 251;
```

And query returns reasonably quickly for all labels with this EXPLAIN...

```
Limit  (cost=53621.54..53621.55 rows=6 width=374)
  ->  Sort  (cost=53621.54..53621.55 rows=6 width=374)
        Sort Key: msgs_msg.created_on
        ->  Nested Loop  (cost=134.77..53621.46 rows=6 width=374)
              ->  Bitmap Heap Scan on msgs_msg_labels  (cost=134.20..2772.04 rows=5907 width=4)
                    Recheck Cond: (label_id = 268)
                    ->  Bitmap Index Scan on msgs_msg_labels_label_id  (cost=0.00..132.73 rows=5907 width=0)
                          Index Cond: (label_id = 268)
              ->  Index Scan using msgs_msg_pkey on msgs_msg  (cost=0.57..8.60 rows=1 width=374)
                    Index Cond: (id = msgs_msg_labels.msg_id)
                    Filter: ((msg_type IS NOT NULL) AND ((visibility)::text <> 'D'::text) AND (org_id = 289) AND (contact_id <> ALL ('{1861837,2377502,3001871,3097377,3154264,3145837,3110880}'::integer[])))
```

(Tho not entirely sure why the first is sometimes slow as I don't entirely understand query plans)