### PR TITLE
Contact group fixes

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -603,11 +603,8 @@ class APITest(TembaTest):
 
         self.assertEndpointAccess(url)
 
-        customers = ContactGroup.get_or_create(self.org, self.admin, "Customers")
-        customers.update_contacts(self.admin, [self.frank], add=True)
-
-        developers = ContactGroup.get_or_create(self.org, self.admin, "Developers")
-        developers.update_query("isdeveloper = YES")
+        customers = self.create_group("Customers", [self.frank])
+        developers = self.create_group("Developers", query="isdeveloper = YES")
 
         # group belong to other org
         ContactGroup.get_or_create(self.org2, self.admin2, "Spammers")

--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -551,7 +551,7 @@ class ContactWriteSerializer(WriteSerializer):
 
         # update our contact's groups
         if self.group_objs is not None:
-            self.instance.update_groups(self.user, self.group_objs)
+            self.instance.update_static_groups(self.user, self.group_objs)
 
         return self.instance
 

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -94,7 +94,7 @@ class Campaign(SmartModel):
 
                 # all else fails, create the objects from scratch
                 if not group:
-                    group = ContactGroup.create(org, user, campaign_spec['group']['name'])
+                    group = ContactGroup.create_static(org, user, campaign_spec['group']['name'])
 
                 if not campaign:
                     campaign_name = Campaign.get_unique_name(org, name)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -5778,7 +5778,7 @@ class MageHandlerTest(TembaTest):
 
         self.joe = self.create_contact("Joe", number="+250788383383")
 
-        self.dyn_group = ContactGroup.create(self.org, self.user, "Bobs", query="name has Bob")
+        self.dyn_group = self.create_group("Bobs", query="name has Bob")
 
     def create_contact_like_mage(self, name, twitter):
         """

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -381,8 +381,9 @@ class Contact(TembaModel):
     UUID = 'uuid'
 
     # reserved contact fields
-    RESERVED_FIELDS = [NAME, FIRST_NAME, PHONE, LANGUAGE,
-                       'created_by', 'modified_by', 'org', UUID, 'groups'] + [c[0] for c in IMPORT_HEADERS]
+    RESERVED_FIELDS = [
+        NAME, FIRST_NAME, PHONE, LANGUAGE, 'created_by', 'modified_by', 'org', UUID, 'groups', 'is', 'has'
+    ] + [c[0] for c in IMPORT_HEADERS]
 
     @classmethod
     def get_contacts(cls, org, blocked=False):

--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -150,7 +150,7 @@ def generate_queryset(lexer, identifier, comparator, value):
             q = generate_datetime_field_comparison(field, comparator, value, lexer.org)
         elif field.value_type == Value.TYPE_STATE or field.value_type == Value.TYPE_DISTRICT:
             q = generate_location_field_comparison(field, comparator, value)
-        else:
+        else:  # pragma: no cover
             raise SearchException("Unrecognized contact field type '%s'" % field.value_type)
 
     return lexer.base_queryset.filter(q)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -139,115 +139,6 @@ class ContactCRUDLTest(_CRUDLTest):
         self.assertEqual(0, ContactURN.objects.filter(contact=object).count())  # check no attached URNs
 
 
-class ContactGroupCRUDLTest(_CRUDLTest):
-    def setUp(self):
-        from temba.contacts.views import ContactGroupCRUDL
-
-        super(ContactGroupCRUDLTest, self).setUp()
-        self.crudl = ContactGroupCRUDL
-        self.user = self.create_user("tito")
-        self.org = Org.objects.create(name="Nyaruka Ltd.", timezone="Africa/Kigali", created_by=self.user, modified_by=self.user)
-        self.org.administrators.add(self.user)
-        self.org.initialize()
-
-        self.user.set_org(self.org)
-        self.channel = Channel.create(self.org, self.user, 'RW', 'A', "Test Channel", "0785551212",
-                                      secret="12345", gcm_id="123")
-
-        self.joe = Contact.get_or_create(self.org, self.user, name="Joe Blow", urns=["tel:123"])
-        self.frank = Contact.get_or_create(self.org, self.user, name="Frank Smith", urns=["tel:1234"])
-
-    def getCreatePostData(self):
-        return dict(name="My Group")
-
-    def getUpdatePostData(self):
-        return dict(name="My Updated Group", contacts="%s" % self.frank.pk, join_keyword="updated", join_response="Thanks for joining the group")
-
-    def getManager(self):
-        return ContactGroup.user_groups
-
-    def testDelete(self):
-        obj = self.getTestObject()
-        self._do_test_view('delete', obj, post_data=dict())
-        self.assertIsNone(self.getCRUDL().model.user_groups.filter(pk=obj.pk).first())
-        self.assertFalse(self.getCRUDL().model.all_groups.get(pk=obj.pk).is_active)
-
-    def test_create(self):
-        create_url = reverse('contacts.contactgroup_create')
-        self.login(self.user)
-
-        # clear our current groups
-        ContactGroup.user_groups.filter(org=self.org).delete()
-
-        # try to create a contact group whose name is only whitespace
-        response = self.client.post(create_url, dict(name="  "))
-        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
-
-        # try to create a contact group whose name begins with reserved character
-        response = self.client.post(create_url, dict(name="+People"))
-        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
-
-        response = self.client.post(create_url, dict(name="first  "))
-        self.assertNoFormErrors(response)
-        group = ContactGroup.user_groups.get(org=self.org, name="first")
-
-        # create a group with preselected contacts
-        self.client.post(create_url, dict(name="Joe and Frank", preselected_contacts=','.join([unicode(self.joe.pk),
-                                                                                               unicode(self.frank.pk)])))
-        group = ContactGroup.user_groups.get(org=self.org, name="Joe and Frank")
-        self.assertEquals(group.get_member_count(), 2)
-
-        # now one with a query
-        self.client.post(create_url, dict(name="Frank", group_query='frank'))
-        group = ContactGroup.user_groups.get(org=self.org, name="Frank")
-        self.assertEquals(group.get_member_count(), 1)
-
-        # try to create another with the same name, fails
-        response = self.client.post(create_url, dict(name="First"))
-        self.assertFormError(response, 'form', 'name', "Name is used by another group")
-        self.assertEquals(3, ContactGroup.user_groups.filter(org=self.org).count())
-
-        # direct calls are the same thing
-        existing_group = ContactGroup.get_or_create(self.org, self.user, "  FIRST")
-        self.assertEquals('first', existing_group.name)
-
-        # try existing group by Id should not modify the existing group
-        group_1 = ContactGroup.get_or_create(self.org, self.user, "Kigali", existing_group.pk)
-        self.assertEqual(group_1.pk, existing_group.pk)
-        self.assertEqual(group_1.name, existing_group.name)
-        self.assertNotEqual(group_1.name, 'Kigali')
-        self.assertEqual(group_1.name, 'first')
-
-    def test_update(self):
-        group = ContactGroup.create_static(self.org, self.user, "one")
-
-        update_url = reverse('contacts.contactgroup_update', args=[group.pk])
-        self.login(self.user)
-
-        # try to update name to only whitespace
-        response = self.client.post(update_url, dict(name="   "))
-        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
-
-        # try to update name to start with reserved character
-        response = self.client.post(update_url, dict(name="+People"))
-        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
-
-        response = self.client.post(update_url, dict(name="new name   "))
-        self.assertNoFormErrors(response)
-        ContactGroup.user_groups.get(org=self.org, name="new name")
-
-        # create a dynamic group based on frank
-        self.client.post(reverse('contacts.contactgroup_create'), dict(name="Frank", group_query='frank'))
-        group = ContactGroup.user_groups.get(org=self.org, name='Frank')
-        self.assertEquals(1, group.get_member_count())
-
-        # now update that group to joe
-        self.client.post(reverse('contacts.contactgroup_update', args=[group.pk]), dict(name='Frank', query='joe'))
-        group = ContactGroup.user_groups.filter(org=self.org, name='Frank').first()
-        self.assertEquals(1, group.get_member_count())
-        self.assertIsNotNone(group.contacts.filter(name='Joe Blow').first())
-
-
 class ContactGroupTest(TembaTest):
     def setUp(self):
         super(ContactGroupTest, self).setUp()
@@ -256,35 +147,78 @@ class ContactGroupTest(TembaTest):
         self.frank = Contact.get_or_create(self.org, self.admin, name="Frank Smith", urns=["tel:1234"])
         self.mary = Contact.get_or_create(self.org, self.admin, name="Mary Mo", urns=["tel:345"])
 
-    def test_create(self):
+    def test_create_static(self):
+        group = ContactGroup.create_static(self.org, self.admin, " group one ")
+
+        self.assertEqual(group.org, self.org)
+        self.assertEqual(group.name, "group one")
+        self.assertEqual(group.created_by, self.admin)
+
+        # can't call update_query on a static group
+        self.assertRaises(ValueError, group.update_query, "gender=M")
+
         # exception if group name is blank
         self.assertRaises(ValueError, ContactGroup.create_static, self.org, self.admin, "   ")
 
-        # create static group
-        group1 = ContactGroup.create_static(self.org, self.admin, " group one ")
-
-        self.assertEqual(group1.org, self.org)
-        self.assertEqual(group1.name, "group one")
-        self.assertEqual(group1.created_by, self.admin)
-
-        # create dynamic group
-        age = ContactField.get_or_create(self.org, self.admin, 'age')
+    def test_create_dynamic(self):
+        age = ContactField.get_or_create(self.org, self.admin, 'age', value_type=Value.TYPE_DECIMAL)
         gender = ContactField.get_or_create(self.org, self.admin, 'gender')
-        group2 = ContactGroup.create_dynamic(self.org, self.admin, "Group two",
-                                             query='(age < 18 and gender = "male") or (age > 18 and gender = "female")')
+        self.joe.set_field(self.admin, 'age', 17)
+        self.joe.set_field(self.admin, 'gender', "male")
+        self.mary.set_field(self.admin, 'age', 21)
+        self.mary.set_field(self.admin, 'gender', "female")
 
-        self.assertEqual(group2.query, '(age < 18 and gender = "male") or (age > 18 and gender = "female")')
-        self.assertEqual(set(group2.query_fields.all()), {age, gender})
+        group = ContactGroup.create_dynamic(self.org, self.admin, "Group two",
+                                            '(age < 18 and gender = "male") or (age > 18 and gender = "female")')
 
-        self.assertEqual(set(ContactGroup.get_user_groups(self.org)), {group1, group2})
-        self.assertEqual(set(ContactGroup.get_user_groups(self.org, dynamic=False)), {group1})
-        self.assertEqual(set(ContactGroup.get_user_groups(self.org, dynamic=True)), {group2})
+        self.assertEqual(group.query, '(age < 18 and gender = "male") or (age > 18 and gender = "female")')
+        self.assertEqual(set(group.query_fields.all()), {age, gender})
+        self.assertEqual(set(group.contacts.all()), {self.joe, self.mary})
+
+        # update group query
+        group.update_query('age > 18')
+
+        group.refresh_from_db()
+        self.assertEqual(group.query, 'age > 18')
+        self.assertEqual(set(group.query_fields.all()), {age})
+        self.assertEqual(set(group.contacts.all()), {self.mary})
+
+        # can't create a dynamic group with empty query
+        self.assertRaises(ValueError, ContactGroup.create_dynamic, self.org, self.admin, "Empty", "")
+
+        # can't call update_contacts on a dynamic group
+        self.assertRaises(ValueError, group.update_contacts, self.admin, [self.joe], True)
 
         # dynamic group should not have remove to group button
         self.login(self.admin)
-        filter_url = reverse('contacts.contact_filter', args=[group2.pk])
+        filter_url = reverse('contacts.contact_filter', args=[group.pk])
         response = self.client.get(filter_url)
         self.assertFalse('unlabel' in response.context['actions'])
+
+    def test_get_or_create(self):
+        group = ContactGroup.get_or_create(self.org, self.user, " first ")
+        self.assertEqual(group.name, "first")
+        self.assertFalse(group.is_dynamic)
+
+        # name look up is case insensitive
+        self.assertEqual(ContactGroup.get_or_create(self.org, self.user, "  FIRST"), group)
+
+        # fetching by id shouldn't modify original group
+        self.assertEqual(ContactGroup.get_or_create(self.org, self.user, "Kigali", group.pk), group)
+
+        group.refresh_from_db()
+        self.assertEqual(group.name, "first")
+
+    def test_get_user_groups(self):
+        static = ContactGroup.create_static(self.org, self.admin, "Static")
+        dynamic = ContactGroup.create_dynamic(self.org, self.admin, "Dynamic", "gender=M")
+        deleted = ContactGroup.create_static(self.org, self.admin, "Deleted")
+        deleted.is_active = False
+        deleted.save()
+
+        self.assertEqual(set(ContactGroup.get_user_groups(self.org)), {static, dynamic})
+        self.assertEqual(set(ContactGroup.get_user_groups(self.org, dynamic=False)), {static})
+        self.assertEqual(set(ContactGroup.get_user_groups(self.org, dynamic=True)), {dynamic})
 
     def test_is_valid_name(self):
         self.assertTrue(ContactGroup.is_valid_name('x'))
@@ -434,6 +368,108 @@ class ContactGroupTest(TembaTest):
         self.assertFalse(ContactGroup.all_groups.get(pk=group.pk).is_active)
         self.assertFalse(Trigger.objects.get(pk=trigger.pk).is_active)
         self.assertFalse(Trigger.objects.get(pk=second_trigger.pk).is_active)
+
+
+class ContactGroupCRUDLTest(TembaTest):
+    def setUp(self):
+        super(ContactGroupCRUDLTest, self).setUp()
+
+        self.joe = Contact.get_or_create(self.org, self.user, name="Joe Blow", urns=["tel:123"])
+        self.frank = Contact.get_or_create(self.org, self.user, name="Frank Smith", urns=["tel:1234"])
+
+        self.joe_and_frank = self.create_group("Customers", [self.joe, self.frank])
+        self.dynamic_group = self.create_group("Dynamic", query="joe")
+
+    def test_create(self):
+        url = reverse('contacts.contactgroup_create')
+
+        # can't create group as viewer
+        self.login(self.user)
+        response = self.client.post(url, dict(name="Spammers"))
+        self.assertLoginRedirect(response)
+
+        self.login(self.admin)
+
+        # try to create a contact group whose name is only whitespace
+        response = self.client.post(url, dict(name="  "))
+        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
+
+        # try to create a contact group whose name begins with reserved character
+        response = self.client.post(url, dict(name="+People"))
+        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
+
+        # try to create with name that's already taken
+        response = self.client.post(url, dict(name="Customers"))
+        self.assertFormError(response, 'form', 'name', "Name is used by another group")
+
+        # create with valid name (that will be trimmed)
+        response = self.client.post(url, dict(name="first  "))
+        self.assertNoFormErrors(response)
+        ContactGroup.user_groups.get(org=self.org, name="first")
+
+        # create a group with preselected contacts
+        self.client.post(url, dict(name="Everybody", preselected_contacts='%d,%d' % (self.joe.pk, self.frank.pk)))
+        group = ContactGroup.user_groups.get(org=self.org, name="Everybody")
+        self.assertEqual(set(group.contacts.all()), {self.joe, self.frank})
+
+        # create a dynamic group using a query
+        self.client.post(url, dict(name="Frank", group_query="frank"))
+        group = ContactGroup.user_groups.get(org=self.org, name="Frank", query="frank")
+        self.assertEqual(set(group.contacts.all()), {self.frank})
+
+    def test_update(self):
+        url = reverse('contacts.contactgroup_update', args=[self.joe_and_frank.pk])
+
+        # can't create group as viewer
+        self.login(self.user)
+        response = self.client.post(url, dict(name="Spammers"))
+        self.assertLoginRedirect(response)
+
+        self.login(self.admin)
+
+        # try to update name to only whitespace
+        response = self.client.post(url, dict(name="   "))
+        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
+
+        # try to update name to start with reserved character
+        response = self.client.post(url, dict(name="+People"))
+        self.assertFormError(response, 'form', 'name', "Group name must not be blank or begin with + or -")
+
+        # update with valid name (that will be trimmed)
+        response = self.client.post(url, dict(name="new name   "))
+        self.assertNoFormErrors(response)
+
+        self.joe_and_frank.refresh_from_db()
+        self.assertEqual(self.joe_and_frank.name, "new name")
+
+        # now try a dynamic group
+        url = reverse('contacts.contactgroup_update', args=[self.dynamic_group.pk])
+
+        # update both name and query
+        self.client.post(url, dict(name='Frank', query='frank'))
+        self.assertNoFormErrors(response)
+
+        self.dynamic_group.refresh_from_db()
+        self.assertEqual(self.dynamic_group.name, "Frank")
+        self.assertEqual(self.dynamic_group.query, "frank")
+        self.assertEqual(set(self.dynamic_group.contacts.all()), {self.frank})
+
+    def test_delete(self):
+        url = reverse('contacts.contactgroup_delete', args=[self.joe_and_frank.pk])
+
+        # can't delete group as viewer
+        self.login(self.user)
+        response = self.client.post(url)
+        self.assertLoginRedirect(response)
+
+        # can as admin user
+        self.login(self.admin)
+        response = self.client.post(url)
+        self.assertRedirect(response, reverse('contacts.contact_list'))
+
+        self.joe_and_frank.refresh_from_db()
+        self.assertFalse(self.joe_and_frank.is_active)
+        self.assertFalse(self.joe_and_frank.contacts.all())
 
 
 class ContactTest(TembaTest):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -988,6 +988,15 @@ class ContactTest(TembaTest):
             self.assertTrue(contact in Contact.search(self.org, '%d' % contact.pk)[0])
             self.assertTrue(contact in Contact.search(self.org, '%010d' % contact.pk)[0])
 
+        # syntactically invalid queries should return no results
+        self.assertEqual(q('name > trey'), 0)  # unrecognized non-field operator
+        self.assertEqual(q('profession > trey'), 0)  # unrecognized text-field operator
+        self.assertEqual(q('age has 4'), 0)  # unrecognized decimal-field operator
+        self.assertEqual(q('age = x'), 0)  # unparseable decimal-field comparison
+        self.assertEqual(q('join_date has 30/1/2014'), 0)  # unrecognized date-field operator
+        self.assertEqual(q('join_date > xxxxx'), 0)  # unparseable date-field comparison
+        self.assertEqual(q('home > kigali'), 0)  # unrecognized location-field operator
+
     def test_omnibox(self):
         # add a group with members and an empty group
         joe_and_frank = self.create_group("Joe and Frank", [self.joe, self.frank])

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -23,7 +23,7 @@ from smartmin.csv_imports.models import ImportTask
 from smartmin.views import SmartCreateView, SmartCRUDL, SmartCSVImportView, SmartDeleteView, SmartFormView
 from smartmin.views import SmartListView, SmartReadView, SmartUpdateView, SmartXlsView, smart_url
 from temba.channels.models import ChannelEvent
-from temba.msgs.models import Broadcast, Msg
+from temba.msgs.models import Msg
 from temba.msgs.views import SendMessageForm
 from temba.orgs.views import OrgPermsMixin, OrgObjPermsMixin, ModalMixin
 from temba.values.models import Value

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1144,20 +1144,7 @@ class ContactCRUDL(SmartCRUDL):
 
 class ContactGroupCRUDL(SmartCRUDL):
     model = ContactGroup
-    actions = ('read', 'update', 'create', 'delete', 'list')
-
-    class List(OrgPermsMixin, SmartListView):
-        pass
-
-    class Read(OrgObjPermsMixin, SmartReadView):
-        fields = ('name', 'contacts')
-
-        def get_context_data(self, **kwargs):
-            context = super(ContactGroupCRUDL.Read, self).get_context_data(**kwargs)
-            group = self.object
-            broadcasts = Broadcast.objects.filter(groups=group.id).order_by('-created_on')
-            context['broadcasts'] = broadcasts
-            return context
+    actions = ('create', 'update', 'delete')
 
     class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
         form_class = ContactGroupForm
@@ -1167,26 +1154,22 @@ class ContactGroupCRUDL(SmartCRUDL):
         submit_button_name = _("Create")
 
         def save(self, obj):
-            obj.org = self.request.user.get_org()
-            self.object = ContactGroup.get_or_create(obj.org, self.request.user, obj.name)
+            org = self.request.user.get_org()
+            user = self.request.user
+            name = self.form.cleaned_data.get('name')
+            query = self.form.cleaned_data.get('group_query')
+            preselected_contacts = self.form.cleaned_data.get('preselected_contacts')
 
-        def post_save(self, obj, *args, **kwargs):
-            obj = super(ContactGroupCRUDL.Create, self).post_save(self.object, *args, **kwargs)
-            data = self.form.cleaned_data
-
-            # static group with initial contact ids
-            if data['preselected_contacts']:
-                preselected_ids = [int(c_id) for c_id in data['preselected_contacts'].split(',') if c_id.isdigit()]
-                preselected_contacts = Contact.objects.filter(pk__in=preselected_ids, org=obj.org, is_active=True)
+            if query:
+                self.object = ContactGroup.create_dynamic(org, user, name, query)
+            else:
+                self.object = ContactGroup.create_static(org, user, name)
 
                 if preselected_contacts:
-                    obj.update_contacts(self.request.user, preselected_contacts, True)
+                    preselected_ids = [int(c_id) for c_id in preselected_contacts.split(',') if c_id.isdigit()]
+                    contacts = Contact.objects.filter(org=org, pk__in=preselected_ids, is_active=True)
 
-            # dynamic group with a query
-            elif data['group_query']:
-                obj.update_query(data['group_query'])
-
-            return obj
+                    self.object.update_contacts(user, contacts, add=True)
 
         def get_form_kwargs(self):
             kwargs = super(ContactGroupCRUDL.Create, self).get_form_kwargs()

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -309,10 +309,11 @@ class UpdateContactForm(ContactForm):
 
         choices += [(l.iso_code, l.name) for l in self.instance.org.languages.all().order_by('orgs', 'name')]
 
-        self.fields['language'] = forms.ChoiceField(required=False, label=_('Language'), initial=self.instance.language, choices=choices)
+        self.fields['language'] = forms.ChoiceField(required=False, label=_('Language'),
+                                                    initial=self.instance.language, choices=choices)
 
         self.fields['groups'].initial = self.instance.user_groups.all()
-        self.fields['groups'].queryset = ContactGroup.user_groups.filter(org=self.user.get_org(), is_active=True)
+        self.fields['groups'].queryset = ContactGroup.get_user_groups(self.user.get_org(), dynamic=False)
         self.fields['groups'].help_text = _("The groups which this contact belongs to")
 
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1037,7 +1037,7 @@ class ContactCRUDL(SmartCRUDL):
 
             new_groups = self.form.cleaned_data.get('groups')
             if new_groups is not None:
-                obj.update_groups(self.request.user, new_groups)
+                obj.update_static_groups(self.request.user, new_groups)
 
         def get_context_data(self, **kwargs):
             context = super(ContactCRUDL.Update, self).get_context_data(**kwargs)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4149,7 +4149,7 @@ class AddToGroupAction(Action):
                     if group:
                         groups.append(group)
                     else:
-                        groups.append(ContactGroup.create(org, org.get_user(), g))
+                        groups.append(ContactGroup.create_static(org, org.get_user(), g))
         return groups
 
     def as_json(self):
@@ -4184,7 +4184,7 @@ class AddToGroupAction(Action):
                         if not group:
 
                             try:
-                                group = ContactGroup.create(contact.org, user, name=value)
+                                group = ContactGroup.create_static(contact.org, user, name=value)
                                 if run.contact.is_test:
                                     ActionLog.info(run, _("Group '%s' created") % value)
                             except ValueError:

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4214,7 +4214,7 @@ class FlowsTest(FlowFileTest):
         self.assertEquals(1, self.contact.msgs.all().count())
         self.assertEquals('You are not in the enrolled group.', self.contact.msgs.all()[0].text)
 
-        enrolled_group = ContactGroup.create(self.org, self.user, "Enrolled")
+        enrolled_group = ContactGroup.create_static(self.org, self.user, "Enrolled")
         enrolled_group.update_contacts(self.user, [self.contact], True)
 
         runs_started = flow.start_msg_flow([self.contact.id])

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -10,8 +10,8 @@ from django.core.urlresolvers import reverse
 from django.utils import timezone
 from mock import patch
 from temba.channels.models import Channel, ChannelEvent
-from temba.contacts.models import ContactField, ContactURN, TEL_SCHEME
-from temba.msgs.models import Msg, Contact, ContactGroup, ExportMessagesTask, RESENT, FAILED, OUTGOING, PENDING, WIRED
+from temba.contacts.models import Contact, ContactField, ContactURN, TEL_SCHEME
+from temba.msgs.models import Msg, ExportMessagesTask, RESENT, FAILED, OUTGOING, PENDING, WIRED
 from temba.msgs.models import Broadcast, Label, SystemLabel, UnreachableException, SMS_BULK_PRIORITY
 from temba.msgs.models import HANDLED, QUEUED, SENT, INCOMING, INBOX, FLOW
 from temba.msgs.tasks import purge_broadcasts_task

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -1255,7 +1255,7 @@ class BroadcastCRUDLTest(TembaTest):
         # but editors can
         self.login(self.editor)
 
-        just_joe = ContactGroup.create(self.org, self.user, "Just Joe")
+        just_joe = self.create_group("Just Joe")
         just_joe.contacts.add(self.joe)
         post_data = dict(omnibox="g-%d,c-%d,n-0780000001" % (just_joe.pk, self.frank.pk),
                          text="Hey Joe, where you goin' with that gun in your hand?")

--- a/temba/perf_tests.py
+++ b/temba/perf_tests.py
@@ -85,7 +85,7 @@ class PerformanceTest(TembaTest):  # pragma: no cover
         num_bases = len(base_names)
         for g in range(0, count):
             name = '%s %d' % (base_names[g % num_bases], g + 1)
-            group = ContactGroup.create(self.org, self.user, name)
+            group = ContactGroup.create_static(self.org, self.user, name)
             group.contacts.add(*contacts[(g % num_bases)::num_bases])
             groups.append(ContactGroup.user_groups.get(pk=group.pk))
         return groups

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -243,10 +243,13 @@ class TembaTest(SmartminTest):
         if contacts and query:
             raise ValueError("Can't provide contact list for a dynamic group")
 
-        group = ContactGroup.create(self.org, self.user, name, query=query)
-        if contacts:
-            group.contacts.add(*contacts)
-        return group
+        if query:
+            return ContactGroup.create_dynamic(self.org, self.user, name, query=query)
+        else:
+            group = ContactGroup.create_static(self.org, self.user, name)
+            if contacts:
+                group.contacts.add(*contacts)
+            return group
 
     def create_msg(self, **kwargs):
         if 'org' not in kwargs:

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -109,7 +109,7 @@ class Trigger(SmartModel):
                         group = ContactGroup.get_user_group(org, group_spec['name'])
 
                     if not group:
-                        group = ContactGroup.create(org, user, group_spec['name'])
+                        group = ContactGroup.create_static(org, user, group_spec['name'])
 
                     if not group.is_active:
                         group.is_active = True

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -175,7 +175,7 @@ class RegisterTriggerForm(BaseTriggerForm):
                 # we must get groups for this org only
                 group = ContactGroup.get_user_group(self.user.get_org(), value)
                 if not group:
-                    group = ContactGroup.create(self.user.get_org(), self.user, name=value)
+                    group = ContactGroup.create_static(self.user.get_org(), self.user, name=value)
                 return group
 
             return super(RegisterTriggerForm.AddNewGroupChoiceField, self).clean(value)


### PR DESCRIPTION
* Prevent changing dynamic groups from contact update form
* Make group creation more explicit with `create_static` vs `create_dynamic`
* Fix blocking and failing (permanently) contacts so that we only remove them from static groups
* Fix releasing contacts so that we remove from dynamic groups in way that doesn't blow up
* Remove unused group views
* Disallow contact fields called "is" or "has"
* Improve unit tests