### PR TITLE
Long message wrapping

### DIFF
--- a/static/less/style.less
+++ b/static/less/style.less
@@ -2669,3 +2669,10 @@ span.label a {
   display:none;
 }
 
+.wrapped {
+  /* forces wrapping of messages with no spaces, see http://stackoverflow.com/questions/26292408/ */
+  max-width: 0;
+  word-wrap: break-word;  /* IE 10 */
+  overflow-wrap: break-word;
+}
+

--- a/templates/contacts/contact_history.haml
+++ b/templates/contacts/contact_history.haml
@@ -40,7 +40,7 @@
             -else
               {{item|activity_icon}}
 
-      %td.details
+      %td.details.wrapped
         -if item.event_type
           -with item as call
             -if call.event_type == 'mt_miss'

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -316,9 +316,6 @@
           .details {
             border: 0px solid;
             padding: 14px;
-            max-width: 0;
-            word-wrap: break-word; /* IE 10 */
-            overflow-wrap: break-word;
 
             .activity-message {
 

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -316,6 +316,9 @@
 
                 .text {
                   display: inline-block;
+                  max-width: 800px;
+                  word-wrap: break-word;
+                  overflow-wrap: break-word;
                 }
 
                 .channel {

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -72,6 +72,13 @@
 
 -block content
 
+  // Needed for table wrapping on IE 9
+  <!--[if IE]>
+  <style>
+    table.activity { table-layout: fixed; }
+  </style>
+  <![endif]-->
+
   -if contact_fields
     .contact-fields{class:'{% if fields %}clickable{%endif%}'}
       -for field in contact_fields
@@ -309,17 +316,13 @@
           .details {
             border: 0px solid;
             padding: 14px;
+            max-width: 0;
+            word-wrap: break-word; /* IE 10 */
+            overflow-wrap: break-word;
 
             .activity-message {
 
               .activity-body {
-
-                .text {
-                  display: inline-block;
-                  max-width: 800px;
-                  word-wrap: break-word;
-                  overflow-wrap: break-word;
-                }
 
                 .channel {
                   display:inline-block;

--- a/templates/msgs/message_box.haml
+++ b/templates/msgs/message_box.haml
@@ -305,3 +305,14 @@
       modal.show();
     });
     {% endif %}
+
+
+-block extra-style
+  {{ block.super }}
+  :css
+    .field_text {
+      /* forces wrapping of messages with no spaces */
+      max-width: 600px;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+    }

--- a/templates/msgs/message_box.haml
+++ b/templates/msgs/message_box.haml
@@ -20,6 +20,13 @@
 
 -block content
 
+  // Needed for table wrapping on IE 9
+  <!--[if IE]>
+  <style>
+    table.sms_list { table-layout: fixed; }
+  </style>
+  <![endif]-->
+
   #numeric-form.hide
     %form
       %label
@@ -312,7 +319,7 @@
   :css
     .field_text {
       /* forces wrapping of messages with no spaces */
-      max-width: 600px;
-      word-wrap: break-word;
+      max-width: 0;
+      word-wrap: break-word;  /* IE 10 */
       overflow-wrap: break-word;
     }

--- a/templates/msgs/message_box.haml
+++ b/templates/msgs/message_box.haml
@@ -177,7 +177,7 @@
                       %td.value-phone.field_phone
                         %nobr
                           {{ object.contact|short_name:user_org }}
-                      %td.value-text.field_text
+                      %td.value-text.field_text.wrapped
                         {% get_value object 'text' %}
                         - if 'label' in actions
                           .value-labels
@@ -312,14 +312,3 @@
       modal.show();
     });
     {% endif %}
-
-
--block extra-style
-  {{ block.super }}
-  :css
-    .field_text {
-      /* forces wrapping of messages with no spaces */
-      max-width: 0;
-      word-wrap: break-word;  /* IE 10 */
-      overflow-wrap: break-word;
-    }


### PR DESCRIPTION
Addresses https://github.com/rapidpro/rapidpro/issues/308 which affects inbox views and contact history view.

Before:
<img width="1412" alt="screen shot 2016-10-04 at 12 07 46" src="https://cloud.githubusercontent.com/assets/675558/19071867/85188c86-8a32-11e6-80bc-bb5b86d935fa.png">

<img width="1300" alt="screen shot 2016-10-04 at 13 07 43" src="https://cloud.githubusercontent.com/assets/675558/19072086/962ef84c-8a33-11e6-99fe-3949ceece312.png">

After:
<img width="1188" alt="screen shot 2016-10-04 at 12 06 33" src="https://cloud.githubusercontent.com/assets/675558/19071871/8dab462c-8a32-11e6-98bf-0e8ef58e66ed.png">

<img width="962" alt="screen shot 2016-10-04 at 12 56 07" src="https://cloud.githubusercontent.com/assets/675558/19072033/54515a96-8a33-11e6-96dd-4ee096961379.png">

Difficulty is that the CSS wrapping properties only seem to take affect if the container has a fixed size - so I've added max-width settings. That becomes noticeable on history view if page is really wide:

<img width="1190" alt="screen shot 2016-10-04 at 12 56 22" src="https://cloud.githubusercontent.com/assets/675558/19072136/d7ae7c52-8a33-11e6-8a24-3a7429c1490c.png">



