### PR TITLE
Don't pass raw enum to notify_mage_task as it's not JSON serializable

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -638,7 +638,7 @@ class Channel(TembaModel):
 
                 # notify Mage so that it activates this channel
                 from .tasks import MageStreamAction, notify_mage_task
-                on_transaction_commit(lambda: notify_mage_task.delay(channel.uuid, MageStreamAction.activate))
+                on_transaction_commit(lambda: notify_mage_task.delay(channel.uuid, MageStreamAction.activate.name))
 
         return channel
 
@@ -1081,7 +1081,7 @@ class Channel(TembaModel):
         if notify_mage and self.channel_type == Channel.TYPE_TWITTER:
             # notify Mage so that it deactivates this channel
             from .tasks import MageStreamAction, notify_mage_task
-            on_transaction_commit(lambda: notify_mage_task.delay(self.uuid, MageStreamAction.deactivate))
+            on_transaction_commit(lambda: notify_mage_task.delay(self.uuid, MageStreamAction.deactivate.name))
 
         from temba.triggers.models import Trigger
         Trigger.objects.filter(channel=self, org=org).update(is_active=False)

--- a/temba/channels/tasks.py
+++ b/temba/channels/tasks.py
@@ -108,6 +108,7 @@ def notify_mage_task(channel_uuid, action):
     """
     Notifies Mage of a change to a Twitter channel
     """
+    action = MageStreamAction[action]
     mage = MageClient(settings.MAGE_API_URL, settings.MAGE_AUTH_TOKEN)
 
     if action == MageStreamAction.activate:

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -889,7 +889,7 @@ class ChannelCRUDL(SmartCRUDL):
             if obj.channel_type == Channel.TYPE_TWITTER:
                 # notify Mage so that it refreshes this channel
                 from .tasks import MageStreamAction, notify_mage_task
-                on_transaction_commit(lambda: notify_mage_task.delay(obj.uuid, MageStreamAction.refresh))
+                on_transaction_commit(lambda: notify_mage_task.delay(obj.uuid, MageStreamAction.refresh.name))
 
             return obj
 


### PR DESCRIPTION
Not sure why this has only started being a problem recently. Maybe celery wasn't actually using JSON?

Fixes https://sentry.io/nyaruka/textit/issues/206692165/