### PR TITLE
Tweaks to definitions API for consistency with other v2 endpoints

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -571,7 +571,6 @@ class APITest(TembaTest):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json['next'], None)
-        print response
         self.assertResultsByUUID(response, [contact4, self.joe, contact2, contact1, self.frank])
         self.assertEqual(response.json['results'][0], {
             'uuid': contact4.uuid,
@@ -613,6 +612,78 @@ class APITest(TembaTest):
         # filter by after
         response = self.fetchJSON(url, 'after=%s' % format_datetime(self.joe.modified_on))
         self.assertResultsByUUID(response, [contact4, self.joe])
+
+    def test_definitions(self):
+        url = reverse('api.v2.definitions')
+
+        self.assertEndpointAccess(url)
+
+        self.import_file('subflow')
+        flow = Flow.objects.filter(name='Parent Flow').first()
+
+        # all flow dependencies and we should get the child flow
+        response = self.fetchJSON(url, 'flow=%s' % flow.uuid)
+        self.assertEqual(len(response.json['flows']), 2)
+        self.assertEqual(response.json['flows'][0]['metadata']['name'], "Parent Flow")
+        self.assertEqual(response.json['flows'][1]['metadata']['name'], "Child Flow")
+
+        # export just the parent flow
+        response = self.fetchJSON(url, 'flow=%s&dependencies=false' % flow.uuid)
+        self.assertEqual(len(response.json['flows']), 1)
+        self.assertEqual(response.json['flows'][0]['metadata']['name'], "Parent Flow")
+
+        # import the clinic app which has campaigns
+        self.import_file('the_clinic')
+
+        # our catchall flow, all alone
+        flow = Flow.objects.filter(name='Catch All').first()
+        response = self.fetchJSON(url, 'flow=%s&dependencies=false' % flow.uuid)
+        self.assertEqual(len(response.json['flows']), 1)
+        self.assertEqual(len(response.json['campaigns']), 0)
+        self.assertEqual(len(response.json['triggers']), 0)
+
+        # with it's trigger dependency
+        response = self.fetchJSON(url, 'flow_uuid=%s' % flow.uuid)
+        self.assertEqual(len(response.json['flows']), 1)
+        self.assertEqual(len(response.json['campaigns']), 0)
+        self.assertEqual(len(response.json['triggers']), 1)
+
+        # our registration flow, all alone
+        flow = Flow.objects.filter(name='Register Patient').first()
+        response = self.fetchJSON(url, 'flow=%s&dependencies=false' % flow.uuid)
+        self.assertEqual(len(response.json['flows']), 1)
+        self.assertEqual(len(response.json['campaigns']), 0)
+        self.assertEqual(len(response.json['triggers']), 0)
+
+        # touches a lot of stuff
+        response = self.fetchJSON(url, 'flow=%s' % flow.uuid)
+        self.assertEqual(len(response.json['flows']), 6)
+        self.assertEqual(len(response.json['campaigns']), 1)
+        self.assertEqual(len(response.json['triggers']), 2)
+
+        # add our missed call flow
+        missed_call = Flow.objects.filter(name='Missed Call').first()
+        response = self.fetchJSON(url, 'flow=%s&flow=%s&dependencies=true' % (flow.uuid, missed_call.uuid))
+        self.assertEqual(len(response.json['flows']), 7)
+        self.assertEqual(len(response.json['campaigns']), 1)
+        self.assertEqual(len(response.json['triggers']), 3)
+
+        campaign = Campaign.objects.filter(name='Appointment Schedule').first()
+        response = self.fetchJSON(url, 'campaign=%s&dependencies=false' % campaign.uuid)
+        self.assertEqual(len(response.json['flows']), 0)
+        self.assertEqual(len(response.json['campaigns']), 1)
+        self.assertEqual(len(response.json['triggers']), 0)
+
+        response = self.fetchJSON(url, 'campaign=%s' % campaign.uuid)
+        self.assertEqual(len(response.json['flows']), 4)
+        self.assertEqual(len(response.json['campaigns']), 1)
+        self.assertEqual(len(response.json['triggers']), 1)
+
+        # test deprecated param names
+        response = self.fetchJSON(url, 'flow_uuid=%s&campaign_uuid=%s&dependencies=false' % (flow.uuid, campaign.uuid))
+        self.assertEqual(len(response.json['flows']), 1)
+        self.assertEqual(len(response.json['campaigns']), 1)
+        self.assertEqual(len(response.json['triggers']), 0)
 
     def test_fields(self):
         url = reverse('api.v2.fields')
@@ -1071,68 +1142,3 @@ class APITest(TembaTest):
         response = self.fetchJSON(url, 'contact=%s&flow=%s' % (self.joe.uuid, flow1.uuid))
         self.assertResponseError(response, None,
                                  "You may only specify one of the contact, flow parameters")
-
-    def test_api_definitions(self):
-        url = reverse('api.v2.definitions')
-        self.assertEndpointAccess(url)
-
-        self.import_file('subflow')
-        flow = Flow.objects.filter(name='Parent Flow').first()
-
-        # all flow dependencies and we should get the child flow
-        response = self.fetchJSON(url, 'flow_uuid=%s' % flow.uuid)
-        self.assertEqual(2, len(response.json['flows']))
-        self.assertEquals('Parent Flow', response.json['flows'][0]['metadata']['name'])
-        self.assertEquals('Child Flow', response.json['flows'][1]['metadata']['name'])
-
-        # export just the parent flow
-        response = self.fetchJSON(url, 'flow_uuid=%s&dependencies=false' % flow.uuid)
-        self.assertEqual(1, len(response.json['flows']))
-        self.assertEquals('Parent Flow', response.json['flows'][0]['metadata']['name'])
-
-        # import the clinic app which has campaigns
-        self.import_file('the_clinic')
-
-        # our catchall flow, all alone
-        flow = Flow.objects.filter(name='Catch All').first()
-        response = self.fetchJSON(url, 'flow_uuid=%s&dependencies=false' % flow.uuid)
-        self.assertEqual(1, len(response.json['flows']))
-        self.assertEqual(0, len(response.json['campaigns']))
-        self.assertEqual(0, len(response.json['triggers']))
-
-        # with it's trigger dependency
-        response = self.fetchJSON(url, 'flow_uuid=%s' % flow.uuid)
-        self.assertEqual(1, len(response.json['flows']))
-        self.assertEqual(0, len(response.json['campaigns']))
-        self.assertEqual(1, len(response.json['triggers']))
-
-        # our registration flow, all alone
-        flow = Flow.objects.filter(name='Register Patient').first()
-        response = self.fetchJSON(url, 'flow_uuid=%s&dependencies=false' % flow.uuid)
-        self.assertEqual(1, len(response.json['flows']))
-        self.assertEqual(0, len(response.json['campaigns']))
-        self.assertEqual(0, len(response.json['triggers']))
-
-        # touches a lot of stuff
-        response = self.fetchJSON(url, 'flow_uuid=%s' % flow.uuid)
-        self.assertEqual(6, len(response.json['flows']))
-        self.assertEqual(1, len(response.json['campaigns']))
-        self.assertEqual(2, len(response.json['triggers']))
-
-        # add our missed call flow
-        missed_call = Flow.objects.filter(name='Missed Call').first()
-        response = self.fetchJSON(url, 'flow_uuid=%s&flow_uuid=%s&dependencies=true' % (flow.uuid, missed_call.uuid))
-        self.assertEqual(7, len(response.json['flows']))
-        self.assertEqual(1, len(response.json['campaigns']))
-        self.assertEqual(3, len(response.json['triggers']))
-
-        campaign = Campaign.objects.filter(name='Appointment Schedule').first()
-        response = self.fetchJSON(url, 'campaign_uuid=%s&dependencies=false' % campaign.uuid)
-        self.assertEqual(0, len(response.json['flows']))
-        self.assertEqual(1, len(response.json['campaigns']))
-        self.assertEqual(0, len(response.json['triggers']))
-
-        response = self.fetchJSON(url, 'campaign_uuid=%s' % campaign.uuid)
-        self.assertEqual(4, len(response.json['flows']))
-        self.assertEqual(1, len(response.json['campaigns']))
-        self.assertEqual(1, len(response.json['triggers']))

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -900,7 +900,7 @@ class DefinitionsEndpoint(BaseAPIView):
             'fields': [
                 {'name': "flow", 'required': False, 'help': "One or more flow UUIDs to include"},
                 {'name': "campaign", 'required': False, 'help': "One or more campaign UUIDs to include"},
-                {'name': "dependencies", 'required': False, 'help': "Whether to include dependebcies of the requested items. ex: false"}
+                {'name': "dependencies", 'required': False, 'help': "Whether to include dependencies of the requested items. ex: false"}
             ]
         }
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -759,12 +759,10 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
 
 class DefinitionsEndpoint(BaseAPIView):
     """
-    This endpoint exports flows, campaigns, and triggers and optionally will include automatically all dependencies for
-    the requested items.
+    ## Exporting Definitions
 
-    ## Getting Definitions
-
-    Returns JSON export for all items requested
+    A **GET** exports a set of flows and campaigns, and can automatically include dependencies for the requested items,
+    such as groups, triggers and other flows.
 
       * **flow** - the UUIDs of flows to include (string, repeatable)
       * **campaign** - the UUIDs of campaigns to include (string, repeatable)
@@ -774,7 +772,7 @@ class DefinitionsEndpoint(BaseAPIView):
 
         GET /api/v2/definitions.json?flow=f14e4ff0-724d-43fe-a953-1d16aefd1c0b&flow=09d23a05-47fe-11e4-bfe9-b8f6b119e9ab
 
-    Response is a collection of definitions
+    Response is a collection of definitions:
 
         {
           version: 8,
@@ -785,9 +783,9 @@ class DefinitionsEndpoint(BaseAPIView):
               "name": "Water Point Survey",
               "uuid": "f14e4ff0-724d-43fe-a953-1d16aefd1c0b",
               "saved_on": "2015-09-23T00:25:50.709164Z",
-              "revision":28,
-              "expires":7880,
-              "id":12712,
+              "revision": 28,
+              "expires": 7880,
+              "id": 12712,
             },
             "version": 7,
             "flow_type": "S",

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -759,20 +759,20 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
 
 class DefinitionsEndpoint(BaseAPIView):
     """
-    This endpoint exports flows, campaigns, and triggers and optionally will determine
-    the dependency graph for the provided uuids.
+    This endpoint exports flows, campaigns, and triggers and optionally will include automatically all dependencies for
+    the requested items.
 
     ## Getting Definitions
 
-    Returns json export for all items requested
+    Returns JSON export for all items requested
 
-      * **flow_uuid** - the UUID of the flow to export (string, repeatable)
-      * **campaign_uuid** - the UUID of the campaign to export (string, repeatable)
+      * **flow** - the UUIDs of flows to include (string, repeatable)
+      * **campaign** - the UUIDs of campaigns to include (string, repeatable)
       * **dependencies** - whether to include dependencies (boolean, default: true)
 
     Example:
 
-        GET /api/v2/definitions.json?flow_uuid=f14e4ff0-724d-43fe-a953-1d16aefd1c0b
+        GET /api/v2/definitions.json?flow=f14e4ff0-724d-43fe-a953-1d16aefd1c0b&flow=09d23a05-47fe-11e4-bfe9-b8f6b119e9ab
 
     Response is a collection of definitions
 
@@ -846,18 +846,25 @@ class DefinitionsEndpoint(BaseAPIView):
     permission = 'orgs.org_api'
 
     def get(self, request, *args, **kwargs):
+        org = request.user.get_org()
+        params = request.query_params
 
-        depends = self.request.GET.get('dependencies', 'true').lower() == 'true'
-        org = self.request.user.get_org()
+        if 'flow_uuid' in params or 'campaign_uuid' in params:  # deprecated
+            flow_uuids = splitting_getlist(self.request, 'flow_uuid')
+            campaign_uuids = splitting_getlist(self.request, 'campaign_uuid')
+        else:
+            flow_uuids = params.getlist('flow')
+            campaign_uuids = params.getlist('campaign')
 
-        flows = set()
-        flow_uuids = splitting_getlist(self.request, 'flow_uuid')
+        depends = str_to_bool(params.get('dependencies', 'true'))
+
         if flow_uuids:
             flows = set(Flow.objects.filter(uuid__in=flow_uuids, org=org))
+        else:
+            flows = set()
 
         # any fetched campaigns
         campaigns = []
-        campaign_uuids = splitting_getlist(self.request, 'campaign_uuid')
         if campaign_uuids:
             campaigns = Campaign.objects.filter(uuid__in=campaign_uuids, org=org)
 
@@ -880,7 +887,7 @@ class DefinitionsEndpoint(BaseAPIView):
         # add in our primary requested flows
         to_export['flows'].update(flows)
 
-        export = self.request.user.get_org().export_definitions(self.request.branding['link'], **to_export)
+        export = org.export_definitions(self.request.branding['link'], **to_export)
 
         return Response(export, status=status.HTTP_200_OK)
 
@@ -888,10 +895,15 @@ class DefinitionsEndpoint(BaseAPIView):
     def get_read_explorer(cls):
         return {
             'method': "GET",
-            'title': "Definitions",
+            'title': "Export Definitions",
             'url': reverse('api.v2.definitions'),
-            'slug': 'org-definitions',
-            'request': ""
+            'slug': 'export-definitions',
+            'request': "flow=f14e4ff0-724d-43fe-a953-1d16aefd1c0b&flow=09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
+            'fields': [
+                {'name': "flow", 'required': False, 'help': "One or more flow UUIDs to include"},
+                {'name': "campaign", 'required': False, 'help': "One or more campaign UUIDs to include"},
+                {'name': "dependencies", 'required': False, 'help': "Whether to include dependebcies of the requested items. ex: false"}
+            ]
         }
 
 


### PR DESCRIPTION
* Use type agnostic param names - e.g. `campaign` rather than `campaign_uuid` [1]
* Use `.getlist(..)` for repeated params (i.e. don't support comma separated params)
* Use `str_to_bool` for boolean params (parses "1" etc)

[1] On the campaign events endpoint we allow `campaign` to be a UUID or a campaign name, but wasn't sure about allowing that here.