### PR TITLE
Require phone numbers to always have a country code in UI and API v2

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -838,7 +838,7 @@ class APITest(TembaTest):
         response = self.postJSON(url, {
             'name': "Jean",
             'language': "fre",
-            'urns': ["tel:1-2345-56789", "twitter:JEAN"],
+            'urns': ["tel:+250783333333", "twitter:JEAN"],
             'groups': [group.uuid],
             'fields': {'nickname': "Jado"}
         })
@@ -846,7 +846,7 @@ class APITest(TembaTest):
 
         # URNs will be normalized
         jean = Contact.objects.filter(name="Jean", language='fre').order_by('-pk').first()
-        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {"tel:1234556789", "twitter:jean"})
+        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {"tel:+250783333333", "twitter:jean"})
         self.assertEqual(set(jean.user_groups.all()), {group, dyn_group})
         self.assertEqual(jean.get_field('nickname').string_value, "Jado")
 
@@ -859,7 +859,7 @@ class APITest(TembaTest):
             'fields': {'hmmm': "X"}
         })
         self.assertResponseError(response, 'language', "Ensure this field has no more than 3 characters.")
-        self.assertResponseError(response, 'urns', "Invalid URN: 1234556789")
+        self.assertResponseError(response, 'urns', "Invalid URN: 1234556789. Ensure phone numbers contain country codes.")
         self.assertResponseError(response, 'groups', "No such object with UUID: 59686b4e-14bc-4160-9376-b649b218c806")
         self.assertResponseError(response, 'fields', "Invalid contact field key: hmmm")
 
@@ -871,7 +871,7 @@ class APITest(TembaTest):
         jean = Contact.objects.get(pk=jean.pk)
         self.assertEqual(jean.name, "Jean")
         self.assertEqual(jean.language, "fre")
-        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {"tel:1234556789", "twitter:jean"})
+        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {"tel:+250783333333", "twitter:jean"})
         self.assertEqual(set(jean.user_groups.all()), {group, dyn_group})
         self.assertEqual(jean.get_field('nickname').string_value, "Jado")
 
@@ -880,7 +880,7 @@ class APITest(TembaTest):
             'uuid': jean.uuid,
             'name': "Jean II",
             'language': "eng",
-            'urns': ["tel:2234556700"],
+            'urns': ["tel:+250784444444"],
             'groups': [],
             'fields': {'nickname': "John"}
         })
@@ -889,19 +889,19 @@ class APITest(TembaTest):
         jean = Contact.objects.get(pk=jean.pk)
         self.assertEqual(jean.name, "Jean II")
         self.assertEqual(jean.language, "eng")
-        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {'tel:2234556700'})
+        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {'tel:+250784444444'})
         self.assertEqual(set(jean.user_groups.all()), set())
         self.assertEqual(jean.get_field('nickname').string_value, "John")
 
         # update by URN whilst changing URNs
-        response = self.postJSON(url, {'urn': "tel:2234556700", 'urns': ["tel:3333333333"]})
+        response = self.postJSON(url, {'urn': "tel:+250784444444", 'urns': ["tel:+250785555555"]})
         self.assertEqual(response.status_code, 201)
 
         # only URN should have changed
         jean = Contact.objects.get(pk=jean.pk)
         self.assertEqual(jean.name, "Jean II")
         self.assertEqual(jean.language, "eng")
-        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {'tel:3333333333'})
+        self.assertEqual(set(jean.urns.values_list('urn', flat=True)), {'tel:+250785555555'})
         self.assertEqual(set(jean.user_groups.all()), set())
         self.assertEqual(jean.get_field('nickname').string_value, "John")
 
@@ -955,20 +955,20 @@ class APITest(TembaTest):
 
         with AnonymousOrg(self.org):
             # can't update via URN
-            response = self.postJSON(url, {'urn': 'tel:3333333333'})
+            response = self.postJSON(url, {'urn': 'tel:+250785555555'})
             self.assertResponseError(response, 'urn', "Referencing by URN not allowed for anonymous organizations")
 
             # can't update contact URNs
-            response = self.postJSON(url, {'uuid': jean.uuid, 'urns': ["tel:2234556700"]})
+            response = self.postJSON(url, {'uuid': jean.uuid, 'urns': ["tel:+250786666666"]})
             self.assertResponseError(response, 'non_field_errors',
                                      "Updating contact URNs not allowed for anonymous organizations")
 
             # can create with URNs
-            response = self.postJSON(url, {'name': "Xavier", 'urns': ["tel:2234556701"]})
+            response = self.postJSON(url, {'name': "Xavier", 'urns': ["tel:+250787777777"]})
             self.assertEqual(response.status_code, 201)
 
             xavier = Contact.objects.get(name="Xavier")
-            self.assertEqual(set(xavier.urns.values_list('urn', flat=True)), {"tel:2234556701"})
+            self.assertEqual(set(xavier.urns.values_list('urn', flat=True)), {"tel:+250787777777"})
 
         # try an empty delete request
         response = self.deleteJSON(url, {})

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -173,6 +173,13 @@ class APITest(TembaTest):
 
         self.assertEqual(field.to_internal_value(flow.uuid), flow)
 
+        field = fields.URNField(source='test')
+        field.context = {'org': self.org}
+
+        self.assertEqual(field.to_internal_value('tel:+1-800-123-4567'), 'tel:+18001234567')
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, '12345')  # un-parseable
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, 'tel:800-123-4567')  # no country code
+
     def test_authentication(self):
         def api_request(endpoint, token):
             response = self.client.get(endpoint + '.json', content_type="application/json",

--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -425,7 +425,9 @@ class ContactWriteSerializer(WriteSerializer):
             for urn in value:
                 try:
                     normalized = URN.normalize(urn)
-                    if not URN.validate(normalized):
+                    scheme, path = URN.to_parts(normalized)
+                    # for backwards compatibility we don't validate phone numbers here
+                    if scheme != TEL_SCHEME and not URN.validate(normalized):
                         raise ValueError()
                 except ValueError:
                     raise serializers.ValidationError("Invalid URN: '%s'" % urn)

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -40,12 +40,11 @@ class URNField(serializers.CharField):
 
     def to_internal_value(self, data):
         try:
-            country_code = self.context['org'].get_country_code()
-            normalized = URN.normalize(data, country_code=country_code)
+            normalized = URN.normalize(data)
             if not URN.validate(normalized):
                 raise ValueError()
         except ValueError:
-            raise serializers.ValidationError("Invalid URN: %s" % data)
+            raise serializers.ValidationError("Invalid URN: %s. Ensure phone numbers contain country codes." % data)
 
         return normalized
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -117,14 +117,11 @@ class URN(object):
             return False
 
         if scheme == TEL_SCHEME:
-            if country_code:
-                try:
-                    normalized = phonenumbers.parse(path, country_code)
-                    return phonenumbers.is_possible_number(normalized)
-                except Exception:
-                    return False
-
-            return True  # if we don't have a channel with country, we can't for now validate tel numbers
+            try:
+                parsed = phonenumbers.parse(path, country_code)
+                return phonenumbers.is_possible_number(parsed)
+            except Exception:
+                return False
 
         # validate twitter URNs look like handles
         elif scheme == TWITTER_SCHEME:

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1901,7 +1901,7 @@ class ContactGroup(TembaModel):
         """
         Manually adds or removes contacts from a static group. Returns contact ids of contacts whose membership changed.
         """
-        if self.group_type != self.TYPE_USER_DEFINED or self.is_dynamic:
+        if self.group_type != self.TYPE_USER_DEFINED or self.is_dynamic:  # pragma: no cover
             raise ValueError("Can't add or remove contacts from system or dynamic groups")
 
         return self._update_contacts(user, contacts, add)
@@ -1910,7 +1910,7 @@ class ContactGroup(TembaModel):
         """
         Re-evaluates whether contacts belong in a dynamic group. Returns contacts whose membership changed.
         """
-        if self.group_type != self.TYPE_USER_DEFINED or not self.is_dynamic:
+        if self.group_type != self.TYPE_USER_DEFINED or not self.is_dynamic:  # pragma: no cover
             raise ValueError("Can't re-evaluate contacts against system or static groups")
 
         user = get_anonymous_user()
@@ -1926,7 +1926,7 @@ class ContactGroup(TembaModel):
         """
         Forces removal of contacts from this group regardless of whether it is static or dynamic
         """
-        if self.group_type != self.TYPE_USER_DEFINED:
+        if self.group_type != self.TYPE_USER_DEFINED:  # pragma: no cover
             raise ValueError("Can't remove contacts from system groups")
 
         return self._update_contacts(user, contacts, add=False)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -493,13 +493,13 @@ class ContactTest(TembaTest):
         self.user1 = self.create_user("nash")
         self.manager1 = self.create_user("mike")
 
-        self.joe = self.create_contact(name="Joe Blow", number="123", twitter="blow80")
-        self.frank = self.create_contact(name="Frank Smith", number="123222")
+        self.joe = self.create_contact(name="Joe Blow", number="+250781111111", twitter="blow80")
+        self.frank = self.create_contact(name="Frank Smith", number="+250782222222")
         self.billy = self.create_contact(name="Billy Nophone")
-        self.voldemort = self.create_contact(number="+250788383383")
+        self.voldemort = self.create_contact(number="+250768383383")
 
         # create an orphaned URN
-        ContactURN.objects.create(org=self.org, scheme='tel', path='8888', urn='tel:8888', priority=50)
+        ContactURN.objects.create(org=self.org, scheme='tel', path='+250788888888', urn='tel:+250788888888', priority=50)
 
         # create an deleted contact
         self.jim = self.create_contact(name="Jim")
@@ -563,7 +563,7 @@ class ContactTest(TembaTest):
         # create a URN-less contact and try to update them with a taken URN
         snoop = Contact.get_or_create(self.org, self.user, name='Snoop')
         with self.assertRaises(ValueError):
-            Contact.get_or_create(self.org, self.user, uuid=snoop.uuid, urns=['tel:123'])
+            Contact.get_or_create(self.org, self.user, uuid=snoop.uuid, urns=['tel:+250781111111'])
 
         # now give snoop his own urn
         Contact.get_or_create(self.org, self.user, uuid=snoop.uuid, urns=['tel:456'])
@@ -609,15 +609,15 @@ class ContactTest(TembaTest):
         self.assertEquals(1, len(response.context['form'].errors))
 
         # now repost with a unique phone number
-        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="123-456"))
+        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250 783-835665"))
         self.assertNoFormErrors(response)
 
         # repost with the phone number of an orphaned URN
-        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="8888"))
+        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250788888888"))
         self.assertNoFormErrors(response)
 
         # check that the orphaned URN has been associated with the contact
-        self.assertEqual('Ben Haggerty', Contact.from_urn(self.org, 'tel:8888').name)
+        self.assertEqual('Ben Haggerty', Contact.from_urn(self.org, 'tel:+250788888888').name)
 
         # check we display error for invalid input
         response = self.client.post(reverse('contacts.contact_create'),
@@ -841,24 +841,24 @@ class ContactTest(TembaTest):
         self.assertEqual("Joe Blow", self.joe.get_display(org=self.org, formatted=False))
         self.assertEqual("Joe Blow", self.joe.get_display(short=True))
         self.assertEqual("Joe Blow", self.joe.get_display())
-        self.assertEqual("+250788383383", self.voldemort.get_display(org=self.org, formatted=False))
-        self.assertEqual("0788 383 383", self.voldemort.get_display())
+        self.assertEqual("+250768383383", self.voldemort.get_display(org=self.org, formatted=False))
+        self.assertEqual("0768 383 383", self.voldemort.get_display())
         self.assertEqual("Wolfeschlegelsteinhausenbergerdorff", mr_long_name.get_display())
         self.assertEqual("Wolfeschlegelstei...", mr_long_name.get_display(short=True))
         self.assertEqual("Billy Nophone", self.billy.get_display())
 
-        self.assertEqual("123", self.joe.get_urn_display(scheme=TEL_SCHEME))
+        self.assertEqual("0781 111 111", self.joe.get_urn_display(scheme=TEL_SCHEME))
         self.assertEqual("blow80", self.joe.get_urn_display(org=self.org, formatted=False))
         self.assertEqual("blow80", self.joe.get_urn_display())
-        self.assertEqual("+250788383383", self.voldemort.get_urn_display(org=self.org, formatted=False))
-        self.assertEqual("+250788383383", self.voldemort.get_urn_display(org=self.org, formatted=False, international=True))
-        self.assertEqual("+250 788 383 383", self.voldemort.get_urn_display(org=self.org, international=True))
-        self.assertEqual("0788 383 383", self.voldemort.get_urn_display())
+        self.assertEqual("+250768383383", self.voldemort.get_urn_display(org=self.org, formatted=False))
+        self.assertEqual("+250768383383", self.voldemort.get_urn_display(org=self.org, formatted=False, international=True))
+        self.assertEqual("+250 768 383 383", self.voldemort.get_urn_display(org=self.org, international=True))
+        self.assertEqual("0768 383 383", self.voldemort.get_urn_display())
         self.assertEqual("8877", mr_long_name.get_urn_display())
         self.assertEqual("", self.billy.get_urn_display())
 
         self.assertEqual("Joe Blow", self.joe.__unicode__())
-        self.assertEqual("0788 383 383", self.voldemort.__unicode__())
+        self.assertEqual("0768 383 383", self.voldemort.__unicode__())
         self.assertEqual("Wolfeschlegelsteinhausenbergerdorff", mr_long_name.__unicode__())
         self.assertEqual("Billy Nophone", self.billy.__unicode__())
 
@@ -1069,9 +1069,8 @@ class ContactTest(TembaTest):
         # Postgres will defer to strcoll for ordering which even for en_US.UTF-8 will return different results on OSX
         # and Ubuntu. To keep ordering consistent for this test, we don't let URNs start with +
         # (see http://postgresql.nabble.com/a-strange-order-by-behavior-td4513038.html)
-        voldemort_tel.path = "250788383383"
-        voldemort_tel.urn = "tel:250788383383"
-        voldemort_tel.save()
+        from django.db.models.functions import Substr, Concat, Value
+        ContactURN.objects.filter(path__startswith="+").update(path=Substr('path', 2), urn=Concat(Value('tel:'), Substr('path', 2)))
 
         self.admin.set_org(self.org)
         self.login(self.admin)
@@ -1090,12 +1089,12 @@ class ContactTest(TembaTest):
             dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
             dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
             dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
-            dict(id='c-%s' % self.voldemort.uuid, text="250788383383"),
+            dict(id='c-%s' % self.voldemort.uuid, text="250768383383"),
 
             # 3 sendable URNs with names as extra
-            dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel'),
-            dict(id='u-%d' % voldemort_tel.pk, text="250788383383", extra=None, scheme='tel')
+            dict(id='u-%d' % voldemort_tel.pk, text="250768383383", extra=None, scheme='tel'),
+            dict(id='u-%d' % joe_tel.pk, text="250781111111", extra="Joe Blow", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel'),
         ])
 
         # apply type filters...
@@ -1118,15 +1117,15 @@ class ContactTest(TembaTest):
             dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
             dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
             dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
-            dict(id='c-%s' % self.voldemort.uuid, text="250788383383"),
-            dict(id='u-%d' % joe_tel.pk, text="123", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel'),
-            dict(id='u-%d' % voldemort_tel.pk, text="250788383383", extra=None, scheme='tel')
+            dict(id='c-%s' % self.voldemort.uuid, text="250768383383"),
+            dict(id='u-%d' % voldemort_tel.pk, text="250768383383", extra=None, scheme='tel'),
+            dict(id='u-%d' % joe_tel.pk, text="250781111111", extra="Joe Blow", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel')
         ])
 
         # search for Frank by phone
-        self.assertEqual(omnibox_request("search=123222"), [
-            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel')
+        self.assertEqual(omnibox_request("search=222"), [
+            dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel')
         ])
 
         # search for Joe by twitter - won't return anything because there is no twitter channel
@@ -1168,7 +1167,7 @@ class ContactTest(TembaTest):
         # lookup by URN ids
         urn_query = "u=%d,%d" % (self.joe.get_urn(TWITTER_SCHEME).pk, self.frank.get_urn(TEL_SCHEME).pk)
         self.assertEqual(omnibox_request(urn_query), [
-            dict(id='u-%d' % frank_tel.pk, text="123222", extra="Frank Smith", scheme='tel'),
+            dict(id='u-%d' % frank_tel.pk, text="0782 222 222", extra="Frank Smith", scheme='tel'),
             dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
         ])
 
@@ -1207,7 +1206,7 @@ class ContactTest(TembaTest):
             ])
 
             # but not by frank number
-            self.assertEqual(omnibox_request("search=123222"), [])
+            self.assertEqual(omnibox_request("search=222"), [])
 
     def test_history(self):
         url = reverse('contacts.contact_history', args=[self.joe.uuid])
@@ -1823,7 +1822,7 @@ class ContactTest(TembaTest):
         response = self.client.get(reverse('contacts.contact_update', args=[self.joe.id]))
         self.assertEqual(response.context['form'].fields.keys(), ['name', 'groups', 'urn__twitter__0', 'urn__tel__1', 'loc'])
         self.assertEqual(response.context['form'].initial['name'], "Joe Blow")
-        self.assertEqual(response.context['form'].fields['urn__tel__1'].initial, "123")
+        self.assertEqual(response.context['form'].fields['urn__tel__1'].initial, "+250781111111")
 
         response = self.client.get(reverse('contacts.contact_update_fields', args=[self.joe.id]))
         self.assertEqual(response.context['form'].fields['__field__state'].initial, "Kigali City")  # parsed name
@@ -1836,7 +1835,7 @@ class ContactTest(TembaTest):
         self.assertContains(response, "Eastern Province")
 
         # update joe - change his tel URN
-        data = dict(name="Joe Blow", urn__tel__1="12345", order__urn__tel__1="0")
+        data = dict(name="Joe Blow", urn__tel__1="+250 783835665", order__urn__tel__1="0")
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), data)
 
         # update the state contact field to something invalid
@@ -1844,46 +1843,45 @@ class ContactTest(TembaTest):
 
         # check that old URN is detached, new URN is attached, and Joe still exists
         self.joe = Contact.objects.get(pk=self.joe.id)
-        self.assertEquals("12345", self.joe.get_urn_display(scheme=TEL_SCHEME))
-        self.assertEquals(self.joe.get_field_raw('state'), "newyork")  # raw user input as location wasn't matched
-        self.assertFalse(Contact.from_urn(self.org, "tel:123"))  # tel 123 is nobody now
+        self.assertEqual(self.joe.get_urn_display(scheme=TEL_SCHEME), "0783 835 665")
+        self.assertEqual(self.joe.get_field_raw('state'), "newyork")  # raw user input as location wasn't matched
+        self.assertIsNone(Contact.from_urn(self.org, "tel:+250781111111"))  # original tel is nobody now
 
         # update joe, change his number back
-        data = dict(name="Joe Blow", urn__tel__0="123", order__urn__tel__0="0", __field__location="Kigali")
+        data = dict(name="Joe Blow", urn__tel__0="+250781111111", order__urn__tel__0="0", __field__location="Kigali")
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), data)
 
         # check that old URN is re-attached
-        self.assertIsNone(ContactURN.objects.get(urn="tel:12345").contact)
-        self.assertEquals(self.joe, ContactURN.objects.get(urn="tel:123").contact)
+        self.assertIsNone(ContactURN.objects.get(urn="tel:+250783835665").contact)
+        self.assertEquals(self.joe, ContactURN.objects.get(urn="tel:+250781111111").contact)
 
         # add another URN to joe
-        ContactURN.create(self.org, self.joe, "tel:67890")
+        ContactURN.create(self.org, self.joe, "tel:+250786666666")
 
         # assert that our update form has the extra URN
         response = self.client.get(reverse('contacts.contact_update', args=[self.joe.id]))
-        self.assertEquals("123", response.context['form'].fields['urn__tel__0'].initial)
-        self.assertEquals("67890", response.context['form'].fields['urn__tel__1'].initial)
+        self.assertEqual(response.context['form'].fields['urn__tel__0'].initial, "+250781111111")
+        self.assertEqual(response.context['form'].fields['urn__tel__1'].initial, "+250786666666")
 
         # update joe, add him to "Just Joe" group
         post_data = dict(name="Joe Gashyantare", groups=[self.just_joe.id],
-                         urn__tel__0="123", urn__tel__1="67890")
+                         urn__tel__0="+250781111111", urn__tel__1="+250786666666")
         response = self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), post_data, follow=True)
         self.assertEqual(response.context['contact'].name, "Joe Gashyantare")
         self.assertEqual(set(self.joe.user_groups.all()), {self.just_joe})
-        self.assertTrue(ContactURN.objects.filter(contact=self.joe, path="123"))
-        self.assertTrue(ContactURN.objects.filter(contact=self.joe, path="67890"))
+        self.assertTrue(ContactURN.objects.filter(contact=self.joe, path="+250781111111"))
+        self.assertTrue(ContactURN.objects.filter(contact=self.joe, path="+250786666666"))
 
         # remove him from this group "Just joe", and his second number
-        post_data = dict(name="Joe Gashyantare", urn__tel__0="12345", groups=[])
+        post_data = dict(name="Joe Gashyantare", urn__tel__0="+250781111111", groups=[])
         response = self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), post_data, follow=True)
         self.assertEqual(set(self.joe.user_groups.all()), set())
-        self.assertTrue(ContactURN.objects.filter(contact=self.joe, path="12345"))
-        self.assertFalse(ContactURN.objects.filter(contact=self.joe, path="67890"))
-        self.assertFalse(ContactURN.objects.filter(contact=self.joe, path="1232"))
+        self.assertTrue(ContactURN.objects.filter(contact=self.joe, path="+250781111111"))
+        self.assertFalse(ContactURN.objects.filter(contact=self.joe, path="+250786666666"))
 
         # should no longer be in our update form either
         response = self.client.get(reverse('contacts.contact_update', args=[self.joe.id]))
-        self.assertEquals("12345", response.context['form'].fields['urn__tel__0'].initial)
+        self.assertEqual(response.context['form'].fields['urn__tel__0'].initial, "+250781111111")
         self.assertFalse('urn__tel__1' in response.context['form'].fields)
 
         # check that groups field isn't displayed when contact is blocked
@@ -1892,7 +1890,7 @@ class ContactTest(TembaTest):
         self.assertNotIn('groups', response.context['form'].fields)
 
         # and that we can still update the contact
-        post_data = dict(name="Joe Bloggs", urn__tel__0="12345")
+        post_data = dict(name="Joe Bloggs", urn__tel__0="+250781111111")
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), post_data, follow=True)
 
         self.joe = Contact.objects.get(pk=self.joe.pk)
@@ -1902,7 +1900,7 @@ class ContactTest(TembaTest):
 
         # add new urn for joe
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]),
-                         dict(name='Joey', urn__tel__0="12345", new_scheme="ext", new_path="EXT123"))
+                         dict(name='Joey', urn__tel__0="+250781111111", new_scheme="ext", new_path="EXT123"))
 
         urn = ContactURN.objects.filter(contact=self.joe, scheme='ext').first()
         self.assertIsNotNone(urn)
@@ -1910,7 +1908,7 @@ class ContactTest(TembaTest):
 
         # now try adding one that is invalid
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]),
-                         dict(name='Joey', urn__tel__0="12345", new_scheme="mailto", new_path="malformed"))
+                         dict(name='Joey', urn__tel__0="+250781111111", new_scheme="mailto", new_path="malformed"))
         self.assertIsNone(ContactURN.objects.filter(contact=self.joe, scheme='mailto').first())
 
         # update our language to something not on the org
@@ -1920,11 +1918,9 @@ class ContactTest(TembaTest):
 
         # add some languages to our org, but not french
         self.client.post(reverse('orgs.org_languages'), dict(primary_lang='hat', languages='arc,spa'))
-        response = self.client.get(reverse('contacts.contact_update', args=[self.joe.id]))
 
+        response = self.client.get(reverse('contacts.contact_update', args=[self.joe.id]))
         self.assertContains(response, 'French (Missing)')
-        self.client.post(reverse('contacts.contact_update', args=[self.joe.id]),
-                         dict(name='Joey', urn__tel__0="12345", new_scheme="mailto", new_path="malformed"))
 
         # update our contact with some locations
         state = ContactField.get_or_create(self.org, self.admin, 'state', "Home State", value_type='S')
@@ -1988,8 +1984,10 @@ class ContactTest(TembaTest):
 
         post_data = dict(name="Joe X", groups=[self.just_joe.id])
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), post_data, follow=True)
-        self.assertEquals(Contact.from_urn(self.org, "tel:12345"), self.joe)  # ensure Joe still has tel 12345
-        self.assertEquals(Contact.from_urn(self.org, "tel:12345").name, "Joe X")
+
+        self.joe.refresh_from_db()
+        self.assertEqual(self.joe.name, "Joe X")
+        self.assertEqual({u.urn for u in self.joe.urns.all()}, {"tel:+250781111111", "ext:EXT123"})  # urns unaffected
 
         # try delete action
         call = ChannelEvent.create(self.channel, self.frank.get_urn(TEL_SCHEME).urn, ChannelEvent.TYPE_CALL_OUT_MISSED,
@@ -2077,8 +2075,8 @@ class ContactTest(TembaTest):
         self.assertFalse(contact4.urns.all())
 
     def test_from_urn(self):
-        self.assertEqual(self.joe, Contact.from_urn(self.org, 'tel:123'))  # URN with contact
-        self.assertIsNone(Contact.from_urn(self.org, 'tel:8888'))  # URN with no contact
+        self.assertEqual(Contact.from_urn(self.org, 'tel:+250781111111'), self.joe)  # URN with contact
+        self.assertIsNone(Contact.from_urn(self.org, 'tel:+250788888888'))  # URN with no contact
         self.assertIsNone(Contact.from_urn(self.org, 'snoop@dogg.com'))  # URN with no scheme
 
     def test_validate_import_header(self):
@@ -2983,7 +2981,7 @@ class ContactTest(TembaTest):
         self.assertEquals("Joe", message_context['first_name'])
         self.assertEquals("Joe Blow", message_context['name'])
         self.assertEquals("Joe Blow", message_context['__default__'])
-        self.assertEquals("123", message_context['tel'])
+        self.assertEquals("0781 111 111", message_context['tel'])
         self.assertEquals("", message_context['groups'])
         self.assertTrue('uuid' in message_context)
         self.assertEquals(self.joe.uuid, message_context['uuid'])
@@ -3008,7 +3006,7 @@ class ContactTest(TembaTest):
         self.assertEquals("Joe", message_context['first_name'])
         self.assertEquals("Joe Blow", message_context['name'])
         self.assertEquals("Joe Blow", message_context['__default__'])
-        self.assertEquals("123", message_context['tel'])
+        self.assertEquals("0781 111 111", message_context['tel'])
         self.assertEquals("Reporters", message_context['groups'])
 
         self.assertEqual("SeaHawks", message_context['team'])
@@ -3081,9 +3079,9 @@ class ContactTest(TembaTest):
 
             # create groups based on name or URN (checks that contacts are added correctly on contact create)
             joes_group = self.create_group("People called Joe", query='name has joe')
-            _123_group = self.create_group("People with number containing '123'", query='tel has "123"')
+            mtn_group = self.create_group("People with number containing '078'", query='tel has "078"')
 
-            self.mary = self.create_contact("Mary", "123456")
+            self.mary = self.create_contact("Mary", "+250783333333")
             self.mary.set_field(self.user, 'gender', "Female")
             self.mary.set_field(self.user, 'age', 21)
             self.mary.set_field(self.user, 'joined', '31/12/2013')
@@ -3109,7 +3107,7 @@ class ContactTest(TembaTest):
             EventFire.update_campaign_events(joes_campaign)
 
             # check initial group members added correctly
-            self.assertEquals([self.frank, self.joe, self.mary], list(_123_group.contacts.order_by('name')))
+            self.assertEquals([self.frank, self.joe, self.mary], list(mtn_group.contacts.order_by('name')))
             self.assertEquals([self.frank, self.joe], list(men_group.contacts.order_by('name')))
             self.assertEquals([self.mary], list(women_group.contacts.order_by('name')))
             self.assertEquals([self.joe], list(joes_group.contacts.order_by('name')))
@@ -3142,7 +3140,7 @@ class ContactTest(TembaTest):
 
             # change Mary's URNs
             self.mary.update_urns(self.user, ['tel:54321', 'twitter:mary_mary'])
-            self.assertEquals([self.frank, self.joe], list(_123_group.contacts.order_by('name')))
+            self.assertEquals([self.frank, self.joe], list(mtn_group.contacts.order_by('name')))
 
     def test_simulator_contact_views(self):
         simulator_contact = Contact.get_test_contact(self.admin)
@@ -3700,10 +3698,10 @@ class URNTest(TembaTest):
         self.assertTrue(URN.validate("tel:+23761234567", "CM"))  # old Cameroon format
         self.assertTrue(URN.validate("tel:+237661234567", "CM"))  # new Cameroon format
         self.assertTrue(URN.validate("tel:+250788383383", None))
-        self.assertTrue(URN.validate("tel:0788383383", None))  # assumed valid because no country
 
         # invalid tel numbers
         self.assertFalse(URN.validate("tel:0788383383", "ZZ"))  # invalid country
+        self.assertFalse(URN.validate("tel:0788383383", None))  # no country
         self.assertFalse(URN.validate("tel:MTN", "RW"))
 
         # twitter handles

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -605,8 +605,8 @@ class ContactTest(TembaTest):
         self.login(self.admin)
 
         # try creating a contact with a number that belongs to another contact
-        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="123"))
-        self.assertEquals(1, len(response.context['form'].errors))
+        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250781111111"))
+        self.assertFormError(response, 'form', 'urn__tel__0', "Used by another contact")
 
         # now repost with a unique phone number
         response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250 783-835665"))

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -24,7 +24,7 @@ from temba.orgs.views import OrgPermsMixin, OrgObjPermsMixin, ModalMixin
 from temba.values.models import Value
 from temba.utils import analytics, slugify_with, languages, datetime_to_ms, ms_to_datetime
 from temba.utils.views import BaseActionForm
-from .models import Contact, ContactGroup, ContactField, ContactURN, URN, URN_SCHEME_CONFIG
+from .models import Contact, ContactGroup, ContactField, ContactURN, URN, URN_SCHEME_CONFIG, TEL_SCHEME
 from .models import ExportContactsTask
 from .omnibox import omnibox_query, omnibox_results_to_dict
 from .tasks import export_contacts_task
@@ -267,7 +267,10 @@ class ContactForm(forms.ModelForm):
                     return False
                 # validate but not with country as users are allowed to enter numbers before adding a channel
                 elif not URN.validate(normalized):
-                    self._errors[key] = _("Invalid format")
+                    if scheme == TEL_SCHEME:
+                        self._errors[key] = _("Invalid number. Ensure number includes country code, e.g. +1-541-754-3010")
+                    else:
+                        self._errors[key] = _("Invalid format")
                     return False
                 return True
             except ValueError:


### PR DESCRIPTION
API v1 skips tel URN validation for the sake of backwards compatibility.

Doesn't yet add any sort of fancy UI control, but error message shows required format:

<img width="576" alt="screen shot 2016-09-15 at 13 26 38" src="https://cloud.githubusercontent.com/assets/675558/18548273/2b78f36c-7b48-11e6-9732-966fdcda1a1e.png">
