### PR TITLE
Multiple media attachments per messages

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -2810,13 +2810,13 @@ class ViberPublicHandler(BaseChannelHandler):
 
             elif message_type == 'picture':
                 # "media": "http://www.images.com/img.jpg"
-                if message.get('media', None):
+                if message.get('media', None):  # pragma: needs cover
                     downloaded_url = channel.org.download_and_save_media(Request('GET', message['media']))
                     attachments.append('%s:%s' % (Msg.MEDIA_IMAGE, downloaded_url))
 
-            elif message_type == 'video':
+            elif message_type == 'video':  # pragma: needs cover
                 # "media": "http://www.images.com/video.mp4"
-                if message.get('media', None):
+                if message.get('media', None):  # pragma: needs cover
                     downloaded_url = channel.org.download_and_save_media(Request('GET', message['media']))
                     attachments.append('%s:%s' % (Msg.MEDIA_VIDEO, downloaded_url))
 

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -651,7 +651,7 @@ class TelegramHandler(BaseChannelHandler):
             text = body['message']['text']
         elif 'caption' in body['message']:
             text = body['message']['caption']
-        elif 'contact' in body['message']:
+        elif 'contact' in body['message']:  # pragma: needs cover
             contact = body['message']['contact']
 
             if 'first_name' in contact and 'phone_number' in contact:

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -10295,7 +10295,7 @@ class JiochatTest(TembaTest):
                 self.assertEqual(msg.direction, INCOMING)
                 self.assertEqual(msg.org, self.org)
                 self.assertEqual(msg.channel, self.channel)
-                self.assertEqual(msg.text, '<MEDIA_SAVED_URL>')
+                self.assertEqual(msg.text, "")
                 self.assertEqual(msg.sent_on.date(), an_hour_ago.date())
                 self.assertEqual(msg.attachments[0], 'image/jpeg:<MEDIA_SAVED_URL>')
 
@@ -10935,7 +10935,7 @@ class ViberPublicTest(TembaTest):
             }
 
             response = self.assertSignedRequest(json.dumps(data), 400)
-            self.assertIn("Missing 'text' key in 'message' in request_body.", response.content)
+            self.assertContains(response, "Missing text or media in message in request body.", status_code=400)
             Msg.objects.all().delete()
 
     def test_receive_picture_missing_media_key(self):
@@ -10951,7 +10951,7 @@ class ViberPublicTest(TembaTest):
         self.assertMessageReceived('url', 'media', 'http://foo.com/', 'http://foo.com/')
 
     def test_receive_gps(self):
-        self.assertMessageReceived('location', 'location', dict(lat='1.2', lon='-1.3'), 'geo:1.2,-1.3')
+        self.assertMessageReceived('location', 'location', dict(lat='1.2', lon='-1.3'), 'incoming msg')
 
     def test_webhook_check(self):
         data = {

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -7617,19 +7617,11 @@ class TelegramTest(TembaTest):
                     response = self.client.post(receive_url, data, content_type='application/json', post_data=data)
                     self.assertEquals(201, response.status_code)
 
-                    # should have a media message now with an image
-                    msgs = Msg.objects.all().order_by('-pk')
-
-                    if caption:
-                        self.assertEqual(msgs.count(), 2)
-                        self.assertEqual(msgs[1].text, caption)
-                    else:
-                        self.assertEqual(msgs.count(), 1)
-
-                    self.assertTrue(msgs[0].attachments[0].startswith('%s:https://' % content_type))
-                    self.assertTrue(msgs[0].attachments[0].endswith(extension))
-                    self.assertTrue(msgs[0].text.startswith('https://'))
-                    self.assertTrue(msgs[0].text.endswith(extension))
+                    # should have a new message
+                    msg = Msg.objects.get()
+                    self.assertEqual(msg.text, caption or "")
+                    self.assertTrue(msg.attachments[0].startswith('%s:https://' % content_type))
+                    self.assertTrue(msg.attachments[0].endswith(extension))
 
         # stickers are allowed
         sticker_data = """


### PR DESCRIPTION
Updates Twilio, Telegram, Vider and JioChat channels to save a single message with multiple attachments rather than creating multiple messages. These are the only channels which currently actually create attachments.

Message text no longer includes media URLs, tho this is still included in `@step.value` (#1308)