### PR TITLE
API v2 fixes

### DIFF
--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -175,6 +175,7 @@ class APITest(TembaTest):
         field.context = {'org': self.org}
 
         self.assertEqual(field.to_internal_value(campaign.uuid), campaign)
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, {'id': 3})  # not a string or int
 
         field = fields.CampaignEventField(source='test')
         field.context = {'org': self.org}

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -1983,6 +1983,10 @@ class APITest(TembaTest):
         results = {m['id'] for m in response.json()['results']}
         self.assertEqual(expected, results)
 
+        # can't filter with invalid id
+        response = self.fetchJSON(url, 'id=xyz')
+        self.assertResponseError(response, None, "Value for id must be an integer")
+
         # can't filter by more than one of contact, folder, label or broadcast together
         for query in ('contact=%s&label=Spam' % self.joe.uuid, 'label=Spam&folder=inbox',
                       'broadcast=12345&folder=inbox', 'broadcast=12345&label=Spam'):

--- a/temba/api/tests/test_v2.py
+++ b/temba/api/tests/test_v2.py
@@ -1536,6 +1536,10 @@ class APITest(TembaTest):
         self.assertEqual(len(resp_json['campaigns']), 1)
         self.assertEqual(len(resp_json['triggers']), 0)
 
+        # test an invalid value for dependencies
+        response = self.fetchJSON(url, 'flow_uuid=%s&campaign_uuid=%s&dependencies=xx' % (flow.uuid, campaign.uuid))
+        self.assertResponseError(response, None, 'dependencies must be one of none, flows, all')
+
     def test_fields(self):
         url = reverse('api.v2.fields')
 

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -153,6 +153,9 @@ class TembaModelField(serializers.RelatedField):
         return {'uuid': obj.uuid, 'name': obj.name}
 
     def to_internal_value(self, data):
+        if not (isinstance(data, six.string_types) or isinstance(data, six.integer_types)):
+            raise serializers.ValidationError("Must be a string or integer")
+
         obj = self.get_object(data)
 
         if not obj:

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1573,7 +1573,11 @@ class DefinitionsEndpoint(BaseAPIView):
             flow_uuids = params.getlist('flow')
             campaign_uuids = params.getlist('campaign')
 
-        include = DefinitionsEndpoint.Depends[params.get('dependencies', 'all')]
+        include = params.get('dependencies', 'all')
+        if include not in DefinitionsEndpoint.Depends.__members__:
+            raise InvalidQueryError("dependencies must be one of %s" % ', '.join(DefinitionsEndpoint.Depends.__members__))
+
+        include = DefinitionsEndpoint.Depends[include]
 
         if flow_uuids:
             flows = set(Flow.objects.filter(uuid__in=flow_uuids, org=org, is_active=True))

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1244,7 +1244,7 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             "name": "Ben Haggerty",
             "language": "eng",
             "urns": ["tel:+250788123123", "twitter:ben"],
-            "groups": [{"name": "Devs", "uuid": "6685e933-26e1-4363-a468-8f7268ab63a9"}],
+            "groups": ["6685e933-26e1-4363-a468-8f7268ab63a9"],
             "fields": {
               "nickname": "Macklemore",
               "side_kick": "Ryan Lewis"


### PR DESCRIPTION
Fixes some cases where we blow up instead of returning an error message:

* User passes something invalid for a param which is expected to be an integer, e,g, https://sentry.io/nyaruka/rapidpro/issues/275291981/
* User passes invalid value for `dependencies` param, e.g. https://sentry.io/nyaruka/rapidpro/issues/275266509/
* User passes an object to foreign key field, e.g. https://sentry.io/nyaruka/rapidpro/issues/227900322/

Also fixes contacts endpoint docs https://github.com/rapidpro/rapidpro/issues/561