### PR TITLE
Fix groups prefetch not being used on contact list pages

### DIFF
--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -181,10 +181,11 @@
                         %td.hide
                           .value-labels
                             %nobr
-                              - for group in object.user_groups.all
-                                %span.label.label-info.lbl{ data-id: '{{group.id}}'}
-                                  %a{'href':'{% url "contacts.contact_filter" group.uuid %}'}
-                                    {{group.name}}
+                              - for group in object.all_groups.all
+                                - if group.group_type == 'U'
+                                  %span.label.label-info.lbl{ data-id: '{{group.id}}'}
+                                    %a{'href':'{% url "contacts.contact_filter" group.uuid %}'}
+                                      {{group.name}}
 
                     -empty
                       %tr


### PR DESCRIPTION
A tiny change but about the only change I'm certain about right now.

![screen shot 2017-02-24 at 16 01 46](https://cloud.githubusercontent.com/assets/675558/23306124/a9a5085c-faaa-11e6-804e-4c599d3d058d.png)
