### PR TITLE
Allow admins to import into anonymous orgs

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -687,7 +687,7 @@ class Contact(TembaModel):
 
         org = field_dict.pop('org')
         user = field_dict.pop('created_by')
-        is_admin = org.administrators.filter(id=user.id).first()
+        is_admin = org.administrators.filter(id=user.id).exists()
         uuid = field_dict.pop('uuid', None)
 
         country = org.get_country_code()


### PR DESCRIPTION
It was decided that administrators on organizations should be allowed to import contacts, even if those URNs already exist in the db.