### PR TITLE
Use flow user for migrations

### DIFF
--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -636,6 +636,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
                 body: -> "Sorry, but we were unable to save your flow. Please reload the page and try again, this may clear your latest changes."
                 details: -> data.description
                 ok: -> 'Reload'
+                details: -> ''
 
               modalInstance = utils.openModal("/partials/modal?v=" + version, ModalController, resolveObj)
 
@@ -667,6 +668,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
                 title: -> "Editing Conflict"
                 body: -> data.saved_by + " is currently editing this Flow. Your changes will not be saved until the Flow is reloaded."
                 ok: -> 'Reload'
+                details: -> ''
               modalInstance = utils.openModal("/partials/modal?v=" + version, ModalController, resolveObj)
 
               modalInstance.result.then (reload) ->

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2125,7 +2125,7 @@ class Flow(TembaModel):
         revision = self.revisions.all().order_by('-revision').first()
 
         last_saved = self.saved_on
-        if self.saved_by == get_flow_user():
+        if self.saved_by == get_flow_user(self.org):
             last_saved = self.modified_on
 
         metadata[Flow.NAME] = self.name
@@ -2219,7 +2219,7 @@ class Flow(TembaModel):
                 else:  # pragma: needs cover
                     json_flow = self.as_json()
 
-                self.update(json_flow, user=get_flow_user())
+                self.update(json_flow, user=get_flow_user(self.org))
                 self.refresh_from_db()
 
     def update(self, json_dict, user=None, force=False):
@@ -2240,15 +2240,15 @@ class Flow(TembaModel):
             raise FlowException("Found invalid cycle: %s" % cycle)
 
         try:
+            flow_user = get_flow_user(self.org)
             # check whether the flow has changed since this flow was last saved
             if user and not force:
                 saved_on = json_dict.get(Flow.METADATA).get(Flow.SAVED_ON, None)
                 org = user.get_org()
 
                 # check our last save if we aren't the system flow user
-                if user != get_flow_user():
-
-                    migrated = self.saved_by == get_flow_user()
+                if user != flow_user:
+                    migrated = self.saved_by == flow_user
                     last_save = self.saved_on
 
                     # use modified on if it was a migration
@@ -2258,16 +2258,15 @@ class Flow(TembaModel):
                     if not saved_on or str_to_datetime(saved_on, org.timezone) < last_save:
                         saver = ""
 
-                        if migrated:
-                            saver = 'System User'
-                        else:
-                            if self.saved_by.first_name:  # pragma: needs cover
-                                saver += "%s " % self.saved_by.first_name
-                            if self.saved_by.last_name:  # pragma: needs cover
-                                saver += "%s" % self.saved_by.last_name
+                        if self.saved_by.first_name:  # pragma: needs cover
+                            saver += "%s " % self.saved_by.first_name
+                        if self.saved_by.last_name:  # pragma: needs cover
+                            saver += "%s" % self.saved_by.last_name
 
                         if not saver:
                             saver = self.saved_by.username
+
+                        saver = saver.strip()
 
                         return dict(status="unsaved", description="Flow NOT Saved", saved_on=datetime_to_str(last_save), saved_by=saver)
 
@@ -2481,7 +2480,7 @@ class Flow(TembaModel):
                 self.saved_by = user
 
             # if it's our migration user, don't update saved on
-            if user and user != get_flow_user():
+            if user and user != flow_user:
                 self.saved_on = timezone.now()
 
             self.version_number = CURRENT_EXPORT_VERSION
@@ -3736,14 +3735,7 @@ class FlowRevision(SmartModel):
     def as_json(self, include_definition=False):
 
         name = self.created_by.get_full_name()
-        email = self.created_by.username
-
-        # show our flow user differently
-        if self.created_by == get_flow_user():
-            name = _('System Update')
-            email = self.flow.org.get_branding().get('support_email')
-
-        return dict(user=dict(email=email, name=name),
+        return dict(user=dict(email=self.created_by.email, name=name),
                     created_on=datetime_to_str(self.created_on),
                     id=self.pk,
                     version=self.spec_version,
@@ -4570,26 +4562,36 @@ class FlowLabel(models.Model):
         unique_together = ('name', 'parent', 'org')
 
 
-__flow_user = None
+__flow_users = None
 
 
-def clear_flow_user():
-    global __flow_user
-    __flow_user = None
+def clear_flow_users():
+    global __flow_users
+    __flow_users = None
 
 
-def get_flow_user():
-    global __flow_user
-    if not __flow_user:
-        user = User.objects.filter(username='flow').first()
-        if user:  # pragma: needs cover
-            __flow_user = user
+def get_flow_user(org):
+    global __flow_users
+    if not __flow_users:
+        __flow_users = {}
+
+    branding = org.get_branding()
+    username = '%s_flow' % branding['slug']
+    flow_user = __flow_users.get(username)
+
+    # not cached, let's look it up
+    if not flow_user:
+        email = branding['support_email']
+        flow_user = User.objects.filter(username=username).first()
+        if flow_user:  # pragma: needs cover
+            __flow_users[username] = flow_user
         else:
-            user = User.objects.create_user('flow')
-            user.groups.add(Group.objects.get(name='Service Users'))
-            __flow_user = user
+            # doesn't exist for this brand, create it
+            flow_user = User.objects.create_user(username, email, first_name='System Update')
+            flow_user.groups.add(Group.objects.get(name='Service Users'))
+            __flow_users[username] = flow_user
 
-    return __flow_user
+    return flow_user
 
 
 class Action(object):
@@ -4800,7 +4802,7 @@ class AddToGroupAction(Action):
     def execute(self, run, actionset_uuid, msg, offline_on=None):
         contact = run.contact
         add = AddToGroupAction.TYPE == self.get_type()
-        user = get_flow_user()
+        user = get_flow_user(run.org)
 
         if contact:
             for group in self.groups:
@@ -4872,7 +4874,7 @@ class DeleteFromGroupAction(AddToGroupAction):
     def execute(self, run, actionset, msg, offline_on=None):
         if len(self.groups) == 0:
             contact = run.contact
-            user = get_flow_user()
+            user = get_flow_user(run.org)
             if contact:
                 # remove from all active and inactive user-defined, static groups
                 for group in ContactGroup.user_groups.filter(org=contact.org,
@@ -5087,7 +5089,7 @@ class ReplyAction(Action):
         reply = None
 
         if self.msg:
-            user = get_flow_user()
+            user = get_flow_user(run.org)
             text = run.flow.get_localized_text(self.msg, run.contact)
 
             if offline_on:
@@ -5254,7 +5256,7 @@ class VariableContactAction(Action):
 
                 # otherwise, really create the contact
                 else:
-                    contacts.append(Contact.get_or_create(run.flow.org, get_flow_user(), name=None, urns=()))
+                    contacts.append(Contact.get_or_create(run.org, get_flow_user(run.org), name=None, urns=()))
 
             # other type of variable, perform our substitution
             else:
@@ -5269,7 +5271,7 @@ class VariableContactAction(Action):
                     if country:
                         (number, valid) = URN.normalize_number(variable, country)
                         if number and valid:
-                            contact = Contact.get_or_create(run.flow.org, get_flow_user(), urns=[URN.from_tel(number)])
+                            contact = Contact.get_or_create(run.org, get_flow_user(run.org), urns=[URN.from_tel(number)])
                             contacts.append(contact)
 
         return groups, contacts
@@ -5480,7 +5482,7 @@ class SaveToContactAction(Action):
             if contact_field:
                 label = contact_field.label
             else:
-                ContactField.get_or_create(org, get_flow_user(), field, label)
+                ContactField.get_or_create(org, get_flow_user(org), field, label)
 
         return label
 
@@ -5509,7 +5511,7 @@ class SaveToContactAction(Action):
     def execute(self, run, actionset_uuid, msg, offline_on=None):
         # evaluate our value
         contact = run.contact
-        user = get_flow_user()
+        user = get_flow_user(run.org)
         message_context = run.flow.build_message_context(contact, msg)
         (value, errors) = Msg.substitute_variables(self.value, contact, message_context, org=run.flow.org)
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3733,7 +3733,7 @@ class FlowRevision(SmartModel):
         # show our flow user differently
         if self.created_by == get_flow_user():
             name = _('System Update')
-            email = 'support@textit.in'
+            email = self.flow.org.get_branding().get('support_email')
 
         return dict(user=dict(email=email, name=name),
                     created_on=datetime_to_str(self.created_on),

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -88,8 +88,8 @@ class FlowTest(TembaTest):
         return load_workbook(filename=os.path.join(settings.MEDIA_ROOT, filename))
 
     def test_get_flow_user(self):
-        user = get_flow_user()
-        self.assertEqual(user.pk, get_flow_user().pk)
+        user = get_flow_user(self.org)
+        self.assertEqual(user.pk, get_flow_user(self.org).pk)
 
     def test_get_unique_name(self):
         flow1 = Flow.create(self.org, self.admin, Flow.get_unique_name(self.org, "Sheep Poll"), base_language='base')
@@ -5651,7 +5651,7 @@ class FlowMigrationTest(FlowFileTest):
         self.assertEqual(saved_on, flow.saved_on)
 
         # but should still create a revision using the flow user
-        self.assertEqual(1, flow.revisions.filter(created_by=get_flow_user()).count())
+        self.assertEqual(1, flow.revisions.filter(created_by=get_flow_user(self.org)).count())
 
         # should see the system user on our revision json
         self.login(self.admin)
@@ -5662,12 +5662,12 @@ class FlowMigrationTest(FlowFileTest):
         # attempt to save with old json, no bueno
         failed = flow.update(old_json, user=self.admin)
         self.assertEqual('unsaved', failed.get('status'))
-        self.assertEqual('System User', failed.get('saved_by'))
+        self.assertEqual('System Update', failed.get('saved_by'))
 
         # now refresh and save a new version
         flow.update(flow.as_json(), user=self.admin)
         self.assertEqual(3, flow.revisions.all().count())
-        self.assertEqual(1, flow.revisions.filter(created_by=get_flow_user()).count())
+        self.assertEqual(1, flow.revisions.filter(created_by=get_flow_user(self.org)).count())
 
     def test_migrate_malformed_single_message_flow(self):
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2022,7 +2022,7 @@ class FlowTest(TembaTest):
 
         # check flow listing
         response = self.client.get(reverse('flows.flow_list'))
-        self.assertEqual(list(response.context['object_list']), [flow1, flow3, voice_flow, flow2, self.flow])  # by last modified
+        self.assertEqual(list(response.context['object_list']), [flow3, voice_flow, flow2, flow1, self.flow])  # by saved_on
 
         # start a contact on that flow
         flow = flow1

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -5735,10 +5735,6 @@ class FlowMigrationTest(FlowFileTest):
         # this is really just testing our rewriting of webhook rulesets
         webhook_flow = self.get_flow('dual_webhook')
 
-        print (webhook_flow.revisions.all().first().created_by)
-        print (webhook_flow.saved_by)
-        print (webhook_flow.__dict__)
-
         self.assertNotEqual(webhook_flow.modified_on, webhook_flow.saved_on)
 
         # get our definition out

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -655,7 +655,7 @@ class FlowCRUDL(SmartCRUDL):
         refresh = 10000
         fields = ('name', 'modified_on')
         default_template = 'flows/flow_list.html'
-        default_order = ('-modified_on',)
+        default_order = ('-saved_on',)
         search_fields = ('name__icontains',)
 
         def get_context_data(self, **kwargs):

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 import pstats
 import traceback
-import copy
 
 from cStringIO import StringIO
 from django.conf import settings
@@ -38,16 +37,13 @@ class BrandingMiddleware(object):
         if ':' in host:
             host = host[0:host.rindex(':')]
 
-        # our default branding
-        branding = settings.BRANDING.get(settings.DEFAULT_BRAND)
-        branding['host'] = settings.DEFAULT_BRAND
-
         # override with site specific branding if we have that
-        site_branding = settings.BRANDING.get(host, None)
-        if site_branding:
-            branding = copy.deepcopy(branding)
-            branding.update(site_branding)
-            branding['host'] = host
+        branding = settings.BRANDING.get(host, None)
+
+        # if that brand isn't configured, use the default
+        if not branding:
+            branding = settings.BRANDING.get(settings.DEFAULT_BRAND)
+            branding['host'] = settings.DEFAULT_BRAND
 
         return branding
 

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -162,8 +162,8 @@ class TembaTest(SmartminTest):
 
             settings.DEBUG = False
 
-        from temba.flows.models import clear_flow_user
-        clear_flow_user()
+        from temba.flows.models import clear_flow_users
+        clear_flow_users()
 
     def clear_cache(self):
         """


### PR DESCRIPTION
* Use flow system user as the user for migrations when they are needed. This will show up in the revision history as "System User" and the support box as the email address.
* Sort our flow list by ```saved_on``` instead of ```modified_on```
* Don't update ```saved_on``` when migrating flows forward, only for user initiated saves

Fixes: https://github.com/rapidpro/rapidpro/issues/305