### PR TITLE
Simpler squash tasks

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -18,7 +18,6 @@ from django.db.models import Q, Count, Prefetch, Sum
 from django.utils import timezone
 from django.utils.html import escape
 from django.utils.translation import ugettext, ugettext_lazy as _
-from django_redis import get_redis_connection
 from smartmin.models import SmartModel
 from temba_expressions.evaluator import EvaluationContext, DateStyle
 from temba.contacts.models import Contact, ContactGroup, ContactURN, URN, TEL_SCHEME
@@ -29,7 +28,7 @@ from temba.utils import get_datetime_format, datetime_to_str, analytics, chunk_l
 from temba.utils.cache import get_cacheable_attr
 from temba.utils.email import send_template_email
 from temba.utils.expressions import evaluate_template
-from temba.utils.models import TembaModel
+from temba.utils.models import TembaModel, HighpointMixin
 from temba.utils.queues import DEFAULT_PRIORITY, push_task, LOW_PRIORITY, HIGH_PRIORITY
 from uuid import uuid4
 from .handler import MessageHandler
@@ -1559,7 +1558,7 @@ STOP_WORDS = 'a,able,about,across,after,all,almost,also,am,among,an,and,any,are,
              'who,whom,why,will,with,would,yet,you,your'.split(',')
 
 
-class SystemLabel(models.Model):
+class SystemLabel(models.Model, HighpointMixin):
     """
     Counts of messages/broadcasts/calls maintained by database level triggers
     """
@@ -1572,7 +1571,7 @@ class SystemLabel(models.Model):
     TYPE_SCHEDULED = 'E'
     TYPE_CALLS = 'C'
 
-    LAST_SQUASH_KEY = 'last_systemlabel_squash'
+    HIGHPOINT_KEY = 'last_systemlabel_squash'
 
     TYPE_CHOICES = ((TYPE_INBOX, "Inbox"),
                     (TYPE_FLOWS, "Flows"),
@@ -1592,10 +1591,7 @@ class SystemLabel(models.Model):
     @classmethod
     def squash_counts(cls):
         # get the id of the last count we squashed
-        r = get_redis_connection()
-        last_squash = r.get(SystemLabel.LAST_SQUASH_KEY)
-        if not last_squash:
-            last_squash = 0
+        last_squash = cls.get_last_highpoint()
 
         # get the unique systemlabel ids for all new ones
         start = time.time()
@@ -1608,11 +1604,9 @@ class SystemLabel(models.Model):
             squash_count += 1
 
         # insert our new top squashed id
-        max_id = SystemLabel.objects.all().order_by('-id').first()
-        if max_id:
-            r.set(SystemLabel.LAST_SQUASH_KEY, max_id.id)
+        cls.save_new_highpoint()
 
-        print "Squashed system label counts for %d pairs in %0.3fs" % (squash_count, time.time() - start)
+        print("Squashed system label counts for %d pairs in %0.3fs" % (squash_count, time.time() - start))
 
     @classmethod
     def create_all(cls, org):


### PR DESCRIPTION
Add `HighpointMixin` to hold code common to tasks which operate on a highpoint - depending on what gets merged first between this and #1021, I'll update for the `FlowPathRecentStep.prune()` task.

Also fixes the case in one task where we record the new highpoint before doing the squash. This avoids missing new records which are inserted during the squash - but it means that rows inserted by the squash process, are continually re-squashed, e.g.

| id | count |
|---|-------|
| 1 | 1 |
| 2 | 1 |
| 3 | 1 |

squashing for the first time saves the highpoint as 3, and leaves table as:

| id | count |
|---|-------|
| 4 | 3 |

next squash will squash everything above 3, save new highpoint as 4, and leave table as:

| id | count |
|---|-------|
| 5 | 3 |

and so on

Saving the highpoint after the squash process has it's own problem - you can miss items inserted during the squash process and these might never be squashed - but that could be rectified occasionally by resetting the highpoint record to zero. 

In fact we could solve that by setting an expiry time on the highpoint key?