### PR TITLE
Contact.get_activity should include activity an hour before contact creation

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1222,8 +1222,10 @@ class ContactTest(TembaTest):
             self.create_msg(direction='I', contact=self.joe, text="Inbound message %d" % i,
                             created_on=timezone.now() - timedelta(days=(100 - i)))
 
+        # because messages are stored with timestamps from external systems, possible to have initial message
+        # which is little bit older than the contact itself
         self.create_msg(direction='I', contact=self.joe, text="Very old inbound message",
-                        created_on=timezone.now() - timedelta(days=500))
+                        created_on=self.joe.created_on - timedelta(seconds=10))
 
         # start a joe flow
         self.reminder_flow.start([], [self.joe])

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -821,6 +821,10 @@ class ContactCRUDL(SmartCRUDL):
             context = super(ContactCRUDL.History, self).get_context_data(*args, **kwargs)
             contact = self.get_object()
 
+            # since we create messages with timestamps from external systems, always a chance a contact's initial
+            # message has a timestamp slightly earlier than the contact itself.
+            contact_creation = contact.created_on - timedelta(hours=1)
+
             refresh_recent = self.request.REQUEST.get('r', False)
             recent_start = ms_to_datetime(int(self.request.GET.get('rs', 0)))
 
@@ -836,20 +840,20 @@ class ContactCRUDL(SmartCRUDL):
 
                 activity = contact.get_activity(start_time, end_time)
             else:
-                start_time = max(older_before - timedelta(days=90), contact.created_on)
+                start_time = max(older_before - timedelta(days=90), contact_creation)
                 end_time = older_before
 
                 while True:
                     activity = contact.get_activity(start_time, end_time)
 
                     # keep looking further back until we get at least 20 items
-                    if len(activity) >= 20 or start_time == contact.created_on:
+                    if len(activity) >= 20 or start_time == contact_creation:
                         break
                     else:
-                        start_time = max(start_time - timedelta(days=90), contact.created_on)
+                        start_time = max(start_time - timedelta(days=90), contact_creation)
 
             if start_time > contact.created_on:
-                has_older = bool(contact.get_activity(contact.created_on, start_time))
+                has_older = bool(contact.get_activity(contact_creation, start_time))
             else:
                 has_older = False
 


### PR DESCRIPTION
Because sometimes messages are saved with a timestamp from the channel which may be earlier than the contact creation time.

Fixes https://github.com/rapidpro/rapidpro/issues/344
