### PR TITLE
Ignore failed DLRs from Vumi

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -918,20 +918,20 @@ class VumiHandler(View):
                 if sms:
                     delivery_status = body.get('delivery_status', 'success')
                     if delivery_status == 'failed':
-
+                        # Vumi and M-Tech disagree on what 'failed' means in a DLR, so for now, ignore these
+                        # cases.
+                        #
                         # we can get multiple reports from vumi if they multi-part the message for us
-                        if sms.status in (WIRED, DELIVERED):
-                            print "!! [%d] marking %s message as error" % (sms.pk, sms.get_status_display())
-                            Msg.mark_error(get_redis_connection(), channel, sms)
+                        #if sms.status in (WIRED, DELIVERED):
+                        #    print "!! [%d] marking %s message as error" % (sms.pk, sms.get_status_display())
+                        #    Msg.mark_error(get_redis_connection(), channel, sms)
+                        pass
                     else:
 
                         # we should only mark it as delivered if it's in a wired state, we want to hold on to our
                         # delivery failures if any part of the message comes back as failed
                         if sms.status == WIRED:
                             sms.status_delivered()
-
-            # disabled for performance reasons
-            # sms.first().broadcast.update()
 
             return HttpResponse("SMS Status Updated")
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -3603,22 +3603,22 @@ class VumiTest(TembaTest):
 
         callback_url = reverse('handlers.vumi_handler', args=['event', self.channel.uuid])
 
-        response = self.client.post(callback_url, json.dumps(data), content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        #response = self.client.post(callback_url, json.dumps(data), content_type="application/json")
+        #self.assertEquals(200, response.status_code)
 
         # check that we've become errored
-        sms = Msg.all_messages.get(pk=sms.pk)
-        self.assertEquals(ERRORED, sms.status)
+        #sms = Msg.all_messages.get(pk=sms.pk)
+        #self.assertEquals(ERRORED, sms.status)
 
         # couple more failures should move to failure
-        Msg.all_messages.filter(pk=sms.pk).update(status=WIRED)
-        self.client.post(callback_url, json.dumps(data), content_type="application/json")
+        #Msg.all_messages.filter(pk=sms.pk).update(status=WIRED)
+        #self.client.post(callback_url, json.dumps(data), content_type="application/json")
 
-        Msg.all_messages.filter(pk=sms.pk).update(status=WIRED)
-        self.client.post(callback_url, json.dumps(data), content_type="application/json")
+        #Msg.all_messages.filter(pk=sms.pk).update(status=WIRED)
+        #self.client.post(callback_url, json.dumps(data), content_type="application/json")
 
-        sms = Msg.all_messages.get(pk=sms.pk)
-        self.assertEquals(FAILED, sms.status)
+        #sms = Msg.all_messages.get(pk=sms.pk)
+        #self.assertEquals(FAILED, sms.status)
 
         # successful deliveries shouldn't stomp on failures
         del data['delivery_status']

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -3621,12 +3621,13 @@ class VumiTest(TembaTest):
         #self.assertEquals(FAILED, sms.status)
 
         # successful deliveries shouldn't stomp on failures
-        del data['delivery_status']
-        self.client.post(callback_url, json.dumps(data), content_type="application/json")
-        sms = Msg.all_messages.get(pk=sms.pk)
-        self.assertEquals(FAILED, sms.status)
+        #del data['delivery_status']
+        #self.client.post(callback_url, json.dumps(data), content_type="application/json")
+        #sms = Msg.all_messages.get(pk=sms.pk)
+        #self.assertEquals(FAILED, sms.status)
 
         # if we are wired we can now be successful again
+        data['delivery_status'] = 'delivered'
         Msg.all_messages.filter(pk=sms.pk).update(status=WIRED)
         self.client.post(callback_url, json.dumps(data), content_type="application/json")
         sms = Msg.all_messages.get(pk=sms.pk)
@@ -3677,9 +3678,11 @@ class VumiTest(TembaTest):
 
                 # get the message again
                 msg = bcast.get_messages()[0]
-                self.assertEquals(ERRORED, msg.status)
-                self.assertTrue(msg.next_attempt)
-                self.assertFalse(r.sismember(timezone.now().strftime(MSG_SENT_KEY), str(msg.id)))
+                self.assertEquals(WIRED, msg.status)
+                #self.assertTrue(msg.next_attempt)
+                #self.assertFalse(r.sismember(timezone.now().strftime(MSG_SENT_KEY), str(msg.id)))
+
+                self.clear_cache()
 
             with patch('requests.put') as mock:
                 mock.return_value = MockResponse(500, "Error")


### PR DESCRIPTION
Apparently M-Tech sends these when DLR requests expire, not just when messages fail. Vumi wants us to ignore these until they sort their shit out.