### PR TITLE
Improvements to External Channels

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -109,6 +109,7 @@ class Channel(TembaModel):
     CONFIG_PASSWORD = 'password'
     CONFIG_KEY = 'key'
     CONFIG_API_ID = 'api_id'
+    CONFIG_CONTENT_TYPE = 'content_type'
     CONFIG_VERIFY_SSL = 'verify_ssl'
     CONFIG_USE_NATIONAL = 'use_national'
     CONFIG_ENCODING = 'encoding'
@@ -152,6 +153,20 @@ class Channel(TembaModel):
     YO_API_URL_3 = 'http://164.40.148.210:9100/sendsms'
 
     VUMI_GO_API_URL = 'https://go.vumi.org/api/v1/go/http_api_nostream'
+
+    CONTENT_TYPE_URLENCODED = 'urlencoded'
+    CONTENT_TYPE_JSON = 'json'
+    CONTENT_TYPE_XML = 'xml'
+
+    CONTENT_TYPES = {
+        CONTENT_TYPE_URLENCODED: "application/x-www-form-urlencoded",
+        CONTENT_TYPE_JSON: "application/json",
+        CONTENT_TYPE_XML: "text/xml; charset=utf-8"
+    }
+
+    CONTENT_TYPE_CHOICES = ((CONTENT_TYPE_URLENCODED, _("URL Encoded - application/x-www-form-urlencoded")),
+                            (CONTENT_TYPE_JSON, _("JSON - application/json")),
+                            (CONTENT_TYPE_XML, _("XML - text/xml; charset=utf-8")))
 
     # various hard coded settings for the channel types
     CHANNEL_SETTINGS = {
@@ -1164,11 +1179,25 @@ class Channel(TembaModel):
                 channel.save()
 
     @classmethod
-    def build_send_url(cls, url, variables):
+    def replace_variables(cls, text, variables, content_type=CONTENT_TYPE_URLENCODED):
         for key in variables.keys():
-            url = url.replace("{{%s}}" % key, quote_plus(six.text_type(variables[key]).encode('utf-8')))
+            replacement = six.text_type(variables[key]).encode('utf-8')
 
-        return url
+            # encode based on our content type
+            if content_type == Channel.CONTENT_TYPE_URLENCODED:
+                replacement = quote_plus(replacement)
+
+            # if this is JSON, need to wrap in quotes (and escape them)
+            elif content_type == Channel.CONTENT_TYPE_JSON:
+                replacement = json.dumps(replacement)
+
+            # XML needs to be escaped
+            elif content_type == Channel.CONTENT_TYPE_XML:
+                replacement = escape(replacement)
+
+            text = text.replace("{{%s}}" % key, replacement)
+
+        return text
 
     @classmethod
     def success(cls, channel, msg, msg_status, start, external_id=None, event=None, events=None):
@@ -1638,18 +1667,20 @@ class Channel(TembaModel):
         }
 
         # build our send URL
-        url = Channel.build_send_url(channel.config[Channel.CONFIG_SEND_URL], payload)
+        url = Channel.replace_variables(channel.config[Channel.CONFIG_SEND_URL], payload)
         start = time.time()
 
         method = channel.config.get(Channel.CONFIG_SEND_METHOD, 'POST')
 
         headers = TEMBA_HEADERS.copy()
+        content_type = channel.config.get(Channel.CONFIG_CONTENT_TYPE, Channel.CONTENT_TYPE_URLENCODED)
+        headers['Content-Type'] = content_type
+
         event = HttpEvent(method, url)
 
         if method in ('POST', 'PUT'):
             body = channel.config.get(Channel.CONFIG_SEND_BODY, Channel.CONFIG_DEFAULT_SEND_BODY)
-            body = Channel.build_send_url(body, payload)
-            headers['Content-Type'] = 'application/x-www-form-urlencoded'
+            body = Channel.replace_variables(body, payload, content_type)
             event.request_body = body
 
         try:

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1527,14 +1527,17 @@ class ChannelCRUDL(SmartCRUDL):
             country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"), required=False,
                                         help_text=_("The country this phone number is used in"))
 
-            url = forms.URLField(max_length=1024, label=_("Send URL"),
-                                 help_text=_("The URL we will call when sending messages, with variable substitutions"))
-
             method = forms.ChoiceField(choices=(('POST', "HTTP POST"), ('GET', "HTTP GET"), ('PUT', "HTTP PUT")),
                                        help_text=_("What HTTP method to use when calling the URL"))
 
-            body = forms.CharField(max_length=1024, label=_("Request Body"), required=False,
-                                   help_text=_("The URL encoded form body, if any, with variable substitutions (only used for PUT or POST)"))
+            content_type = forms.ChoiceField(choices=Channel.CONTENT_TYPE_CHOICES,
+                                             help_text=_("The content type used when sending the request"))
+
+            url = forms.URLField(max_length=1024, label=_("Send URL"),
+                                 help_text=_("The URL we will call when sending messages, with variable substitutions"))
+
+            body = forms.CharField(max_length=2048, label=_("Request Body"), required=False, widget=forms.Textarea,
+                                   help_text=_("The request body if any, with variable substitutions (only used for PUT or POST)"))
 
         class EXSendClaimForm(forms.Form):
             url = forms.URLField(max_length=1024, label=_("Send URL"),
@@ -1589,7 +1592,12 @@ class ChannelCRUDL(SmartCRUDL):
                 # make sure they own it
                 channel = self.request.user.get_org().channels.filter(pk=channel).first()
 
-            config = {Channel.CONFIG_SEND_URL: data['url'], Channel.CONFIG_SEND_METHOD: data['method'], Channel.CONFIG_SEND_BODY: data['body']}
+            config = {
+                Channel.CONFIG_SEND_URL: data['url'],
+                Channel.CONFIG_SEND_METHOD: data['method'],
+                Channel.CONFIG_SEND_BODY: data['body'],
+                Channel.CONFIG_CONTENT_TYPE: data['content_type']
+            }
             self.object = Channel.add_config_external_channel(org, self.request.user, country, address, Channel.TYPE_EXTERNAL,
                                                               config, role, scheme, parent=channel)
 
@@ -2166,19 +2174,24 @@ class ChannelCRUDL(SmartCRUDL):
 
             # if this is an external channel, build an example URL
             if self.object.channel_type == Channel.TYPE_EXTERNAL:
-                send_url = self.object.config_json()[Channel.CONFIG_SEND_URL]
-                send_body = self.object.config_json().get(Channel.CONFIG_SEND_BODY, Channel.CONFIG_DEFAULT_SEND_BODY)
+                config = self.object.config_json()
+                send_url = config[Channel.CONFIG_SEND_URL]
+                send_body = config.get(Channel.CONFIG_SEND_BODY, Channel.CONFIG_DEFAULT_SEND_BODY)
+
                 example_payload = {
                     'to': '+250788123123',
                     'to_no_plus': '+250788123123',
-                    'text': "Love is patient. Love is kind",
+                    'text': "Love is patient. Love is kind.",
                     'from': self.object.address,
                     'from_no_plus': self.object.address.lstrip('+'),
                     'id': '1241244',
                     'channel': str(self.object.id)
                 }
-                context['example_url'] = Channel.build_send_url(send_url, example_payload)
-                context['example_body'] = Channel.build_send_url(send_body, example_payload)
+
+                content_type = config.get(Channel.CONFIG_CONTENT_TYPE, Channel.CONTENT_TYPE_URLENCODED)
+                context['example_content_type'] = "Content-Type: " + Channel.CONTENT_TYPES[content_type]
+                context['example_url'] = Channel.replace_variables(send_url, example_payload)
+                context['example_body'] = Channel.replace_variables(send_body, example_payload, content_type)
 
             context['domain'] = settings.HOSTNAME
             context['ip_addresses'] = settings.IP_ADDRESSES

--- a/templates/channels/channel_claim.haml
+++ b/templates/channels/channel_claim.haml
@@ -716,7 +716,7 @@
                     and receive messages.
 
     %h3
-      -trans "Mobile Channels"
+      -trans "API Channels"
 
     .claim-row
       .row

--- a/templates/channels/channel_claim_external.haml
+++ b/templates/channels/channel_claim_external.haml
@@ -51,17 +51,31 @@
   :javascript
     $(function(){
       var schemeSelect = $('#id_scheme');
-
-      schemeSelect.select2({ minimumResultsForSearch: -1, width: '200px' });
-      $('#id_country').select2();
-      $('#id_method').select2({ minimumResultsForSearch: -1, width: '370px' });
-
       schemeSelect.on('change', function() {
         updateFormForScheme($(this).val());
       });
-
       updateFormForScheme(schemeSelect.val());
+
+      var methodSelect = $("#id_method");
+      methodSelect.on('change', function(){
+        updateFormForMethod($(this).val());
+      })
+      updateFormForMethod($(this).val());
+
+      schemeSelect.select2({ minimumResultsForSearch: -1, width: '370px' });
+      $('#id_country').select2({width:'370px'});
+      $('#id_method').select2({ minimumResultsForSearch: -1, width: '370px' });
+      $('#id_content_type').select2({ minimumResultsForSearch: -1, width: '370px' });
     });
+
+    function updateFormForMethod(method){
+      var bodyCtrlGroup = $('#id_body').parents('.control-group');
+      if (method == 'GET'){
+        bodyCtrlGroup.hide();
+      } else {
+        bodyCtrlGroup.show();
+      }
+    }
 
     function updateFormForScheme(scheme) {
       var numberCtrlGroup = $('#id_number').parents('.control-group');

--- a/templates/channels/channel_configuration.haml
+++ b/templates/channels/channel_configuration.haml
@@ -897,7 +897,9 @@
       %pre.prettyprint.example<
         :plain
           {{ object.config_json.method }} {{ example_url }}
-          to=%2B250788123123&from={{ object.address|urlencode }}&channel={{ object.pk }}&id=2599235&text=One+mans+trash+is+another_mans+come+up
+          {{ example_content_type }}
+
+          {{ example_body }}
     %hr
 
     -if object.role != 'S'


### PR DESCRIPTION
Allows us to use the External Channel config to send to JSON and XML endpoints as well, substituting variables with the right kind of escaping for each.