### PR TITLE
Fix loader animation background

### DIFF
--- a/static/less/style.less
+++ b/static/less/style.less
@@ -2692,21 +2692,23 @@ span.label a {
   overflow-wrap: break-word;
 }
 
-.loader {
-  height: 1px;
-  width: 100%;
-  position: relative;
-  overflow: hidden;
-  background-color: #ddd;
-  &:before{
-    display: block;
-    position: absolute;
-    content: "";
-    left: -200px;
-    width: 200px;
+#indicator {
+  .loader {
     height: 1px;
-    background-color: #2980b9;
-    animation: loading 2s linear infinite;
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+    background-color: #ddd;
+    &:before{
+      display: block;
+      position: absolute;
+      content: "";
+      left: -200px;
+      width: 200px;
+      height: 1px;
+      background-color: #2980b9;
+      animation: loading 2s linear infinite;
+    }
   }
 }
 


### PR DESCRIPTION
Just a styling tweak. Issue was collision with .loader from flow results. Properly nested now.