### PR TITLE
Add the destination address (shortcode usually) to what Kannel posts

### DIFF
--- a/templates/channels/channel_configuration.haml
+++ b/templates/channels/channel_configuration.haml
@@ -584,7 +584,7 @@
           keyword = default
           allowed-receiver-prefix = {{channel.address}}
           max-messages = 0
-          post-url = "https://{{domain}}{% url 'handlers.kannel_handler' 'receive' object.uuid %}/?backend=%i&sender=%p&message=%b&ts=%T&id=%I"
+          post-url = "https://{{domain}}{% url 'handlers.kannel_handler' 'receive' object.uuid %}/?backend=%i&sender=%p&message=%b&ts=%T&id=%I&to=%P"
           concatenation = true
           assume-plain-text = true
           accept-x-kannel-headers = true


### PR DESCRIPTION
No functional change on our side as we only use the channel uuid as identification but can aid when debugging carriers that do weird things.