### PR TITLE
Increase the maximum length of message that can be sent over the API

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -101,7 +101,7 @@ class BroadcastReadSerializer(ReadSerializer):
 
 
 class BroadcastWriteSerializer(WriteSerializer):
-    text = serializers.CharField(required=True, max_length=480)
+    text = serializers.CharField(required=True, max_length=640)
     urns = fields.URNListField(required=False)
     contacts = fields.ContactField(many=True, required=False)
     groups = fields.ContactGroupField(many=True, required=False)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -592,7 +592,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
 
     A `POST` allows you to create and send new broadcasts, with the following JSON data:
 
-      * **text** - the text of the message to send (string, limited to 480 characters)
+      * **text** - the text of the message to send (string, limited to 640 characters)
       * **urns** - the URNs of contacts to send to (array of up to 100 strings, optional)
       * **contacts** - the UUIDs of contacts to send to (array of up to 100 strings, optional)
       * **groups** - the UUIDs of contact groups to send to (array of up to 100 strings, optional)


### PR DESCRIPTION
To 640 to match rest of app. CasePro users want to send longer messages.