### PR TITLE
Optional Tiers

### DIFF
--- a/temba/orgs/migrations/0023_remove_org_multi_org.py
+++ b/temba/orgs/migrations/0023_remove_org_multi_org.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0022_auto_20160815_1726'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='org',
+            name='multi_org',
+        ),
+    ]

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -231,7 +231,7 @@ class Org(SmartModel):
 
     def create_sub_org(self, name, timezone=None, created_by=None):
 
-        if self.is_multi_org_level() and not self.parent:
+        if self.is_multi_org_tier() and not self.parent:
 
             if not timezone:
                 timezone = self.timezone
@@ -1022,11 +1022,15 @@ class Org(SmartModel):
     def is_free_plan(self):
         return self.plan == FREE_PLAN or self.plan == TRIAL_PLAN
 
-    def is_multi_user_level(self):
-        return self.get_purchased_credits() >= settings.MULTI_USER_THRESHOLD
+    def is_multi_user_tier(self):
+        if self.get_branding().get('tiers', True):
+            return self.get_purchased_credits() >= settings.MULTI_USER_THRESHOLD
+        return True
 
-    def is_multi_org_level(self):
-        return not self.parent and (self.multi_org or self.get_purchased_credits() >= settings.MULTI_ORG_THRESHOLD)
+    def is_multi_org_tier(self):
+        if self.get_branding().get('tiers', True):
+            return not self.parent and (self.multi_org or self.get_purchased_credits() >= settings.MULTI_ORG_THRESHOLD)
+        return True
 
     def has_added_credits(self):
         return self.get_credits_total() > WELCOME_TOPUP_SIZE

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -212,8 +212,6 @@ class Org(SmartModel):
 
     parent = models.ForeignKey('orgs.Org', null=True, blank=True, help_text=_('The parent org that manages this org'))
 
-    multi_org = models.BooleanField(default=False, help_text=_('Put this org on the multi org level'))
-
     @classmethod
     def get_unique_slug(cls, name):
         slug = slugify(name)
@@ -1023,14 +1021,10 @@ class Org(SmartModel):
         return self.plan == FREE_PLAN or self.plan == TRIAL_PLAN
 
     def is_multi_user_tier(self):
-        if self.get_branding().get('tiers', True):
-            return self.get_purchased_credits() >= settings.MULTI_USER_THRESHOLD
-        return True
+        return self.get_purchased_credits() >= self.get_branding().get('tiers').get('multi_user')
 
     def is_multi_org_tier(self):
-        if self.get_branding().get('tiers', True):
-            return not self.parent and (self.multi_org or self.get_purchased_credits() >= settings.MULTI_ORG_THRESHOLD)
-        return True
+        return not self.parent and self.get_purchased_credits() >= self.get_branding().get('tiers').get('multi_org')
 
     def has_added_credits(self):
         return self.get_credits_total() > WELCOME_TOPUP_SIZE

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -892,6 +892,9 @@ class OrgTest(TembaTest):
         self.assertEqual(topup.get_price_display(), "$1.00")
 
     def test_topups(self):
+
+        settings.BRANDING[settings.DEFAULT_BRAND]['tiers'] = True
+
         contact = self.create_contact("Michael Shumaucker", "+250788123123")
         test_contact = Contact.get_test_contact(self.user)
         welcome_topup = TopUp.objects.get()
@@ -984,8 +987,8 @@ class OrgTest(TembaTest):
         # test special status
         settings.MULTI_USER_THRESHOLD = 100000
         settings.MULTI_ORG_THRESHOLD = 1000000
-        self.assertFalse(self.org.is_multi_user_level())
-        self.assertFalse(self.org.is_multi_org_level())
+        self.assertFalse(self.org.is_multi_user_tier())
+        self.assertFalse(self.org.is_multi_org_tier())
 
         # add new topup with lots of credits
         mega_topup = TopUp.create(self.admin, price=0, credits=100000)
@@ -999,7 +1002,7 @@ class OrgTest(TembaTest):
 
         # we aren't yet multi user since this topup was free
         self.assertEquals(0, self.org.get_purchased_credits())
-        self.assertFalse(self.org.is_multi_user_level())
+        self.assertFalse(self.org.is_multi_user_tier())
 
         self.assertEquals(100025, self.org.get_credits_total())
         self.assertEquals(30, self.org.get_credits_used())
@@ -1114,14 +1117,14 @@ class OrgTest(TembaTest):
         # now buy some credits to make us multi user
         TopUp.create(self.admin, price=100, credits=100000)
         self.org.update_caches(OrgEvent.topup_updated, None)
-        self.assertTrue(self.org.is_multi_user_level())
-        self.assertFalse(self.org.is_multi_org_level())
+        self.assertTrue(self.org.is_multi_user_tier())
+        self.assertFalse(self.org.is_multi_org_tier())
 
         # good deal!
         TopUp.create(self.admin, price=100, credits=1000000)
         self.org.update_caches(OrgEvent.topup_updated, None)
-        self.assertTrue(self.org.is_multi_user_level())
-        self.assertTrue(self.org.is_multi_org_level())
+        self.assertTrue(self.org.is_multi_user_tier())
+        self.assertTrue(self.org.is_multi_org_tier())
 
     @patch('temba.orgs.views.TwilioRestClient', MockTwilioClient)
     @patch('temba.orgs.models.TwilioRestClient', MockTwilioClient)
@@ -1481,10 +1484,28 @@ class OrgTest(TembaTest):
         response = self.client.get('/org/download/flows/123/')
         self.assertRedirect(response, '/assets/download/results_export/123/')
 
+    def test_tiers(self):
+        settings.MULTI_ORG_THRESHOLD = 1000000
+        settings.BRANDING[settings.DEFAULT_BRAND]['tiers'] = True
+
+        # not enough credits with tiers enabled
+        self.assertIsNone(self.org.create_sub_org('Sub Org A'))
+
+        # not enough credits, but tiers disabled
+        settings.BRANDING[settings.DEFAULT_BRAND]['tiers'] = False
+        self.assertIsNotNone(self.org.create_sub_org('Sub Org A'))
+
+        # tiers enabled, but enough credits
+        settings.BRANDING[settings.DEFAULT_BRAND]['tiers'] = True
+        TopUp.create(self.admin, price=100, credits=1000000)
+        self.org.update_caches(OrgEvent.topup_updated, None)
+        self.assertIsNotNone(self.org.create_sub_org('Sub Org B'))
+
     def test_sub_orgs(self):
 
         from temba.orgs.models import Debit
         settings.MULTI_ORG_THRESHOLD = 1000000
+        settings.BRANDING[settings.DEFAULT_BRAND]['tiers'] = True
 
         # lets start with two topups
         expires = timezone.now() + timedelta(days=400)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1513,9 +1513,8 @@ class OrgTest(TembaTest):
         # we won't create sub orgs if the org isn't the proper level
         self.assertIsNone(sub_org)
 
-        # upgrade our org and go again
-        self.org.multi_org = True
-        self.org.save()
+        # lower the tier and try again
+        settings.BRANDING[settings.DEFAULT_BRAND]['tiers'] = dict(multi_org=0)
         sub_org = self.org.create_sub_org('Sub Org')
 
         # suborgs can't create suborgs

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1062,7 +1062,7 @@ class OrgCRUDL(SmartCRUDL):
         # if we don't support multi orgs, go home
         def pre_process(self, request, *args, **kwargs):
             response = super(OrgPermsMixin, self).pre_process(request, *args, **kwargs)
-            if not response and not request.user.get_org().is_multi_org_level():
+            if not response and not request.user.get_org().is_multi_org_tier():
                 return HttpResponseRedirect(reverse('orgs.org_home'))
             return response
 
@@ -1845,7 +1845,7 @@ class OrgCRUDL(SmartCRUDL):
                 formax.add_section('resthooks', reverse('orgs.org_resthooks'), icon='icon-cloud-lightning', dependents="resthooks")
 
             # only pro orgs get multiple users
-            if self.has_org_perm("orgs.org_manage_accounts") and org.is_multi_user_level():
+            if self.has_org_perm("orgs.org_manage_accounts") and org.is_multi_user_tier():
                 formax.add_section('accounts', reverse('orgs.org_accounts'), icon='icon-users', action='redirect')
 
     class TransferToAccount(InferOrgMixin, OrgPermsMixin, SmartUpdateView):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -87,10 +87,6 @@ USE_I18N = True
 # calendars according to the current locale
 USE_L10N = True
 
-# number of credits before they get user management
-MULTI_USER_THRESHOLD = 0
-MULTI_ORG_THRESHOLD = 0
-
 # URL prefix for admin static files -- CSS, JavaScript and images.
 # Make sure to use a trailing slash.
 # Examples: "http://foo.com/static/admin/", "/static/admin/".
@@ -279,8 +275,8 @@ BRANDING = {
         'favico': 'brands/rapidpro/rapidpro.ico',
         'splash': '/brands/rapidpro/splash.jpg',
         'logo': '/brands/rapidpro/logo.png',
-        'tiers': False,
         'allow_signups': True,
+        'tiers': dict(multi_user=0, multi_org=0),
         'welcome_packs': [dict(size=5000, name="Demo Account"), dict(size=100000, name="UNICEF Account")],
         'description': _("Visually build nationally scalable mobile applications from anywhere in the world."),
         'credits': _("Copyright &copy; 2012-2015 UNICEF, Nyaruka. All Rights Reserved.")

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -279,6 +279,7 @@ BRANDING = {
         'favico': 'brands/rapidpro/rapidpro.ico',
         'splash': '/brands/rapidpro/splash.jpg',
         'logo': '/brands/rapidpro/logo.png',
+        'tiers': False,
         'allow_signups': True,
         'welcome_packs': [dict(size=5000, name="Demo Account"), dict(size=100000, name="UNICEF Account")],
         'description': _("Visually build nationally scalable mobile applications from anywhere in the world."),

--- a/templates/orgs/org_edit.haml
+++ b/templates/orgs/org_edit.haml
@@ -18,7 +18,7 @@
 -block post-form
 
 -block summary
-  -if object.is_multi_org_level
+  -if object.is_multi_org_tier
     %p.pull-right
       %a.sub-orgs.btn.btn-secondary{url:'{% url "orgs.org_sub_orgs" %}'}
         Manage Organizations
@@ -29,7 +29,7 @@
   -blocktrans with timezone=object.timezone
     which is in the <span class='attn'>{{timezone}}</span> timezone.
 
-  -if object.is_multi_org_level and sub_orgs
+  -if object.is_multi_org_tier and sub_orgs
     %br
     {% blocktrans count sub_orgs|length as org_count%}
       You have <span class='attn'>{{org_count}}</span> child organization.


### PR DESCRIPTION
Make multi user or multi org tiers brand-optional. Also makes rapid not require brands in the default brand.