### PR TITLE
FlowPathCount triggers

### DIFF
--- a/karma/flows/test_controllers.coffee
+++ b/karma/flows/test_controllers.coffee
@@ -232,16 +232,16 @@ describe 'Controllers:', ->
       loadFavoritesFlow()
       ruleset = flowService.flow.rule_sets[0]
 
-      # three rules and our other
-      expect(ruleset.rules.length).toBe(4)
+      # four rules and our other
+      expect(ruleset.rules.length).toBe(5)
 
       editRules ruleset, (scope) ->
         scope.formData.hasTimeout = true
         scope.formData.timeout = scope.formData.timeoutOptions[5]
 
-      # now we have three rules, our other, and a timeout
+      # now we have four rules, our other, and a timeout
       ruleset = flowService.flow.rule_sets[0]
-      expect(ruleset.rules.length).toBe(5)
+      expect(ruleset.rules.length).toBe(6)
 
       # checkout our timeout rule as the right settings
       lastRule = ruleset.rules[ruleset.rules.length - 1]
@@ -493,9 +493,9 @@ describe 'Controllers:', ->
 
       loadFavoritesFlow()
 
-      # our first ruleset, starts off with four rules
+      # our first ruleset, starts off with five rules
       ruleset = flowService.flow.rule_sets[0]
-      expect(ruleset.rules.length).toBe(4)
+      expect(ruleset.rules.length).toBe(5)
 
       # make our last "true" rule route to the entry node
       ruleset.rules[3].destination = '127f3736-77ce-4006-9ab0-0c07cea88956'
@@ -510,9 +510,9 @@ describe 'Controllers:', ->
       # click on ruleset, then check timeout option
       editRules(ruleset, (scope) -> scope.formData.hasTimeout = true)
 
-      # should now have 5 rules to account for the timeout
+      # should now have 6 rules to account for the timeout
       ruleset = flowService.flow.rule_sets[0]
-      expect(ruleset.rules.length).toBe(5)
+      expect(ruleset.rules.length).toBe(6)
 
       # but our route should still be there
       expect(ruleset.rules[3].destination).toBe('127f3736-77ce-4006-9ab0-0c07cea88956')

--- a/karma/flows/test_services.coffee
+++ b/karma/flows/test_services.coffee
@@ -478,13 +478,13 @@ describe 'Services:', ->
 
         # check we have the right number of categories to start
         colors = getNode(flow, colorRulesId)
-        expect(colors._categories.length).toBe(4, 'categories were not derived properly')
+        expect(colors._categories.length).toBe(5, 'categories were not derived properly')
 
         # now set the green category name to the same as red
         green = getRule(flow, colorRulesId, greenRuleId)
         green.category = {base: 'red'}
         flowService.deriveCategories(colors, 'base')
-        expect(colors._categories.length).toBe(3, 'like named category did not get merged')
+        expect(colors._categories.length).toBe(4, 'like named category did not get merged')
 
         # change red to skip a question
         flowService.updateDestination(colorRulesId + '_' + redRuleId, nameActionsId)

--- a/media/test_flows/favorites.json
+++ b/media/test_flows/favorites.json
@@ -142,6 +142,20 @@
             },
             {
               "test": {
+                "test": {
+                  "base": "Cyan"
+                },
+                "type": "contains_any"
+              },
+              "category": {
+                "base": "Cyan"
+              },
+              "destination": null,
+              "uuid": "6f463a78-b176-49c1-bb5c-6e152502b0db",
+              "destination_type": null
+            },
+            {
+              "test": {
                 "test": "true",
                 "type": "true"
               },

--- a/temba/flows/migrations/0077_auto_20161215_2232.py
+++ b/temba/flows/migrations/0077_auto_20161215_2232.py
@@ -114,7 +114,6 @@ def do_populate(Contact, FlowRun, FlowStep, FlowPathCount):
             squash_counts(FlowPathCount)
             highpoint += CHUNK_SIZE
 
-    r.delete('flowpathcount_backfill_highpoint')
 
 def apply_manual():
     from temba.flows.models import FlowRun, FlowStep, FlowPathCount

--- a/temba/flows/migrations/0078_auto_20161216_1803.py
+++ b/temba/flows/migrations/0078_auto_20161216_1803.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.db.models import Count
+from django_redis import get_redis_connection
+from django.db import connection
+from temba.utils import chunk_list
+from temba.sql import InstallSQL
+import time
+
+HIGHPOINT_KEY = 'flowpathcount_backfill_highpoint'
+CHUNK_SIZE = 200000
+MAX_INT = 2147483647
+
+def dictfetchall(cursor):
+    "Return all rows from a cursor as a dict"
+    columns = [col[0] for col in cursor.description]
+    return [
+        dict(zip(columns, row))
+        for row in cursor.fetchall()
+    ]
+
+def apply_migration(apps, schema_editor):
+
+    FlowRun = apps.get_model('flows', 'FlowRun')
+    FlowStep = apps.get_model('flows', 'FlowStep')
+    FlowPathCount = apps.get_model('flows', 'FlowPathCount')
+    Contact = apps.get_model('contacts', 'Contact')
+
+    r = get_redis_connection()
+
+    highpoint = r.get(HIGHPOINT_KEY)
+    if highpoint is None:
+        highpoint = 0
+    else:
+        highpoint = int(highpoint)
+
+    last_add = None
+
+    print '\nStarting at %d' % highpoint
+
+    while last_add is None or last_id < MAX_INT:
+
+        start = time.time()
+
+        test_contacts = Contact.objects.filter(is_test=True).values_list('id', flat=True)
+
+        counts = []
+        last_id = highpoint + CHUNK_SIZE
+
+        # jump to the end if we didnt record any last time
+        if last_add == 0:
+            last_id = MAX_INT
+
+        query = "SELECT max(fs.id) as max_id, fr.flow_id as \"flow_id\", step_uuid, next_uuid, rule_uuid, count(*), date_trunc('hour', left_on) as \"period\" "
+        query += "FROM flows_flowstep fs, flows_flowrun fr, contacts_contact c "
+        query += "WHERE fs.run_id = fr.id AND fs.contact_id = c.id AND c.is_test = False AND fs.left_on is not null "
+        query += "AND fs.id > %s AND fs.id <= %s GROUP BY fr.flow_id, fs.step_uuid, fs.next_uuid, fs.rule_uuid, period;"
+
+        with connection.cursor() as cursor:
+            cursor.execute(query, [highpoint, last_id])
+            results = dictfetchall(cursor)
+
+            max_id = 0
+            for result in results:
+                from_uuid = result.get('rule_uuid')
+                if not from_uuid:
+                    from_uuid = result.get('step_uuid')
+
+                if max_id < result.get('max_id'):
+                    max_id = result.get('max_id')
+
+                counts.append(FlowPathCount(flow_id=result.get('flow_id'),
+                                            from_uuid=from_uuid,
+                                            to_uuid=result.get('next_uuid'),
+                                            period=result.get('period'),
+                                            count=result.get('count')))
+
+            FlowPathCount.objects.bulk_create(counts)
+            last_add = len(counts)
+
+            seconds = time.time() - start
+            total = len(counts)
+            print 'Added %d counts (Max: %d) in %0.3fs (%0.0fs/s)' % (total, max_id, seconds, float(total) / float(seconds))
+
+            if max_id > 0:
+                r.set(HIGHPOINT_KEY, max_id)
+
+            counts = []
+            highpoint += CHUNK_SIZE
+
+    r.delete(HIGHPOINT_KEY)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flows', '0077_auto_20161215_2232'),
+    ]
+
+    operations = [
+        migrations.RunPython(apply_migration),
+        InstallSQL('0078_flows')
+    ]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1835,7 +1835,10 @@ class Flow(TembaModel):
         step_uuid = step.step_uuid
         if step.rule_uuid:
             step_uuid = step.rule_uuid
-        r.hincrby(self.get_stats_cache_key(FlowStatsCache.visit_count_map), "%s:%s" % (step_uuid, step.next_uuid), -1)
+
+        # only activity for paths taken are recorded
+        if step.next_uuid:
+            r.hincrby(self.get_stats_cache_key(FlowStatsCache.visit_count_map), "%s:%s" % (step_uuid, step.next_uuid), -1)
 
     def update_activity(self, step, previous_step=None, rule_uuid=None):
         """

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3886,7 +3886,7 @@ class FlowsTest(FlowFileTest):
         other_rule_destination = other_rule.destination
         other_rule_uuid = other_rule.uuid
 
-        blue_rule = ruleset.get_rules()[-2]
+        blue_rule = ruleset.get_rules()[-3]
         blue_rule_uuid = blue_rule.uuid
         blue_rule_destination = blue_rule.destination
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4341,6 +4341,10 @@ class FlowsTest(FlowFileTest):
         # ie, there are no counts added with respect to the next question
         self.assertEqual(counts, len(flow.get_visit_counts()))
 
+        # ensure no negative counts
+        for k, v in flow.get_visit_counts().iteritems():
+            self.assertTrue(v >= 0)
+
     def test_destination_type(self):
         flow = self.get_flow('pick_a_number')
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4104,14 +4104,19 @@ class FlowsTest(FlowFileTest):
         self.clear_activity(flow)
 
         other_action = ActionSet.objects.get(y=8, flow=flow)
+        beer_question = ActionSet.objects.get(y=237, flow=flow)
         beer = RuleSet.objects.get(label='Beer', flow=flow)
         color = RuleSet.objects.get(label='Color', flow=flow)
-        color_other_uuid = color.get_rules()[-1].uuid
-        color_cyan_uuid = color.get_rules()[-2].uuid
+
+        rules = color.get_rules()
+        color_other_uuid = rules[-1].uuid
+        color_cyan_uuid = rules[-2].uuid
+        color_blue_uuid = rules[-3].uuid
 
         other_rule_to_msg = '%s:%s' % (color_other_uuid, other_action.uuid)
         msg_to_color_step = '%s:%s' % (other_action.uuid, color.uuid)
         cyan_to_nothing = '%s:None' % (color_cyan_uuid)
+        blue_to_beer = '%s:%s' % (color_blue_uuid, beer_question.uuid)
 
         # we don't know this shade of green, it should route us to the beginning again
         self.send_message(flow, 'chartreuse')
@@ -4312,6 +4317,29 @@ class FlowsTest(FlowFileTest):
 
         # but now we have a single count
         self.assertEqual(1, FlowPathCount.objects.filter(from_uuid=color_cyan_uuid).count())
+
+        counts = len(flow.get_visit_counts())
+
+        # check that flow interruption counts properly
+        rawls = self.create_contact('Thomas Rawls', '+12065557777')
+        self.send_message(flow, 'blue', contact=rawls)
+
+        # but he's got other things on his mind
+        random_word = self.get_flow('random_word')
+        self.send_message(random_word, 'blerg', contact=rawls)
+
+        # here's our count for our response path
+        self.assertEqual(1, flow.get_visit_counts()[blue_to_beer])
+
+        # let's also create a flow run that gets expired
+        pete = self.create_contact('Pete', '+12065554444')
+        self.send_message(flow, 'blue', contact=pete)
+        run = FlowRun.objects.filter(contact=pete).first()
+        run.expire()
+
+        # but there should be no additional records due to the interruption or expiration
+        # ie, there are no counts added with respect to the next question
+        self.assertEqual(counts, len(flow.get_visit_counts()))
 
     def test_destination_type(self):
         flow = self.get_flow('pick_a_number')

--- a/temba/sql/0075_flows.sql
+++ b/temba/sql/0075_flows.sql
@@ -3,11 +3,20 @@
 ----------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION temba_squash_flowpathcount(_flow_id INTEGER, _from_uuid UUID, _to_uuid UUID, _period TIMESTAMP WITH TIME ZONE) RETURNS VOID AS $$
   BEGIN
-    WITH removed as (DELETE FROM flows_flowpathcount
-      WHERE "flow_id" = _flow_id AND "from_uuid" = _from_uuid
-            AND "to_uuid" = _to_uuid AND "period" = date_trunc('hour', _period)
-      RETURNING "count")
-      INSERT INTO flows_flowpathcount("flow_id", "from_uuid", "to_uuid", "period", "count")
-      VALUES (_flow_id, _from_uuid, _to_uuid, date_trunc('hour', _period), GREATEST(0, (SELECT SUM("count") FROM removed)));
+    IF _to_uuid IS NULL THEN
+      WITH removed as (DELETE FROM flows_flowpathcount
+        WHERE "flow_id" = _flow_id AND "from_uuid" = _from_uuid
+              AND "to_uuid" IS NULL AND "period" = date_trunc('hour', _period)
+        RETURNING "count")
+        INSERT INTO flows_flowpathcount("flow_id", "from_uuid", "to_uuid", "period", "count")
+        VALUES (_flow_id, _from_uuid, NULL, date_trunc('hour', _period), GREATEST(0, (SELECT SUM("count") FROM removed)));
+    ELSE
+      WITH removed as (DELETE FROM flows_flowpathcount
+        WHERE "flow_id" = _flow_id AND "from_uuid" = _from_uuid
+              AND "to_uuid" = _to_uuid AND "period" = date_trunc('hour', _period)
+        RETURNING "count")
+        INSERT INTO flows_flowpathcount("flow_id", "from_uuid", "to_uuid", "period", "count")
+        VALUES (_flow_id, _from_uuid, _to_uuid, date_trunc('hour', _period), GREATEST(0, (SELECT SUM("count") FROM removed)));
+    END IF;
   END;
 $$ LANGUAGE plpgsql;

--- a/temba/sql/0078_flows.sql
+++ b/temba/sql/0078_flows.sql
@@ -202,8 +202,6 @@ BEGIN
     is_test = temba_flows_contact_is_test(OLD.contact_id);
     flow_id = temba_flow_for_run(OLD.run_id);
 
-    RAISE LOG 'Updating %', OLD;
-
     IF NOT is_test AND NEW.left_on IS NOT NULL THEN
       IF NEW.next_uuid is NOT NULL THEN
         PERFORM temba_insert_flowpathcount(flow_id, temba_step_from_uuid(NEW), uuid(NEW.next_uuid), NEW.left_on, 1);

--- a/temba/sql/0078_flows.sql
+++ b/temba/sql/0078_flows.sql
@@ -1,0 +1,237 @@
+----------------------------------------------------------------------
+-- Squashes the flowrun counts for a particular flow and exit type
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  temba_squash_flowruncount(_flow_id INT, _exit_type CHAR(1))
+RETURNS VOID AS $$
+BEGIN
+  IF _exit_type IS NULL THEN
+    WITH removed as (DELETE FROM flows_flowruncount
+      WHERE "flow_id" = _flow_id AND "exit_type" IS NULL RETURNING "count")
+      INSERT INTO flows_flowruncount("flow_id", "exit_type", "count")
+      VALUES (_flow_id, _exit_type, GREATEST(0, (SELECT SUM("count") FROM removed)));
+  ELSE
+    WITH removed as (DELETE FROM flows_flowruncount
+      WHERE "flow_id" = _flow_id AND "exit_type" = _exit_type RETURNING "count")
+      INSERT INTO flows_flowruncount("flow_id", "exit_type", "count")
+      VALUES (_flow_id, _exit_type, GREATEST(0, (SELECT SUM("count") FROM removed)));
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Inserts a new flowrun_count
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  temba_insert_flowruncount(_flow_id INT, _exit_type CHAR(1), _count INT)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO flows_flowruncount("flow_id", "exit_type", "count")
+  VALUES(_flow_id, _exit_type, _count);
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Increments or decrements our counts for each exit type
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_update_flowruncount() RETURNS TRIGGER AS $$
+BEGIN
+  -- Table being cleared, reset all counts
+  IF TG_OP = 'TRUNCATE' THEN
+    TRUNCATE flows_flowruncounts;
+    RETURN NULL;
+  END IF;
+
+  -- FlowRun being added
+  IF TG_OP = 'INSERT' THEN
+     -- Is this a test contact, ignore
+     IF temba_contact_is_test(NEW.contact_id) THEN
+       RETURN NULL;
+     END IF;
+
+    -- Increment appropriate type
+    PERFORM temba_insert_flowruncount(NEW.flow_id, NEW.exit_type, 1);
+
+  -- FlowRun being removed
+  ELSIF TG_OP = 'DELETE' THEN
+     -- Is this a test contact, ignore
+     IF temba_contact_is_test(OLD.contact_id) THEN
+       RETURN NULL;
+     END IF;
+
+    PERFORM temba_insert_flowruncount(OLD.flow_id, OLD.exit_type, -1);
+
+  -- Updating exit type
+  ELSIF TG_OP = 'UPDATE' THEN
+     -- Is this a test contact, ignore
+     IF temba_contact_is_test(NEW.contact_id) THEN
+       RETURN NULL;
+     END IF;
+
+    PERFORM temba_insert_flowruncount(OLD.flow_id, OLD.exit_type, -1);
+    PERFORM temba_insert_flowruncount(NEW.flow_id, NEW.exit_type, 1);
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Install INSERT, UPDATE and DELETE triggers
+DROP TRIGGER IF EXISTS temba_flowrun_update_flowruncount on flows_flowrun;
+CREATE TRIGGER temba_flowrun_update_flowruncount
+   AFTER INSERT OR DELETE OR UPDATE OF exit_type
+   ON flows_flowrun
+   FOR EACH ROW
+   EXECUTE PROCEDURE temba_update_flowruncount();
+
+-- Install TRUNCATE trigger
+DROP TRIGGER IF EXISTS temba_flowrun_truncate_flowruncount on flows_flowrun;
+CREATE TRIGGER temba_flowrun_truncate_flowruncount
+  AFTER TRUNCATE
+  ON flows_flowrun
+  EXECUTE PROCEDURE temba_update_flowruncount();
+
+----------------------------------------------------------------------
+----------------------------------------------------------------------
+-- Triggers for managing FlowPathCount squashing
+----------------------------------------------------------------------
+----------------------------------------------------------------------
+
+----------------------------------------------------------------------
+-- Utility function to lookup whether a contact is a simulator contact
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_flows_contact_is_test(_contact_id INT) RETURNS BOOLEAN AS $$
+DECLARE
+  _is_test BOOLEAN;
+BEGIN
+  SELECT is_test INTO STRICT _is_test FROM contacts_contact WHERE id = _contact_id;
+  RETURN _is_test;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Inserts a new flowpathcount
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_insert_flowpathcount(_flow_id INTEGER, _from_uuid UUID, _to_uuid UUID, _period TIMESTAMP WITH TIME ZONE, _count INTEGER) RETURNS VOID AS $$
+  BEGIN
+    INSERT INTO flows_flowpathcount("flow_id", "from_uuid", "to_uuid", "period", "count")
+      VALUES(_flow_id, _from_uuid, _to_uuid, date_trunc('hour', _period), _count);
+  END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Squashes all the existing flowpathcounts into a single row
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_squash_flowpathcount(_flow_id INTEGER, _from_uuid UUID, _to_uuid UUID, _period TIMESTAMP WITH TIME ZONE) RETURNS VOID AS $$
+  BEGIN
+    IF _to_uuid IS NULL THEN
+      WITH removed as (DELETE FROM flows_flowpathcount
+        WHERE "flow_id" = _flow_id AND "from_uuid" = _from_uuid
+              AND "to_uuid" IS NULL AND "period" = date_trunc('hour', _period)
+        RETURNING "count")
+        INSERT INTO flows_flowpathcount("flow_id", "from_uuid", "to_uuid", "period", "count")
+        VALUES (_flow_id, _from_uuid, NULL, date_trunc('hour', _period), GREATEST(0, (SELECT SUM("count") FROM removed)));
+    ELSE
+      WITH removed as (DELETE FROM flows_flowpathcount
+        WHERE "flow_id" = _flow_id AND "from_uuid" = _from_uuid
+              AND "to_uuid" = _to_uuid AND "period" = date_trunc('hour', _period)
+        RETURNING "count")
+        INSERT INTO flows_flowpathcount("flow_id", "from_uuid", "to_uuid", "period", "count")
+        VALUES (_flow_id, _from_uuid, _to_uuid, date_trunc('hour', _period), GREATEST(0, (SELECT SUM("count") FROM removed)));
+    END IF;
+  END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Utility function to fetch the flow id from a run
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_flow_for_run(_run_id INT) RETURNS INTEGER AS $$
+DECLARE
+  _flow_id INTEGER;
+BEGIN
+  SELECT flow_id INTO STRICT _flow_id FROM flows_flowrun WHERE id = _run_id;
+  RETURN _flow_id;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Utility function to return the appropriate from uuid
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_step_from_uuid(_row flows_flowstep) RETURNS UUID AS $$
+BEGIN
+  IF _row.rule_uuid IS NOT NULL THEN
+    RETURN uuid(_row.rule_uuid);
+  ELSIF _row.step_uuid IS NOT NULL THEN
+    RETURN uuid(_row.step_uuid);
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------
+-- Keeps track of our flowpathcounts as steps are updated
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION temba_update_flowpathcount() RETURNS TRIGGER AS $$
+DECLARE is_test boolean;
+DECLARE flow_id int;
+BEGIN
+
+  -- FlowStep being added, increment if next is set
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.next_uuid is NOT NULL THEN
+      IF NEW.left_on IS NOT NULL AND NOT temba_flows_contact_is_test(NEW.contact_id) THEN
+        PERFORM temba_insert_flowpathcount(temba_flow_for_run(NEW.run_id), temba_step_from_uuid(NEW), uuid(NEW.next_uuid), NEW.left_on, 1);
+      END IF;
+    ELSE
+      IF NEW.left_on IS NOT NULL AND NOT temba_flows_contact_is_test(NEW.contact_id) THEN
+        PERFORM temba_insert_flowpathcount(temba_flow_for_run(NEW.run_id), temba_step_from_uuid(NEW), NULL, NEW.left_on, 1);
+      END IF;
+    END IF;
+  -- FlowStep being removed
+  ELSIF TG_OP = 'DELETE' THEN
+    IF OLD.next_uuid is NOT NULL THEN
+      IF OLD.left_on IS NOT NULL AND NOT temba_flows_contact_is_test(OLD.contact_id) THEN
+        PERFORM temba_insert_flowpathcount(temba_flow_for_run(OLD.run_id), temba_step_from_uuid(OLD), uuid(OLD.next_uuid), OLD.left_on, -1);
+      END IF;
+    ELSE
+      IF OLD.left_on IS NOT NULL AND NOT temba_flows_contact_is_test(OLD.contact_id) THEN
+        PERFORM temba_insert_flowpathcount(temba_flow_for_run(OLD.run_id), temba_step_from_uuid(OLD), NULL, OLD.left_on, -1);
+      END IF;
+    END IF;
+  -- FlowStep being updated
+  ELSIF TG_OP = 'UPDATE' THEN
+    is_test = temba_flows_contact_is_test(OLD.contact_id);
+    flow_id = temba_flow_for_run(OLD.run_id);
+
+    RAISE LOG 'Updating %', OLD;
+
+    IF NOT is_test AND NEW.left_on IS NOT NULL THEN
+      IF NEW.next_uuid is NOT NULL THEN
+        PERFORM temba_insert_flowpathcount(flow_id, temba_step_from_uuid(NEW), uuid(NEW.next_uuid), NEW.left_on, 1);
+      ELSE
+        PERFORM temba_insert_flowpathcount(flow_id, temba_step_from_uuid(NEW), NULL, NEW.left_on, 1);
+      END IF;
+    END IF;
+
+  -- Table being cleared, reset all counts
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    DELETE FROM flows_flowpathcount;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Install INSERT, UPDATE and DELETE triggers
+DROP TRIGGER IF EXISTS temba_flowstep_update_flowpathcount on flows_flowstep;
+CREATE TRIGGER temba_flowstep_update_flowpathcount
+   AFTER INSERT OR DELETE OR UPDATE OF left_on
+   ON flows_flowstep
+   FOR EACH ROW
+   EXECUTE PROCEDURE temba_update_flowpathcount();
+
+-- Install TRUNCATE trigger
+DROP TRIGGER IF EXISTS temba_flowstep_truncate_flowpathcount on flows_flowstep;
+CREATE TRIGGER temba_flowstep_truncate_flowpathcount
+  AFTER TRUNCATE
+  ON flows_flowstep
+  EXECUTE PROCEDURE temba_update_flowpathcount();


### PR DESCRIPTION
* Same triggers as before, but now handles null next_uuid
* Changes update trigger to check on left_on instead of next_uuid
* Fixed case for redis-based activity resulting in negative counters for null destinations
* Fixes squashing method which results in null destinations not getting squashed during backfill, will squash these by hand once complete
