### PR TITLE
Creating and updating contacts in API v2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length=120
 filename=*.py,*.py.dev
-exclude=./env/*,*/migrations/*,./config/*,./fab*
+exclude=./env/*,*/migrations/*,./config/*,./fab*,.git/*
 ignore=E501

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -1216,6 +1216,11 @@ class APITest(TembaTest):
             self.assertResponseError(response, None,
                                      "You may only specify one of the contact, folder, label, broadcast parameters")
 
+        with AnonymousOrg(self.org):
+            # for anon orgs, don't return URN values
+            response = self.fetchJSON(url, 'id=%d' % joe_msg3.pk)
+            self.assertIsNone(response.json['results'][0]['urn'])
+
     def test_org(self):
         url = reverse('api.v2.org')
 

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -824,12 +824,19 @@ class APITest(TembaTest):
         bobby = Contact.objects.get(name="Bobby")
         self.assertEqual(set(bobby.urns.values_list('urn', flat=True)), {'twitter:bobby'})
 
+        # if URNs list also provided, it takes precedence
+        response = self.postJSON(url, {'urn': "twitter:jimmy", 'name': "Jimmy", 'urns': ["twitter:jimmy2"]})
+        self.assertEqual(response.status_code, 201)
+
+        jimmy = Contact.objects.get(name="Jimmy")
+        self.assertEqual(set(jimmy.urns.values_list('urn', flat=True)), {'twitter:jimmy2'})
+
         # URN identifier is also normalized for updates
         response = self.postJSON(url, {'urn': "twitter:BOBBY", 'name': "Bobby II"})
         self.assertEqual(response.status_code, 201)
 
         bobby.refresh_from_db()
-        self.assertEqual(bobby.name, "Bobby II")
+        self.assertEqual(bobby.name, "Bobby II")  # updated existing contact
 
         # try to create a contact with a URN belonging to another contact
         response = self.postJSON(url, {'name': "Robert", 'urns': ["twitter:bobby"]})

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import json
+import six
 
 from django.forms import ValidationError
 from rest_framework import serializers
@@ -60,8 +61,8 @@ class UUIDListField(serializers.ListField):
 
 
 class URNField(serializers.CharField):
-    def to_representation(self, obj):
-        return unicode(obj)
+    def to_representation(self, obj):  # pragma: no cover
+        return six.text_type(obj)
 
     def to_internal_value(self, data):
         if not URN.validate(data):
@@ -187,7 +188,7 @@ class ChannelReadSerializer(ReadSerializer):
     device = serializers.SerializerMethodField()
 
     def get_country(self, obj):
-        return unicode(obj.country) if obj.country else None
+        return six.text_type(obj.country) if obj.country else None
 
     def get_device(self, obj):
         if obj.channel_type != ANDROID:

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
 import json
-from django.forms import ValidationError
 
+from django.forms import ValidationError
 from rest_framework import serializers
 from temba.api.models import Resthook, ResthookSubscriber, WebHookEvent
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel, ChannelEvent, ANDROID
 
-from temba.contacts.models import Contact, ContactField, ContactGroup, ContactURN, URN
+from temba.contacts.models import Contact, ContactField, ContactGroup, URN
 from temba.flows.models import Flow, FlowRun, FlowStep, FlowStart
 from temba.locations.models import AdminBoundary
 from temba.msgs.models import Broadcast, Msg, Label, STATUS_CONFIG, INCOMING, OUTGOING, INBOX, FLOW, IVR, PENDING
@@ -48,7 +48,9 @@ class WriteSerializer(serializers.Serializer):
 
     def run_validation(self, data=serializers.empty):
         if not isinstance(data, dict):
-            raise serializers.ValidationError(detail={'non_field_errors': ["Request body should be a single JSON object"]})
+            raise serializers.ValidationError(detail={
+                'non_field_errors': ["Request body should be a single JSON object"]
+            })
 
         return super(WriteSerializer, self).run_validation(data)
 

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -61,8 +61,11 @@ class UUIDListField(serializers.ListField):
 
 
 class URNField(serializers.CharField):
-    def to_representation(self, obj):  # pragma: no cover
-        return six.text_type(obj)
+    def to_representation(self, obj):
+        if self.context['org'].is_anon:
+            return None
+        else:
+            return six.text_type(obj)
 
     def to_internal_value(self, data):
         try:
@@ -606,7 +609,7 @@ class MsgReadSerializer(ReadSerializer):
 
     broadcast = serializers.SerializerMethodField()
     contact = serializers.SerializerMethodField()
-    urn = serializers.SerializerMethodField()
+    urn = URNField(source='contact_urn')
     channel = serializers.SerializerMethodField()
     direction = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
@@ -620,14 +623,6 @@ class MsgReadSerializer(ReadSerializer):
 
     def get_contact(self, obj):
         return {'uuid': obj.contact.uuid, 'name': obj.contact.name}
-
-    def get_urn(self, obj):
-        if self.context['org'].is_anon:
-            return None
-        elif obj.contact_urn_id:
-            return obj.contact_urn.urn
-        else:
-            return None
 
     def get_channel(self, obj):
         return {'uuid': obj.channel.uuid, 'name': obj.channel.name} if obj.channel_id else None

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -24,7 +24,7 @@ from temba.locations.models import AdminBoundary, BoundaryAlias
 from temba.msgs.models import Broadcast, Msg, Label, SystemLabel
 from temba.utils import str_to_bool, json_date_to_datetime, splitting_getlist
 from .serializers import BroadcastReadSerializer, CampaignReadSerializer, CampaignEventReadSerializer
-from .serializers import ChannelReadSerializer, ChannelEventReadSerializer, ContactReadSerializer
+from .serializers import ChannelReadSerializer, ChannelEventReadSerializer, ContactReadSerializer, ContactWriteSerializer
 from .serializers import FlowStartReadSerializer, FlowStartWriteSerializer
 from .serializers import WebHookEventReadSerializer, ResthookReadSerializer, ResthookSubscriberReadSerializer, ResthookSubscriberWriteSerializer
 from .serializers import ContactFieldReadSerializer, ContactGroupReadSerializer, FlowReadSerializer
@@ -800,14 +800,12 @@ class ChannelEventsEndpoint(ListAPIMixin, BaseAPIView):
         }
 
 
-class ContactsEndpoint(ListAPIMixin, BaseAPIView):
+class ContactsEndpoint(CreateAPIMixin, ListAPIMixin, BaseAPIView):
     """
-    ## Adding or Updating Contacts
+    ## Adding Contacts
 
-    You can add a new contact to your account, or update the fields on a contact by sending a **POST** request to this
-    URL with the following JSON data:
+    You can add a new contact to your account by sending a **POST** request to this URL with the following JSON data:
 
-    * **uuid** - the UUID of the contact (string, optional)
     * **name** - the full name of the contact (string, optional)
     * **language** - the preferred language for the contact (3 letter iso code, optional)
     * **urns** - a list of URNs you want associated with the contact (string array)
@@ -841,12 +839,29 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
               "side_kick": "Ryan Lewis"
             }
             "blocked": false,
-            "stopped": false
+            "stopped": false,
+            "created_on": "2015-11-11T13:05:57.457742Z",
+            "modified_on": "2015-11-11T13:05:57.576056Z"
         }
 
-    You can update contacts in the same manner as adding them but we recommend you pass in the UUID for the contact
-    as a way of specifying which contact to update. Note that when you pass in the contact UUID and ```urns```, all
-    existing URNs will be evaluated against this new set and updated accordingly.
+    ## Updating Contacts
+
+    You can update contacts in the same manner by including one of the following fields:
+
+    * **uuid** - the UUID of the contact (string, optional)
+    * **urn** - a URN belonging to the contact (string, optional)
+
+    Example:
+
+        POST /api/v2/contacts.json
+        {
+            "uuid": "09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
+            "name": "Ben Haggerty",
+            "language": "eng",
+            "urns": ["tel:+250788123123", "twitter:ben"],
+            "groups": [{"name": "Devs", "uuid": "6685e933-26e1-4363-a468-8f7268ab63a9"}],
+            "fields": {}
+        }
 
     ## Listing Contacts
 
@@ -859,6 +874,8 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
      * **urns** - the URNs associated with the contact (string array), filterable as `urn`.
      * **groups** - the UUIDs of any groups the contact is part of (array of objects), filterable as `group` with group name or UUID.
      * **fields** - any contact fields on this contact (dictionary).
+     * **blocked** - whether the contact is blocked (boolean).
+     * **stopped** - whether the contact is stopped, i.e. has opted out (boolean).
      * **created_on** - when this contact was created (datetime).
      * **modified_on** - when this contact was last modified (datetime), filterable as `before` and `after`.
 
@@ -882,6 +899,8 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
                   "nickname": "Macklemore",
                   "side_kick": "Ryan Lewis"
                 }
+                "blocked": false,
+                "stopped": false,
                 "created_on": "2015-11-11T13:05:57.457742Z",
                 "modified_on": "2015-11-11T13:05:57.576056Z"
             }]
@@ -890,6 +909,7 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
     permission = 'contacts.contact_api'
     model = Contact
     serializer_class = ContactReadSerializer
+    write_serializer_class = ContactWriteSerializer
     pagination_class = ModifiedOnCursorPagination
     throttle_scope = 'v2.contacts'
 
@@ -954,6 +974,25 @@ class ContactsEndpoint(ListAPIMixin, BaseAPIView):
                 {'name': "deleted", 'required': False, 'help': "Whether to return only deleted contacts. ex: false"},
                 {'name': 'before', 'required': False, 'help': "Only return contacts modified before this date, ex: 2015-01-28T18:00:00.000"},
                 {'name': 'after', 'required': False, 'help': "Only return contacts modified after this date, ex: 2015-01-28T18:00:00.000"}
+            ]
+        }
+
+    @classmethod
+    def get_write_explorer(cls):
+        return {
+            'method': "POST",
+            'title': "Add or Update Contacts",
+            'url': reverse('api.v2.contacts'),
+            'slug': 'contact-update',
+            'request': '{"name": "Ben Haggerty", "groups": [], "urns": ["tel:+250788123123"]}',
+            'fields': [
+                {'name': "uuid", 'required': False, 'help': "UUID of the contact to be updated"},
+                {'name': "urn", 'required': False, 'help': "URN of the contact to be updated. ex: tel:+250788123123"},
+                {'name': "name", 'required': False, 'help': "List of UUIDs of this contact's groups."},
+                {'name': "language", 'required': False, 'help': "Preferred language of the contact (3-letter ISO code). ex: fre, eng"},
+                {'name': "urns", 'required': False, 'help': "List of URNs belonging to the contact."},
+                {'name': "groups", 'required': False, 'help': "List of UUIDs of groups that the contact belongs to."},
+                {'name': "fields", 'required': False, 'help': "Custom fields as a JSON dictionary."},
             ]
         }
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -48,7 +48,7 @@ def api(request, format=None):
      * [/api/v2/campaign_events](/api/v2/campaign_events) - to list campaign events
      * [/api/v2/channels](/api/v2/channels) - to list channels
      * [/api/v2/channel_events](/api/v2/channel_events) - to list channel events
-     * [/api/v2/contacts](/api/v2/contacts) - to list contacts
+     * [/api/v2/contacts](/api/v2/contacts) - to list, create or update contacts
      * [/api/v2/definitions](/api/v2/definitions) - to export flow definitions, campaigns, and triggers
      * [/api/v2/fields](/api/v2/fields) - to list contact fields
      * [/api/v2/flow_starts](/api/v2/flow_starts) - to list flow starts and start contacts in flows
@@ -59,8 +59,8 @@ def api(request, format=None):
      * [/api/v2/org](/api/v2/org) - to view your org
      * [/api/v2/runs](/api/v2/runs) - to list flow runs
      * [/api/v2/resthooks](/api/v2/resthooks) - to list resthooks
-     * [/api/v2/resthook_subscribers](/api/v2/resthook_subscribers) - to list subscribers on your resthooks
      * [/api/v2/resthook_events](/api/v2/resthook_events) - to list resthook events
+     * [/api/v2/resthook_subscribers](/api/v2/resthook_subscribers) - to list subscribers on your resthooks
 
     You may wish to use the [API Explorer](/api/v2/explorer) to interactively experiment with the API.
     """
@@ -103,6 +103,7 @@ class ApiExplorerView(SmartTemplateView):
             ChannelsEndpoint.get_read_explorer(),
             ChannelEventsEndpoint.get_read_explorer(),
             ContactsEndpoint.get_read_explorer(),
+            ContactsEndpoint.get_write_explorer(),
             DefinitionsEndpoint.get_read_explorer(),
             FieldsEndpoint.get_read_explorer(),
             FlowsEndpoint.get_read_explorer(),
@@ -801,6 +802,52 @@ class ChannelEventsEndpoint(ListAPIMixin, BaseAPIView):
 
 class ContactsEndpoint(ListAPIMixin, BaseAPIView):
     """
+    ## Adding or Updating Contacts
+
+    You can add a new contact to your account, or update the fields on a contact by sending a **POST** request to this
+    URL with the following JSON data:
+
+    * **uuid** - the UUID of the contact (string, optional)
+    * **name** - the full name of the contact (string, optional)
+    * **language** - the preferred language for the contact (3 letter iso code, optional)
+    * **urns** - a list of URNs you want associated with the contact (string array)
+    * **groups** - a list of the UUIDs of any groups this contact is part of (string array, optional)
+    * **fields** - the contact fields you want to set or update on this contact (dictionary, optional)
+
+    Example:
+
+        POST /api/v2/contacts.json
+        {
+            "name": "Ben Haggerty",
+            "language": "eng",
+            "urns": ["tel:+250788123123", "twitter:ben"],
+            "groups": [{"name": "Devs", "uuid": "6685e933-26e1-4363-a468-8f7268ab63a9"}],
+            "fields": {
+              "nickname": "Macklemore",
+              "side_kick": "Ryan Lewis"
+            }
+        }
+
+    You will receive a contact object as a response if successful:
+
+        {
+            "uuid": "09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
+            "name": "Ben Haggerty",
+            "language": "eng",
+            "urns": ["tel:+250788123123", "twitter:ben"],
+            "groups": [{"name": "Devs", "uuid": "6685e933-26e1-4363-a468-8f7268ab63a9"}],
+            "fields": {
+              "nickname": "Macklemore",
+              "side_kick": "Ryan Lewis"
+            }
+            "blocked": false,
+            "stopped": false
+        }
+
+    You can update contacts in the same manner as adding them but we recommend you pass in the UUID for the contact
+    as a way of specifying which contact to update. Note that when you pass in the contact UUID and ```urns```, all
+    existing URNs will be evaluated against this new set and updated accordingly.
+
     ## Listing Contacts
 
     A **GET** returns the list of contacts for your organization, in the order of last activity date. You can return


### PR DESCRIPTION
Bit different from v1 in that we don't identify a contact to update by the `urns` field, but instead introduce a `urn` field. This allows URNs to be removed/stolen even when looking up contacts by their URN.

Also only updates contacts with the provided field - i.e. if name isn't provided, it won't be changed.