### PR TITLE
Fix styling of nested lists in sidebar nav pane

### DIFF
--- a/static/less/legacy.less
+++ b/static/less/legacy.less
@@ -1601,7 +1601,7 @@ input[type='text'].search-query {
 
 #sidebar-nav {
   border: 1px solid #e6e6e6;
-  .nav.nav-list {
+  .nav.nav-list:not(.level2) {
     .scroll-y();
     height: 450px;
     li {


### PR DESCRIPTION
E.g. avoid this for labels within folders:

<img width="593" alt="screen shot 2017-03-31 at 15 54 31" src="https://cloud.githubusercontent.com/assets/675558/24555117/3936abce-1630-11e7-9716-3d2f39a728c0.png">