### PR TITLE
Multiple message attachments part 3

### DIFF
--- a/temba/api/tests/test_v1.py
+++ b/temba/api/tests/test_v1.py
@@ -567,14 +567,14 @@ class APITest(TembaTest):
 
         step = FlowStep.objects.filter(step_uuid=ruleset_photo.uuid).first()
         msg = step.messages.all().first()
-        self.assertTrue(msg.media.startswith('image/jpeg:http'))
-        self.assertTrue(msg.media.endswith('.jpg'))
+        self.assertTrue(msg.attachments[0].startswith('image/jpeg:http'))
+        self.assertTrue(msg.attachments[0].endswith('.jpg'))
         self.assertTrue(msg.is_media_type_image())
 
         step = FlowStep.objects.filter(step_uuid=ruleset_video.uuid).first()
         msg = step.messages.all().first()
-        self.assertTrue(msg.media.startswith('video/mp4:http'))
-        self.assertTrue(msg.media.endswith('.mp4'))
+        self.assertTrue(msg.attachments[0].startswith('video/mp4:http'))
+        self.assertTrue(msg.attachments[0].endswith('.mp4'))
         self.assertTrue(msg.is_media_type_video())
 
     def test_api_steps(self):

--- a/temba/api/tests/test_v1.py
+++ b/temba/api/tests/test_v1.py
@@ -563,7 +563,7 @@ class APITest(TembaTest):
         step = FlowStep.objects.filter(step_uuid=ruleset_location.uuid).first()
         msg = step.messages.all().first()
         self.assertEqual('47.7579804,-121.0821648', msg.text)
-        self.assertEqual('geo:47.7579804,-121.0821648', msg.media)
+        self.assertEqual(['geo:47.7579804,-121.0821648'], msg.attachments)
 
         step = FlowStep.objects.filter(step_uuid=ruleset_photo.uuid).first()
         msg = step.messages.all().first()

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -807,7 +807,7 @@ class MsgReadSerializer(ReadSerializer):
         return self.STATUSES.get(QUEUED if obj.status == PENDING else obj.status)
 
     def get_media(self, obj):
-        return obj.media
+        return obj.attachments[0] if obj.attachments else None
 
     def get_archived(self, obj):
         return obj.visibility == Msg.VISIBILITY_ARCHIVED

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -243,7 +243,7 @@ class TwimlAPIHandler(BaseChannelHandler):
             for i in range(int(request.POST.get('NumMedia', 0))):
                 media_url = client.download_media(request.POST['MediaUrl%d' % i])
                 path = media_url.partition(':')[2]
-                Msg.create_incoming(channel, urn, path, media=media_url)
+                Msg.create_incoming(channel, urn, path, attachments=[media_url])
 
             if body:
                 # Twilio sometimes sends concat sms as base64 encoded MMS
@@ -655,7 +655,7 @@ class TelegramHandler(BaseChannelHandler):
                 # if we got a media URL for this attachment, save it away
                 if media_url:
                     url = media_url.partition(':')[2]
-                    msg = Msg.create_incoming(channel, urn, url, date=msg_date, media=media_url)
+                    msg = Msg.create_incoming(channel, urn, url, date=msg_date, attachments=[media_url])
                     log(msg, 'Incoming media', json.dumps(dict(description='Message accepted')))
 
             # this one's a little kludgy cause we might create more than
@@ -683,7 +683,7 @@ class TelegramHandler(BaseChannelHandler):
                 if 'title' in body['message']['venue']:
                     msg_text = '%s (%s)' % (msg_text, body['message']['venue']['title'])
             media_url = 'geo:%s' % location
-            msg = Msg.create_incoming(channel, urn, msg_text, date=msg_date, media=media_url)
+            msg = Msg.create_incoming(channel, urn, msg_text, date=msg_date, attachments=[media_url])
             return make_response('Message accepted', msg)
 
         if 'photo' in body['message']:
@@ -2809,7 +2809,8 @@ class ViberPublicHandler(BaseChannelHandler):
             if caption:  # pragma: needs cover
                 Msg.create_incoming(channel, urn, caption, contact=contact, date=msg_date)
 
-            msg = Msg.create_incoming(channel, urn, text, contact=contact, date=msg_date, external_id=body['message_token'], media=media)
+            msg = Msg.create_incoming(channel, urn, text, contact=contact, date=msg_date,
+                                      external_id=body['message_token'], attachments=[media] if media else None)
             return HttpResponse('Msg Accepted: %d' % msg.id)
 
         else:  # pragma: no cover

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -2607,7 +2607,7 @@ class Channel(TembaModel):
         start = time.time()
         media_url = []
 
-        if msg.media:
+        if msg.attachments:
             (media_type, media_url) = Msg.get_media(msg)
             media_url = [media_url]
 
@@ -3051,13 +3051,13 @@ class Channel(TembaModel):
         # append media url if our channel doesn't support it
         text = msg.text
 
-        if msg.media and not Channel.supports_media(channel):
+        if msg.attachments and not Channel.supports_media(channel):
             media_type, media_url = Msg.get_media(msg)
             if media_type and media_url:
                 text = '%s\n%s' % (text, media_url)
 
             # don't send as media
-            msg.media = None
+            msg.attachments = None
 
         parts = Msg.get_text_parts(text, channel.config.get(Channel.CONFIG_MAX_LENGTH, type_settings[Channel.CONFIG_MAX_LENGTH]))
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -3871,7 +3871,7 @@ class AfricasTalkingTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -4209,7 +4209,7 @@ class ExternalTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -4416,7 +4416,7 @@ class YoTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+252788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -4519,7 +4519,7 @@ class ShaqodoonTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -4670,7 +4670,7 @@ class M3TechTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -4762,7 +4762,7 @@ class KannelTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -5163,7 +5163,7 @@ class NexmoTest(TembaTest):
         self.channel.save()
 
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -5434,7 +5434,7 @@ class VumiTest(TembaTest):
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
         self.create_group("Reporters", [joe])
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -5584,7 +5584,7 @@ class ZenviaTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -5711,7 +5711,7 @@ class InfobipTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -5968,7 +5968,7 @@ class MacrokioskTest(TembaTest):
     def test_send_media(self):
         joe = self.create_contact("Joe", "+9771488532")
         msg = joe.send("Test message", self.admin, trigger_send=False,
-                       media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+                       attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -6092,7 +6092,7 @@ class BlackmynaTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+9771488532")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -6252,7 +6252,7 @@ class SMSCentralTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+9771488532")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -6388,7 +6388,7 @@ class Hub9Test(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -6564,7 +6564,7 @@ class DartMediaTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -6644,7 +6644,7 @@ class HighConnectionTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -6772,9 +6772,9 @@ class TwilioTest(TembaTest):
         msgs = Msg.objects.all().order_by('-created_on')
         self.assertEqual(2, msgs.count())
         self.assertEqual('Test', msgs[0].text)
-        self.assertIsNone(msgs[0].media)
-        self.assertTrue(msgs[1].media.startswith('audio/x-wav:https://%s' % settings.AWS_BUCKET_DOMAIN))
-        self.assertTrue(msgs[1].media.endswith('.wav'))
+        self.assertIsNone(msgs[0].attachments)
+        self.assertTrue(msgs[1].attachments[0].startswith('audio/x-wav:https://%s' % settings.AWS_BUCKET_DOMAIN))
+        self.assertTrue(msgs[1].attachments[0].endswith('.wav'))
 
         # text should have the url (without the content type)
         self.assertTrue(msgs[1].text.startswith('https://%s' % settings.AWS_BUCKET_DOMAIN))
@@ -6795,8 +6795,8 @@ class TwilioTest(TembaTest):
 
         # just a single message this time
         msg = Msg.objects.get()
-        self.assertTrue(msg.media.startswith('audio/x-wav:https://%s' % settings.AWS_BUCKET_DOMAIN))
-        self.assertTrue(msg.media.endswith('.wav'))
+        self.assertTrue(msg.attachments[0].startswith('audio/x-wav:https://%s' % settings.AWS_BUCKET_DOMAIN))
+        self.assertTrue(msg.attachments[0].endswith('.wav'))
 
         Msg.objects.all().delete()
 
@@ -6812,8 +6812,8 @@ class TwilioTest(TembaTest):
             response = self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
         msg = Msg.objects.get()
-        self.assertTrue(msg.media.startswith('text/x-vcard:https://%s' % settings.AWS_BUCKET_DOMAIN))
-        self.assertTrue(msg.media.endswith('.vcf'))
+        self.assertTrue(msg.attachments[0].startswith('text/x-vcard:https://%s' % settings.AWS_BUCKET_DOMAIN))
+        self.assertTrue(msg.attachments[0].endswith('.vcf'))
 
     def test_receive_base64(self):
         post_data = dict(To=self.channel.address, From='+250788383383', Body="QmFubm9uIEV4cGxhaW5zIFRoZSBXb3JsZCAuLi4K4oCcVGhlIENhbXAgb2YgdGhlIFNhaW50c+KA\r")
@@ -7077,7 +7077,7 @@ class TwilioTest(TembaTest):
         self.org.save()
 
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
 
@@ -7115,7 +7115,7 @@ class TwilioTest(TembaTest):
             self.channel.save()
             self.clear_cache()
 
-            msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+            msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
             # manually send it off
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
@@ -7480,7 +7480,7 @@ class ClickatellTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -7583,8 +7583,8 @@ class TelegramTest(TembaTest):
                     else:
                         self.assertEqual(msgs.count(), 1)
 
-                    self.assertTrue(msgs[0].media.startswith('%s:https://' % content_type))
-                    self.assertTrue(msgs[0].media.endswith(extension))
+                    self.assertTrue(msgs[0].attachments[0].startswith('%s:https://' % content_type))
+                    self.assertTrue(msgs[0].attachments[0].endswith(extension))
                     self.assertTrue(msgs[0].text.startswith('https://'))
                     self.assertTrue(msgs[0].text.endswith(extension))
 
@@ -7787,7 +7787,7 @@ class TelegramTest(TembaTest):
         # should have a media message now with an image
         msgs = Msg.objects.all().order_by('-created_on')
         self.assertEqual(msgs.count(), 1)
-        self.assertTrue(msgs[0].media.startswith('geo:'))
+        self.assertTrue(msgs[0].attachments[0].startswith('geo:'))
         self.assertTrue('Fogo Mar' in msgs[0].text)
 
         no_message = """
@@ -7863,7 +7863,7 @@ class TelegramTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Ernie", urn='telegram:1234')
-        msg = joe.send("Test message", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Test message", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
 
@@ -7885,7 +7885,7 @@ class TelegramTest(TembaTest):
             self.assertEqual(mock.call_args[0][1]['chat_id'], "1234")
 
             msg = joe.send("Test message", self.admin, trigger_send=False,
-                           media='audio/mp3:https://example.com/attachments/sound.mp3')[0]
+                           attachments=['audio/mp3:https://example.com/attachments/sound.mp3'])[0]
 
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
@@ -7900,7 +7900,7 @@ class TelegramTest(TembaTest):
             self.assertEqual(mock.call_args[0][1]['chat_id'], "1234")
 
             msg = joe.send("Test message", self.admin, trigger_send=False,
-                           media='video/mpeg4:https://example.com/attachments/video.mp4')[0]
+                           attachments=['video/mpeg4:https://example.com/attachments/video.mp4'])[0]
 
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
@@ -8049,7 +8049,7 @@ class PlivoTest(TembaTest):
             settings.SEND_MESSAGES = False
 
     def test_send_media(self):
-        msg = self.joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = self.joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -8092,7 +8092,7 @@ class TwitterTest(TembaTest):
     def test_send_media(self):
         joe = self.create_contact("Joe", number="+250788383383", twitter="joe1981")
 
-        msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
         try:
             settings.SEND_MESSAGES = True
 
@@ -8582,7 +8582,7 @@ class StartMobileTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+977788123123")
-        msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         try:
             settings.SEND_MESSAGES = True
@@ -8817,7 +8817,7 @@ class ChikkaTest(TembaTest):
         incoming.external_id = '4004'
         incoming.save()
 
-        msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         with self.settings(SEND_MESSAGES=True):
 
@@ -8960,7 +8960,7 @@ class JasminTest(TembaTest):
         from temba.utils import gsm7
 
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
 
@@ -9154,7 +9154,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
 
@@ -9366,7 +9366,7 @@ class MbloxTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
 
@@ -9926,7 +9926,7 @@ class FacebookTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", urn="facebook:1234")
-        msg = joe.send("Facebook Msg", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Facebook Msg", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
 
@@ -10135,7 +10135,7 @@ class GlobeTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+639171234567")
-        msg = joe.send("MT", self.admin, trigger_send=False, media="image/jpeg:https://example.com/attachments/pic.jpg")[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=["image/jpeg:https://example.com/attachments/pic.jpg"])[0]
 
         settings.SEND_MESSAGES = True
 
@@ -10305,7 +10305,7 @@ class ViberTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+639171234567")
-        msg = joe.send("Hello, world!", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Hello, world!", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
         with patch('requests.post') as mock:
@@ -10447,7 +10447,7 @@ class LineTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", urn="line:uabcdefghijkl")
-        msg = joe.send("Hello, world!", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Hello, world!", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         with self.settings(SEND_MESSAGES=True):
 
@@ -10602,7 +10602,7 @@ class ViberPublicTest(TembaTest):
         self.assertEqual(msg.text, assert_text)
 
         if assert_media:
-            self.assertEqual(msg.media, assert_media)
+            self.assertIn(assert_media, msg.attachments)
 
     def test_reject_message_missing_text(self):
         for viber_msg_type in ['text', 'picture', 'video']:
@@ -10773,7 +10773,7 @@ class ViberPublicTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", urn="viber:xy5/5y6O81+/kbWHpLhBoA==")
-        msg = joe.send("MT", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("MT", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         settings.SEND_MESSAGES = True
         with patch('requests.post') as mock:
@@ -10918,7 +10918,7 @@ class FcmTest(TembaTest):
 
     def test_send_media(self):
         joe = self.create_contact("Joe", urn="fcm:12345abcde", auth="123456abcdef")
-        msg = joe.send("Hello, world!", self.admin, trigger_send=False, media='image/jpeg:https://example.com/attachments/pic.jpg')[0]
+        msg = joe.send("Hello, world!", self.admin, trigger_send=False, attachments=['image/jpeg:https://example.com/attachments/pic.jpg'])[0]
 
         with self.settings(SEND_MESSAGES=True):
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -521,6 +521,9 @@ class Contact(TembaModel):
         msgs = Msg.objects.filter(contact=self, created_on__gte=after, created_on__lt=before)
         msgs = msgs.exclude(visibility=Msg.VISIBILITY_DELETED).select_related('channel').prefetch_related('channel_logs')
 
+        for msg in msgs:
+            msg.media = msg.attachments[0] if msg.attachments else None
+
         # we also include in the timeline purged broadcasts with a best guess at the translation used
         recipients = BroadcastRecipient.objects.filter(contact=self)
         recipients = recipients.filter(broadcast__purged=True, broadcast__created_on__gte=after, broadcast__created_on__lt=before)

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1798,7 +1798,7 @@ class Contact(TembaModel):
             return tel.path
 
     def send(self, text, user, trigger_send=True, response_to=None, message_context=None, session=None,
-             media=None, msg_type=None, created_on=None, all_urns=False):
+             attachments=None, msg_type=None, created_on=None, all_urns=False):
         from temba.msgs.models import Msg, INBOX, PENDING, SENT, UnreachableException
 
         status = SENT if created_on else PENDING
@@ -1813,7 +1813,7 @@ class Contact(TembaModel):
             try:
                 msg = Msg.create_outgoing(self.org, user, recipient, text, priority=Msg.PRIORITY_HIGH,
                                           response_to=response_to, message_context=message_context, session=session,
-                                          media=media, msg_type=msg_type or INBOX, status=status,
+                                          attachments=attachments, msg_type=msg_type or INBOX, status=status,
                                           created_on=created_on)
                 msgs.append(msg)
             except UnreachableException:

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -521,6 +521,8 @@ class Contact(TembaModel):
         msgs = Msg.objects.filter(contact=self, created_on__gte=after, created_on__lt=before)
         msgs = msgs.exclude(visibility=Msg.VISIBILITY_DELETED).select_related('channel').prefetch_related('channel_logs')
 
+        # TODO for now we assume a message can only have one attachment but this will change and read page needs updated
+        # accordingly
         for msg in msgs:
             msg.media = msg.attachments[0] if msg.attachments else None
 

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -193,7 +193,7 @@ def history_class(item):
 
     if item['type'] == 'msg':
         classes.append('msg')
-        if obj.media and obj.media[:6] == 'video:':
+        if obj.attachments and obj.attachments[0][:6] == 'video:':
             classes.append('video')
         if obj.status in (ERRORED, FAILED):
             classes.append('warning')

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1426,7 +1426,8 @@ class ContactTest(TembaTest):
         self.create_campaign()
 
         # add one that is a video
-        self.create_msg(direction='I', contact=self.joe, media="video:http://blah/file.mp4", text="Video caption", created_on=timezone.now())
+        self.create_msg(direction='I', contact=self.joe, attachments=["video:http://blah/file.mp4"],
+                        text="Video caption", created_on=timezone.now())
 
         # create some messages
         for i in range(99):
@@ -1471,7 +1472,7 @@ class ContactTest(TembaTest):
         self.assertEqual(activity[3]['obj'].direction, 'O')
         self.assertIsInstance(activity[4]['obj'], FlowRun)
         self.assertIsInstance(activity[5]['obj'], Msg)
-        self.assertEqual(activity[5]['obj'].media, "video:http://blah/file.mp4")
+        self.assertEqual(activity[5]['obj'].attachments[0], "video:http://blah/file.mp4")
         self.assertIsInstance(activity[6]['obj'], Msg)
         self.assertEqual(activity[6]['obj'].text, "Inbound message 98")
         self.assertIsInstance(activity[9]['obj'], EventFire)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -773,9 +773,9 @@ class Flow(TembaModel):
             step.add_message(msg)
             run.update_expiration(timezone.now())
 
-        if ruleset.ruleset_type in RuleSet.TYPE_MEDIA and msg.media is not None:
+        if ruleset.ruleset_type in RuleSet.TYPE_MEDIA and msg.attachments:
             # store the media path as the value
-            value = msg.media.split(':', 1)[1]
+            value = msg.attachments[0].split(':', 1)[1]
 
         step.save_rule_match(rule, value)
         ruleset.save_run_value(run, rule, value)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2789,12 +2789,12 @@ class FlowRun(models.Model):
         # create a Msg object to track what happened
         from temba.msgs.models import DELIVERED, IVR
 
-        media = None
+        attachments = None
         if recording_url:
-            media = '%s/x-wav:%s' % (Msg.MEDIA_AUDIO, recording_url)
+            attachments = ['%s/x-wav:%s' % (Msg.MEDIA_AUDIO, recording_url)]
 
         msg = Msg.create_outgoing(self.flow.org, self.flow.created_by, self.contact, text, channel=self.session.channel,
-                                  response_to=response_to, media=media,
+                                  response_to=response_to, attachments=attachments,
                                   status=DELIVERED, msg_type=IVR, session=session)
 
         # play a recording or read some text

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2874,7 +2874,7 @@ class ActionTest(TembaTest):
         self.execute_action(action, run, msg)
         reply_msg = Msg.objects.get(contact=self.contact, direction='O')
         self.assertEquals("We love green too!", reply_msg.text)
-        self.assertEquals(reply_msg.media, "image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg'))
+        self.assertEquals(reply_msg.attachments, ["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg')])
 
         Broadcast.objects.all().delete()
         Msg.objects.all().delete()
@@ -2889,7 +2889,7 @@ class ActionTest(TembaTest):
 
         response = msg.responses.get()
         self.assertEquals("We love green too!", response.text)
-        self.assertEquals(response.media, "image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg'))
+        self.assertEquals(response.attachments, ["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg')])
         self.assertEquals(self.contact, response.contact)
 
     def test_ussd_action(self):
@@ -3130,7 +3130,7 @@ class ActionTest(TembaTest):
         msg = broadcast.get_messages().first()
         self.assertEqual(msg.contact, self.contact2)
         self.assertEqual(msg.text, msg_body)
-        self.assertEqual(msg.media, "image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'attachments/picture.jpg'))
+        self.assertEqual(msg.attachments, ["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'attachments/picture.jpg')])
 
         # also send if we have empty message but have an attachment
         action = SendAction(dict(base=""), [], [self.contact], [], dict(base='image/jpeg:attachments/picture.jpg'))
@@ -5348,9 +5348,8 @@ class FlowsTest(FlowFileTest):
         self.assertEquals(1, len(runs))
         self.assertEquals(1, self.contact.msgs.all().count())
         self.assertEquals('Hey', self.contact.msgs.all()[0].text)
-        self.assertEquals("image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN,
-                          "attachments/2/53/steps/87d34837-491c-4541-98a1-fa75b52ebccc.jpg"),
-                          self.contact.msgs.all()[0].media)
+        self.assertEquals(["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, "attachments/2/53/steps/87d34837-491c-4541-98a1-fa75b52ebccc.jpg")],
+                          self.contact.msgs.all()[0].attachments)
 
     def test_substitution(self):
         flow = self.get_flow('substitution')

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1414,7 +1414,7 @@ class FlowCRUDL(SmartCRUDL):
                         Msg.create_incoming(None,
                                             test_contact.get_urn(TEL_SCHEME).urn,
                                             new_message,
-                                            media=media,
+                                            attachments=[media] if media else None,
                                             org=user.get_org(),
                                             status=PENDING)
                 except Exception as e:  # pragma: needs cover

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -270,17 +270,17 @@ class IVRTests(FlowFileTest):
 
         # we should have played a recording from the contact back to them
         outbound_msg = messages[1]
-        self.assertTrue(outbound_msg.media.startswith('audio/x-wav:https://'))
-        self.assertTrue(outbound_msg.media.endswith('.wav'))
+        self.assertTrue(outbound_msg.attachments[0].startswith('audio/x-wav:https://'))
+        self.assertTrue(outbound_msg.attachments[0].endswith('.wav'))
         self.assertTrue(outbound_msg.text.startswith('https://'))
         self.assertTrue(outbound_msg.text.endswith('.wav'))
 
         media_msg = messages[2]
-        self.assertTrue(media_msg.media.startswith('audio/x-wav:https://'))
-        self.assertTrue(media_msg.media.endswith('.wav'))
+        self.assertTrue(media_msg.attachments[0].startswith('audio/x-wav:https://'))
+        self.assertTrue(media_msg.attachments[0].endswith('.wav'))
         self.assertEqual('Played contact recording', media_msg.text)
 
-        (host, directory, filename) = media_msg.media.rsplit('/', 2)
+        (host, directory, filename) = media_msg.attachments[0].rsplit('/', 2)
         recording = '%s/%s/%s/media/%s/%s' % (settings.MEDIA_ROOT, settings.STORAGE_ROOT_DIR,
                                               self.org.pk, directory, filename)
         self.assertTrue(os.path.isfile(recording))
@@ -404,17 +404,17 @@ class IVRTests(FlowFileTest):
 
         # we should have played a recording from the contact back to them
         outbound_msg = messages[1]
-        self.assertTrue(outbound_msg.media.startswith('audio/x-wav:https://'))
-        self.assertTrue(outbound_msg.media.endswith('.wav'))
+        self.assertTrue(outbound_msg.attachments[0].startswith('audio/x-wav:https://'))
+        self.assertTrue(outbound_msg.attachments[0].endswith('.wav'))
         self.assertTrue(outbound_msg.text.startswith('https://'))
         self.assertTrue(outbound_msg.text.endswith('.wav'))
 
         media_msg = messages[2]
-        self.assertTrue(media_msg.media.startswith('audio/x-wav:https://'))
-        self.assertTrue(media_msg.media.endswith('.wav'))
+        self.assertTrue(media_msg.attachments[0].startswith('audio/x-wav:https://'))
+        self.assertTrue(media_msg.attachments[0].endswith('.wav'))
         self.assertEqual('Played contact recording', media_msg.text)
 
-        (host, directory, filename) = media_msg.media.rsplit('/', 2)
+        (host, directory, filename) = media_msg.attachments[0].rsplit('/', 2)
         recording = '%s/%s/%s/media/%s/%s' % (settings.MEDIA_ROOT, settings.STORAGE_ROOT_DIR,
                                               self.org.pk, directory, filename)
         self.assertTrue(os.path.isfile(recording))

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -938,7 +938,7 @@ class Msg(models.Model):
 
     @classmethod
     def get_media(cls, msg):
-        if hasattr(msg, 'media') and msg.media:
+        if hasattr(msg, 'media') and msg.media:  # pragma: no cover
             media = msg.media
         elif hasattr(msg, 'attachments') and msg.attachments:
             media = msg.attachments[0]  # for now we only support a single attachment

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -480,7 +480,7 @@ class Broadcast(models.Model):
                                           status=status,
                                           msg_type=msg_type,
                                           insert_object=False,
-                                          media=media,
+                                          attachments=[media] if media else None,
                                           priority=priority,
                                           created_on=created_on)
 
@@ -938,8 +938,15 @@ class Msg(models.Model):
 
     @classmethod
     def get_media(cls, msg):
-        if msg.media:
-            parts = msg.media.split(':', 1)
+        if hasattr(msg, 'media') and msg.media:
+            media = msg.media
+        elif hasattr(msg, 'attachments') and msg.attachments:
+            media = msg.attachments[0]  # for now we only support a single attachment
+        else:
+            media = None
+
+        if media:
+            parts = media.split(':', 1)
             if len(parts) == 2:
                 return parts
         return None, None
@@ -948,7 +955,7 @@ class Msg(models.Model):
         return dict(direction=self.direction,
                     text=self.text,
                     id=self.id,
-                    media=self.media,
+                    attachments=self.attachments,
                     created_on=self.created_on.strftime('%x %X'),
                     model="msg")
 
@@ -1026,24 +1033,12 @@ class Msg(models.Model):
         return sorted_logs[0] if sorted_logs else None
 
     def get_media_path(self):
-
-        if self.media:
-            # TODO: remove after migration msgs.0053
-            if self.media.startswith('http'):  # pragma: needs cover
-                return self.media
-
-            if ':' in self.media:
-                return self.media.split(':', 1)[1]
+        if self.attachments and ':' in self.attachments[0]:
+            return self.attachments[0].split(':', 1)[1]
 
     def get_media_type(self):
-
-        if self.media:
-            # TODO: remove after migration msgs.0053
-            if self.media.startswith('http'):  # pragma: needs cover
-                return 'audio'
-
-        if self.media and ':' in self.media:
-            type = self.media.split(':', 1)[0]
+        if self.attachments and ':' in self.attachments[0]:
+            type = self.attachments[0].split(':', 1)[0]
             if type == 'application/octet-stream':  # pragma: needs cover
                 return 'audio'
             return type.split('/', 1)[0]
@@ -1057,11 +1052,11 @@ class Msg(models.Model):
     def is_media_type_image(self):
         return Msg.MEDIA_IMAGE == self.get_media_type()
 
-    def reply(self, text, user, trigger_send=False, message_context=None, session=None, media=None, msg_type=None,
+    def reply(self, text, user, trigger_send=False, message_context=None, session=None, attachments=None, msg_type=None,
               send_all=False, created_on=None):
 
         return self.contact.send(text, user, trigger_send=trigger_send, message_context=message_context,
-                                 response_to=self if self.id else None, session=session, media=media,
+                                 response_to=self if self.id else None, session=session, attachments=attachments,
                                  msg_type=msg_type or self.msg_type, created_on=created_on, all_urns=send_all)
 
     def update(self, cmd):
@@ -1192,7 +1187,7 @@ class Msg(models.Model):
                     text=self.text, urn_path=self.contact_urn.path,
                     contact=self.contact_id, contact_urn=self.contact_urn_id,
                     priority=self.priority, error_count=self.error_count, next_attempt=self.next_attempt,
-                    status=self.status, direction=self.direction, media=self.media,
+                    status=self.status, direction=self.direction, attachments=self.attachments,
                     external_id=self.external_id, response_to_id=self.response_to_id,
                     sent_on=self.sent_on, queued_on=self.queued_on,
                     created_on=self.created_on, modified_on=self.modified_on, session_id=self.session_id)
@@ -1207,7 +1202,7 @@ class Msg(models.Model):
 
     @classmethod
     def create_incoming(cls, channel, urn, text, user=None, date=None, org=None, contact=None,
-                        status=PENDING, media=None, msg_type=None, topup=None, external_id=None, session=None):
+                        status=PENDING, attachments=None, msg_type=None, topup=None, external_id=None, session=None):
 
         from temba.api.models import WebHookEvent
         if not org and channel:
@@ -1264,8 +1259,7 @@ class Msg(models.Model):
                         queued_on=now,
                         direction=INCOMING,
                         msg_type=msg_type,
-                        media=media,
-                        attachments=[media] if media else [],
+                        attachments=attachments,
                         status=status,
                         external_id=external_id,
                         session=session)
@@ -1340,7 +1334,7 @@ class Msg(models.Model):
     @classmethod
     def create_outgoing(cls, org, user, recipient, text, broadcast=None, channel=None, priority=PRIORITY_NORMAL,
                         created_on=None, response_to=None, message_context=None, status=PENDING, insert_object=True,
-                        media=None, topup_id=None, msg_type=INBOX, session=None, role=None):
+                        attachments=None, topup_id=None, msg_type=INBOX, session=None):
 
         if not org or not user:  # pragma: no cover
             raise ValueError("Trying to create outgoing message with no org or user")
@@ -1395,7 +1389,7 @@ class Msg(models.Model):
             same_msgs = Msg.objects.filter(contact_urn=contact_urn,
                                            contact__is_test=False,
                                            channel=channel,
-                                           media=media,
+                                           attachments=attachments,
                                            text=text,
                                            direction=OUTGOING,
                                            created_on__gte=created_on - timedelta(minutes=10))
@@ -1447,8 +1441,7 @@ class Msg(models.Model):
                         response_to=response_to,
                         msg_type=msg_type,
                         priority=priority,
-                        media=media,
-                        attachments=[media] if media else [],
+                        attachments=attachments,
                         session=session,
                         has_template_error=len(errors) > 0)
 

--- a/temba/msgs/templatetags/sms.py
+++ b/temba/msgs/templatetags/sms.py
@@ -13,10 +13,14 @@ def as_icon(contact_event):
     icon = 'icon-bubble-dots-2 green'
     direction = getattr(contact_event, 'direction', 'O')
     msg_type = getattr(contact_event, 'msg_type', 'I')
-    media_type = getattr(contact_event, 'media', None)
+    attachments = getattr(contact_event, 'attachments', None)
 
-    if media_type and ':' in media_type:
-        media_type = media_type.split(':', 1)[0].split('/', 1)[0]
+    if attachments:
+        media_type = attachments[0]
+        if media_type and ':' in media_type:
+            media_type = media_type.split(':', 1)[0].split('/', 1)[0]
+    else:
+        media_type = None
 
     if hasattr(contact_event, 'status'):
         status = contact_event.status

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -695,7 +695,7 @@ class MsgTest(TembaTest):
 
         # inbound message with media attached, such as an ivr recording
         msg5 = self.create_msg(contact=self.joe, text="Media message", direction='I', status=HANDLED,
-                               msg_type='I', media='audio:http://rapidpro.io/audio/sound.mp3',
+                               msg_type='I', attachments=['audio:http://rapidpro.io/audio/sound.mp3'],
                                created_on=datetime(2017, 1, 5, 10, tzinfo=pytz.UTC))
 
         # create some outbound messages with different statuses
@@ -1925,15 +1925,12 @@ class BroadcastLanguageTest(TembaTest):
 
         # assert the right language was used for each contact on both text and media
         self.assertEqual(francois_media.text, fre_msg)
-        self.assertEqual(francois_media.media, francois_media_url)
         self.assertEqual(francois_media.attachments, [francois_media_url])
 
         self.assertEqual(greg_media.text, eng_msg)
-        self.assertEqual(greg_media.media, greg_media_url)
         self.assertEqual(greg_media.attachments, [greg_media_url])
 
         self.assertEqual(wilbert_media.text, fre_msg)
-        self.assertEqual(wilbert_media.media, wilbert_media_url)
         self.assertEqual(wilbert_media.attachments, [wilbert_media_url])
 
 

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -273,9 +273,6 @@ class TembaTest(SmartminTest):
         if not kwargs['contact'].is_test:
             (kwargs['topup_id'], amount) = kwargs['org'].decrement_credit()
 
-        if 'media' in kwargs:
-            raise ValueError("Use attachments instead of media")
-
         return Msg.objects.create(**kwargs)
 
     def create_flow(self, uuid_start=None, **kwargs):

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -273,6 +273,9 @@ class TembaTest(SmartminTest):
         if not kwargs['contact'].is_test:
             (kwargs['topup_id'], amount) = kwargs['org'].decrement_credit()
 
+        if 'media' in kwargs:
+            raise ValueError("Use attachments instead of media")
+
         return Msg.objects.create(**kwargs)
 
     def create_flow(self, uuid_start=None, **kwargs):


### PR DESCRIPTION
This part just switches code to using `Msg.attachments` instead of `Msg.media` - we still only support one attachment per message at this point.