### PR TITLE
Send channel and flow UUID with webhook flow events

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -229,11 +229,6 @@ class WebHookEvent(SmartModel):
             channel = event.channel
             contact_urn = event.contact_urn
 
-        if channel:
-            channel_id = channel.pk
-        else:
-            channel_id = -1
-
         steps = []
         for step in run.steps.prefetch_related('messages', 'broadcasts').order_by('arrived_on'):
             steps.append(dict(type=step.step_type,
@@ -243,9 +238,11 @@ class WebHookEvent(SmartModel):
                               text=step.get_text(),
                               value=step.rule_value))
 
-        data = dict(channel=channel_id,
-                    relayer=channel_id,
+        data = dict(channel=channel.id if channel else -1,
+                    channel_uuid=channel.uuid if channel else None,
+                    relayer=channel.id if channel else -1,
                     flow=flow.id,
+                    flow_uuid=flow.uuid,
                     flow_name=flow.name,
                     flow_base_language=flow.base_language,
                     run=run.id,
@@ -438,6 +435,7 @@ class WebHookEvent(SmartModel):
 
         json_time = channel.last_seen.strftime('%Y-%m-%dT%H:%M:%S.%f')
         data = dict(channel=channel.pk,
+                    channel_uuid=channel.uuid,
                     power_source=sync_event.power_source,
                     power_status=sync_event.power_status,
                     power_level=sync_event.power_level,

--- a/temba/api/tests/test_models.py
+++ b/temba/api/tests/test_models.py
@@ -96,9 +96,6 @@ class WebHookTest(TembaTest):
         super(WebHookTest, self).tearDown()
         settings.SEND_WEBHOOKS = False
 
-    def assertStringContains(self, test, str):
-        self.assertTrue(str.find(test) >= 0, "'%s' not found in '%s'" % (test, str))
-
     def setupChannel(self):
         org = self.channel.org
         org.webhook = u'{"url": "http://fake.com/webhook.php"}'
@@ -145,8 +142,8 @@ class WebHookTest(TembaTest):
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("Event delivered successfully", result.message)
-            self.assertStringContains("not JSON", result.message)
+            self.assertIn("Event delivered successfully", result.message)
+            self.assertIn("not JSON", result.message)
             self.assertEquals(200, result.status_code)
             self.assertEquals("Hello World", result.body)
 
@@ -205,7 +202,7 @@ class WebHookTest(TembaTest):
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("Event delivered successfully", result.message)
+            self.assertIn("Event delivered successfully", result.message)
             self.assertEquals(200, result.status_code)
             self.assertEquals("", result.body)
 
@@ -255,22 +252,25 @@ class WebHookTest(TembaTest):
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("successfully", result.message)
+            self.assertIn("successfully", result.message)
             self.assertEquals(200, result.status_code)
 
             self.assertTrue(mock.called)
 
             args = mock.call_args_list[0][0]
             prepared_request = args[0]
-            self.assertStringContains(self.channel.org.get_webhook_url(), prepared_request.url)
+            self.assertIn(self.channel.org.get_webhook_url(), prepared_request.url)
 
             data = parse_qs(prepared_request.body)
-            self.assertEquals(self.channel.pk, int(data['channel'][0]))
-            self.assertEquals(actionset.uuid, data['step'][0])
-            self.assertEquals(flow.pk, int(data['flow'][0]))
-            self.assertEquals(self.joe.uuid, data['contact'][0])
-            self.assertEquals(self.joe.name, data['contact_name'][0])
-            self.assertEquals(six.text_type(self.joe.get_urn('tel')), data['urn'][0])
+
+            self.assertEqual(data['channel'], [str(self.channel.id)])
+            self.assertEqual(data['channel_uuid'], [self.channel.uuid])
+            self.assertEqual(data['step'], [actionset.uuid])
+            self.assertEqual(data['flow'], [str(flow.id)])
+            self.assertEqual(data['flow_uuid'], [flow.uuid])
+            self.assertEqual(data['contact'], [self.joe.uuid])
+            self.assertEqual(data['contact_name'], [self.joe.name])
+            self.assertEqual(data['urn'], [six.text_type(self.joe.get_urn('tel'))])
 
             values = json.loads(data['values'][0])
 
@@ -324,7 +324,7 @@ class WebHookTest(TembaTest):
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("No active user", result.message)
+            self.assertIn("No active user", result.message)
             self.assertEquals(0, result.status_code)
 
             self.assertFalse(mock.called)
@@ -349,8 +349,8 @@ class WebHookTest(TembaTest):
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("Event delivered successfully", result.message)
-            self.assertStringContains("not JSON", result.message)
+            self.assertIn("Event delivered successfully", result.message)
+            self.assertIn("not JSON", result.message)
             self.assertEquals(200, result.status_code)
 
             self.assertTrue(mock.called)
@@ -398,8 +398,8 @@ class WebHookTest(TembaTest):
             self.assertTrue(mock.called)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("Event delivered successfully", result.message)
-            self.assertStringContains("ignoring", result.message)
+            self.assertIn("Event delivered successfully", result.message)
+            self.assertIn("ignoring", result.message)
             self.assertEquals(200, result.status_code)
             self.assertEquals(bad_json, result.body)
 
@@ -460,7 +460,7 @@ class WebHookTest(TembaTest):
             self.assertTrue(next_attempt_earliest < event.next_attempt and next_attempt_latest > event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("Error", result.message)
+            self.assertIn("Error", result.message)
             self.assertEquals(500, result.status_code)
             self.assertEquals("I am error", result.body)
 
@@ -476,7 +476,7 @@ class WebHookTest(TembaTest):
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertStringContains("Error", result.message)
+            self.assertIn("Error", result.message)
             self.assertEquals(500, result.status_code)
             self.assertEquals("I am error", result.body)
             self.assertEquals("http://fake.com/webhook.php", result.url)
@@ -507,8 +507,8 @@ class WebHookTest(TembaTest):
 
             result = WebHookResult.objects.get()
             # both headers should be in the json-encoded url string
-            self.assertStringContains('X-My-Header: foobar', result.request)
-            self.assertStringContains('Authorization: Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==', result.request)
+            self.assertIn('X-My-Header: foobar', result.request)
+            self.assertIn('Authorization: Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==', result.request)
 
     def test_webhook(self):
         response = self.client.get(reverse('api.webhook'))

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3476,6 +3476,7 @@ class ActionTest(TembaTest):
                                                          'urn': u'tel:+250788382382',
                                                          'text': None,
                                                          'flow': self.flow.pk,
+                                                         'flow_uuid': self.flow.uuid,
                                                          'flow_name': self.flow.name,
                                                          'flow_base_language': self.flow.base_language,
                                                          'relayer': -1,
@@ -3483,7 +3484,8 @@ class ActionTest(TembaTest):
                                                          'values': '[]',
                                                          'time': '2015-10-27T14:07:30.000006Z',
                                                          'steps': '[]',
-                                                         'channel': -1},
+                                                         'channel': -1,
+                                                         'channel_uuid': None},
                                                    timeout=10)
         mock_requests_post.reset_mock()
 
@@ -3504,6 +3506,7 @@ class ActionTest(TembaTest):
                                                          'urn': u'tel:+250788382382',
                                                          'text': "Green is my favorite",
                                                          'flow': self.flow.pk,
+                                                         'flow_uuid': self.flow.uuid,
                                                          'flow_name': self.flow.name,
                                                          'flow_base_language': self.flow.base_language,
                                                          'relayer': msg.channel.pk,
@@ -3511,7 +3514,8 @@ class ActionTest(TembaTest):
                                                          'values': '[]',
                                                          'time': '2015-10-27T14:07:30.000006Z',
                                                          'steps': '[]',
-                                                         'channel': msg.channel.pk},
+                                                         'channel': msg.channel.pk,
+                                                         'channel_uuid': msg.channel.uuid},
                                                    timeout=10)
 
         # check simulator warns of webhook URL errors


### PR DESCRIPTION
Send channel and flow UUID with webhook flow events, since API v2 now only exposes UUIDs for these objects.