### PR TITLE
Increase non-overlap on timeout queueing, never double queue

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -2823,7 +2823,7 @@ class Channel(TembaModel):
 
         if sent_today or sent_yesterday:
             Msg.mark_sent(r, msg, WIRED, -1)
-            print("!! [%d] prevented duplicate send" % (msg.id))
+            print("!! [%d] prevented duplicate send" % msg.id)
             return
 
         # channel can be none in the case where the channel has been removed

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -5,12 +5,16 @@ import time
 from celery.task import task
 from django.utils import timezone
 from django_redis import get_redis_connection
+from datetime import timedelta
 from temba.flows.models import FlowStatsCache
 from temba.msgs.models import Broadcast, Msg, TIMEOUT_EVENT, HANDLER_QUEUE, HANDLE_EVENT_TASK
 from temba.orgs.models import Org
+from temba.utils import datetime_to_epoch
 from temba.utils.queues import start_task, complete_task
 from temba.utils.queues import push_task, nonoverlapping_task
 from .models import ExportFlowResultsTask, Flow, FlowStart, FlowRun, FlowStep, FlowRunCount, FlowPathCount, FlowPathRecentStep
+
+FLOW_TIMEOUT_KEY = 'flow_timeouts_%y_%m_%d'
 
 
 @task(track_started=True, name='send_email_action_task')
@@ -41,17 +45,36 @@ def check_flows_task():
     FlowRun.bulk_exit(runs, FlowRun.EXIT_TYPE_EXPIRED)
 
 
-@nonoverlapping_task(track_started=True, name='check_flow_timeouts_task', lock_key='check_flow_timeouts')  # pragma: no cover
+@nonoverlapping_task(track_started=True, name='check_flow_timeouts_task', lock_key='check_flow_timeouts', lock_timeout=3600)  # pragma: no cover
 def check_flow_timeouts_task():
     """
     See if any flow runs have timed out
     """
+    r = get_redis_connection()
+
     # find any runs that should have timed out
     runs = FlowRun.objects.filter(is_active=True, timeout_on__lte=timezone.now())
     runs = runs.only('id', 'org', 'timeout_on')
     for run in runs:
-        # move this flow forward via the handler queue
-        push_task(run.org_id, HANDLER_QUEUE, HANDLE_EVENT_TASK, dict(type=TIMEOUT_EVENT, run=run.id, timeout_on=run.timeout_on))
+        run_key = '%d:%d' % (run.id, datetime_to_epoch(run.timeout_on))
+
+        # check whether we have already queued this timeout
+        pipe = r.pipeline()
+        pipe.sismember(timezone.now().strftime(FLOW_TIMEOUT_KEY), run_key)
+        pipe.sismember((timezone.now() - timedelta(days=1)).strftime(FLOW_TIMEOUT_KEY), run_key)
+        (queued_today, queued_yesterday) = pipe.execute()
+
+        # if not, add a task to handle the timeout
+        if not queued_today and not queued_yesterday:
+            push_task(run.org_id, HANDLER_QUEUE, HANDLE_EVENT_TASK,
+                      dict(type=TIMEOUT_EVENT, run=run.id, timeout_on=run.timeout_on))
+
+            # tag this run as being worked on so we don't double queue
+            pipe = r.pipeline()
+            sent_key = timezone.now().strftime(FLOW_TIMEOUT_KEY)
+            pipe.sadd(sent_key, run_key)
+            pipe.expire(sent_key, 86400)
+            pipe.execute()
 
 
 @task(track_started=True, name='continue_parent_flows')  # pragma: no cover

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -6472,7 +6472,7 @@ class TimeoutTest(FlowFileTest):
         last_msg.sent_on = timezone.now() - timedelta(minutes=5)
         last_msg.save()
 
-        time.sleep(.5)
+        time.sleep(1)
 
         # ok, change our timeout to the past
         timeout = timezone.now()
@@ -6491,6 +6491,13 @@ class TimeoutTest(FlowFileTest):
         self.assertIsNone(run.timeout_on)
         current_step = run.steps.order_by('-id').first()
         self.assertEqual(current_step.step_uuid, start_step.step_uuid)
+
+        # check that we can't be double queued by manually moving our timeout back
+        with patch('temba.utils.queues.push_task') as mock_push:
+            FlowRun.objects.all().update(timeout_on=timeout)
+            check_flow_timeouts_task()
+
+            self.assertEqual(0, mock_push.call_count)
 
     def test_timeout_loop(self):
         from temba.flows.tasks import check_flow_timeouts_task
@@ -6556,6 +6563,7 @@ class TimeoutTest(FlowFileTest):
 
         # nothing should have changed as we haven't yet sent our msg
         self.assertTrue(run.is_active)
+        time.sleep(1)
 
         # ok, mark our message as sent, but only two minutes ago
         last_msg = run.get_last_msg(OUTGOING)
@@ -6572,6 +6580,8 @@ class TimeoutTest(FlowFileTest):
         # ok, finally mark our message sent a while ago
         last_msg.sent_on = timezone.now() - timedelta(minutes=10)
         last_msg.save()
+
+        time.sleep(1)
         FlowRun.objects.all().update(timeout_on=timezone.now())
         check_flow_timeouts_task()
         run.refresh_from_db()
@@ -6631,7 +6641,7 @@ class TimeoutTest(FlowFileTest):
         self.assertTrue(run.is_active)
         self.assertTrue(timezone.now() - timedelta(minutes=1) < run.timeout_on > timezone.now() + timedelta(minutes=4))
 
-        time.sleep(.5)
+        time.sleep(1)
 
         # ok, change our timeout to the past
         FlowRun.objects.all().update(timeout_on=timezone.now())

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -174,6 +174,14 @@ def ms_to_datetime(ms):
     return dt.replace(microsecond=(ms % 1000) * 1000).replace(tzinfo=pytz.utc)
 
 
+def datetime_to_epoch(dt):
+    """
+    Converts a datetime to seconds since 1970
+    """
+    utc_naive = dt.replace(tzinfo=None) - dt.utcoffset()
+    return (utc_naive - datetime.datetime(1970, 1, 1)).total_seconds()
+
+
 def str_to_bool(text):
     """
     Parses a boolean value from the given text

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -39,7 +39,7 @@ from . import format_decimal, slugify_with, str_to_datetime, str_to_time, trunca
     clean_string
 from . import PageableQuery, json_to_dict, dict_to_struct, datetime_to_ms, ms_to_datetime, dict_to_json, str_to_bool
 from . import percentage, datetime_to_json_date, json_date_to_datetime, non_atomic_gets
-from . import datetime_to_str, chunk_list, get_country_code_by_name
+from . import datetime_to_str, chunk_list, get_country_code_by_name, datetime_to_epoch
 
 
 class InitTest(TembaTest):
@@ -75,6 +75,10 @@ class InitTest(TembaTest):
         self.assertEqual(datetime_to_str(d2, tz=tz), '2014-01-02T03:04:05.000006Z')  # in specific timezone
         self.assertEqual(datetime_to_str(d2, ms=False), '2014-01-02T01:04:05Z')  # no ms
         self.assertEqual(datetime_to_str(d2.date()), '2014-01-02T00:00:00.000000Z')  # no ms
+
+    def test_datetime_to_epoch(self):
+        dt = json_date_to_datetime('2014-01-02T01:04:05.000Z')
+        self.assertEqual(1388624645, datetime_to_epoch(dt))
 
     def test_str_to_datetime(self):
         tz = pytz.timezone('Asia/Kabul')


### PR DESCRIPTION
When we are timing out a huge number of runs we can double queue the handling of those and get in a giant loop.

Two changes:
 - task grabs a lock for 1 hour instead of 15 mins
 - we keep track of run/timeout pairs we have queued to process and never double queue

Should keep us from getting too out of control.