### PR TITLE
Contact search improvements

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -951,7 +951,7 @@ class Contact(TembaModel):
         """
         from temba.contacts import search
 
-        if not base_queryset:
+        if base_queryset is None:
             base_queryset = Contact.objects.filter(org=org, is_active=True, is_test=False, is_blocked=False, is_stopped=False)
 
         return search.contact_search(org, query, base_queryset)

--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -15,7 +15,7 @@
 
 -block above-bar
   -block top-form
-    %form{'method':'get', 'action': "{% url 'contacts.contact_list' %}" }
+    %form{method:'get'}
       %input.input-medium.search-query{'type':'text', 'placeholder':'{% trans "Search" %}', 'name':"search", 'value':"{{search}}"}
 
 -block content


### PR DESCRIPTION
- Enables searching in groups and blocked/stopped contacts. Currently the search box is shown at the top of any contact listing page, but using it always takes the user back to the 'All Contacts' list page and does a search on that group.
- Fixes `Contact.search` so it doesn't try to evaluate the base_query just to see it is provided.