### PR TITLE
Various perf improvements for bcasts

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -134,8 +134,6 @@ class TwilioHandler(View):
             elif status == 'failed':
                 sms.fail()
 
-            sms.broadcast.update()
-
             return HttpResponse("", status=200)
 
         # this is an incoming message that is being received by Twilio
@@ -249,8 +247,6 @@ class AfricasTalkingHandler(View):
             elif status == 'Rejected' or status == 'Failed':
                 sms.fail()
 
-            sms.broadcast.update()
-
             return HttpResponse("SMS Status Updated")
 
         # this is a new incoming message
@@ -308,9 +304,6 @@ class ZenviaHandler(View):
                 sms.status_sent()
             else:
                 sms.fail()
-
-            # update our broadcast status
-            sms.broadcast.update()
 
             return HttpResponse("SMS Status Updated")
 
@@ -381,8 +374,6 @@ class ExternalHandler(View):
                 sms.status_sent()
             elif action == 'failed':
                 sms.fail()
-
-            sms.broadcast.update()
 
             return HttpResponse("SMS Status Updated")
 
@@ -590,9 +581,6 @@ class InfobipHandler(View):
                         'REJECTED', 'INVALID_MESSAGE_FORMAT']:
             sms.fail()
 
-        if sms.broadcast:
-            sms.broadcast.update()
-
         return HttpResponse("SMS Status Updated")
 
     def get(self, request, *args, **kwargs):
@@ -663,7 +651,6 @@ class Hub9Handler(View):
             elif status != -1:
                 sms.status_sent()
 
-            sms.broadcast.update()
             return HttpResponse("000")
 
         # An MO message
@@ -715,7 +702,6 @@ class HighConnectionHandler(View):
             elif status in [2, 11, 12, 13, 14, 15, 16]:
                 sms.fail()
 
-            sms.broadcast.update()
             return HttpResponse(json.dumps(dict(msg="Status Updated")))
 
         # An MO message
@@ -778,7 +764,6 @@ class BlackmynaHandler(View):
             elif status in [2, 16]:
                 sms.fail()
 
-            sms.broadcast.update()
             return HttpResponse("")
 
         # An MO message
@@ -896,8 +881,6 @@ class NexmoHandler(View):
                 sms.status_sent()
             elif status == 'expired' or status == 'failed':
                 sms.fail()
-
-            sms.broadcast.update()
 
             return HttpResponse("SMS Status Updated")
 
@@ -1097,9 +1080,6 @@ class KannelHandler(View):
             elif status == FAILED:
                 for sms_obj in sms:
                     sms_obj.fail()
-
-            # disabled for performance reasons
-            # sms.first().broadcast.update()
 
             return HttpResponse("SMS Status Updated")
 

--- a/temba/msgs/migrations/0058_update_triggers.py
+++ b/temba/msgs/migrations/0058_update_triggers.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from temba.sql import InstallSQL
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0057_update_triggers'),
+    ]
+
+    operations = [
+        InstallSQL("0058_msgs")
+    ]

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -1750,6 +1750,12 @@ class SystemLabelTest(TembaTest):
         Broadcast.create(self.org, self.user, "Broadcast 2", [contact1, contact2],
                          schedule=Schedule.create_schedule(timezone.now(), 'D', self.user))
 
+        # create a broadcast with a test contact to make sure they aren't included
+        test_bcast = Broadcast.create(self.org, self.user, "Test Broadcast", [Contact.get_test_contact(self.admin)])
+
+        # this will create some test outgoing messages as well
+        test_bcast.send()
+
         self.assertEqual(SystemLabel.get_counts(self.org), {SystemLabel.TYPE_INBOX: 4, SystemLabel.TYPE_FLOWS: 0,
                                                             SystemLabel.TYPE_ARCHIVED: 0, SystemLabel.TYPE_OUTBOX: 0,
                                                             SystemLabel.TYPE_SENT: 0, SystemLabel.TYPE_FAILED: 0,

--- a/temba/sql/0058_msgs.sql
+++ b/temba/sql/0058_msgs.sql
@@ -1,0 +1,401 @@
+----------------------------------------------------------------------
+-- Deprecated functions
+----------------------------------------------------------------------
+DROP FUNCTION IF EXISTS temba_call_on_change();
+
+----------------------------------------------------------------------
+-- Utility function to lookup whether a contact is a simulator contact
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_contact_is_test(_contact_id INT) RETURNS BOOLEAN AS $$
+DECLARE
+  _is_test BOOLEAN;
+BEGIN
+  SELECT is_test INTO STRICT _is_test FROM contacts_contact WHERE id = _contact_id;
+  RETURN _is_test;
+END;
+$$ LANGUAGE plpgsql;
+
+
+----------------------------------------------------------------------
+-- Utility function to lookup whether a contact is a simulator contact
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_channelevent_is_call(_event channels_channelevent) RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN _event.event_type IN ('mo_call', 'mo_miss', 'mt_call', 'mt_miss');
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Reset (i.e. zero-ize) system labels of the given type across all orgs
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_reset_system_labels(_label_types CHAR(1)[]) RETURNS VOID AS $$
+BEGIN
+  UPDATE msgs_systemlabel SET "count" = 0 WHERE label_type = ANY(_label_types);
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Determines the (mutually exclusive) system label for a msg record
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_determine_system_label(_msg msgs_msg) RETURNS CHAR(1) AS $$
+BEGIN
+  IF _msg.direction = 'I' THEN
+    IF _msg.visibility = 'V' THEN
+      IF _msg.msg_type = 'I' THEN
+        RETURN 'I';
+      ELSIF _msg.msg_type = 'F' THEN
+        RETURN 'W';
+      END IF;
+    ELSIF _msg.visibility = 'A' THEN
+      RETURN 'A';
+    END IF;
+  ELSE
+    IF _msg.VISIBILITY = 'V' THEN
+      IF _msg.status = 'P' OR _msg.status = 'Q' THEN
+        RETURN 'O';
+      ELSIF _msg.status = 'W' OR _msg.status = 'S' OR _msg.status = 'D' THEN
+        RETURN 'S';
+      ELSIF _msg.status = 'F' THEN
+        RETURN 'X';
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NULL; -- might not match any label
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Determines the (mutually exclusive) system label for a broadcast record
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_broadcast_determine_system_label(_broadcast msgs_broadcast) RETURNS CHAR(1) AS $$
+BEGIN
+  IF _broadcast.is_active AND _broadcast.schedule_id IS NOT NULL THEN
+    RETURN 'E';
+  END IF;
+
+  RETURN NULL; -- might not match any label
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Trigger procedure to update system labels on channel event changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_channelevent_on_change() RETURNS TRIGGER AS $$
+BEGIN
+  -- new event inserted
+  IF TG_OP = 'INSERT' THEN
+    -- don't update anything for a non-call event or test call
+    IF NOT temba_channelevent_is_call(NEW) OR temba_contact_is_test(NEW.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    IF NEW.is_active THEN
+      PERFORM temba_insert_system_label(NEW.org_id, 'C', 1);
+    END IF;
+
+  -- existing call updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- don't update anything for a non-call event or test call
+    IF NOT temba_channelevent_is_call(NEW) OR temba_contact_is_test(NEW.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    -- is being de-activated
+    IF OLD.is_active AND NOT NEW.is_active THEN
+      PERFORM temba_insert_system_label(NEW.org_id, 'C', -1);
+    -- is being re-activated
+    ELSIF NOT OLD.is_active AND NEW.is_active THEN
+      PERFORM temba_insert_system_label(NEW.org_id, 'C', 1);
+    END IF;
+
+  -- existing call deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- don't update anything for a test call
+    IF NOT temba_channelevent_is_call(OLD) OR temba_contact_is_test(OLD.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    IF OLD.is_active THEN
+      PERFORM temba_insert_system_label(OLD.org_id, 'C', -1);
+    END IF;
+
+  -- all calls deleted
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    PERFORM temba_reset_system_labels('{"C"}');
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT, UPDATE and DELETE on channels_channelevent
+DROP TRIGGER IF EXISTS temba_channelevent_on_change_trg ON channels_channelevent;
+CREATE TRIGGER temba_channelevent_on_change_trg
+  AFTER INSERT OR UPDATE OR DELETE ON channels_channelevent
+  FOR EACH ROW EXECUTE PROCEDURE temba_channelevent_on_change();
+
+-- install for TRUNCATE on channels_channelevent
+DROP TRIGGER IF EXISTS temba_channelevent_on_truncate_trg ON channels_channelevent;
+CREATE TRIGGER temba_channelevent_on_truncate_trg
+  AFTER TRUNCATE ON channels_channelevent
+  EXECUTE PROCEDURE temba_channelevent_on_change();
+
+----------------------------------------------------------------------
+-- Trigger procedure to update system labels on broadcast changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_broadcast_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  _is_test BOOLEAN;
+  _new_label_type CHAR(1);
+  _old_label_type CHAR(1);
+BEGIN
+  -- new broadcast inserted
+  IF TG_OP = 'INSERT' THEN
+    -- don't update anything for a test broadcast
+    IF NEW.recipient_count = 1 THEN
+      SELECT c.is_test INTO _is_test FROM contacts_contact c
+      INNER JOIN msgs_msg m ON m.contact_id = c.id AND m.broadcast_id = NEW.id;
+      IF _is_test = TRUE THEN
+        RETURN NULL;
+      END IF;
+    END IF;
+
+    _new_label_type := temba_broadcast_determine_system_label(NEW);
+    IF _new_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+    END IF;
+
+  -- existing broadcast updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    _old_label_type := temba_broadcast_determine_system_label(OLD);
+    _new_label_type := temba_broadcast_determine_system_label(NEW);
+
+    IF _old_label_type IS DISTINCT FROM _new_label_type THEN
+      -- if this could be a test broadcast, check it and exit if so
+      IF NEW.recipient_count = 1 THEN
+        SELECT c.is_test INTO _is_test FROM contacts_contact c
+        INNER JOIN msgs_msg m ON m.contact_id = c.id AND m.broadcast_id = NEW.id;
+        IF _is_test = TRUE THEN
+          RETURN NULL;
+        END IF;
+      END IF;
+
+      IF _old_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, -1);
+      END IF;
+      IF _new_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+      END IF;
+    END IF;
+
+  -- existing broadcast deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- don't update anything for a test broadcast
+    IF OLD.recipient_count = 1 THEN
+      SELECT c.is_test INTO _is_test FROM contacts_contact c
+      INNER JOIN msgs_msg m ON m.contact_id = c.id AND m.broadcast_id = OLD.id;
+      IF _is_test = TRUE THEN
+        RETURN NULL;
+      END IF;
+    END IF;
+
+    _old_label_type := temba_broadcast_determine_system_label(OLD);
+
+    IF _old_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, 1);
+    END IF;
+
+  -- all broadcast deleted
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    PERFORM temba_reset_system_labels('{"E"}');
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT, UPDATE and DELETE on msgs_broadcast
+DROP TRIGGER IF EXISTS temba_broadcast_on_change_trg ON msgs_broadcast;
+CREATE TRIGGER temba_broadcast_on_change_trg
+  AFTER INSERT OR UPDATE OR DELETE ON msgs_broadcast
+  FOR EACH ROW EXECUTE PROCEDURE temba_broadcast_on_change();
+
+-- install for TRUNCATE on msgs_broadcast
+DROP TRIGGER IF EXISTS temba_broadcast_on_truncate_trg ON msgs_broadcast;
+CREATE TRIGGER temba_broadcast_on_truncate_trg
+  AFTER TRUNCATE ON msgs_broadcast
+  EXECUTE PROCEDURE temba_broadcast_on_change();
+
+----------------------------------------------------------------------
+-- Trigger procedure to maintain user label counts
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_labels_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  is_visible BOOLEAN;
+BEGIN
+  -- label applied to message
+  IF TG_OP = 'INSERT' THEN
+    -- is this message visible
+    SELECT msgs_msg.visibility = 'V' INTO STRICT is_visible FROM msgs_msg WHERE msgs_msg.id = NEW.msg_id;
+
+    IF is_visible THEN
+      UPDATE msgs_label SET visible_count = visible_count + 1 WHERE id = NEW.label_id;
+    END IF;
+
+  -- label removed from message
+  ELSIF TG_OP = 'DELETE' THEN
+    -- is this message visible
+    SELECT msgs_msg.visibility = 'V' INTO STRICT is_visible FROM msgs_msg WHERE msgs_msg.id = OLD.msg_id;
+
+    IF is_visible THEN
+      UPDATE msgs_label SET visible_count = visible_count - 1 WHERE id = OLD.label_id;
+    END IF;
+
+  -- no more labels for any messages
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    UPDATE msgs_label SET visible_count = 0;
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT and DELETE on msgs_msg_labels
+DROP TRIGGER IF EXISTS temba_msg_labels_on_change_trg ON msgs_msg_labels;
+CREATE TRIGGER temba_msg_labels_on_change_trg
+   AFTER INSERT OR DELETE ON msgs_msg_labels
+   FOR EACH ROW EXECUTE PROCEDURE temba_msg_labels_on_change();
+
+-- install for TRUNCATE on msgs_msg_labels
+DROP TRIGGER IF EXISTS temba_msg_labels_on_truncate_trg ON msgs_msg_labels;
+CREATE TRIGGER temba_msg_labels_on_truncate_trg
+  AFTER TRUNCATE ON msgs_msg_labels
+  EXECUTE PROCEDURE temba_msg_labels_on_change();
+
+---------------------------------------------------------------------------------
+-- Increment or decrement a system label
+---------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  temba_insert_system_label(_org_id INT, _label_type CHAR(1), _count INT)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO msgs_systemlabel("org_id", "label_type", "count") VALUES(_org_id, _label_type, _count);
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Trigger procedure to update user and system labels on column changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  _is_test BOOLEAN;
+  _new_label_type CHAR(1);
+  _old_label_type CHAR(1);
+BEGIN
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    -- prevent illegal message states
+    IF NEW.direction = 'I' AND NEW.status NOT IN ('P', 'H') THEN
+      RAISE EXCEPTION 'Incoming messages can only be PENDING or HANDLED';
+    END IF;
+    IF NEW.direction = 'O' AND NEW.visibility = 'A' THEN
+      RAISE EXCEPTION 'Outgoing messages cannot be archived';
+    END IF;
+  END IF;
+
+  -- new message inserted
+  IF TG_OP = 'INSERT' THEN
+    -- don't update anything for a test message
+    IF temba_contact_is_test(NEW.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    _new_label_type := temba_msg_determine_system_label(NEW);
+    IF _new_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+    END IF;
+
+  -- existing message updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    _old_label_type := temba_msg_determine_system_label(OLD);
+    _new_label_type := temba_msg_determine_system_label(NEW);
+
+    IF _old_label_type IS DISTINCT FROM _new_label_type THEN
+      -- don't update anything for a test message
+      IF temba_contact_is_test(NEW.contact_id) THEN
+        RETURN NULL;
+      END IF;
+
+      IF _old_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, -1);
+      END IF;
+      IF _new_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+      END IF;
+    END IF;
+
+    -- is being archived or deleted (i.e. no longer included for user labels)
+    IF OLD.visibility = 'V' AND NEW.visibility != 'V' THEN
+      UPDATE msgs_label SET visible_count = visible_count - 1
+      FROM msgs_msg_labels
+      WHERE msgs_label.label_type = 'L' AND msgs_msg_labels.label_id = msgs_label.id AND msgs_msg_labels.msg_id = NEW.id;
+    END IF;
+
+    -- is being restored (i.e. now included for user labels)
+    IF OLD.visibility != 'V' AND NEW.visibility = 'V' THEN
+      UPDATE msgs_label SET visible_count = visible_count + 1
+      FROM msgs_msg_labels
+      WHERE msgs_label.label_type = 'L' AND msgs_msg_labels.label_id = msgs_label.id AND msgs_msg_labels.msg_id = NEW.id;
+    END IF;
+
+  -- existing message deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- don't update anything for a test message
+    IF temba_contact_is_test(OLD.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    _old_label_type := temba_msg_determine_system_label(OLD);
+
+    IF _old_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, -1);
+    END IF;
+
+  -- all messages deleted
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    PERFORM temba_reset_system_labels('{"I", "W", "A", "O", "S", "X"}');
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT, UPDATE and DELETE on msgs_msg
+DROP TRIGGER IF EXISTS temba_msg_on_change_trg ON msgs_msg;
+CREATE TRIGGER temba_msg_on_change_trg
+  AFTER INSERT OR UPDATE OR DELETE ON msgs_msg
+  FOR EACH ROW EXECUTE PROCEDURE temba_msg_on_change();
+
+-- install for TRUNCATE on msgs_msg
+DROP TRIGGER IF EXISTS temba_msg_on_truncate_trg ON msgs_msg;
+CREATE TRIGGER temba_msg_on_truncate_trg
+  AFTER TRUNCATE ON msgs_msg
+  EXECUTE PROCEDURE temba_msg_on_change();
+
+----------------------------------------------------------------------------------
+-- Squash the label by gathering the counts into a single row
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_squash_systemlabel(_org_id INTEGER, _label_type CHAR(1))
+RETURNS VOID AS $$
+BEGIN
+  WITH deleted as (DELETE FROM msgs_systemlabel
+    WHERE "org_id" = _org_id AND "label_type" = _label_type
+    RETURNING "count")
+    INSERT INTO msgs_systemlabel("org_id", "label_type", "count")
+    VALUES (_org_id, _label_type, GREATEST(0, (SELECT SUM("count") FROM deleted)));
+END;
+$$ LANGUAGE plpgsql;

--- a/temba/sql/current_channels.sql
+++ b/temba/sql/current_channels.sql
@@ -1,0 +1,206 @@
+----------------------------------------------------------------------
+-- Deprecated functions
+----------------------------------------------------------------------
+DROP FUNCTION IF EXISTS temba_increment_channelcount();
+DROP FUNCTION IF EXISTS temba_decrement_channelcount();
+DROP FUNCTION IF EXISTS temba_maybe_squash_channelcount();
+
+----------------------------------------------------------------------
+-- Inserts a new channelcount row with the given values
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_insert_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE, _count INT) RETURNS VOID AS $$
+  BEGIN
+    INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
+      VALUES(_channel_id, _count_type, _count_day, _count);
+  END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Squashes all the existing channel counts with the passed in values into a single row
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_squash_channelcount(_channel_id INTEGER, _count_type VARCHAR(2), _count_day DATE) RETURNS VOID AS $$
+  BEGIN
+    IF _count_day IS NULL THEN
+      WITH removed as (DELETE FROM channels_channelcount
+        WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" IS NULL
+        RETURNING "count")
+        INSERT INTO channels_channelcount("channel_id", "count_type", "count")
+        VALUES (_channel_id, _count_type, GREATEST(0, (SELECT SUM("count") FROM removed)));
+    ELSE
+      WITH removed as (DELETE FROM channels_channelcount
+        WHERE "channel_id" = _channel_id AND "count_type" = _count_type AND "day" = _count_day
+        RETURNING "count")
+        INSERT INTO channels_channelcount("channel_id", "count_type", "day", "count")
+        VALUES (_channel_id, _count_type, _count_day, GREATEST(0, (SELECT SUM("count") FROM removed)));
+    END IF;
+  END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Manages keeping track of the # of messages in our channel log
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_update_channellog_count() RETURNS TRIGGER AS $$
+BEGIN
+  -- ChannelLog being added
+  IF TG_OP = 'INSERT' THEN
+    -- Error, increment our error count
+    IF NEW.is_error THEN
+      PERFORM temba_insert_channelcount(NEW.channel_id, 'LE', NULL::date, 1);
+    -- Success, increment that count instead
+    ELSE
+      PERFORM temba_insert_channelcount(NEW.channel_id, 'LS', NULL::date, 1);
+    END IF;
+
+  -- ChannelLog being removed
+  ELSIF TG_OP = 'DELETE' THEN
+    -- Error, decrement our error count
+    if OLD.is_error THEN
+      PERFORM temba_insert_channelcount(OLD.channel_id, 'LE', NULL::date, -1);
+    -- Success, decrement that count instead
+    ELSE
+      PERFORM temba_insert_channelcount(OLD.channel_id, 'LS', NULL::date, -1);
+    END IF;
+
+  -- Updating is_error is forbidden
+  ELSIF TG_OP = 'UPDATE' THEN
+    RAISE EXCEPTION 'Cannot update is_error or channel_id on ChannelLog events';
+
+  -- Table being cleared, reset all counts
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    DELETE FROM channels_channel WHERE count_type IN ('LE', 'LS');
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Manages keeping track of the # of messages sent and received by a channel
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_update_channelcount() RETURNS TRIGGER AS $$
+DECLARE
+  is_test boolean;
+BEGIN
+  -- Message being updated
+  IF TG_OP = 'INSERT' THEN
+    -- Return if there is no channel on this message
+    IF NEW.channel_id IS NULL THEN
+      RETURN NULL;
+    END IF;
+
+    -- Find out if this is a test contact
+    SELECT contacts_contact.is_test INTO STRICT is_test FROM contacts_contact WHERE id=NEW.contact_id;
+
+    -- Return if it is
+    IF is_test THEN
+      RETURN NULL;
+    END IF;
+
+    -- If this is an incoming message, without message type, then increment that count
+    IF NEW.direction = 'I' THEN
+      -- This is a voice message, increment that count
+      IF NEW.msg_type = 'V' THEN
+        PERFORM temba_insert_channelcount(NEW.channel_id, 'IV', NEW.created_on::date, 1);
+      -- Otherwise, this is a normal message
+      ELSE
+        PERFORM temba_insert_channelcount(NEW.channel_id, 'IM', NEW.created_on::date, 1);
+      END IF;
+
+    -- This is an outgoing message
+    ELSIF NEW.direction = 'O' THEN
+      -- This is a voice message, increment that count
+      IF NEW.msg_type = 'V' THEN
+        PERFORM temba_insert_channelcount(NEW.channel_id, 'OV', NEW.created_on::date, 1);
+      -- Otherwise, this is a normal message
+      ELSE
+        PERFORM temba_insert_channelcount(NEW.channel_id, 'OM', NEW.created_on::date, 1);
+      END IF;
+
+    END IF;
+
+  -- Assert that updates aren't happening that we don't approve of
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- If the direction is changing, blow up
+    IF NEW.direction <> OLD.direction THEN
+      RAISE EXCEPTION 'Cannot change direction on messages';
+    END IF;
+
+    -- Cannot move from IVR to Text, or IVR to Text
+    IF (OLD.msg_type <> 'V' AND NEW.msg_type = 'V') OR (OLD.msg_type = 'V' AND NEW.msg_type <> 'V') THEN
+      RAISE EXCEPTION 'Cannot change a message from voice to something else or vice versa';
+    END IF;
+
+    -- Cannot change created_on
+    IF NEW.created_on <> OLD.created_on THEN
+      RAISE EXCEPTION 'Cannot change created_on on messages';
+    END IF;
+
+  -- Message is being deleted, we need to decrement our count
+  ELSIF TG_OP = 'DELETE' THEN
+    -- Find out if this is a test contact
+    SELECT contacts_contact.is_test INTO STRICT is_test FROM contacts_contact WHERE id=OLD.contact_id;
+
+    -- Escape out if this is a test contact
+    IF is_test THEN
+      RETURN NULL;
+    END IF;
+
+    -- This is an incoming message
+    IF OLD.direction = 'I' THEN
+      -- And it is voice
+      IF OLD.msg_type = 'V' THEN
+        PERFORM temba_insert_channelcount(OLD.channel_id, 'IV', OLD.created_on::date, -1);
+      -- Otherwise, this is a normal message
+      ELSE
+        PERFORM temba_insert_channelcount(OLD.channel_id, 'IM', OLD.created_on::date, -1);
+      END IF;
+
+    -- This is an outgoing message
+    ELSIF OLD.direction = 'O' THEN
+      -- And it is voice
+      IF OLD.msg_type = 'V' THEN
+        PERFORM temba_insert_channelcount(OLD.channel_id, 'OV', OLD.created_on::date, -1);
+      -- Otherwise, this is a normal message
+      ELSE
+        PERFORM temba_insert_channelcount(OLD.channel_id, 'OM', OLD.created_on::date, -1);
+      END IF;
+    END IF;
+
+  -- Table being cleared, reset all counts
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    DELETE FROM channels_channel WHERE count_type IN ('IV', 'IM', 'OV', 'OM');
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Install INSERT, UPDATE and DELETE triggers
+DROP TRIGGER IF EXISTS temba_channellog_update_channelcount on channels_channellog;
+CREATE TRIGGER temba_channellog_update_channelcount
+   AFTER INSERT OR DELETE OR UPDATE OF is_error, channel_id
+   ON channels_channellog
+   FOR EACH ROW
+   EXECUTE PROCEDURE temba_update_channellog_count();
+
+-- Install TRUNCATE trigger
+DROP TRIGGER IF EXISTS temba_channellog_truncate_channelcount on channels_channellog;
+CREATE TRIGGER temba_channellog_truncate_channelcount
+  AFTER TRUNCATE
+  ON channels_channellog
+  EXECUTE PROCEDURE temba_update_channellog_count();
+
+-- Install INSERT, UPDATE and DELETE triggers
+DROP TRIGGER IF EXISTS temba_msg_update_channelcount on msgs_msg;
+CREATE TRIGGER temba_msg_update_channelcount
+   AFTER INSERT OR DELETE OR UPDATE OF direction, msg_type, created_on
+   ON msgs_msg
+   FOR EACH ROW
+   EXECUTE PROCEDURE temba_update_channelcount();
+
+-- Install TRUNCATE trigger
+DROP TRIGGER IF EXISTS temba_msg_clear_channelcount on msgs_msg;
+CREATE TRIGGER temba_msg_clear_channelcount
+  AFTER TRUNCATE
+  ON msgs_msg
+  EXECUTE PROCEDURE temba_update_channelcount();

--- a/temba/sql/current_contacts.sql
+++ b/temba/sql/current_contacts.sql
@@ -1,0 +1,205 @@
+----------------------------------------------------------------------
+-- Trigger procedure to update group count
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION update_group_count() RETURNS TRIGGER AS $$
+DECLARE
+  is_test BOOLEAN;
+BEGIN
+  -- contact being added to group
+  IF TG_OP = 'INSERT' THEN
+    -- is this a test contact
+    SELECT contacts_contact.is_test INTO STRICT is_test FROM contacts_contact WHERE id = NEW.contact_id;
+
+    IF NOT is_test THEN
+      INSERT INTO contacts_contactgroupcount("group_id", "count") VALUES(NEW.contactgroup_id, 1);
+    END IF;
+
+  -- contact being removed from a group
+  ELSIF TG_OP = 'DELETE' THEN
+    -- is this a test contact
+    SELECT contacts_contact.is_test INTO STRICT is_test FROM contacts_contact WHERE id = OLD.contact_id;
+
+    IF NOT is_test THEN
+      INSERT INTO contacts_contactgroupcount("group_id", "count") VALUES(OLD.contactgroup_id, -1);
+    END IF;
+
+  -- table being cleared, clear our counts
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    TRUNCATE contacts_contactgroupcount;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT and DELETE on contacts_contactgroup_contacts
+DROP TRIGGER IF EXISTS when_contact_groups_changed_then_update_count_trg on contacts_contactgroup_contacts;
+CREATE TRIGGER when_contact_groups_changed_then_update_count_trg
+   AFTER INSERT OR DELETE ON contacts_contactgroup_contacts
+   FOR EACH ROW EXECUTE PROCEDURE update_group_count();
+
+-- install for TRUNCATE on contacts_contactgroup_contacts
+DROP TRIGGER IF EXISTS when_contact_groups_truncate_then_update_count_trg on contacts_contactgroup_contacts;
+CREATE TRIGGER when_contact_groups_truncate_then_update_count_trg
+  AFTER TRUNCATE ON contacts_contactgroup_contacts
+  EXECUTE PROCEDURE update_group_count();
+
+----------------------------------------------------------------------
+-- Toggle a contact's membership of a system group in their org
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  contact_toggle_system_group(_contact_id INT, _org_id INT, _group_type CHAR(1), _add BOOLEAN)
+RETURNS VOID AS $$
+DECLARE
+  _group_id INT;
+BEGIN
+  -- lookup the group id
+  SELECT id INTO STRICT _group_id FROM contacts_contactgroup
+  WHERE org_id = _org_id AND group_type = _group_type;
+
+  -- don't do anything if group doesn't exist for some inexplicable reason
+  IF _group_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF _add THEN
+    BEGIN
+      INSERT INTO contacts_contactgroup_contacts (contactgroup_id, contact_id) VALUES (_group_id, _contact_id);
+    EXCEPTION WHEN unique_violation THEN
+      -- do nothing
+    END;
+  ELSE
+    DELETE FROM contacts_contactgroup_contacts WHERE contactgroup_id = _group_id AND contact_id = _contact_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Convenience method to call contact_toggle_system_group with a row
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  contact_toggle_system_group(_contact contacts_contact, _group_type CHAR(1), _add BOOLEAN)
+RETURNS VOID AS $$
+DECLARE
+  _group_id INT;
+BEGIN
+  PERFORM contact_toggle_system_group(_contact.id, _contact.org_id, _group_type, _add);
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Trigger procedure to update contact system groups on column changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION update_contact_system_groups() RETURNS TRIGGER AS $$
+BEGIN
+  -- new contact added
+  IF TG_OP = 'INSERT' AND NEW.is_active AND NOT NEW.is_test THEN
+    IF NEW.is_blocked THEN
+      PERFORM contact_toggle_system_group(NEW, 'B', true);
+    ELSE
+      PERFORM contact_toggle_system_group(NEW, 'A', true);
+      IF NEW.is_failed THEN
+          PERFORM contact_toggle_system_group(NEW, 'F', true);
+      END IF;
+    END IF;
+  END IF;
+
+  -- existing contact updated
+  IF TG_OP = 'UPDATE' AND NOT NEW.is_test THEN
+    -- do nothing for inactive contacts
+    IF NOT OLD.is_active AND NOT NEW.is_active THEN
+      RETURN NULL;
+    END IF;
+
+    -- is being blocked
+    IF NOT OLD.is_blocked AND NEW.is_blocked THEN
+      PERFORM contact_toggle_system_group(NEW, 'A', false);
+      PERFORM contact_toggle_system_group(NEW, 'B', true);
+      PERFORM contact_toggle_system_group(NEW, 'F', false);
+    END IF;
+
+    -- is being unblocked
+    IF OLD.is_blocked AND NOT NEW.is_blocked THEN
+      PERFORM contact_toggle_system_group(NEW, 'A', true);
+      PERFORM contact_toggle_system_group(NEW, 'B', false);
+      IF NEW.is_failed THEN
+        PERFORM contact_toggle_system_group(NEW, 'F', true);
+      END IF;
+    END IF;
+
+    -- is being failed
+    IF NOT OLD.is_failed AND NEW.is_failed THEN
+      PERFORM contact_toggle_system_group(NEW, 'F', true);
+    END IF;
+
+    -- is being unfailed
+    IF OLD.is_failed AND NOT NEW.is_failed THEN
+      PERFORM contact_toggle_system_group(NEW, 'F', false);
+    END IF;
+
+    -- is being released
+    IF OLD.is_active AND NOT NEW.is_active THEN
+      PERFORM contact_toggle_system_group(NEW, 'A', false);
+      PERFORM contact_toggle_system_group(NEW, 'B', false);
+      PERFORM contact_toggle_system_group(NEW, 'F', false);
+    END IF;
+
+    -- is being unreleased
+    IF NOT OLD.is_active AND NEW.is_active THEN
+      IF NOT NEW.is_blocked THEN
+        PERFORM contact_toggle_system_group(NEW, 'A', true);
+      ELSE
+        PERFORM contact_toggle_system_group(NEW, 'B', true);
+      END IF;
+      IF NEW.is_failed THEN
+        PERFORM contact_toggle_system_group(NEW, 'F', true);
+      END IF;
+    END IF;
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT and UPDATE on contacts_contact
+DROP TRIGGER IF EXISTS when_contacts_changed_then_update_groups_trg ON contacts_contact;
+CREATE TRIGGER when_contacts_changed_then_update_groups_trg
+   AFTER INSERT OR UPDATE ON contacts_contact
+   FOR EACH ROW EXECUTE PROCEDURE update_contact_system_groups();
+
+----------------------------------------------------------------------
+-- Trigger procedure to prevent illegal state changes to contacts
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION contact_check_update() RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.is_test != NEW.is_test THEN
+    RAISE EXCEPTION 'Contact.is_test cannot be changed';
+  END IF;
+
+  IF NEW.is_test AND (NEW.is_blocked OR NEW.is_failed) THEN
+    RAISE EXCEPTION 'Test contacts cannot be blocked or failed';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for UPDATE on contacts_contact
+DROP TRIGGER IF EXISTS contact_check_update_trg ON contacts_contact;
+CREATE TRIGGER contact_check_update_trg
+   BEFORE UPDATE OF is_test, is_blocked, is_failed ON contacts_contact
+   FOR EACH ROW EXECUTE PROCEDURE contact_check_update();
+
+----------------------------------------------------------------------------------
+-- Squash the group counts by gathering the counts into a single row
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_squash_contactgroupcounts(_group_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+  WITH deleted as (DELETE FROM contacts_contactgroupcount
+    WHERE "group_id" = _group_id RETURNING "count")
+    INSERT INTO contacts_contactgroupcount("group_id", "count")
+    VALUES (_group_id, GREATEST(0, (SELECT SUM("count") FROM deleted)));
+END;
+$$ LANGUAGE plpgsql;

--- a/temba/sql/current_msgs.sql
+++ b/temba/sql/current_msgs.sql
@@ -1,0 +1,401 @@
+----------------------------------------------------------------------
+-- Deprecated functions
+----------------------------------------------------------------------
+DROP FUNCTION IF EXISTS temba_call_on_change();
+
+----------------------------------------------------------------------
+-- Utility function to lookup whether a contact is a simulator contact
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_contact_is_test(_contact_id INT) RETURNS BOOLEAN AS $$
+DECLARE
+  _is_test BOOLEAN;
+BEGIN
+  SELECT is_test INTO STRICT _is_test FROM contacts_contact WHERE id = _contact_id;
+  RETURN _is_test;
+END;
+$$ LANGUAGE plpgsql;
+
+
+----------------------------------------------------------------------
+-- Utility function to lookup whether a contact is a simulator contact
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_channelevent_is_call(_event channels_channelevent) RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN _event.event_type IN ('mo_call', 'mo_miss', 'mt_call', 'mt_miss');
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Reset (i.e. zero-ize) system labels of the given type across all orgs
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_reset_system_labels(_label_types CHAR(1)[]) RETURNS VOID AS $$
+BEGIN
+  UPDATE msgs_systemlabel SET "count" = 0 WHERE label_type = ANY(_label_types);
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Determines the (mutually exclusive) system label for a msg record
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_determine_system_label(_msg msgs_msg) RETURNS CHAR(1) AS $$
+BEGIN
+  IF _msg.direction = 'I' THEN
+    IF _msg.visibility = 'V' THEN
+      IF _msg.msg_type = 'I' THEN
+        RETURN 'I';
+      ELSIF _msg.msg_type = 'F' THEN
+        RETURN 'W';
+      END IF;
+    ELSIF _msg.visibility = 'A' THEN
+      RETURN 'A';
+    END IF;
+  ELSE
+    IF _msg.VISIBILITY = 'V' THEN
+      IF _msg.status = 'P' OR _msg.status = 'Q' THEN
+        RETURN 'O';
+      ELSIF _msg.status = 'W' OR _msg.status = 'S' OR _msg.status = 'D' THEN
+        RETURN 'S';
+      ELSIF _msg.status = 'F' THEN
+        RETURN 'X';
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NULL; -- might not match any label
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Determines the (mutually exclusive) system label for a broadcast record
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_broadcast_determine_system_label(_broadcast msgs_broadcast) RETURNS CHAR(1) AS $$
+BEGIN
+  IF _broadcast.is_active AND _broadcast.schedule_id IS NOT NULL THEN
+    RETURN 'E';
+  END IF;
+
+  RETURN NULL; -- might not match any label
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Trigger procedure to update system labels on channel event changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_channelevent_on_change() RETURNS TRIGGER AS $$
+BEGIN
+  -- new event inserted
+  IF TG_OP = 'INSERT' THEN
+    -- don't update anything for a non-call event or test call
+    IF NOT temba_channelevent_is_call(NEW) OR temba_contact_is_test(NEW.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    IF NEW.is_active THEN
+      PERFORM temba_insert_system_label(NEW.org_id, 'C', 1);
+    END IF;
+
+  -- existing call updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- don't update anything for a non-call event or test call
+    IF NOT temba_channelevent_is_call(NEW) OR temba_contact_is_test(NEW.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    -- is being de-activated
+    IF OLD.is_active AND NOT NEW.is_active THEN
+      PERFORM temba_insert_system_label(NEW.org_id, 'C', -1);
+    -- is being re-activated
+    ELSIF NOT OLD.is_active AND NEW.is_active THEN
+      PERFORM temba_insert_system_label(NEW.org_id, 'C', 1);
+    END IF;
+
+  -- existing call deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- don't update anything for a test call
+    IF NOT temba_channelevent_is_call(OLD) OR temba_contact_is_test(OLD.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    IF OLD.is_active THEN
+      PERFORM temba_insert_system_label(OLD.org_id, 'C', -1);
+    END IF;
+
+  -- all calls deleted
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    PERFORM temba_reset_system_labels('{"C"}');
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT, UPDATE and DELETE on channels_channelevent
+DROP TRIGGER IF EXISTS temba_channelevent_on_change_trg ON channels_channelevent;
+CREATE TRIGGER temba_channelevent_on_change_trg
+  AFTER INSERT OR UPDATE OR DELETE ON channels_channelevent
+  FOR EACH ROW EXECUTE PROCEDURE temba_channelevent_on_change();
+
+-- install for TRUNCATE on channels_channelevent
+DROP TRIGGER IF EXISTS temba_channelevent_on_truncate_trg ON channels_channelevent;
+CREATE TRIGGER temba_channelevent_on_truncate_trg
+  AFTER TRUNCATE ON channels_channelevent
+  EXECUTE PROCEDURE temba_channelevent_on_change();
+
+----------------------------------------------------------------------
+-- Trigger procedure to update system labels on broadcast changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_broadcast_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  _is_test BOOLEAN;
+  _new_label_type CHAR(1);
+  _old_label_type CHAR(1);
+BEGIN
+  -- new broadcast inserted
+  IF TG_OP = 'INSERT' THEN
+    -- don't update anything for a test broadcast
+    IF NEW.recipient_count = 1 THEN
+      SELECT c.is_test INTO _is_test FROM contacts_contact c
+      INNER JOIN msgs_msg m ON m.contact_id = c.id AND m.broadcast_id = NEW.id;
+      IF _is_test = TRUE THEN
+        RETURN NULL;
+      END IF;
+    END IF;
+
+    _new_label_type := temba_broadcast_determine_system_label(NEW);
+    IF _new_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+    END IF;
+
+  -- existing broadcast updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    _old_label_type := temba_broadcast_determine_system_label(OLD);
+    _new_label_type := temba_broadcast_determine_system_label(NEW);
+
+    IF _old_label_type IS DISTINCT FROM _new_label_type THEN
+      -- if this could be a test broadcast, check it and exit if so
+      IF NEW.recipient_count = 1 THEN
+        SELECT c.is_test INTO _is_test FROM contacts_contact c
+        INNER JOIN msgs_msg m ON m.contact_id = c.id AND m.broadcast_id = NEW.id;
+        IF _is_test = TRUE THEN
+          RETURN NULL;
+        END IF;
+      END IF;
+
+      IF _old_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, -1);
+      END IF;
+      IF _new_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+      END IF;
+    END IF;
+
+  -- existing broadcast deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- don't update anything for a test broadcast
+    IF OLD.recipient_count = 1 THEN
+      SELECT c.is_test INTO _is_test FROM contacts_contact c
+      INNER JOIN msgs_msg m ON m.contact_id = c.id AND m.broadcast_id = OLD.id;
+      IF _is_test = TRUE THEN
+        RETURN NULL;
+      END IF;
+    END IF;
+
+    _old_label_type := temba_broadcast_determine_system_label(OLD);
+
+    IF _old_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, 1);
+    END IF;
+
+  -- all broadcast deleted
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    PERFORM temba_reset_system_labels('{"E"}');
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT, UPDATE and DELETE on msgs_broadcast
+DROP TRIGGER IF EXISTS temba_broadcast_on_change_trg ON msgs_broadcast;
+CREATE TRIGGER temba_broadcast_on_change_trg
+  AFTER INSERT OR UPDATE OR DELETE ON msgs_broadcast
+  FOR EACH ROW EXECUTE PROCEDURE temba_broadcast_on_change();
+
+-- install for TRUNCATE on msgs_broadcast
+DROP TRIGGER IF EXISTS temba_broadcast_on_truncate_trg ON msgs_broadcast;
+CREATE TRIGGER temba_broadcast_on_truncate_trg
+  AFTER TRUNCATE ON msgs_broadcast
+  EXECUTE PROCEDURE temba_broadcast_on_change();
+
+----------------------------------------------------------------------
+-- Trigger procedure to maintain user label counts
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_labels_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  is_visible BOOLEAN;
+BEGIN
+  -- label applied to message
+  IF TG_OP = 'INSERT' THEN
+    -- is this message visible
+    SELECT msgs_msg.visibility = 'V' INTO STRICT is_visible FROM msgs_msg WHERE msgs_msg.id = NEW.msg_id;
+
+    IF is_visible THEN
+      UPDATE msgs_label SET visible_count = visible_count + 1 WHERE id = NEW.label_id;
+    END IF;
+
+  -- label removed from message
+  ELSIF TG_OP = 'DELETE' THEN
+    -- is this message visible
+    SELECT msgs_msg.visibility = 'V' INTO STRICT is_visible FROM msgs_msg WHERE msgs_msg.id = OLD.msg_id;
+
+    IF is_visible THEN
+      UPDATE msgs_label SET visible_count = visible_count - 1 WHERE id = OLD.label_id;
+    END IF;
+
+  -- no more labels for any messages
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    UPDATE msgs_label SET visible_count = 0;
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT and DELETE on msgs_msg_labels
+DROP TRIGGER IF EXISTS temba_msg_labels_on_change_trg ON msgs_msg_labels;
+CREATE TRIGGER temba_msg_labels_on_change_trg
+   AFTER INSERT OR DELETE ON msgs_msg_labels
+   FOR EACH ROW EXECUTE PROCEDURE temba_msg_labels_on_change();
+
+-- install for TRUNCATE on msgs_msg_labels
+DROP TRIGGER IF EXISTS temba_msg_labels_on_truncate_trg ON msgs_msg_labels;
+CREATE TRIGGER temba_msg_labels_on_truncate_trg
+  AFTER TRUNCATE ON msgs_msg_labels
+  EXECUTE PROCEDURE temba_msg_labels_on_change();
+
+---------------------------------------------------------------------------------
+-- Increment or decrement a system label
+---------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  temba_insert_system_label(_org_id INT, _label_type CHAR(1), _count INT)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO msgs_systemlabel("org_id", "label_type", "count") VALUES(_org_id, _label_type, _count);
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Trigger procedure to update user and system labels on column changes
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_msg_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  _is_test BOOLEAN;
+  _new_label_type CHAR(1);
+  _old_label_type CHAR(1);
+BEGIN
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    -- prevent illegal message states
+    IF NEW.direction = 'I' AND NEW.status NOT IN ('P', 'H') THEN
+      RAISE EXCEPTION 'Incoming messages can only be PENDING or HANDLED';
+    END IF;
+    IF NEW.direction = 'O' AND NEW.visibility = 'A' THEN
+      RAISE EXCEPTION 'Outgoing messages cannot be archived';
+    END IF;
+  END IF;
+
+  -- new message inserted
+  IF TG_OP = 'INSERT' THEN
+    -- don't update anything for a test message
+    IF temba_contact_is_test(NEW.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    _new_label_type := temba_msg_determine_system_label(NEW);
+    IF _new_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+    END IF;
+
+  -- existing message updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    _old_label_type := temba_msg_determine_system_label(OLD);
+    _new_label_type := temba_msg_determine_system_label(NEW);
+
+    IF _old_label_type IS DISTINCT FROM _new_label_type THEN
+      -- don't update anything for a test message
+      IF temba_contact_is_test(NEW.contact_id) THEN
+        RETURN NULL;
+      END IF;
+
+      IF _old_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, -1);
+      END IF;
+      IF _new_label_type IS NOT NULL THEN
+        PERFORM temba_insert_system_label(NEW.org_id, _new_label_type, 1);
+      END IF;
+    END IF;
+
+    -- is being archived or deleted (i.e. no longer included for user labels)
+    IF OLD.visibility = 'V' AND NEW.visibility != 'V' THEN
+      UPDATE msgs_label SET visible_count = visible_count - 1
+      FROM msgs_msg_labels
+      WHERE msgs_label.label_type = 'L' AND msgs_msg_labels.label_id = msgs_label.id AND msgs_msg_labels.msg_id = NEW.id;
+    END IF;
+
+    -- is being restored (i.e. now included for user labels)
+    IF OLD.visibility != 'V' AND NEW.visibility = 'V' THEN
+      UPDATE msgs_label SET visible_count = visible_count + 1
+      FROM msgs_msg_labels
+      WHERE msgs_label.label_type = 'L' AND msgs_msg_labels.label_id = msgs_label.id AND msgs_msg_labels.msg_id = NEW.id;
+    END IF;
+
+  -- existing message deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- don't update anything for a test message
+    IF temba_contact_is_test(OLD.contact_id) THEN
+      RETURN NULL;
+    END IF;
+
+    _old_label_type := temba_msg_determine_system_label(OLD);
+
+    IF _old_label_type IS NOT NULL THEN
+      PERFORM temba_insert_system_label(OLD.org_id, _old_label_type, -1);
+    END IF;
+
+  -- all messages deleted
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    PERFORM temba_reset_system_labels('{"I", "W", "A", "O", "S", "X"}');
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT, UPDATE and DELETE on msgs_msg
+DROP TRIGGER IF EXISTS temba_msg_on_change_trg ON msgs_msg;
+CREATE TRIGGER temba_msg_on_change_trg
+  AFTER INSERT OR UPDATE OR DELETE ON msgs_msg
+  FOR EACH ROW EXECUTE PROCEDURE temba_msg_on_change();
+
+-- install for TRUNCATE on msgs_msg
+DROP TRIGGER IF EXISTS temba_msg_on_truncate_trg ON msgs_msg;
+CREATE TRIGGER temba_msg_on_truncate_trg
+  AFTER TRUNCATE ON msgs_msg
+  EXECUTE PROCEDURE temba_msg_on_change();
+
+----------------------------------------------------------------------------------
+-- Squash the label by gathering the counts into a single row
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_squash_systemlabel(_org_id INTEGER, _label_type CHAR(1))
+RETURNS VOID AS $$
+BEGIN
+  WITH deleted as (DELETE FROM msgs_systemlabel
+    WHERE "org_id" = _org_id AND "label_type" = _label_type
+    RETURNING "count")
+    INSERT INTO msgs_systemlabel("org_id", "label_type", "count")
+    VALUES (_org_id, _label_type, GREATEST(0, (SELECT SUM("count") FROM deleted)));
+END;
+$$ LANGUAGE plpgsql;

--- a/temba/sql/current_orgs.sql
+++ b/temba/sql/current_orgs.sql
@@ -1,0 +1,90 @@
+----------------------------------------------------------------------------------
+-- No longer used
+----------------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS update_topup_used();
+DROP FUNCTION IF EXISTS temba_maybe_squash_topupcredits();
+
+----------------------------------------------------------------------------------
+-- Squashes the topup credits for a single topup into a single row
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_squash_topupcredits(_topup_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+  WITH deleted as (DELETE FROM orgs_topupcredits
+    WHERE "topup_id" = _topup_id
+    RETURNING "used")
+    INSERT INTO orgs_topupcredits("topup_id", "used")
+    VALUES (_topup_id, GREATEST(0, (SELECT SUM("used") FROM deleted)));
+END;
+$$ LANGUAGE plpgsql;
+
+---------------------------------------------------------------------------------
+-- Increment or decrement the credits used on a topup
+---------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  temba_insert_topupcredits(_topup_id INT, _count INT)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO orgs_topupcredits("topup_id", "used") VALUES(_topup_id, _count);
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------------------
+-- Updates our topup credits for the topup being assigned to the Msg
+----------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_update_topupcredits() RETURNS TRIGGER AS $$
+BEGIN
+  -- Msg is being created
+  IF TG_OP = 'INSERT' THEN
+    -- If we have a topup, increment our # of used credits
+    IF NEW.topup_id IS NOT NULL THEN
+      PERFORM temba_insert_topupcredits(NEW.topup_id, 1);
+    END IF;
+
+  -- Msg is being updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- If the topup has changed
+    IF NEW.topup_id IS DISTINCT FROM OLD.topup_id THEN
+      -- If our old topup wasn't null then decrement our used credits on it
+      IF OLD.topup_id IS NOT NULL THEN
+        PERFORM temba_insert_topupcredits(OLD.topup_id, -1);
+      END IF;
+
+      -- if our new topup isn't null, then increment our used credits on it
+      IF NEW.topup_id IS NOT NULL THEN
+        PERFORM temba_insert_topupcredits(NEW.topup_id, 1);
+      END IF;
+    END IF;
+
+  -- Msg is being deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- Remove a used credit if this Msg had one assigned
+    IF OLD.topup_id IS NOT NULL THEN
+      PERFORM temba_insert_topupcredits(OLD.topup_id, -1);
+    END IF;
+
+  -- Msgs table is being truncated
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    -- Clear all used credits
+    TRUNCATE orgs_topupcredits;
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS when_msgs_update_then_update_topup_trg on msgs_msg;
+DROP TRIGGER IF EXISTS temba_when_msgs_update_then_update_topupcredits on msgs_msg;
+CREATE TRIGGER temba_when_msgs_update_then_update_topupcredits
+   AFTER INSERT OR DELETE OR UPDATE OF topup_id
+   ON msgs_msg
+   FOR EACH ROW
+   EXECUTE PROCEDURE temba_update_topupcredits();
+
+DROP TRIGGER IF EXISTS when_msgs_truncate_then_update_topup_trg on msgs_msg;
+DROP TRIGGER IF EXISTS temba_when_msgs_truncate_then_update_topupcredits on msgs_msg;
+CREATE TRIGGER temba_when_msgs_truncate_then_update_topupcredits
+  AFTER TRUNCATE
+  ON msgs_msg
+  EXECUTE PROCEDURE temba_update_topupcredits();


### PR DESCRIPTION
Couple tweaks and changes here:

1. Added a few optimizations to how / when we look for test contacts when broadcasts are updated. Specifically we first check whether we are actually going to change anything since that can all be done without hitting the DB before testing for test contacts and we also only check for test contacts when the number of recipients for a broadcast is exactly 1. (the only case where a test contact could be included)

2. I've removed us trying to keep track of status on Broadcast when we get delivery reports. We were already ignoring this on Vumi and now that we no longer show broadcasts in the Inbox (just an outbox) this seems like being consistent is right. It was also slow for Uganda with huge broadcasts. I think we may actually just want to remove status from Broadcast entirely but want to ship this first and see if anything falls out of that.

3. I've added `current_` sql trigger files that have the current version of the triggers. This should allow for easier diffing when updating triggers. When doing so, you'll need to create your current numbered trigger file as well as copy it over the `current_` file.