### PR TITLE
API v2: limit number of posted contact fields and document limits

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -1147,7 +1147,11 @@ class APITest(TembaTest):
 
         # try to give a contact more than 100 URNs
         response = self.postJSON(url, 'uuid=%s' % jean.uuid, {'urns': ['twitter:bob%d' % u for u in range(101)]})
-        self.assertResponseError(response, 'urns', "Exceeds maximum list size of 100")
+        self.assertResponseError(response, 'urns', "This field can only contain up to 100 items.")
+
+        # try to give a contact more than 100 contact fields
+        response = self.postJSON(url, 'uuid=%s' % jean.uuid, {'fields': {'field_%d' % f: f for f in range(101)}})
+        self.assertResponseError(response, 'fields', "This field can only contain up to 100 items.")
 
         # ok to give them 100 URNs
         response = self.postJSON(url, 'uuid=%s' % jean.uuid, {'urns': ['twitter:bob%d' % u for u in range(100)]})
@@ -1237,7 +1241,7 @@ class APITest(TembaTest):
 
         # try adding more contacts to group than this endpoint is allowed to operate on at one time
         response = self.postJSON(url, None, {'contacts': [unicode(x) for x in range(101)], 'action': 'add', 'group': "Testers"})
-        self.assertResponseError(response, 'contacts', "Exceeds maximum list size of 100")
+        self.assertResponseError(response, 'contacts', "This field can only contain up to 100 items.")
 
         # try adding all contacts to a group by its name
         response = self.postJSON(url, None, {
@@ -2490,7 +2494,7 @@ class APITest(TembaTest):
             group_uuids.append(self.create_group("Group %d" % g).uuid)
 
         response = self.postJSON(url, None, dict(flow=flow.uuid, restart_participants=True, groups=group_uuids))
-        self.assertResponseError(response, 'groups', "Exceeds maximum list size of 100")
+        self.assertResponseError(response, 'groups', "This field can only contain up to 100 items.")
 
         # check our list
         anon_contact = Contact.objects.get(urns__path="+12067791212")

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -369,7 +369,7 @@ class ContactWriteSerializer(WriteSerializer):
     language = serializers.CharField(required=False, min_length=3, max_length=3, allow_null=True)
     urns = fields.URNListField(required=False)
     groups = fields.ContactGroupField(many=True, required=False, allow_dynamic=False)
-    fields = serializers.DictField(required=False)
+    fields = fields.LimitedDictField(required=False)
 
     def __init__(self, *args, **kwargs):
         super(ContactWriteSerializer, self).__init__(*args, **kwargs)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -69,7 +69,8 @@ def api(request, format=None):
      * [/api/v2/resthook_events](/api/v2/resthook_events) - to list resthook events
      * [/api/v2/resthook_subscribers](/api/v2/resthook_subscribers) - to list, create or delete subscribers on your resthooks
 
-    You may wish to use the [API Explorer](/api/v2/explorer) to interactively experiment with the API.
+    You may wish to use the [API Explorer](/api/v2/explorer) to interactively experiment with the API. There is also an
+    official [Python client library](https://github.com/rapidpro/rapidpro-python) for the API.
     """
     return Response({
         'boundaries': reverse('api.v2.boundaries', request=request),

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -533,9 +533,9 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
     A `POST` allows you to create and send new broadcasts, with the following JSON data:
 
       * **text** - the text of the message to send (string, limited to 480 characters)
-      * **urns** - the URNs of contacts to send to (array of strings, optional)
-      * **contacts** - the UUIDs of contacts to send to (array of strings, optional)
-      * **groups** - the UUIDs of contact groups to send to (array of strings, optional)
+      * **urns** - the URNs of contacts to send to (array of up to 100 strings, optional)
+      * **contacts** - the UUIDs of contacts to send to (array of up to 100 strings, optional)
+      * **groups** - the UUIDs of contact groups to send to (array of up to 100 strings, optional)
       * **channel** - the UUID of the channel to use. Contacts which can't be reached with this channel are ignored (string, optional)
 
     Example:
@@ -1150,9 +1150,9 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
 
     * **name** - the full name of the contact (string, optional)
     * **language** - the preferred language for the contact (3 letter iso code, optional)
-    * **urns** - a list of URNs you want associated with the contact (string array)
-    * **groups** - a list of the UUIDs of any groups this contact is part of (string array, optional)
-    * **fields** - the contact fields you want to set or update on this contact (dictionary, optional)
+    * **urns** - a list of URNs you want associated with the contact (array of up to 100 strings, optional)
+    * **groups** - a list of the UUIDs of any groups this contact is part of (array of up to 100 strings, optional)
+    * **fields** - the contact fields you want to set or update on this contact (dictionary of up to 100 items, optional)
 
     Example:
 
@@ -1348,7 +1348,7 @@ class ContactActionsEndpoint(BulkWriteAPIMixin, BaseAPIView):
 
     A **POST** can be used to perform an action on a set of contacts in bulk.
 
-    * **contacts** - a JSON array of up to 100 contact UUIDs or URNs (array of strings)
+    * **contacts** - the contact UUIDs or URNs (array of up to 100 strings)
     * **action** - the action to perform, a string one of:
 
         * _add_ - Add the contacts to the given group
@@ -2229,7 +2229,7 @@ class MessageActionsEndpoint(BulkWriteAPIMixin, BaseAPIView):
 
     A **POST** can be used to perform an action on a set of messages in bulk.
 
-    * **messages** - a JSON array of up to 100 message ids (array of ints)
+    * **messages** - the message ids (array of up to 100 integers)
     * **action** - the action to perform, a string one of:
 
         * _label_ - Apply the given label to the messages
@@ -2800,9 +2800,9 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
     runs created by this start.
 
      * **flow** - the UUID of the flow to start contacts in (required)
-     * **groups** - a list of the UUIDs of the groups you want to start in this flow (optional)
-     * **contacts** - a list of the UUIDs of the contacts you want to start in this flow (optional)
-     * **urns** - a list of URNs you want to start in this flow (optional)
+     * **groups** - the UUIDs of the groups you want to start in this flow (array of up to 100 strings, optional)
+     * **contacts** - the UUIDs of the contacts you want to start in this flow (array of up to 100 strings, optional)
+     * **urns** - the URNs you want to start in this flow (array of up to 100 strings, optional)
      * **restart_participants** - whether to restart participants already in this flow (optional, defaults to true)
      * **extra** - a dictionary of extra parameters to pass to the flow start (accessible via @extra in your flow)
 


### PR DESCRIPTION
We currently limit the size of all posted lists in the API - e.g. you can't create a contact that belongs to more than 100 groups or you can't start a flow with more than 100 urns..

This adds a check for the size of field dict for created contacts, and also ensures all the limits are documented on the endpoint HTML page.

For now all the limits are 100 but we can easily modify these per field.