### PR TITLE
Optimize contact searching when used to determine single contact's membership

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -964,7 +964,7 @@ class Contact(TembaModel):
         return test_contact
 
     @classmethod
-    def search(cls, org, query, base_queryset=None):
+    def search(cls, org, query, base_queryset=None, base_set=None):
         """
         Performs a search of contacts based on a query. Returns a tuple of the queryset and a bool for whether
         or not the query was a valid complex query, e.g. name = "Bob" AND age = 21
@@ -974,7 +974,7 @@ class Contact(TembaModel):
         if base_queryset is None:
             base_queryset = Contact.objects.filter(org=org, is_active=True, is_test=False, is_blocked=False, is_stopped=False)
 
-        return search.contact_search(org, query, base_queryset)
+        return search.contact_search(org, query, base_queryset, base_set)
 
     @classmethod
     def create_instance(cls, field_dict):
@@ -2192,21 +2192,21 @@ class ContactGroup(TembaModel):
         self.contacts.clear()
         self.contacts.add(*members)
 
-    def _get_dynamic_members(self):
+    def _get_dynamic_members(self, base_set=None):
         """
         For dynamic groups, this returns the set of contacts who belong in this group
         """
         if not self.is_dynamic:  # pragma: no cover
             raise ValueError("Can only be called on dynamic groups")
 
-        members, is_complex = Contact.search(self.org, self.query)
+        members, is_complex = Contact.search(self.org, self.query, base_set=base_set)
         return members
 
     def _check_dynamic_membership(self, contact):
         """
         For dynamic groups, determines whether the given contact belongs in the group
         """
-        return self._get_dynamic_members().filter(pk=contact.pk).count() == 1
+        return self._get_dynamic_members(base_set=[contact]).filter(pk=contact.pk).exists()
 
     @classmethod
     def get_system_group_queryset(cls, org, group_type):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2206,7 +2206,7 @@ class ContactGroup(TembaModel):
         """
         For dynamic groups, determines whether the given contact belongs in the group
         """
-        return self._get_dynamic_members(base_set=[contact]).filter(pk=contact.pk).exists()
+        return self._get_dynamic_members(base_set=[contact]).exists()
 
     @classmethod
     def get_system_group_queryset(cls, org, group_type):

--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -70,6 +70,9 @@ def contact_search(org, query, base_queryset, base_set):
     if not PROPERTY_ALIASES:
         PROPERTY_ALIASES = {scheme: 'urns__path' for scheme, label in ContactURN.SCHEME_CHOICES}
 
+    if base_set:
+        base_queryset = base_queryset.filter(id__in=[c.id for c in base_set])
+
     try:
         return contact_search_complex(org, query, base_queryset, base_set), True
     except SearchException:

--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -56,12 +56,13 @@ class SearchException(Exception):
         self.message = message
 
 
-def contact_search(org, query, base_queryset):
+def contact_search(org, query, base_queryset, base_set):
     """
     Searches for contacts
     :param org: the org (used for date formats and timezones)
     :param query: the query, e.g. 'name = "Bob"'
     :param base_queryset: the base query set which queries operate on
+    :param base_queryset: the base set of contacts (used to optimize membership tests)
     :return: a tuple of the contact query set, a boolean whether query was complex
     """
     from .models import ContactURN
@@ -70,7 +71,7 @@ def contact_search(org, query, base_queryset):
         PROPERTY_ALIASES = {scheme: 'urns__path' for scheme, label in ContactURN.SCHEME_CHOICES}
 
     try:
-        return contact_search_complex(org, query, base_queryset), True
+        return contact_search_complex(org, query, base_queryset, base_set), True
     except SearchException:
         pass
 
@@ -104,7 +105,7 @@ def contact_search_simple(org, query, base_queryset):
     return base_queryset.filter(q).distinct()
 
 
-def contact_search_complex(org, query, base_queryset):
+def contact_search_complex(org, query, base_queryset, base_set):
     """
     Performs a complex query based search, e.g. 'name = "Bob" AND age > 18'
     """
@@ -113,6 +114,7 @@ def contact_search_complex(org, query, base_queryset):
     # attach context to the lexer
     search_lexer.org = org
     search_lexer.base_queryset = base_queryset
+    search_lexer.base_set = base_set
 
     # combining results from multiple joins can lead to duplicates
     return search_parser.parse(query, lexer=search_lexer).distinct()
@@ -144,7 +146,7 @@ def generate_queryset(lexer, identifier, comparator, value):
             raise SearchException("Unrecognized contact field identifier %s" % identifier)
 
         if comparator.lower() in ('=', 'is') and value == "":
-            q = generate_empty_field_test(field)
+            q = generate_empty_field_test(field, lexer.base_set)
         elif field.value_type == Value.TYPE_TEXT:
             q = generate_text_field_comparison(field, comparator, value)
         elif field.value_type == Value.TYPE_DECIMAL:
@@ -167,8 +169,13 @@ def generate_non_field_comparison(relation, comparator, value):
     return Q(**{'%s__%s' % (relation, lookup): value})
 
 
-def generate_empty_field_test(field):
-    contacts_with_field = field.org.org_contacts.filter(Q(**{'values__contact_field__id': field.id}))
+def generate_empty_field_test(field, base_set):
+    params = {'values__contact_field__id': field.id}
+
+    if base_set:
+        params['values__contact__in'] = base_set
+
+    contacts_with_field = field.org.org_contacts.filter(Q(**params))
     return ~Q(**{'pk__in': contacts_with_field})
 
 


### PR DESCRIPTION
We implement searches like `field=""` as a request for contacts not in the set of contacts who _do_ have a value for that field. This is obviously not an efficient way of determining whether a single contact has a value for that particular field.

PR introduces the idea of a base set of contacts within which the search is applied. For membership checks 