### PR TITLE
Adds recipients to Broadcasts

### DIFF
--- a/temba/msgs/migrations/0054_auto_20160426_2130.py
+++ b/temba/msgs/migrations/0054_auto_20160426_2130.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0035_auto_20160414_0642'),
+        ('msgs', '0053_auto_20160415_1337'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='broadcast',
+            name='recipients',
+            field=models.ManyToManyField(help_text='The URNs which received this message', related_name='broadcasts', verbose_name='Recipients', to='contacts.ContactURN'),
+        ),
+        migrations.AlterField(
+            model_name='broadcast',
+            name='contacts',
+            field=models.ManyToManyField(help_text='Individual contacts included in this message', related_name='addressed_broadcasts', verbose_name='Contacts', to='contacts.Contact'),
+        ),
+        migrations.AlterField(
+            model_name='broadcast',
+            name='groups',
+            field=models.ManyToManyField(help_text='The groups to send the message to', related_name='addressed_broadcasts', verbose_name='Groups', to='contacts.ContactGroup'),
+        ),
+        migrations.AlterField(
+            model_name='broadcast',
+            name='recipient_count',
+            field=models.IntegerField(help_text='Number of urns which received this broadcast', null=True, verbose_name='Number of recipients'),
+        ),
+        migrations.AlterField(
+            model_name='broadcast',
+            name='urns',
+            field=models.ManyToManyField(help_text='Individual URNs included in this message', related_name='addressed_broadcasts', verbose_name='URNs', to='contacts.ContactURN'),
+        ),
+    ]

--- a/temba/msgs/migrations/0055_auto_20160427_1937.py
+++ b/temba/msgs/migrations/0055_auto_20160427_1937.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from temba.utils import chunk_list
+from redis_cache import get_redis_connection
+import time
+
+HIGHPOINT_KEY = 'recipient_backfill_highpoint'
+
+def populate_recipients_for_broadcast(Broadcast, MsgManager, broadcast_id):
+    """
+    Populates the recipients for the passed in broadcast, we just select all the
+    msgs for this broadcast, then populate the recipients based on the URNs of
+    those messages
+    """
+    urn_ids = MsgManager.filter(broadcast=broadcast_id).values_list('contact_urn_id', flat=True)
+
+    # clear any current recipients, we are rebuilding
+    RelatedRecipients = Broadcast.recipients.through
+    Broadcast.objects.get(id=broadcast_id).recipients.clear()
+
+    for urn_batch in chunk_list(urn_ids, 1000):
+        recipient_batch = [RelatedRecipients(contacturn_id=u, broadcast_id=broadcast_id) for u in urn_batch]
+        RelatedRecipients.objects.bulk_create(recipient_batch)
+
+    return len(urn_ids)
+
+
+def backfill_recipients(Broadcast, MsgManager):
+    # we keep track of our completed broadcasts so we can pick up where we left off if interrupted
+    r = get_redis_connection()
+    highpoint = r.get(HIGHPOINT_KEY)
+    if highpoint is None:
+        highpoint = 0
+
+    broadcast_ids = Broadcast.objects.filter(id__gt=highpoint).order_by('id').values_list('id', flat=True)
+    start = time.time()
+    for (i, broadcast_id) in enumerate(broadcast_ids):
+        recipient_count = populate_recipients_for_broadcast(Broadcast, MsgManager, broadcast_id)
+        print "%d - %d ... (%d of %d) in %d" % (broadcast_id, recipient_count, i, len(broadcast_ids)-1, int(time.time() - start))
+        r.set(HIGHPOINT_KEY, broadcast_id)
+
+    # we finished, no need to track any more status
+    r.delete(HIGHPOINT_KEY)
+
+
+def migration_backfill_recipients(apps, schema):
+    backfill_recipients(apps.get_model('msgs', 'Broadcast'), apps.get_model('msgs', 'Msg').objects)
+
+def noop(apps, schema):
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0054_auto_20160426_2130'),
+    ]
+
+    operations = [
+        migrations.RunPython(migration_backfill_recipients, noop)
+    ]

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -310,6 +310,13 @@ class MsgTest(TembaTest):
         broadcast.refresh_from_db()
         self.assertEquals(1, broadcast.recipient_count)
 
+        # send it
+        broadcast.send()
+
+        # assert that recipient is set
+        self.assertEqual(broadcast.recipients.all().count(), 1)
+        self.assertEqual(broadcast.recipients.all()[0], self.joe.urns.all().first())
+
     def test_outbox(self):
         self.login(self.admin)
 
@@ -843,9 +850,13 @@ class BroadcastTest(TembaTest):
         self.assertEquals('I', broadcast.status)
         self.assertEquals(4, broadcast.recipient_count)
 
+        # no recipients created yet, done when we send
+        self.assertEquals(0, broadcast.recipients.all().count())
+
         broadcast.send(trigger_send=False)
         self.assertEquals('Q', broadcast.status)
         self.assertEquals(broadcast.get_message_count(), 4)
+        self.assertEqual(broadcast.recipients.all().count(), 4)
 
         bcast_commands = broadcast.get_sync_commands(self.channel)
         self.assertEquals(1, len(bcast_commands))


### PR DESCRIPTION
We now have a recipients m2m that keeps track of all the URNs that a broadcast sent to. These are populated as messages are created so will be kept in sync.

This also takes care of backfilling all past broadcasts in a super mega migration that will need to be run outside a ship.