### PR TITLE
Fix SaveToContactAction to deal with empty path

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -5392,11 +5392,16 @@ class SaveToContactAction(Action):
                         new_value = new_value[1:]
 
             # only valid urns get added, sorry
-            new_urn = URN.normalize(URN.from_parts(scheme, new_value))
-            if not URN.validate(new_urn, contact.org.get_country_code()):
-                new_urn = None
+            new_urn = None
+            if new_value:
+                new_urn = URN.normalize(URN.from_parts(scheme, new_value))
+                if not URN.validate(new_urn, contact.org.get_country_code()):
+                    new_urn = False
+                    if contact.is_test:
+                        ActionLog.warn(run, _('Contact not updated, invalid connection for contact (%s:%s)' % (scheme, new_value)))
+            else:
                 if contact.is_test:
-                    ActionLog.warn(run, _('Skipping invalid connection for contact (%s:%s)' % (scheme, new_value)))
+                    ActionLog.warn(run, _('Contact not updated, missing connection for contact'))
 
             if new_urn:
                 urns = [urn.urn for urn in contact.urns.all()]

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2822,7 +2822,7 @@ class ActionTest(TembaTest):
         ActionLog.objects.all().delete()
         action = SaveToContactAction.from_json(self.org, dict(type='save', label="mailto", value='foobar.com'))
         action.execute(run, None, None)
-        self.assertEquals(ActionLog.objects.get().text, "Skipping invalid connection for contact (mailto:foobar.com)")
+        self.assertEquals(ActionLog.objects.get().text, "Contact not updated, invalid connection for contact (mailto:foobar.com)")
 
         # URN should be unchanged on the simulator contact
         test_contact = Contact.objects.get(id=test_contact.id)
@@ -2832,6 +2832,12 @@ class ActionTest(TembaTest):
         SaveToContactAction.from_json(self.org, dict(type='save', label="[_NEW_]Ecole", value='@step'))
         field = ContactField.objects.get(org=self.org, key="ecole")
         self.assertEquals("Ecole", field.label)
+
+        # try saving some empty data into mailto
+        ActionLog.objects.all().delete()
+        action = SaveToContactAction.from_json(self.org, dict(type='save', label="mailto", value='@contact.mailto'))
+        action.execute(run, None, None)
+        self.assertEquals(ActionLog.objects.get().text, "Contact not updated, missing connection for contact")
 
     def test_set_language_action(self):
         action = SetLanguageAction('kli', 'Klingon')


### PR DESCRIPTION
Fixes rapidpro/rapidpro#369

See:
https://sentry.io/nyaruka/textit/issues/173141285/
https://sentry.io/nyaruka/textit/issues/173143616/