### PR TITLE
Nonoverlapping tasks

### DIFF
--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -9,7 +9,7 @@ from django.core.cache import cache
 from djcelery_transactions import task
 from redis_cache import get_redis_connection
 from temba.utils.mage import mage_handle_new_message, mage_handle_new_contact
-from temba.utils.queues import pop_task
+from temba.utils.queues import pop_task, nonoverlapping_task
 from temba.utils import json_date_to_datetime
 from .models import Msg, Broadcast, ExportMessagesTask, PENDING, HANDLE_EVENT_TASK, MSG_EVENT
 from .models import FIRE_EVENT, TIMEOUT_EVENT, SystemLabel
@@ -112,7 +112,7 @@ def fail_old_messages():
     Msg.fail_old_messages()
 
 
-@task(track_started=True, name='collect_message_metrics_task', time_limit=900, soft_time_limit=900)
+@nonoverlapping_task(track_started=True, name='collect_message_metrics_task', time_limit=900)
 def collect_message_metrics_task():
     """
     Collects message metrics and sends them to our analytics.
@@ -120,42 +120,36 @@ def collect_message_metrics_task():
     from .models import INCOMING, OUTGOING, PENDING, QUEUED, ERRORED, INITIALIZING
     from temba.utils import analytics
 
-    r = get_redis_connection()
+    # current # of queued messages (excluding Android)
+    count = Msg.objects.filter(direction=OUTGOING, status=QUEUED).exclude(channel=None).\
+        exclude(topup=None).exclude(channel__channel_type='A').exclude(next_attempt__gte=timezone.now()).count()
+    analytics.gauge('temba.current_outgoing_queued', count)
 
-    # only do this if we aren't already running
-    key = 'collect_message_metrics'
-    if not r.get(key):
-        with r.lock(key, timeout=900):
-            # current # of queued messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=QUEUED).exclude(channel=None).\
-                exclude(topup=None).exclude(channel__channel_type='A').exclude(next_attempt__gte=timezone.now()).count()
-            analytics.gauge('temba.current_outgoing_queued', count)
+    # current # of initializing messages (excluding Android)
+    count = Msg.objects.filter(direction=OUTGOING, status=INITIALIZING).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
+    analytics.gauge('temba.current_outgoing_initializing', count)
 
-            # current # of initializing messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=INITIALIZING).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
-            analytics.gauge('temba.current_outgoing_initializing', count)
+    # current # of pending messages (excluding Android)
+    count = Msg.objects.filter(direction=OUTGOING, status=PENDING).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
+    analytics.gauge('temba.current_outgoing_pending', count)
 
-            # current # of pending messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=PENDING).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
-            analytics.gauge('temba.current_outgoing_pending', count)
+    # current # of errored messages (excluding Android)
+    count = Msg.objects.filter(direction=OUTGOING, status=ERRORED).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
+    analytics.gauge('temba.current_outgoing_errored', count)
 
-            # current # of errored messages (excluding Android)
-            count = Msg.objects.filter(direction=OUTGOING, status=ERRORED).exclude(channel=None).exclude(topup=None).exclude(channel__channel_type='A').count()
-            analytics.gauge('temba.current_outgoing_errored', count)
+    # current # of android outgoing messages waiting to be sent
+    count = Msg.objects.filter(direction=OUTGOING, status__in=[PENDING, QUEUED], channel__channel_type='A').exclude(channel=None).exclude(topup=None).count()
+    analytics.gauge('temba.current_outgoing_android', count)
 
-            # current # of android outgoing messages waiting to be sent
-            count = Msg.objects.filter(direction=OUTGOING, status__in=[PENDING, QUEUED], channel__channel_type='A').exclude(channel=None).exclude(topup=None).count()
-            analytics.gauge('temba.current_outgoing_android', count)
+    # current # of pending incoming messages that haven't yet been handled
+    count = Msg.objects.filter(direction=INCOMING, status=PENDING).exclude(channel=None).count()
+    analytics.gauge('temba.current_incoming_pending', count)
 
-            # current # of pending incoming messages that haven't yet been handled
-            count = Msg.objects.filter(direction=INCOMING, status=PENDING).exclude(channel=None).count()
-            analytics.gauge('temba.current_incoming_pending', count)
-
-            # stuff into redis when we last run, we do this as a canary as to whether our tasks are falling behind or not running
-            cache.set('last_cron', timezone.now())
+    # stuff into redis when we last run, we do this as a canary as to whether our tasks are falling behind or not running
+    cache.set('last_cron', timezone.now())
 
 
-@task(track_started=True, name='check_messages_task', time_limit=900, soft_time_limit=900)
+@nonoverlapping_task(track_started=True, name='check_messages_task', time_limit=900)
 def check_messages_task():
     """
     Checks to see if any of our aggregators have errored messages that need to be retried.
@@ -166,36 +160,30 @@ def check_messages_task():
     from temba.orgs.models import Org
     from temba.channels.tasks import send_msg_task
 
-    r = get_redis_connection()
+    now = timezone.now()
+    five_minutes_ago = now - timedelta(minutes=5)
 
-    # only do this if we aren't already running
-    key = 'check_messages_task'
-    if not r.get(key):
-        with r.lock(key, timeout=900):
-            now = timezone.now()
-            five_minutes_ago = now - timedelta(minutes=5)
+    # for any org that sent messages in the past five minutes, check for pending messages
+    for org in Org.objects.filter(msgs__created_on__gte=five_minutes_ago).distinct():
+        org.trigger_send()
 
-            # for any org that sent messages in the past five minutes, check for pending messages
-            for org in Org.objects.filter(msgs__created_on__gte=five_minutes_ago).distinct():
-                org.trigger_send()
+    # fire a few send msg tasks in case we dropped one somewhere during a restart
+    # (these will be no-ops if there is nothing to do)
+    send_msg_task.delay()
+    send_msg_task.delay()
 
-            # fire a few send msg tasks in case we dropped one somewhere during a restart
-            # (these will be no-ops if there is nothing to do)
-            send_msg_task.delay()
-            send_msg_task.delay()
+    handle_event_task.delay()
+    handle_event_task.delay()
 
-            handle_event_task.delay()
-            handle_event_task.delay()
+    # also check any incoming messages that are still pending somehow, reschedule them to be handled
+    unhandled_messages = Msg.objects.filter(direction=INCOMING, status=PENDING, created_on__lte=five_minutes_ago)
+    unhandled_messages = unhandled_messages.exclude(channel__org=None).exclude(contact__is_test=True)
+    unhandled_count = unhandled_messages.count()
 
-            # also check any incoming messages that are still pending somehow, reschedule them to be handled
-            unhandled_messages = Msg.objects.filter(direction=INCOMING, status=PENDING, created_on__lte=five_minutes_ago)
-            unhandled_messages = unhandled_messages.exclude(channel__org=None).exclude(contact__is_test=True)
-            unhandled_count = unhandled_messages.count()
-
-            if unhandled_count:
-                print "** Found %d unhandled messages" % unhandled_count
-                for msg in unhandled_messages[:100]:
-                    msg.handle()
+    if unhandled_count:
+        print("** Found %d unhandled messages" % unhandled_count)
+        for msg in unhandled_messages[:100]:
+            msg.handle()
 
 
 @task(track_started=True, name='export_sms_task')
@@ -253,38 +241,26 @@ def handle_event_task():
         raise Exception("Unexpected event type: %s" % event_task)
 
 
-@task(track_started=True, name='purge_broadcasts_task', time_limit=900, soft_time_limit=900)
+@nonoverlapping_task(track_started=True, name='purge_broadcasts_task', time_limit=900)
 def purge_broadcasts_task():
     """
     Looks for broadcasts older than 90 days and marks their messages as purged
     """
+    purge_date = timezone.now() - timedelta(days=90)  # 90 days ago
 
-    r = get_redis_connection()
+    # determine which broadcasts are old
+    broadcasts = Broadcast.objects.filter(created_on__lt=purge_date, purged=False)
 
-    # 90 days ago
-    purge_date = timezone.now() - timedelta(days=90)
-    key = 'purge_broadcasts_task'
-    if not r.get(key):
-        with r.lock(key, timeout=900):
+    for broadcast in broadcasts:
+        # TODO actually delete messages!
+        #
+        # Need to also create Debit objects for topups associated with messages being deleted, and then
+        # regularly squash those.
 
-            # determine which broadcasts are old
-            broadcasts = Broadcast.objects.filter(created_on__lt=purge_date, purged=False)
-
-            for broadcast in broadcasts:
-                # TODO actually delete messages!
-                #
-                # Need to also create Debit objects for topups associated with messages being deleted, and then
-                # regularly squash those.
-
-                broadcast.purged = True
-                broadcast.save(update_fields=['purged'])
+        broadcast.purged = True
+        broadcast.save(update_fields=['purged'])
 
 
-@task(track_started=True, name="squash_systemlabels")
+@nonoverlapping_task(track_started=True, name="squash_systemlabels")
 def squash_systemlabels():
-    r = get_redis_connection()
-
-    key = 'squash_systemlabels'
-    if not r.get(key):
-        with r.lock(key, timeout=900):
-            SystemLabel.squash_counts()
+    SystemLabel.squash_counts()

--- a/temba/utils/queues.py
+++ b/temba/utils/queues.py
@@ -1,15 +1,22 @@
-from redis_cache import get_redis_connection
-from celery import current_app
-from temba.utils import dict_to_json
-from django.conf import settings
+from __future__ import unicode_literals
+
 import json
 import time
 import importlib
+
+from celery import current_app, shared_task
+from django.conf import settings
+from redis_cache import get_redis_connection
+from temba.utils import dict_to_json
+
 
 LOW_PRIORITY = +10000000   # +10M ~ 110 days
 DEFAULT_PRIORITY = 0
 HIGH_PRIORITY = -10000000  # -10M ~ 110 days
 HIGHER_PRIORITY = -20000000  # -20M ~ 220 days
+
+# for tasks using a redis lock to prevent overlapping this is the default timeout for the lock
+DEFAULT_TASK_LOCK_TIMEOUT = 900
 
 
 def push_task(org, queue, task_name, args, priority=DEFAULT_PRIORITY):
@@ -98,3 +105,31 @@ def lookup_task_function(task_name):
     m, f = task_function.rsplit('.', 1)
     mod = importlib.import_module(m)
     return getattr(mod, f)
+
+
+def nonoverlapping_task(*task_args, **task_kwargs):
+    """
+    Decorator to create an task whose executions are prevented from overlapping by a redis lock
+    """
+    def _nonoverlapping_task(task_func):
+        def wrapper(*exec_args, **exec_kwargs):
+            r = get_redis_connection()
+
+            task_name = task_kwargs.get('name', task_func.__name__)
+
+            # lock key can be provided or defaults to celery-task-lock:<task_name>
+            lock_key = task_kwargs.pop('lock_key', 'celery-task-lock:' + task_name)
+
+            # lock timeout can be provided or defaults to task hard time limit
+            lock_timeout = task_kwargs.pop('lock_timeout', None)
+            if lock_timeout is None:
+                lock_timeout = task_kwargs.get('time_limit', DEFAULT_TASK_LOCK_TIMEOUT)
+
+            if r.get(lock_key):
+                print("Skipping task %s to prevent overlapping" % task_name)
+            else:
+                with r.lock(lock_key, timeout=lock_timeout):
+                    task_func(*exec_args, **exec_kwargs)
+
+        return shared_task(*task_args, **task_kwargs)(wrapper)
+    return _nonoverlapping_task


### PR DESCRIPTION
Introduces a decorator which wraps tasks with the a redis lock to prevent overlapping executions. This is a pattern we repeat widely for scheduled tasks.

So far have only switched the tasks in the msgs app to use this, as don't want to change too much without some feedback.