### PR TITLE
Shared Export

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -273,7 +273,7 @@ class Flow(TembaModel):
         return flow
 
     @classmethod
-    def export_definitions(cls, flows, fail_on_dependencies=True):
+    def export_definitions(cls, flows):
         """
         Builds a json definition fit for export
         """
@@ -281,25 +281,11 @@ class Flow(TembaModel):
         exported_flows = []
 
         for flow in flows:
-
             # only export current versions
             flow.ensure_current_version()
 
             # get our json with group names
-            flow_definition = flow.as_json(expand_contacts=True)
-            if fail_on_dependencies:
-                # if the flow references other flows, don't allow export yet
-                other_flows = set()
-                for action_set in flow_definition.get('action_sets', []):
-                    for action in action_set.get('actions', []):
-                        action_type = action['type']
-                        if action_type == StartFlowAction.TYPE or action_type == TriggerFlowAction.TYPE:
-                            other_flows.add(action['name'].strip())
-
-                if len(other_flows):
-                    raise FlowReferenceException(other_flows)
-
-            exported_flows.append(flow_definition)
+            exported_flows.append(flow.as_json(expand_contacts=True))
 
         # get all non-schedule based triggers that are active for these flows
         triggers = set()

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -53,11 +53,6 @@ class FlowException(Exception):
         super(FlowException, self).__init__(*args, **kwargs)
 
 
-class FlowReferenceException(Exception):
-    def __init__(self, flow_names):
-        self.flow_names = flow_names
-
-
 FLOW_LOCK_TTL = 60  # 1 minute
 FLOW_LOCK_KEY = 'org:%d:lock:flow:%d:%s'
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3905,32 +3905,6 @@ class FlowsTest(FlowFileTest):
         sms = Msg.all_messages.filter(contact=chw).order_by('-created_on')[0]
         self.assertEquals("Please follow up with Judy Pottier, she has reported she is in pain.", sms.text)
 
-    def test_flow_export_dynamic_group(self):
-        flow = self.get_flow('favorites')
-
-        # get one of our flow actionsets, change it to an AddToGroupAction
-        actionset = ActionSet.objects.filter(flow=flow).order_by('y').first()
-
-        # replace the actions
-        actionset.set_actions_dict([AddToGroupAction([dict(id=1, name="Other Group"), '@contact.name']).as_json()])
-        actionset.save()
-
-        # now try to export it
-        self.login(self.admin)
-        response = self.client.get(reverse('flows.flow_export', args=[flow.pk]))
-        self.assertEquals(200, response.status_code)
-
-        # try to import the flow
-        flow.delete()
-        definition = json.loads(response.content)
-        Flow.import_flows(definition, self.org, self.admin)
-
-        # make sure the created flow has the same action set
-        flow = Flow.objects.filter(name="%s" % flow.name).first()
-        actionset = ActionSet.objects.filter(flow=flow).order_by('y').first()
-
-        self.assertTrue('@contact.name' in actionset.get_actions()[0].groups)
-
     def test_flow_delete(self):
         from temba.campaigns.models import Campaign, CampaignEvent
         flow = self.get_flow('favorites')

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1784,6 +1784,33 @@ class BulkExportTest(TembaTest):
         self.assertEquals(1, len(actions))
         self.assertEquals('Triggered Flow', actions[0]['name'])
 
+    def test_flow_export_dynamic_group(self):
+        flow = self.get_flow('favorites')
+
+        # get one of our flow actionsets, change it to an AddToGroupAction
+        actionset = ActionSet.objects.filter(flow=flow).order_by('y').first()
+
+        # replace the actions
+        from temba.flows.models import AddToGroupAction
+        actionset.set_actions_dict([AddToGroupAction([dict(id=1, name="Other Group"), '@contact.name']).as_json()])
+        actionset.save()
+
+        # now let's export!
+        self.login(self.admin)
+        post_data = dict(flows=[flow.pk], campaigns=[])
+        response = self.client.post(reverse('orgs.org_export'), post_data)
+        exported = json.loads(response.content)
+
+        # try to import the flow
+        flow.delete()
+        json.loads(response.content)
+        Flow.import_flows(exported, self.org, self.admin)
+
+        # make sure the created flow has the same action set
+        flow = Flow.objects.filter(name="%s" % flow.name).first()
+        actionset = ActionSet.objects.filter(flow=flow).order_by('y').first()
+        self.assertTrue('@contact.name' in actionset.get_actions()[0].groups)
+
     def test_missing_flows_on_import(self):
         # import a flow that starts a missing flow
         self.import_file('start-missing-flow')

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -500,7 +500,7 @@ class OrgCRUDL(SmartCRUDL):
                     flows.add(flow)
                 exported_campaigns.append(campaign.as_json())
 
-            definition = Flow.export_definitions(flows, fail_on_dependencies=False)
+            definition = Flow.export_definitions(flows)
             definition['campaigns'] = exported_campaigns
             definition['site'] = request.branding['link']
 

--- a/templates/orgs/org_export.haml
+++ b/templates/orgs/org_export.haml
@@ -10,6 +10,26 @@
   {{ block.super }}
 
   :javascript
+
+    function get_param(name){
+       if(name=(new RegExp('[?&]'+encodeURIComponent(name)+'=([^&]*)')).exec(location.search))
+          return decodeURIComponent(name[1]);
+    }
+
+    $(document).ready(function() {
+      var flow_id = get_param('flow');
+
+      // check the entire group if it's bucketed
+      $('#flows-' + flow_id).parents('.exportables.bucket').each(function(){
+        $(this).find('.select-section').each(function() {
+          $(this).click();
+        })
+      })
+
+      // check individually if for the other group
+      $('#flows_' + flow_id).each(function(){$(this).click()});
+    });
+
     $('.toggle-all').on('change', function() {
       var checked = 'checked' == $(this).attr('checked');
       var id = $(this).attr('id');
@@ -141,7 +161,7 @@
         -trans "Group"
         {{ forloop.counter|apnumber|capfirst }}
 
-      .exportables
+      .exportables.bucket
         .pull-right
           %a.btn.btn-tiny.select-section
             -trans "Select Group"


### PR DESCRIPTION
Remove the single flow export in favor of linking to the bulk export with the current flow's group selected by default. This removes the scenario where users were blocked from exporting flows that depend on other flows and instead gives them to ability export a flow and all of it's dependencies if they chose.