### PR TITLE
pass charset parameter to kannel when sending unicode

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1479,9 +1479,10 @@ class Channel(TembaModel):
         # figure out if we should send encoding or do any of our own substitution
         desired_encoding = channel.config.get(Channel.CONFIG_ENCODING, Channel.ENCODING_DEFAULT)
 
-        # they want unicde, they get unicode!
+        # they want unicode, they get unicode!
         if desired_encoding == Channel.ENCODING_UNICODE:
             payload['coding'] = '2'
+            payload['charset'] = 'utf8'
 
         # otherwise, if this is smart encoding, try to derive it
         elif desired_encoding == Channel.ENCODING_SMART:
@@ -1491,6 +1492,7 @@ class Channel(TembaModel):
 
             if encoding == Encoding.UNICODE:
                 payload['coding'] = '2'
+                payload['charset'] = 'utf8'
 
         log_payload = payload.copy()
         log_payload['password'] = 'x' * len(log_payload['password'])

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -4094,6 +4094,7 @@ class KannelTest(TembaTest):
                 # assert verify was set to true
                 self.assertEquals("Unicode. ☺", mock.call_args[1]['params']['text'])
                 self.assertEquals('2', mock.call_args[1]['params']['coding'])
+                self.assertEquals('utf8', mock.call_args[1]['params']['charset'])
 
                 self.clear_cache()
 
@@ -4114,6 +4115,7 @@ class KannelTest(TembaTest):
                 # assert verify was set to true
                 self.assertEquals("Normal", mock.call_args[1]['params']['text'])
                 self.assertFalse('coding' in mock.call_args[1]['params'])
+                self.assertFalse('charset' in mock.call_args[1]['params'])
 
                 self.clear_cache()
 
@@ -4136,6 +4138,7 @@ class KannelTest(TembaTest):
                 # assert verify was set to true
                 self.assertEquals("Normal", mock.call_args[1]['params']['text'])
                 self.assertEquals('2', mock.call_args[1]['params']['coding'])
+                self.assertEquals('utf8', mock.call_args[1]['params']['charset'])
 
                 self.clear_cache()
 


### PR DESCRIPTION
Turns out we need that to send things in the right format at the SMSC level.