### PR TITLE
Fix broadcast recipient migration

### DIFF
--- a/temba/msgs/migrations/0055_auto_20160427_1937.py
+++ b/temba/msgs/migrations/0055_auto_20160427_1937.py
@@ -14,7 +14,7 @@ def populate_recipients_for_broadcast(Broadcast, MsgManager, broadcast_id):
     msgs for this broadcast, then populate the recipients based on the URNs of
     those messages
     """
-    urn_ids = MsgManager.filter(broadcast=broadcast_id).values_list('contact_urn_id', flat=True)
+    urn_ids = set(MsgManager.filter(broadcast=broadcast_id).values_list('contact_urn_id', flat=True))
 
     # clear any current recipients, we are rebuilding
     RelatedRecipients = Broadcast.recipients.through


### PR DESCRIPTION
When messages are retried, you can end up with same URN being included twice for a broadcast.