### PR TITLE
Offline context per brand

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -290,7 +290,6 @@ LOGGING = {
 # -----------------------------------------------------------------------------------
 BRANDING = {
     'rapidpro.io': {
-        'host': 'rapidpro.ngrok.com',
         'slug': 'rapidpro',
         'name': 'RapidPro',
         'org': 'UNICEF',

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -290,11 +290,12 @@ LOGGING = {
 # -----------------------------------------------------------------------------------
 BRANDING = {
     'rapidpro.io': {
+        'host': 'rapidpro.ngrok.com',
         'slug': 'rapidpro',
         'name': 'RapidPro',
         'org': 'UNICEF',
         'colors': dict(primary='#0c6596'),
-        'styles': ['brands/rapidpro/font/style.css', 'brands/rapidpro/less/style.less'],
+        'styles': ['brands/rapidpro/font/style.css'],
         'welcome_topup': 1000,
         'email': 'join@rapidpro.io',
         'support_email': 'support@rapidpro.io',
@@ -310,7 +311,7 @@ BRANDING = {
         'bundles': [],
         'welcome_packs': [dict(size=5000, name="Demo Account"), dict(size=100000, name="UNICEF Account")],
         'description': _("Visually build nationally scalable mobile applications from anywhere in the world."),
-        'credits': _("Copyright &copy; 2012-2015 UNICEF, Nyaruka. All Rights Reserved.")
+        'credits': _("Copyright &copy; 2012-2017 UNICEF, Nyaruka. All Rights Reserved.")
     }
 }
 DEFAULT_BRAND = 'rapidpro.io'
@@ -1152,11 +1153,17 @@ else:
         ('text/less', 'lessc --include-path="%s" {infile} {outfile}' % os.path.join(PROJECT_DIR, '../static', 'less')),
         ('text/coffeescript', 'coffee --compile --stdio')
     )
-    COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL, base_template='frame.html')
 
 COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = False
 COMPRESS_URL = '/sitestatic/'
+
+# build up our offline compression context based on available brands
+COMPRESS_OFFLINE_CONTEXT = []
+for brand in BRANDING.values():
+    context = dict(STATIC_URL=COMPRESS_URL, base_template='frame.html', debug=False, testing=False)
+    context['brand'] = dict(slug=brand['slug'], styles=brand['styles'])
+    COMPRESS_OFFLINE_CONTEXT.append(context)
 
 MAGE_API_URL = 'http://localhost:8026/api/v1'
 MAGE_AUTH_TOKEN = '___MAGE_TOKEN_YOU_PICK__'

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -117,7 +117,7 @@ FIXTURE_DIRS = (os.path.join(PROJECT_DIR, '../fixtures'),)
 TESTFILES_DIR = os.path.join(PROJECT_DIR, '../testfiles')
 STATICFILES_DIRS = (os.path.join(PROJECT_DIR, '../static'), os.path.join(PROJECT_DIR, '../media'), )
 STATIC_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
-STATIC_URL = '/static/'
+STATIC_URL = '/sitestatic/'
 COMPRESS_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
 MEDIA_ROOT = os.path.join(PROJECT_DIR, '../media')
 MEDIA_URL = "/media/"
@@ -1155,12 +1155,11 @@ else:
 
 COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = False
-COMPRESS_URL = '/sitestatic/'
 
 # build up our offline compression context based on available brands
 COMPRESS_OFFLINE_CONTEXT = []
 for brand in BRANDING.values():
-    context = dict(STATIC_URL=COMPRESS_URL, base_template='frame.html', debug=False, testing=False)
+    context = dict(STATIC_URL=STATIC_URL, base_template='frame.html', debug=False, testing=False)
     context['brand'] = dict(slug=brand['slug'], styles=brand['styles'])
     COMPRESS_OFFLINE_CONTEXT.append(context)
 


### PR DESCRIPTION
Uses the standard compress command, but with a list of offline contexts per brand.

Addresses same issue as rapidpro/rapidpro/pull/446