### PR TITLE
gate import on tier instead of purchased credits

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1024,11 +1024,14 @@ class Org(SmartModel):
     def is_free_plan(self):
         return self.plan == FREE_PLAN or self.plan == TRIAL_PLAN
 
+    def is_import_flows_tier(self):
+        return self.get_purchased_credits() >= self.get_branding().get('tiers', {}).get('import_flows', 0)
+
     def is_multi_user_tier(self):
-        return self.get_purchased_credits() >= self.get_branding().get('tiers').get('multi_user')
+        return self.get_purchased_credits() >= self.get_branding().get('tiers', {}).get('multi_user', 0)
 
     def is_multi_org_tier(self):
-        return not self.parent and self.get_purchased_credits() >= self.get_branding().get('tiers').get('multi_org')
+        return not self.parent and self.get_purchased_credits() >= self.get_branding().get('tiers', {}).get('multi_org', 0)
 
     def get_user_org_group(self, user):
         if user in self.get_org_admins():

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -442,8 +442,8 @@ class OrgCRUDL(SmartCRUDL):
             def clean_import_file(self):
                 from temba.orgs.models import EARLIEST_IMPORT_VERSION
 
-                # make sure they have purchased credits
-                if not self.org.get_purchased_credits():
+                # make sure they are in the proper tier
+                if not self.org.is_import_flows_tier():
                     raise ValidationError("Sorry, import is a premium feature")
 
                 # check that it isn't too old

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -277,7 +277,7 @@ BRANDING = {
         'splash': '/brands/rapidpro/splash.jpg',
         'logo': '/brands/rapidpro/logo.png',
         'allow_signups': True,
-        'tiers': dict(multi_user=0, multi_org=0),
+        'tiers': dict(import_flows=0, multi_user=0, multi_org=0),
         'bundles': [],
         'welcome_packs': [dict(size=5000, name="Demo Account"), dict(size=100000, name="UNICEF Account")],
         'description': _("Visually build nationally scalable mobile applications from anywhere in the world."),

--- a/templates/orgs/org_import.haml
+++ b/templates/orgs/org_import.haml
@@ -9,10 +9,8 @@
 
 - block pjax
 
-  -if not user_org.get_purchased_credits
+  -if not user_org.is_import_flows_tier
     -include "includes/import_disabled.html"
-
-
   -else
     #pjax
       .row{style:"height:250px;"}


### PR DESCRIPTION
Gate import on a import_flows tier instead of looking at whether they have purchased credits. Make defaults 0 if tiers are not defined.