### PR TITLE
Better error message for external channel handler for wrong time format

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -507,7 +507,10 @@ class ExternalHandler(BaseChannelHandler):
             # handlers can optionally specify the date/time of the message (as 'date' or 'time') in ECMA format
             date = self.get_param('date', self.get_param('time'))
             if date:
-                date = json_date_to_datetime(date)
+                try:
+                    date = json_date_to_datetime(date)
+                except ValueError as e:
+                    return HttpResponse("Bad parameter error: %s" % e.message, status=400)
 
             urn = URN.from_parts(channel.scheme, sender)
             sms = Msg.create_incoming(channel, urn, text, date=date)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -4039,6 +4039,16 @@ class ExternalTest(TembaTest):
         self.assertEquals(2012, msg.sent_on.year)
         self.assertEquals(18, msg.sent_on.hour)
 
+        Msg.objects.all().delete()
+
+        data = {'from': '5511996458779', 'text': 'Hello World!', 'date': '2012-04-23T18:25:43Z'}
+        response = self.client.post(callback_url, data)
+
+        self.assertEquals(400, response.status_code)
+        self.assertEquals("Bad parameter error: time data '2012-04-23T18:25:43Z' "
+                          "does not match format '%Y-%m-%dT%H:%M:%S.%fZ'", response.content)
+        self.assertFalse(Msg.objects.all())
+
     def test_receive_external(self):
         self.channel.scheme = 'ext'
         self.channel.save()


### PR DESCRIPTION
Fix https://sentry.io/nyaruka/textit/issues/284564732/