### PR TITLE
Record recipient contacts instead of URNs on broadcasts, pt 1

### DIFF
--- a/temba/msgs/migrations/0060_broadcast_recipient_contacts.py
+++ b/temba/msgs/migrations/0060_broadcast_recipient_contacts.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0041_indexes_update'),
+        ('msgs', '0059_indexes_update'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='broadcast',
+            name='recipient_contacts',
+            field=models.ManyToManyField(help_text='The contacts which received this message', related_name='broadcasts', verbose_name='Recipients', to='contacts.Contact'),
+        ),
+    ]

--- a/temba/msgs/migrations/0060_remove_broadcast_recipients.py
+++ b/temba/msgs/migrations/0060_remove_broadcast_recipients.py
@@ -7,14 +7,12 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contacts', '0041_indexes_update'),
         ('msgs', '0059_indexes_update'),
     ]
 
     operations = [
-        migrations.AddField(
+        migrations.RemoveField(
             model_name='broadcast',
-            name='recipient_contacts',
-            field=models.ManyToManyField(help_text='The contacts which received this message', related_name='broadcasts', verbose_name='Recipients', to='contacts.Contact'),
+            name='recipients',
         ),
     ]

--- a/temba/msgs/migrations/0061_broadcast_recipients.py
+++ b/temba/msgs/migrations/0061_broadcast_recipients.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0041_indexes_update'),
+        ('msgs', '0060_remove_broadcast_recipients'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='broadcast',
+            name='recipients',
+            field=models.ManyToManyField(help_text='The contacts which received this message', related_name='broadcasts', verbose_name='Recipients', to='contacts.Contact'),
+        ),
+    ]

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -162,11 +162,8 @@ class Broadcast(models.Model):
     urns = models.ManyToManyField(ContactURN, verbose_name=_("URNs"), related_name='addressed_broadcasts',
                                   help_text=_("Individual URNs included in this message"))
 
-    recipients = models.ManyToManyField(ContactURN, verbose_name=_("Recipients"), related_name='broadcasts',
-                                        help_text=_("The URNs which received this message"))
-
-    recipient_contacts = models.ManyToManyField(Contact, verbose_name=_("Recipients"), related_name='broadcasts',
-                                                help_text=_("The contacts which received this message"))
+    recipients = models.ManyToManyField(Contact, verbose_name=_("Recipients"), related_name='broadcasts',
+                                        help_text=_("The contacts which received this message"))
 
     recipient_count = models.IntegerField(verbose_name=_("Number of recipients"), null=True,
                                           help_text=_("Number of urns which received this broadcast"))
@@ -399,7 +396,7 @@ class Broadcast(models.Model):
         Contact.bulk_cache_initialize(self.org, contacts)
         recipients = list(urns) + list(contacts)
 
-        RelatedRecipient = Broadcast.recipient_contacts.through
+        RelatedRecipient = Broadcast.recipients.through
 
         # we batch up our SQL calls to speed up the creation of our SMS objects
         batch = []

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -165,6 +165,9 @@ class Broadcast(models.Model):
     recipients = models.ManyToManyField(ContactURN, verbose_name=_("Recipients"), related_name='broadcasts',
                                         help_text=_("The URNs which received this message"))
 
+    recipient_contacts = models.ManyToManyField(Contact, verbose_name=_("Recipients"), related_name='broadcasts',
+                                                help_text=_("The contacts which received this message"))
+
     recipient_count = models.IntegerField(verbose_name=_("Number of recipients"), null=True,
                                           help_text=_("Number of urns which received this broadcast"))
 
@@ -396,7 +399,7 @@ class Broadcast(models.Model):
         Contact.bulk_cache_initialize(self.org, contacts)
         recipients = list(urns) + list(contacts)
 
-        RelatedRecipient = Broadcast.recipients.through
+        RelatedRecipient = Broadcast.recipient_contacts.through
 
         # we batch up our SQL calls to speed up the creation of our SMS objects
         batch = []
@@ -458,7 +461,7 @@ class Broadcast(models.Model):
             if msg:
                 batch.append(msg)
                 # keep track of this URN as a recipient
-                recipient_batch.append(RelatedRecipient(contacturn_id=msg.contact_urn_id, broadcast_id=self.id))
+                recipient_batch.append(RelatedRecipient(contact_id=msg.contact_id, broadcast_id=self.id))
 
             # we commit our messages in batches
             if len(batch) >= BATCH_SIZE:

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -314,7 +314,7 @@ class MsgTest(TembaTest):
         broadcast.send()
 
         # assert that recipient is set
-        self.assertEqual(set(broadcast.recipient_contacts.all()), {self.joe})
+        self.assertEqual(set(broadcast.recipients.all()), {self.joe})
 
     def test_outbox(self):
         self.login(self.admin)
@@ -918,7 +918,7 @@ class BroadcastTest(TembaTest):
             broadcast.send()
 
             self.assertEquals(broadcast.get_message_count(), 3)
-            self.assertEqual(set(broadcast.recipient_contacts.all()), {self.joe, self.frank, self.kevin})
+            self.assertEqual(set(broadcast.recipients.all()), {self.joe, self.frank, self.kevin})
         finally:
             msgs_models.BATCH_SIZE = orig_batch_size
 
@@ -935,12 +935,12 @@ class BroadcastTest(TembaTest):
         self.assertEquals(4, broadcast.recipient_count)
 
         # no recipients created yet, done when we send
-        self.assertEqual(set(broadcast.recipient_contacts.all()), set())
+        self.assertEqual(set(broadcast.recipients.all()), set())
 
         broadcast.send(trigger_send=False)
         self.assertEqual('Q', broadcast.status)
         self.assertEqual(broadcast.get_message_count(), 4)
-        self.assertEqual(set(broadcast.recipient_contacts.all()), {self.joe, self.frank, self.kevin, self.lucy})
+        self.assertEqual(set(broadcast.recipients.all()), {self.joe, self.frank, self.kevin, self.lucy})
 
         bcast_commands = broadcast.get_sync_commands(self.channel)
         self.assertEquals(1, len(bcast_commands))

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -314,8 +314,7 @@ class MsgTest(TembaTest):
         broadcast.send()
 
         # assert that recipient is set
-        self.assertEqual(broadcast.recipients.all().count(), 1)
-        self.assertEqual(broadcast.recipients.all()[0], self.joe.urns.all().first())
+        self.assertEqual(set(broadcast.recipient_contacts.all()), {self.joe})
 
     def test_outbox(self):
         self.login(self.admin)
@@ -919,7 +918,7 @@ class BroadcastTest(TembaTest):
             broadcast.send()
 
             self.assertEquals(broadcast.get_message_count(), 3)
-            self.assertEqual(broadcast.recipients.all().count(), 3)
+            self.assertEqual(set(broadcast.recipient_contacts.all()), {self.joe, self.frank, self.kevin})
         finally:
             msgs_models.BATCH_SIZE = orig_batch_size
 
@@ -936,12 +935,12 @@ class BroadcastTest(TembaTest):
         self.assertEquals(4, broadcast.recipient_count)
 
         # no recipients created yet, done when we send
-        self.assertEquals(0, broadcast.recipients.all().count())
+        self.assertEqual(set(broadcast.recipient_contacts.all()), set())
 
         broadcast.send(trigger_send=False)
-        self.assertEquals('Q', broadcast.status)
-        self.assertEquals(broadcast.get_message_count(), 4)
-        self.assertEqual(broadcast.recipients.all().count(), 4)
+        self.assertEqual('Q', broadcast.status)
+        self.assertEqual(broadcast.get_message_count(), 4)
+        self.assertEqual(set(broadcast.recipient_contacts.all()), {self.joe, self.frank, self.kevin, self.lucy})
 
         bcast_commands = broadcast.get_sync_commands(self.channel)
         self.assertEquals(1, len(bcast_commands))


### PR DESCRIPTION
Originally this added a new `recipient_contacts` field, leaving the existing `recipients` field for use in the backfill migration. But it's just as easy to use messages for the backfill, so now this removes the existing field, and adds a new field for contacts with the same name.

Other problem with backfilling based on the URNs m2m, is that that is no longer updated for new broadcasts - whereas the messages m2m is always populated.