### PR TITLE
Django 1.9: Templates

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -105,8 +105,8 @@ SECRET_KEY = 'your own secret key'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'hamlpy.template.loaders.HamlPyFilesystemLoader',
-    'hamlpy.template.loaders.HamlPyAppDirectoriesLoader',
+    'temba.utils.haml.HamlFilesystemLoader',
+    'temba.utils.haml.HamlAppDirectoriesLoader',
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
     'django.template.loaders.eggs.Loader',

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -13,7 +13,6 @@ from django.utils.translation import ugettext_lazy as _
 # Default to debugging
 # -----------------------------------------------------------------------------------
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 # -----------------------------------------------------------------------------------
 # Sets TESTING to True if this configuration is read during a unit test
@@ -23,7 +22,6 @@ TESTING = sys.argv[1:2] == ['test']
 if TESTING:
     PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
     DEBUG = False
-    TEMPLATE_DEBUG = False
 
 ADMINS = (
     ('RapidPro', 'code@yourdomain.io'),
@@ -103,36 +101,63 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'your own secret key'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'temba.utils.haml.HamlFilesystemLoader',
-    'temba.utils.haml.HamlAppDirectoriesLoader',
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    'django.template.loaders.eggs.Loader',
-)
-
 EMAIL_CONTEXT_PROCESSORS = ('temba.utils.email.link_components',)
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.contrib.messages.context_processors.messages',
-    'django.core.context_processors.request',
-    'temba.context_processors.branding',
-    'temba.orgs.context_processors.user_group_perms_processor',
-    'temba.orgs.context_processors.unread_count_processor',
-    'temba.channels.views.channel_status_processor',
-    'temba.msgs.views.send_message_auto_complete_processor',
-    'temba.api.views.webhook_status_processor',
-    'temba.orgs.context_processors.settings_includer',
-)
+
+# -----------------------------------------------------------------------------------
+# Directory Configuration
+# -----------------------------------------------------------------------------------
+PROJECT_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)))
+LOCALE_PATHS = (os.path.join(PROJECT_DIR, '../locale'),)
+RESOURCES_DIR = os.path.join(PROJECT_DIR, '../resources')
+FIXTURE_DIRS = (os.path.join(PROJECT_DIR, '../fixtures'),)
+TESTFILES_DIR = os.path.join(PROJECT_DIR, '../testfiles')
+STATICFILES_DIRS = (os.path.join(PROJECT_DIR, '../static'), os.path.join(PROJECT_DIR, '../media'), )
+STATIC_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
+STATIC_URL = '/static/'
+COMPRESS_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
+MEDIA_ROOT = os.path.join(PROJECT_DIR, '../media')
+MEDIA_URL = "/media/"
+
+
+# -----------------------------------------------------------------------------------
+# Templates Configuration
+# -----------------------------------------------------------------------------------
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(PROJECT_DIR, '../templates')],
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.core.context_processors.debug',
+                'django.core.context_processors.i18n',
+                'django.core.context_processors.media',
+                'django.core.context_processors.static',
+                'django.contrib.messages.context_processors.messages',
+                'django.core.context_processors.request',
+                'temba.context_processors.branding',
+                'temba.orgs.context_processors.user_group_perms_processor',
+                'temba.orgs.context_processors.unread_count_processor',
+                'temba.channels.views.channel_status_processor',
+                'temba.msgs.views.send_message_auto_complete_processor',
+                'temba.api.views.webhook_status_processor',
+                'temba.orgs.context_processors.settings_includer',
+            ],
+            'loaders': [
+                'temba.utils.haml.HamlFilesystemLoader',
+                'temba.utils.haml.HamlAppDirectoriesLoader',
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+                'django.template.loaders.eggs.Loader'
+            ],
+            'debug': False if TESTING else DEBUG
+        },
+    },
+]
 
 if TESTING:
-    TEMPLATE_CONTEXT_PROCESSORS += ('temba.tests.add_testing_flag_to_context', )
+    TEMPLATES[0]['OPTIONS']['context_processors'] += ('temba.tests.add_testing_flag_to_context', )
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -285,22 +310,6 @@ BRANDING = {
     }
 }
 DEFAULT_BRAND = 'rapidpro.io'
-
-# -----------------------------------------------------------------------------------
-# Directory Configuration
-# -----------------------------------------------------------------------------------
-PROJECT_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)))
-LOCALE_PATHS = (os.path.join(PROJECT_DIR, '../locale'),)
-RESOURCES_DIR = os.path.join(PROJECT_DIR, '../resources')
-FIXTURE_DIRS = (os.path.join(PROJECT_DIR, '../fixtures'),)
-TESTFILES_DIR = os.path.join(PROJECT_DIR, '../testfiles')
-TEMPLATE_DIRS = (os.path.join(PROJECT_DIR, '../templates'),)
-STATICFILES_DIRS = (os.path.join(PROJECT_DIR, '../static'), os.path.join(PROJECT_DIR, '../media'), )
-STATIC_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
-STATIC_URL = '/static/'
-COMPRESS_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
-MEDIA_ROOT = os.path.join(PROJECT_DIR, '../media')
-MEDIA_URL = "/media/"
 
 # -----------------------------------------------------------------------------------
 # Permission Management

--- a/temba/utils/haml.py
+++ b/temba/utils/haml.py
@@ -1,0 +1,86 @@
+from __future__ import unicode_literals
+
+"""
+Our dashboards typically use HamlPy (https://github.com/jessemiller/HamlPy) for templates, but we need our own custom
+template loaders for two reasons:
+
+  1. That library is not being actively maintained and the included loaders are not compatible with Django 1.9
+  2. We allow templates to be overridden even when the extension doesn't match, i.e. a template called index.haml can
+     override index.html in Smartmin
+
+"""
+
+import os
+
+from django.template import TemplateDoesNotExist
+from django.template.base import Origin
+from django.template.loaders import filesystem, app_directories
+
+from hamlpy import hamlpy
+from hamlpy.template.utils import get_django_template_loaders
+
+
+def get_haml_loader(loader):
+    if hasattr(loader, 'Loader'):
+        baseclass = loader.Loader
+    else:
+        class baseclass(object):
+            def load_template_source(self, *args, **kwargs):
+                return loader.load_template_source(*args, **kwargs)
+
+    class Loader(baseclass):
+        def load_template_source(self, template_name, *args, **kwargs):
+            """
+            Used by Django 1.7, 1.8
+            """
+            _name, _extension = os.path.splitext(template_name)
+
+            for extension in hamlpy.VALID_EXTENSIONS:
+                try:
+                    haml_source, template_path = super(Loader, self).load_template_source(
+                        self._generate_template_name(_name, extension), *args, **kwargs
+                    )
+                except TemplateDoesNotExist:
+                    pass
+                else:
+                    haml_parser = hamlpy.Compiler()
+                    html = haml_parser.process(haml_source)
+
+                    return html, template_path
+
+            raise TemplateDoesNotExist(template_name)
+
+        load_template_source.is_usable = True
+
+        def get_contents(self, origin):
+            """
+            Used by Django 1.9+
+            """
+            name, _extension = os.path.splitext(origin.name)
+            template_name, _extension = os.path.splitext(origin.template_name)
+
+            for extension in hamlpy.VALID_EXTENSIONS:
+                try_name = self._generate_template_name(name, extension)
+                try_template_name = self._generate_template_name(template_name, extension)
+                try_origin = Origin(try_name, try_template_name, origin.loader)
+                try:
+                    haml_source = super(Loader, self).get_contents(try_origin)
+                except TemplateDoesNotExist:
+                    pass
+                else:
+                    haml_parser = hamlpy.Compiler()
+                    return haml_parser.process(haml_source)
+
+            raise TemplateDoesNotExist(origin.template_name)
+
+        def _generate_template_name(self, name, extension="hamlpy"):
+            return "%s.%s" % (name, extension)
+
+    return Loader
+
+
+haml_loaders = dict((name, get_haml_loader(loader)) for (name, loader) in get_django_template_loaders())
+
+
+HamlFilesystemLoader = get_haml_loader(filesystem)
+HamlAppDirectoriesLoader = get_haml_loader(app_directories)


### PR DESCRIPTION
* Adds custom HAML template loader currently in Dash and used by CasePro
* Switches to new TEMPLATES setting required by Django 1.10

Requires https://github.com/nyaruka/textit/pull/47