### PR TITLE
Move api tests into the packages that they're testing

### DIFF
--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -19,7 +19,7 @@ from temba.msgs.models import Broadcast, FAILED
 from temba.orgs.models import ALL_EVENTS
 from temba.tests import MockResponse, TembaTest
 from urlparse import parse_qs
-from ..models import APIToken, WebHookEvent, WebHookResult
+from temba.api.models import APIToken, WebHookEvent, WebHookResult
 
 
 class APITokenTest(TembaTest):

--- a/temba/api/tests/__init__.py
+++ b/temba/api/tests/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, unicode_literals

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -24,9 +24,9 @@ from temba.orgs.models import Language
 from temba.tests import TembaTest, AnonymousOrg
 from temba.utils import datetime_to_json_date
 from temba.values.models import Value
-from ..models import APIToken
-from ..v1.serializers import StringDictField, StringArrayField, PhoneArrayField, ChannelField, DateTimeField
-from ..v1.serializers import MsgCreateSerializer
+from temba.api.models import APIToken
+from .serializers import StringDictField, StringArrayField, PhoneArrayField, ChannelField, DateTimeField
+from .serializers import MsgCreateSerializer
 
 
 class APITest(TembaTest):

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -27,9 +27,9 @@ from temba.orgs.models import Language
 from temba.tests import TembaTest, AnonymousOrg
 from temba.values.models import Value
 from urllib import quote_plus
-from ..models import APIToken, Resthook, WebHookEvent
-from ..v2 import fields
-from ..v2.serializers import format_datetime
+from temba.api.models import APIToken, Resthook, WebHookEvent
+from . import fields
+from .serializers import format_datetime
 
 
 NUM_BASE_REQUEST_QUERIES = 7  # number of db queries required for any API request


### PR DESCRIPTION
Just moving these test files into the sub-packages that they test, since I discovered Django no longer requires test files to all be in a single package called tests, and this just seems a more logical way to organize them.