### PR TITLE
Add sender ID config for Macrokiosk channels

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -129,6 +129,7 @@ class Channel(TembaModel):
     CONFIG_FCM_TITLE = 'FCM_TITLE'
     CONFIG_FCM_NOTIFICATION = 'FCM_NOTIFICATION'
     CONFIG_MAX_LENGTH = 'max_length'
+    CONFIG_MACROKIOSK_SENDER_ID = 'macrokiosk_sender_id'
     CONFIG_MACROKIOSK_SERVICE_ID = 'macrokiosk_service_id'
 
     ENCODING_DEFAULT = 'D'  # we just pass the text down to the endpoint
@@ -2104,7 +2105,7 @@ class Channel(TembaModel):
 
         data = {
             'user': channel.config[Channel.CONFIG_USERNAME], 'pass': channel.config[Channel.CONFIG_PASSWORD],
-            'to': recipient, 'text': text, 'from': channel.address.lstrip('+'),
+            'to': recipient, 'text': text, 'from': channel.config[Channel.CONFIG_MACROKIOSK_SENDER_ID],
             'servid': channel.config[Channel.CONFIG_MACROKIOSK_SERVICE_ID], 'type': message_type
         }
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -3432,6 +3432,7 @@ class ChannelClaimTest(TembaTest):
         post_data['number'] = '250788123123'
         post_data['username'] = 'user1'
         post_data['password'] = 'pass1'
+        post_data['sender_id'] = 'macro'
         post_data['service_id'] = 'SERVID'
 
         response = self.client.post(reverse('channels.channel_claim_macrokiosk'), post_data)
@@ -3441,6 +3442,7 @@ class ChannelClaimTest(TembaTest):
         self.assertEquals(channel.country, 'MY')
         self.assertEquals(channel.config_json()['username'], post_data['username'])
         self.assertEquals(channel.config_json()['password'], post_data['password'])
+        self.assertEquals(channel.config_json()[Channel.CONFIG_MACROKIOSK_SENDER_ID], post_data['sender_id'])
         self.assertEquals(channel.config_json()[Channel.CONFIG_MACROKIOSK_SERVICE_ID], post_data['service_id'])
         self.assertEquals(channel.address, '250788123123')
         self.assertEquals(channel.channel_type, Channel.TYPE_MACROKIOSK)
@@ -5754,6 +5756,7 @@ class MacrokioskTest(TembaTest):
         self.channel.delete()
         config = dict(username='mk-user', password='mk-password')
         config[Channel.CONFIG_MACROKIOSK_SERVICE_ID] = 'SERVICE-ID'
+        config[Channel.CONFIG_MACROKIOSK_SENDER_ID] = 'macro'
 
         self.channel = Channel.create(self.org, self.user, 'NP', 'MK', None, '1212',
                                       config=config, uuid='00000000-0000-0000-0000-000000001234')
@@ -5915,6 +5918,7 @@ class MacrokioskTest(TembaTest):
                 self.assertEquals('asdf-asdf-asdf-asdf', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['json']['text'], 'Test message')
+                self.assertEqual(mock.call_args[1]['json']['from'], 'macro')
 
                 self.clear_cache()
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1519,6 +1519,9 @@ class ChannelCRUDL(SmartCRUDL):
             number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
                                      help_text=_("The phone number or short code you are connecting with country code. "
                                                  "ex: +250788123124"))
+            sender_id = forms.CharField(label=_("Sender ID"),
+                                        help_text=_("The sender ID provided by Macrokiosk to use their API"))
+
             username = forms.CharField(label=_("Username"),
                                        help_text=_("The username provided by Macrokiosk to use their API"))
             password = forms.CharField(label=_("Password"),
@@ -1544,6 +1547,7 @@ class ChannelCRUDL(SmartCRUDL):
             config = {
                 Channel.CONFIG_USERNAME: data.get('username', None),
                 Channel.CONFIG_PASSWORD: data.get('password', None),
+                Channel.CONFIG_MACROKIOSK_SENDER_ID: data.get('sender_id', data['number']),
                 Channel.CONFIG_MACROKIOSK_SERVICE_ID: data.get('service_id', None)
             }
             self.object = Channel.add_config_external_channel(org, self.request.user,


### PR DESCRIPTION
Macrokisok expect us to use sender ID when sending MT message and we want to keep the verification for the MO to number https://github.com/nyaruka/rapidpro/blob/7d769fe802be477dd82b4e971b8122cc4ca220b1/temba/channels/handlers.py#L1068

I added the config for sender ID and that should be provided by Macrokiosk