### PR TITLE
Flows API v2

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -15,7 +15,7 @@ from rest_framework.test import APIClient
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel, ChannelEvent
 from temba.contacts.models import Contact, ContactGroup, ContactField
-from temba.flows.models import Flow, FlowRun
+from temba.flows.models import Flow, FlowRun, FlowLabel
 from temba.msgs.models import Broadcast, Label
 from temba.orgs.models import Language
 from temba.tests import TembaTest, AnonymousOrg
@@ -708,6 +708,56 @@ class APITest(TembaTest):
         # filter by key
         response = self.fetchJSON(url, 'key=nick_name')
         self.assertEqual(response.json['results'], [{'key': 'nick_name', 'label': "Nick Name", 'value_type': "text"}])
+
+    def test_flows(self):
+        url = reverse('api.v2.flows')
+
+        self.assertEndpointAccess(url)
+
+        registration = self.create_flow(name="Registration", uuid_start=0)
+        survey = self.create_flow(name="Survey", uuid_start=1000)
+
+        # add a flow label
+        reporting = FlowLabel.objects.create(org=self.org, name="Reporting")
+        survey.labels.add(reporting)
+
+        # run joe through through a flow
+        survey.start([], [self.joe])
+        self.create_msg(direction='I', contact=self.joe, text="it is blue").handle()
+
+        # flow belong to other org
+        self.create_flow(org=self.org2, name="Other", uuid_start=2000)
+
+        # no filtering
+        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
+            response = self.fetchJSON(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['next'], None)
+        self.assertEqual(response.json['results'], [
+            {
+                'uuid': survey.uuid,
+                'name': "Survey",
+                'archived': False,
+                'labels': [{'uuid': reporting.uuid, 'name': "Reporting"}],
+                'expires': 720,
+                'runs': {'completed': 1, 'expired': 0},
+                'created_on': format_datetime(survey.created_on)
+            },
+            {
+                'uuid': registration.uuid,
+                'name': "Registration",
+                'archived': False,
+                'labels': [],
+                'expires': 720,
+                'runs': {'completed': 0, 'expired': 0},
+                'created_on': format_datetime(registration.created_on)
+            }
+        ])
+
+        # filter by UUID
+        response = self.fetchJSON(url, 'uuid=%s' % survey.uuid)
+        self.assertResultsByUUID(response, [survey])
 
     def test_groups(self):
         url = reverse('api.v2.groups')

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -729,7 +729,7 @@ class APITest(TembaTest):
         self.create_flow(org=self.org2, name="Other", uuid_start=2000)
 
         # no filtering
-        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
+        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 8):
             response = self.fetchJSON(url)
 
         self.assertEqual(response.status_code, 200)
@@ -741,7 +741,7 @@ class APITest(TembaTest):
                 'archived': False,
                 'labels': [{'uuid': reporting.uuid, 'name': "Reporting"}],
                 'expires': 720,
-                'runs': {'completed': 1, 'expired': 0},
+                'runs': {'completed': 1, 'interrupted': 0, 'expired': 0},
                 'created_on': format_datetime(survey.created_on)
             },
             {
@@ -750,7 +750,7 @@ class APITest(TembaTest):
                 'archived': False,
                 'labels': [],
                 'expires': 720,
-                'runs': {'completed': 0, 'expired': 0},
+                'runs': {'completed': 0, 'interrupted': 0, 'expired': 0},
                 'created_on': format_datetime(registration.created_on)
             }
         ])

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel, ChannelEvent, ANDROID
 from temba.contacts.models import Contact, ContactField, ContactGroup
-from temba.flows.models import FlowRun, FlowStep
+from temba.flows.models import Flow, FlowRun, FlowStep
 from temba.msgs.models import Broadcast, Msg, Label, STATUS_CONFIG, INCOMING, OUTGOING, INBOX, FLOW, IVR, PENDING
 from temba.msgs.models import QUEUED
 from temba.utils import datetime_to_json_date
@@ -218,6 +218,23 @@ class ContactGroupReadSerializer(ReadSerializer):
     class Meta:
         model = ContactGroup
         fields = ('uuid', 'name', 'query', 'count')
+
+
+class FlowReadSerializer(ReadSerializer):
+    archived = serializers.ReadOnlyField(source='is_archived')
+    labels = serializers.SerializerMethodField()
+    expires = serializers.ReadOnlyField(source='expires_after_minutes')
+    runs = serializers.SerializerMethodField()
+
+    def get_labels(self, obj):
+        return [{'uuid': l.uuid, 'name': l.name} for l in obj.labels.all()]
+
+    def get_runs(self, obj):
+        return {'completed': obj.get_completed_runs(), 'expired': obj.get_expired_runs()}
+
+    class Meta:
+        model = Flow
+        fields = ('uuid', 'name', 'archived', 'labels', 'expires', 'runs', 'created_on')
 
 
 class FlowRunReadSerializer(ReadSerializer):

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -230,7 +230,11 @@ class FlowReadSerializer(ReadSerializer):
         return [{'uuid': l.uuid, 'name': l.name} for l in obj.labels.all()]
 
     def get_runs(self, obj):
-        return {'completed': obj.get_completed_runs(), 'expired': obj.get_expired_runs()}
+        return {
+            'completed': obj.get_completed_runs(),
+            'interrupted': obj.get_interrupted_runs(),
+            'expired': obj.get_expired_runs()
+        }
 
     class Meta:
         model = Flow

--- a/temba/api/v2/urls.py
+++ b/temba/api/v2/urls.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import url
 from rest_framework.urlpatterns import format_suffix_patterns
 from .views import api, ApiExplorerView, AuthenticateView, BroadcastEndpoint, ChannelsEndpoint, ChannelEventsEndpoint
-from .views import CampaignsEndpoint, CampaignEventsEndpoint, ContactsEndpoint, DefinitionsEndpoint
+from .views import CampaignsEndpoint, CampaignEventsEndpoint, ContactsEndpoint, DefinitionsEndpoint, FlowsEndpoint
 from .views import FieldsEndpoint, GroupsEndpoint, LabelsEndpoint, MediaEndpoint, MessagesEndpoint
 from .views import OrgEndpoint, RunsEndpoint
 
@@ -20,8 +20,9 @@ urlpatterns = [
     url(r'^/channels$', ChannelsEndpoint.as_view(), name='api.v2.channels'),
     url(r'^/channel_events$', ChannelEventsEndpoint.as_view(), name='api.v2.channel_events'),
     url(r'^/contacts$', ContactsEndpoint.as_view(), name='api.v2.contacts'),
-    url(r'^/fields$', FieldsEndpoint.as_view(), name='api.v2.fields'),
     url(r'^/definitions$', DefinitionsEndpoint.as_view(), name='api.v2.definitions'),
+    url(r'^/fields$', FieldsEndpoint.as_view(), name='api.v2.fields'),
+    url(r'^/flows$', FlowsEndpoint.as_view(), name='api.v2.flows'),
     url(r'^/groups$', GroupsEndpoint.as_view(), name='api.v2.groups'),
     url(r'^/labels$', LabelsEndpoint.as_view(), name='api.v2.labels'),
     url(r'^/media$', MediaEndpoint.as_view(), name='api.v2.media'),

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -978,7 +978,7 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
      * **labels** - the labels for this flow (array of objects)
      * **expires** - the time (in minutes) when this flow's inactive contacts will expire (integer)
      * **created_on** - when this flow was created (datetime)
-     * **runs** - the counts of completed and expired runs (object)
+     * **runs** - the counts of completed, interrupted and expired runs (object)
 
     Example:
 
@@ -999,6 +999,7 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
                     "created_on": "2016-01-06T15:33:00.813162Z",
                     "runs": {
                         "completed": 123,
+                        "interrupted": 2,
                         "expired": 34
                     }
                 },

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -48,6 +48,7 @@ def api(request, format=None):
      * [/api/v2/contacts](/api/v2/contacts) - to list contacts
      * [/api/v2/definitions](/api/v2/definitions) - to export flow definitions, campaigns, and triggers
      * [/api/v2/fields](/api/v2/fields) - to list contact fields
+     * [/api/v2/flows](/api/v2/flows) - to list flows
      * [/api/v2/groups](/api/v2/groups) - to list contact groups
      * [/api/v2/labels](/api/v2/labels) - to list message labels
      * [/api/v2/messages](/api/v2/messages) - to list messages
@@ -65,6 +66,7 @@ def api(request, format=None):
         'contacts': reverse('api.v2.contacts', request=request),
         'definitions': reverse('api.v2.definitions', request=request),
         'fields': reverse('api.v2.fields', request=request),
+        'flows': reverse('api.v2.flows', request=request),
         'groups': reverse('api.v2.groups', request=request),
         'labels': reverse('api.v2.labels', request=request),
         'messages': reverse('api.v2.messages', request=request),
@@ -90,6 +92,7 @@ class ApiExplorerView(SmartTemplateView):
             ContactsEndpoint.get_read_explorer(),
             DefinitionsEndpoint.get_read_explorer(),
             FieldsEndpoint.get_read_explorer(),
+            FlowsEndpoint.get_read_explorer(),
             GroupsEndpoint.get_read_explorer(),
             LabelsEndpoint.get_read_explorer(),
             MessagesEndpoint.get_read_explorer(),
@@ -959,6 +962,76 @@ class FieldsEndpoint(ListAPIMixin, BaseAPIView):
             'request': "key=nick_name",
             'fields': [
                 {'name': "key", 'required': False, 'help': "A field key to filter by. ex: nick_name"}
+            ]
+        }
+
+
+class FlowsEndpoint(ListAPIMixin, BaseAPIView):
+    """
+    ## Listing Flows
+
+    A **GET** returns the list of flows for your organization, in the order of last created.
+
+     * **uuid** - the UUID of the flow (string), filterable as `uuid`
+     * **name** - the name of the flow (string)
+     * **archived** - whether this flow is archived (boolean)
+     * **labels** - the labels for this flow (array of objects)
+     * **expires** - the time (in minutes) when this flow's inactive contacts will expire (integer)
+     * **created_on** - when this flow was created (datetime)
+     * **runs** - the counts of completed and expired runs (object)
+
+    Example:
+
+        GET /api/v2/flows.json
+
+    Response containing the groups for your organization:
+
+        {
+            "next": null,
+            "previous": null,
+            "results": [
+                {
+                    "uuid": "5f05311e-8f81-4a67-a5b5-1501b6d6496a",
+                    "name": "Survey",
+                    "archived": false,
+                    "labels": [{"name": "Important", "uuid": "5a4eb79e-1b1f-4ae3-8700-09384cca385f"}],
+                    "expires": 600,
+                    "created_on": "2016-01-06T15:33:00.813162Z",
+                    "runs": {
+                        "completed": 123,
+                        "expired": 34
+                    }
+                },
+                ...
+            ]
+        }
+    """
+    permission = 'flows.flow_api'
+    model = ContactGroup
+    model_manager = 'user_groups'
+    serializer_class = ContactGroupReadSerializer
+    pagination_class = CreatedOnCursorPagination
+
+    def filter_queryset(self, queryset):
+        params = self.request.query_params
+
+        # filter by UUID (optional)
+        uuid = params.get('uuid')
+        if uuid:
+            queryset = queryset.filter(uuid=uuid)
+
+        return queryset.filter(is_active=True)
+
+    @classmethod
+    def get_read_explorer(cls):
+        return {
+            'method': "GET",
+            'title': "List Groups",
+            'url': reverse('api.v2.groups'),
+            'slug': 'group-list',
+            'request': "",
+            'fields': [
+                {'name': "uuid", 'required': False, 'help': "A group UUID filter by. ex: 5f05311e-8f81-4a67-a5b5-1501b6d6496a"}
             ]
         }
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -25,8 +25,8 @@ from temba.orgs.models import Org
 from temba.utils import str_to_bool, json_date_to_datetime, splitting_getlist
 from .serializers import BroadcastReadSerializer, CampaignReadSerializer, CampaignEventReadSerializer
 from .serializers import ChannelReadSerializer, ChannelEventReadSerializer, ContactReadSerializer
-from .serializers import ContactFieldReadSerializer, ContactGroupReadSerializer, FlowRunReadSerializer
-from .serializers import LabelReadSerializer, MsgReadSerializer
+from .serializers import ContactFieldReadSerializer, ContactGroupReadSerializer, FlowReadSerializer
+from .serializers import FlowRunReadSerializer, LabelReadSerializer, MsgReadSerializer
 from ..models import APIPermission, SSLPermission
 from ..support import InvalidQueryError
 
@@ -1007,9 +1007,8 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
         }
     """
     permission = 'flows.flow_api'
-    model = ContactGroup
-    model_manager = 'user_groups'
-    serializer_class = ContactGroupReadSerializer
+    model = Flow
+    serializer_class = FlowReadSerializer
     pagination_class = CreatedOnCursorPagination
 
     def filter_queryset(self, queryset):
@@ -1020,18 +1019,20 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
         if uuid:
             queryset = queryset.filter(uuid=uuid)
 
-        return queryset.filter(is_active=True)
+        queryset = queryset.prefetch_related('labels')
+
+        return queryset
 
     @classmethod
     def get_read_explorer(cls):
         return {
             'method': "GET",
-            'title': "List Groups",
-            'url': reverse('api.v2.groups'),
-            'slug': 'group-list',
+            'title': "List Flows",
+            'url': reverse('api.v2.flows'),
+            'slug': 'flow-list',
             'request': "",
             'fields': [
-                {'name': "uuid", 'required': False, 'help': "A group UUID filter by. ex: 5f05311e-8f81-4a67-a5b5-1501b6d6496a"}
+                {'name': "uuid", 'required': False, 'help': "A flow UUID filter by. ex: 5f05311e-8f81-4a67-a5b5-1501b6d6496a"}
             ]
         }
 

--- a/temba/flows/migrations/0062_flowlabel_uuid.py
+++ b/temba/flows/migrations/0062_flowlabel_uuid.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from temba.utils.models import generate_uuid
+
+
+def populate_flowlabel_uuid(apps, schema_editor):
+    FlowLabel = apps.get_model('flows', 'FlowLabel')
+    for label in FlowLabel.objects.all():
+        label.uuid = generate_uuid()
+        label.save(update_fields=('uuid',))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0061_flowrun_timeout_on'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='flowlabel',
+            name='uuid',
+            field=models.CharField(null=True, max_length=36, help_text='The unique identifier for this label', unique=True, verbose_name='Unique Identifier', db_index=True),
+        ),
+        migrations.RunPython(populate_flowlabel_uuid),
+        migrations.AlterField(
+            model_name='flowlabel',
+            name='uuid',
+            field=models.CharField(default=generate_uuid, max_length=36,
+                                   help_text='The unique identifier for this label', unique=True,
+                                   verbose_name='Unique Identifier', db_index=True),
+        ),
+    ]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -35,7 +35,7 @@ from temba.msgs.models import Broadcast, Msg, FLOW, INBOX, INCOMING, QUEUED, INI
 from temba.orgs.models import Org, Language, UNREAD_FLOW_MSGS, CURRENT_EXPORT_VERSION
 from temba.utils import get_datetime_format, str_to_datetime, datetime_to_str, analytics, json_date_to_datetime, chunk_list
 from temba.utils.email import send_template_email, is_valid_address
-from temba.utils.models import TembaModel, ChunkIterator
+from temba.utils.models import TembaModel, ChunkIterator, generate_uuid
 from temba.utils.profiler import SegmentProfiler
 from temba.utils.queues import push_task
 from temba.values.models import Value
@@ -4036,10 +4036,13 @@ class FlowStart(SmartModel):
 
 
 class FlowLabel(models.Model):
+    org = models.ForeignKey(Org)
+
+    uuid = models.CharField(max_length=36, unique=True, db_index=True, default=generate_uuid,
+                            verbose_name=_("Unique Identifier"), help_text=_("The unique identifier for this label"))
     name = models.CharField(max_length=64, verbose_name=_("Name"),
                             help_text=_("The name of this flow label"))
     parent = models.ForeignKey('FlowLabel', verbose_name=_("Parent"), null=True, related_name="children")
-    org = models.ForeignKey(Org)
 
     def get_flows_count(self):
         """

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1111,6 +1111,9 @@ class Flow(TembaModel):
     def get_completed_runs(self):
         return FlowRunCount.run_count_for_type(self, FlowRun.EXIT_TYPE_COMPLETED)
 
+    def get_interrupted_runs(self):
+        return FlowRunCount.run_count_for_type(self, FlowRun.EXIT_TYPE_INTERRUPTED)
+
     def get_expired_runs(self):
         return FlowRunCount.run_count_for_type(self, FlowRun.EXIT_TYPE_EXPIRED)
 


### PR DESCRIPTION
Since we have a definitions endpoint which handles (potentially expensive) flow definition fetching, this endpoint does not include flow definition

Adds UUIDs to flow labels for consistency with message labels, groups etc.