### PR TITLE
Make sure calls have expiration on initiation

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -400,6 +400,10 @@ class Flow(TembaModel):
     def handle_call(cls, call, text=None, saved_media_url=None, hangup=False, resume=False):
         run = FlowRun.objects.filter(session=call, is_active=True).order_by('-created_on').first()
 
+        # set our initial expiration date if we don't have one yet
+        if not run.expires_on:
+            run.update_expiration()
+
         # what we will send back
         voice_response = call.channel.generate_ivr_response()
 
@@ -1575,6 +1579,9 @@ class Flow(TembaModel):
             run = FlowRun.create(self, contact_id, start=flow_start, parent=parent_run)
             if extra:  # pragma: needs cover
                 run.update_fields(extra)
+
+            # set our initial run expiration
+            run.update_expiration()
 
             # create our call objects
             if parent_run and parent_run.session:
@@ -2848,7 +2855,7 @@ class FlowRun(models.Model):
             self.timeout_on = now + timedelta(minutes=minutes)
             self.save(update_fields=['timeout_on', 'modified_on'])
 
-    def update_expiration(self, point_in_time):
+    def update_expiration(self, point_in_time=None):
         """
         Set our expiration according to the flow settings
         """

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -677,6 +677,9 @@ class IVRTests(FlowFileTest):
         flow.start([], [eric])
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
 
+        # our run should have an initial expiration
+        self.assertIsNotNone(FlowRun.objects.filter(session=call).first().expires_on)
+
         # after a call is picked up, twilio will call back to our server
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)


### PR DESCRIPTION
This is to further combat Twilio not sending hangup notifications at random.