### PR TITLE
Deactivate runs when releasing flows

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -849,6 +849,10 @@ class Flow(TembaModel):
         """
         Removes all flow runs, values and steps for a flow.
         """
+
+        # any outstanding active runs should interrupted
+        FlowRun.bulk_exit(self.runs.filter(is_active=True), FlowRun.EXIT_TYPE_INTERRUPTED)
+
         # grab the ids of all our runs
         run_ids = self.runs.all().values_list('id', flat=True)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4881,6 +4881,9 @@ class FlowsTest(FlowFileTest):
         # should still have a run though
         self.assertEqual(flow.runs.count(), 1)
 
+        # but they should all be inactive
+        self.assertEqual(flow.runs.filter(is_active=True).count(), 0)
+
         # just no steps or values
         self.assertEqual(Value.objects.all().count(), 0)
         self.assertEqual(FlowStep.objects.all().count(), 0)


### PR DESCRIPTION
We were leaving runs active when nuking their steps during ```flow.release()```. Aside from having active runs against inactive flows, this also throws off monitoring for empty flow run creation.