### PR TITLE
Improved API v2 serializer fields

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -1,0 +1,89 @@
+from __future__ import unicode_literals
+
+import six
+
+from rest_framework import serializers
+
+from temba.campaigns.models import Campaign
+from temba.channels.models import Channel
+from temba.contacts.models import Contact, ContactGroup, URN
+from temba.flows.models import Flow
+
+# maximum number of items in a posted list
+MAX_LIST_SIZE = 100
+
+
+class LimitedWriteListField(serializers.ListField):
+    """
+    A list field which can be only be written to with a limited number of items
+    """
+    def to_internal_value(self, data):
+        if hasattr(data, '__len__') and len(data) >= MAX_LIST_SIZE:
+            raise serializers.ValidationError("Exceeds maximum list size of %d" % MAX_LIST_SIZE)
+
+        return super(LimitedWriteListField, self).to_internal_value(data)
+
+
+class URNField(serializers.CharField):
+    max_length = 255
+
+    def to_representation(self, obj):
+        if self.context['org'].is_anon:
+            return None
+        else:
+            return six.text_type(obj)
+
+    def to_internal_value(self, data):
+        try:
+            country_code = self.context['org'].get_country_code()
+            normalized = URN.normalize(data, country_code=country_code)
+            if not URN.validate(normalized):
+                raise ValueError()
+        except ValueError:
+            raise serializers.ValidationError("Invalid URN: %s" % data)
+
+        return normalized
+
+
+class URNListField(LimitedWriteListField):
+    child = URNField()
+
+
+class TembaModelField(serializers.UUIDField):
+    model = None
+    model_manager = 'objects'
+
+    def to_representation(self, obj):
+        return {'uuid': obj.uuid, 'name': obj.name}
+
+    def to_internal_value(self, data):
+        uuid = super(TembaModelField, self).to_internal_value(data)
+
+        manager = getattr(self.model, self.model_manager)
+        obj = manager.filter(org=self.context['org'], uuid=uuid, is_active=True).first()
+
+        if not obj:
+            raise serializers.ValidationError("No such object with UUID: %s" % uuid)
+
+        return obj
+
+
+class CampaignField(TembaModelField):
+    model = Campaign
+
+
+class ChannelField(TembaModelField):
+    model = Channel
+
+
+class ContactField(TembaModelField):
+    model = Contact
+
+
+class ContactGroupField(TembaModelField):
+    model = ContactGroup
+    model_manager = 'user_groups'
+
+
+class FlowField(TembaModelField):
+    model = Flow

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -13,15 +13,19 @@ from temba.flows.models import Flow
 MAX_LIST_SIZE = 100
 
 
-class LimitedWriteListField(serializers.ListField):
+def validate_list_size(value):
+    if hasattr(value, '__len__') and len(value) >= MAX_LIST_SIZE:
+        raise serializers.ValidationError("Exceeds maximum list size of %d" % MAX_LIST_SIZE)
+
+
+class LimitedListField(serializers.ListField):
     """
     A list field which can be only be written to with a limited number of items
     """
     def to_internal_value(self, data):
-        if hasattr(data, '__len__') and len(data) >= MAX_LIST_SIZE:
-            raise serializers.ValidationError("Exceeds maximum list size of %d" % MAX_LIST_SIZE)
+        validate_list_size(data)
 
-        return super(LimitedWriteListField, self).to_internal_value(data)
+        return super(LimitedListField, self).to_internal_value(data)
 
 
 class URNField(serializers.CharField):
@@ -45,7 +49,7 @@ class URNField(serializers.CharField):
         return normalized
 
 
-class URNListField(LimitedWriteListField):
+class URNListField(LimitedListField):
     child = URNField()
 
 
@@ -55,8 +59,7 @@ class TembaModelField(serializers.RelatedField):
 
     class LimitedSizeList(serializers.ManyRelatedField):
         def run_validation(self, data=serializers.empty):
-            if hasattr(data, '__len__') and len(data) > MAX_LIST_SIZE:
-                raise serializers.ValidationError("Exceeds maximum list size of %d" % MAX_LIST_SIZE)
+            validate_list_size(data)
 
             return super(TembaModelField.LimitedSizeList, self).run_validation(data)
 

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -9,13 +9,15 @@ from temba.api.models import Resthook, ResthookSubscriber, WebHookEvent
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel, ChannelEvent
 
-from temba.contacts.models import Contact, ContactField, ContactGroup, URN
+from temba.contacts.models import Contact, ContactField, ContactGroup
 from temba.flows.models import Flow, FlowRun, FlowStep, FlowStart
 from temba.locations.models import AdminBoundary
 from temba.msgs.models import Broadcast, Msg, Label, STATUS_CONFIG, INCOMING, OUTGOING, INBOX, FLOW, IVR, PENDING
 from temba.msgs.models import QUEUED
 from temba.utils import datetime_to_json_date
 from temba.values.models import Value
+
+from . import fields
 
 
 def format_datetime(value):
@@ -54,32 +56,6 @@ class WriteSerializer(serializers.Serializer):
             })
 
         return super(WriteSerializer, self).run_validation(data)
-
-
-class UUIDListField(serializers.ListField):
-    child = serializers.UUIDField()
-
-
-class URNField(serializers.CharField):
-    def to_representation(self, obj):
-        if self.context['org'].is_anon:
-            return None
-        else:
-            return six.text_type(obj)
-
-    def to_internal_value(self, data):
-        try:
-            normalized = URN.normalize(data)
-            if not URN.validate(normalized):
-                raise ValueError()
-        except ValueError:
-            raise serializers.ValidationError("Invalid URN: %s" % data)
-
-        return normalized
-
-
-class URNListField(serializers.ListField):
-    child = URNField()
 
 
 # ============================================================
@@ -134,17 +110,11 @@ class ChannelEventReadSerializer(ReadSerializer):
     TYPES = ReadSerializer.extract_constants(ChannelEvent.TYPE_CONFIG)
 
     type = serializers.SerializerMethodField()
-    contact = serializers.SerializerMethodField()
-    channel = serializers.SerializerMethodField()
+    contact = fields.ContactField()
+    channel = fields.ChannelField()
 
     def get_type(self, obj):
         return self.TYPES.get(obj.event_type)
-
-    def get_contact(self, obj):
-        return {'uuid': obj.contact.uuid, 'name': obj.contact.name}
-
-    def get_channel(self, obj):
-        return {'uuid': obj.channel.uuid, 'name': obj.channel.name}
 
     class Meta:
         model = ChannelEvent
@@ -152,10 +122,7 @@ class ChannelEventReadSerializer(ReadSerializer):
 
 
 class CampaignReadSerializer(ReadSerializer):
-    group = serializers.SerializerMethodField()
-
-    def get_group(self, obj):
-        return {'uuid': obj.group.uuid, 'name': obj.group.name}
+    group = fields.ContactGroupField()
 
     class Meta:
         model = Campaign
@@ -165,13 +132,10 @@ class CampaignReadSerializer(ReadSerializer):
 class CampaignEventReadSerializer(ReadSerializer):
     UNITS = ReadSerializer.extract_constants(CampaignEvent.UNIT_CONFIG)
 
-    campaign = serializers.SerializerMethodField()
+    campaign = fields.CampaignField()
     flow = serializers.SerializerMethodField()
     relative_to = serializers.SerializerMethodField()
     unit = serializers.SerializerMethodField()
-
-    def get_campaign(self, obj):
-        return {'uuid': obj.campaign.uuid, 'name': obj.campaign.name}
 
     def get_flow(self, obj):
         if obj.event_type == CampaignEvent.TYPE_FLOW:
@@ -266,11 +230,11 @@ class ContactReadSerializer(ReadSerializer):
 
 class ContactWriteSerializer(WriteSerializer):
     uuid = serializers.UUIDField(required=False)
-    urn = URNField(required=False)
+    urn = fields.URNField(required=False)
     name = serializers.CharField(required=False, max_length=64, allow_null=True)
     language = serializers.CharField(required=False, min_length=3, max_length=3, allow_null=True)
-    urns = URNListField(required=False)
-    groups = UUIDListField(required=False)
+    urns = fields.URNListField(required=False)
+    groups = fields.LimitedWriteListField(child=fields.ContactGroupField(), required=False)
     fields = serializers.DictField(required=False)
 
     def __init__(self, *args, **kwargs):
@@ -289,16 +253,11 @@ class ContactWriteSerializer(WriteSerializer):
         return value
 
     def validate_groups(self, value):
-        groups = []
-        for uuid in value:
-            group = ContactGroup.user_groups.filter(org=self.context['org'], uuid=uuid).first()
-            if not group:
-                raise serializers.ValidationError("No such group with UUID: %s" % uuid)
+        for group in value:
             if group.is_dynamic:
-                raise serializers.ValidationError("Can't add contact to dynamic group with UUID: %s" % uuid)
-            groups.append(group)
+                raise serializers.ValidationError("Can't add contact to dynamic group with UUID: %s" % group.uuid)
 
-        return groups
+        return value
 
     def validate_fields(self, value):
         valid_keys = {f.key for f in self.context['contact_fields']}
@@ -434,16 +393,10 @@ class FlowRunReadSerializer(ReadSerializer):
         FlowRun.EXIT_TYPE_EXPIRED: 'expired'
     }
 
-    flow = serializers.SerializerMethodField()
-    contact = serializers.SerializerMethodField()
+    flow = fields.FlowField()
+    contact = fields.ContactField()
     steps = serializers.SerializerMethodField()
     exit_type = serializers.SerializerMethodField()
-
-    def get_flow(self, obj):
-        return {'uuid': obj.flow.uuid, 'name': obj.flow.name}
-
-    def get_contact(self, obj):
-        return {'uuid': obj.contact.uuid, 'name': obj.contact.name}
 
     def get_steps(self, obj):
         # avoiding fetching org again
@@ -493,7 +446,7 @@ class FlowStartReadSerializer(ReadSerializer):
         FlowStart.STATUS_FAILED: 'failed'
     }
 
-    flow = serializers.SerializerMethodField()
+    flow = fields.FlowField()
     status = serializers.SerializerMethodField()
     groups = serializers.SerializerMethodField()
     contacts = serializers.SerializerMethodField()
@@ -511,9 +464,6 @@ class FlowStartReadSerializer(ReadSerializer):
             groups.append(dict(uuid=group.uuid, name=group.name))
         return groups
 
-    def get_flow(self, obj):
-        return dict(uuid=obj.flow.uuid, name=obj.flow.name)
-
     def get_status(self, obj):
         return FlowStartReadSerializer.STATUSES.get(obj.status)
 
@@ -529,37 +479,11 @@ class FlowStartReadSerializer(ReadSerializer):
 
 
 class FlowStartWriteSerializer(WriteSerializer):
-    flow = serializers.UUIDField()
-    contacts = UUIDListField(required=False)
-    groups = UUIDListField(required=False)
-    urns = URNListField(required=False)
+    flow = fields.FlowField()
+    contacts = fields.LimitedWriteListField(child=fields.ContactField(), required=False)
+    groups = fields.LimitedWriteListField(child=fields.ContactGroupField(), required=False)
+    urns = fields.URNListField(required=False)
     extra = serializers.JSONField(required=False)
-
-    def validate_flow(self, value):
-        flow = Flow.objects.filter(org=self.context['org'], is_active=True, uuid=value).first()
-        if not flow:
-            raise ValidationError("No flow found with UUID: %s" % value)
-        return flow
-
-    def validate_contacts(self, value):
-        contacts = []
-        for contact_uuid in value:
-            contact = Contact.objects.filter(org=self.context['org'], is_active=True, uuid=contact_uuid).first()
-            if not contact:
-                raise ValidationError("No contact found with UUID: %s" % value)
-            contacts.append(contact)
-
-        return contacts
-
-    def validate_groups(self, value):
-        groups = []
-        for group_uuid in value:
-            group = ContactGroup.user_groups.filter(org=self.context['org'], is_active=True, uuid=group_uuid).first()
-            if not group:
-                raise ValidationError("No group found with UUID: %s" % value)
-            groups.append(group)
-
-        return groups
 
     def validate_urns(self, value):
         urn_contacts = []
@@ -623,9 +547,9 @@ class MsgReadSerializer(ReadSerializer):
     }
 
     broadcast = serializers.SerializerMethodField()
-    contact = serializers.SerializerMethodField()
-    urn = URNField(source='contact_urn')
-    channel = serializers.SerializerMethodField()
+    contact = fields.ContactField()
+    urn = fields.URNField(source='contact_urn')
+    channel = fields.ChannelField()
     direction = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
@@ -635,12 +559,6 @@ class MsgReadSerializer(ReadSerializer):
 
     def get_broadcast(self, obj):
         return obj.broadcast_id
-
-    def get_contact(self, obj):
-        return {'uuid': obj.contact.uuid, 'name': obj.contact.name}
-
-    def get_channel(self, obj):
-        return {'uuid': obj.channel.uuid, 'name': obj.channel.name} if obj.channel_id else None
 
     def get_direction(self, obj):
         return self.DIRECTIONS.get(obj.direction)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -399,7 +399,7 @@ class BoundariesEndpoint(ListAPIMixin, BaseAPIView):
         }
 
 
-class BroadcastEndpoint(CreateAPIMixin, ListAPIMixin, BaseAPIView):
+class BroadcastEndpoint(ListAPIMixin, BaseAPIView):
     """
     This endpoint allows you to list message broadcasts on your account using the ```GET``` method.
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -43,7 +43,7 @@ def api(request, format=None):
     The following endpoints are provided:
 
      * [/api/v2/boundaries](/api/v2/boundaries) - to list administrative boundaries
-     * [/api/v2/broadcasts](/api/v2/broadcasts) - to list and send message broadcasts
+     * [/api/v2/broadcasts](/api/v2/broadcasts) - to list message broadcasts
      * [/api/v2/campaigns](/api/v2/campaigns) - to list campaigns
      * [/api/v2/campaign_events](/api/v2/campaign_events) - to list campaign events
      * [/api/v2/channels](/api/v2/channels) - to list channels

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -43,7 +43,7 @@ def api(request, format=None):
     The following endpoints are provided:
 
      * [/api/v2/boundaries](/api/v2/boundaries) - to list administrative boundaries
-     * [/api/v2/broadcasts](/api/v2/broadcasts) - to list message broadcasts
+     * [/api/v2/broadcasts](/api/v2/broadcasts) - to list and send message broadcasts
      * [/api/v2/campaigns](/api/v2/campaigns) - to list campaigns
      * [/api/v2/campaign_events](/api/v2/campaign_events) - to list campaign events
      * [/api/v2/channels](/api/v2/channels) - to list channels
@@ -399,7 +399,7 @@ class BoundariesEndpoint(ListAPIMixin, BaseAPIView):
         }
 
 
-class BroadcastEndpoint(ListAPIMixin, BaseAPIView):
+class BroadcastEndpoint(CreateAPIMixin, ListAPIMixin, BaseAPIView):
     """
     This endpoint allows you to list message broadcasts on your account using the ```GET``` method.
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1089,7 +1089,7 @@ class ChannelTest(TembaTest):
         us_channel = self.org.get_send_channel(TEL_SCHEME, ContactURN.create(self.org, None, 'tel:+593997290044'))
         self.assertEqual(us_channel, channel)
 
-        self.org = Org.objects.get(pk=self.org.pk)
+        self.org = Org.objects.get(id=self.org.id)
         self.assertIsNone(self.org.get_country_code())
 
         # yet another registration in rwanda

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1088,6 +1088,8 @@ class ChannelTest(TembaTest):
         # a different country altogether should just give us the default
         us_channel = self.org.get_send_channel(TEL_SCHEME, ContactURN.create(self.org, None, 'tel:+593997290044'))
         self.assertEqual(us_channel, channel)
+
+        self.org = Org.objects.get(pk=self.org.pk)
         self.assertIsNone(self.org.get_country_code())
 
         # yet another registration in rwanda

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -493,7 +493,7 @@ class ContactTest(TembaTest):
         self.manager1 = self.create_user("mike")
 
         self.joe = self.create_contact(name="Joe Blow", number="123", twitter="blow80")
-        self.frank = self.create_contact(name="Frank Smith", number="12345")
+        self.frank = self.create_contact(name="Frank Smith", number="123222")
         self.billy = self.create_contact(name="Billy Nophone")
         self.voldemort = self.create_contact(number="+250788383383")
 
@@ -1082,7 +1082,7 @@ class ContactTest(TembaTest):
 
             # 3 sendable URNs with names as extra
             dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % voldemort_tel.pk, text="250788383383", extra=None, scheme='tel')
         ])
 
@@ -1108,13 +1108,13 @@ class ContactTest(TembaTest):
             dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
             dict(id='c-%s' % self.voldemort.uuid, text="250788383383"),
             dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % voldemort_tel.pk, text="250788383383", extra=None, scheme='tel')
         ])
 
         # search for Frank by phone
-        self.assertEqual(omnibox_request("search=12345"), [
-            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel')
+        self.assertEqual(omnibox_request("search=123222"), [
+            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel')
         ])
 
         # search for Joe by twitter - won't return anything because there is no twitter channel
@@ -1156,7 +1156,7 @@ class ContactTest(TembaTest):
         # lookup by URN ids
         urn_query = "u=%d,%d" % (self.joe.get_urn(TWITTER_SCHEME).pk, self.frank.get_urn(TEL_SCHEME).pk)
         self.assertEqual(omnibox_request(urn_query), [
-            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
         ])
 
@@ -1195,7 +1195,7 @@ class ContactTest(TembaTest):
             ])
 
             # but not by frank number
-            self.assertEqual(omnibox_request("search=12345"), [])
+            self.assertEqual(omnibox_request("search=123222"), [])
 
     def test_history(self):
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -493,7 +493,7 @@ class ContactTest(TembaTest):
         self.manager1 = self.create_user("mike")
 
         self.joe = self.create_contact(name="Joe Blow", number="123", twitter="blow80")
-        self.frank = self.create_contact(name="Frank Smith", number="1234")
+        self.frank = self.create_contact(name="Frank Smith", number="12345")
         self.billy = self.create_contact(name="Billy Nophone")
         self.voldemort = self.create_contact(number="+250788383383")
 
@@ -1082,7 +1082,7 @@ class ContactTest(TembaTest):
 
             # 3 sendable URNs with names as extra
             dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="1234", extra="Frank Smith", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % voldemort_tel.pk, text="250788383383", extra=None, scheme='tel')
         ])
 
@@ -1108,13 +1108,13 @@ class ContactTest(TembaTest):
             dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
             dict(id='c-%s' % self.voldemort.uuid, text="250788383383"),
             dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="1234", extra="Frank Smith", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % voldemort_tel.pk, text="250788383383", extra=None, scheme='tel')
         ])
 
         # search for Frank by phone
-        self.assertEqual(omnibox_request("search=1234"), [
-            dict(id='u-%d' % frank_tel.pk, text="1234", extra="Frank Smith", scheme='tel')
+        self.assertEqual(omnibox_request("search=12345"), [
+            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel')
         ])
 
         # search for Joe by twitter - won't return anything because there is no twitter channel
@@ -1156,7 +1156,7 @@ class ContactTest(TembaTest):
         # lookup by URN ids
         urn_query = "u=%d,%d" % (self.joe.get_urn(TWITTER_SCHEME).pk, self.frank.get_urn(TEL_SCHEME).pk)
         self.assertEqual(omnibox_request(urn_query), [
-            dict(id='u-%d' % frank_tel.pk, text="1234", extra="Frank Smith", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="12345", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
         ])
 
@@ -1195,7 +1195,7 @@ class ContactTest(TembaTest):
             ])
 
             # but not by frank number
-            self.assertEqual(omnibox_request("search=1234"), [])
+            self.assertEqual(omnibox_request("search=12345"), [])
 
     def test_history(self):
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -844,7 +844,7 @@ class Org(SmartModel):
                 country = pycountry.countries.get(name=self.country.name)
                 if country:
                     return country.alpha2
-            except KeyError:
+            except KeyError:  # pragma: no cover
                 # pycountry blows up if we pass it a country name it doesn't know
                 pass
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -835,6 +835,9 @@ class Org(SmartModel):
         """
         Gets the 2-digit country code, e.g. RW, US
         """
+        return get_cacheable_attr(self, '_country_code', lambda: self.calculate_country_code())
+
+    def calculate_country_code(self):
         # first try the actual country field
         if self.country:
             try:

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -22,6 +22,7 @@ from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel
 from temba.contacts.models import Contact, ContactGroup, TEL_SCHEME, TWITTER_SCHEME
 from temba.flows.models import Flow, ActionSet
+from temba.locations.models import AdminBoundary
 from temba.middleware import BrandingMiddleware
 from temba.msgs.models import Label, Msg, INCOMING
 from temba.nexmo import NexmoValidationError
@@ -167,7 +168,6 @@ class OrgTest(TembaTest):
         self.assertEquals(self.org.get_recommended_channel(), 'android')
 
     def test_country(self):
-        from temba.locations.models import AdminBoundary
         country_url = reverse('orgs.org_country')
 
         # can't see this page if not logged in
@@ -203,6 +203,7 @@ class OrgTest(TembaTest):
 
         # remove all our channels so we no longer have a backdown
         org.channels.all().delete()
+        org = Org.objects.get(pk=self.org.pk)
 
         # now really don't have a clue of our country code
         self.assertIsNone(org.get_country_code())


### PR DESCRIPTION
Introduces a bunch of new custom field classes which simplify the v2 serializers, and provide consistent validation and error feedback

All deserialized lists are now limited to 100 items