### PR TITLE
UUIDs in nested flow objects

### DIFF
--- a/karma/flows/test_controllers.coffee
+++ b/karma/flows/test_controllers.coffee
@@ -216,7 +216,7 @@ describe 'Controllers:', ->
 
         splitEditor =
           flow:
-            selected:[{id: 123, text: 'Child Flow'}]
+            selected:[{id: 'cf785f12-658a-4821-ae62-7735ea5c6cef', text: 'Child Flow'}]
         
         modalScope.okRules(splitEditor)
 
@@ -229,7 +229,7 @@ describe 'Controllers:', ->
       expect(ruleset.rules.length).toBe(2)
       config = JSON.stringify(ruleset.config)
 
-      expect(JSON.stringify(ruleset.config)).toBe('{"flow":{"name":"Child Flow","id":123}}')
+      expect(JSON.stringify(ruleset.config)).toBe('{"flow":{"name":"Child Flow","uuid":"cf785f12-658a-4821-ae62-7735ea5c6cef"}}')
 
     it 'should filter action options based on flow type', ->
 

--- a/media/test_flows/call-channel-split.json
+++ b/media/test_flows/call-channel-split.json
@@ -95,7 +95,12 @@
         "name": "Call Channel Split", 
         "id": 40799
       }, 
-      "groups": [], 
+      "groups": [
+        {
+          "id":4,
+          "name":"Trigger Group"
+        }
+      ], 
       "keyword": null, 
       "channel": null
     }

--- a/media/test_flows/migrate_to_9.json
+++ b/media/test_flows/migrate_to_9.json
@@ -43,7 +43,7 @@
             {
               "msg": {
                 "base": "Hi there!"
-              }, 
+              },
               "type": "reply"
             },
             {
@@ -66,10 +66,18 @@
               }, 
               "action": "GET", 
               "type": "send"
+            },
+            {
+              "labels": [
+                {
+                  "name": "this label",
+                  "id": label_id
+                }
+              ],
+             "type": "add_label"
             }
           ]
-        }, 
-
+        },
         {
           "y": 142, 
           "x": 166, 

--- a/media/test_flows/migrate_to_9.json
+++ b/media/test_flows/migrate_to_9.json
@@ -1,5 +1,33 @@
 {
-  "campaigns": [], 
+  "campaigns": [
+    {
+      "events": [
+        {
+          "event_type": "M",
+          "relative_to": {
+            "id": 1134,
+            "key": "next_appointment",
+            "label": "Next Show"
+          },
+          "flow": {
+            "name": "Single Message",
+            "id": 2814
+          },
+          "offset": -1,
+          "delivery_hour": -1,
+          "message": "Hi there, your next show is @contact.next_show. Don't miss it!",
+          "id": 9959,
+          "unit": "H"
+        }
+      ],
+      "group": {
+        "name": "Pending Appointments",
+        "id": 2308
+      },
+      "id": 405,
+      "name": "Appointment Schedule"
+    }
+  ],
   "version": 9, 
   "site": "https://app.rapidpro.io", 
   "flows": [

--- a/media/test_flows/migrate_to_9.json
+++ b/media/test_flows/migrate_to_9.json
@@ -1,0 +1,103 @@
+{
+  "campaigns": [], 
+  "version": 9, 
+  "site": "https://app.rapidpro.io", 
+  "flows": [
+    {
+      "base_language": "base", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 100, 
+          "destination": "a04f3046-e053-444f-b018-eff019766ad9", 
+          "uuid": "e4a03298-dd43-4afb-b185-2782fc36a006", 
+          "actions": [
+            {
+              "msg": {
+                "base": "Hi there!"
+              }, 
+              "type": "reply"
+            },
+            {
+              "uuid": "c756af8f-4480-4a91-875d-c0600597c0ae", 
+              "contacts": [
+                {
+                  "id": contact_id, 
+                  "name": "Trey Anastasio"
+                }
+              ],
+              "groups": [
+                {
+                  "id": group_id, 
+                  "name": "Phans"
+                }
+              ],
+              "variables": [], 
+              "msg": {
+                "base": "You're phantastic"
+              }, 
+              "action": "GET", 
+              "type": "send"
+            }
+          ]
+        }, 
+
+        {
+          "y": 142, 
+          "x": 166, 
+          "destination": null, 
+          "uuid": "a04f3046-e053-444f-b018-eff019766ad9", 
+          "actions": [
+            {
+              "type": "add_group", 
+              "groups": [
+                {
+                  "name": "Survey Audience", 
+                  "id": group_id
+                }
+              ]
+            }, 
+            {
+              "type": "del_group", 
+              "groups": [
+                {
+                  "name": "Unsatisfied Customers", 
+                  "id": group_id
+                }
+              ]
+            }, 
+            {
+              "name": "Test flow", 
+              "contacts": [], 
+              "variables": [
+                {
+                  "id": "@contact.tel_e164"
+                }
+              ], 
+              "groups": [], 
+              "type": "trigger-flow", 
+              "id": start_flow_id
+            }, 
+            {
+              "type": "flow", 
+              "name": "Parent Flow", 
+              "id": start_flow_id
+            }
+          ]
+        }
+      ], 
+      "version": 9, 
+      "flow_type": "F", 
+      "entry": "e4a03298-dd43-4afb-b185-2782fc36a006", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 11, 
+        "id": previous_flow_id, 
+        "name": "Migrate to 9", 
+        "saved_on": "2016-06-22T15:05:12.074490Z"
+      }
+    }
+  ], 
+  "triggers": []
+}

--- a/media/test_flows/new_mother.json
+++ b/media/test_flows/new_mother.json
@@ -38,8 +38,10 @@
               },
               {
                 "type": "add_group",
-                "groups": [
-                  "Expecting Mothers"
+                "groups": [ 
+                  {
+                  "name": "Expecting Mothers"
+                  }
                 ]
               }
             ]

--- a/media/test_flows/parent.json
+++ b/media/test_flows/parent.json
@@ -33,7 +33,9 @@
                 "type": "add_group",
                 "uuid": "4ea70294-ca92-478c-b0f4-ffc4fd858412",
                 "groups": [
-                  "Campaign"
+                  {
+                    "name": "Campaign" 
+                  }
                 ]
               },
               {

--- a/media/test_flows/subflow-no-pause.json
+++ b/media/test_flows/subflow-no-pause.json
@@ -1,6 +1,6 @@
 {
   "campaigns": [], 
-  "version": 8, 
+  "version": 9, 
   "site": "https://textit.in", 
   "flows": [
     {
@@ -79,7 +79,7 @@
           "config": {
             "flow": {
               "name": "Flow B",
-              "id": 35641
+              "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93"
             }
           }
         }
@@ -87,7 +87,7 @@
       "metadata": {
         "expires": 10080, 
         "revision": 19, 
-        "id": 35640, 
+        "uuid": "555c48a7-0592-4863-85c1-6b32584d4a93", 
         "name": "Flow A", 
         "saved_on": "2016-05-06T19:54:29.629761Z"
       }
@@ -143,7 +143,7 @@
       "metadata": {
         "expires": 10080, 
         "revision": 3, 
-        "id": 35641, 
+        "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93", 
         "name": "Flow B", 
         "saved_on": "2016-05-06T19:55:33.195336Z"
       }

--- a/media/test_flows/subflow.json
+++ b/media/test_flows/subflow.json
@@ -1,6 +1,6 @@
 {
   "campaigns": [], 
-  "version": 8, 
+  "version": 9, 
   "site": "https://textit.in", 
   "flows": [
     {
@@ -147,7 +147,7 @@
           "x": 248, 
           "config": {
             "flow": {
-              "id": 35637,
+              "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93",
               "name": "Child Flow"
             }
           }
@@ -156,7 +156,7 @@
       "metadata": {
         "expires": 10080, 
         "revision": 24, 
-        "id": 35636, 
+        "uuid": "7c1dee9b-af4c-407b-a269-5553e59149e1", 
         "name": "Parent Flow", 
         "saved_on": "2016-04-26T23:13:32.368766Z"
       }
@@ -264,7 +264,7 @@
       "metadata": {
         "expires": 10080, 
         "revision": 11, 
-        "id": 35637, 
+        "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93", 
         "name": "Child Flow", 
         "saved_on": "2016-04-26T21:34:39.525175Z"
       }

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -1472,7 +1472,14 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
   $scope.saveGroups = (actionType, omnibox) ->
 
     $scope.action.type = actionType
-    $scope.action.groups = omnibox.groups
+
+    groups = []
+    for group in omnibox.groups
+      groups.push
+        uuid: group.id
+        name: group.name
+
+    $scope.action.groups = groups
 
     # add our list of variables
     for variable in omnibox.variables

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -1452,16 +1452,15 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
         if label.id == msgLabel
           found = true
           labels.push
-            id: label.id
+            uuid: label.id
             name: label.text
 
       if not found
         labels.push
-          id: msgLabel.id
+          uuid: msgLabel.id
           name: msgLabel.text
 
     $scope.action.labels = labels
-
 
     $scope.action.type = 'add_label'
     Flow.saveAction(actionset, $scope.action)

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -869,6 +869,9 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
   $scope.showFlip = ->
     return actionset.actions.length < 2
 
+  $scope.get_action_id = (action) ->
+    return action.id
+
   #-----------------------------------------------------------------
   # Rule editor
   #-----------------------------------------------------------------

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -1144,7 +1144,6 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
 
     # subflow rulesets have their own kind of rules
     if ruleset.ruleset_type == 'subflow'
-      $log.debug(ruleset.rules)
 
       needs_completed = true
       needs_expired = true
@@ -1291,7 +1290,7 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
         ruleset.config =
           flow:
             name: flow.text
-            id: flow.id
+            uuid: flow.id
 
         # remove any non subflow actions
         rules = []
@@ -1546,7 +1545,7 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
     $scope.action.flow = 
       uuid: flow.id
       name: flow.text
-      
+
     Flow.saveAction(actionset, $scope.action)
     $modalInstance.close()
 

--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -869,9 +869,6 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
   $scope.showFlip = ->
     return actionset.actions.length < 2
 
-  $scope.get_action_id = (action) ->
-    return action.id
-
   #-----------------------------------------------------------------
   # Rule editor
   #-----------------------------------------------------------------
@@ -1546,8 +1543,10 @@ NodeEditorController = ($rootScope, $scope, $modalInstance, $timeout, $log, Flow
       $scope.action.type = 'flow'
 
     flow = flow[0]
-    $scope.action.id = flow.id
-    $scope.action.name = flow.text
+    $scope.action.flow = 
+      uuid: flow.id
+      name: flow.text
+      
     Flow.saveAction(actionset, $scope.action)
     $modalInstance.close()
 

--- a/static/coffee/flows/widgets.coffee
+++ b/static/coffee/flows/widgets.coffee
@@ -133,7 +133,6 @@ app.directive "select2", ["$timeout", ($timeout) ->
   }
 ]
 
-
 app.directive "selectLabel", ["$timeout", "Flow", ($timeout, Flow) ->
   link = (scope, element, attrs, form) ->
 
@@ -147,7 +146,9 @@ app.directive "selectLabel", ["$timeout", "Flow", ($timeout, Flow) ->
     if scope.ngModel
       initLabels = []
       for label in scope.ngModel
-        initLabels.push(label)
+        initLabels.push
+          id: label.uuid
+          text: label.name
 
       select2.data(initLabels)
 

--- a/static/coffee/flows/widgets.coffee
+++ b/static/coffee/flows/widgets.coffee
@@ -436,9 +436,9 @@ app.directive "omnibox", [ "$timeout", "$log", "Flow", ($timeout, $log, Flow) ->
 
     for item in data
       if item.id[0] == 'g'
-        groups.push({id:parseInt(item.id.slice(2)), name:item.text})
+        groups.push({id:item.id.slice(2), name:item.text})
       else if item.id[0] == 'c'
-        contacts.push({id:parseInt(item.id.slice(2)), name:item.text})
+        contacts.push({id:item.id.slice(2), name:item.text})
       else if item.id[0] == '@'
         variables.push({id:item.id, name:item.id})
       else
@@ -468,14 +468,14 @@ app.directive "omnibox", [ "$timeout", "$log", "Flow", ($timeout, $log, Flow) ->
     if scope.groups
       for group in scope.groups
         if group.name
-          data.push({ id:'g-' + group.id, text:group.name})
+          data.push({ id:'g-' + group.uuid, text:group.name})
         else
           data.push({ id:group, text:group })
 
     if scope.contacts
       for contact in scope.contacts
         if contact.name
-          data.push({ id:'c-' + contact.id, text:contact.name})
+          data.push({ id:'c-' + contact.uuid, text:contact.name})
         else
           data.push({ id:contact, text:contact })
 

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -1,3 +1,4 @@
+
 from __future__ import absolute_import, unicode_literals
 
 import hmac

--- a/temba/api/tests/test_models.py
+++ b/temba/api/tests/test_models.py
@@ -394,8 +394,7 @@ class WebHookTest(TembaTest):
             self.assertTrue(mock.called)
 
             broadcast = Broadcast.objects.get()
-            contact = Contact.get_or_create(self.org, self.admin, name=None, urns=["tel:+250788123123"],
-                                            incoming_channel=self.channel)
+            contact = Contact.get_or_create(self.org, self.admin, name=None, urns=["tel:+250788123123"], channel=self.channel)
             self.assertTrue("I am success", broadcast.text)
             self.assertTrue(contact, broadcast.contacts.all())
 

--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -1087,16 +1087,15 @@ class FlowWriteSerializer(WriteSerializer):
         # first, migrate our definition forward if necessary
         version = flow_json.get('version', CURRENT_EXPORT_VERSION)
         if version < CURRENT_EXPORT_VERSION:
-            flow_json = FlowRevision.migrate_definition(flow_json, version, CURRENT_EXPORT_VERSION)
+            flow_json = FlowRevision.migrate_definition(self.org, flow_json, version, CURRENT_EXPORT_VERSION)
 
         # previous to version 7, uuid could be supplied on the outer element
         uuid = flow_json.get('metadata').get('uuid', flow_json.get('uuid', None))
         name = flow_json.get('metadata').get('name')
 
         if uuid:
-            flow = Flow.objects.get(org=self.org, uuid=uuid)
+            flow = Flow.objects.filter(org=self.org, uuid=uuid).first()
             flow.name = name
-
             flow_type = flow_json.get('flow_type', None)
             if flow_type:
                 flow.flow_type = flow_type
@@ -1239,7 +1238,7 @@ class FlowRunWriteSerializer(WriteSerializer):
         definition = json.loads(flow_revision.definition)
 
         # make sure we are operating off a current spec
-        definition = FlowRevision.migrate_definition(definition, self.flow_obj.version_number, CURRENT_EXPORT_VERSION)
+        definition = FlowRevision.migrate_definition(self.org, definition, self.flow_obj.version_number, CURRENT_EXPORT_VERSION)
 
         for step in steps:
             node_obj = None

--- a/temba/api/v1/views.py
+++ b/temba/api/v1/views.py
@@ -1851,7 +1851,7 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
     By making a ```GET``` request you can list all the flow runs for your organization, filtering them as needed.  Each
     run has the following attributes:
 
-    * **uuid** - the UUID of the run (string) (filterable: ```uuid``` repeatable)
+    * **run** - the id of the run (integer) (filterable: ```run``` repeatable)
     * **flow_uuid** - the UUID of the flow (string) (filterable: ```flow_uuid``` repeatable)
     * **contact** - the UUID of the contact this run applies to (string) filterable: ```contact``` repeatable)
     * **group_uuids** - the UUIDs of any groups this contact is part of (string array, optional) (filterable: ```group_uuids``` repeatable)
@@ -1875,7 +1875,7 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
             "previous": null,
             "results": [
             {
-                "uuid": "988e040c-33ff-4917-a36e-8cfa6a5ac731",
+                "run": 10150051,
                 "flow_uuid": "f5901b62-ba76-4003-9c62-72fdacc1b7b7",
                 "contact": "09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
                 "created_on": "2013-03-02T17:28:12",
@@ -2032,7 +2032,6 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
             queryset = queryset.filter(org=org)
 
         # other queries on the runs themselves...
-
         runs = splitting_getlist(self.request, 'run')
         if runs:
             queryset = queryset.filter(pk__in=runs)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -139,11 +139,11 @@ class AuthenticateView(SmartFormView):
 
 
 class CreatedOnCursorPagination(CustomCursorPagination):
-    ordering = ('-created_on',)
+    ordering = ('-created_on', '-id')
 
 
 class ModifiedOnCursorPagination(CustomCursorPagination):
-    ordering = ('-modified_on',)
+    ordering = ('-modified_on', '-id')
 
 
 class BaseAPIView(generics.GenericAPIView):

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -175,7 +175,7 @@ class Campaign(SmartModel):
                                delivery_hour=event.delivery_hour,
                                message=event.message,
                                flow=dict(uuid=event.flow.uuid, name=event.flow.name),
-                               relative_to=dict(label=event.relative_to.label, key=event.relative_to.key, id=event.relative_to.pk)))
+                               relative_to=dict(label=event.relative_to.label, key=event.relative_to.key)))
         definition['events'] = events
         return definition
 

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -75,12 +75,12 @@ class Campaign(SmartModel):
 
                 # first check if we have the objects by id
                 if same_site:
-                    group = ContactGroup.user_groups.filter(id=campaign_spec['group']['id'], org=org).first()
+                    group = ContactGroup.user_groups.filter(uuid=campaign_spec['group']['uuid'], org=org).first()
                     if group:
                         group.name = campaign_spec['group']['name']
                         group.save()
 
-                    campaign = Campaign.objects.filter(org=org, id=campaign_spec['id']).first()
+                    campaign = Campaign.objects.filter(org=org, uuid=campaign_spec['uuid']).first()
                     if campaign:
                         campaign.name = Campaign.get_unique_name(org, name, ignore=campaign)
                         campaign.save()
@@ -126,7 +126,7 @@ class Campaign(SmartModel):
                                                                    event_spec['delivery_hour'])
                         event.update_flow_name()
                     else:
-                        flow = Flow.objects.filter(org=org, is_active=True, id=event_spec['flow']['id']).first()
+                        flow = Flow.objects.filter(org=org, is_active=True, uuid=event_spec['flow']['uuid']).first()
                         if flow:
                             CampaignEvent.create_flow_event(org, user, campaign, relative_to,
                                                             event_spec['offset'],
@@ -165,16 +165,16 @@ class Campaign(SmartModel):
         A json representation of this event, suitable for export. Note this only returns the ids and names
         of the dependent flows. You will want to export these flows seperately using get_all_flows()
         """
-        definition = dict(name=self.name, id=self.pk, group=dict(id=self.group.id, name=self.group.name))
+        definition = dict(name=self.name, uuid=self.uuid, group=dict(uuid=self.group.uuid, name=self.group.name))
         events = []
 
-        for event in self.events.all().order_by('flow__id'):
-            events.append(dict(id=event.pk, offset=event.offset,
+        for event in self.events.all().order_by('flow__uuid'):
+            events.append(dict(uuid=event.uuid, offset=event.offset,
                                unit=event.unit,
                                event_type=event.event_type,
                                delivery_hour=event.delivery_hour,
                                message=event.message,
-                               flow=dict(id=event.flow.pk, name=event.flow.name),
+                               flow=dict(uuid=event.flow.uuid, name=event.flow.name),
                                relative_to=dict(label=event.relative_to.label, key=event.relative_to.key, id=event.relative_to.pk)))
         definition['events'] = events
         return definition

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -77,7 +77,7 @@ class TwilioHandler(View):
 
                 # find a contact for the one initiating us
                 urn = URN.from_tel(from_number)
-                contact = Contact.get_or_create(channel.org, channel.created_by, urns=[urn], incoming_channel=channel)
+                contact = Contact.get_or_create(channel.org, channel.created_by, urns=[urn], channel=channel)
                 urn_obj = contact.urn_objects[urn]
 
                 flow = Trigger.find_flow_for_inbound_call(contact)
@@ -1728,7 +1728,7 @@ class FacebookHandler(View):
                                         traceback.print_exc()
 
                                 contact = Contact.get_or_create(channel.org, channel.created_by,
-                                                                name=name, urns=[urn], incoming_channel=channel)
+                                                                name=name, urns=[urn], channel=channel)
 
                             msg_date = datetime.fromtimestamp(envelope['timestamp'] / 1000.0).replace(tzinfo=pytz.utc)
                             msg = Msg.create_incoming(channel, urn, content, date=msg_date, contact=contact)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -2668,7 +2668,7 @@ class ChannelEvent(models.Model):
         org = channel.org
         user = User.objects.get(pk=settings.ANONYMOUS_USER_ID)  # TODO lookup by name for latest django-guardian
 
-        contact = Contact.get_or_create(org, user, name=None, urns=[urn], incoming_channel=channel)
+        contact = Contact.get_or_create(org, user, name=None, urns=[urn], channel=channel)
         contact_urn = contact.urn_objects[urn]
 
         event = cls.objects.create(org=org, channel=channel, contact=contact, contact_urn=contact_urn,

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -358,7 +358,11 @@ def sync(request, channel_id):
                         # assumptions
                         if cmd['phone']:
                             urn = URN.from_parts(TEL_SCHEME, cmd['phone'])
-                            ChannelEvent.create(channel, urn, cmd['type'], date, duration)
+                            try:
+                                ChannelEvent.create(channel, urn, cmd['type'], date, duration)
+                            except ValueError:
+                                # in some cases Android passes us invalid URNs, in those cases just ignore them
+                                pass
                         handled = True
 
                     elif keyword == 'gcm':
@@ -1709,7 +1713,7 @@ class ChannelCRUDL(SmartCRUDL):
 
     class ClaimFacebook(OrgPermsMixin, SmartFormView):
         class FacebookForm(forms.Form):
-            page_access_token = forms.CharField(min_length=100, required=True,
+            page_access_token = forms.CharField(min_length=43, required=True,
                                                 help_text=_("The Page Access Token for your Application"))
 
             def clean_page_access_token(self):

--- a/temba/contacts/migrations/0041_indexes_update.py
+++ b/temba/contacts/migrations/0041_indexes_update.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+INDEX_SQL = """
+-- for the API view of active contacts
+CREATE INDEX contacts_contact_org_modified_id_where_nontest_active
+ON contacts_contact (org_id, modified_on DESC, id DESC)
+WHERE is_test = false AND is_active = true;
+
+DROP INDEX IF EXISTS contacts_contact_org_id_modified_on_active;
+
+-- for the API view of deleted contacts
+CREATE INDEX contacts_contact_org_modified_id_where_nontest_inactive
+ON contacts_contact (org_id, modified_on DESC, id DESC)
+WHERE is_test = false AND is_active = false;
+
+DROP INDEX IF EXISTS contacts_contact_org_id_modified_on_inactive;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0040_rename_groups_key'),
+    ]
+
+    operations = [
+        migrations.RunSQL(INDEX_SQL)
+    ]

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -638,7 +638,7 @@ class Contact(TembaModel):
             return None
 
     @classmethod
-    def get_or_create(cls, org, user, name=None, urns=None, incoming_channel=None, uuid=None, language=None, is_test=False, force_urn_update=False):
+    def get_or_create(cls, org, user, name=None, urns=None, channel=None, uuid=None, language=None, is_test=False, force_urn_update=False):
         """
         Gets or creates a contact with the given URNs
         """
@@ -647,7 +647,7 @@ class Contact(TembaModel):
             raise ValueError("Attempt to create contact without org or user")
 
         # if channel is specified then urns should contain the single URN that communicated with the channel
-        if incoming_channel and (not urns or len(urns) > 1):
+        if channel and (not urns or len(urns) > 1):
             raise ValueError("Only one URN may be specified when calling from channel event")
 
         # deal with None being passed into urns
@@ -655,8 +655,8 @@ class Contact(TembaModel):
             urns = ()
 
         # get country from channel or org
-        if incoming_channel:
-            country = incoming_channel.country.code
+        if channel:
+            country = channel.country.code
         else:
             country = org.get_country_code()
 
@@ -669,11 +669,6 @@ class Contact(TembaModel):
 
             if existing_urn and existing_urn.contact:
                 contact = existing_urn.contact
-
-                # update the channel on this URN if this is an incoming message
-                if incoming_channel and incoming_channel != existing_urn.channel:
-                    existing_urn.channel = incoming_channel
-                    existing_urn.save(update_fields=['channel'])
 
                 # return our contact, mapping our existing urn appropriately
                 contact.urn_objects = {urns[0]: existing_urn}
@@ -736,11 +731,6 @@ class Contact(TembaModel):
                         existing_orphan_urns[urn] = existing_urn
                         if not contact and existing_urn.contact:
                             contact = existing_urn.contact
-
-                    # update this URN's channel
-                    if incoming_channel and existing_urn.channel != incoming_channel:
-                        existing_urn.channel = incoming_channel
-                        existing_urn.save(update_fields=['channel'])
                 else:
                     urns_to_create[urn] = normalized
 
@@ -778,7 +768,7 @@ class Contact(TembaModel):
 
             # add all new URNs
             for raw, normalized in urns_to_create.iteritems():
-                urn = ContactURN.create(org, contact, normalized, channel=incoming_channel)
+                urn = ContactURN.create(org, contact, normalized, channel=channel)
                 urn_objects[raw] = urn
 
             # save which urns were updated
@@ -1574,6 +1564,16 @@ class ContactURN(models.Model):
                                 help_text="The preferred channel for this URN")
 
     @classmethod
+    def get_or_create(cls, org, contact, urn_as_string, channel=None):
+        urn = cls.lookup(org, urn_as_string)
+
+        # not found? create it
+        if not urn:
+            urn = cls.create(org, contact, urn_as_string, channel=channel)
+
+        return urn
+
+    @classmethod
     def create(cls, org, contact, urn_as_string, channel=None, priority=None):
         scheme, path = URN.to_parts(urn_as_string)
 
@@ -1592,6 +1592,14 @@ class ContactURN(models.Model):
             urn_as_string = URN.normalize(urn_as_string, country_code)
 
         return cls.objects.filter(org=org, urn=urn_as_string).select_related('contact').first()
+
+    def update_affinity(self, channel):
+        """
+        Checks and optionally updates the affinity for this contact URN
+        """
+        if channel and self.channel != channel:
+            self.channel = channel
+            self.save(update_fields=['channel'])
 
     def ensure_number_normalization(self, country_code):
         """

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -408,7 +408,7 @@ class Contact(TembaModel):
         return self.all_groups.filter(group_type=ContactGroup.TYPE_USER_DEFINED)
 
     def as_json(self):
-        obj = dict(id=self.pk, name=unicode(self))
+        obj = dict(id=self.pk, name=unicode(self), uuid=self.uuid)
 
         if not self.org.is_anon:
             urns = []
@@ -1720,11 +1720,11 @@ class ContactGroup(TembaModel):
         return groups
 
     @classmethod
-    def get_or_create(cls, org, user, name, group_id=None):
+    def get_or_create(cls, org, user, name, group_uuid=None):
         existing = None
 
-        if group_id is not None:
-            existing = ContactGroup.user_groups.filter(org=org, id=group_id).first()
+        if group_uuid is not None:
+            existing = ContactGroup.user_groups.filter(org=org, uuid=group_uuid).first()
 
         if not existing:
             existing = ContactGroup.get_user_group(org, name)

--- a/temba/contacts/omnibox.py
+++ b/temba/contacts/omnibox.py
@@ -16,29 +16,29 @@ def omnibox_query(org, **kwargs):
     Performs a omnibox query based on the given arguments
     """
     # determine what type of group/contact/URN lookup is being requested
-    contact_ids = kwargs.get('c', None)  # contacts with ids
+    contact_uuids = kwargs.get('c', None)  # contacts with ids
     step_uuid = kwargs.get('s', None)    # contacts in flow step with UUID
     message_ids = kwargs.get('m', None)  # contacts with message ids
     label_id = kwargs.get('l', None)     # contacts in flow step with UUID
-    group_ids = kwargs.get('g', None)    # groups with ids
+    group_uuids = kwargs.get('g', None)    # groups with ids
     urn_ids = kwargs.get('u', None)      # URNs with ids
     search = kwargs.get('search', None)  # search of groups, contacts and URNs
     types = kwargs.get('types', None)    # limit search to types (g | s | c | u)
     simulation = kwargs.get('simulation', 'false') == 'true'
 
     # these lookups return a Contact queryset
-    if contact_ids or step_uuid or message_ids or label_id:
+    if contact_uuids or step_uuid or message_ids or label_id:
         qs = Contact.objects.filter(org=org, is_blocked=False, is_active=True, is_test=simulation)
 
-        if contact_ids:
-            qs = qs.filter(id__in=contact_ids.split(","))
+        if contact_uuids:
+            qs = qs.filter(uuid__in=contact_uuids.split(","))
 
         elif step_uuid:
             from temba.flows.models import FlowStep
             steps = FlowStep.objects.filter(run__is_active=True, step_uuid=step_uuid,
                                             left_on=None, run__flow__org=org).distinct('contact').select_related('contact')
-            contact_ids = [f.contact_id for f in steps]
-            qs = qs.filter(id__in=contact_ids)
+            contact_uuids = [f.contact.uuid for f in steps]
+            qs = qs.filter(uuid__in=contact_uuids)
 
         elif message_ids:
             qs = qs.filter(msgs__in=message_ids.split(","))
@@ -50,8 +50,8 @@ def omnibox_query(org, **kwargs):
         return qs.distinct().order_by('name')
 
     # this lookup returns a ContactGroup queryset
-    elif group_ids:
-        qs = ContactGroup.user_groups.filter(org=org, id__in=group_ids.split(","))
+    elif group_uuids:
+        qs = ContactGroup.user_groups.filter(org=org, uuid__in=group_uuids.split(","))
         return qs.annotate(members=Count('contacts')).order_by('name')
 
     # this lookup returns a ContactURN queryset
@@ -110,7 +110,7 @@ def omnibox_mixed_search(org, search, types):
     query_component = namedtuple('query_component', 'clauses params')
 
     if 'g' in types or 's' in types:
-        group_query = """SELECT 1 AS type, g.id AS id, g.name AS text, NULL AS owner, NULL AS scheme
+        group_query = """SELECT 1 AS type, g.uuid AS id, g.name AS text, NULL AS owner, NULL AS scheme
                          FROM contacts_contactgroup g
                          WHERE g.is_active = TRUE AND g.group_type = 'U' AND g.org_id = %s"""
 
@@ -125,7 +125,7 @@ def omnibox_mixed_search(org, search, types):
         union_queries.append(query_component(clauses, params))
 
     if 'c' in types:
-        clauses = ["""SELECT 2 AS type, c.id AS id, c.name AS text, NULL AS owner, NULL AS scheme
+        clauses = ["""SELECT 2 AS type, c.uuid AS id, c.name AS text, NULL AS owner, NULL AS scheme
                       FROM contacts_contact c
                       WHERE c.is_active = TRUE AND c.is_blocked = FALSE AND c.is_test = FALSE AND c.org_id = %s"""]
         params = [org.pk]
@@ -134,7 +134,7 @@ def omnibox_mixed_search(org, search, types):
         union_queries.append(query_component(clauses, params))
 
     if 'u' in types and not org.is_anon and allowed_schemes:
-        clauses = ["""SELECT 3 AS type, cu.id AS id, cu.path AS text, c.name AS owner, cu.scheme AS scheme
+        clauses = ["""SELECT 3 AS type, cast(cu.id as text) AS id, cu.path AS text, c.name AS owner, cu.scheme AS scheme
                       FROM contacts_contacturn cu
                       INNER JOIN contacts_contact c ON c.id = cu.contact_id
                       WHERE cu.org_id = %s AND cu.scheme = ANY(%s)"""]
@@ -163,26 +163,26 @@ def omnibox_results_to_dict(org, results):
             _id, text = obj['id'], obj['text']
 
             if obj['type'] == RESULT_TYPE_GROUP:
-                result['id'] = 'g-%d' % _id
+                result['id'] = 'g-%s' % _id
                 result['text'] = text
-                result['extra'] = ContactGroup.user_groups.get(pk=_id).get_member_count()
+                result['extra'] = ContactGroup.user_groups.get(uuid=_id).get_member_count()
             elif obj['type'] == RESULT_TYPE_CONTACT:
-                result['id'] = 'c-%d' % _id
+                result['id'] = 'c-%s' % _id
                 if not text:
-                    result['text'] = Contact.objects.get(pk=_id).get_display(org)
+                    result['text'] = Contact.objects.get(uuid=_id).get_display(org)
                 else:
                     result['text'] = text
             elif obj['type'] == RESULT_TYPE_URN:
-                result['id'] = 'u-%d' % _id
+                result['id'] = 'u-%s' % _id
                 result['text'] = text
                 result['extra'] = obj['owner']
                 result['scheme'] = obj['scheme']
         elif isinstance(obj, ContactGroup):
-            result['id'] = 'g-%d' % obj.pk
+            result['id'] = 'g-%s' % obj.uuid
             result['text'] = obj.name
             result['extra'] = obj.members
         elif isinstance(obj, Contact):
-            result['id'] = 'c-%d' % obj.pk
+            result['id'] = 'c-%s' % obj.uuid
             result['text'] = obj.get_display(org)
         elif isinstance(obj, ContactURN):
             result['id'] = 'u-%d' % obj.pk

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -528,12 +528,11 @@ class ContactTest(TembaTest):
 
         # incoming channel with no urns
         with self.assertRaises(ValueError):
-            Contact.get_or_create(self.org, self.user, incoming_channel=self.channel, name='Joe', urns=None)
+            Contact.get_or_create(self.org, self.user, channel=self.channel, name='Joe', urns=None)
 
         # incoming channel with two urns
         with self.assertRaises(ValueError):
-            Contact.get_or_create(self.org, self.user, incoming_channel=self.channel, name='Joe', urns=['tel:123',
-                                                                                                        'tel:456'])
+            Contact.get_or_create(self.org, self.user, channel=self.channel, name='Joe', urns=['tel:123', 'tel:456'])
 
         # missing scheme
         with self.assertRaises(ValueError):
@@ -564,9 +563,8 @@ class ContactTest(TembaTest):
         Contact.get_or_create(self.org, self.user, uuid=snoop.uuid, urns=['tel:456'])
 
         self.assertIsNone(snoop.urns.all().first().channel)
-        snoop = Contact.get_or_create(self.org, self.user, incoming_channel=self.channel, urns=['tel:456'])
+        snoop = Contact.get_or_create(self.org, self.user, channel=self.channel, urns=['tel:456'])
         self.assertEquals(1, snoop.urns.all().count())
-        self.assertEqual(snoop.urns.all().first().channel, self.channel)
 
     def test_get_test_contact(self):
         test_contact_admin = Contact.get_test_contact(self.admin)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -216,7 +216,7 @@ class ContactGroupTest(TembaTest):
         self.assertEqual(ContactGroup.get_or_create(self.org, self.user, "  FIRST"), group)
 
         # fetching by id shouldn't modify original group
-        self.assertEqual(ContactGroup.get_or_create(self.org, self.user, "Kigali", group.pk), group)
+        self.assertEqual(ContactGroup.get_or_create(self.org, self.user, "Kigali", group.uuid), group)
 
         group.refresh_from_db()
         self.assertEqual(group.name, "first")
@@ -1067,15 +1067,15 @@ class ContactTest(TembaTest):
 
         self.assertEqual(omnibox_request(""), [
             # all 3 groups A-Z
-            dict(id='g-%d' % joe_and_frank.pk, text="Joe and Frank", extra=2),
-            dict(id='g-%d' % men.pk, text="Men", extra=0),
-            dict(id='g-%d' % nobody.pk, text="Nobody", extra=0),
+            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+            dict(id='g-%s' % men.uuid, text="Men", extra=0),
+            dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0),
 
             # all 4 contacts A-Z
-            dict(id='c-%d' % self.billy.pk, text="Billy Nophone"),
-            dict(id='c-%d' % self.frank.pk, text="Frank Smith"),
-            dict(id='c-%d' % self.joe.pk, text="Joe Blow"),
-            dict(id='c-%d' % self.voldemort.pk, text="250788383383"),
+            dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
+            dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+            dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
+            dict(id='c-%s' % self.voldemort.uuid, text="250788383383"),
 
             # 3 sendable URNs with names as extra
             dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
@@ -1087,23 +1087,23 @@ class ContactTest(TembaTest):
 
         # g = just the 3 groups
         self.assertEqual(omnibox_request("types=g"), [
-            dict(id='g-%d' % joe_and_frank.pk, text="Joe and Frank", extra=2),
-            dict(id='g-%d' % men.pk, text="Men", extra=0),
-            dict(id='g-%d' % nobody.pk, text="Nobody", extra=0)
+            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+            dict(id='g-%s' % men.uuid, text="Men", extra=0),
+            dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0)
         ])
 
         # s = just the 2 non-dynamic (static) groups
         self.assertEqual(omnibox_request("types=s"), [
-            dict(id='g-%d' % joe_and_frank.pk, text="Joe and Frank", extra=2),
-            dict(id='g-%d' % nobody.pk, text="Nobody", extra=0)
+            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+            dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0)
         ])
 
         # c,u = contacts and URNs
         self.assertEqual(omnibox_request("types=c,u"), [
-            dict(id='c-%d' % self.billy.pk, text="Billy Nophone"),
-            dict(id='c-%d' % self.frank.pk, text="Frank Smith"),
-            dict(id='c-%d' % self.joe.pk, text="Joe Blow"),
-            dict(id='c-%d' % self.voldemort.pk, text="250788383383"),
+            dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
+            dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+            dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
+            dict(id='c-%s' % self.voldemort.uuid, text="250788383383"),
             dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
             dict(id='u-%d' % frank_tel.pk, text="1234", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % voldemort_tel.pk, text="250788383383", extra=None, scheme='tel')
@@ -1127,27 +1127,27 @@ class ContactTest(TembaTest):
 
         # search for Joe again - match on last name and twitter handle
         self.assertEqual(omnibox_request("search=BLOW"), [
-            dict(id='c-%d' % self.joe.pk, text="Joe Blow"),
+            dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
             dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
         ])
 
         # make sure our matches are ANDed
         self.assertEqual(omnibox_request("search=Joe+o&types=c"), [
-            dict(id='c-%d' % self.joe.pk, text="Joe Blow")
+            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
         ])
         self.assertEqual(omnibox_request("search=Joe+o&types=g"), [
-            dict(id='g-%d' % joe_and_frank.pk, text="Joe and Frank", extra=2),
+            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
         ])
 
         # lookup by contact ids
-        self.assertEqual(omnibox_request("c=%d,%d" % (self.joe.pk, self.frank.pk)), [
-            dict(id='c-%d' % self.frank.pk, text="Frank Smith"),
-            dict(id='c-%d' % self.joe.pk, text="Joe Blow")
+        self.assertEqual(omnibox_request("c=%s,%s" % (self.joe.uuid, self.frank.uuid)), [
+            dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
         ])
 
         # lookup by group id
-        self.assertEqual(omnibox_request("g=%d" % joe_and_frank.pk), [
-            dict(id='g-%d' % joe_and_frank.pk, text="Joe and Frank", extra=2)
+        self.assertEqual(omnibox_request("g=%s" % joe_and_frank.uuid), [
+            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2)
         ])
 
         # lookup by URN ids
@@ -1160,7 +1160,7 @@ class ContactTest(TembaTest):
         # lookup by message ids
         msg = self.create_msg(direction='I', contact=self.joe, text="some message")
         self.assertEqual(omnibox_request("m=%d" % msg.pk), [
-            dict(id='c-%d' % self.joe.pk, text="Joe Blow")
+            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
         ])
 
         # lookup by label ids
@@ -1169,26 +1169,26 @@ class ContactTest(TembaTest):
 
         msg.labels.add(label)
         self.assertEqual(omnibox_request("l=%d" % label.pk), [
-            dict(id='c-%d' % self.joe.pk, text="Joe Blow")
+            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
         ])
 
         with AnonymousOrg(self.org):
             self.assertEqual(omnibox_request(""), [
                 # all 3 groups...
-                dict(id='g-%d' % joe_and_frank.pk, text="Joe and Frank", extra=2),
-                dict(id='g-%d' % men.pk, text="Men", extra=0),
-                dict(id='g-%d' % nobody.pk, text="Nobody", extra=0),
+                dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+                dict(id='g-%s' % men.uuid, text="Men", extra=0),
+                dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0),
 
                 # all 4 contacts A-Z
-                dict(id='c-%d' % self.billy.pk, text="Billy Nophone"),
-                dict(id='c-%d' % self.frank.pk, text="Frank Smith"),
-                dict(id='c-%d' % self.joe.pk, text="Joe Blow"),
-                dict(id='c-%d' % self.voldemort.pk, text=self.voldemort.anon_identifier)
+                dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
+                dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+                dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
+                dict(id='c-%s' % self.voldemort.uuid, text=self.voldemort.anon_identifier)
             ])
 
             # can search by frank id
             self.assertEqual(omnibox_request("search=%d" % self.frank.pk), [
-                dict(id='c-%d' % self.frank.pk, text="Frank Smith")
+                dict(id='c-%s' % self.frank.uuid, text="Frank Smith")
             ])
 
             # but not by frank number

--- a/temba/flows/migrations/0056_indexes_update.py
+++ b/temba/flows/migrations/0056_indexes_update.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+INDEX_SQL = """
+CREATE INDEX flows_flowrun_org_modified_id
+ON flows_flowrun (org_id, modified_on DESC, id DESC);
+
+DROP INDEX IF EXISTS flows_flowrun_org_id_modified_on;
+
+CREATE INDEX flows_flowrun_org_modified_id_where_responded
+ON flows_flowrun (org_id, modified_on DESC, id DESC)
+WHERE responded = TRUE;
+
+DROP INDEX IF EXISTS flows_flowrun_org_id_modified_on_responded;
+
+CREATE INDEX flows_flowrun_flow_modified_id
+ON flows_flowrun (flow_id, modified_on DESC, id DESC);
+
+DROP INDEX IF EXISTS flows_flowrun_flow_id_modified_on;
+
+CREATE INDEX flows_flowrun_flow_modified_id_where_responded
+ON flows_flowrun (flow_id, modified_on DESC, id DESC)
+WHERE responded = TRUE;
+
+DROP INDEX IF EXISTS flows_flowrun_flow_id_modified_on_responded;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0055_populate_step_broadcasts'),
+    ]
+
+    operations = [
+        migrations.RunSQL(INDEX_SQL)
+    ]

--- a/temba/flows/migrations/0057_flowrun_parent.py
+++ b/temba/flows/migrations/0057_flowrun_parent.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('flows', '0055_populate_step_broadcasts'),
+        ('flows', '0056_indexes_update'),
     ]
 
     operations = [

--- a/temba/flows/migrations/0058_auto_20160524_2147.py
+++ b/temba/flows/migrations/0058_auto_20160524_2147.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('flows', '0056_flowrun_parent'),
+        ('flows', '0057_flowrun_parent'),
     ]
 
     operations = [

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4353,7 +4353,7 @@ class AddLabelAction(Action):
     """
     TYPE = 'add_label'
     LABELS = 'labels'
-    ID = 'id'
+    UUID = 'uuid'
     NAME = 'name'
 
     def __init__(self, labels):
@@ -4364,29 +4364,24 @@ class AddLabelAction(Action):
         labels_data = json_obj.get(AddLabelAction.LABELS)
 
         labels = []
-        for l_data in labels_data:
-            if isinstance(l_data, dict):
-                label_id = l_data.get(AddLabelAction.ID, None)
-                label_name = l_data.get(AddLabelAction.NAME)
+        for label_data in labels_data:
+            if isinstance(label_data, dict):
+                label_uuid = label_data.get(AddLabelAction.UUID, None)
+                label_name = label_data.get(AddLabelAction.NAME)
 
-                try:
-                    label_id = int(label_id)
-                except (TypeError, ValueError):
-                    label_id = 0
-
-                if label_id and Label.label_objects.filter(org=org, id=label_id).first():
-                    label = Label.label_objects.filter(org=org, id=label_id).first()
+                if label_uuid and Label.label_objects.filter(org=org, uuid=label_uuid).first():
+                    label = Label.label_objects.filter(org=org, uuid=label_uuid).first()
                     if label:
                         labels.append(label)
                 else:
                     labels.append(Label.get_or_create(org, org.get_user(), label_name))
 
-            elif isinstance(l_data, basestring):
-                if l_data and l_data[0] == '@':
+            elif isinstance(label_data, basestring):
+                if label_data and label_data[0] == '@':
                     # label name is a variable substitution
-                    labels.append(l_data)
+                    labels.append(label_data)
                 else:
-                    labels.append(Label.get_or_create(org, org.get_user(), l_data))
+                    labels.append(Label.get_or_create(org, org.get_user(), label_data))
             else:
                 raise ValueError("Label data must be a dict or string")
 
@@ -4396,7 +4391,7 @@ class AddLabelAction(Action):
         labels = []
         for action_label in self.labels:
             if isinstance(action_label, Label):
-                labels.append(dict(id=action_label.pk, name=action_label.name))
+                labels.append(dict(uuid=action_label.uuid, name=action_label.name))
             else:
                 labels.append(action_label)
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1927,7 +1927,7 @@ class Flow(TembaModel):
             if 'groups' in action:
                 for group in action['groups']:
                     if isinstance(group, dict):
-                        if 'uuid' in groups:
+                        if 'uuid' in group:
                             groups.append(group['uuid'])
 
         def replace_action_contacts(action, contacts, groups):

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4538,11 +4538,13 @@ class FlowMigrationTest(FlowFileTest):
         group = self.create_group("Phans", [])
         previous_flow = self.create_flow()
         start_flow = self.create_flow()
+        label = Label.get_or_create(self.org, self.admin, 'My label')
 
         substitutions = dict(group_id=group.pk,
                              contact_id=self.contact.pk,
                              start_flow_id=start_flow.pk,
-                             previous_flow_id=previous_flow.pk)
+                             previous_flow_id=previous_flow.pk,
+                             label_id=label.pk)
 
         exported_json = json.loads(self.get_import_json('migrate_to_9', substitutions))
         exported_json = migrate_export_to_version_9(exported_json, self.org, True)
@@ -4578,6 +4580,11 @@ class FlowMigrationTest(FlowFileTest):
         for group in send_action['groups']:
             self.assertIn('uuid', group)
             self.assertNotIn('id', contact)
+
+        label_action = flow_json['action_sets'][0]['actions'][2]
+        for label in label_action.get('labels'):
+            self.assertNotIn('id', label)
+            self.assertIn('uuid', label)
 
         action_set = flow_json['action_sets'][1]
         actions = action_set['actions']

--- a/temba/msgs/migrations/0059_indexes_update.py
+++ b/temba/msgs/migrations/0059_indexes_update.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+INDEX_SQL = """
+-- for the Inbox, Flow and Archived folders
+CREATE INDEX msgs_msg_visibility_type_created_id_where_inbound
+ON msgs_msg(org_id, visibility, msg_type, created_on DESC, id DESC)
+WHERE direction = 'I';
+
+DROP INDEX msg_visibility_direction_type_created_inbound;
+
+-- for the Incoming folder (API only)
+CREATE INDEX msgs_msg_org_modified_id_where_inbound
+ON msgs_msg (org_id, modified_on DESC, id DESC)
+WHERE direction = 'I';
+
+DROP INDEX IF EXISTS msg_direction_modified_inbound;
+
+-- for the Outbox folder
+CREATE INDEX msgs_msg_org_created_id_where_outbound_visible_outbox
+ON msgs_msg(org_id, created_on DESC, id DESC)
+WHERE direction = 'O' AND visibility = 'V' AND status IN ('P', 'Q');
+
+DROP INDEX IF EXISTS msgs_msg_outbox_label;
+
+-- for the Sent folder
+CREATE INDEX msgs_msg_org_created_id_where_outbound_visible_sent
+ON msgs_msg(org_id, created_on DESC, id DESC)
+WHERE direction = 'O' AND visibility = 'V' AND status IN ('W', 'S', 'D');
+
+DROP INDEX IF EXISTS msgs_msg_sent_label;
+
+-- for the Failed folder
+CREATE INDEX msgs_msg_org_created_id_where_outbound_visible_failed
+ON msgs_msg(org_id, created_on DESC, id DESC)
+WHERE direction = 'O' AND visibility = 'V' AND status = 'F';
+
+DROP INDEX IF EXISTS msgs_msg_failed_label;
+
+-- for the Scheduled folder and API view of broadcasts
+CREATE INDEX msgs_broadcasts_org_created_id_where_active
+ON msgs_broadcast(org_id, created_on DESC, id DESC)
+WHERE is_active = true;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0058_update_triggers'),
+    ]
+
+    operations = [
+        migrations.RunSQL(INDEX_SQL)
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1135,11 +1135,16 @@ class Msg(models.Model):
         if not date:
             date = timezone.now()  # no date?  set it to now
 
+        contact_urn = None
         if not contact:
-            contact = Contact.get_or_create(org, user, name=None, urns=[urn], incoming_channel=channel)
+            contact = Contact.get_or_create(org, user, name=None, urns=[urn], channel=channel)
             contact_urn = contact.urn_objects[urn]
-        else:
-            contact_urn = None
+        elif urn:
+            contact_urn = ContactURN.get_or_create(org, contact, urn, channel=channel)
+
+        # check our URN's affinity
+        if contact_urn:
+            contact_urn.update_affinity(channel)
 
         existing = Msg.all_messages.filter(text=text, created_on=date, contact=contact, direction='I').first()
         if existing:

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -747,7 +747,7 @@ class LabelCRUDL(SmartCRUDL):
             return Label.label_objects.filter(org=self.request.user.get_org())
 
         def render_to_response(self, context, **response_kwargs):
-            results = [dict(id=l.pk, text=l.name) for l in context['object_list']]
+            results = [dict(id=l.uuid, text=l.name) for l in context['object_list']]
             return HttpResponse(json.dumps(results), content_type='application/javascript')
 
     class Create(ModalMixin, OrgPermsMixin, SmartCreateView):

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -154,8 +154,6 @@ class BroadcastForm(forms.ModelForm):
             if 'omnibox' not in self.data or len(self.data['omnibox'].strip()) == 0:
                 self.errors['__all__'] = self.error_class([_("At least one recipient is required")])
                 return False
-            else:
-                print "omni: '%s'" % self.data['omnibox']
 
         return valid
 
@@ -202,8 +200,8 @@ class BroadcastCRUDL(SmartCRUDL):
             return args
 
         def derive_initial(self):
-            selected = ['g-%d' % _.pk for _ in self.object.groups.all()]
-            selected += ['c-%d' % _.pk for _ in self.object.contacts.all()]
+            selected = ['g-%s' % _.uuid for _ in self.object.groups.all()]
+            selected += ['c-%s' % _.uuid for _ in self.object.contacts.all()]
             selected = ','.join(selected)
             message = self.object.text
             return dict(message=message, omnibox=selected)
@@ -743,6 +741,7 @@ class LabelCRUDL(SmartCRUDL):
 
     class List(OrgPermsMixin, SmartListView):
         paginate_by = None
+        default_order = ('name',)
 
         def derive_queryset(self, **kwargs):
             return Label.label_objects.filter(org=self.request.user.get_org())

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1784,6 +1784,50 @@ class BulkExportTest(TembaTest):
         self.assertEquals(1, len(actions))
         self.assertEquals('Triggered Flow', actions[0]['flow']['name'])
 
+    def test_subflow_dependencies(self):
+        self.import_file('subflow')
+
+        parent = Flow.objects.filter(name='Parent Flow').first()
+        child = Flow.objects.filter(name='Child Flow').first()
+        self.assertIn(child, parent.get_dependencies()['flows'])
+
+        self.login(self.admin)
+        response = self.client.get(reverse('orgs.org_export'))
+
+        from BeautifulSoup import BeautifulSoup
+        soup = BeautifulSoup(response.content)
+        group = str(soup.findAll("div", {"class": "exportables bucket"})[0])
+
+        self.assertIn('Parent Flow', group)
+        self.assertIn('Child Flow', group)
+
+    def test_flow_export_dynamic_group(self):
+        flow = self.get_flow('favorites')
+
+        # get one of our flow actionsets, change it to an AddToGroupAction
+        actionset = ActionSet.objects.filter(flow=flow).order_by('y').first()
+
+        # replace the actions
+        from temba.flows.models import AddToGroupAction
+        actionset.set_actions_dict([AddToGroupAction([dict(id=1, name="Other Group"), '@contact.name']).as_json()])
+        actionset.save()
+
+        # now let's export!
+        self.login(self.admin)
+        post_data = dict(flows=[flow.pk], campaigns=[])
+        response = self.client.post(reverse('orgs.org_export'), post_data)
+        exported = json.loads(response.content)
+
+        # try to import the flow
+        flow.delete()
+        json.loads(response.content)
+        Flow.import_flows(exported, self.org, self.admin)
+
+        # make sure the created flow has the same action set
+        flow = Flow.objects.filter(name="%s" % flow.name).first()
+        actionset = ActionSet.objects.filter(flow=flow).order_by('y').first()
+        self.assertTrue('@contact.name' in actionset.get_actions()[0].groups)
+
     def test_missing_flows_on_import(self):
         # import a flow that starts a missing flow
         self.import_file('start-missing-flow')

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -193,7 +193,7 @@ class OrgTest(TembaTest):
         with patch('stripe.Charge.retrieve') as stripe:
             stripe.return_value = ''
             response = self.client.get(reverse('orgs.topup_read', args=[TopUp.objects.filter(org=self.org).first().pk]))
-            self.assertContains(response, '1,000 Credits')
+            self.assertContains(response, '1000 Credits')
 
     def test_user_update(self):
         update_url = reverse('orgs.user_edit')

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -193,7 +193,7 @@ class OrgTest(TembaTest):
         with patch('stripe.Charge.retrieve') as stripe:
             stripe.return_value = ''
             response = self.client.get(reverse('orgs.topup_read', args=[TopUp.objects.filter(org=self.org).first().pk]))
-            self.assertContains(response, '1000 Credits')
+            self.assertContains(response, '1,000 Credits')
 
     def test_user_update(self):
         update_url = reverse('orgs.user_edit')
@@ -240,7 +240,7 @@ class OrgTest(TembaTest):
         # while we are suspended, we can't send broadcasts
         send_url = reverse('msgs.broadcast_send')
         mark = self.create_contact('Mark', number='+12065551212')
-        post_data = dict(text="send me ur bank account login im ur friend.", omnibox="c-%d" % mark.pk)
+        post_data = dict(text="send me ur bank account login im ur friend.", omnibox="c-%s" % mark.uuid)
         response = self.client.post(send_url, post_data, follow=True)
 
         self.assertEquals('Sorry, your account is currently suspended. To enable sending messages, please contact support.',
@@ -248,7 +248,7 @@ class OrgTest(TembaTest):
 
         # we also can't start flows
         flow = self.create_flow()
-        post_data = dict(omnibox="c-%d" % mark.pk, restart_participants='on')
+        post_data = dict(omnibox="c-%s" % mark.uuid, restart_participants='on')
         response = self.client.post(reverse('flows.flow_broadcast', args=[flow.pk]), post_data, follow=True)
 
         self.assertEquals('Sorry, your account is currently suspended. To enable sending messages, please contact support.',
@@ -275,7 +275,7 @@ class OrgTest(TembaTest):
 
         # unsuspend our org and start a flow
         self.org.set_restored()
-        post_data = dict(omnibox="c-%d" % mark.pk, restart_participants='on')
+        post_data = dict(omnibox="c-%s" % mark.uuid, restart_participants='on')
         response = self.client.post(reverse('flows.flow_broadcast', args=[flow.pk]), post_data, follow=True)
         self.assertEqual(1, FlowRun.objects.all().count())
 
@@ -1782,7 +1782,7 @@ class BulkExportTest(TembaTest):
         definition = flow.as_json()
         actions = definition[Flow.ACTION_SETS][0]['actions']
         self.assertEquals(1, len(actions))
-        self.assertEquals('Triggered Flow', actions[0]['name'])
+        self.assertEquals('Triggered Flow', actions[0]['flow']['name'])
 
     def test_missing_flows_on_import(self):
         # import a flow that starts a missing flow

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -500,7 +500,7 @@ class OrgCRUDL(SmartCRUDL):
                     flows.add(flow)
                 exported_campaigns.append(campaign.as_json())
 
-            definition = Flow.export_definitions(flows, fail_on_dependencies=False)
+            definition = Flow.export_definitions(flows)
             definition['campaigns'] = exported_campaigns
             definition['site'] = request.branding['link']
 

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -120,12 +120,12 @@ class ScheduleTest(TembaTest):
         self.assertIn("At least one recipient is required", response.content)
 
         # missing message
-        post_data = dict(text="", omnibox="c-%d" % joe.pk, sender=self.channel.pk, _format="json", schedule=True)
+        post_data = dict(text="", omnibox="c-%s" % joe.uuid, sender=self.channel.pk, _format="json", schedule=True)
         response = self.client.post(reverse('msgs.broadcast_send'), post_data, follow=True)
         self.assertIn("This field is required", response.content)
 
         # finally create our message
-        post_data = dict(text="A scheduled message to Joe", omnibox="c-%d" % joe.pk, sender=self.channel.pk, _format="json", schedule=True)
+        post_data = dict(text="A scheduled message to Joe", omnibox="c-%s" % joe.uuid, sender=self.channel.pk, _format="json", schedule=True)
         response = json.loads(self.client.post(reverse('msgs.broadcast_send'), post_data, follow=True).content)
         self.assertIn("/broadcast/schedule_read", response['redirect'])
 
@@ -135,7 +135,7 @@ class ScheduleTest(TembaTest):
         broadcast = response.context['object']
 
         # update our message
-        post_data = dict(message="An updated scheduled message", omnibox="c-%d" % joe.pk)
+        post_data = dict(message="An updated scheduled message", omnibox="c-%s" % joe.uuid)
         self.client.post(reverse('msgs.broadcast_update', args=[broadcast.pk]), post_data)
         self.assertEquals("An updated scheduled message", Broadcast.objects.get(pk=broadcast.pk).text)
 

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -79,9 +79,9 @@ class Trigger(SmartModel):
         """
         return dict(trigger_type=self.trigger_type,
                     keyword=self.keyword,
-                    flow=dict(id=self.flow.pk, name=self.flow.name),
-                    groups=[dict(id=group.pk, name=group.name) for group in self.groups.all()],
-                    channel=self.channel.pk if self.channel else None)
+                    flow=dict(uuid=self.flow.uuid, name=self.flow.name),
+                    groups=[dict(uuid=group.uuid, name=group.name) for group in self.groups.all()],
+                    channel=self.channel.uuid if self.channel else None)
 
     @classmethod
     def import_triggers(cls, exported_json, org, user, same_site=False):
@@ -103,7 +103,7 @@ class Trigger(SmartModel):
                     group = None
 
                     if same_site:
-                        group = ContactGroup.user_groups.filter(org=org, pk=group_spec['id']).first()
+                        group = ContactGroup.user_groups.filter(org=org, uuid=group_spec['uuid']).first()
 
                     if not group:
                         group = ContactGroup.get_user_group(org, group_spec['name'])
@@ -117,7 +117,7 @@ class Trigger(SmartModel):
 
                     groups.append(group)
 
-                flow = Flow.objects.get(org=org, pk=trigger_spec['flow']['id'], is_active=True)
+                flow = Flow.objects.get(org=org, uuid=trigger_spec['flow']['uuid'], is_active=True)
 
                 # see if that trigger already exists
                 trigger = Trigger.objects.filter(org=org, trigger_type=trigger_spec['trigger_type'])
@@ -138,7 +138,7 @@ class Trigger(SmartModel):
                     # if we have a channel resolve it
                     channel = trigger_spec.get('channel', None)  # older exports won't have a channel
                     if channel:
-                        channel = Channel.objects.filter(pk=channel, org=org).first()
+                        channel = Channel.objects.filter(uuid=channel, org=org).first()
 
                     trigger = Trigger.objects.create(org=org, trigger_type=trigger_spec['trigger_type'],
                                                      keyword=trigger_spec['keyword'], flow=flow,

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -215,7 +215,7 @@ class TriggerTest(TembaTest):
         tommorrow_stamp = time.mktime(tommorrow.timetuple())
 
         post_data = dict()
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['repeat_period'] = 'D'
         post_data['start'] = 'later'
         post_data['start_datetime_value'] = "%d" % tommorrow_stamp
@@ -227,7 +227,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['start'] = 'never'
         post_data['repeat_period'] = 'O'
 
@@ -242,7 +242,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['start'] = 'stop'
         post_data['repeat_period'] = 'O'
 
@@ -257,7 +257,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['repeat_period'] = 'O'
         post_data['start'] = 'now'
         post_data['start_datetime_value'] = "%d" % now_stamp
@@ -275,7 +275,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['repeat_period'] = 'D'
         post_data['start'] = 'later'
         post_data['start_datetime_value'] = "%d" % tommorrow_stamp
@@ -292,7 +292,7 @@ class TriggerTest(TembaTest):
         update_url = reverse('triggers.trigger_update', args=[trigger.pk])
 
         post_data = dict()
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['repeat_period'] = 'O'
         post_data['start'] = 'now'
         post_data['start_datetime_value'] = "%d" % now_stamp
@@ -302,7 +302,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d" % linkin_park.pk
+        post_data['omnibox'] = "g-%s" % linkin_park.uuid
         post_data['repeat_period'] = 'O'
         post_data['start'] = 'now'
         post_data['start_datetime_value'] = "%d" % now_stamp
@@ -318,7 +318,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['start'] = 'never'
         post_data['repeat_period'] = 'O'
 
@@ -332,7 +332,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['start'] = 'stop'
         post_data['repeat_period'] = 'O'
 
@@ -346,7 +346,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         post_data['flow'] = flow.pk
-        post_data['omnibox'] = "g-%d,c-%d" % (linkin_park.pk, stromae.pk)
+        post_data['omnibox'] = "g-%s,c-%s" % (linkin_park.uuid, stromae.uuid)
         post_data['repeat_period'] = 'D'
         post_data['start'] = 'later'
         post_data['start_datetime_value'] = "%d" % tommorrow_stamp

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -358,8 +358,8 @@ class TriggerCRUDL(SmartCRUDL):
             trigger_type = obj.trigger_type
             if trigger_type == Trigger.TYPE_SCHEDULE:
                 repeat_period = obj.schedule.repeat_period
-                selected = ['g-%d' % _.pk for _ in self.object.groups.all()]
-                selected += ['c-%d' % _.pk for _ in self.object.contacts.all()]
+                selected = ['g-%s' % _.uuid for _ in self.object.groups.all()]
+                selected += ['c-%s' % _.uuid for _ in self.object.contacts.all()]
                 selected = ','.join(selected)
                 return dict(repeat_period=repeat_period, omnibox=selected)
 

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -391,7 +391,7 @@
                   .group-name.force-wrap{ng-show:'group.name'}
                     [[group.name]]
                   .group-name.force-wrap{ng-hide:'group.name'}
-                    [[group]]
+                    [[group.name]]
 
                 // updating contacts
                 %span{ng-show:'action.type == "save"'}
@@ -407,7 +407,7 @@
                 // starting flows
                 %span{ng-show:'action.type == "flow" || action.type == "trigger-flow"'}
                   .start-flow
-                    [[action.name]]
+                    [[action.flow.name]]
 
                 // webhooks
                 %span{ng-show:'action.type == "api"'}

--- a/templates/orgs/org_export.haml
+++ b/templates/orgs/org_export.haml
@@ -10,6 +10,26 @@
   {{ block.super }}
 
   :javascript
+
+    function get_param(name){
+       if(name=(new RegExp('[?&]'+encodeURIComponent(name)+'=([^&]*)')).exec(location.search))
+          return decodeURIComponent(name[1]);
+    }
+
+    $(document).ready(function() {
+      var flow_id = get_param('flow');
+
+      // check the entire group if it's bucketed
+      $('#flows-' + flow_id).parents('.exportables.bucket').each(function(){
+        $(this).find('.select-section').each(function() {
+          $(this).click();
+        })
+      })
+
+      // check individually if for the other group
+      $('#flows_' + flow_id).each(function(){$(this).click()});
+    });
+
     $('.toggle-all').on('change', function() {
       var checked = 'checked' == $(this).attr('checked');
       var id = $(this).attr('id');
@@ -141,7 +161,7 @@
         -trans "Group"
         {{ forloop.counter|apnumber|capfirst }}
 
-      .exportables
+      .exportables.bucket
         .pull-right
           %a.btn.btn-tiny.select-section
             -trans "Select Group"

--- a/templates/partials/action_editor.haml
+++ b/templates/partials/action_editor.haml
@@ -93,14 +93,14 @@
           This action starts the contacts you specify down a flow.
           The flow variables collected up to this point will be available in @extra.
       %input{ng-model:"omnibox", name:"omnibox", required:"", variables:"action.variables", omnibox:'{"types":"gc", "completions":true}', groups:"action.groups", type:"hidden"}
-      %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[action.id]]",select-server:"/flow/?_format=select2",type:"hidden"}
+      %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[get_action_id(action)]]",select-server:"/flow/?_format=select2",type:"hidden"}
       %button{ng-click:"saveStartFlow(action_editor.flow.selected, action_editor.omnibox.selected)",class:"submit hide"}
         -trans "Ok"
     %div{ng-if:'config.type == "flow"'}
       %p{class:"description"}
         -blocktrans
           This action redirects contacts to a new flow. When they start that flow, they will exit this one.
-      %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[action.id]]",select-server:"/flow/?_format=select2",type:"hidden"}
+      %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[get_action_id(action)]]",select-server:"/flow/?_format=select2",type:"hidden"}
       %button{ng-click:"saveStartFlow(action_editor.flow.selected)",class:"submit hide"}
         -trans "Ok"
     %div{ng-if:'config.type == "api"'}

--- a/templates/partials/action_editor.haml
+++ b/templates/partials/action_editor.haml
@@ -93,14 +93,14 @@
           This action starts the contacts you specify down a flow.
           The flow variables collected up to this point will be available in @extra.
       %input{ng-model:"omnibox", name:"omnibox", required:"", variables:"action.variables", omnibox:'{"types":"gc", "completions":true}', groups:"action.groups", type:"hidden"}
-      %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[get_action_id(action)]]",select-server:"/flow/?_format=select2",type:"hidden"}
+      %input{ng-model:"action.flow",search:"true",init-text:"[[action.flow.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[action.flow.uuid]]",select-server:"/flow/?_format=select2",type:"hidden"}
       %button{ng-click:"saveStartFlow(action_editor.flow.selected, action_editor.omnibox.selected)",class:"submit hide"}
         -trans "Ok"
     %div{ng-if:'config.type == "flow"'}
       %p{class:"description"}
         -blocktrans
           This action redirects contacts to a new flow. When they start that flow, they will exit this one.
-      %input{ng-model:"action.flow",search:"true",init-text:"[[action.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[get_action_id(action)]]",select-server:"/flow/?_format=select2",type:"hidden"}
+      %input{ng-model:"action.flow",search:"true",init-text:"[[action.flow.name]]",name:"flow",placeholder:"Select the flow to start",required:"",init-id:"[[action.flow.uuid]]",select-server:"/flow/?_format=select2",type:"hidden"}
       %button{ng-click:"saveStartFlow(action_editor.flow.selected)",class:"submit hide"}
         -trans "Ok"
     %div{ng-if:'config.type == "api"'}

--- a/templates/partials/split_editor.haml
+++ b/templates/partials/split_editor.haml
@@ -31,7 +31,7 @@
         %p{class:"description"}
           -blocktrans
             Call out to another flow and return the results to this flow in the @child variable.
-        %input{style:"width:620px",ng-model:"formData.flow",search:"true",init-text:"[[formData.flow.name]]",name:"flow",placeholder:"Select the flow to run",required:"",init-id:"[[formData.flow.id]]",select-server:"/flow/?_format=select2",type:"hidden"}
+        %input{style:"width:620px",ng-model:"formData.flow",search:"true",init-text:"[[formData.flow.name]]",name:"flow",placeholder:"Select the flow to run",required:"",init-id:"[[formData.flow.uuid]]",select-server:"/flow/?_format=select2",type:"hidden"}
 
     .expression{ng-if:'formData.rulesetConfig.type == "expression"'}><
       #split-on


### PR DESCRIPTION
Refactor to use UUIDs extensively in flow definitions. Also changes omnibox to use UUIDS for contacts and groups (urns remain the same).

Ids changed to UUIDS for:
- Groups in
  - Triggers
  - Add Group / Remove Group actions
  - Campaigns

- Flows in
  - Start Flow, Trigger flow actions
  - Flow metadata
  - Campaign events
  - Triggers

Added ability to migrate entire export files (not just flow definitions). This is necessary due to common references of migrated flows from campaigns and triggers.

These changes are tied to the subflow work in the branch https://github.com/nyaruka/rapidpro/tree/subflows. 

This PR is for reviewing this block of work so we can avoid doing it as an epic. It's actually to be merged into the subflows branch once that PR is also reviewed.