### PR TITLE
Fix initial status not changing to pending for child flows

### DIFF
--- a/media/test_flows/split_first_child_msg.json
+++ b/media/test_flows/split_first_child_msg.json
@@ -1,0 +1,161 @@
+{
+  "campaigns": [], 
+  "version": 10, 
+  "site": "https://textit.staging.nyaruka.com", 
+  "flows": [
+    {
+      "base_language": "base", 
+      "action_sets": [
+        {
+          "y": 165, 
+          "x": 102, 
+          "destination": null, 
+          "uuid": "f0cf6595-780c-4f67-bf56-959e8e015db1", 
+          "actions": [
+            {
+              "type": "flow", 
+              "flow": {
+                "name": "Child Msg Flow", 
+                "uuid": "e5e1f237-925e-4597-91bb-7852970104fe"
+              }
+            }
+          ]
+        }
+      ], 
+      "version": 10, 
+      "flow_type": "F", 
+      "entry": "cf81408f-f529-4e58-a8d3-7329b93dab03", 
+      "rule_sets": [
+        {
+          "uuid": "cf81408f-f529-4e58-a8d3-7329b93dab03", 
+          "rules": [
+            {
+              "test": {
+                "test": {
+                  "name": "Group Chat", 
+                  "uuid": "1587ece7-d20b-4bd0-b114-0dedf3273a03"
+                }, 
+                "type": "in_group"
+              }, 
+              "category": {
+                "base": "Group Chat"
+              }, 
+              "destination": "f0cf6595-780c-4f67-bf56-959e8e015db1", 
+              "uuid": "7944f1f7-c1fc-444b-b547-28401b39d52f", 
+              "destination_type": "A"
+            }, 
+            {
+              "test": {
+                "test": "true", 
+                "type": "true"
+              }, 
+              "category": {
+                "base": "Other"
+              }, 
+              "destination": "f0cf6595-780c-4f67-bf56-959e8e015db1", 
+              "uuid": "2c72ee86-de4c-44c7-8520-7c53bc7f87a7", 
+              "destination_type": "A"
+            }
+          ], 
+          "ruleset_type": "group", 
+          "label": "Group", 
+          "operand": "@step.value", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 0, 
+          "x": 100, 
+          "config": {}
+        }
+      ], 
+      "metadata": {
+        "expires": 10080, 
+        "saved_on": "2016-10-19T17:51:38.624883Z", 
+        "uuid": "46a2af91-5346-42e3-87d2-78412ca218fb", 
+        "name": "Parent Msg Flow", 
+        "revision": 5
+      }
+    }, 
+    {
+      "base_language": "base", 
+      "action_sets": [
+        {
+          "y": 0, 
+          "x": 100, 
+          "destination": "65c93b0d-b27d-4928-a316-d079549e1495", 
+          "uuid": "833e12f7-f789-4919-b61e-0e457b11b80a", 
+          "actions": [
+            {
+              "msg": {
+                "base": "Child Msg 1"
+              }, 
+              "type": "reply"
+            }
+          ]
+        }, 
+        {
+          "y": 329, 
+          "x": 109, 
+          "destination": null, 
+          "uuid": "3db9c9bc-a66c-478f-8fcf-56a21a9a1ed4", 
+          "actions": [
+            {
+              "msg": {
+                "base": "Child Msg 2"
+              }, 
+              "type": "reply"
+            }
+          ]
+        }
+      ], 
+      "version": 10, 
+      "flow_type": "F", 
+      "entry": "833e12f7-f789-4919-b61e-0e457b11b80a", 
+      "rule_sets": [
+        {
+          "uuid": "65c93b0d-b27d-4928-a316-d079549e1495", 
+          "rules": [
+            {
+              "test": {
+                "test": "true", 
+                "type": "true"
+              }, 
+              "category": {
+                "base": "All Responses"
+              }, 
+              "destination": "3db9c9bc-a66c-478f-8fcf-56a21a9a1ed4", 
+              "uuid": "07bc57e3-a73a-46d6-b960-c586726f1182", 
+              "destination_type": "A"
+            }
+          ], 
+          "ruleset_type": "wait_message", 
+          "label": "Response 1", 
+          "operand": "@step.value", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 171, 
+          "x": 148, 
+          "config": {}
+        }
+      ], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 7, 
+        "uuid": "e5e1f237-925e-4597-91bb-7852970104fe", 
+        "name": "Child Msg Flow", 
+        "saved_on": "2016-10-19T19:38:34.732570Z"
+      }
+    }
+  ], 
+  "triggers": [
+    {
+      "trigger_type": "K", 
+      "flow": {
+        "name": "Parent Msg Flow", 
+        "uuid": "46a2af91-5346-42e3-87d2-78412ca218fb"
+      }, 
+      "groups": [], 
+      "keyword": "split", 
+      "channel": null
+    }
+  ]
+}


### PR DESCRIPTION
Fixes case were weren't properly setting the msg status to PENDING when a child flow was immediately triggered, preventing android messages from going out.