### PR TITLE
API ordering part III

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -35,7 +35,7 @@ Django-Select2==4.2.2
 django-storages==1.1.8
 django-timezones==0.2
 -e git+https://github.com/caktus/django-ttag.git@40c97c01325d436f5d04529526fa7468ff778137#egg=django_ttag
-djangorestframework==3.3.1
+djangorestframework==3.4.0
 djangorestframework-xml==1.2.0
 djorm-ext-core==0.7
 djorm-ext-expressions==0.6

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -2,15 +2,11 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
-from base64 import b64decode
-from urlparse import parse_qs
-
 from django.conf import settings
 from django.http import HttpResponseServerError
 from rest_framework import exceptions, status
 from rest_framework.authentication import TokenAuthentication
-from rest_framework.exceptions import APIException, NotFound
-from rest_framework.pagination import Cursor, CursorPagination, _positive_int
+from rest_framework.exceptions import APIException
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import exception_handler
@@ -117,37 +113,3 @@ def temba_exception_handler(exc, context):
 
         # respond with simple message
         return HttpResponseServerError("Server Error. Site administrators have been notified.")
-
-
-class CustomCursorPagination(CursorPagination):
-
-    def decode_cursor(self, request):
-        """
-        Given a request with a cursor, return a `Cursor` instance.
-        """
-        # Determine if we have a cursor, and if so then decode it.
-        encoded = request.query_params.get(self.cursor_query_param)
-        if encoded is None:
-            return None
-
-        # The offset in the cursor is used in situations where we have a
-        # nearly-unique index. (Eg millisecond precision creation timestamps)
-        # We guard against malicious users attempting to cause expensive database
-        # queries, by having a hard cap on the maximum possible size of the offset.
-        offset_cutoff = getattr(settings, 'CURSOR_PAGINATION_OFFSET_CUTOFF', 1000)
-
-        try:
-            querystring = b64decode(encoded.encode('ascii')).decode('ascii')
-            tokens = parse_qs(querystring, keep_blank_values=True)
-
-            offset = tokens.get('o', ['0'])[0]
-            offset = _positive_int(offset, cutoff=offset_cutoff)
-
-            reverse = tokens.get('r', ['0'])[0]
-            reverse = bool(int(reverse))
-
-            position = tokens.get('p', [None])[0]
-        except (TypeError, ValueError):
-            raise NotFound(self.invalid_cursor_message)
-
-        return Cursor(offset=offset, reverse=reverse, position=position)

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -12,7 +12,6 @@ from django.db import connection
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
-from mock import patch
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel, ChannelEvent
 from temba.contacts.models import Contact, ContactGroup, ContactField
@@ -205,6 +204,44 @@ class APITest(TembaTest):
         response = self.fetchHTML(url)
         self.assertEquals(200, response.status_code)
         self.assertNotContains(response, "Log in to use the Explorer")
+
+    def test_pagination(self):
+        url = reverse('api.v2.runs') + '.json'
+        self.login(self.admin)
+
+        # create 1255 test runs (5 full pages of 250 items + 1 partial with 5 items)
+        flow = self.create_flow(uuid_start=0)
+
+        runs = [FlowRun(org=self.org, flow=flow, contact=self.joe) for r in range(1255)]
+        FlowRun.objects.bulk_create(runs)
+        runs = FlowRun.objects.order_by('pk')
+
+        returned_ids = []
+        runs = list(reversed(runs))
+
+        # give them all the same modified_on
+        FlowRun.objects.all().update(modified_on=datetime(2015, 9, 15, 0, 0, 0, 0, pytz.UTC))
+
+        # fetch all full pages
+        response = None
+        for p in range(5):
+            response = self.fetchJSON(url if p == 0 else response.json['next'], raw_url=True)
+
+            self.assertResultsById(response, [runs[p * 250 + i] for i in range(250)])
+            self.assertIsNotNone(response.json['next'])
+
+            returned_ids += set([r['id'] for r in response.json['results']])
+
+        # fetch final partial page
+        response = self.fetchJSON(response.json['next'], raw_url=True)
+
+        self.assertEqual(len(response.json['results']), 5)
+        self.assertResultsById(response, [runs[1250], runs[1251], runs[1252], runs[1253], runs[1254]])
+        self.assertIsNone(response.json['next'])
+
+        returned_ids += set([r['id'] for r in response.json['results']])
+
+        self.assertEqual(set(returned_ids), {r.pk for r in runs})  # ensure all results were returned
 
     def test_authenticate(self):
         url = reverse('api.v2.authenticate')
@@ -866,81 +903,6 @@ class APITest(TembaTest):
         response = self.client.post(url, dict(), HTTP_X_FORWARDED_HTTPS='https')
         self.assertEqual(response.status_code, 400)
         self.clear_storage()
-
-    def test_runs_offset(self):
-        url = reverse('api.v2.runs')
-
-        self.assertEndpointAccess(url)
-
-        flow1 = self.create_flow(uuid_start=0)
-
-        for i in range(600):
-            FlowRun.create(flow1, self.joe.pk)
-
-        with patch.object(timezone, 'now', return_value=datetime(2015, 9, 15, 0, 0, 0, 0, pytz.UTC)):
-            now = timezone.now()
-            for r in FlowRun.objects.all():
-                r.modified_on = now
-                r.save()
-
-        with self.settings(CURSOR_PAGINATION_OFFSET_CUTOFF=10):
-            response = self.fetchJSON(url)
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-            query = response.json['next'].split('?')[1]
-            response = self.fetchJSON(url, query=query)
-
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-            query = response.json['next'].split('?')[1]
-            response = self.fetchJSON(url, query=query)
-
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-            query = response.json['next'].split('?')[1]
-            response = self.fetchJSON(url, query=query)
-
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-        with self.settings(CURSOR_PAGINATION_OFFSET_CUTOFF=400):
-            url = reverse('api.v2.runs')
-            response = self.fetchJSON(url)
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-            query = response.json['next'].split('?')[1]
-            response = self.fetchJSON(url, query=query)
-
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-            query = response.json['next'].split('?')[1]
-            response = self.fetchJSON(url, query=query)
-
-            self.assertEqual(len(response.json['results']), 200)
-            self.assertIsNone(response.json['next'])
-
-        with self.settings(CURSOR_PAGINATION_OFFSET_CUTOFF=5000):
-            url = reverse('api.v2.runs')
-            response = self.fetchJSON(url)
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-            query = response.json['next'].split('?')[1]
-            response = self.fetchJSON(url, query=query)
-
-            self.assertEqual(len(response.json['results']), 250)
-            self.assertTrue(response.json['next'])
-
-            query = response.json['next'].split('?')[1]
-            response = self.fetchJSON(url, query=query)
-
-            self.assertEqual(len(response.json['results']), 100)
-            self.assertIsNone(response.json['next'])
 
     def test_runs(self):
         url = reverse('api.v2.runs')

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse, JsonResponse
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import generics, mixins, status
+from rest_framework.pagination import CursorPagination
 from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -27,7 +28,7 @@ from .serializers import ChannelReadSerializer, ChannelEventReadSerializer, Cont
 from .serializers import ContactFieldReadSerializer, ContactGroupReadSerializer, FlowRunReadSerializer
 from .serializers import LabelReadSerializer, MsgReadSerializer
 from ..models import APIPermission, SSLPermission
-from ..support import InvalidQueryError, CustomCursorPagination
+from ..support import InvalidQueryError
 
 
 @api_view(['GET'])
@@ -138,12 +139,14 @@ class AuthenticateView(SmartFormView):
             return HttpResponse(status=403)
 
 
-class CreatedOnCursorPagination(CustomCursorPagination):
-    ordering = ('-created_on', '-id')
+class CreatedOnCursorPagination(CursorPagination):
+    ordering = ('-created_on', '-pk')
+    offset_cutoff = 1000000
 
 
-class ModifiedOnCursorPagination(CustomCursorPagination):
-    ordering = ('-modified_on', '-id')
+class ModifiedOnCursorPagination(CursorPagination):
+    ordering = ('-modified_on', '-pk')
+    offset_cutoff = 1000000
 
 
 class BaseAPIView(generics.GenericAPIView):
@@ -1008,7 +1011,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
             ...
         }
     """
-    class Pagination(CustomCursorPagination):
+    class Pagination(CreatedOnCursorPagination):
         """
         Overridden paginator for Msg endpoint that switches from created_on to modified_on when looking
         at all incoming messages.

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -140,12 +140,12 @@ class AuthenticateView(SmartFormView):
 
 
 class CreatedOnCursorPagination(CursorPagination):
-    ordering = ('-created_on', '-pk')
+    ordering = ('-created_on', '-id')
     offset_cutoff = 1000000
 
 
 class ModifiedOnCursorPagination(CursorPagination):
-    ordering = ('-modified_on', '-pk')
+    ordering = ('-modified_on', '-id')
     offset_cutoff = 1000000
 
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1021,7 +1021,6 @@ REST_FRAMEWORK = {
     'UNICODE_JSON': False
 }
 REST_HANDLE_EXCEPTIONS = not TESTING
-CURSOR_PAGINATION_OFFSET_CUTOFF = 1000000
 
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
* Updates to latest DRF so we can remove our custom pagination code
* Adds test to ensure result order is correct for multi-page result sets