### PR TITLE
Use empty string when we in channel log when we fail to post to aggre…

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1233,7 +1233,7 @@ class Channel(TembaModel):
                                 response_status=503,
                                 start=start)
 
-        if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
+        if response.status_code not in [200, 201, 202]:
             raise SendException("Got non-200 response [%d] from Line" % response.status_code,
                                 method='POST',
                                 url=send_url,

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1221,20 +1221,28 @@ class Channel(TembaModel):
         headers.update(TEMBA_HEADERS)
         send_url = 'https://api.line.me/v2/bot/message/push'
 
-        response = requests.post(send_url,
-                                 data=data,
-                                 headers=headers)
-        content = json.loads(response.content)
+        try:
+            response = requests.post(send_url, data=data, headers=headers)
+            content = json.loads(response.content)
+        except Exception as e:
+            raise SendException(unicode(e),
+                                method='POST',
+                                url=send_url,
+                                request=data,
+                                response="",
+                                response_status=503,
+                                start=start)
 
-        if response.status_code == 200:
-            Channel.success(channel, msg, WIRED, start, 'POST', response.request.url, data, response)
-        else:
-            raise SendException(content.get('message'),
-                                send_url,
-                                'POST',
-                                data,
-                                response.content,
-                                response.status_code)
+        if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
+            raise SendException("Got non-200 response [%d] from Line" % response.status_code,
+                                method='POST',
+                                url=send_url,
+                                request=data,
+                                response=content.get('message'),
+                                response_status=response.status_code,
+                                start=start)
+
+        Channel.success(channel, msg, WIRED, start, 'POST', response.request.url, data, response)
 
     @classmethod
     def send_mblox_message(cls, channel, msg, text):
@@ -1991,8 +1999,8 @@ class Channel(TembaModel):
                                     url=url,
                                     method='POST',
                                     request=json.dumps(payload),
-                                    response=response.text,
-                                    response_status=response.status_code,
+                                    response="",
+                                    response_status=503,
                                     start=start)
 
         if response.status_code != 200 and response.status_code != 201:
@@ -2129,8 +2137,8 @@ class Channel(TembaModel):
                                 url=zenvia_url,
                                 method='POST',
                                 request=json.dumps(payload),
-                                response=response.text,
-                                response_status=response.status_code,
+                                response="",
+                                response_status=503,
                                 start=start)
 
         if response.status_code != 200 and response.status_code != 201:
@@ -2175,8 +2183,8 @@ class Channel(TembaModel):
                                 url=api_url,
                                 method='POST',
                                 request=json.dumps(payload),
-                                response=response.text,
-                                response_status=response.status_code,
+                                response="",
+                                response_status=503,
                                 start=start)
 
         if response.status_code != 200 and response.status_code != 201:
@@ -2338,6 +2346,7 @@ class Channel(TembaModel):
             log_payload = urlencode(payload)
 
         except Exception as e:
+            log_payload = urlencode(payload)
             raise SendException(unicode(e),
                                 method='GET',
                                 url=url,

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -3231,6 +3231,9 @@ class AfricasTalkingTest(TembaTest):
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
         finally:
             settings.SEND_MESSAGES = False
 
@@ -3431,6 +3434,9 @@ class ExternalTest(TembaTest):
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
         finally:
             settings.SEND_MESSAGES = False
 
@@ -3569,6 +3575,9 @@ class YoTest(TembaTest):
 
                 self.clear_cache()
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
             with patch('requests.get') as mock:
                 mock.return_value = MockResponse(200, "ybs_autocreate_status=ERROR&ybs_autocreate_message=" +
                                                       "YBS+AutoCreate+Subsystem%3A+Access+denied" +
@@ -3606,6 +3615,9 @@ class YoTest(TembaTest):
                 self.assertFalse(joe.is_stopped)
 
                 self.clear_cache()
+
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
 
             with patch('requests.get') as mock:
                 mock.return_value = MockResponse(200, "ybs_autocreate_status=ERROR&ybs_autocreate_message=" +
@@ -3697,6 +3709,9 @@ class ShaqodoonTest(TembaTest):
                 # message should be marked as an error
                 msg.refresh_from_db()
                 self.assertEquals(ERRORED, msg.status)
+
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
 
         finally:
             settings.SEND_MESSAGES = False
@@ -3820,6 +3835,9 @@ class M3TechTest(TembaTest):
                 self.assertEquals(FAILED, msg.status)
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
+
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
 
                 self.clear_cache()
         finally:
@@ -4026,6 +4044,9 @@ class KannelTest(TembaTest):
                 # message should be marked as an error
                 msg.refresh_from_db()
                 self.assertEquals(ERRORED, msg.status)
+
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
         finally:
             settings.SEND_MESSAGES = False
 
@@ -4406,6 +4427,9 @@ class VumiTest(TembaTest):
                 self.assertEquals(FAILED, msg.status)
                 self.assertEquals(2, msg.error_count)
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
             with patch('requests.put') as mock:
                 # set our next attempt as if we are trying anew
                 msg.next_attempt = timezone.now()
@@ -4731,6 +4755,9 @@ class ZenviaTest(TembaTest):
                 self.assertEquals(ERRORED, msg.status)
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
+
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
 
             with patch('requests.get') as mock:
                 mock.return_value = MockResponse(200, '001-error', method='GET')
@@ -5069,6 +5096,9 @@ class SMSCentralTest(TembaTest):
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
         finally:
             settings.SEND_MESSAGES = False
 
@@ -5274,6 +5304,9 @@ class HighConnectionTest(TembaTest):
                 self.assertEquals(ERRORED, msg.status)
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
+
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
 
         finally:
             settings.SEND_MESSAGES = False
@@ -6037,6 +6070,9 @@ class ClickatellTest(TembaTest):
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
         finally:
             settings.SEND_MESSAGES = False
 
@@ -6509,6 +6545,9 @@ class PlivoTest(TembaTest):
                 self.assertEquals(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
         finally:
             settings.SEND_MESSAGES = False
 
@@ -6962,6 +7001,9 @@ class StartMobileTest(TembaTest):
                 self.assertTrue(msg.next_attempt)
                 self.clear_cache()
 
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))
+
         finally:
             settings.SEND_MESSAGES = False
 
@@ -7279,6 +7321,9 @@ class JasminTest(TembaTest):
             msg.refresh_from_db()
             self.assertEquals(ERRORED, msg.status)
 
+            self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                              "referenced before assignment"))
+
 
 class MbloxTest(TembaTest):
 
@@ -7405,6 +7450,9 @@ class MbloxTest(TembaTest):
             # check the status of the message now errored
             msg.refresh_from_db()
             self.assertEquals(ERRORED, msg.status)
+
+            self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                              "referenced before assignment"))
 
 
 class FacebookTest(TembaTest):
@@ -7801,6 +7849,9 @@ class FacebookTest(TembaTest):
             msg.refresh_from_db()
             self.assertEquals(ERRORED, msg.status)
 
+            self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                              "referenced before assignment"))
+
 
 class GlobeTest(TembaTest):
 
@@ -7938,6 +7989,9 @@ class GlobeTest(TembaTest):
             msg.refresh_from_db()
             self.assertEquals(FAILED, msg.status)
             self.clear_cache()
+
+            self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                              "referenced before assignment"))
 
 
 class ViberTest(TembaTest):
@@ -8187,3 +8241,18 @@ class LineTest(TembaTest):
                 self.assertEquals(ERRORED, msg.status)
                 self.assertEquals(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
+
+            with patch('requests.post') as mock:
+                mock.side_effect = Exception('Kaboom!')
+
+                # manually send it off
+                Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
+
+                # message should be marked as an error
+                msg.refresh_from_db()
+                self.assertEquals(ERRORED, msg.status)
+                self.assertEquals(2, msg.error_count)
+                self.assertTrue(msg.next_attempt)
+
+                self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
+                                                                                  "referenced before assignment"))


### PR DESCRIPTION
…gator instead or referencing an unassigned variable