### PR TITLE
Tweaks to reduce our analytics usage 

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3448,7 +3448,7 @@ class ContactFieldTest(TembaTest):
         blocking_export.is_finished = True
         blocking_export.save()
 
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(37):
             self.client.get(reverse('contacts.contact_export'), dict())
             task = ExportContactsTask.objects.all().order_by('-id').first()
 
@@ -3472,7 +3472,7 @@ class ContactFieldTest(TembaTest):
         contact4 = self.create_contact('Stephen', '+12078778899', twitter='stephen')
         ContactURN.create(self.org, contact, 'tel:+12062233445')
 
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(37):
             self.client.get(reverse('contacts.contact_export'), dict())
             task = ExportContactsTask.objects.all().order_by('-id').first()
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -589,6 +589,8 @@ class ContactCRUDL(SmartCRUDL):
             if previous_import and previous_import.created_on < timezone.now() - timedelta(hours=24):
                 analytics.track(self.request.user.username, 'temba.contact_imported')
 
+            return task
+
         def post_save(self, task):
             # configure import params with current org and timezone
             org = self.derive_org()

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -331,9 +331,6 @@ class ContactCRUDL(SmartCRUDL):
     class Export(OrgPermsMixin, SmartXlsView):
 
         def render_to_response(self, context, **response_kwargs):
-
-            analytics.track(self.request.user.username, 'temba.contact_exported')
-
             user = self.request.user
             org = user.get_org()
 
@@ -358,6 +355,10 @@ class ContactCRUDL(SmartCRUDL):
 
             # otherwise, off we go
             else:
+                previous_export = ExportContactsTask.objects.filter(org=org, created_by=user).order_by('-modified_on').first()
+                if previous_export and previous_export.created_on < timezone.now() - timedelta(hours=24):
+                    analytics.track(self.request.user.username, 'temba.contact_exported')
+
                 export = ExportContactsTask.objects.create(created_by=user, modified_by=user, org=org, group=group)
                 export_contacts_task.delay(export.pk)
 
@@ -581,12 +582,20 @@ class ContactCRUDL(SmartCRUDL):
         fields = ('csv_file',)
         success_message = ''
 
+        def pre_save(self, task):
+            super(ContactCRUDL.Import, self).pre_save(task)
+
+            previous_import = ImportTask.objects.filter(created_by=self.request.user).order_by('-created_on').first()
+            if previous_import and previous_import.created_on < timezone.now() - timedelta(hours=24):
+                analytics.track(self.request.user.username, 'temba.contact_imported')
+
         def post_save(self, task):
             # configure import params with current org and timezone
             org = self.derive_org()
             params = dict(org_id=org.id, timezone=six.text_type(org.timezone), extra_fields=[], original_filename=self.form.cleaned_data['csv_file'].name)
             params_dump = json.dumps(params)
             ImportTask.objects.filter(pk=task.pk).update(import_params=params_dump)
+
             return task
 
         def get_form_kwargs(self):
@@ -599,8 +608,6 @@ class ContactCRUDL(SmartCRUDL):
             context['task'] = None
             context['group'] = None
             context['show_form'] = True
-
-            analytics.track(self.request.user.username, 'temba.contact_imported')
 
             task_id = self.request.REQUEST.get('task', None)
             if task_id:

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1415,7 +1415,7 @@ class FlowCRUDL(SmartCRUDL):
             json_string = request.body
 
             # if the last modified on this flow is more than a day ago, log that this flow as updated
-            if self.get_object().last_modified < timezone.now() - timedelta(hours=24):
+            if self.get_object().saved_on < timezone.now() - timedelta(hours=24):
                 analytics.track(self.request.user.username, 'temba.flow_updated')
 
             # try to save the our flow, if this fails, let's let that bubble up to our logger


### PR DESCRIPTION
For things that get repeated a lot (simulations, flow updates) only saves one even per day. For imports and exports makes sure that we aren't creating events when we are just refreshing the page to check for status.