### PR TITLE
Contact history intercooler updates

### DIFF
--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -168,7 +168,7 @@ def history_class(item):
     css = ''
     from temba.msgs.models import Msg
     if isinstance(item, Msg):
-        if item.media and item.media[:6] == 'video':
+        if item.media and item.media[:6] == 'video:':
             css = '%s %s' % (css, 'video')
         if item.direction or item.recipient_count:
             css = '%s %s' % (css, 'msg')

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -164,6 +164,21 @@ def activity_icon(item):
 
 
 @register.filter
+def history_class(item):
+    css = ''
+    from temba.msgs.models import Msg
+    if isinstance(item, Msg):
+        if item.media and item.media[:6] == 'video':
+            css = '%s %s' % (css, 'video')
+        if item.direction or item.recipient_count:
+            css = '%s %s' % (css, 'msg')
+    else:
+        css = '%s %s' % (css, 'non-msg')
+
+    return css
+
+
+@register.filter
 def event_time(event):
 
     unit = event.unit

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1218,9 +1218,13 @@ class ContactTest(TembaTest):
         self.create_campaign()
 
         # create some messages
-        for i in range(100):
+        for i in range(99):
             self.create_msg(direction='I', contact=self.joe, text="Inbound message %d" % i,
                             created_on=timezone.now() - timedelta(days=(100 - i)))
+
+        # add one that is a video
+        self.create_msg(direction='I', contact=self.joe, media="video:http://blah/file.mp4",
+                        created_on=timezone.now())
 
         # because messages are stored with timestamps from external systems, possible to have initial message
         # which is little bit older than the contact itself
@@ -1256,7 +1260,9 @@ class ContactTest(TembaTest):
         self.assertEqual(activity[2].direction, 'O')
         self.assertIsInstance(activity[3], FlowRun)
         self.assertIsInstance(activity[4], Msg)
-        self.assertEqual(activity[4].text, "Inbound message 99")
+        self.assertEqual(activity[4].media, "video:http://blah/file.mp4")
+        self.assertIsInstance(activity[5], Msg)
+        self.assertEqual(activity[5].text, "Inbound message 98")
         self.assertIsInstance(activity[8], EventFire)
         self.assertEqual(activity[-1].text, "Inbound message 11")
 
@@ -1311,7 +1317,8 @@ class ContactTest(TembaTest):
 
         # with our recent flag on, should not see the older messages
         activity = response.context['activity']
-        self.assertEqual(len(activity), 5)
+        self.assertEqual(len(activity), 6)
+        self.assertContains(response, 'video')
 
         # can't view history of contact in another org
         self.create_secondary_org()

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1217,14 +1217,13 @@ class ContactTest(TembaTest):
 
         self.create_campaign()
 
+        # add one that is a video
+        self.create_msg(direction='I', contact=self.joe, media="video:http://blah/file.mp4", text="Video caption", created_on=timezone.now())
+
         # create some messages
         for i in range(99):
             self.create_msg(direction='I', contact=self.joe, text="Inbound message %d" % i,
                             created_on=timezone.now() - timedelta(days=(100 - i)))
-
-        # add one that is a video
-        self.create_msg(direction='I', contact=self.joe, media="video:http://blah/file.mp4",
-                        created_on=timezone.now())
 
         # because messages are stored with timestamps from external systems, possible to have initial message
         # which is little bit older than the contact itself
@@ -1318,7 +1317,7 @@ class ContactTest(TembaTest):
         # with our recent flag on, should not see the older messages
         activity = response.context['activity']
         self.assertEqual(len(activity), 6)
-        self.assertContains(response, 'video')
+        self.assertContains(response, 'file.mp4')
 
         # can't view history of contact in another org
         self.create_secondary_org()

--- a/templates/contacts/contact_history.haml
+++ b/templates/contacts/contact_history.haml
@@ -1,10 +1,9 @@
 -load contacts humanize smartmin temba i18n
 
 -for item in activity
+  %tr{class:"{{item|history_class}}"}
 
-  %tr.item{data-created:'{{item.created_on|date:"U.u"}}', class:'msg_{{item.msg_type}} {%if item.media|slice:":6" == "video:" %}video{%endif%} {% if item.is_recent %}recent{%endif%} {% if item.direction or item.recipient_count%}msg{%else%}non-msg{%endif%}'}
     -with media_type=item.media|media_type media_content_type=item.media|media_content_type media_url=item.media|media_url
-
       %td.icon
         -if item.media
           -if media_type == 'audio'
@@ -41,6 +40,8 @@
               {{item|activity_icon}}
 
       %td.details.wrapped
+        -if recent
+          {% now "U"%}
         -if item.event_type
           -with item as call
             -if call.event_type == 'mt_miss'
@@ -168,12 +169,9 @@
         %span.long.hide
           {{item.created_on}}
 
--if not recent
-  %tr.since
-    %td{colspan:3}
-      %span.loading
-      -if has_older
-        %a.btn.btn-tiny.btn-secondary.load-more
-          Load More
-      %span#start_time.hidden
-        {{ start_time }}
+-if has_older and not recent
+  %tr{ ic-append-from:"/contact/history/{{contact.uuid}}/?rs={{ recent_start }}&before={{ start_time }}", 
+       ic-trigger-on:"scrolled-into-view", 
+       ic-target:"table.activity tbody.previous", 
+       ic-indicator:"#indicator" }
+

--- a/templates/contacts/contact_history.haml
+++ b/templates/contacts/contact_history.haml
@@ -40,8 +40,6 @@
               {{item|activity_icon}}
 
       %td.details.wrapped
-        -if recent
-          {% now "U"%}
         -if item.event_type
           -with item as call
             -if call.event_type == 'mt_miss'
@@ -170,7 +168,7 @@
           {{item.created_on}}
 
 -if has_older and not recent
-  %tr{ ic-append-from:"/contact/history/{{contact.uuid}}/?rs={{ recent_start }}&before={{ start_time }}", 
+  %tr{ ic-append-from:"/contact/history/{{contact.uuid}}/?after={{after}}&before={{before}}", 
        ic-trigger-on:"scrolled-into-view", 
        ic-target:"table.activity tbody.previous", 
        ic-indicator:"#indicator" }

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -133,13 +133,28 @@
               -elif evt.repeat_period == 'W'
                 -trans 'repeats weekly'
 
-  .header
-    -trans "Message History"
+  -trans "Message History"
+
   %table.activity.history
-    %tr.since
-      %td{colspan:3}
-        %span.loading
-          -trans "One moment..."
+    // poll for our most recent messages
+    %tr.poll{ ic-src:"/contact/history/{{contact.uuid}}/?rs={{recent_start}}&r=True",
+              ic-poll:"5s",
+              ic-trigger-on:"scrolled-into-view",
+              ic-target:"table .recent",
+              ic-poll-repeats:"30" }
+
+    %tbody.recent
+
+    // trigger the first batch of previous messages
+    %tr{ ic-append-from:"/contact/history/{{contact.uuid}}/?rs={{recent_start}}", 
+         ic-trigger-on:"scrolled-into-view", 
+         ic-target:"table .previous", 
+         ic-indicator:"#indicator" }
+
+    %tbody.previous
+
+  #indicator{style:"display:none"}
+    .loader
 
 
 -block post-content
@@ -171,7 +186,6 @@
 
     {% lessblock %}
       :plain
-
         .header {
           padding: 8px;
           font-size:14px;
@@ -508,25 +522,25 @@
         $(this).children('.long').hide();
       });
       // fetch our first chunk of history
-      $.get('/contact/history/{{contact.uuid}}/?rs={{recent_start}}', function(data){
-        $('.history tr:last').remove();
-        $('.history').append(data);
+      //$.get('/contact/history/{{contact.uuid}}/?rs={{recent_start}}', function(data){
+      //  $('.history tr:last').remove();
+      //  $('.history').append(data);
 
-        startTime = parseInt($('.history #start_time').text());
-      });
+      //  startTime = parseInt($('.history #start_time').text());
+      //});
 
       // when they click to load more, fetch more history
-      $('.load-more').live('click', function() {
-        $(this).css('visibility', 'hidden');
-        $('.since .loading').text('One moment...');
+      //$('.load-more').live('click', function() {
+      //  $(this).css('visibility', 'hidden');
+      //  $('.since .loading').text('One moment...');
 
-        $.get('/contact/history/{{contact.uuid}}/?rs={{recent_start}}&before=' + startTime, function(data){
-          $('.history tr:last').remove();
-          $('.history').append(data);
+      //  $.get('/contact/history/{{contact.uuid}}/?rs={{recent_start}}&before=' + startTime, function(data){
+      //    $('.history tr:last').remove();
+      //    $('.history').append(data);
 
-          startTime = parseInt($('.history #start_time').text());
-        });
-      });
+      //    startTime = parseInt($('.history #start_time').text());
+      //  });
+      // });
 
       // configure the number of contact fields to show
       var featuredMax = 4;
@@ -551,10 +565,17 @@
       })
 
       // update messages every 30s
-      scheduledRefresh = setTimeout(fetchRecentMessages, refreshSeconds * 1000)
+      // scheduledRefresh = setTimeout(fetchRecentMessages, refreshSeconds * 1000)
     });
 
     function fetchRecentMessages(){
+
+      Intercooler.triggerRequest($('tr.poll'));
+
+      if (true) {
+        return;
+      }
+      
       clearTimeout(scheduledRefresh);
       $.get('/contact/history/{{contact.uuid}}/?r=true&rs={{recent_start}}', function(data){
           $('.history tr.recent').remove();

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -133,9 +133,9 @@
               -elif evt.repeat_period == 'W'
                 -trans 'repeats weekly'
 
-  -trans "Message History"
-
-  %table.activity.history
+  %h5
+    -trans "Message History"
+  %table.activity.history{style:'padding:0;margin:0'}
     // poll for our most recent messages
     %tr.poll{ ic-src:"/contact/history/{{contact.uuid}}/?after={{recent_start}}",
               ic-poll:"5s",
@@ -504,8 +504,6 @@
   :javascript
 
     var startTime = null;
-    var refreshSeconds = 30;
-    var scheduledRefresh = null;
 
     $(document).ready(function() {
 
@@ -521,26 +519,6 @@
         $(this).children('.short').show();
         $(this).children('.long').hide();
       });
-      // fetch our first chunk of history
-      //$.get('/contact/history/{{contact.uuid}}/?rs={{recent_start}}', function(data){
-      //  $('.history tr:last').remove();
-      //  $('.history').append(data);
-
-      //  startTime = parseInt($('.history #start_time').text());
-      //});
-
-      // when they click to load more, fetch more history
-      //$('.load-more').live('click', function() {
-      //  $(this).css('visibility', 'hidden');
-      //  $('.since .loading').text('One moment...');
-
-      //  $.get('/contact/history/{{contact.uuid}}/?rs={{recent_start}}&before=' + startTime, function(data){
-      //    $('.history tr:last').remove();
-      //    $('.history').append(data);
-
-      //    startTime = parseInt($('.history #start_time').text());
-      //  });
-      // });
 
       // configure the number of contact fields to show
       var featuredMax = 4;
@@ -563,27 +541,10 @@
           $('.normal').css('display', 'inline-block').show();
         }
       })
-
-      // update messages every 30s
-      // scheduledRefresh = setTimeout(fetchRecentMessages, refreshSeconds * 1000)
     });
 
-    function fetchRecentMessages(){
-
+    function refreshRecents(){
       Intercooler.triggerRequest($('tr.poll'));
-
-      if (true) {
-        return;
-      }
-      
-      clearTimeout(scheduledRefresh);
-      $.get('/contact/history/{{contact.uuid}}/?r=true&rs={{recent_start}}', function(data){
-          $('.history tr.recent').remove();
-          if (data.strip().length > 0) {
-            $('.history').prepend(data);
-          }
-          scheduledRefresh = setTimeout(fetchRecentMessages, refreshSeconds * 1000)
-      });
     }
 
     // plays the audio recording for a message
@@ -672,7 +633,7 @@
     $(".contact-send-button").on('click', function() {
       {% if has_sendable_urn %}
       $(".gear-menu").removeClass("open");
-      showComposeInitialized("c={{object.uuid}}", null, fetchRecentMessages);
+      showComposeInitialized("c={{object.uuid}}", null, refreshRecents);
       {% else %}
       modal = new Modal('{% trans "Error" %}', '{% trans "This contact does not have any number which you can send to. Please edit the contact first or add a new phone." %}');
       modal.addClass('alert');

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -137,7 +137,7 @@
 
   %table.activity.history
     // poll for our most recent messages
-    %tr.poll{ ic-src:"/contact/history/{{contact.uuid}}/?rs={{recent_start}}&r=True",
+    %tr.poll{ ic-src:"/contact/history/{{contact.uuid}}/?after={{recent_start}}",
               ic-poll:"5s",
               ic-trigger-on:"scrolled-into-view",
               ic-target:"table .recent",
@@ -146,7 +146,7 @@
     %tbody.recent
 
     // trigger the first batch of previous messages
-    %tr{ ic-append-from:"/contact/history/{{contact.uuid}}/?rs={{recent_start}}", 
+    %tr{ ic-append-from:"/contact/history/{{contact.uuid}}/?before={{recent_start}}", 
          ic-trigger-on:"scrolled-into-view", 
          ic-target:"table .previous", 
          ic-indicator:"#indicator" }


### PR DESCRIPTION
* Switch to using intercooler for message fetching and status/new message polling
* Simplify history parameters to just `before` and `after` to denote time windows; recent polling inferred when before is not included
* Message history list now infinite scrolls
* Use same loading indicator as flow results run table