### PR TITLE
Fix text flow triggering ivr

### DIFF
--- a/media/test_flows/text_trigger_ivr.json
+++ b/media/test_flows/text_trigger_ivr.json
@@ -1,0 +1,75 @@
+{
+  "campaigns": [], 
+  "version": 8, 
+  "site": "https://textit.in", 
+  "flows": [
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 100, 
+          "destination": null, 
+          "uuid": "5dcc27f0-e227-4a14-98dc-7b7c4b3037ba", 
+          "actions": [
+            {
+              "recording": null, 
+              "msg": {
+                "eng": "Congratulations, this is call. You did it."
+              }, 
+              "type": "say", 
+              "uuid": "502f88fb-b851-4c90-991a-8f41f327fcd2"
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "V", 
+      "entry": "5dcc27f0-e227-4a14-98dc-7b7c4b3037ba", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 4, 
+        "id": 35634, 
+        "name": "IVR Flow - Child", 
+        "saved_on": "2016-04-01T16:50:53.669478Z"
+      }
+    }, 
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 7, 
+          "x": 105, 
+          "destination": null, 
+          "uuid": "88727c72-2b4a-4f18-b5a3-61caeaab9d9d", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "We are about to call you."
+              }, 
+              "type": "reply"
+            }, 
+            {
+              "type": "flow", 
+              "name": "IVR Flow - Child", 
+              "id": 35634
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "F", 
+      "entry": "88727c72-2b4a-4f18-b5a3-61caeaab9d9d", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "saved_on": "2016-04-01T16:50:43.848391Z", 
+        "id": 35631, 
+        "name": "Message Flow - Parent", 
+        "revision": 45
+      }
+    }
+  ], 
+  "triggers": []
+}

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4535,13 +4535,15 @@ class StartFlowAction(Action):
         extra = message_context.get('extra', {})
         extra['flow'] = message_context.get('flow', {})
 
-        if self.flow.flow_type == Flow.VOICE:
+        # if they are both flow runs, just redirect the call
+        if run.flow.flow_type == Flow.VOICE and self.flow.flow_type == Flow.VOICE:
             new_run = self.flow.start([], [run.contact], started_flows=started_flows,
                                       restart_participants=True, extra=extra, parent_run=run)[0]
             url = "https://%s%s" % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[new_run.call.pk]))
             run.voice_response.redirect(url)
         else:
-            self.flow.start([], [run.contact], started_flows=started_flows, restart_participants=True, extra=extra)
+            self.flow.start([], [run.contact], started_flows=started_flows, restart_participants=True,
+                            extra=extra, parent_run=run)
 
         self.logger(run)
         return []


### PR DESCRIPTION
Fix for text flows triggering ivr flows that was introduced yesterday. Only redirect if both the parent and the child flows are voice flows in  ```StartFlowAction```.