### PR TITLE
Return org id as response header so that it can be logged in nginx

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -170,6 +170,7 @@ MIDDLEWARE_CLASSES = (
     'temba.middleware.FlowSimulationMiddleware',
     'temba.middleware.ActivateLanguageMiddleware',
     'temba.middleware.NonAtomicGetsMiddleware',
+    'temba.utils.middleware.OrgHeaderMiddleware',
 )
 
 ROOT_URLCONF = 'temba.urls'

--- a/temba/utils/middleware.py
+++ b/temba/utils/middleware.py
@@ -28,3 +28,15 @@ class DisableMiddleware(object):
         if getattr(view_func, 'disable_middleware', False):
             return view_func(request, *view_args, **view_kwargs)
         return None
+
+
+class OrgHeaderMiddleware(object):
+    """
+    Simple middleware to add a response header with the current org id, which can then be included in logs
+    """
+    def process_response(self, request, response):
+        if request.user.is_authenticated():
+            org = request.user.get_org()
+            if org:
+                response['X-Temba-Org'] = org.id
+        return response


### PR DESCRIPTION
To include in nginx log, add following to config for our current "json_log" format:

```
'"temba_org": $upstream_http_x_temba_org, '
```