### PR TITLE
Msg ordering

### DIFF
--- a/media/test_flows/two-in-row.json
+++ b/media/test_flows/two-in-row.json
@@ -7,8 +7,8 @@
         {
           "y": 0, 
           "x": 100, 
-          "destination": null, 
-          "uuid": "fd656cc6-1500-4c04-b501-f6839dd63743", 
+          "destination": "e1378197-e569-4444-8944-f7272ad620b4", 
+          "uuid": "c5cb45d8-c62d-4022-b7b6-c7ced970881b", 
           "actions": [
             {
               "msg": {
@@ -23,18 +23,74 @@
               "type": "reply"
             }
           ]
+        }, 
+        {
+          "y": 389, 
+          "x": 240, 
+          "destination": "91e160fb-6dda-403f-96b6-e746d74bf961", 
+          "uuid": "2cd72df1-808e-4ac3-8ae4-e03e49452924", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "Here is your third."
+              }, 
+              "type": "reply"
+            }
+          ]
+        }, 
+        {
+          "y": 561, 
+          "x": 240, 
+          "destination": null, 
+          "uuid": "91e160fb-6dda-403f-96b6-e746d74bf961", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "Here is your fourth."
+              }, 
+              "type": "reply"
+            }
+          ]
         }
       ], 
       "version": 8, 
       "flow_type": "F", 
-      "entry": "fd656cc6-1500-4c04-b501-f6839dd63743", 
-      "rule_sets": [], 
+      "entry": "c5cb45d8-c62d-4022-b7b6-c7ced970881b", 
+      "rule_sets": [
+        {
+          "uuid": "e1378197-e569-4444-8944-f7272ad620b4", 
+          "webhook_action": null, 
+          "rules": [
+            {
+              "test": {
+                "test": "true", 
+                "type": "true"
+              }, 
+              "category": {
+                "eng": "All Responses"
+              }, 
+              "destination": "2cd72df1-808e-4ac3-8ae4-e03e49452924", 
+              "uuid": "ed5bf291-5801-49a2-915d-7c13269f9ec8", 
+              "destination_type": "A"
+            }
+          ], 
+          "webhook": null, 
+          "ruleset_type": "wait_message", 
+          "label": "Response 1", 
+          "operand": "@step.value", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 218, 
+          "x": 277, 
+          "config": {}
+        }
+      ], 
       "metadata": {
         "expires": 10080, 
-        "revision": 3, 
+        "revision": 11, 
         "id": 51612, 
         "name": "Two In Row", 
-        "saved_on": "2016-04-18T18:27:17.206199Z"
+        "saved_on": "2016-05-02T22:22:39.470785Z"
       }
     }
   ], 

--- a/temba/channels/tasks.py
+++ b/temba/channels/tasks.py
@@ -50,6 +50,7 @@ def send_msg_task():
         with r.lock('send_msg_%d' % msg.id, timeout=300):
             Channel.send_message(msg)
 
+
 @task(track_started=True, name='check_channels_task')
 def check_channels_task():
     """

--- a/temba/channels/tasks.py
+++ b/temba/channels/tasks.py
@@ -45,10 +45,9 @@ def send_msg_task():
     # send it off
     r = get_redis_connection()
 
-    # acquire a lock both for our msg and our contact to make sure sending is ordered
+    # acquire a lock on our contact to make sure sending is always serialized
     with r.lock('send_contact_%d' % msg.contact, timeout=300):
-        with r.lock('send_msg_%d' % msg.id, timeout=300):
-            Channel.send_message(msg)
+        Channel.send_message(msg)
 
 
 @task(track_started=True, name='check_channels_task')

--- a/temba/channels/tasks.py
+++ b/temba/channels/tasks.py
@@ -44,9 +44,11 @@ def send_msg_task():
 
     # send it off
     r = get_redis_connection()
-    with r.lock('send_msg_%d' % msg.id, timeout=300):
-        Channel.send_message(msg)
 
+    # acquire a lock both for our msg and our contact to make sure sending is ordered
+    with r.lock('send_contact_%d' % msg.contact, timeout=300):
+        with r.lock('send_msg_%d' % msg.id, timeout=300):
+            Channel.send_message(msg)
 
 @task(track_started=True, name='check_channels_task')
 def check_channels_task():

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -634,6 +634,7 @@ class Flow(TembaModel):
 
         # send any messages generated
         if msgs:
+            msgs.sort(key=lambda message: message.created_on)
             run.flow.org.trigger_send(msgs)
 
         return handled
@@ -1670,6 +1671,7 @@ class Flow(TembaModel):
         # trigger our messages to be sent
         if msgs:
             # then send them off
+            msgs.sort(key=lambda message: message.created_on)
             msg_ids = [m.id for m in msgs]
             Msg.all_messages.filter(id__in=msg_ids).update(status=PENDING)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4844,7 +4844,7 @@ class TwoInRowTest(FlowFileTest):
 
         # the difference in the time they sent should be more than 250ms
         self.assertEqual(msgs[0].text, "Here is your first message.")
-        self.assertTrue(msgs[1].sent_on - msgs[0].sent_on > timedelta(milliseconds=450))
+        self.assertTrue(msgs[1].sent_on > msgs[0].sent_on)
 
         # our next step sends two messages in different action sets, reply
         msg = self.create_msg(contact=self.contact, direction=INCOMING, text="onwards!")
@@ -4852,7 +4852,7 @@ class TwoInRowTest(FlowFileTest):
 
         msgs = Msg.all_messages.filter(direction=OUTGOING).order_by('pk')
         self.assertEqual(msgs[2].text, "Here is your third.")
-        self.assertTrue(msgs[3].sent_on - msgs[2].sent_on > timedelta(milliseconds=450))
+        self.assertTrue(msgs[3].sent_on > msgs[2].sent_on)
 
         Msg.all_messages.all().delete()
 
@@ -4866,4 +4866,4 @@ class TwoInRowTest(FlowFileTest):
         self.assertTrue(second[1].sent_on - first[0].sent_on < timedelta(milliseconds=650))
 
         # but gap between two was long enough
-        self.assertTrue(second[0].sent_on - first[0].sent_on > timedelta(milliseconds=450))
+        self.assertTrue(second[0].sent_on > first[0].sent_on)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4843,7 +4843,16 @@ class TwoInRowTest(FlowFileTest):
         msgs = Msg.all_messages.all().order_by('pk')
 
         # the difference in the time they sent should be more than 250ms
+        self.assertEqual(msgs[0].text, "Here is your first message.")
         self.assertTrue(msgs[1].sent_on - msgs[0].sent_on > timedelta(milliseconds=450))
+
+        # our next step sends two messages in different action sets, reply
+        msg = self.create_msg(contact=self.contact, direction=INCOMING, text="onwards!")
+        Flow.find_and_handle(msg)
+
+        msgs = Msg.all_messages.filter(direction=OUTGOING).order_by('pk')
+        self.assertEqual(msgs[2].text, "Here is your third.")
+        self.assertTrue(msgs[3].sent_on - msgs[2].sent_on > timedelta(milliseconds=450))
 
         Msg.all_messages.all().delete()
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -670,21 +670,12 @@ class Msg(models.Model):
                 send_messages.update(status=QUEUED, queued_on=queued_on, modified_on=queued_on)
 
                 # now push each onto our queue
-                seen_contact_ids = set()
                 for msg in msgs:
                     if (msg.msg_type != IVR and msg.channel and msg.channel.channel_type != ANDROID) and \
                             msg.topup and not msg.contact.is_test:
                         # serialize the model to a dictionary
                         msg.queued_on = queued_on
                         task = msg.as_task_json()
-
-                        # if we've already seen this contact in our current 500ms batch, then pause
-                        # to make sure ordering remains the same
-                        if msg.contact_id in seen_contact_ids:
-                            time.sleep(.5)
-                            seen_contact_ids = set()
-
-                        seen_contact_ids.add(msg.contact_id)
 
                         task_priority = DEFAULT_PRIORITY
                         if msg.priority == SMS_BULK_PRIORITY:

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -523,8 +523,6 @@ class Org(SmartModel):
 
         # if we have msgs, then send just those
         if msgs:
-            # sort them by creation date
-            msgs.sort(key=lambda message: message.created_on)
             ids = [m.id for m in msgs]
 
             # trigger syncs for our android channels

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -523,6 +523,8 @@ class Org(SmartModel):
 
         # if we have msgs, then send just those
         if msgs:
+            # sort them by creation date
+            msgs.sort(key=lambda message: message.created_on)
             ids = [m.id for m in msgs]
 
             # trigger syncs for our android channels


### PR DESCRIPTION
Another attempt at making sure our distributed sending machine doesn't get out of order in sending.

This makes a few relevant changes:
1. We gather all messages to send at once when executing a flow step, even if that spans across actions.
2. We no longer pause when adding things to the queue because that was probably ineffective as the tasks were waiting to fire until the transaction was committed, instead we lock on the contact when sending so that in theory no two tasks should be sending to the same contact at once.

2) does depend on the implicit race to the lock being fair, that is that the first msg added to our queue grabs the lock before the second when there are consecutive messages. I could certainly envision scenarios where that wouldn't be the case though. (say if one box is assigned the first message but has significantly more load for whatever reason)

In any case, won't know till we go.