### PR TITLE
Show campaign message properly in upcoming events

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1467,7 +1467,7 @@ class ContactTest(TembaTest):
             self.message_event = CampaignEvent.create_message_event(self.org, self.admin, self.campaign,
                                                                     relative_to=self.planting_date,
                                                                     offset=i + 10, unit='D',
-                                                                    message='Sent %d days after planting date' % (i + 10))
+                                                                    message='{"base": "Sent %d days after planting date"}' % (i + 10))
 
         now = timezone.now()
         self.joe.set_field(self.user, 'planting_date', unicode(now + timedelta(days=1)))

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -697,7 +697,7 @@ class ContactCRUDL(SmartCRUDL):
 
             merged_upcoming_events = []
             for fire in event_fires:
-                merged_upcoming_events.append(dict(event_type=fire.event.event_type, message=fire.event.message,
+                merged_upcoming_events.append(dict(event_type=fire.event.event_type, message=fire.event.get_message(),
                                                    flow_uuid=fire.event.flow.uuid, flow_name=fire.event.flow.name,
                                                    scheduled=fire.scheduled))
 


### PR DESCRIPTION
Fix upcoming messages on contact read page to properly show campaign events which are localized. Existing tests are generally good, but they weren't creating localized message events which would have caught this behavior.