### PR TITLE
Removing non_atomic_when_eager decorator which is no longer needed

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -35,7 +35,7 @@ from temba.msgs.views import InboxView
 from temba.orgs.models import Org, ACCOUNT_SID, ACCOUNT_TOKEN
 from temba.orgs.views import OrgPermsMixin, OrgObjPermsMixin, ModalMixin
 from temba.channels.models import ChannelSession
-from temba.utils import analytics, non_atomic_when_eager, on_transaction_commit
+from temba.utils import analytics, on_transaction_commit
 from temba.utils.middleware import disable_middleware
 from temba.utils.timezones import timezone_to_country_code
 from twilio import TwilioRestException
@@ -2256,14 +2256,6 @@ class ChannelCRUDL(SmartCRUDL):
             return org
 
     class ClaimTwitter(OrgPermsMixin, SmartTemplateView):
-
-        @non_atomic_when_eager
-        def dispatch(self, *args, **kwargs):
-            """
-            Decorated with @non_atomic_when_eager so that channel object is always committed to database before Mage
-            tries to access it
-            """
-            return super(ChannelCRUDL.ClaimTwitter, self).dispatch(*args, **kwargs)
 
         def pre_process(self, *args, **kwargs):
             response = super(ChannelCRUDL.ClaimTwitter, self).pre_process(*args, **kwargs)

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -419,16 +419,6 @@ class PageableQuery(object):
         return self._count
 
 
-def non_atomic_when_eager(view_func):
-    """
-    Decorator which disables atomic requests for a view/dispatch function when celery is running in eager mode
-    """
-    if getattr(settings, 'CELERY_ALWAYS_EAGER', False):
-        return transaction.non_atomic_requests(view_func)
-    else:
-        return view_func
-
-
 def non_atomic_gets(view_func):
     """
     Decorator which disables atomic requests for a view/dispatch function when the request method is GET. Works in

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -38,7 +38,7 @@ from .email import send_simple_email
 from .timezones import TimeZoneFormField, timezone_to_country_code
 from .queues import start_task, complete_task, push_task, HIGH_PRIORITY, LOW_PRIORITY, nonoverlapping_task
 from .currencies import currency_for_country
-from . import format_decimal, slugify_with, str_to_datetime, str_to_time, truncate, random_string, non_atomic_when_eager
+from . import format_decimal, slugify_with, str_to_datetime, str_to_time, truncate, random_string
 from . import PageableQuery, json_to_dict, dict_to_struct, datetime_to_ms, ms_to_datetime, dict_to_json, str_to_bool
 from . import percentage, datetime_to_json_date, json_date_to_datetime, non_atomic_gets, clean_string
 from . import datetime_to_str, chunk_list, get_country_code_by_name, datetime_to_epoch
@@ -167,26 +167,6 @@ class InitTest(TembaTest):
         rs = random_string(1000)
         self.assertEquals(1000, len(rs))
         self.assertFalse('1' in rs or 'I' in rs or '0' in rs or 'O' in rs)
-
-    def test_non_atomic_when_eager(self):
-        settings.CELERY_ALWAYS_EAGER = False
-
-        @non_atomic_when_eager
-        def dispatch_func1(*args, **kwargs):
-            return args[0] + kwargs['arg2']
-
-        settings.CELERY_ALWAYS_EAGER = True
-
-        @non_atomic_when_eager
-        def dispatch_func2(*args, **kwargs):
-            return args[0] + kwargs['arg2']
-
-        self.assertFalse(hasattr(dispatch_func1, '_non_atomic_requests'))
-        self.assertIsNotNone(dispatch_func2._non_atomic_requests)
-
-        # check that both functions call correctly
-        self.assertEqual(dispatch_func1(1, arg2=2), 3)
-        self.assertEqual(dispatch_func2(1, arg2=2), 3)
 
     def test_non_atomic_gets(self):
         @non_atomic_gets


### PR DESCRIPTION
`Channel.add_twitter_channel` uses `on_transaction_commit` now so this isn't needed... but I'm also not 100% sure it was needed previously, especially since its only for tests