### PR TITLE
revert angular debug

### DIFF
--- a/static/coffee/flows/app.coffee
+++ b/static/coffee/flows/app.coffee
@@ -27,5 +27,5 @@ app.config [ '$httpProvider', '$sceDelegateProvider', ($httpProvider, $sceDelega
 app.config [ '$compileProvider', '$interpolateProvider' , ($compileProvider, $interpolateProvider) ->
   $interpolateProvider.startSymbol "[["
   $interpolateProvider.endSymbol "]]"
-  $compileProvider.debugInfoEnabled false
+  # $compileProvider.debugInfoEnabled false
 ]


### PR DESCRIPTION
since that breaks our use of `scope()` in various places.