### PR TITLE
Fix brand login restrictions

### DIFF
--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -29,21 +29,25 @@ class BrandingMiddleware(object):
 
     @classmethod
     def get_branding_for_host(cls, host):
+
+        brand_key = host
+
         # ignore subdomains
-        if len(host.split('.')) > 2:  # pragma: needs cover
-            host = '.'.join(host.split('.')[-2:])
+        if len(brand_key.split('.')) > 2:  # pragma: needs cover
+            brand_key = '.'.join(brand_key.split('.')[-2:])
 
         # prune off the port
-        if ':' in host:
-            host = host[0:host.rindex(':')]
+        if ':' in brand_key:
+            brand_key = brand_key[0:brand_key.rindex(':')]
 
         # override with site specific branding if we have that
-        branding = settings.BRANDING.get(host, None)
+        branding = settings.BRANDING.get(brand_key, None)
 
-        # if that brand isn't configured, use the default
-        if not branding:
+        if branding:
+            branding['brand'] = brand_key
+        else:
+            # if that brand isn't configured, use the default
             branding = settings.BRANDING.get(settings.DEFAULT_BRAND)
-            branding['host'] = settings.DEFAULT_BRAND
 
         return branding
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -995,9 +995,15 @@ class OrgCRUDL(SmartCRUDL):
 
         def derive_queryset(self, **kwargs):
             queryset = super(OrgCRUDL.Manage, self).derive_queryset(**kwargs)
-            queryset = queryset.filter(is_active=True, brand=self.request.branding['host'])
+            queryset = queryset.filter(is_active=True)
+
+            brand = self.request.branding.get('brand')
+            if brand:
+                queryset = queryset.filter(brand=brand)
+
             queryset = queryset.annotate(credits=Sum('topups__credits'))
             queryset = queryset.annotate(paid=Sum('topups__price'))
+
             return queryset
 
         def get_context_data(self, **kwargs):
@@ -1394,7 +1400,7 @@ class OrgCRUDL(SmartCRUDL):
         title = _("Select your Organization")
 
         def get_user_orgs(self):
-            host = self.request.branding.get('host', settings.DEFAULT_BRAND)
+            host = self.request.branding.get('brand')
             return self.request.user.get_user_orgs(host)
 
         def pre_process(self, request, *args, **kwargs):


### PR DESCRIPTION
* Use the brand key instead of the 'host' when determining login gating (host is the parent deployment the brand belongs to)