### PR TITLE
Log celery exceptions

### DIFF
--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -18,7 +18,7 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 # register raven if configured
 raven_config = getattr(settings, 'RAVEN_CONFIG', None)
-if raven_config:
+if raven_config:  # pragma: no cover
     client = raven.Client(settings.RAVEN_CONFIG['dsn'])
     register_logger_signal(client)
     register_signal(client)

--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -1,12 +1,26 @@
 from __future__ import absolute_import, unicode_literals
 
+import celery
 import os
+import raven
 import sys
-from celery import Celery
+
 from django.conf import settings
+from raven.contrib.celery import register_signal, register_logger_signal
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'temba.settings')
+
+
+# Custom Celery so that we can hook in raven
+class Celery(celery.Celery):
+
+    def on_configure(self):
+        client = raven.Client(settings.RAVEN_CONFIG['dsn'])
+
+        # register raven for error tracking
+        register_logger_signal(client)
+        register_signal(client)
 
 app = Celery('temba')
 

--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -11,23 +11,14 @@ from raven.contrib.celery import register_signal, register_logger_signal
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'temba.settings')
 
+app = celery.Celery('temba')
 
-# Custom Celery so that we can hook in raven
-class Celery(celery.Celery):
-
-    def on_configure(self):
-        client = raven.Client(settings.RAVEN_CONFIG['dsn'])
-
-        # register raven for error tracking
-        register_logger_signal(client)
-        register_signal(client)
-
-app = Celery('temba')
-
-# Using a string here means the worker will not have to
-# pickle the object when using Windows.
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+client = raven.Client(settings.RAVEN_CONFIG['dsn'])
+register_logger_signal(client)
+register_signal(client)
 
 
 @app.task(bind=True)

--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -16,9 +16,12 @@ app = celery.Celery('temba')
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
-client = raven.Client(settings.RAVEN_CONFIG['dsn'])
-register_logger_signal(client)
-register_signal(client)
+# register raven if configured
+raven_config = getattr(settings, 'RAVEN_CONFIG', None)
+if raven_config:
+    client = raven.Client(settings.RAVEN_CONFIG['dsn'])
+    register_logger_signal(client)
+    register_signal(client)
 
 
 @app.task(bind=True)


### PR DESCRIPTION
Logs all exceptions that bubble out of celery tasks to sentry (tested on staging and seems to be doing the right thing)