### PR TITLE
Reworked POSTs in API v2

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -983,7 +983,7 @@ class APITest(TembaTest):
 
         # try an empty delete request
         response = self.deleteJSON(url, None)
-        self.assertResponseError(response, None, "Must provide one of the following fields: urn, uuid")
+        self.assertResponseError(response, None, "URL must contain one of the following parameters: urn, uuid")
 
         # delete a contact by UUID
         response = self.deleteJSON(url, 'uuid=%s' % jean.uuid)
@@ -1200,7 +1200,7 @@ class APITest(TembaTest):
 
         # update group by UUID
         response = self.postJSON(url, 'uuid=%s' % reporters.uuid, {'name': "U-Reporters"})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
 
         reporters.refresh_from_db()
         self.assertEqual(reporters.name, "U-Reporters")
@@ -1276,7 +1276,7 @@ class APITest(TembaTest):
 
         # update label by UUID
         response = self.postJSON(url, 'uuid=%s' % interesting.uuid, {'name': "More Interesting"})
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
 
         interesting.refresh_from_db()
         self.assertEqual(interesting.name, "More Interesting")

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -19,6 +19,17 @@ def validate_list_size(value):
         raise serializers.ValidationError("Exceeds maximum list size of %d" % MAX_LIST_SIZE)
 
 
+def validate_urn(value, strict=True):
+    try:
+        normalized = URN.normalize(value)
+
+        if strict and not URN.validate(normalized):
+            raise ValueError()
+    except ValueError:
+        raise serializers.ValidationError("Invalid URN: %s. Ensure phone numbers contain country codes." % value)
+    return normalized
+
+
 class LimitedListField(serializers.ListField):
     """
     A list field which can be only be written to with a limited number of items
@@ -39,14 +50,7 @@ class URNField(serializers.CharField):
             return six.text_type(obj)
 
     def to_internal_value(self, data):
-        try:
-            normalized = URN.normalize(data)
-            if not URN.validate(normalized):
-                raise ValueError()
-        except ValueError:
-            raise serializers.ValidationError("Invalid URN: %s. Ensure phone numbers contain country codes." % data)
-
-        return normalized
+        return validate_urn(data)
 
 
 class URNListField(LimitedListField):

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -257,8 +257,6 @@ class ContactReadSerializer(ReadSerializer):
 
 
 class ContactWriteSerializer(WriteSerializer):
-    uuid = serializers.UUIDField(required=False)
-    urn = fields.URNField(required=False)
     name = serializers.CharField(required=False, max_length=64, allow_null=True)
     language = serializers.CharField(required=False, min_length=3, max_length=3, allow_null=True)
     urns = fields.URNListField(required=False)
@@ -268,22 +266,14 @@ class ContactWriteSerializer(WriteSerializer):
     def __init__(self, *args, **kwargs):
         super(ContactWriteSerializer, self).__init__(*args, **kwargs)
 
-    def validate_uuid(self, value):
-        self.instance = Contact.objects.filter(org=self.context['org'], uuid=value, is_active=True).first()
-        if not self.instance:
-            raise serializers.ValidationError("No such contact with UUID: %s" % value)
-
-    def validate_urn(self, value):
-        if self.context['org'].is_anon:
-            raise serializers.ValidationError("Referencing by URN not allowed for anonymous organizations")
-
-        self.instance = Contact.from_urn(self.context['org'], value)
-        return value
-
     def validate_groups(self, value):
         for group in value:
             if group.is_dynamic:
                 raise serializers.ValidationError("Can't add contact to dynamic group with UUID: %s" % group.uuid)
+
+        # if contact is blocked, they can't be added to groups
+        if self.instance and (self.instance.is_blocked or self.instance.is_stopped) and value:
+            raise serializers.ValidationError("Blocked or stopped contacts can't be added to groups")
 
         return value
 
@@ -296,23 +286,31 @@ class ContactWriteSerializer(WriteSerializer):
 
         return value
 
-    def validate(self, data):
+    def validate_urns(self, value):
         org = self.context['org']
 
-        # we don't allow updating of contact URNs for anon orgs - tho we do allow creation of contacts with URNs
-        if org.is_anon and self.instance and data.get('urns'):
-            raise serializers.ValidationError("Updating contact URNs not allowed for anonymous organizations")
+        # this field isn't allowed if we are looking up by URN in the URL
+        if 'urns__urn' in self.context['lookup_values']:
+            raise serializers.ValidationError("Field not allowed when using URN in URL")
 
-        # if creating a contact, urns can't include URNs which are already taken
-        if not self.instance and 'urns' in data:
-            country_code = org.get_country_code()
-            for urn in data['urns']:
-                if Contact.from_urn(org, urn, country_code):
-                    raise serializers.ValidationError("Contact URN belongs to another contact: %s" % urn)
+        # or for updates by anonymous organizations (we do allow creation of contacts with URNs)
+        if org.is_anon and self.instance:
+            raise serializers.ValidationError("Updating URNs not allowed for anonymous organizations")
 
-        # if contact is blocked, they can't be added to groups
-        if self.instance and (self.instance.is_blocked or self.instance.is_stopped) and data['groups']:
-            raise serializers.ValidationError("Blocked or stopped contacts can't be added to groups")
+        # if creating a contact, URNs can't belong to other contacts
+        if not self.instance:
+            for urn in value:
+                if Contact.from_urn(org, urn):
+                    raise serializers.ValidationError("URN belongs to another contact: %s" % urn)
+
+        return value
+
+    def validate(self, data):
+        # we allow creation of contacts by URN used for lookup
+        if not data.get('urns') and 'urns__urn' in self.context['lookup_values']:
+            url_urn = self.context['lookup_values']['urns__urn']
+
+            data['urns'] = [fields.validate_urn(url_urn)]
 
         return data
 
@@ -324,7 +322,7 @@ class ContactWriteSerializer(WriteSerializer):
         language = self.validated_data.get('language')
         urns = self.validated_data.get('urns')
         groups = self.validated_data.get('groups')
-        fields = self.validated_data.get('fields')
+        custom_fields = self.validated_data.get('fields')
 
         changed = []
 
@@ -343,19 +341,12 @@ class ContactWriteSerializer(WriteSerializer):
             if changed:
                 self.instance.save(update_fields=changed)
         else:
-            if urns is None:
-                # if user is using URN as identifier, ok to create contact from it if they don't already exist
-                urn_as_id = self.validated_data.get('urn')
-                if urn_as_id:
-                    urns = [urn_as_id]
-                else:
-                    urns = []
-
-            self.instance = Contact.get_or_create(self.context['org'], self.context['user'], name, urns=urns, language=language)
+            self.instance = Contact.get_or_create(self.context['org'], self.context['user'], name,
+                                                  urns=urns, language=language)
 
         # update our fields
-        if fields is not None:
-            for key, value in fields.items():
+        if custom_fields is not None:
+            for key, value in six.iteritems(custom_fields):
                 self.instance.set_field(self.context['user'], key, value)
 
         # update our groups

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1672,7 +1672,7 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
         return {
             'method': "DELETE",
             'title': "Delete Message Labels",
-            'url': reverse('api.v2.contacts'),
+            'url': reverse('api.v2.labels'),
             'slug': 'label-delete',
             'params': [
                 {'name': "uuid", 'required': True, 'help': "The UUID of the message label to delete"}

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -444,7 +444,7 @@ class BoundariesEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.boundaries'),
             'slug': 'boundary-list',
             'request': "",
-            'fields': []
+            'params': []
         }
 
 
@@ -550,7 +550,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.broadcasts'),
             'slug': 'broadcast-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': 'id', 'required': False, 'help': "A broadcast ID to filter by, ex: 123456"},
                 {'name': 'before', 'required': False, 'help': "Only return broadcasts created before this date, ex: 2015-01-28T18:00:00.000"},
                 {'name': 'after', 'required': False, 'help': "Only return broadcasts created after this date, ex: 2015-01-28T18:00:00.000"}
@@ -563,7 +563,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'method': "POST",
             'title': "Send Broadcasts",
             'url': reverse('api.v2.broadcasts'),
-            'slug': 'broadcast-send',
+            'slug': 'broadcast-write',
             'request': "",
             'fields': [
                 {'name': 'text', 'required': True, 'help': "The text of the message you want to send"},
@@ -635,7 +635,7 @@ class CampaignsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.campaigns'),
             'slug': 'campaign-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "A campaign UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
             ]
         }
@@ -726,7 +726,7 @@ class CampaignEventsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.campaign_events'),
             'slug': 'campaign-event-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "An event UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': "campaign", 'required': False, 'help': "A campaign UUID or name to filter by. ex: Reminders"},
             ]
@@ -810,7 +810,7 @@ class ChannelsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.channels'),
             'slug': 'channel-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "A channel UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': "address", 'required': False, 'help': "A channel address to filter by. ex: +250783530001"},
             ]
@@ -890,7 +890,7 @@ class ChannelEventsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.channel_events'),
             'slug': 'channel-event-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "id", 'required': False, 'help': "An event ID to filter by. ex: 12345"},
                 {'name': "contact", 'required': False, 'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': 'before', 'required': False, 'help': "Only return events created before this date, ex: 2015-01-28T18:00:00.000"},
@@ -1083,7 +1083,7 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-list',
             'request': "urn=tel%3A%2B250788123123",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': "urn", 'required': False, 'help': "A contact URN to filter by. ex: tel:+250788123123"},
                 {'name': "group", 'required': False, 'help': "A group name or UUID to filter by. ex: Customers"},
@@ -1099,11 +1099,13 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'method': "POST",
             'title': "Add or Update Contacts",
             'url': reverse('api.v2.contacts'),
-            'slug': 'contact-update',
+            'slug': 'contact-write',
             'request': '{"name": "Ben Haggerty", "groups": [], "urns": ["tel:+250788123123"]}',
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "UUID of the contact to be updated"},
                 {'name': "urn", 'required': False, 'help': "URN of the contact to be updated. ex: tel:+250788123123"},
+            ],
+            'fields': [
                 {'name': "name", 'required': False, 'help': "List of UUIDs of this contact's groups."},
                 {'name': "language", 'required': False, 'help': "Preferred language of the contact (3-letter ISO code). ex: fre, eng"},
                 {'name': "urns", 'required': False, 'help': "List of URNs belonging to the contact."},
@@ -1120,7 +1122,7 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-delete',
             'request': '',
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "UUID of the contact to be deleted"},
                 {'name': "urn", 'required': False, 'help': "URN of the contact to be deleted. ex: tel:+250788123123"}
             ],
@@ -1265,9 +1267,9 @@ class DefinitionsEndpoint(BaseAPIView):
             'method': "GET",
             'title': "Export Definitions",
             'url': reverse('api.v2.definitions'),
-            'slug': 'export-definitions',
+            'slug': 'definition-list',
             'request': "flow=f14e4ff0-724d-43fe-a953-1d16aefd1c0b&flow=09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
-            'fields': [
+            'params': [
                 {'name': "flow", 'required': False, 'help': "One or more flow UUIDs to include"},
                 {'name': "campaign", 'required': False, 'help': "One or more campaign UUIDs to include"},
                 {'name': "dependencies", 'required': False, 'help': "Whether to include dependencies of the requested items. ex: false"}
@@ -1327,7 +1329,7 @@ class FieldsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.fields'),
             'slug': 'field-list',
             'request': "key=nick_name",
-            'fields': [
+            'params': [
                 {'name': "key", 'required': False, 'help': "A field key to filter by. ex: nick_name"}
             ]
         }
@@ -1399,7 +1401,7 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.flows'),
             'slug': 'flow-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "A flow UUID filter by. ex: 5f05311e-8f81-4a67-a5b5-1501b6d6496a"}
             ]
         }
@@ -1512,7 +1514,7 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.groups'),
             'slug': 'group-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "A contact group UUID to filter by"}
             ]
         }
@@ -1525,6 +1527,9 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.groups'),
             'slug': 'group-write',
             'request': "",
+            'params': [
+                {'name': "uuid", 'required': False, 'help': "The UUID of the contact group to update"}
+            ],
             'fields': [
                 {'name': "name", 'required': True, 'help': "The name of the contact group"}
             ]
@@ -1538,8 +1543,8 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.groups'),
             'slug': 'group-delete',
             'request': '',
-            'fields': [
-                {'name': "uuid", 'required': False, 'help': "The UUID of the contact group to delete"}
+            'params': [
+                {'name': "uuid", 'required': True, 'help': "The UUID of the contact group to delete"}
             ],
         }
 
@@ -1648,7 +1653,7 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.labels'),
             'slug': 'label-list',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "A message label UUID to filter by"}
             ]
         }
@@ -1661,8 +1666,10 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.labels'),
             'slug': 'label-write',
             'request': "",
-            'fields': [
+            'params': [
                 {'name': "uuid", 'required': False, 'help': "The UUID of the message label to update"},
+            ],
+            'fields': [
                 {'name': "name", 'required': True, 'help': "The name of the message label"}
             ]
         }
@@ -1675,8 +1682,8 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.contacts'),
             'slug': 'label-delete',
             'request': '',
-            'fields': [
-                {'name': "uuid", 'required': False, 'help': "The UUID of the message label to delete"}
+            'params': [
+                {'name': "uuid", 'required': True, 'help': "The UUID of the message label to delete"}
             ],
         }
 
@@ -1863,7 +1870,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.messages'),
             'slug': 'msg-list',
             'request': "folder=incoming&after=2014-01-01T00:00:00.000",
-            'fields': [
+            'params': [
                 {'name': 'id', 'required': False, 'help': "A message ID to filter by, ex: 123456"},
                 {'name': 'broadcast', 'required': False, 'help': "A broadcast ID to filter by, ex: 12345"},
                 {'name': 'contact', 'required': False, 'help': "A contact UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
@@ -1972,7 +1979,7 @@ class ResthooksEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.resthooks'),
             'slug': 'resthook-list',
             'request': "?",
-            'fields': []
+            'params': []
         }
 
 
@@ -2089,35 +2096,29 @@ class ResthookSubscribersEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, B
             'url': reverse('api.v2.resthook_subscribers'),
             'slug': 'resthooksubscriber-list',
             'request': "?",
-            'fields': []
+            'params': []
         }
 
     @classmethod
     def get_write_explorer(cls):
-        spec = dict(method="POST",
+        return dict(method="POST",
                     title="Add Resthook Subscriber",
                     url=reverse('api.v2.resthook_subscribers'),
-                    slug='resthooksubscriber-create',
-                    request='{ "resthook": "new-report", "target_url": "https://zapier.com/handle/1515155" }')
-
-        spec['fields'] = [dict(name='resthook', required=True,
-                               help="The slug for the resthook you want to subscribe to"),
-                          dict(name='target_url', required=True,
-                               help="The URL that will be called when the resthook is triggered.")]
-
-        return spec
+                    slug='resthooksubscriber-write',
+                    request='{ "resthook": "new-report", "target_url": "https://zapier.com/handle/1515155" }',
+                    fields=[dict(name='resthook', required=True,
+                                 help="The slug for the resthook you want to subscribe to"),
+                            dict(name='target_url', required=True,
+                                 help="The URL that will be called when the resthook is triggered.")])
 
     @classmethod
     def get_delete_explorer(cls):
-        spec = dict(method="DELETE",
+        return dict(method="DELETE",
                     title="Delete Resthook Subscriber",
                     url=reverse('api.v2.resthook_subscribers'),
                     slug='resthooksubscriber-delete',
-                    request="id=10404055")
-        spec['fields'] = [dict(name='id', required=True,
-                               help="The id of the subscriber you want to remove")]
-
-        return spec
+                    request="id=10404055",
+                    params=[dict(name='id', required=True, help="The id of the subscriber to delete")])
 
 
 class ResthookEventsEndpoint(ListAPIMixin, BaseAPIView):
@@ -2214,7 +2215,7 @@ class ResthookEventsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.resthook_events'),
             'slug': 'resthook-event-list',
             'request': "?",
-            'fields': []
+            'params': []
         }
 
 
@@ -2344,7 +2345,7 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.runs'),
             'slug': 'run-list',
             'request': "after=2014-01-01T00:00:00.000",
-            'fields': [
+            'params': [
                 {'name': 'id', 'required': False, 'help': "A run ID to filter by, ex: 123456"},
                 {'name': 'flow', 'required': False, 'help': "A flow UUID to filter by, ex: f5901b62-ba76-4003-9c62-72fdacc1b7b7"},
                 {'name': 'contact', 'required': False, 'help': "A contact UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
@@ -2488,36 +2489,31 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'method': "GET",
             'title': "List Flow Starts",
             'url': reverse('api.v2.flow_starts'),
-            'slug': 'flow_start-list',
+            'slug': 'flow-start-list',
             'request': "?after=2014-01-01T00:00:00.000",
-            'fields': [dict(name='id', required=False,
-                            help="Only return the flow start with this id"),
-                       dict(name='after', required=False,
-                            help="Only return flow starts modified after this date"),
-                       dict(name='before', required=False,
-                            help="Only return flow starts modified before this date")]
+            'params': [
+                {'name': 'id', 'required': False, 'help': "Only return the flow start with this id"},
+                {'name': 'after', 'required': False, 'help': "Only return flow starts modified after this date"},
+                {'name': 'before', 'required': False, 'help': "Only return flow starts modified before this date"}
+            ]
         }
 
     @classmethod
     def get_write_explorer(cls):
-        spec = dict(method="POST",
+        return dict(method="POST",
                     title="Start contacts in a flow",
                     url=reverse('api.v2.flow_starts'),
-                    slug='flow_start-create',
-                    request='{ "flow": "f5901b62-ba76-4003-9c62-72fdacc1b7b7", "urns": ["twitter:sirmixalot"] }')
-
-        spec['fields'] = [dict(name='flow', required=True,
-                               help="The UUID of the flow to start"),
-                          dict(name='groups', required=False,
-                               help="The UUIDs of any contact groups you want to start"),
-                          dict(name='contacts', required=False,
-                               help="The UUIDs of any contacts you want to start"),
-                          dict(name='urns', required=False,
-                               help="The URNS of any contacts you want to start"),
-                          dict(name='restart_participants', required=False,
-                               help="Whether to restart any participants already in the flow"),
-                          dict(name='extra', required=False,
-                               help="Any extra parameters to pass to the flow start"),
-                          ]
-
-        return spec
+                    slug='flow-start-write',
+                    request='{ "flow": "f5901b62-ba76-4003-9c62-72fdacc1b7b7", "urns": ["twitter:sirmixalot"] }',
+                    fields=[dict(name='flow', required=True,
+                                 help="The UUID of the flow to start"),
+                            dict(name='groups', required=False,
+                                 help="The UUIDs of any contact groups you want to start"),
+                            dict(name='contacts', required=False,
+                                 help="The UUIDs of any contacts you want to start"),
+                            dict(name='urns', required=False,
+                                 help="The URNS of any contacts you want to start"),
+                            dict(name='restart_participants', required=False,
+                                 help="Whether to restart any participants already in the flow"),
+                            dict(name='extra', required=False,
+                                 help="Any extra parameters to pass to the flow start")])

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -497,7 +497,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
                     "contacts": [{"uuid": "09d23a05-47fe-11e4-bfe9-b8f6b119e9ab", "name": "Joe"}]
                     "groups": [],
                     "text": "hello world",
-                    "created_on": "2013-03-02T17:28:12.123Z"
+                    "created_on": "2013-03-02T17:28:12.123456Z"
                 },
                 ...
 
@@ -513,7 +513,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
 
     Example:
 
-        POST /api/v1/broadcasts.json
+        POST /api/v2/broadcasts.json
         {
             "urns": ["tel:+250788123123", "tel:+250788123124"],
             "contacts": ["09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"],
@@ -528,8 +528,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             "contacts": [{"uuid": "09d23a05-47fe-11e4-bfe9-b8f6b119e9ab", "name": "Joe"}]
             "groups": [],
             "text": "hello world",
-            "created_on": "2013-03-02T17:28:12",
-            "status": "Q"
+            "created_on": "2013-03-02T17:28:12.123456Z"
         }
     """
     permission = 'msgs.broadcast_api'
@@ -2083,9 +2082,7 @@ class ResthookSubscribersEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, B
 
     ## Deleting a Subscription
 
-    By making a `DELETE` request with the id of the subscription, you can remove it.
-
-     * **id** - the id of the resthook subscription you want to remove
+    A **DELETE** can be used to delete a subscription if you specify its id in the URL.
 
     Example:
 
@@ -2531,7 +2528,7 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
     @classmethod
     def get_write_explorer(cls):
         return dict(method="POST",
-                    title="Start contacts in a flow",
+                    title="Start Contacts in a Flow",
                     url=reverse('api.v2.flow_starts'),
                     slug='flow-start-write',
                     fields=[dict(name='flow', required=True,

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -443,7 +443,6 @@ class BoundariesEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Administrative Boundaries",
             'url': reverse('api.v2.boundaries'),
             'slug': 'boundary-list',
-            'request': "",
             'params': []
         }
 
@@ -549,7 +548,6 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "List Broadcasts",
             'url': reverse('api.v2.broadcasts'),
             'slug': 'broadcast-list',
-            'request': "",
             'params': [
                 {'name': 'id', 'required': False, 'help': "A broadcast ID to filter by, ex: 123456"},
                 {'name': 'before', 'required': False, 'help': "Only return broadcasts created before this date, ex: 2015-01-28T18:00:00.000"},
@@ -564,7 +562,6 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "Send Broadcasts",
             'url': reverse('api.v2.broadcasts'),
             'slug': 'broadcast-write',
-            'request': "",
             'fields': [
                 {'name': 'text', 'required': True, 'help': "The text of the message you want to send"},
                 {'name': 'urns', 'required': False, 'help': "The URNs of contacts you want to send to"},
@@ -634,7 +631,6 @@ class CampaignsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Campaigns",
             'url': reverse('api.v2.campaigns'),
             'slug': 'campaign-list',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "A campaign UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
             ]
@@ -725,7 +721,6 @@ class CampaignEventsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Campaign Events",
             'url': reverse('api.v2.campaign_events'),
             'slug': 'campaign-event-list',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "An event UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': "campaign", 'required': False, 'help': "A campaign UUID or name to filter by. ex: Reminders"},
@@ -809,7 +804,6 @@ class ChannelsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Channels",
             'url': reverse('api.v2.channels'),
             'slug': 'channel-list',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "A channel UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': "address", 'required': False, 'help': "A channel address to filter by. ex: +250783530001"},
@@ -889,7 +883,6 @@ class ChannelEventsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Channel Events",
             'url': reverse('api.v2.channel_events'),
             'slug': 'channel-event-list',
-            'request': "",
             'params': [
                 {'name': "id", 'required': False, 'help': "An event ID to filter by. ex: 12345"},
                 {'name': "contact", 'required': False, 'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
@@ -1082,7 +1075,6 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'title': "List Contacts",
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-list',
-            'request': "urn=tel%3A%2B250788123123",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
                 {'name': "urn", 'required': False, 'help': "A contact URN to filter by. ex: tel:+250788123123"},
@@ -1090,7 +1082,8 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
                 {'name': "deleted", 'required': False, 'help': "Whether to return only deleted contacts. ex: false"},
                 {'name': 'before', 'required': False, 'help': "Only return contacts modified before this date, ex: 2015-01-28T18:00:00.000"},
                 {'name': 'after', 'required': False, 'help': "Only return contacts modified after this date, ex: 2015-01-28T18:00:00.000"}
-            ]
+            ],
+            'example': {'query': "urn=tel%3A%2B250788123123"},
         }
 
     @classmethod
@@ -1100,7 +1093,6 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'title': "Add or Update Contacts",
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-write',
-            'request': '{"name": "Ben Haggerty", "groups": [], "urns": ["tel:+250788123123"]}',
             'params': [
                 {'name': "uuid", 'required': False, 'help': "UUID of the contact to be updated"},
                 {'name': "urn", 'required': False, 'help': "URN of the contact to be updated. ex: tel:+250788123123"},
@@ -1111,7 +1103,8 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
                 {'name': "urns", 'required': False, 'help': "List of URNs belonging to the contact."},
                 {'name': "groups", 'required': False, 'help': "List of UUIDs of groups that the contact belongs to."},
                 {'name': "fields", 'required': False, 'help': "Custom fields as a JSON dictionary."},
-            ]
+            ],
+            'example': {'body': '{"name": "Ben Haggerty", "groups": [], "urns": ["tel:+250788123123"]}'},
         }
 
     @classmethod
@@ -1121,7 +1114,6 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'title': "Delete Contacts",
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-delete',
-            'request': '',
             'params': [
                 {'name': "uuid", 'required': False, 'help': "UUID of the contact to be deleted"},
                 {'name': "urn", 'required': False, 'help': "URN of the contact to be deleted. ex: tel:+250788123123"}
@@ -1268,7 +1260,6 @@ class DefinitionsEndpoint(BaseAPIView):
             'title': "Export Definitions",
             'url': reverse('api.v2.definitions'),
             'slug': 'definition-list',
-            'request': "flow=f14e4ff0-724d-43fe-a953-1d16aefd1c0b&flow=09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
             'params': [
                 {'name': "flow", 'required': False, 'help': "One or more flow UUIDs to include"},
                 {'name': "campaign", 'required': False, 'help': "One or more campaign UUIDs to include"},
@@ -1328,10 +1319,10 @@ class FieldsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Fields",
             'url': reverse('api.v2.fields'),
             'slug': 'field-list',
-            'request': "key=nick_name",
             'params': [
                 {'name': "key", 'required': False, 'help': "A field key to filter by. ex: nick_name"}
-            ]
+            ],
+            'example': {'query': "key=nick_name"},
         }
 
 
@@ -1400,7 +1391,6 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Flows",
             'url': reverse('api.v2.flows'),
             'slug': 'flow-list',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "A flow UUID filter by. ex: 5f05311e-8f81-4a67-a5b5-1501b6d6496a"}
             ]
@@ -1513,7 +1503,6 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "List Contact Groups",
             'url': reverse('api.v2.groups'),
             'slug': 'group-list',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "A contact group UUID to filter by"}
             ]
@@ -1526,7 +1515,6 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "Add or Update Contact Groups",
             'url': reverse('api.v2.groups'),
             'slug': 'group-write',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "The UUID of the contact group to update"}
             ],
@@ -1542,7 +1530,6 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "Delete Contact Groups",
             'url': reverse('api.v2.groups'),
             'slug': 'group-delete',
-            'request': '',
             'params': [
                 {'name': "uuid", 'required': True, 'help': "The UUID of the contact group to delete"}
             ],
@@ -1652,7 +1639,6 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "List Message Labels",
             'url': reverse('api.v2.labels'),
             'slug': 'label-list',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "A message label UUID to filter by"}
             ]
@@ -1665,7 +1651,6 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "Add or Update Message Labels",
             'url': reverse('api.v2.labels'),
             'slug': 'label-write',
-            'request': "",
             'params': [
                 {'name': "uuid", 'required': False, 'help': "The UUID of the message label to update"},
             ],
@@ -1681,7 +1666,6 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "Delete Message Labels",
             'url': reverse('api.v2.contacts'),
             'slug': 'label-delete',
-            'request': '',
             'params': [
                 {'name': "uuid", 'required': True, 'help': "The UUID of the message label to delete"}
             ],
@@ -1869,7 +1853,6 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Messages",
             'url': reverse('api.v2.messages'),
             'slug': 'msg-list',
-            'request': "folder=incoming&after=2014-01-01T00:00:00.000",
             'params': [
                 {'name': 'id', 'required': False, 'help': "A message ID to filter by, ex: 123456"},
                 {'name': 'broadcast', 'required': False, 'help': "A broadcast ID to filter by, ex: 12345"},
@@ -1878,7 +1861,8 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
                 {'name': 'label', 'required': False, 'help': "A label name or UUID to filter by, ex: Spam"},
                 {'name': 'before', 'required': False, 'help': "Only return messages created before this date, ex: 2015-01-28T18:00:00.000"},
                 {'name': 'after', 'required': False, 'help': "Only return messages created after this date, ex: 2015-01-28T18:00:00.000"}
-            ]
+            ],
+            'example': {'query': "folder=incoming&after=2014-01-01T00:00:00.000"},
         }
 
 
@@ -1927,8 +1911,7 @@ class OrgEndpoint(BaseAPIView):
             'method': "GET",
             'title': "View Current Org",
             'url': reverse('api.v2.org'),
-            'slug': 'org-read',
-            'request': ""
+            'slug': 'org-read'
         }
 
 
@@ -1978,7 +1961,6 @@ class ResthooksEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Resthooks",
             'url': reverse('api.v2.resthooks'),
             'slug': 'resthook-list',
-            'request': "?",
             'params': []
         }
 
@@ -2095,7 +2077,6 @@ class ResthookSubscribersEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, B
             'title': "List Resthook Subscribers",
             'url': reverse('api.v2.resthook_subscribers'),
             'slug': 'resthooksubscriber-list',
-            'request': "?",
             'params': []
         }
 
@@ -2105,11 +2086,11 @@ class ResthookSubscribersEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, B
                     title="Add Resthook Subscriber",
                     url=reverse('api.v2.resthook_subscribers'),
                     slug='resthooksubscriber-write',
-                    request='{ "resthook": "new-report", "target_url": "https://zapier.com/handle/1515155" }',
                     fields=[dict(name='resthook', required=True,
                                  help="The slug for the resthook you want to subscribe to"),
                             dict(name='target_url', required=True,
-                                 help="The URL that will be called when the resthook is triggered.")])
+                                 help="The URL that will be called when the resthook is triggered.")],
+                    example=dict(body='{"resthook": "new-report", "target_url": "https://zapier.com/handle/1515155"}'))
 
     @classmethod
     def get_delete_explorer(cls):
@@ -2117,7 +2098,6 @@ class ResthookSubscribersEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, B
                     title="Delete Resthook Subscriber",
                     url=reverse('api.v2.resthook_subscribers'),
                     slug='resthooksubscriber-delete',
-                    request="id=10404055",
                     params=[dict(name='id', required=True, help="The id of the subscriber to delete")])
 
 
@@ -2214,7 +2194,6 @@ class ResthookEventsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Resthook Events",
             'url': reverse('api.v2.resthook_events'),
             'slug': 'resthook-event-list',
-            'request': "?",
             'params': []
         }
 
@@ -2344,7 +2323,6 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Flow Runs",
             'url': reverse('api.v2.runs'),
             'slug': 'run-list',
-            'request': "after=2014-01-01T00:00:00.000",
             'params': [
                 {'name': 'id', 'required': False, 'help': "A run ID to filter by, ex: 123456"},
                 {'name': 'flow', 'required': False, 'help': "A flow UUID to filter by, ex: f5901b62-ba76-4003-9c62-72fdacc1b7b7"},
@@ -2352,7 +2330,8 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
                 {'name': 'responded', 'required': False, 'help': "Whether to only return runs with contact responses"},
                 {'name': 'before', 'required': False, 'help': "Only return runs modified before this date, ex: 2015-01-28T18:00:00.000"},
                 {'name': 'after', 'required': False, 'help': "Only return runs modified after this date, ex: 2015-01-28T18:00:00.000"}
-            ]
+            ],
+            'example': {'query': "after=2016-01-01T00:00:00.000"}
         }
 
 
@@ -2490,12 +2469,12 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "List Flow Starts",
             'url': reverse('api.v2.flow_starts'),
             'slug': 'flow-start-list',
-            'request': "?after=2014-01-01T00:00:00.000",
             'params': [
                 {'name': 'id', 'required': False, 'help': "Only return the flow start with this id"},
                 {'name': 'after', 'required': False, 'help': "Only return flow starts modified after this date"},
                 {'name': 'before', 'required': False, 'help': "Only return flow starts modified before this date"}
-            ]
+            ],
+            'example': {'query': "after=2016-01-01T00:00:00.000"}
         }
 
     @classmethod
@@ -2504,7 +2483,6 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
                     title="Start contacts in a flow",
                     url=reverse('api.v2.flow_starts'),
                     slug='flow-start-write',
-                    request='{ "flow": "f5901b62-ba76-4003-9c62-72fdacc1b7b7", "urns": ["twitter:sirmixalot"] }',
                     fields=[dict(name='flow', required=True,
                                  help="The UUID of the flow to start"),
                             dict(name='groups', required=False,
@@ -2516,4 +2494,5 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
                             dict(name='restart_participants', required=False,
                                  help="Whether to restart any participants already in the flow"),
                             dict(name='extra', required=False,
-                                 help="Any extra parameters to pass to the flow start")])
+                                 help="Any extra parameters to pass to the flow start")],
+                    example=dict(body='{"flow":"f5901b62-ba76-4003-9c62-72fdacc1b7b7","urns":["twitter:sirmixalot"]}'))

--- a/templates/api/v2/api_explorer.haml
+++ b/templates/api/v2/api_explorer.haml
@@ -37,7 +37,7 @@
     .endpoint{ class: "endpoint-{{ endpoint.method|lower }}" }
       -if endpoint.params
         .field-title
-          -trans "Query Parameters"
+          -trans "Query String Parameters"
         %table.table
           .tbody
             -for item in endpoint.params
@@ -50,7 +50,7 @@
                     (optional)
       -if endpoint.fields
         .field-title
-          -trans "Post Body"
+          -trans "Post Body Fields"
         %table.table
           .tbody
             -for item in endpoint.fields
@@ -62,39 +62,41 @@
                   -else
                     (optional)
 
-      %pre.prettyprint<
-        :plain
-          <b>{{ endpoint.method }}</b> {{brand.api_link}}{{ endpoint.url }}.json
+      .request-form.form-horizontal
+        .request-header
+          <b>{{ endpoint.method }}</b> {{brand.api_link}}{{ endpoint.url }}.json<br/>
           <b>Authorization:</b> Token {{ request.user.api_token }}
 
-      -if endpoint.method == 'GET' or endpoint.method == 'DELETE'
-        .request.request-get
-          %textarea{ id: "request-{{ endpoint.slug }}", rows:"1" }<
-            {{ endpoint.request }}
-      -else
-        .request.request-post
-          %textarea{ id: "request-{{ endpoint.slug }}", rows:"5" }<
-            {{ endpoint.request }}
+        -if endpoint.params
+          .form-group
+            %label.col-sm-2.control-label
+              -trans "Query String"
+            .col-sm-10
+              .request-query
+                %textarea{ id:"request-query-{{ endpoint.slug }}", rows:"1" }<
+                  {{ endpoint.example.query }}
 
-      .request-buttons
-        -if endpoint.method == 'GET'
-          %i GET query parameters
-        -elif endpoint.method == 'DELETE'
-          %i DELETE query parameters
-        -else
-          %i POST body
+        -if endpoint.fields
+          .form-group
+            %label.col-sm-2.control-label
+              -trans "Post Body"
+            .col-sm-10
+              .request-body
+                %textarea{ id:"request-body-{{ endpoint.slug }}", rows:"5" }<
+                  {{ endpoint.example.body }}
 
-        %a{ href: '{{ endpoint.url }}' }
-          %i - View Full Documentation
+        .request-buttons
+          %a{ href: '{{ endpoint.url }}' }
+            -trans "View Full Documentation"
 
-        -if user.api_token
-          %a.btn.btn-primary.pull-right{ onclick:'javascript:send("{{ endpoint.slug }}", "{{ endpoint.method }}", "{{ endpoint.url }}.json")' }= endpoint.method|upper
-        -else
-          %span.pull-right Log in to use the Explorer
+          -if user.api_token
+            %a.btn.btn-primary.pull-right{ onclick:'javascript:send("{{ endpoint.slug }}", "{{ endpoint.method }}", "{{ endpoint.url }}.json")' }= endpoint.method|upper
+          -else
+            %span.pull-right Log in to use the Explorer
 
-      .clearfix
+        .clearfix
 
-      %pre.prettyprint.result{ id: "result-{{ endpoint.slug }}" }
+        %pre.prettyprint.result{ id: "result-{{ endpoint.slug }}" }
 
 -block extra-script
   {{ block.super }}
@@ -103,17 +105,17 @@
   :javascript
     var codeMirrors = {};
     $(function(){
-        var textareas = $(".request textarea");
-        for (var i=0; i<textareas.length; i++){
-          codeMirrors[textareas[i].id] = CodeMirror.fromTextArea(textareas[i],
-                                         { mode: "application/json", "lineNumbers": false });
+        // setup syntax highlighting on all textareas used to edit JSON
+        var textareas = $(".request-body textarea");
+        for (var i = 0; i < textareas.length; i++) {
+          codeMirrors[textareas[i].id] = CodeMirror.fromTextArea(textareas[i], { mode: "application/json", "lineNumbers": false });
         }
 
         $(".endpoint-title").click(function(){
           $(this).next(".endpoint").toggle();
           var slug = $(this).attr("data-slug");
           var method = $(this).attr("data-method");
-          refresh(codeMirrors["request-" + slug], method);
+          // refresh(codeMirrors["request-" + slug], method);
         });
     });
 
@@ -129,36 +131,39 @@
     }
 
     function send(slug, method, url){
-      var codeMirror = codeMirrors['request-' + slug];
-      var data = codeMirror.getValue();
-      $("#result-" + slug).text("Requesting..");
+      var query = $('#request-query-' + slug).val();
+      var body = codeMirrors['request-body-' + slug].getValue();
 
-      // by default jQuery sends delete data as the body
-      if (method == 'DELETE') {
-        url += '?' + data
-        data = null;
+      if (query) {
+        if (!query.startsWith('?')) {
+          query = '?' + query;
+        }
+        url += query;
       }
 
-      $.ajax({ type: method,
-               url: url,
-               data: data,
-               headers: {
-                 Accept : "application/json; charset=utf-8; indent=4;",
-                 "Content-Type": "application/json; charset=utf-8; indent=4;"
-               },
-               dataType: "text",
-               success: function(data, textStatus, xhr){
-                 var data = "HTTP/1.0 " + xhr.status + " " + textStatus.toUpperCase() + "\n" + data;
-                 $("#result-" + slug).show();
-                 $("#result-" + slug).text(data);
-                 prettyPrint();
-               },
-               error: function(request, status, error){
-                 var data = "HTTP/1.0 " + request.status + " " + error + "\n" + request.responseText;
-                 $("#result-" + slug).show();
-                 $("#result-" + slug).text(data);
-                 prettyPrint();
-               }
+      $("#result-" + slug).text("Requesting...");
+
+      $.ajax({
+        type: method,
+        url: url,
+        data: data,
+        headers: {
+          Accept : "application/json; charset=utf-8; indent=4;",
+          "Content-Type": "application/json; charset=utf-8; indent=4;"
+        },
+        dataType: "text",
+        success: function(data, textStatus, xhr){
+          var data = "HTTP/1.0 " + xhr.status + " " + textStatus.toUpperCase() + "\n" + data;
+          $("#result-" + slug).show();
+          $("#result-" + slug).text(data);
+          prettyPrint();
+        },
+        error: function(request, status, error){
+          var data = "HTTP/1.0 " + request.status + " " + error + "\n" + request.responseText;
+          $("#result-" + slug).show();
+          $("#result-" + slug).text(data);
+          prettyPrint();
+        }
       });
     }
 
@@ -168,40 +173,29 @@
   <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}css/codemirror.css"/>
   <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}rest_framework/css/prettify.css"/>
   :css
-    .request {
+    .request-form {
+      background-color: #EEE;
+    }
+    .request-header {
+      font-family: monospace;
+      line-height: 110%;
+    }
+
+    .request-query .CodeMirror {
+      height: 30px;
       border: 1px solid #ccc;
     }
 
-    .request-post .CodeMirror {
+    .request-body .CodeMirror {
+      background-color: white;
       height: 110px;
-    }
-
-    .request-get .CodeMirror {
-      height: 30px;
+      border: 1px solid #ccc;
     }
 
     .request-buttons {
       margin-top: 5px;
       margin-bottom: 5px;
       height: 35px;
-    }
-
-    select {
-      width: 400px;
-    }
-
-    pre.prettyprint {
-      margin-top: 0px;
-      margin-bottom: 0px;
-
-      font-family: monospace;
-      font-size: inherit;
-      white-space: pre;
-      line-height: 110%;
-
-      -webkit-border-radius: 0px;
-      -moz-border-radius: 0px;
-      border-radius: 0px;
     }
 
     .endpoint-title {

--- a/templates/api/v2/api_explorer.haml
+++ b/templates/api/v2/api_explorer.haml
@@ -64,7 +64,7 @@
 
       .request-form.form-horizontal
         .request-header
-          <b>{{ endpoint.method }}</b> {{brand.api_link}}{{ endpoint.url }}.json<br/>
+          <b>{{ endpoint.method }}</b> {{brand.api_link}}{{ endpoint.url }}.json<span class="query-display"></span><br/>
           <b>Authorization:</b> Token {{ request.user.api_token }}
 
         -if endpoint.params
@@ -85,18 +85,19 @@
                 %textarea{ id:"request-body-{{ endpoint.slug }}", rows:"5" }<
                   {{ endpoint.example.body }}
 
-        .request-buttons
+      .request-buttons
+        .pull-left
           %a{ href: '{{ endpoint.url }}' }
             -trans "View Full Documentation"
 
-          -if user.api_token
-            %a.btn.btn-primary.pull-right{ onclick:'javascript:send("{{ endpoint.slug }}", "{{ endpoint.method }}", "{{ endpoint.url }}.json")' }= endpoint.method|upper
-          -else
-            %span.pull-right Log in to use the Explorer
+        -if user.api_token
+          %a.btn.btn-primary.pull-right{ onclick:'javascript:onRequest("{{ endpoint.slug }}", "{{ endpoint.method }}", "{{ endpoint.url }}.json")' }= endpoint.method|upper
+        -else
+          %span.pull-right Log in to use the Explorer
 
-        .clearfix
+      .clearfix
 
-        %pre.prettyprint.result{ id: "result-{{ endpoint.slug }}" }
+      %pre.prettyprint.result{ id: "result-{{ endpoint.slug }}" }
 
 -block extra-script
   {{ block.super }}
@@ -104,49 +105,78 @@
   <script src="{{ STATIC_URL }}rest_framework/js/prettify-min.js"></script>
   :javascript
     var codeMirrors = {};
-    $(function(){
-        // setup syntax highlighting on all textareas used to edit JSON
-        var textareas = $(".request-body textarea");
+    $(function() {
+        // setup syntax highlighting on all request form textareas
+        var textareas = $(".request-form textarea");
         for (var i = 0; i < textareas.length; i++) {
-          codeMirrors[textareas[i].id] = CodeMirror.fromTextArea(textareas[i], { mode: "application/json", "lineNumbers": false });
+          var textarea = textareas[i]
+          var editor = CodeMirror.fromTextArea(textarea, { mode: "application/json", "lineNumbers": false });
+
+          // configure change event for query editors to update endpoint URL
+          if (textarea.id.startsWith('request-query-')) {
+            editor.on('change', function(instance) {
+              onQueryChange(instance);
+            });
+          }
+
+          codeMirrors[textareas[i].id] = editor
         }
 
         $(".endpoint-title").click(function(){
           $(this).next(".endpoint").toggle();
           var slug = $(this).attr("data-slug");
           var method = $(this).attr("data-method");
-          // refresh(codeMirrors["request-" + slug], method);
+          var queryEditor = codeMirrors["request-query-" + slug];
+          var bodyEditor = codeMirrors["request-body-" + slug];
+
+          if (queryEditor) {
+            refreshEditor(queryEditor);
+          }
+          if (bodyEditor) {
+            refreshEditor(bodyEditor);
+          }
         });
     });
 
-    function refresh(editor, method){
-        editor.refresh();
+    /**
+     * Called when a query string editor's value has been changed
+     */
+    function onQueryChange(editor) {
+      query = ensureQueryPrefix(editor.getValue());
 
-        if (method == 'POST'){
-          var totalLines = editor.lineCount();
-          var totalChars = editor.getTextArea().value.length;
-          editor.autoFormatRange({line:0, ch:0}, {line:totalLines, ch:totalChars});
-          editor.setCursor(0);
-        }
+      $(editor.getTextArea()).parents('.request-form').find('.query-display').text(query)
     }
 
-    function send(slug, method, url){
-      var query = $('#request-query-' + slug).val();
-      var body = codeMirrors['request-body-' + slug].getValue();
+    function refreshEditor(editor) {
+      editor.refresh();
 
-      if (query) {
-        if (!query.startsWith('?')) {
-          query = '?' + query;
-        }
-        url += query;
+      var totalLines = editor.lineCount();
+      var totalChars = editor.getTextArea().value.length;
+      editor.autoFormatRange({line:0, ch:0}, {line:totalLines, ch:totalChars});
+      editor.setCursor(0);
+    }
+
+    function ensureQueryPrefix(query) {
+      if (query && !query.startsWith('?')) {
+        return '?' + query;
+      } else {
+        return query
       }
+    }
+
+    function onRequest(slug, method, url){
+      var queryEditor = codeMirrors["request-query-" + slug];
+      var bodyEditor = codeMirrors["request-body-" + slug];
+
+      var query = queryEditor ? ensureQueryPrefix(queryEditor.getValue()) : null;
+      var body = bodyEditor ? bodyEditor.getValue() : null;
 
       $("#result-" + slug).text("Requesting...");
 
       $.ajax({
         type: method,
         url: url,
-        data: data,
+        data: body,
         headers: {
           Accept : "application/json; charset=utf-8; indent=4;",
           "Content-Type": "application/json; charset=utf-8; indent=4;"
@@ -174,22 +204,28 @@
   <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}rest_framework/css/prettify.css"/>
   :css
     .request-form {
-      background-color: #EEE;
+      background-color: #f7f7f9;
+      border: 1px solid #e1e1e8;
+      padding: 7px;
     }
+
     .request-header {
       font-family: monospace;
-      line-height: 110%;
+      padding-bottom: 10px;
+    }
+
+    .request-form .CodeMirror {
+      background-color: white;
+      border: 1px solid #e1e1e8;
     }
 
     .request-query .CodeMirror {
       height: 30px;
-      border: 1px solid #ccc;
+      margin-bottom: 7px;
     }
 
     .request-body .CodeMirror {
-      background-color: white;
       height: 110px;
-      border: 1px solid #ccc;
     }
 
     .request-buttons {
@@ -260,6 +296,7 @@
 
     .result {
       display: none;
+      border-radius: 0;
     }
 
     .endpoint {

--- a/templates/api/v2/api_explorer.haml
+++ b/templates/api/v2/api_explorer.haml
@@ -1,8 +1,7 @@
-{% extends "frame.html" %}
-{% load smartmin %}
+- extends "frame.html"
+- load smartmin i18n
 
-{% block page-top %}
-{% endblock %}
+- block page-top
 
 -block page-title
   {{ brand.name }} - API Explorer
@@ -36,22 +35,32 @@
       %span.endpoint-url {{ endpoint.url }}.json
 
     .endpoint{ class: "endpoint-{{ endpoint.method|lower }}" }
-      .field-title
-        -if endpoint.method == 'GET' or endpoint.method == 'DELETE'
-          Query Parameters
-        -else
-          Post Body
-
-      %table.table
-        .tbody
-          -for field in endpoint.fields
-            %tr
-              %td.field{ class:"{% if field.required %}field-required{% endif %}" }= field.name
-              %td {{ field.help }}
-                -if field.required
-                  (required)
-                -else
-                  (optional)
+      -if endpoint.params
+        .field-title
+          -trans "Query Parameters"
+        %table.table
+          .tbody
+            -for item in endpoint.params
+              %tr
+                %td.field{ class:"{% if item.required %}field-required{% endif %}" }= item.name
+                %td {{ item.help }}
+                  -if item.required
+                    (required)
+                  -else
+                    (optional)
+      -if endpoint.fields
+        .field-title
+          -trans "Post Body"
+        %table.table
+          .tbody
+            -for item in endpoint.fields
+              %tr
+                %td.field{ class:"{% if item.required %}field-required{% endif %}" }= item.name
+                %td {{ item.help }}
+                  -if item.required
+                    (required)
+                  -else
+                    (optional)
 
       %pre.prettyprint<
         :plain


### PR DESCRIPTION
## Summary

- Changes POSTs to use params in the URL to identity existing objects to update
- Updates API explorer to support submission of both query params and post bodies (see screenshots below)
- Ensures all URNs are normalized before use
- Makes response status codes consistent - 200=Updated, 201=Created, 404=Object not found
- Makes endpoint documentation more consistent

##  UI Changes
API explorer, before:
<img width="955" alt="screen shot 2016-09-26 at 12 51 23" src="https://cloud.githubusercontent.com/assets/675558/18832065/9abcc3c6-83e9-11e6-8730-131a1c786d9b.png">

After:
<img width="953" alt="screen shot 2016-09-26 at 12 51 10" src="https://cloud.githubusercontent.com/assets/675558/18832069/a0588af4-83e9-11e6-8cc3-4593bb5bfe14.png">

Note that when you edit the query string text, the URL above it is automatically updated