### PR TITLE
User groups and API token lock down

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -12,7 +12,6 @@ from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User, Group
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
 from hashlib import sha1
 from rest_framework.permissions import BasePermission
 from smartmin.models import SmartModel

--- a/temba/api/tests/test_models.py
+++ b/temba/api/tests/test_models.py
@@ -5,6 +5,7 @@ import json
 
 from datetime import timedelta
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from mock import patch
@@ -14,7 +15,63 @@ from temba.msgs.models import Broadcast
 from temba.orgs.models import ALL_EVENTS
 from temba.tests import MockResponse, TembaTest
 from urlparse import parse_qs
-from ..models import WebHookEvent, WebHookResult, SMS_RECEIVED
+from ..models import APIToken, WebHookEvent, WebHookResult, SMS_RECEIVED
+
+
+class APITokenTest(TembaTest):
+    def setUp(self):
+        super(APITokenTest, self).setUp()
+
+        self.admins_group = Group.objects.get(name="Administrators")
+        self.editors_group = Group.objects.get(name="Editors")
+        self.surveyors_group = Group.objects.get(name="Surveyors")
+
+    def test_get_or_create(self):
+        token1 = APIToken.get_or_create(self.org, self.admin)
+        self.assertEqual(token1.org, self.org)
+        self.assertEqual(token1.user, self.admin)
+        self.assertEqual(token1.role, self.admins_group)
+        self.assertTrue(token1.key)
+        self.assertEqual(unicode(token1), token1.key)
+
+        # tokens for different roles with same user should differ
+        token2 = APIToken.get_or_create(self.org, self.admin, self.admins_group)
+        token3 = APIToken.get_or_create(self.org, self.admin, self.editors_group)
+        token4 = APIToken.get_or_create(self.org, self.admin, self.surveyors_group)
+
+        self.assertEqual(token1, token2)
+        self.assertNotEqual(token1, token3)
+        self.assertNotEqual(token1, token4)
+        self.assertNotEqual(token1.key, token3.key)
+
+        # tokens with same role for different users should differ
+        token5 = APIToken.get_or_create(self.org, self.editor)
+
+        self.assertNotEqual(token3, token5)
+
+        APIToken.get_or_create(self.org, self.surveyor)
+
+        # can't create token for viewer users or other users using viewers role
+        self.assertRaises(ValueError, APIToken.get_or_create, self.org, self.admin, Group.objects.get(name="Viewers"))
+        self.assertRaises(ValueError, APIToken.get_or_create, self.org, self.user)
+
+    def test_get_orgs_for_role(self):
+        orgs = APIToken.get_orgs_for_role(self.admin, self.admins_group)
+        self.assertEqual(list(orgs), [self.org])
+
+    def test_get_allowed_roles(self):
+        self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.admin)),
+                         {self.admins_group, self.editors_group, self.surveyors_group})
+        self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.editor)),
+                         {self.editors_group, self.surveyors_group})
+        self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.surveyor)), {self.surveyors_group})
+        self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.user)), set())
+
+    def test_get_default_role(self):
+        self.assertEqual(APIToken.get_default_role(self.org, self.admin), self.admins_group)
+        self.assertEqual(APIToken.get_default_role(self.org, self.editor), self.editors_group)
+        self.assertEqual(APIToken.get_default_role(self.org, self.surveyor), self.surveyors_group)
+        self.assertIsNone(APIToken.get_default_role(self.org, self.user))
 
 
 class WebHookTest(TembaTest):

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -195,6 +195,14 @@ class APITest(TembaTest):
         admins = Group.objects.get(name='Administrators')
         surveyors = Group.objects.get(name='Surveyors')
 
+        # try to authenticate with incorrect password
+        response = self.client.post(url, {'username': "Administrator", 'password': "XXXX", 'role': 'A'})
+        self.assertEqual(response.status_code, 403)
+
+        # try to authenticate with invalid role
+        response = self.client.post(url, {'username': "Administrator", 'password': "Administrator", 'role': 'X'})
+        self.assertEqual(response.status_code, 404)
+
         # authenticate an admin as an admin
         response = self.client.post(url, {'username': "Administrator", 'password': "Administrator", 'role': 'A'})
 

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -201,7 +201,7 @@ class APITest(TembaTest):
 
         # try to authenticate with invalid role
         response = self.client.post(url, {'username': "Administrator", 'password': "Administrator", 'role': 'X'})
-        self.assertEqual(response.status_code, 404)
+        self.assertFormError(response, 'form', 'role', "Select a valid choice. X is not one of the available choices.")
 
         # authenticate an admin as an admin
         response = self.client.post(url, {'username': "Administrator", 'password': "Administrator", 'role': 'A'})

--- a/temba/api/v1/views.py
+++ b/temba/api/v1/views.py
@@ -15,7 +15,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from smartmin.views import SmartTemplateView, SmartFormView
-from temba.api.models import get_or_create_api_token, APIToken
+from temba.api.models import APIToken
 from temba.assets.models import AssetType
 from temba.assets.views import handle_asset_request
 from temba.campaigns.models import Campaign, CampaignEvent

--- a/temba/api/v1/views.py
+++ b/temba/api/v1/views.py
@@ -26,7 +26,7 @@ from temba.locations.models import AdminBoundary
 from temba.msgs.models import Broadcast, Msg, Label
 from temba.utils import json_date_to_datetime, splitting_getlist, str_to_bool, non_atomic_gets
 from temba.values.models import Value
-from ..models import ApiPermission, SSLPermission
+from ..models import APIPermission, SSLPermission
 from .serializers import BoundarySerializer, AliasSerializer, BroadcastCreateSerializer, BroadcastReadSerializer
 from .serializers import ChannelEventSerializer, CampaignReadSerializer, CampaignWriteSerializer
 from .serializers import CampaignEventReadSerializer, CampaignEventWriteSerializer
@@ -247,7 +247,7 @@ class BaseAPIView(generics.GenericAPIView):
     """
     Base class of all our API endpoints
     """
-    permission_classes = (SSLPermission, ApiPermission)
+    permission_classes = (SSLPermission, APIPermission)
 
     @non_atomic_gets
     def dispatch(self, request, *args, **kwargs):

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import authenticate, login
 from django.db.models import Prefetch, Q
 from django.db.transaction import non_atomic_requests
 from django.http import HttpResponse, JsonResponse
+from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import generics, mixins, status
 from rest_framework.parsers import MultiPartParser, FormParser
@@ -13,7 +14,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from smartmin.views import SmartTemplateView, SmartFormView
-from temba.api.models import get_or_create_api_token, APIToken
+from temba.api.models import APIToken
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel, ChannelEvent
 from temba.contacts.models import Contact, ContactURN, ContactGroup, ContactField
@@ -99,9 +100,11 @@ class AuthenticateView(SmartFormView):
     Provides a login form view for app users to generate and access their API tokens
     """
     class LoginForm(forms.Form):
+        ROLE_CHOICES = (('A', _("Administrator")), ('E', _("Editor")), ('S', _("Surveyor")))
+
         username = forms.CharField()
         password = forms.CharField(widget=forms.PasswordInput)
-        role = forms.ChoiceField(choices=APIToken.ROLE_CHOICES)
+        role = forms.ChoiceField(choices=ROLE_CHOICES)
 
     title = "API Authentication"
     form_class = LoginForm
@@ -113,22 +116,20 @@ class AuthenticateView(SmartFormView):
     def form_valid(self, form, *args, **kwargs):
         username = form.cleaned_data.get('username')
         password = form.cleaned_data.get('password')
-        role = form.cleaned_data.get('role')
+        role_code = form.cleaned_data.get('role')
 
         user = authenticate(username=username, password=password)
         if user and user.is_active:
             login(self.request, user)
+
+            role = APIToken.get_role_from_code(role_code)
             tokens = []
 
-            valid_orgs, role = APIToken.get_orgs_for_role(user, role)
             if role:
+                valid_orgs = APIToken.get_orgs_for_role(user, role)
                 for org in valid_orgs:
-                    user.set_org(org)
-                    user.set_role(role)
-                    token = get_or_create_api_token(user)
-
-                    if token:
-                        tokens.append({'org': {'id': org.pk, 'name': org.name}, 'token': token})
+                    token = APIToken.get_or_create(org, user, role)
+                    tokens.append({'org': {'id': org.pk, 'name': org.name}, 'token': token.key})
             else:
                 return HttpResponse(status=403)
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -26,7 +26,7 @@ from .serializers import BroadcastReadSerializer, CampaignReadSerializer, Campai
 from .serializers import ChannelReadSerializer, ChannelEventReadSerializer, ContactReadSerializer
 from .serializers import ContactFieldReadSerializer, ContactGroupReadSerializer, FlowRunReadSerializer
 from .serializers import LabelReadSerializer, MsgReadSerializer
-from ..models import ApiPermission, SSLPermission
+from ..models import APIPermission, SSLPermission
 from ..support import InvalidQueryError, CustomCursorPagination
 
 
@@ -150,7 +150,7 @@ class BaseAPIView(generics.GenericAPIView):
     """
     Base class of all our API endpoints
     """
-    permission_classes = (SSLPermission, ApiPermission)
+    permission_classes = (SSLPermission, APIPermission)
 
     @non_atomic_requests
     def dispatch(self, request, *args, **kwargs):

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -131,7 +131,7 @@ class AuthenticateView(SmartFormView):
                     token = APIToken.get_or_create(org, user, role)
                     tokens.append({'org': {'id': org.pk, 'name': org.name}, 'token': token.key})
             else:
-                return HttpResponse(status=403)
+                return HttpResponse(status=404)
 
             return JsonResponse({'tokens': tokens})
         else:

--- a/temba/orgs/migrations/0018_fix_org_groups.py
+++ b/temba/orgs/migrations/0018_fix_org_groups.py
@@ -51,8 +51,6 @@ def fix_org_groups(apps, schema_editor):
                 print("Deleted token %s with role %s for user '%s' [%d] in org '%s' [%d]"
                       % (token.key, token.role.name, user.username, user.pk, org.name, org.pk))
 
-    raise ValueError("DOH")
-
 
 class Migration(migrations.Migration):
 

--- a/temba/orgs/migrations/0018_fix_org_groups.py
+++ b/temba/orgs/migrations/0018_fix_org_groups.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from collections import defaultdict
+from django.db import migrations
+
+
+ROLES = ('administrators', 'editors', 'viewers', 'surveyors')
+
+ROLE_TOKEN_GROUPS = {
+    'administrators': ("Administrators", "Editors", "Surveyors"),
+    'editors': ("Editors", "Surveyors"),
+    'viewers': (),
+    'surveyors': ("Surveyors",)
+}
+
+
+def fix_org_groups(apps, schema_editor):
+    Org = apps.get_model('orgs', 'Org')
+
+    for org in Org.objects.all():
+        org_user_roles = defaultdict(list)
+
+        # get the roles for all users in this org
+        for role in ROLES:
+            for user in getattr(org, role).all():
+                org_user_roles[user].append(role)
+
+        for user, user_roles in org_user_roles.iteritems():
+            # fix users who have more than one role
+            if len(user_roles) > 1:
+                keep_role = user_roles[0]
+                for remove_role in user_roles[1:]:
+                    getattr(org, remove_role).remove(user)
+                    print("Removed user '%s' [%d] from %s role in org '%s' [%d] as they have %s role"
+                          % (user.username, user.pk, remove_role, org.name, org.pk, keep_role))
+
+        # delete API tokens where users no longer have that role
+        for token in org.api_tokens.select_related('user', 'role'):
+            user = token.user
+            user_actual_role = org_user_roles.get(user, [])[0]
+            user_allowed_groups = ROLE_TOKEN_GROUPS.get(user_actual_role, [])
+
+            if token.role.name not in user_allowed_groups:
+                token.delete()
+                print("Deleted token %s with role %s for user '%s' [%d] in org '%s' [%d]"
+                      % (token.key, token.role.name, user.username, user.pk, org.name, org.pk))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0017_auto_20160301_0513'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_org_groups)
+    ]

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1495,18 +1495,6 @@ def get_org_group(obj):
     return org_group
 
 
-def set_role(obj, role):
-    obj._role = role
-
-
-def get_role(obj):
-
-    if not hasattr(obj, '_role'):
-        obj._role = obj.get_org_group()
-
-    return obj._role
-
-
 def _user_has_org_perm(user, org, permission):
     """
     Determines if a user has the given permission in this org
@@ -1538,8 +1526,6 @@ User.is_beta = is_beta_user
 User.get_settings = get_settings
 User.get_user_orgs = get_user_orgs
 User.get_org_group = get_org_group
-User.get_role = get_role
-User.set_role = set_role
 User.has_org_perm = _user_has_org_perm
 
 
@@ -1617,6 +1603,11 @@ class Invitation(SmartModel):
     host = models.CharField(max_length=32, help_text=_("The host this invitation was created on"))
 
     user_group = models.CharField(max_length=1, choices=USER_GROUPS, default='V', verbose_name=_("User Role"))
+
+    @classmethod
+    def create(cls, org, user, email, user_group, host):
+        return cls.objects.create(org=org, email=email, user_group=user_group, host=host,
+                                  created_by=user, modified_by=user)
 
     def save(self, *args, **kwargs):
         if not self.secret:

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -15,18 +15,19 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from mock import patch, Mock
 from smartmin.tests import SmartminTest
+from temba.api.models import APIToken
 from temba.campaigns.models import Campaign, CampaignEvent
-from temba.contacts.models import Contact, ContactGroup, TEL_SCHEME, TWITTER_SCHEME
-from temba.middleware import BrandingMiddleware
 from temba.channels.models import Channel, RECEIVE, SEND, TWILIO, TWITTER, PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN
+from temba.contacts.models import Contact, ContactGroup, TEL_SCHEME, TWITTER_SCHEME
 from temba.flows.models import Flow, ActionSet
+from temba.middleware import BrandingMiddleware
 from temba.msgs.models import Label, Msg, INCOMING
 from temba.nexmo import NexmoValidationError
 from temba.orgs.models import UserSettings
-from temba.utils.email import link_components
-from temba.utils import languages, dict_to_struct
 from temba.tests import TembaTest, MockResponse, MockTwilioClient, MockRequestValidator, FlowFileTest
 from temba.triggers.models import Trigger
+from temba.utils.email import link_components
+from temba.utils import languages, dict_to_struct
 from .models import Org, OrgEvent, TopUp, Invitation, Language, DAYFIRST, MONTHFIRST, CURRENT_EXPORT_VERSION
 from .models import CreditAlert, ORG_CREDIT_OVER, ORG_CREDIT_LOW, ORG_CREDIT_EXPIRING
 from .models import UNREAD_FLOW_MSGS, UNREAD_INBOX_MSGS, TopUpCredits
@@ -374,136 +375,129 @@ class OrgTest(TembaTest):
 
     @override_settings(SEND_EMAILS=True)
     def test_manage_accounts(self):
-        manage_accounts_url = reverse('orgs.org_manage_accounts')
+        url = reverse('orgs.org_manage_accounts')
 
         self.login(self.admin)
 
-        response = self.client.get(manage_accounts_url)
-        self.assertEquals(200, response.status_code)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        all_users = [self.surveyor, self.user, self.editor, self.admin]
+        all_roles = ['administrators', 'editors', 'viewers', 'surveyors']
+
+        # ensure all users have an API token
+        for user in all_users:
+            token = user.api_token
+            self.assertIsNotNone(token)
 
         # we have 19 fields in the form including 16 checkboxes for the four users, an email field, a user group field
         # and 'loc' field.
-        self.assertEquals(19, len(response.context['form'].fields))
-        self.assertTrue('emails' in response.context['form'].fields)
-        self.assertTrue('user_group' in response.context['form'].fields)
-        for user in [self.user, self.editor, self.admin]:
-            self.assertTrue("administrators_%d" % user.pk in response.context['form'].fields)
-            self.assertTrue("editors_%d" % user.pk in response.context['form'].fields)
-            self.assertTrue("viewers_%d" % user.pk in response.context['form'].fields)
-            self.assertTrue("surveyors_%d" % user.pk in response.context['form'].fields)
+        expected_fields = {'emails', 'user_group', 'loc'}
+        for user in all_users:
+            expected_fields.update([r + '_%d' % user.pk for r in all_roles])
 
-        self.assertFalse(response.context['form'].fields['emails'].initial)
-        self.assertEquals('V', response.context['form'].fields['user_group'].initial)
+        self.assertEqual(set(response.context['form'].fields.keys()), expected_fields)
+        self.assertEqual(response.context['form'].initial, {
+            'administrators_%d' % self.admin.pk: True,
+            'editors_%d' % self.editor.pk: True,
+            'viewers_%d' % self.user.pk: True,
+            'surveyors_%d' % self.surveyor.pk: True
+        })
+        self.assertEqual(response.context['form'].fields['emails'].initial, None)
+        self.assertEqual(response.context['form'].fields['user_group'].initial, 'V')
 
-        # keep admin as admin, editor as editor, but make user an editor too
+        # keep admin as admin, editor as editor, but make user an editor too, and remove surveyor
         post_data = {
             'administrators_%d' % self.admin.pk: 'on',
             'editors_%d' % self.editor.pk: 'on',
             'editors_%d' % self.user.pk: 'on',
-            'user_group': 'E'
+            'user_group': 'V'
         }
-        response = self.client.post(manage_accounts_url, post_data)
-        self.assertEquals(302, response.status_code)
+        response = self.client.post(url, post_data)
+        self.assertRedirect(response, reverse('orgs.org_home'))
 
-        org = Org.objects.get(pk=self.org.pk)
-        self.assertEqual(set(org.administrators.all()), {self.admin})
-        self.assertEqual(set(org.editors.all()), {self.user, self.editor})
-        self.assertFalse(set(org.viewers.all()), set())
+        self.org.refresh_from_db()
+        self.assertEqual(set(self.org.administrators.all()), {self.admin})
+        self.assertEqual(set(self.org.editors.all()), {self.user, self.editor})
+        self.assertFalse(set(self.org.viewers.all()), set())
+        self.assertEqual(set(self.org.surveyors.all()), set())
 
-        # add to post_data an email to invite as admin
+        # our viewers and surveyor's API tokens will also have been deleted
+        self.assertEqual({t.user for t in APIToken.objects.all()}, {self.admin, self.editor})
+
+        # next we leave existing roles unchanged, but try to invite new user to be admin with invalid email address
         post_data['emails'] = "norkans7gmail.com"
         post_data['user_group'] = 'A'
-        response = self.client.post(manage_accounts_url, post_data)
-        self.assertTrue('emails' in response.context['form'].errors)
-        self.assertEquals("One of the emails you entered is invalid.", response.context['form'].errors['emails'][0])
+        response = self.client.post(url, post_data)
 
-        # now post with right email
+        self.assertFormError(response, 'form', 'emails', "One of the emails you entered is invalid.")
+
+        # try again with valid email
         post_data['emails'] = "norkans7@gmail.com"
-        post_data['user_group'] = 'A'
-        response = self.client.post(manage_accounts_url, post_data)
+        response = self.client.post(url, post_data)
+        self.assertRedirect(response, reverse('orgs.org_home'))
 
-        # an invitation is created and sent by email
-        self.assertEquals(1, Invitation.objects.all().count())
+        # an invitation is created
+        invitation = Invitation.objects.get()
+        self.assertEqual(invitation.org, self.org)
+        self.assertEqual(invitation.email, "norkans7@gmail.com")
+        self.assertEqual(invitation.user_group, "A")
+
+        # and sent by email
         self.assertTrue(len(mail.outbox) == 1)
 
-        invitation = Invitation.objects.get()
-
-        self.assertEquals(invitation.org, self.org)
-        self.assertEquals(invitation.email, "norkans7@gmail.com")
-        self.assertEquals(invitation.user_group, "A")
-
         # pretend our invite was acted on
-        Invitation.objects.all().update(is_active=False)
+        invitation.is_active = False
+        invitation.save()
 
         # send another invitation, different group
         post_data['emails'] = "norkans7@gmail.com"
         post_data['user_group'] = 'E'
-        self.client.post(manage_accounts_url, post_data)
+        self.client.post(url, post_data)
 
         # old invite should be updated
-        new_invite = Invitation.objects.all().first()
-        self.assertEquals(1, Invitation.objects.all().count())
-        self.assertEquals(invitation.pk, new_invite.pk)
-        self.assertEquals('E', new_invite.user_group)
-        self.assertEquals(2, len(mail.outbox))
-        self.assertTrue(new_invite.is_active)
+        invitation.refresh_from_db()
+        self.assertEqual(invitation.user_group, 'E')
+        self.assertTrue(invitation.is_active)
 
-        # post many emails to the form
+        # and new email sent
+        self.assertEqual(len(mail.outbox), 2)
+
+        # include multiple emails on the form
         post_data['emails'] = "norbert@temba.com,code@temba.com"
         post_data['user_group'] = 'A'
-        self.client.post(manage_accounts_url, post_data)
+        self.client.post(url, post_data)
 
         # now 2 new invitations are created and sent
-        self.assertEquals(3, Invitation.objects.all().count())
-        self.assertEquals(4, len(mail.outbox))
+        self.assertEqual(Invitation.objects.all().count(), 3)
+        self.assertEqual(len(mail.outbox), 4)
 
-        response = self.client.get(manage_accounts_url)
+        response = self.client.get(url)
 
         # user ordered by email
-        self.assertEqual(response.context['org_users'][0], self.admin)
-        self.assertEqual(response.context['org_users'][1], self.editor)
-        self.assertEqual(response.context['org_users'][2], self.user)
+        self.assertEqual(list(response.context['org_users']), [self.admin, self.editor, self.user])
 
         # invites ordered by email as well
         self.assertEqual(response.context['invites'][0].email, 'code@temba.com')
         self.assertEqual(response.context['invites'][1].email, 'norbert@temba.com')
         self.assertEqual(response.context['invites'][2].email, 'norkans7@gmail.com')
 
-        # Update our users, making the 'user' user a surveyor
-        post_data = {
-            'administrators_%d' % self.admin.pk: 'on',
+        # now we remove ourselves as a admin
+        response = self.client.post(url, {
             'editors_%d' % self.editor.pk: 'on',
-            'surveyors_%d' % self.user.pk: 'on',
-            'user_group': 'E'
-        }
+            'editors_%d' % self.user.pk: 'on',
+            'user_group': 'V'
+        })
 
-        # successful post redirects
-        response = self.client.post(manage_accounts_url, post_data)
-        self.assertEquals(302, response.status_code)
-
-        org = Org.objects.get(pk=self.org.pk)
-        self.assertEqual(set(org.administrators.all()), {self.admin})
-        self.assertEqual(set(org.editors.all()), {self.editor})
-        self.assertEqual(set(org.surveyors.all()), {self.user})
-
-        # upgrade one of our users to an admin
-        self.org.editors.remove(self.user)
-        self.org.administrators.add(self.user)
-
-        # now remove ourselves as an admin
-        post_data = {
-            'administrators_%d' % self.user.pk: 'on',
-            'editors_%d' % self.editor.pk: 'on',
-            'user_group': 'E'
-        }
-
-        response = self.client.post(manage_accounts_url, post_data)
-
-        # should be redirected to chooser page
+        # we should be redirected to chooser page
         self.assertRedirect(response, reverse('orgs.org_choose'))
 
-        # and should no longer be an admin
-        self.assertFalse(self.admin in self.org.administrators.all())
+        # and removed from this org
+        self.org.refresh_from_db()
+        self.assertEqual(set(self.org.administrators.all()), set())
+        self.assertEqual(set(self.org.editors.all()), {self.user, self.editor})
+        self.assertEqual(set(self.org.viewers.all()), set())
+        self.assertEqual(set(self.org.surveyors.all()), set())
 
     @patch('temba.utils.email.send_temba_email')
     def test_join(self, mock_send_temba_email):

--- a/templates/orgs/org_manage_accounts.haml
+++ b/templates/orgs/org_manage_accounts.haml
@@ -63,10 +63,10 @@
       %tr
         %td.form{colspan: 1}
           .field.formax-vertical
-            {% render_field 'emails' %}
+            {% render_field 'invite_emails' %}
         %td.form{colspan: 3}
           .field.formax-vertical
-            {% render_field 'user_group' %}
+            {% render_field 'invite_group' %}
 
 
 - block summary


### PR DESCRIPTION
Ensures that when users are removed from org groups, API tokens which they are no longer authorised to have are deleted. Includes migration to remove existing API tokens which users shouldn't have.

Migration also fixes case where user belongs to more than one group. Not sure how they got into this state but found examples in my TextIt dump.