### PR TITLE
Voice flow redirects

### DIFF
--- a/media/test_flows/ivr_call_redirect.json
+++ b/media/test_flows/ivr_call_redirect.json
@@ -1,0 +1,77 @@
+{
+  "campaigns": [], 
+  "version": 8, 
+  "site": "https://textit.in", 
+  "flows": [
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 101, 
+          "destination": null, 
+          "uuid": "7fe3d65c-a924-4b96-8dd7-28526316359c", 
+          "actions": [
+            {
+              "recording": null, 
+              "msg": {
+                "eng": "Hi, this is call number 1."
+              }, 
+              "type": "say", 
+              "uuid": "4f035850-5afa-410a-8e35-298f4cdf9cb2"
+            }, 
+            {
+              "type": "flow", 
+              "name": "Call Number 2", 
+              "id": 35634
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "V", 
+      "entry": "7fe3d65c-a924-4b96-8dd7-28526316359c", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 9, 
+        "id": 35632, 
+        "name": "Call Number 1", 
+        "saved_on": "2016-03-31T17:20:29.452224Z"
+      }
+    }, 
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 100, 
+          "destination": null, 
+          "uuid": "5dcc27f0-e227-4a14-98dc-7b7c4b3037ba", 
+          "actions": [
+            {
+              "recording": null, 
+              "msg": {
+                "eng": "Congratulations, this is call number two. You did it."
+              }, 
+              "type": "say", 
+              "uuid": "aa9a25a0-620d-4b66-8bbf-edc4e0fc99cd"
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "V", 
+      "entry": "5dcc27f0-e227-4a14-98dc-7b7c4b3037ba", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 3, 
+        "id": 35634, 
+        "name": "Call Number 2", 
+        "saved_on": "2016-03-31T17:20:37.222560Z"
+      }
+    }
+  ], 
+  "triggers": []
+}

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4537,7 +4537,7 @@ class StartFlowAction(Action):
 
         if self.flow.flow_type == Flow.VOICE:
             new_run = self.flow.start([], [run.contact], started_flows=started_flows,
-                                   restart_participants=True, extra=extra, parent_run=run)[0]
+                                      restart_participants=True, extra=extra, parent_run=run)[0]
             url = "https://%s%s" % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[new_run.call.pk]))
             run.voice_response.redirect(url)
         else:

--- a/temba/ivr/migrations/0004_auto_20150129_1727.py
+++ b/temba/ivr/migrations/0004_auto_20150129_1727.py
@@ -7,18 +7,20 @@ from temba.ivr.models import ContactURN
 
 def populate_unknown_urns(apps, schema_editor):
 
-        # fix any Calls that remain with no contact URN (because their contact doesn't have one)
-        for call in IVRCall.objects.filter(contact_urn=None):
-            # find or create an unknown contact URN for this org
-            unknown = ContactURN.objects.filter(urn='tel:unknown', org=call.org).first()
-            if not unknown:
-                unknown = ContactURN.objects.create(org=call.org,
-                                                    scheme='tel',
-                                                    path='unknown',
-                                                    urn='tel:unknown',
-                                                    priority=50)
-            call.contact_urn = unknown
-            call.save()
+    IVRCall = apps.get_model('ivr', 'IVRCall')
+
+    # fix any Calls that remain with no contact URN (because their contact doesn't have one)
+    for call in IVRCall.objects.filter(contact_urn=None):
+        # find or create an unknown contact URN for this org
+        unknown = ContactURN.objects.filter(urn='tel:unknown', org=call.org).first()
+        if not unknown:
+            unknown = ContactURN.objects.create(org=call.org,
+                                                scheme='tel',
+                                                path='unknown',
+                                                urn='tel:unknown',
+                                                priority=50)
+        call.contact_urn = unknown
+        call.save()
 
 class Migration(migrations.Migration):
 

--- a/temba/ivr/migrations/0008_ivrcall_parent.py
+++ b/temba/ivr/migrations/0008_ivrcall_parent.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ivr', '0007_auto_20150203_0743'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ivrcall',
+            name='parent',
+            field=models.ForeignKey(verbose_name='Parent Call', to='ivr.IVRCall', help_text='The call that triggered this one', null=True),
+        ),
+    ]

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -50,6 +50,7 @@ class IVRCall(SmartModel):
                                    help_text="The external id for this call, our twilio id usually")
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=PENDING,
                               help_text="The status of this call")
+
     channel = models.ForeignKey(Channel,
                                 help_text="The channel that made this call")
     contact = models.ForeignKey(Contact,
@@ -72,6 +73,9 @@ class IVRCall(SmartModel):
                                  help_text="What sort of call is this")
     duration = models.IntegerField(default=0, null=True,
                                    help_text="The length of this call in seconds")
+
+    parent = models.ForeignKey('IVRCall', verbose_name=_("Parent Call"), related_name='child_calls', null=True,
+                               help_text=_("The call that triggered this one"))
 
     @classmethod
     def create_outgoing(cls, channel, contact_id, flow, user, call_type=FLOW):

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -198,8 +198,6 @@ class IVRTests(FlowFileTest):
         self.assertEquals(COMPLETED, first_call.status)
         self.assertEquals(COMPLETED, second_call.status)
 
-
-
     @patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -160,6 +160,49 @@ class IVRTests(FlowFileTest):
     @patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
+    def test_ivr_call_redirect(self):
+        self.org.connect_twilio("TEST_SID", "TEST_TOKEN")
+        self.org.save()
+
+        # import our flows
+        self.get_flow('ivr_call_redirect')
+
+        flow_1 = Flow.objects.get(name="Call Number 1")
+        flow_2 = Flow.objects.get(name="Call Number 2")
+
+        shawn = self.create_contact('Marshawn', '+24')
+        flow_1.start(groups=[], contacts=[shawn])
+
+        # we should have one call now
+        calls = IVRCall.objects.filter(direction=OUTGOING)
+        self.assertEqual(1, calls.count())
+
+        # once the first set of actions are processed, we'll initiate a second call
+        post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
+        self.client.post(reverse('ivr.ivrcall_handle', args=[calls[0].pk]), post_data)
+
+        calls = IVRCall.objects.filter(direction=OUTGOING).order_by('created_on')
+        self.assertEqual(2, calls.count())
+        (first_call, second_call) = calls
+
+        # our second call should have the first call as a parent
+        self.assertEqual(first_call, second_call.parent)
+
+        # completing the first call should complete the second one too
+        post_data = dict(CallSid='CallSid', CallStatus='completed', CallDuration=30)
+        self.client.post(reverse('ivr.ivrcall_handle', args=[first_call.pk]), post_data)
+
+        first_call.refresh_from_db()
+        second_call.refresh_from_db()
+
+        self.assertEquals(COMPLETED, first_call.status)
+        self.assertEquals(COMPLETED, second_call.status)
+
+
+
+    @patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
+    @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
+    @patch('twilio.util.RequestValidator', MockRequestValidator)
     def test_non_blocking_rule_ivr(self):
 
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN")

--- a/temba/ivr/views.py
+++ b/temba/ivr/views.py
@@ -43,8 +43,15 @@ class CallHandler(View):
                     return HttpResponse("Not found", status=404)
 
         if client.validate(request):
-            call.update_status(request.POST.get('CallStatus', None),
-                               request.POST.get('CallDuration', None))
+            status = request.POST.get('CallStatus', None)
+            duration = request.POST.get('CallDuration', None)
+            call.update_status(status, duration)
+
+            # update any calls we have spawned with the same
+            for child in call.child_calls.all():
+                child.update_status(status, duration)
+                child.save()
+
             call.save()
 
             hangup = 'hangup' == request.POST.get('Digits', None)


### PR DESCRIPTION
Update so that using the StartFlowAction in a voice flow will use the Twilio redirect verb to route to the new flow without forcing a hangup.