### PR TITLE
Show the  send broadcast modal only on active participants click

### DIFF
--- a/static/coffee/flows/controllers.coffee
+++ b/static/coffee/flows/controllers.coffee
@@ -408,8 +408,9 @@ app.controller 'FlowController', [ '$scope', '$rootScope', '$timeout', '$log', '
       lastAction = actionset.actions[actionset.actions.length - 1]
       return lastAction._missingTranslation
 
-  $scope.broadcastToStep = (uuid) ->
+  $scope.broadcastToStep = (event, uuid) ->
     window.broadcastToNode(uuid)
+    event.stopPropagation()
 
   $scope.addNote = (event) ->
     Flow.addNote(event.offsetX, event.offsetY)

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -304,7 +304,7 @@
                ng-attr-id:'[[action_set.uuid]]', class:'action-node', ng-class:'{recents:action_set._showMessages, translate:lastActionMissingTranslation(action_set)}',
                ng-style:"{left:action_set.x, top:action_set.y}"}
 
-          .active{ng-show:'action_set._active > 0', ng-click:'broadcastToStep(action_set.uuid)'}
+          .active{ng-show:'action_set._active > 0', ng-click:'broadcastToStep(action_set.uuid); $event.stopPropagation();'}
             [[action_set._active|number]]
 
           .flow-start{ng-show:'action_set.uuid == flow.entry'}
@@ -445,7 +445,7 @@
               ng-style:"{left:ruleset.x, top:ruleset.y}",
               ng-click:'clickRuleset(ruleset)'}
 
-          .active{ng-show:'ruleset._active > 0', ng-click:'broadcastToStep(ruleset.uuid)'}
+          .active{ng-show:'ruleset._active > 0', ng-click:'broadcastToStep(ruleset.uuid); $event.stopPropagation();'}
             [[ruleset._active|number]]
 
           .flow-start{ng-show:'ruleset.uuid == flow.entry'}

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -304,7 +304,7 @@
                ng-attr-id:'[[action_set.uuid]]', class:'action-node', ng-class:'{recents:action_set._showMessages, translate:lastActionMissingTranslation(action_set)}',
                ng-style:"{left:action_set.x, top:action_set.y}"}
 
-          .active{ng-show:'action_set._active > 0', ng-click:'broadcastToStep(action_set.uuid); $event.stopPropagation();'}
+          .active{ng-show:'action_set._active > 0', ng-click:'broadcastToStep($event, action_set.uuid)'}
             [[action_set._active|number]]
 
           .flow-start{ng-show:'action_set.uuid == flow.entry'}
@@ -445,7 +445,7 @@
               ng-style:"{left:ruleset.x, top:ruleset.y}",
               ng-click:'clickRuleset(ruleset)'}
 
-          .active{ng-show:'ruleset._active > 0', ng-click:'broadcastToStep(ruleset.uuid); $event.stopPropagation();'}
+          .active{ng-show:'ruleset._active > 0', ng-click:'broadcastToStep($event, ruleset.uuid)'}
             [[ruleset._active|number]]
 
           .flow-start{ng-show:'ruleset.uuid == flow.entry'}


### PR DESCRIPTION
currently clicking the blue badge opens both the send message modal and the ruleset editor.

this fix to only open the send message modal only.