### PR TITLE
Query against specific org field instead of all fields with same name

### DIFF
--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -136,7 +136,7 @@ def generate_queryset(lexer, identifier, comparator, value):
     else:
         from temba.contacts.models import ContactField
         try:
-            field = ContactField.objects.get(org=lexer.org, key=identifier)
+            field = ContactField.objects.get(org_id=lexer.org.id, key=identifier)
         except ObjectDoesNotExist:
             raise SearchException("Unrecognized contact field identifier %s" % identifier)
 
@@ -165,7 +165,7 @@ def generate_non_field_comparison(relation, comparator, value):
 
 
 def generate_empty_field_test(field):
-    contacts_with_field = field.org.org_contacts.filter(Q(**{'values__contact_field__key': field.key}))
+    contacts_with_field = field.org.org_contacts.filter(Q(**{'values__contact_field__id': field.id}))
     return ~Q(**{'pk__in': contacts_with_field})
 
 
@@ -174,7 +174,7 @@ def generate_text_field_comparison(field, comparator, value):
     if not lookup:
         raise SearchException("Unsupported comparator %s for text field" % comparator)
 
-    return Q(**{'values__contact_field__key': field.key, 'values__string_value__%s' % lookup: value})
+    return Q(**{'values__contact_field__id': field.id, 'values__string_value__%s' % lookup: value})
 
 
 def generate_decimal_field_comparison(field, comparator, value):
@@ -187,7 +187,7 @@ def generate_decimal_field_comparison(field, comparator, value):
     except Exception:
         raise SearchException("Can't convert '%s' to a decimal" % unicode(value))
 
-    return Q(**{'values__contact_field__key': field.key, 'values__decimal_value__%s' % lookup: value})
+    return Q(**{'values__contact_field__id': field.id, 'values__decimal_value__%s' % lookup: value})
 
 
 def generate_datetime_field_comparison(field, comparator, value, org):
@@ -207,19 +207,19 @@ def generate_datetime_field_comparison(field, comparator, value, org):
 
     if lookup == '<equal>':  # check if datetime is between date and date + 1d, i.e. anytime in that 24 hour period
         return Q(**{
-            'values__contact_field__key': field.key,
+            'values__contact_field__id': field.id,
             'values__datetime_value__gte': value,
             'values__datetime_value__lt': value + timedelta(days=1)})
     elif lookup == 'lte':  # check if datetime is less then date + 1d, i.e. that day and all previous
         return Q(**{
-            'values__contact_field__key': field.key,
+            'values__contact_field__id': field.id,
             'values__datetime_value__lt': value + timedelta(days=1)})
     elif lookup == 'gt':  # check if datetime is greater than or equal to date + 1d, i.e. day after and subsequent
         return Q(**{
-            'values__contact_field__key': field.key,
+            'values__contact_field__id': field.id,
             'values__datetime_value__gte': value + timedelta(days=1)})
     else:
-        return Q(**{'values__contact_field__key': field.key, 'values__datetime_value__%s' % lookup: value})
+        return Q(**{'values__contact_field__id': field.id, 'values__datetime_value__%s' % lookup: value})
 
 
 def generate_location_field_comparison(field, comparator, value):
@@ -228,7 +228,7 @@ def generate_location_field_comparison(field, comparator, value):
         raise SearchException("Unsupported comparator %s for location field" % comparator)
 
     return Q(**{
-        'values__contact_field__key': field.key,
+        'values__contact_field__id': field.id,
         'values__location_value__name__%s' % lookup: value})
 
 


### PR DESCRIPTION
We were querying against all contact values with the key we wanted, then filtering by org, this caused us to evaluate against way more rows than needed when there was a matching key like "gender" across orgs.

This uses the contact field id instead.