### PR TITLE
Don't set preferred channels on test contacts

### DIFF
--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -62,4 +62,3 @@ rapidpro-expressions
 python-telegram-bot
 -e git+http://github.com/nyaruka/python-librato-bg.git#egg=librato_bg
 django-mptt==0.7.4
-

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1398,7 +1398,7 @@ class Contact(TembaModel):
 
         # don't set preferred channels for test contacts
         if self.is_test:
-            return
+            raise ValueError(_('Test contacts cannot have a preferred channel'))
 
         urns = self.get_urns()
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1399,6 +1399,10 @@ class Contact(TembaModel):
         if channel is None:
             return
 
+        # don't set preferred channels for test contacts
+        if self.is_test:
+            return
+
         urns = self.get_urns()
 
         # make sure all urns of the same scheme use this channel (only do this for TEL, others are channel specific)

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1398,7 +1398,7 @@ class Contact(TembaModel):
 
         # don't set preferred channels for test contacts
         if self.is_test:
-            raise ValueError(_('Test contacts cannot have a preferred channel'))
+            return
 
         urns = self.get_urns()
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3180,7 +3180,10 @@ class ContactTest(TembaTest):
         # can't set preferred channel for test contacts
         self.test_contact = self.create_contact(name="Test Contact", number="+12065551212", is_test=True)
         self.test_contact.update_urns(self.admin, ['tel:+12065551212', 'telegram:12515', 'twitter:macklemore'])
-        self.test_contact.set_preferred_channel(twitter)
+
+        with self.assertRaises(ValueError):
+            self.test_contact.set_preferred_channel(twitter)
+
         self.assertEqual(self.test_contact.urns.all()[0].scheme, TEL_SCHEME)
 
         # update our contact URNs, give them telegram and twitter with telegram being preferred

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3180,10 +3180,7 @@ class ContactTest(TembaTest):
         # can't set preferred channel for test contacts
         self.test_contact = self.create_contact(name="Test Contact", number="+12065551212", is_test=True)
         self.test_contact.update_urns(self.admin, ['tel:+12065551212', 'telegram:12515', 'twitter:macklemore'])
-
-        with self.assertRaises(ValueError):
-            self.test_contact.set_preferred_channel(twitter)
-
+        self.test_contact.set_preferred_channel(twitter)
         self.assertEqual(self.test_contact.urns.all()[0].scheme, TEL_SCHEME)
 
         # update our contact URNs, give them telegram and twitter with telegram being preferred

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3177,6 +3177,12 @@ class ContactTest(TembaTest):
         twitter = Channel.create(self.org, self.user, None, 'TT', name="Twitter Channel", address="@rapidpro")
         Channel.create(self.org, self.user, None, 'TG', name="Twitter Channel", address="@rapidpro")
 
+        # can't set preferred channel for test contacts
+        self.test_contact = self.create_contact(name="Test Contact", number="+12065551212", is_test=True)
+        self.test_contact.update_urns(self.admin, ['tel:+12065551212', 'telegram:12515', 'twitter:macklemore'])
+        self.test_contact.set_preferred_channel(twitter)
+        self.assertEqual(self.test_contact.urns.all()[0].scheme, TEL_SCHEME)
+
         # update our contact URNs, give them telegram and twitter with telegram being preferred
         self.joe.update_urns(self.admin, ['telegram:12515', 'twitter:macklemore'])
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -5343,7 +5343,11 @@ class SetChannelAction(Action):
     def execute(self, run, actionset_uuid, msg, offline_on=None):
         # if we found the channel to set
         if self.channel:
-            run.contact.set_preferred_channel(self.channel)
+
+            # don't set preferred channel for test contacts
+            if not run.contact.is_test:
+                run.contact.set_preferred_channel(self.channel)
+
             self.log(run, _("Updated preferred channel to %s") % self.channel.name)
             return []
         else:


### PR DESCRIPTION
I spotted a test contact with a preferred channel which should never be the case. This makes sure that action never does anything when simulating.