### PR TITLE
Quick fixes on the flow editor

### DIFF
--- a/static/coffee/flows/app.coffee
+++ b/static/coffee/flows/app.coffee
@@ -15,6 +15,7 @@ app.config [ '$httpProvider', '$sceDelegateProvider', ($httpProvider, $sceDelega
     'http://*.s3.amazonaws.com/**',
     'https://*.s3.amazonaws.com/**',
     'http://textit.ngrok.com/**',
+    'https://textit.ngrok.com/**',
   ])
 ]
 

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -1210,9 +1210,10 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
         Flow.flow.action_sets.push(actionset)
 
       if Flow.flow.action_sets.length == 1
-        $timeout ->
-          DragHelper.showSaveResponse($('#' + Flow.flow.action_sets[0].uuid + ' .source'))
-        ,0
+        if not Flow.flow.action_sets[0].destination
+          $timeout ->
+            DragHelper.showSaveResponse($('#' + Flow.flow.action_sets[0].uuid + ' .source'))
+          ,0
 
       @checkTerminal(actionset)
       @markDirty()

--- a/static/less/style.less
+++ b/static/less/style.less
@@ -2597,3 +2597,7 @@ span.label a {
   bottom: 60px;
   right: 12px;
 }
+
+.select2-hidden-accessible {
+  display:none;
+}

--- a/temba/flows/flow_migrations.py
+++ b/temba/flows/flow_migrations.py
@@ -114,7 +114,8 @@ def migrate_to_version_6(json_flow):
                 if action['type'] in [SendAction.TYPE, ReplyAction.TYPE, SayAction.TYPE]:
                     convert_to_dict(action, 'msg')
                 if action['type'] == SayAction.TYPE:
-                    convert_to_dict(action, 'recording')
+                    if 'recording' in action:
+                        convert_to_dict(action, 'recording')
     return json_flow
 
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4330,6 +4330,15 @@ class FlowMigrationTest(FlowFileTest):
         self.assertEquals('Press one, two, or three. Thanks.', definition['action_sets'][0]['actions'][0]['msg']['base'])
         self.assertEquals('/recording.mp3', definition['action_sets'][0]['actions'][0]['recording']['base'])
 
+        # now try one that doesn't have a recording set
+        voice_json = self.get_flow_json('call-me-maybe')
+        definition = voice_json.get('definition')
+        del definition['action_sets'][0]['actions'][0]['recording']
+        voice_json = migrate_to_version_5(voice_json)
+        voice_json = migrate_to_version_6(voice_json)
+        definition = voice_json.get('definition')
+        self.assertTrue('recording' not in definition['action_sets'][0]['actions'][0])
+
     def test_migrate_to_5_language(self):
 
         flow_json = self.get_flow_json('multi-language-flow')

--- a/templates/partials/action_editor.haml
+++ b/templates/partials/action_editor.haml
@@ -99,8 +99,7 @@
     %div{ng-if:'config.type == "flow"'}
       %p{class:"description"}
         -blocktrans
-          This action redirects contacts to a new flow. When they
-          are done with that flow they can continue the current one.
+          This action redirects contacts to a new flow. When they start a new flow, they will exit this one.
       %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[action.id]]",select-server:"/flow/?_format=select2",type:"hidden"}
       %button{ng-click:"saveStartFlow(action_editor.flow.selected)",class:"submit hide"}
         -trans "Ok"

--- a/templates/partials/action_editor.haml
+++ b/templates/partials/action_editor.haml
@@ -99,7 +99,7 @@
     %div{ng-if:'config.type == "flow"'}
       %p{class:"description"}
         -blocktrans
-          This action redirects contacts to a new flow. When they start a new flow, they will exit this one.
+          This action redirects contacts to a new flow. When they start that flow, they will exit this one.
       %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[action.id]]",select-server:"/flow/?_format=select2",type:"hidden"}
       %button{ng-click:"saveStartFlow(action_editor.flow.selected)",class:"submit hide"}
         -trans "Ok"


### PR DESCRIPTION
Three quick fixes, not really testable..

 * Remove select2 turd when toggling options in flow editor
 * Don't say people will return to this flow for start flow action
 * Don't show the drag helper if the node is already connected

Also a fix for a sentry error on flow migrations:
https://app.getsentry.com/nyaruka/textit/issues/119742419/