### PR TITLE
Fix decimal parsing so that we only return things we can store

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -730,10 +730,16 @@ class Org(SmartModel):
         return str_to_datetime(date_string, self.get_tzinfo(), self.get_dayfirst())
 
     def parse_decimal(self, decimal_string):
+        parsed = None
+
         try:
-            return Decimal(decimal_string)
+            parsed = Decimal(decimal_string)
+            if not parsed.is_finite() or parsed > Decimal('999999999999999999999999'):
+                parsed = None
         except Exception:
-            return None
+            pass
+
+        return parsed
 
     def generate_location_query(self, name, level, is_alias=False):
         if is_alias:

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2218,6 +2218,7 @@ class TestStripeCredits(TembaTest):
         self.assertTrue('Visa' in email.body)
         self.assertTrue('$20' in email.body)
 
+
 class ParsingTest(TembaTest):
 
     def test_parse_decimal(self):
@@ -2229,7 +2230,3 @@ class ParsingTest(TembaTest):
         self.assertEqual(self.org.parse_decimal(""), None)
         self.assertEqual(self.org.parse_decimal("NaN"), None)
         self.assertEqual(self.org.parse_decimal("Infinity"), None)
-
-
-
-

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -5,6 +5,7 @@ import json
 from context_processors import GroupPermWrapper
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
+from decimal import Decimal
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core import mail
@@ -2216,3 +2217,19 @@ class TestStripeCredits(TembaTest):
         self.assertTrue('Rudolph' in email.body)
         self.assertTrue('Visa' in email.body)
         self.assertTrue('$20' in email.body)
+
+class ParsingTest(TembaTest):
+
+    def test_parse_decimal(self):
+        self.assertEqual(self.org.parse_decimal("Not num"), None)
+        self.assertEqual(self.org.parse_decimal("00.123"), Decimal("0.123"))
+        self.assertEqual(self.org.parse_decimal("6e33"), None)
+        self.assertEqual(self.org.parse_decimal("6e5"), Decimal("600000"))
+        self.assertEqual(self.org.parse_decimal("9999999999999999999999999"), None)
+        self.assertEqual(self.org.parse_decimal(""), None)
+        self.assertEqual(self.org.parse_decimal("NaN"), None)
+        self.assertEqual(self.org.parse_decimal("Infinity"), None)
+
+
+
+


### PR DESCRIPTION
Fixes:  
  https://app.getsentry.com/nyaruka/textit/issues/129537314/

Which was caused by someone setting 6e33 on a contact field value which we parsed into a Too Damn Big decimal.