### PR TITLE
Tweak Conversation Trigger Terminology

### DIFF
--- a/templates/triggers/trigger_new_conversation.haml
+++ b/templates/triggers/trigger_new_conversation.haml
@@ -2,7 +2,7 @@
 -load i18n
 
 -block summary
-  -trans "Start a flow when a conversation is started by a contact."
+  -trans "Start a flow when a new Messenger conversation is started by a contact."
 
 
 -block extra-script


### PR DESCRIPTION
Adds 'Messenger' and 'new' to clarify this trigger's purpose and function.