### PR TITLE
API v2: Add label_name field to msg bulk action endpoint 

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -2175,6 +2175,18 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(set(new_label.get_messages()), {msg1, msg2, msg3})
 
+        # can also remove by label_name
+        response = self.postJSON(url, None, {'messages': [msg3.id], 'action': 'unlabel', 'label_name': "New"})
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(set(new_label.get_messages()), {msg1, msg2})
+
+        # and no error if label doesn't exist
+        response = self.postJSON(url, None, {'messages': [msg3.id], 'action': 'unlabel', 'label_name': "XYZ"})
+        self.assertEqual(response.status_code, 204)
+
+        # and label not lazy created in this case
+        self.assertIsNone(Label.all_objects.filter(name="XYZ").first())
+
         # try to use invalid label name
         response = self.postJSON(url, None, {'messages': [msg1.id, msg2.id], 'action': 'label', 'label_name': "$$$"})
         self.assertResponseError(response, 'label_name', "Name contains illegal characters.")

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -871,13 +871,17 @@ class MsgBulkActionSerializer(WriteSerializer):
         label = self.validated_data.get('label')
         label_name = self.validated_data.get('label_name')
 
-        if label_name:
-            label = Label.get_or_create(self.context['org'], self.context['user'], label_name)
-
         if action == self.LABEL:
+            if not label:
+                label = Label.get_or_create(self.context['org'], self.context['user'], label_name)
+
             label.toggle_label(messages, add=True)
         elif action == self.UNLABEL:
-            label.toggle_label(messages, add=False)
+            if not label:
+                label = Label.label_objects.filter(org=self.context['org'], is_active=True, name=label_name).first()
+
+            if label:
+                label.toggle_label(messages, add=False)
         else:
             for msg in messages:
                 if action == self.ARCHIVE:

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 import json
 import six
 
-from django.forms import ValidationError
 from rest_framework import serializers
 from temba.api.models import Resthook, ResthookSubscriber, WebHookEvent
 from temba.campaigns.models import Campaign, CampaignEvent
@@ -549,6 +548,7 @@ class ContactBulkActionSerializer(WriteSerializer):
     DELETE = 'delete'
 
     ACTIONS = (ADD, REMOVE, BLOCK, UNBLOCK, EXPIRE, ARCHIVE, DELETE)
+    ACTIONS_WITH_GROUP = (ADD, REMOVE)
 
     contacts = fields.ContactField(many=True)
     action = serializers.ChoiceField(required=True, choices=ACTIONS)
@@ -559,9 +559,9 @@ class ContactBulkActionSerializer(WriteSerializer):
         action = data['action']
         group = data.get('group')
 
-        if action in (self.ADD, self.REMOVE) and not group:
+        if action in self.ACTIONS_WITH_GROUP and not group:
             raise serializers.ValidationError("For action \"%s\" you should also specify a group" % action)
-        elif action in (self.BLOCK, self.UNBLOCK, self.EXPIRE, self.ARCHIVE, self.DELETE) and group:
+        elif action not in self.ACTIONS_WITH_GROUP and group:
             raise serializers.ValidationError("For action \"%s\" you should not specify a group" % action)
 
         if action == self.ADD:
@@ -719,7 +719,7 @@ class FlowStartWriteSerializer(WriteSerializer):
         # need at least one of urns, groups or contacts
         args = data.get('groups', []) + data.get('contacts', []) + data.get('urns', [])
         if not args:
-            raise ValidationError("Must specify at least one group, contact or URN")
+            raise serializers.ValidationError("Must specify at least one group, contact or URN")
 
         return data
 
@@ -831,10 +831,12 @@ class MsgBulkActionSerializer(WriteSerializer):
     DELETE = 'delete'
 
     ACTIONS = (LABEL, UNLABEL, ARCHIVE, RESTORE, DELETE)
+    ACTIONS_WITH_LABEL = (LABEL, UNLABEL)
 
     messages = fields.MessageField(many=True)
     action = serializers.ChoiceField(required=True, choices=ACTIONS)
     label = fields.LabelField(required=False)
+    label_name = serializers.CharField(required=False, max_length=Label.MAX_NAME_LEN)
 
     def validate_messages(self, value):
         for msg in value:
@@ -843,13 +845,22 @@ class MsgBulkActionSerializer(WriteSerializer):
 
         return value
 
+    def validate_label_name(self, value):
+        if not Label.is_valid_name(value):
+            raise serializers.ValidationError("Name contains illegal characters.")
+        return value
+
     def validate(self, data):
         action = data['action']
         label = data.get('label')
+        label_name = data.get('label_name')
 
-        if action in (self.LABEL, self.UNLABEL) and not label:
+        if label and label_name:
+            raise serializers.ValidationError("Can't specify both label and label_name.")
+
+        if action in self.ACTIONS_WITH_LABEL and not (label or label_name):
             raise serializers.ValidationError("For action \"%s\" you should also specify a label" % action)
-        elif action in (self.ARCHIVE, self.RESTORE, self.DELETE) and label:
+        elif action not in self.ACTIONS_WITH_LABEL and (label or label_name):
             raise serializers.ValidationError("For action \"%s\" you should not specify a label" % action)
 
         return data
@@ -858,6 +869,10 @@ class MsgBulkActionSerializer(WriteSerializer):
         messages = self.validated_data['messages']
         action = self.validated_data['action']
         label = self.validated_data.get('label')
+        label_name = self.validated_data.get('label_name')
+
+        if label_name:
+            label = Label.get_or_create(self.context['org'], self.context['user'], label_name)
 
         if action == self.LABEL:
             label.toggle_label(messages, add=True)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2222,7 +2222,11 @@ class MessageActionsEndpoint(BulkWriteAPIMixin, BaseAPIView):
         * _restore_ - Restore the messages if they are archived
         * _delete_ - Permanently delete the messages
 
-    * **label** - the UUID or name of a label (string, optional)
+    * **label** - the UUID or name of an existing label (string, optional)
+    * **label_name** - the name of a label which will be created if it doesn't exist (string, optional)
+
+    The difference between `label` and `label_name` is that the former will give an error if the label doesn't exist,
+    but the latter will create the label if it doesn't exist.
 
     Example:
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2223,10 +2223,11 @@ class MessageActionsEndpoint(BulkWriteAPIMixin, BaseAPIView):
         * _delete_ - Permanently delete the messages
 
     * **label** - the UUID or name of an existing label (string, optional)
-    * **label_name** - the name of a label which will be created if it doesn't exist (string, optional)
+    * **label_name** - the name of a label which can be created if it doesn't exist (string, optional)
 
-    The difference between `label` and `label_name` is that the former will give an error if the label doesn't exist,
-    but the latter will create the label if it doesn't exist.
+    If labelling or unlabelling messages using `label` you will get an error response (400) if the label doesn't exist.
+    If labelling with `label_name` the label will be created if it doesn't exist, and if unlabelling it is ignored if
+    it doesn't exist.
 
     Example:
 


### PR DESCRIPTION
to allow lazy creation of labels by name, e.g.

```
POST /api/v2/message_actions.json
{
    "messages": [1234, 2345, 3456],
    "action": "label",
    "label_name": "Testing"
}
```

will create label called _Testing_ if it doesn't exist. However labels aren't created if you are unlabelling, e.g.

```
POST /api/v2/message_actions.json
{
    "messages": [1234, 2345, 3456],
    "action": "unlabel",
    "label_name": "No-such-label"
}
```

won't throw an error but also won't create the label.