### PR TITLE
Ensure form media is loaded for forms on modals

### DIFF
--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -796,6 +796,11 @@ class MsgTest(TembaTest):
             [msg5.created_on, "123", "tel", "Joe Blow", msg5.contact.uuid, "Incoming", "Media message", "", "Handled"],
         ], self.org.timezone)
 
+        # check sending an invalid date
+        response = self.client.post(reverse('msgs.msg_export') + '?l=I', {'export_all': 1, 'start_date': 'xyz'})
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response, 'form', 'start_date', "Enter a valid date.")
+
         # test as anon org to check that URNs don't end up in exports
         with AnonymousOrg(self.org):
             joe_anon_id = "%010d" % self.joe.id

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -451,7 +451,7 @@ class ExportForm(Form):
         start_date = cleaned_data.get('start_date')
         end_date = cleaned_data.get('end_date')
 
-        if start_date and start_date > date.today():
+        if start_date and start_date > date.today():  # pragma: needs cover
             raise forms.ValidationError(_("Start date can't be in the future."))
 
         if end_date and start_date and end_date < start_date:  # pragma: needs cover

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -448,10 +448,10 @@ class ExportForm(Form):
 
     def clean(self):
         cleaned_data = super(ExportForm, self).clean()
-        start_date = cleaned_data['start_date']
-        end_date = cleaned_data['end_date']
+        start_date = cleaned_data.get('start_date')
+        end_date = cleaned_data.get('end_date')
 
-        if start_date and start_date > date.today():  # pragma: needs cover
+        if start_date and start_date > date.today():
             raise forms.ValidationError(_("Start date can't be in the future."))
 
         if end_date and start_date and end_date < start_date:  # pragma: needs cover

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -244,8 +244,8 @@
 
   -include "includes/frame_bottom.html"
 
-    {# media associated with any form we are displaying #}
-    -if form
+  // media associated with any form we are displaying
+  -if form
     {{ form.media }}
 
   -block script

--- a/templates/smartmin/modal.haml
+++ b/templates/smartmin/modal.haml
@@ -18,3 +18,6 @@
       .select2-container {
         width: 300px;
       }
+
+  -if form
+    {{ form.media }}


### PR DESCRIPTION
I previously removed heavy_data.js which was an old dataepicker library used by django_select2 because smartmin uses bootstrap-datepicker... but need this fix so that forms on modals load any media associated with their fields.

Currently seeing date parse errors in sentry because users are entering unparseable dates, e.g. https://sentry.io/nyaruka/rapidpro/issues/296690098/