### PR TITLE
fix DST bugs

### DIFF
--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -353,44 +353,47 @@ class CampaignEvent(TembaModel):
         date_value = self.campaign.org.parse_date(date_value)
         tz = self.campaign.org.timezone
 
+        # nothing to base off of, nothing to fire
+        if not date_value:
+            return None
+
+        # field is no longer active? return
+        if not self.relative_to.is_active:  # pragma: no cover
+            return None
+
         # convert to our timezone
         date_value = date_value.astimezone(tz)
 
         # if we got a date, floor to the minute
-        if date_value:
-            date_value = date_value.replace(second=0, microsecond=0)
-
-        if not self.relative_to.is_active:  # pragma: no cover
-            return None
+        date_value = date_value.replace(second=0, microsecond=0)
 
         # try to parse it to a datetime
         try:
-            if date_value:
-                if self.unit == CampaignEvent.UNIT_MINUTES:
-                    delta = timedelta(minutes=self.offset)
-                elif self.unit == CampaignEvent.UNIT_HOURS:
-                    delta = timedelta(hours=self.offset)
-                elif self.unit == CampaignEvent.UNIT_DAYS:
-                    delta = timedelta(days=self.offset)
-                elif self.unit == CampaignEvent.UNIT_WEEKS:
-                    delta = timedelta(weeks=self.offset)
+            if self.unit == CampaignEvent.UNIT_MINUTES:
+                delta = timedelta(minutes=self.offset)
+            elif self.unit == CampaignEvent.UNIT_HOURS:
+                delta = timedelta(hours=self.offset)
+            elif self.unit == CampaignEvent.UNIT_DAYS:
+                delta = timedelta(days=self.offset)
+            elif self.unit == CampaignEvent.UNIT_WEEKS:
+                delta = timedelta(weeks=self.offset)
 
-                scheduled = date_value + delta
+            scheduled = date_value + delta
 
-                # normalize according to our timezone (puts us in the right DST timezone if our date changed)
-                if str(tz) != 'UTC':
-                    scheduled = tz.normalize(scheduled)
+            # normalize according to our timezone (puts us in the right DST timezone if our date changed)
+            if str(tz) != 'UTC':
+                scheduled = tz.normalize(scheduled)
 
-                if self.delivery_hour != -1:
-                    scheduled = scheduled.replace(hour=self.delivery_hour)
+            if self.delivery_hour != -1:
+                scheduled = scheduled.replace(hour=self.delivery_hour)
 
-                # if we've changed utcoffset (DST shift), tweak accordingly (this keeps us at the same hour of the day)
-                elif str(tz) != 'UTC' and date_value.utcoffset() != scheduled.utcoffset():
-                    scheduled = tz.normalize(date_value.utcoffset() - scheduled.utcoffset() + scheduled)
+            # if we've changed utcoffset (DST shift), tweak accordingly (this keeps us at the same hour of the day)
+            elif str(tz) != 'UTC' and date_value.utcoffset() != scheduled.utcoffset():
+                scheduled = tz.normalize(date_value.utcoffset() - scheduled.utcoffset() + scheduled)
 
-                # ignore anything in the past
-                if scheduled > now:
-                    return scheduled
+            # ignore anything in the past
+            if scheduled > now:
+                return scheduled
 
         except Exception:  # pragma: no cover
             pass

--- a/temba/campaigns/tasks.py
+++ b/temba/campaigns/tasks.py
@@ -61,7 +61,6 @@ def update_event_fires_for_campaign(campaign_id):
     key = 'event_fires_campaign_%d' % campaign_id
 
     with r.lock(key, timeout=300):
-
         try:
             with transaction.atomic():
                 campaign = Campaign.objects.filter(pk=campaign_id).first()
@@ -69,6 +68,8 @@ def update_event_fires_for_campaign(campaign_id):
                     EventFire.do_update_campaign_events(campaign)
 
         except Exception as e:  # pragma: no cover
+            import traceback
+            traceback.print_exc(e)
 
             # requeue our task to try again in five minutes
             update_event_fires_for_campaign(campaign_id).delay(countdown=60 * 5)

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 import six
+import pytz
 
 from datetime import timedelta
 from django.core.urlresolvers import reverse
@@ -511,9 +512,56 @@ class CampaignTest(TembaTest):
         self.assertEquals(1, EventFire.objects.all().count())
         self.assertEquals(1, EventFire.objects.filter(contact=self.nonfarmer).count())
 
+    def test_dst_scheduling(self):
+        # set our timezone to something that honors DST
+        eastern = pytz.timezone('US/Eastern')
+        self.org.timezone = eastern
+        self.org.save()
+
+        # create our campaign and event
+        campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
+        CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
+                                        offset=2, unit='D', flow=self.reminder_flow)
+
+        # set the time to something pre-dst (fall back on November 4th at 2am to 1am)
+        self.farmer1.set_field(self.user, 'planting_date', "03-11-2029 12:30:00")
+        EventFire.update_campaign_events(campaign)
+
+        # we should be scheduled to go off on the 5th at 12:30:10 Eastern
+        fire = EventFire.objects.get()
+        self.assertEquals(5, fire.scheduled.day)
+        self.assertEquals(11, fire.scheduled.month)
+        self.assertEquals(2029, fire.scheduled.year)
+        self.assertEqual(12, fire.scheduled.astimezone(eastern).hour)
+
+        # assert our offsets are different (we crossed DST)
+        self.assertNotEqual(fire.scheduled.utcoffset(), self.farmer1.get_field('planting_date').datetime_value.utcoffset())
+
+        # the number of hours between these two events should be 49 (two days 1 hour)
+        delta = fire.scheduled - self.farmer1.get_field('planting_date').datetime_value
+        self.assertEqual(delta.days, 2)
+        self.assertEqual(delta.seconds, 3600)
+
+        # spring forward case, this will go across a DST jump forward scenario
+        self.farmer1.set_field(self.user, 'planting_date', "10-03-2029 02:30:00")
+        EventFire.update_campaign_events(campaign)
+
+        fire = EventFire.objects.get()
+        self.assertEquals(12, fire.scheduled.day)
+        self.assertEquals(3, fire.scheduled.month)
+        self.assertEquals(2029, fire.scheduled.year)
+        self.assertEqual(2, fire.scheduled.astimezone(eastern).hour)
+
+        # assert our offsets changed (we crossed DST)
+        self.assertNotEqual(fire.scheduled.utcoffset(), self.farmer1.get_field('planting_date').datetime_value.utcoffset())
+
+        # delta should be 47 hours exactly
+        delta = fire.scheduled - self.farmer1.get_field('planting_date').datetime_value
+        self.assertEqual(delta.days, 1)
+        self.assertEqual(delta.seconds, 82800)
+
     def test_scheduling(self):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
-
         self.assertEquals("Planting Reminders", unicode(campaign))
 
         # create a reminder for our first planting event

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -77,11 +77,16 @@ def str_to_datetime(date_str, tz, dayfirst=True, fill_time=True):
         return None
 
     try:
-        output_date = None
         if fill_time:
             date = parse(date_str, dayfirst=dayfirst, fuzzy=True, default=DEFAULT_DATE)
+
+            # get the local time and hour
+            default = timezone.now().astimezone(tz)
+            default = datetime.datetime(1, 1, 1, default.hour, default.minute, default.second, default.microsecond, None)
+
             if date != DEFAULT_DATE:
-                output_date = parse(date_str, dayfirst=dayfirst, fuzzy=True, default=timezone.now().astimezone(tz))
+                output_date = parse(date_str, dayfirst=dayfirst, fuzzy=True, default=default)
+                output_date = tz.localize(output_date)  # localize in timezone
             else:
                 output_date = None
         else:
@@ -92,6 +97,7 @@ def str_to_datetime(date_str, tz, dayfirst=True, fill_time=True):
             # only return date if it actually got parsed
             if output_date.year == 1:
                 output_date = None
+
     except Exception:
         output_date = None
 

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -81,9 +81,7 @@ def str_to_datetime(date_str, tz, dayfirst=True, fill_time=True):
             date = parse(date_str, dayfirst=dayfirst, fuzzy=True, default=DEFAULT_DATE)
 
             # get the local time and hour
-            default = timezone.now().astimezone(tz)
-            default = datetime.datetime(default.year, default.month, default.day,
-                                        default.hour, default.minute, default.second, default.microsecond, None)
+            default = timezone.now().astimezone(tz).replace(tzinfo=None)
 
             # we parsed successfully
             if date.tzinfo or date != DEFAULT_DATE:

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -20,7 +20,7 @@ from django.http import HttpResponse
 from django_countries import countries
 from itertools import islice
 
-DEFAULT_DATE = timezone.now().replace(day=1, month=1, year=1)
+DEFAULT_DATE = datetime.datetime(1, 1, 1, 0, 0, 0, 0, None)
 MAX_UTC_OFFSET = 14 * 60 * 60  # max offset postgres supports for a timezone
 
 
@@ -82,17 +82,27 @@ def str_to_datetime(date_str, tz, dayfirst=True, fill_time=True):
 
             # get the local time and hour
             default = timezone.now().astimezone(tz)
-            default = datetime.datetime(1, 1, 1, default.hour, default.minute, default.second, default.microsecond, None)
+            default = datetime.datetime(default.year, default.month, default.day,
+                                        default.hour, default.minute, default.second, default.microsecond, None)
 
-            if date != DEFAULT_DATE:
+            # we parsed successfully
+            if date.tzinfo or date != DEFAULT_DATE:
                 output_date = parse(date_str, dayfirst=dayfirst, fuzzy=True, default=default)
-                output_date = tz.localize(output_date)  # localize in timezone
+
+                # localize it if we don't have a timezone
+                if not output_date.tzinfo:
+                    output_date = tz.localize(output_date)
+
+                # if we aren't UTC, normalize to take care of any DST weirdnesses
+                elif output_date.tzinfo.tzname(output_date) != 'UTC':
+                    output_date = tz.normalize(output_date)
+
             else:
                 output_date = None
         else:
-            default = datetime.datetime(1, 1, 1, 0, 0, 0, 0, None)
+            default = DEFAULT_DATE
             output_date = parse(date_str, dayfirst=dayfirst, fuzzy=True, default=default)
-            output_date = tz.localize(output_date)  # localize in timezone
+            output_date = tz.localize(output_date)
 
             # only return date if it actually got parsed
             if output_date.year == 1:

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -88,14 +88,29 @@ class InitTest(TembaTest):
             self.assertEqual(tz.localize(datetime(2013, 2, 1, 0, 0, 0, 0)),
                              str_to_datetime('01-02-2013', tz, dayfirst=True, fill_time=False))  # no time filling
 
+            # just year
+            self.assertEqual(datetime(123, 1, 2, 3, 4, 5, 6, tz),
+                             str_to_datetime('123', tz))
+
         # localizing while in DST to something outside DST
         tz = pytz.timezone('US/Eastern')
         with patch.object(timezone, 'now', return_value=tz.localize(datetime(2029, 11, 1, 12, 30, 0, 0))):
+            parsed = str_to_datetime('06-11-2029', tz, dayfirst=True)
             self.assertEqual(tz.localize(datetime(2029, 11, 6, 12, 30, 0, 0)),
-                             str_to_datetime('06-11-2029', tz, dayfirst=True))
+                             parsed)
+
+            # assert there is no DST offset
+            self.assertFalse(parsed.tzinfo.dst(parsed))
 
             self.assertEqual(tz.localize(datetime(2029, 11, 6, 13, 45, 0, 0)),
                              str_to_datetime('06-11-2029 13:45', tz, dayfirst=True))
+
+        # deal with datetimes that have timezone info
+        self.assertEqual(pytz.utc.localize(datetime(2016, 11, 21, 20, 36, 51, 215681)).astimezone(tz),
+                         str_to_datetime('2016-11-21T20:36:51.215681Z', tz))
+
+        self.assertEqual(datetime(123, 1, 2, 5, 4, 5, 6, pytz.utc),
+                         str_to_datetime('123-1-2T5:4:5.000006Z', tz))
 
     def test_str_to_time(self):
         tz = pytz.timezone('Asia/Kabul')

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -88,6 +88,15 @@ class InitTest(TembaTest):
             self.assertEqual(tz.localize(datetime(2013, 2, 1, 0, 0, 0, 0)),
                              str_to_datetime('01-02-2013', tz, dayfirst=True, fill_time=False))  # no time filling
 
+        # localizing while in DST to something outside DST
+        tz = pytz.timezone('US/Eastern')
+        with patch.object(timezone, 'now', return_value=tz.localize(datetime(2029, 11, 1, 12, 30, 0, 0))):
+            self.assertEqual(tz.localize(datetime(2029, 11, 6, 12, 30, 0, 0)),
+                             str_to_datetime('06-11-2029', tz, dayfirst=True))
+
+            self.assertEqual(tz.localize(datetime(2029, 11, 6, 13, 45, 0, 0)),
+                             str_to_datetime('06-11-2029 13:45', tz, dayfirst=True))
+
     def test_str_to_time(self):
         tz = pytz.timezone('Asia/Kabul')
         with patch.object(timezone, 'now', return_value=tz.localize(datetime(2014, 1, 2, 3, 4, 5, 6))):


### PR DESCRIPTION
Two bugs:

1) Our date parsing (from a string) wasn't properly dealing with the current time being in a different DST than the time being parsed. We now deal with that properly (and tests added)

2) timedelta thinks of days as 24 hours, which doesn't work across DST transitions. We now detect these transitions and shift accordingly. Tests for those as well.