### PR TITLE
Nexmo uuids

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -1004,14 +1004,14 @@ class NexmoCallHandler(BaseChannelHandler):
             body_json = json.loads(request_body)
             status = body_json.get('status', None)
             duration = body_json.get('duration', None)
-            conversation_uuid = body_json.get('conversation_uuid', None)
+            call_uuid = body_json.get('uuid', None)
 
-            if conversation_uuid is None:
-                return HttpResponse("Missing conversation_uuid parameter, ignoring")
+            if call_uuid is None:
+                return HttpResponse("Missing uuid parameter, ignoring")
 
-            call = IVRCall.objects.filter(external_id=conversation_uuid).first()
+            call = IVRCall.objects.filter(external_id=call_uuid).first()
             if not call:
-                response = dict(message="Call not found for %s" % conversation_uuid)
+                response = dict(message="Call not found for %s" % call_uuid)
                 return JsonResponse(response)
 
             channel = call.channel
@@ -1034,7 +1034,7 @@ class NexmoCallHandler(BaseChannelHandler):
             body_json = json.loads(request_body)
             from_number = body_json.get('from', None)
             channel_number = body_json.get('to', None)
-            external_id = body_json.get('conversation_uuid', None)
+            external_id = body_json.get('uuid', None)
 
             if not from_number or not channel_number or not external_id:
                 return HttpResponse("Missing parameters, Ignoring")

--- a/temba/ivr/clients.py
+++ b/temba/ivr/clients.py
@@ -49,8 +49,8 @@ class NexmoClient(NexmoCli):
 
         try:
             response = self.create_call(params=params)
-            conversation_uuid = response.get('conversation_uuid', None)
-            call.external_id = six.text_type(conversation_uuid)
+            call_uuid = response.get('uuid', None)
+            call.external_id = six.text_type(call_uuid)
             call.save()
 
             ChannelLog.log_ivr_interaction(call, "Started Nexmo call %s" % call.external_id, json.dumps(params),

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -1099,7 +1099,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['uuid'] = 'ext-id'
+        post_data['conversation_uuid'] = 'ext-id'
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
 
@@ -1151,19 +1151,20 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['status'] = 'ringing'
         post_data['duration'] = '0'
-        post_data['uuid'] = 'ext-id'
+        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'call-ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
 
         self.assertEqual(200, response.status_code)
-        self.assertContains(response, 'Call not found for ext-id')
+        self.assertContains(response, 'Call not found for call-ext-id')
 
         # create an inbound call
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['uuid'] = 'ext-id'
+        post_data['conversation_uuid'] = 'ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
@@ -1194,7 +1195,8 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['status'] = 'completed'
         post_data['duration'] = '0'
-        post_data['uuid'] = 'ext-id'
+        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'call-ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
@@ -1207,7 +1209,7 @@ class IVRTests(FlowFileTest):
         self.assertEqual(ChannelLog.objects.all().count(), 2)
         channel_log = ChannelLog.objects.last()
         self.assertEqual(channel_log.session.id, call.id)
-        self.assertEqual(channel_log.description, "Updated call ext-id status to Complete")
+        self.assertEqual(channel_log.description, "Updated call call-ext-id status to Complete")
 
     @patch('nexmo.Client.create_application')
     def test_nexmo_config_empty_callbacks(self, mock_create_application):
@@ -1250,7 +1252,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['uuid'] = 'ext-id'
+        post_data['conversation_uuid'] = 'ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
@@ -1279,7 +1281,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['uuid'] = 'ext-id'
+        post_data['conversation_uuid'] = 'ext-id'
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
 

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -217,7 +217,7 @@ class IVRTests(FlowFileTest):
     @patch('nexmo.Client.create_call')
     def test_ivr_recording_with_nexmo(self, mock_create_call, mock_create_application):
         mock_create_application.return_value = dict(id='app-id', keys=dict(private_key='private-key'))
-        mock_create_call.return_value = dict(conversation_uuid='12345')
+        mock_create_call.return_value = dict(uuid='12345')
 
         # connect Nexmo
         self.org.connect_nexmo('123', '456', self.admin)
@@ -580,7 +580,7 @@ class IVRTests(FlowFileTest):
     @patch('nexmo.Client.create_call')
     def test_ivr_digital_gather_with_nexmo(self, mock_create_call, mock_create_application):
         mock_create_application.return_value = dict(id='app-id', keys=dict(private_key='private-key'))
-        mock_create_call.return_value = dict(conversation_uuid='12345')
+        mock_create_call.return_value = dict(uuid='12345')
 
         self.org.connect_nexmo('123', '456', self.admin)
         self.org.save()
@@ -621,8 +621,8 @@ class IVRTests(FlowFileTest):
     @patch('nexmo.Client.create_call')
     def test_hangup(self, mock_create_call, mock_create_application, mock_update_call):
         mock_create_application.return_value = dict(id='app-id', keys=dict(private_key='private-key'))
-        mock_create_call.return_value = dict(conversation_uuid='12345')
-        mock_update_call.return_value = dict(conversation_uuid='12345')
+        mock_create_call.return_value = dict(uuid='12345')
+        mock_update_call.return_value = dict(uuid='12345')
 
         self.org.connect_nexmo('123', '456', self.admin)
         self.org.save()
@@ -652,7 +652,7 @@ class IVRTests(FlowFileTest):
     @patch('nexmo.Client.create_call')
     def test_ivr_subflow_with_nexmo(self, mock_create_call, mock_create_application):
         mock_create_application.return_value = dict(id='app-id', keys=dict(private_key='private-key'))
-        mock_create_call.return_value = dict(conversation_uuid='12345')
+        mock_create_call.return_value = dict(uuid='12345')
 
         self.org.connect_nexmo('123', '456', self.admin)
         self.org.save()
@@ -1083,7 +1083,7 @@ class IVRTests(FlowFileTest):
     @patch('nexmo.Client.create_application')
     def test_incoming_start_nexmo(self, mock_create_application, mock_update_call):
         mock_create_application.return_value = dict(id='app-id', keys=dict(private_key='private-key'))
-        mock_update_call.return_value = dict(conversation_uuid='12345')
+        mock_update_call.return_value = dict(uuid='12345')
 
         self.org.connect_nexmo('123', '456', self.admin)
         self.org.save()
@@ -1099,7 +1099,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'ext-id'
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
 
@@ -1151,7 +1151,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['status'] = 'ringing'
         post_data['duration'] = '0'
-        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
@@ -1163,7 +1163,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
@@ -1194,7 +1194,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['status'] = 'completed'
         post_data['duration'] = '0'
-        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
@@ -1250,7 +1250,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'ext-id'
 
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
@@ -1279,7 +1279,7 @@ class IVRTests(FlowFileTest):
         post_data = dict()
         post_data['from'] = '250788382382'
         post_data['to'] = '250785551212'
-        post_data['conversation_uuid'] = 'ext-id'
+        post_data['uuid'] = 'ext-id'
         response = self.client.post(reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]),
                                     json.dumps(post_data), content_type="application/json")
 
@@ -1374,7 +1374,7 @@ class IVRTests(FlowFileTest):
     @patch('nexmo.Client.create_call')
     def test_download_media_nexmo(self, mock_create_call, mock_create_application, mock_download_recording):
         mock_create_application.return_value = dict(id='app-id', keys=dict(private_key='private-key'))
-        mock_create_call.return_value = dict(conversation_uuid='12345')
+        mock_create_call.return_value = dict(uuid='12345')
         mock_download_recording.side_effect = [
             MockResponse(200, "SOUND BITS"),
 


### PR DESCRIPTION
* Switch external id to use nexmo's call id instead of conversation uuid. This is needed to successfully hangup calls since the voice api operations with call ids.
* Add logic for accepting inbound calls using the conversation_uuid (this is all they provide in this case) and then switch to call uuid once it is available.