### PR TITLE
FB Channel Claim Update

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1709,7 +1709,7 @@ class ChannelCRUDL(SmartCRUDL):
 
     class ClaimFacebook(OrgPermsMixin, SmartFormView):
         class FacebookForm(forms.Form):
-            page_access_token = forms.CharField(min_length=100, required=True,
+            page_access_token = forms.CharField(min_length=43, required=True,
                                                 help_text=_("The Page Access Token for your Application"))
 
             def clean_page_access_token(self):


### PR DESCRIPTION
Accept Page Access Tokens 43 characters or longer.