### PR TITLE
Flow export improvements

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -297,7 +297,7 @@ class Contact(TembaModel):
             return getattr(self, cache_attr)
 
         value = Value.objects.filter(contact=self, contact_field__key__exact=key).first()
-        setattr(self, cache_attr, value)
+        self.set_cached_field_value(key, value)
         return value
 
     def get_field_raw(self, key):
@@ -414,7 +414,7 @@ class Contact(TembaModel):
                                                 location_value=loc_value, category=category)
 
         # cache
-        setattr(self, '__field__%s' % key, existing)
+        self.set_cached_field_value(key, existing)
 
         self.modified_by = user
         self.modified_on = timezone.now()
@@ -425,6 +425,9 @@ class Contact(TembaModel):
 
         # invalidate our value cache for this contact field
         Value.invalidate_cache(contact_field=field)
+
+    def set_cached_field_value(self, key, value):
+        setattr(self, '__field__%s' % key, value)
 
     def handle_update(self, attrs=(), urns=(), field=None, group=None):
         """
@@ -1442,8 +1445,8 @@ class ContactURN(models.Model):
         elif scheme == EXTERNAL_SCHEME:
             return True
 
-        # telegram uses integer ids
-        elif scheme == TELEGRAM_SCHEME:
+        # telegram and facebook uses integer ids
+        elif scheme in [TELEGRAM_SCHEME, FACEBOOK_SCHEME]:
             try:
                 int(path)
                 return True
@@ -1469,6 +1472,8 @@ class ContactURN(models.Model):
                 norm_path = norm_path[1:]
             norm_path = norm_path.lower()  # Twitter handles are case-insensitive, so we always store as lowercase
         elif norm_scheme == EMAIL_SCHEME:
+            norm_path = norm_path.lower()
+        elif norm_scheme == FACEBOOK_SCHEME:
             norm_path = norm_path.lower()
 
         return norm_scheme, norm_path

--- a/temba/flows/migrations/0052_auto_20160405_1401.py
+++ b/temba/flows/migrations/0052_auto_20160405_1401.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0051_auto_20160203_2203'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='exportflowresultstask',
+            name='config',
+            field=models.TextField(help_text='Any configuration options for this flow export', null=True),
+        ),
+    ]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3083,6 +3083,9 @@ class ExportFlowResultsTask(SmartModel):
     uuid = models.CharField(max_length=36, null=True,
                             help_text=_("The uuid used to name the resulting export file"))
 
+    config = models.TextField(null=True,
+                              help_text=_("Any configuration options for this flow export"))
+
     def start_export(self):
         """
         Starts our export, wrapping it in a try block to make sure we mark it as finished when complete.

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3070,6 +3070,11 @@ class ExportFlowResultsTask(SmartModel):
     """
     Container for managing our export requests
     """
+    INCLUDE_RUNS = 'include_runs'
+    INCLUDE_MSGS = 'include_msgs'
+    CONTACT_FIELDS = 'contact_fields'
+    RESPONDED_ONLY = 'responded_only'
+
     org = models.ForeignKey(Org, related_name='flow_results_exports', help_text=_("The Organization of the user."))
 
     flows = models.ManyToManyField(Flow, related_name='exports', help_text=_("The flows to export"))
@@ -3085,6 +3090,20 @@ class ExportFlowResultsTask(SmartModel):
 
     config = models.TextField(null=True,
                               help_text=_("Any configuration options for this flow export"))
+
+    @classmethod
+    def create(cls, host, org, user, flows, contact_fields, responded_only, include_runs, include_msgs):
+        config = {ExportFlowResultsTask.INCLUDE_RUNS: include_runs,
+                  ExportFlowResultsTask.INCLUDE_MSGS: include_msgs,
+                  ExportFlowResultsTask.CONTACT_FIELDS: [c.id for c in contact_fields],
+                  ExportFlowResultsTask.RESPONDED_ONLY: responded_only}
+
+        export = ExportFlowResultsTask.objects.create(org=org, created_by=user, modified_by=user, host=host,
+                                                      config=json.dumps(config))
+        for flow in flows:
+            export.flows.add(flow)
+
+        return export
 
     def start_export(self):
         """
@@ -3104,6 +3123,18 @@ class ExportFlowResultsTask(SmartModel):
         from xlwt import Workbook
         book = Workbook()
         max_rows = 65535
+
+        config = json.loads(self.config) if self.config else dict()
+        include_runs = config.get(ExportFlowResultsTask.INCLUDE_RUNS, False)
+        include_msgs = config.get(ExportFlowResultsTask.INCLUDE_MSGS, False)
+        responded_only = config.get(ExportFlowResultsTask.RESPONDED_ONLY, True)
+        contact_field_ids = config.get(ExportFlowResultsTask.CONTACT_FIELDS, [])
+
+        contact_fields = []
+        for cf_id in contact_field_ids:
+            cf = ContactField.objects.filter(id=cf_id, org=self.org, is_active=True).first()
+            if cf:
+                contact_fields.append(cf)
 
         date_format = xlwt.easyxf(num_format_str='MM/DD/YYYY HH:MM:SS')
         small_width = 15 * 256
@@ -3136,7 +3167,7 @@ class ExportFlowResultsTask(SmartModel):
         # create a mapping of column id to index
         column_map = dict()
         for col in range(len(columns)):
-            column_map[columns[col].uuid] = 6 + col * 3
+            column_map[columns[col].uuid] = 6 + len(contact_fields) + col * 3
 
         # build a cache of rule uuid to category name, we want to use the most recent name the user set
         # if possible and back down to the cached rule_category only when necessary
@@ -3163,6 +3194,10 @@ class ExportFlowResultsTask(SmartModel):
             all_steps = FlowStep.objects.filter(run__flow__in=flows)\
                                         .order_by('contact', 'run', 'arrived_on', 'pk')\
                                         .values('id')
+
+            if responded_only:
+                all_steps = all_steps.filter(run__responded=True)
+
             step_ids = [s['id'] for s in all_steps]
 
         # build our sheets
@@ -3170,11 +3205,12 @@ class ExportFlowResultsTask(SmartModel):
         total_run_sheet_count = 0
 
         # the full sheets we need for runs
-        for i in range(all_runs_count / max_rows + 1):
-            total_run_sheet_count += 1
-            name = "Runs" if (i + 1) <= 1 else "Runs (%d)" % (i + 1)
-            sheet = book.add_sheet(name, cell_overwrite_ok=True)
-            run_sheets.append(sheet)
+        if include_runs:
+            for i in range(all_runs_count / max_rows + 1):
+                total_run_sheet_count += 1
+                name = "Runs" if (i + 1) <= 1 else "Runs (%d)" % (i + 1)
+                sheet = book.add_sheet(name, cell_overwrite_ok=True)
+                run_sheets.append(sheet)
 
         total_merged_run_sheet_count = 0
 
@@ -3186,7 +3222,7 @@ class ExportFlowResultsTask(SmartModel):
             run_sheets.append(sheet)
 
         # then populate their header columns
-        for sheet in run_sheets:
+        for (sheet_num, sheet) in enumerate(run_sheets):
             # build up our header row
 
             index = 0
@@ -3199,7 +3235,7 @@ class ExportFlowResultsTask(SmartModel):
             sheet.col(index).width = medium_width
             index += 1
 
-            sheet.write(0, index, "Phone")
+            sheet.write(0, index, "URN")
             sheet.col(index).width = small_width
             index += 1
 
@@ -3210,6 +3246,12 @@ class ExportFlowResultsTask(SmartModel):
             sheet.write(0, index, "Groups")
             sheet.col(index).width = medium_width
             index += 1
+
+            # add our contact fields
+            for cf in contact_fields:
+                sheet.write(0, index, cf.label)
+                sheet.col(index).width = medium_width
+                index += 1
 
             sheet.write(0, index, "First Seen")
             sheet.col(index).width = medium_width
@@ -3273,7 +3315,8 @@ class ExportFlowResultsTask(SmartModel):
                                       select_related=['run', 'contact'],
                                       prefetch_related=['messages__contact_urn',
                                                         'messages__channel',
-                                                        'contact__all_groups']):
+                                                        'contact__all_groups'],
+                                      contact_fields=contact_fields):
 
             processed_steps += 1
             if processed_steps % 10000 == 0:
@@ -3311,16 +3354,17 @@ class ExportFlowResultsTask(SmartModel):
                     earliest = run_step.arrived_on
                     latest = None
 
-                    if run_row % 1000 == 0:
-                        runs.flush_row_data()
+                    if include_runs:
+                        if run_row % 1000 == 0:
+                            runs.flush_row_data()
 
-                    run_row += 1
+                        run_row += 1
 
-                    if run_row > max_rows:
-                        # get the next sheet to use for Runs
-                        run_row = 1
-                        run_sheet_index += 1
-                        runs = book.get_sheet(run_sheet_index)
+                        if run_row > max_rows:
+                            # get the next sheet to use for Runs
+                            run_row = 1
+                            run_sheet_index += 1
+                            runs = book.get_sheet(run_sheet_index)
 
                     # build up our group names
                     group_names = []
@@ -3334,23 +3378,41 @@ class ExportFlowResultsTask(SmartModel):
                     padding = 0
                     if show_submitted_by:
                         submitted_by = ''
+
                         # use the login as the submission user
                         if run_step.run.submitted_by:
                             submitted_by = run_step.run.submitted_by.username
 
-                        runs.write(run_row, 0, submitted_by)
+                        if include_runs:
+                            runs.write(run_row, 0, submitted_by)
                         merged_runs.write(merged_row, 0, submitted_by)
                         padding = 1
 
-                    runs.write(run_row, padding + 0, contact_uuid)
-                    runs.write(run_row, padding + 1, contact_urn_display)
-                    runs.write(run_row, padding + 2, run_step.contact.name)
-                    runs.write(run_row, padding + 3, groups)
+                    if include_runs:
+                        runs.write(run_row, padding + 0, contact_uuid)
+                        runs.write(run_row, padding + 1, contact_urn_display)
+                        runs.write(run_row, padding + 2, run_step.contact.name)
+                        runs.write(run_row, padding + 3, groups)
 
                     merged_runs.write(merged_row, padding + 0, contact_uuid)
                     merged_runs.write(merged_row, padding + 1, contact_urn_display)
                     merged_runs.write(merged_row, padding + 2, run_step.contact.name)
                     merged_runs.write(merged_row, padding + 3, groups)
+
+                    cf_padding = 0
+
+                    # write our contact fields if any
+                    for cf in contact_fields:
+                        field_value = Contact.get_field_display_for_value(cf, run_step.contact.get_field(cf.key.lower()))
+                        if field_value is None:
+                            field_value = ''
+
+                        field_value = unicode(field_value)
+
+                        merged_runs.write(merged_row, padding + 4 + cf_padding, field_value)
+                        runs.write(run_row, padding + 4 + cf_padding, field_value)
+
+                        cf_padding += 1
 
                 if not latest or latest < run_step.arrived_on:
                     latest = run_step.arrived_on
@@ -3358,79 +3420,84 @@ class ExportFlowResultsTask(SmartModel):
                 if not merged_latest or merged_latest < run_step.arrived_on:
                     merged_latest = run_step.arrived_on
 
-                runs.write(run_row, padding + 4, as_org_tz(earliest), date_format)
-                runs.write(run_row, padding + 5, as_org_tz(latest), date_format)
+                if include_runs:
+                    runs.write(run_row, padding + 4 + cf_padding, as_org_tz(earliest), date_format)
+                    runs.write(run_row, padding + 5 + cf_padding, as_org_tz(latest), date_format)
 
-                merged_runs.write(merged_row, padding + 4, as_org_tz(merged_earliest), date_format)
-                merged_runs.write(merged_row, padding + 5, as_org_tz(merged_latest), date_format)
+                merged_runs.write(merged_row, padding + 4 + cf_padding, as_org_tz(merged_earliest), date_format)
+                merged_runs.write(merged_row, padding + 5 + cf_padding, as_org_tz(merged_latest), date_format)
 
                 # write the step data
                 col = column_map.get(run_step.step_uuid, 0) + padding
                 if col:
                     category = category_map.get(run_step.rule_uuid, None)
                     if category:
-                        runs.write(run_row, col, category)
+                        if include_runs:
+                            runs.write(run_row, col, category)
                         merged_runs.write(merged_row, col, category)
                     elif run_step.rule_category:
-                        runs.write(run_row, col, run_step.rule_category)
+                        if include_runs: runs.write(run_row, col, run_step.rule_category)
                         merged_runs.write(merged_row, col, run_step.rule_category)
 
                     value = run_step.rule_value
                     if value:
-                        runs.write(run_row, col + 1, value)
+                        if include_runs:
+                            runs.write(run_row, col + 1, value)
                         merged_runs.write(merged_row, col + 1, value)
 
                     text = run_step.get_text()
                     if text:
-                        runs.write(run_row, col + 2, text)
+                        if include_runs:
+                            runs.write(run_row, col + 2, text)
                         merged_runs.write(merged_row, col + 2, text)
 
                 last_run = run_step.run.pk
                 last_contact = run_step.contact.pk
 
             # write out any message associated with this step
-            step_msgs = list(run_step.messages.all())
+            if include_msgs:
+                step_msgs = list(run_step.messages.all())
 
-            if step_msgs:
-                msg = step_msgs[0]
-                msg_row += 1
+                if step_msgs:
+                    msg = step_msgs[0]
+                    msg_row += 1
 
-                if msg_row % 1000 == 0:
-                    msgs.flush_row_data()
+                    if msg_row % 1000 == 0:
+                        msgs.flush_row_data()
 
-                if msg_row > max_rows or not msgs:
-                    msg_row = 1
-                    msg_sheet_index += 1
+                    if msg_row > max_rows or not msgs:
+                        msg_row = 1
+                        msg_sheet_index += 1
 
-                    name = "Messages" if (msg_sheet_index + 1) <= 1 else "Messages (%d)" % (msg_sheet_index + 1)
-                    msgs = book.add_sheet(name)
+                        name = "Messages" if (msg_sheet_index + 1) <= 1 else "Messages (%d)" % (msg_sheet_index + 1)
+                        msgs = book.add_sheet(name)
 
-                    msgs.write(0, 0, "Contact UUID")
-                    msgs.write(0, 1, "Phone")
-                    msgs.write(0, 2, "Name")
-                    msgs.write(0, 3, "Date")
-                    msgs.write(0, 4, "Direction")
-                    msgs.write(0, 5, "Message")
-                    msgs.write(0, 6, "Channel")
+                        msgs.write(0, 0, "Contact UUID")
+                        msgs.write(0, 1, "URN")
+                        msgs.write(0, 2, "Name")
+                        msgs.write(0, 3, "Date")
+                        msgs.write(0, 4, "Direction")
+                        msgs.write(0, 5, "Message")
+                        msgs.write(0, 6, "Channel")
 
-                    msgs.col(0).width = medium_width
-                    msgs.col(1).width = small_width
-                    msgs.col(2).width = medium_width
-                    msgs.col(3).width = medium_width
-                    msgs.col(4).width = small_width
-                    msgs.col(5).width = large_width
-                    msgs.col(6).width = small_width
+                        msgs.col(0).width = medium_width
+                        msgs.col(1).width = small_width
+                        msgs.col(2).width = medium_width
+                        msgs.col(3).width = medium_width
+                        msgs.col(4).width = small_width
+                        msgs.col(5).width = large_width
+                        msgs.col(6).width = small_width
 
-                msg_urn_display = msg.contact_urn.get_display(org=org, full=True) if msg.contact_urn else ''
-                channel_name = msg.channel.name if msg.channel else ''
+                    msg_urn_display = msg.contact_urn.get_display(org=org, full=True) if msg.contact_urn else ''
+                    channel_name = msg.channel.name if msg.channel else ''
 
-                msgs.write(msg_row, 0, run_step.contact.uuid)
-                msgs.write(msg_row, 1, msg_urn_display)
-                msgs.write(msg_row, 2, run_step.contact.name)
-                msgs.write(msg_row, 3, as_org_tz(msg.created_on), date_format)
-                msgs.write(msg_row, 4, "IN" if msg.direction == INCOMING else "OUT")
-                msgs.write(msg_row, 5, msg.text)
-                msgs.write(msg_row, 6, channel_name)
+                    msgs.write(msg_row, 0, run_step.contact.uuid)
+                    msgs.write(msg_row, 1, msg_urn_display)
+                    msgs.write(msg_row, 2, run_step.contact.name)
+                    msgs.write(msg_row, 3, as_org_tz(msg.created_on), date_format)
+                    msgs.write(msg_row, 4, "IN" if msg.direction == INCOMING else "OUT")
+                    msgs.write(msg_row, 5, msg.text)
+                    msgs.write(msg_row, 6, channel_name)
 
         temp = NamedTemporaryFile(delete=True)
         book.save(temp)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3410,7 +3410,8 @@ class ExportFlowResultsTask(SmartModel):
                         field_value = unicode(field_value)
 
                         merged_runs.write(merged_row, padding + 4 + cf_padding, field_value)
-                        runs.write(run_row, padding + 4 + cf_padding, field_value)
+                        if include_runs:
+                            runs.write(run_row, padding + 4 + cf_padding, field_value)
 
                         cf_padding += 1
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -494,6 +494,8 @@ class FlowTest(TembaTest):
         self.flow.update(self.definition)
         contact1_run1, contact2_run1, contact3_run1 = self.flow.start([], [self.contact, self.contact2, self.contact3])
 
+        time.sleep(1)
+
         # simulate two runs each for two contacts...
         contact1_in1 = self.create_msg(direction=INCOMING, contact=self.contact, text="light beige")
         Flow.find_and_handle(contact1_in1)
@@ -504,7 +506,11 @@ class FlowTest(TembaTest):
         contact2_in1 = self.create_msg(direction=INCOMING, contact=self.contact2, text="green")
         Flow.find_and_handle(contact2_in1)
 
+        time.sleep(1)
+
         contact1_run2, contact2_run2 = self.flow.start([], [self.contact, self.contact2], restart_participants=True)
+
+        time.sleep(1)
 
         contact1_in3 = self.create_msg(direction=INCOMING, contact=self.contact, text=" blue ")
         Flow.find_and_handle(contact1_in3)
@@ -636,7 +642,7 @@ class FlowTest(TembaTest):
                                                 c1_run2_last, "Blue", "blue", " blue "], tz)
 
         self.assertExcelRow(sheet_contacts, 2, [contact2_run1.contact.uuid, "+250788383383", "Nic", "", c2_run1_first,
-                                                c2_run2_last, "Other", "green", "green"], tz)
+                                                c2_run1_last, "Other", "green", "green"], tz)
 
         # test export with a contact field
         age = ContactField.get_or_create(self.org, self.admin, 'age', "Age")
@@ -662,7 +668,7 @@ class FlowTest(TembaTest):
                                                 c1_run1_first, c1_run2_last, "Blue", "blue", " blue "], tz)
 
         self.assertExcelRow(sheet_contacts, 2, [contact2_run1.contact.uuid, "+250788383383", "Nic", "", "",
-                                                c2_run1_first, c2_run2_last, "Other", "green", "green"], tz)
+                                                c2_run1_first, c2_run1_last, "Other", "green", "green"], tz)
 
         # check runs sheet...
         self.assertEqual(sheet_runs.nrows, 4)  # header + 3 runs

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -492,7 +492,7 @@ class FlowTest(TembaTest):
     def test_export_results(self):
         # setup flow and start both contacts
         self.flow.update(self.definition)
-        contact1_run1, contact2_run1,  contact3_run1 = self.flow.start([], [self.contact, self.contact2, self.contact3])
+        contact1_run1, contact2_run1, contact3_run1 = self.flow.start([], [self.contact, self.contact2, self.contact3])
 
         # simulate two runs each for two contacts...
         contact1_in1 = self.create_msg(direction=INCOMING, contact=self.contact, text="light beige")

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -911,8 +911,8 @@ class FlowCRUDL(SmartCRUDL):
             include_messages = forms.BooleanField(required=False, label=_("Include Messages"),
                                                   help_text=_("Export all messages sent and received in this flow"))
             include_runs = forms.BooleanField(required=False, label=_("Include Runs"),
-                                              help_text=_("Export every run a contact has made in this flow, "
-                                                          "not just the last one"))
+                                              help_text=_("Include all runs for each contact. Leave unchecked for "
+                                                          "only their most recent runs"))
 
             def __init__(self, user, *args, **kwargs):
                 super(FlowCRUDL.ExportResults.ExportForm, self).__init__(*args, **kwargs)

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from collections import defaultdict
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from smartmin.models import SmartModel
@@ -23,16 +25,20 @@ class ChunkIterator(object):
     """
     Queryset wrapper to chunk queries and reduce in-memory footprint
     """
-    def __init__(self, model, ids, order_by=None, select_related=None, prefetch_related=None, max_obj_num=1000):
+    def __init__(self, model, ids, order_by=None, select_related=None, prefetch_related=None,
+                 contact_fields=None, max_obj_num=1000):
         self._model = model
         self._ids = ids
         self._order_by = order_by
         self._select_related = select_related
         self._prefetch_related = prefetch_related
+        self._contact_fields = contact_fields
         self._generator = self._setup()
         self.max_obj_num = max_obj_num
 
     def _setup(self):
+        from temba.values.models import Value
+
         for i in xrange(0, len(self._ids), self.max_obj_num):
             chunk_queryset = self._model.objects.filter(id__in=self._ids[i:i + self.max_obj_num])
 
@@ -45,7 +51,25 @@ class ChunkIterator(object):
             if self._prefetch_related:
                 chunk_queryset = chunk_queryset.prefetch_related(*self._prefetch_related)
 
+            if self._contact_fields:
+                # get all our contact ids
+                contact_ids = chunk_queryset.values_list('contact_id', flat=True)
+
+                # fetch the contact field values
+                values = Value.objects.filter(contact_field__in=self._contact_fields, contact_id__in=contact_ids)\
+                                      .order_by('contact_id').prefetch_related('contact_field')
+
+                # map these by contact id
+                cid_to_values = defaultdict(list)
+                for value in values:
+                    cid_to_values[value.contact_id].append(value)
+
             for obj in chunk_queryset:
+                # cache our contact field values on our contact object if we have any
+                if self._contact_fields:
+                    for value in cid_to_values[obj.contact_id]:
+                        obj.contact.set_cached_field_value(value.contact_field.key.lower(), value)
+
                 yield obj
 
     def __iter__(self):

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -67,8 +67,14 @@ class ChunkIterator(object):
             for obj in chunk_queryset:
                 # cache our contact field values on our contact object if we have any
                 if self._contact_fields:
+                    empty_values = set([cf.key.lower() for cf in self._contact_fields])
                     for value in cid_to_values[obj.contact_id]:
                         obj.contact.set_cached_field_value(value.contact_field.key.lower(), value)
+                        empty_values.remove(value.contact_field.key.lower())
+
+                    # set empty values for anything remaining
+                    for empty in empty_values:
+                        obj.contact.set_cached_field_value(empty, None)
 
                 yield obj
 

--- a/templates/flows/flow_export_results.haml
+++ b/templates/flows/flow_export_results.haml
@@ -1,0 +1,21 @@
+-extends 'smartmin/form.html'
+-load i18n
+-load smartmin
+-load temba
+
+-block pre-form
+  Flow exports will include the latest result for each contact that has passed through the flow. You may optionally
+  include up to 10 contact fields whose values will also be exported with each row.
+
+  {% pdb %}
+
+-block modal-script
+  {{block.super}}
+  %script
+    $('#id_contact_fields').select2({
+      containerCssClass: "select2-temba-field"
+    });
+
+    useFontCheckbox(".form-horizontal input[type=checkbox]")
+
+

--- a/templates/flows/flow_export_results.haml
+++ b/templates/flows/flow_export_results.haml
@@ -5,7 +5,7 @@
 
 -block pre-form
   Flow exports will include the latest result for each contact that has passed through the flow. You may optionally
-  include up to 10 contact fields whose values will also be exported with each row.
+  include up to 10 contact fields whose values will also be exported with each run.
 
 -block modal-script
   {{block.super}}

--- a/templates/flows/flow_export_results.haml
+++ b/templates/flows/flow_export_results.haml
@@ -7,8 +7,6 @@
   Flow exports will include the latest result for each contact that has passed through the flow. You may optionally
   include up to 10 contact fields whose values will also be exported with each row.
 
-  {% pdb %}
-
 -block modal-script
   {{block.super}}
   %script

--- a/templates/flows/flow_list.haml
+++ b/templates/flows/flow_list.haml
@@ -180,7 +180,6 @@
                   .paginator
                     - include "smartmin/sidebar_pagination.haml"
 
-
 -block extra-script
   {{ block.super }}
 
@@ -189,7 +188,10 @@
     {% if org_perms.flows.flow_update %}
     function exportFlows(){
       var flowIds = getCheckedIds();
-      document.location = '/flow/export_results/' + "?ids=" + flowIds.join();
+      var modal = new Modax('{% trans "Export Flow Results" %}', '{% url "flows.flow_export_results" %}?ids=' + flowIds.join());
+      modal.setIcon('icon-excel');
+      modal.setRedirectOnSuccess(true);
+      modal.show();
     }
 
     {% endif %}


### PR DESCRIPTION
Allows users to add up to 10 contact fields as part of their export, select to export only results for people who have responded, and to leave out the individual runs and msg tabs if they'd like.

<img width="621" alt="screen shot 2016-04-05 at 12 01 47 pm" src="https://cloud.githubusercontent.com/assets/168067/14290855/5ac425ee-fb26-11e5-836a-f370be2863b0.png">
