### PR TITLE
Mark test contacts calls as handled

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -448,8 +448,11 @@ class Flow(TembaModel):
         voice_response = Flow.wrap_voice_response_with_input(call, run, voice_response)
 
         # if we handled it, increment our unread count
-        if handled and not call.contact.is_test:
-            run.flow.increment_unread_responses()
+        if handled:
+
+            if not call.contact.is_test:
+                run.flow.increment_unread_responses()
+
             if msg.id:
                 Msg.mark_handled(msg)
 

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -357,6 +357,16 @@ class IVRTests(FlowFileTest):
         # should be using the usersettings number in test mode
         self.assertEquals('Placing test call to +1 800-555-1212', ActionLog.objects.all().first().text)
 
+        # our twilio callback on pickup
+        post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
+        response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)
+
+        # simulate a button press and that our message is handled
+        response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), dict(Digits=4))
+        msg = Msg.objects.filter(contact=test_contact, text="4", direction='I').first()
+        self.assertIsNotNone(msg)
+        self.assertEqual('H', msg.status)
+
         # explicitly hanging up on a test call should remove it
         call.update_status('in-progress', 0)
         call.save()
@@ -365,6 +375,7 @@ class IVRTests(FlowFileTest):
 
         ActionLog.objects.all().delete()
         IVRCall.objects.all().delete()
+        Msg.objects.all().delete()
 
         # now pretend we are a normal caller
         eric = self.create_contact('Eric Newcomer', number='+13603621737')


### PR DESCRIPTION
During test IVR calls we weren't marking those messages as handled. This causes our monitor to fail for unhandled messages.