### PR TITLE
Fixes for missing groups

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1892,9 +1892,11 @@ class Flow(TembaModel):
                     if not isinstance(group, dict):
                         expanded_groups.append(group)
                     else:
-                        group = groups.get(group['id'], None)
-                        if group:
-                            expanded_groups.append(dict(id=group.id, name=group.name))
+                        group_instance = groups.get(group['id'], None)
+                        if group_instance:
+                            expanded_groups.append(dict(id=group_instance.id, name=group_instance.name))
+                        else:
+                            expanded_groups.append(group)
 
                 action['groups'] = expanded_groups
 
@@ -2027,7 +2029,7 @@ class Flow(TembaModel):
                     json_flow = self.as_json()
 
                 self.update(json_flow)
-                # TODO: After Django 1.8 consider doing a self.refresh_from_db() here
+                self.refresh_from_db()
 
     def update(self, json_dict, user=None, force=False):
         """
@@ -4456,6 +4458,10 @@ class VariableContactAction(Action):
         for group_data in json_obj.get(VariableContactAction.GROUPS):
             group_id = group_data.get(VariableContactAction.ID, None)
             group_name = group_data.get(VariableContactAction.NAME)
+
+            # flows from when true deletion was allowed need this
+            if not group_name:
+                group_name = 'Missing'
 
             group = ContactGroup.get_or_create(org, org.get_user(), group_name, group_id)
             groups.append(group)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -37,7 +37,7 @@ from .models import DateEqualTest, DateAfterTest, DateBeforeTest, HasDateTest
 from .models import StartsWithTest, ContainsTest, ContainsAnyTest, RegexTest, NotEmptyTest
 from .models import HasStateTest, HasDistrictTest, HasWardTest
 from .models import SendAction, AddLabelAction, AddToGroupAction, ReplyAction, SaveToContactAction, SetLanguageAction, SetChannelAction
-from .models import EmailAction, StartFlowAction, TriggerFlowAction, DeleteFromGroupAction, WebhookAction, ActionLog
+from .models import EmailAction, StartFlowAction, TriggerFlowAction, DeleteFromGroupAction, WebhookAction, ActionLog, VariableContactAction
 from temba.msgs.models import WIRED
 
 
@@ -943,6 +943,17 @@ class FlowTest(TembaTest):
         # our json should contain the names of our contact and groups
         self.assertTrue(json_as_string.find('Eric') > 0)
         self.assertTrue(json_as_string.find('Other') > 0)
+
+        # now delete our group
+        self.other_group.delete()
+
+        flow_json = self.flow.as_json(expand_contacts=True)
+        add_group = flow_json['action_sets'][3]['actions'][0]
+        send = flow_json['action_sets'][3]['actions'][1]
+
+        # should still see a reference to our group even (recreated)
+        self.assertEquals(1, len(add_group['groups']))
+        self.assertEquals(1, len(send['groups']))
 
     def assertTest(self, expected_test, expected_value, test, extra=None):
         runs = FlowRun.objects.filter(contact=self.contact)
@@ -2300,6 +2311,11 @@ class ActionTest(TembaTest):
         updated_action = SendAction.from_json(self.org, action.as_json())
         self.assertTrue(updated_action.groups)
         self.assertFalse(self.other_group.pk in [g.pk for g in updated_action.groups])
+
+    def test_variable_contact_parsing(self):
+        groups = dict(groups=[dict(id=-1)])
+        groups = VariableContactAction.parse_groups(self.org, groups)
+        self.assertTrue('Missing', groups[0].name)
 
     @override_settings(SEND_EMAILS=True)
     def test_email_action(self):


### PR DESCRIPTION
Bug fixes for deleted groups in two cases:
* Missing groups when parsing a VariableContactAction (like add groups or send). It looks like this only applies to when groups were truly deleted (not set inactive)
* Missing groups when calling flow.as_json(expand_contacts=True)