### PR TITLE
Allow CS reps to view channel logs

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -14,7 +14,7 @@ import uuid
 
 from datetime import timedelta, date
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.core import mail
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -2866,6 +2866,11 @@ class ExternalTest(TembaTest):
 
         response = self.client.get(reverse('channels.channellog_read', args=[log_item.pk]))
         self.assertEquals(302, response.status_code)
+
+        # change our admin to be a CS rep, see if they can see the page
+        self.admin.groups.add(Group.objects.get(name='Customer Support'))
+        response = self.client.get(reverse('channels.channellog_read', args=[log_item.pk]))
+        self.assertEquals(response.context['object'].description, 'Successfully delivered')
 
 
 class VerboiceTest(TembaTest):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -530,6 +530,12 @@ class ChannelCRUDL(SmartCRUDL):
         """
         def has_permission(self, request, *args, **kwargs):
             org = self.derive_org()
+
+            # can this user break anonymity? then we are fine
+            if self.get_user().has_perm('contacts.contact_break_anon'):
+                return True
+
+            # otherwise if this org is anon, no go
             if not org or org.is_anon:
                 return False
             else:

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -324,6 +324,7 @@ PERMISSIONS = {
     'contacts.contact': ('api',
                          'block',
                          'blocked',
+                         'break_anon',
                          'customize',
                          'export',
                          'failed',
@@ -503,6 +504,7 @@ GROUP_PERMISSIONS = {
     "Customer Support": (
         'auth.user_list',
         'auth.user_update',
+        'contacts.contact_break_anon',
         'flows.flow_editor',
         'flows.flow_json',
         'flows.flow_read',

--- a/templates/contacts/contact_history.haml
+++ b/templates/contacts/contact_history.haml
@@ -15,12 +15,15 @@
             .icon-nav-channels-inverted
       -else
         %span.det{title:'{{item.channel.get_channel_type_name}} {{item.channel.get_name}}'}
-          -with item.channellog_set.all.first as log
-            -if log
-              %a{href:"{% url 'channels.channellog_read' log.pk%}"}
+          -if not user_org.is_anon or perms.contacts.contact_break_anon
+            -with item.channellog_set.all.first as log
+              -if log
+                %a{href:"{% url 'channels.channellog_read' log.pk%}"}
+                  {{item|activity_icon}}
+              -else
                 {{item|activity_icon}}
-            -else
-              {{item|activity_icon}}
+          -else
+            {{item|activity_icon}}
 
     %td.details
       -if item.recipient_count


### PR DESCRIPTION
Allows CS users to view channel logs on anon orgs to help with debugging.