### PR TITLE
Lighter dependency option

### DIFF
--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1573,7 +1573,7 @@ class DefinitionsEndpoint(BaseAPIView):
         dependencies = dict(flows=set(), campaigns=set(campaigns), triggers=set(), groups=set())
         for flow in flows:
             if depends:
-                include_campaigns = dependency_type in ('all', 'campaigns')
+                include_campaigns = dependency_type == 'all'
                 dependencies = flow.get_dependencies(dependencies=dependencies, include_campaigns=include_campaigns)
 
         # make sure our requested items are included flows we requested are included

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1463,7 +1463,7 @@ class DefinitionsEndpoint(BaseAPIView):
 
       * **flow** - the UUIDs of flows to include (string, repeatable)
       * **campaign** - the UUIDs of campaigns to include (string, repeatable)
-      * **dependencies** - whether to include dependencies (string, all, flows, none, default: all)
+      * **dependencies** - whether to include dependencies (all, flows, none, default: all)
 
     Example:
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1463,7 +1463,7 @@ class DefinitionsEndpoint(BaseAPIView):
 
       * **flow** - the UUIDs of flows to include (string, repeatable)
       * **campaign** - the UUIDs of campaigns to include (string, repeatable)
-      * **dependencies** - whether to include dependencies (boolean, default: true)
+      * **dependencies** - whether to include dependencies (string, all, flows, none, default: all)
 
     Example:
 
@@ -1551,7 +1551,8 @@ class DefinitionsEndpoint(BaseAPIView):
             flow_uuids = params.getlist('flow')
             campaign_uuids = params.getlist('campaign')
 
-        depends = str_to_bool(params.get('dependencies', 'true'))
+        dependency_type = params.get('dependencies', 'all')
+        depends = dependency_type != 'none'
 
         if flow_uuids:
             flows = set(Flow.objects.filter(uuid__in=flow_uuids, org=org))
@@ -1572,7 +1573,8 @@ class DefinitionsEndpoint(BaseAPIView):
         dependencies = dict(flows=set(), campaigns=set(campaigns), triggers=set(), groups=set())
         for flow in flows:
             if depends:
-                dependencies = flow.get_dependencies(dependencies=dependencies)
+                include_campaigns = dependency_type in ('all', 'campaigns')
+                dependencies = flow.get_dependencies(dependencies=dependencies, include_campaigns=include_campaigns)
 
         # make sure our requested items are included flows we requested are included
         to_export = dict(flows=dependencies['flows'],

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1878,7 +1878,7 @@ class Flow(TembaModel):
 
         return send_actions
 
-    def get_dependencies(self, dependencies=None):
+    def get_dependencies(self, dependencies=None, include_campaigns=True):
 
         # need to make sure we have the latest version to inspect dependencies
         self.ensure_current_version()
@@ -1906,10 +1906,12 @@ class Flow(TembaModel):
                     flows.add(flow)
 
         # add any campaigns that use our groups
-        from temba.campaigns.models import Campaign
-        campaigns = set(Campaign.objects.filter(org=self.org, group__in=groups, is_archived=False, is_active=True))
-        for campaign in campaigns:
-            flows.update(list(campaign.get_flows()))
+        campaigns = ()
+        if include_campaigns:
+            from temba.campaigns.models import Campaign
+            campaigns = set(Campaign.objects.filter(org=self.org, group__in=groups, is_archived=False, is_active=True))
+            for campaign in campaigns:
+                flows.update(list(campaign.get_flows()))
 
         # and any of our triggers that reference us
         from temba.triggers.models import Trigger
@@ -1924,7 +1926,7 @@ class Flow(TembaModel):
             return dependencies
 
         for flow in flows:
-            dependencies = flow.get_dependencies(dependencies)
+            dependencies = flow.get_dependencies(dependencies, include_campaigns=include_campaigns)
 
         return dependencies
 


### PR DESCRIPTION
This allows surveyor to fetch only dependent flows instead the whole graph through following groups and campaigns.