### PR TITLE
Fix case where we skip reply actions in first flow step

### DIFF
--- a/media/test_flows/two_in_row.json
+++ b/media/test_flows/two_in_row.json
@@ -1,0 +1,62 @@
+{
+  "version": 8, 
+  "flows": [
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 100, 
+          "destination": null, 
+          "uuid": "be59c0db-2e49-4b05-a42f-b886aba58327", 
+          "actions": [
+            {
+              "msg": {
+                "eng": "This is the first message."
+              }, 
+              "type": "reply"
+            }, 
+            {
+              "type": "add_group", 
+              "groups": [
+                {
+                  "name": "bootstrap 3", 
+                  "id": 12644
+                }
+              ]
+            }, 
+            {
+              "msg": {
+                "eng": "This is the second message."
+              }, 
+              "type": "reply"
+            }
+          ]
+        }
+      ], 
+      "version": 8, 
+      "flow_type": "F", 
+      "entry": "be59c0db-2e49-4b05-a42f-b886aba58327", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 3, 
+        "id": 57118, 
+        "name": "Two in Row", 
+        "saved_on": "2016-07-12T13:31:24.894313Z"
+      }
+    }
+  ], 
+  "triggers": [
+    {
+      "trigger_type": "K", 
+      "flow": {
+        "name": "Two in Row", 
+        "id": 57118
+      }, 
+      "groups": [], 
+      "keyword": "two", 
+      "channel": null
+    }
+  ]
+}

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4960,6 +4960,17 @@ class FlowBatchTest(FlowFileTest):
         self.assertEqual(step.broadcasts.all().count(), 1)
 
 
+class TwoInRowTest(FlowFileTest):
+
+    def test_two_in_row(self):
+        flow = self.get_flow('two_in_row')
+        flow.start([], [self.contact])
+
+        # assert contact received both messages
+        msgs = self.contact.msgs.all()
+        self.assertEqual(msgs.count(), 2)
+
+
 class OrderingTest(FlowFileTest):
 
     def setUp(self):


### PR DESCRIPTION
Kind of crazy this has been lurking so long.

If a flow's first action includes replies, we optimize those in the flow start, creating a single broadcast etc.. When we go and execute the actual actions for each run, we then skip reply actions.

Problem is we can't optimize replies that occur after any other action, as the other actions may later the content of the message. This fix deals with that, making sure to execute replies that occur after other actions even when skipping.