### PR TITLE
Allow searching for contacts with any value for something

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1700,8 +1700,8 @@ class Contact(TembaModel):
         # detach any existing URNs that weren't included
         urn_ids = [u.pk for u in (urns_created + urns_attached + urns_retained)]
         urns_detached_qs = ContactURN.objects.filter(contact=self).exclude(pk__in=urn_ids)
-        urns_detached_qs.update(contact=None)
         urns_detached = list(urns_detached_qs)
+        urns_detached_qs.update(contact=None)
 
         self.modified_by = user
         self.save(update_fields=('modified_on', 'modified_by'))

--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -219,17 +219,7 @@ class Condition(QueryNode):
         prop_type, prop_obj = prop_map[self.prop]
 
         if prop_type == ContactQuery.PROP_FIELD:
-            # empty string equality means contacts without that field set
-            if self.comparator.lower() in ('=', 'is') and self.value == "":
-                values_query = Value.objects.filter(contact_field=prop_obj).values('contact_id')
-
-                # optimize for the single membership test case
-                if base_set:
-                    values_query = values_query.filter(contact__in=base_set)
-
-                return ~Q(id__in=values_query)
-            else:
-                return self._build_value_query(prop_obj, base_set)
+            return self._build_value_query(prop_obj, base_set)
         elif prop_type == ContactQuery.PROP_SCHEME:
             if org.is_anon:
                 return Q(id=-1)

--- a/temba/contacts/search.py
+++ b/temba/contacts/search.py
@@ -76,7 +76,7 @@ class SearchLexer(object):
         return self.lexer.token()
 
     def t_COMPARATOR(self, t):
-        r"""(?i)~|=|[<>]=?|~~?"""
+        r"""(?i)=|!=|~|[<>]=?"""
         return t
 
     def t_STRING(self, t):
@@ -341,7 +341,7 @@ class Condition(QueryNode):
     def _build_location_field_params(self, field):
         lookup = self.LOCATION_LOOKUPS.get(self.comparator)
         if not lookup:
-            raise SearchException("Unsupported comparator %s for location field" % self.comparator)
+            raise SearchException(_("Unsupported comparator %s for location field") % self.comparator)
 
         level_query = Q(level=BOUNDARY_LEVELS_BY_VALUE_TYPE.get(field.value_type))
 
@@ -372,6 +372,54 @@ class Condition(QueryNode):
 
     def __str__(self):
         return '%s%s%s' % (self.prop, self.comparator, self.value)
+
+
+class IsSetCondition(Condition):
+    """
+    A special type of condition which is just checking whether a property is set or not.
+      * A condition of the form x != "" is interpreted as "x is set"
+      * A condition of the form x = "" is interpreted as "x is not set"
+    """
+    IS_SET_LOOKUPS = ('!=',)
+    IS_NOT_SET_LOOKUPS = ('is', '=')
+
+    def __init__(self, prop, comparator):
+        super(IsSetCondition, self).__init__(prop, comparator, "")
+
+    def as_query(self, org, prop_map, base_set):
+        prop_type, prop_obj = prop_map[self.prop]
+
+        if self.comparator.lower() in self.IS_SET_LOOKUPS:
+            is_set = True
+        elif self.comparator.lower() in self.IS_NOT_SET_LOOKUPS:
+            is_set = False
+        else:
+            raise SearchException(_("Invalid operator for empty string comparison"))
+
+        if prop_type == ContactQuery.PROP_FIELD:
+            values_query = Value.objects.filter(contact_field=prop_obj).values('contact_id')
+
+            # optimize for the single membership test case
+            if base_set:
+                values_query = values_query.filter(contact__in=base_set)
+
+            return Q(id__in=values_query) if is_set else ~Q(id__in=values_query)
+
+        elif prop_type == ContactQuery.PROP_SCHEME:
+            if org.is_anon:
+                return Q(id=-1)
+            else:
+                urns_query = ContactURN.objects.filter(org=org, scheme=prop_obj).values('contact_id')
+
+                # optimize for the single membership test case
+                if base_set:
+                    urns_query = urns_query.filter(contact__in=base_set)
+
+                return Q(id__in=urns_query) if is_set else ~Q(id__in=urns_query)
+        else:
+            # for attributes, being not-set can mean a NULL value or empty string value
+            where_not_set = Q(**{prop_obj: ""}) | Q(**{prop_obj: None})
+            return ~where_not_set if is_set else where_not_set
 
 
 @six.python_2_unicode_compatible
@@ -527,7 +575,10 @@ def p_expression_grouping(p):
 
 def p_condition(p):
     """expression : TEXT COMPARATOR literal"""
-    p[0] = Condition(p[1].lower(), p[2].lower(), p[3])
+    if p[3] == "":
+        p[0] = IsSetCondition(p[1].lower(), p[2].lower())
+    else:
+        p[0] = Condition(p[1].lower(), p[2].lower(), p[3])
 
 
 def p_condition_implicit(p):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1171,6 +1171,8 @@ class ContactTest(TembaTest):
 
         self.assertEqual(q('home is ""'), 0)
         self.assertEqual(q('profession = ""'), 60)
+        self.assertEqual(q('profession is ""'), 60)
+        self.assertEqual(q('profession != ""'), 30)
 
         # contact fields beginning with 'is' or 'has'
         self.assertEqual(q('isureporter = "yes"'), 90)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1100,7 +1100,7 @@ class ContactTest(TembaTest):
         ContactField.get_or_create(self.org, self.admin, 'isureporter', "Is UReporter", value_type='T')
         ContactField.get_or_create(self.org, self.admin, 'hasbirth', "Has Birth", value_type='T')
 
-        names = ['Trey', 'Mike', 'Paige', 'Fish']
+        names = ['Trey', 'Mike', 'Paige', None]
         districts = ['Gatsibo', 'Kayônza', 'Rwamagana']
         wards = ['Kageyo', 'Kabara', 'Bukure']
         date_format = get_datetime_format(True)[0]
@@ -1109,7 +1109,7 @@ class ContactTest(TembaTest):
         for i in range(10, 100):
             name = names[(i + 2) % len(names)]
             number = "0788382%s" % str(i).zfill(3)
-            twitter = "tweep_%d" % (i + 1)
+            twitter = ("tweep_%d" % (i + 1)) if (i % 3 == 0) else None  # 1 in 3 have twitter URN
             contact = self.create_contact(name=name, number=number, twitter=twitter)
             join_date = datetime_to_str(date(2013, 12, 22) + timezone.timedelta(days=i), date_format)
 
@@ -1133,7 +1133,6 @@ class ContactTest(TembaTest):
         self.assertEqual(q('trey'), 23)
         self.assertEqual(q('MIKE'), 23)
         self.assertEqual(q('  paige  '), 22)
-        self.assertEqual(q('fish'), 22)
         self.assertEqual(q('0788382011'), 1)
         self.assertEqual(q('trey 0788382'), 23)
 
@@ -1141,14 +1140,17 @@ class ContactTest(TembaTest):
         self.assertEqual(q('name is "trey"'), 23)
         self.assertEqual(q('name is mike'), 23)
         self.assertEqual(q('name = paige'), 22)
-        self.assertEqual(q('NAME=fish'), 22)
+        self.assertEqual(q('name is ""'), 22)
+        self.assertEqual(q('NAME=""'), 22)
         self.assertEqual(q('name has e'), 68)
 
         # URN as property
         self.assertEqual(q('tel is +250788382011'), 1)
         self.assertEqual(q('tel has 0788382011'), 1)
-        self.assertEqual(q('twitter = tweep_12'), 1)
-        self.assertEqual(q('TWITTER has tweep'), 90)
+        self.assertEqual(q('twitter = tweep_13'), 1)
+        self.assertEqual(q('twitter = ""'), 60)
+        self.assertEqual(q('twitter != ""'), 30)
+        self.assertEqual(q('TWITTER has tweep'), 30)
 
         # contact field as property
         self.assertEqual(q('age > 30'), 69)

--- a/temba/utils/management/commands/perf_test.py
+++ b/temba/utils/management/commands/perf_test.py
@@ -58,6 +58,7 @@ TEST_URLS = (
     '/contact/?search=' + urlquote_plus('name is Dave or tel has 2507001'),
     '/contact/?search=' + urlquote_plus('gender=F'),
     '/contact/?search=' + urlquote_plus('joined=""'),
+    '/contact/?search=' + urlquote_plus('joined!=""'),
     '/contact/?search=' + urlquote_plus('district=Wudil or district=Anka or district=Zuru or district=Kaura or '
                                         'district=Giwa or district=Kalgo or district=Shanga or district=Bunza'),
     '/contact/?search=' + urlquote_plus('gender=M and state=Katsina and age<40 and joined>') + '{1-year-ago}',


### PR DESCRIPTION
`x != ""` means "x has a value"
`x = ""` means "x has no value"

For fields/values this becomes a check as to whether a value exists because `Value` instances can't have empty values. Likewise for URNs this becomes a check as to whether the contact has a URN with that scheme. For attributes (i.e. name) it becomes a check whether that attribute is null or an empty string.