### PR TITLE
Replace crazy characters inserted by word in GSM7 messages

### DIFF
--- a/temba/utils/gsm7.py
+++ b/temba/utils/gsm7.py
@@ -35,7 +35,15 @@ GSM7_REPLACEMENTS = {u'á': 'a',
                      u'Ô': 'O',
                      u'Õ': 'O',
                      u'Ú': 'U',
-                     u'Ù': 'U'}
+                     u'Ù': 'U',
+
+                     # shit Word likes replacing automatically
+                     u'’': '\'',
+                     u'‘': '\'',
+                     u'“': '"',
+                     u'”': '"',
+                     u'–': '-',
+                     }
 
 
 def is_gsm7(text):

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -693,6 +693,10 @@ class GSM7Test(TembaTest):
         self.assertEquals("No capital accented E!", replaced)
         self.assertTrue(is_gsm7(replaced))
 
+        replaced = replace_non_gsm7_accents("No crazy “word” quotes.")
+        self.assertEquals('No crazy "word" quotes.', replaced)
+        self.assertTrue(is_gsm7(replaced))
+
 
 class TableExporterTest(TembaTest):
 


### PR DESCRIPTION
Deals with people copy/pasting special chars from Word docs. On Kannel instances (where GSM7 vs Unicode tends to matter most) these will be replaced if the Channel policy supports it.