### PR TITLE
IVR msg status

### DIFF
--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -402,6 +402,11 @@ class IVRTests(FlowFileTest):
 
         # press the number 4 (unexpected)
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), dict(Digits=4))
+
+        # our inbound message should be handled
+        msg = Msg.current_messages.filter(text='4', msg_type=IVR).order_by('-created_on').first()
+        self.assertEqual('H', msg.status)
+
         self.assertContains(response, '<Say>Press one, two, or three. Thanks.</Say>')
         self.assertEquals(6, self.org.get_credits_used())
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1189,7 +1189,8 @@ class Msg(models.Model):
         if channel:
             analytics.gauge('temba.msg_incoming_%s' % channel.channel_type.lower())
 
-        if status == PENDING:
+        # ivr messages are handled in handle_call
+        if status == PENDING and msg_type != IVR:
             msg.handle()
 
             # fire an event off for this message


### PR DESCRIPTION
Don't create ivr messages with a handled state, but instead switch them from pending to handled when the flow actually does it's work. Change process_message to ignore inbound ivr messages.