### PR TITLE
Disable coffeescript and less compilation during tests

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1115,6 +1115,10 @@ COMPRESS_PRECOMPILERS = (
     ('text/coffeescript', 'coffee --compile --stdio'))
 COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL, base_template='frame.html')
 
+# if only testing, disable CSS filtering which is used regardless of whether compression is enabled
+if TESTING:
+    COMPRESS_CSS_FILTERS = []
+
 COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = False
 COMPRESS_URL = '/sitestatic/'

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1110,14 +1110,15 @@ HUB9_ENDPOINT = 'http://175.103.48.29:28078/testing/smsmt.php'
 # Django Compressor configuration
 # -----------------------------------------------------------------------------------
 
-COMPRESS_PRECOMPILERS = (
-    ('text/less', 'lessc --include-path="%s" {infile} {outfile}' % os.path.join(PROJECT_DIR, '../static', 'less')),
-    ('text/coffeescript', 'coffee --compile --stdio'))
-COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL, base_template='frame.html')
-
-# if only testing, disable CSS filtering which is used regardless of whether compression is enabled
 if TESTING:
-    COMPRESS_CSS_FILTERS = []
+    # if only testing, disable coffeescript and less compilation
+    COMPRESS_PRECOMPILERS = ()
+else:
+    COMPRESS_PRECOMPILERS = (
+        ('text/less', 'lessc --include-path="%s" {infile} {outfile}' % os.path.join(PROJECT_DIR, '../static', 'less')),
+        ('text/coffeescript', 'coffee --compile --stdio')
+    )
+    COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL, base_template='frame.html')
 
 COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = False


### PR DESCRIPTION
So turns our recent test slow down (from ~30-35 mins to 45-50mins, travis time limit is 50) was due to this commit https://github.com/nyaruka/rapidpro/commit/589ec5db6b862f55980368f000aa1eb9838a3069

When we upgraded to Django-compressor 1.6 it started throwing an error message about not being able to find lessc (1.5 had been silently not compiling any less) so I added less to package.json.

This PR disables precompiling of coffeescript and less during testing which may mean we miss problems in templates, but does speed up tests considerably (~20 mins)

