### PR TITLE
Deploy: Management command for applying migrations manually

### DIFF
--- a/temba/utils/management/commands/migrate_manual.py
+++ b/temba/utils/management/commands/migrate_manual.py
@@ -9,11 +9,11 @@ from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.loader import AmbiguityError
 from importlib import import_module
 
-APPLY_OFFLINE_FUNCTION = 'apply_offline'
+APPLY_FUNCTION = 'apply_manual'
 
 
 class Command(BaseCommand):  # pragma: no cover
-    help = "Applies a previously faked migration"
+    help = "Applies a migration manually which may have been previously applied or faked"
 
     def add_arguments(self, parser):
         parser.add_argument('app_label',
@@ -58,9 +58,9 @@ class Command(BaseCommand):  # pragma: no cover
         migration_module = import_module(migration.__module__)
 
         # check migration can be run offline
-        apply_function = getattr(migration_module, APPLY_OFFLINE_FUNCTION, None)
+        apply_function = getattr(migration_module, APPLY_FUNCTION, None)
         if not apply_function or not callable(apply_function):
-            raise CommandError("Migration %s does not contain function named '%s'" % (migration, APPLY_OFFLINE_FUNCTION))
+            raise CommandError("Migration %s does not contain function named '%s'" % (migration, APPLY_FUNCTION))
 
         plan = executor.migration_plan([(app_label, migration.name)])
         if record and not plan:

--- a/temba/utils/management/commands/migrate_manual.py
+++ b/temba/utils/management/commands/migrate_manual.py
@@ -68,9 +68,11 @@ class Command(BaseCommand):  # pragma: no cover
 
         emit_pre_migrate_signal([], self.verbosity, interactive, connection.alias)
 
-        self.stdout.write(self.style.MIGRATE_HEADING("Operation to perform:"))
-        self.stdout.write("  Fake and then apply migration %s offline" % migration)
-        self.stdout.write(self.style.MIGRATE_HEADING("Offline migration:"))
+        self.stdout.write(self.style.MIGRATE_HEADING("Operations to perform:"))
+        self.stdout.write("  Manually apply migration %s" % migration)
+        if record:
+            self.stdout.write("  Record migration %s as applied" % migration)
+        self.stdout.write(self.style.MIGRATE_HEADING("Manual migration:"))
 
         self.apply_migration(migration, apply_function)
 

--- a/temba/utils/management/commands/migrateoffline.py
+++ b/temba/utils/management/commands/migrateoffline.py
@@ -1,0 +1,100 @@
+from __future__ import unicode_literals
+
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management.sql import emit_pre_migrate_signal, emit_post_migrate_signal
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.loader import AmbiguityError
+from importlib import import_module
+
+APPLY_OFFLINE_FUNCTION = 'apply_offline'
+
+
+class Command(BaseCommand):  # pragma: no cover
+    help = "Runs an expensive migration offline"
+
+    def add_arguments(self, parser):
+        parser.add_argument('app_label',
+                            help='App label of an application to synchronize the state.')
+        parser.add_argument('migration_name',
+                            help='Database state will be brought to the state after that migration.')
+
+    def handle(self, app_label, migration_name, *args, **options):
+        self.verbosity = options.get('verbosity')
+        self.interactive = options.get('interactive')
+
+        connection = connections[DEFAULT_DB_ALIAS]
+        connection.prepare_database()
+        executor = MigrationExecutor(connection, None)
+
+        # before anything else, see if there's conflicting apps and drop out hard if there are any
+        conflicts = executor.loader.detect_conflicts()
+        if conflicts:
+            name_str = "; ".join("%s in %s" % (", ".join(names), app) for app, names in conflicts.items())
+            raise CommandError(
+                "Conflicting migrations detected (%s).\nTo fix them run "
+                "'python manage.py makemigrations --merge'" % name_str
+            )
+
+        if app_label not in executor.loader.migrated_apps:
+            raise CommandError(
+                "App '%s' does not have migrations (you cannot selectively sync unmigrated apps)" % app_label
+            )
+        try:
+            migration = executor.loader.get_migration_by_prefix(app_label, migration_name)
+        except AmbiguityError:
+            raise CommandError(
+                "More than one migration matches '%s' in app '%s'. Please be more specific." %
+                (migration_name, app_label)
+            )
+        except KeyError:
+            raise CommandError("Cannot find a migration matching '%s' from app '%s'." % (migration_name, app_label))
+
+        migration_module = import_module(migration.__module__)
+
+        # check migration can be run offline
+        apply_function = getattr(migration_module, APPLY_OFFLINE_FUNCTION, None)
+        if not apply_function or not callable(apply_function):
+            raise CommandError("Migration %s does not contain function named '%s'" % (migration, APPLY_OFFLINE_FUNCTION))
+
+        plan = executor.migration_plan([(app_label, migration.name)])
+        if not plan:
+            raise CommandError("Migration %s has already been applied" % migration)
+
+        emit_pre_migrate_signal([], self.verbosity, self.interactive, connection.alias)
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Operation to perform:"))
+        self.stdout.write("  Apply migration %s offline and fake" % migration)
+        self.stdout.write(self.style.MIGRATE_HEADING("Offline migration:"))
+
+        self.apply_migration(migration, apply_function)
+
+        self.fake_migration(migration, executor)
+
+        # send the post_migrate signal, so individual apps can do whatever they need to do at this point.
+        emit_post_migrate_signal([], self.verbosity, self.interactive, connection.alias)
+
+    def apply_migration(self, migration, apply_function):
+        compute_time = self.verbosity > 1
+
+        self.stdout.write("  Applying %s... " % migration, ending="")
+        self.stdout.flush()
+
+        if compute_time:
+            self.start = time.time()
+
+        apply_function()
+
+        elapsed = " (%.3fs)" % (time.time() - self.start) if compute_time else ""
+
+        self.stdout.write(self.style.MIGRATE_SUCCESS("OK" + elapsed))
+
+    def fake_migration(self, migration, executor):
+        self.stdout.write("  Faking %s... " % migration, ending="")
+        self.stdout.flush()
+
+        executor.recorder.record_applied(migration.app_label, migration.name)
+
+        self.stdout.write(self.style.MIGRATE_SUCCESS("DONE"))


### PR DESCRIPTION
Supports any migration module with a `def apply_offline()` function.

* Same syntax as migrate, makemigrations etc
* Can reference migrations by prefix, e.g. "msgs 0023"
* Detects any migration conflicts or if migration has already been applied
* Setting verbosity > 1 enables timing of migration (e.g. "-v 2")

![screen shot 2016-11-23 at 11 51 06](https://cloud.githubusercontent.com/assets/675558/20557191/31afcea2-b173-11e6-994b-4e15b1e4ed72.png)
