### PR TITLE
Include attachments in webhook payloads

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -230,12 +230,14 @@ class WebHookEvent(SmartModel):
 
         if msg:
             text = msg.text
+            attachments = msg.get_attachments()
             channel = msg.channel
             contact_urn = msg.contact_urn
         else:
             # if the action is on the first node we might not have an sms (or channel) yet
             channel = None
             text = None
+            attachments = []
             contact_urn = contact.get_urn()
 
         steps = []
@@ -256,6 +258,7 @@ class WebHookEvent(SmartModel):
                     flow_base_language=flow.base_language,
                     run=run.id,
                     text=text,
+                    attachments=[a.as_json() for a in attachments],
                     step=six.text_type(node_uuid),
                     phone=contact.get_urn_display(org=org, scheme=TEL_SCHEME, formatted=False),
                     contact=contact.uuid,
@@ -384,6 +387,7 @@ class WebHookEvent(SmartModel):
                     contact_name=msg.contact.name,
                     urn=six.text_type(msg.contact_urn),
                     text=msg.text,
+                    attachments=[a.as_json() for a in msg.get_attachments()],
                     time=json_time,
                     status=msg.status,
                     direction=msg.direction)

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -258,7 +258,7 @@ class WebHookEvent(SmartModel):
                     flow_base_language=flow.base_language,
                     run=run.id,
                     text=text,
-                    attachments=[a.as_json() for a in attachments],
+                    attachments=[a.url for a in attachments],
                     step=six.text_type(node_uuid),
                     phone=contact.get_urn_display(org=org, scheme=TEL_SCHEME, formatted=False),
                     contact=contact.uuid,
@@ -387,7 +387,7 @@ class WebHookEvent(SmartModel):
                     contact_name=msg.contact.name,
                     urn=six.text_type(msg.contact_urn),
                     text=msg.text,
-                    attachments=[a.as_json() for a in msg.get_attachments()],
+                    attachments=[a.url for a in msg.get_attachments()],
                     time=json_time,
                     status=msg.status,
                     direction=msg.direction)

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -378,7 +378,7 @@ class WebHookEvent(SmartModel):
         api_user = get_api_user()
 
         json_time = time.strftime('%Y-%m-%dT%H:%M:%S.%f')
-        data = dict(sms=msg.pk,
+        data = dict(sms=msg.id,
                     phone=msg.contact.get_urn_display(org=org, scheme=TEL_SCHEME, formatted=False),
                     contact=msg.contact.uuid,
                     contact_name=msg.contact.name,

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -15,6 +15,7 @@ from mock import patch
 from temba.api.tasks import trim_webhook_event_task
 from temba.channels.models import ChannelEvent, SyncEvent
 from temba.contacts.models import Contact, TEL_SCHEME
+from temba.flows.models import ActionSet, WebhookAction, Flow
 from temba.msgs.models import Broadcast, FAILED
 from temba.orgs.models import ALL_EVENTS
 from temba.tests import MockResponse, TembaTest
@@ -223,13 +224,13 @@ class WebHookTest(TembaTest):
             self.assertEquals(5, int(data['pending_message_count'][0]))
             self.assertEquals(4, int(data['retry_message_count'][0]))
 
-    def test_flow_event(self):
+    @patch('requests.Session.send')
+    def test_flow_event(self, mock_send):
         self.setupChannel()
 
         org = self.channel.org
         org.save()
 
-        from temba.flows.models import ActionSet, WebhookAction, Flow
         flow = self.create_flow()
 
         # replace our uuid of 4 with the right thing
@@ -237,51 +238,53 @@ class WebHookTest(TembaTest):
         actionset.set_actions_dict([WebhookAction(org.get_webhook_url()).as_json()])
         actionset.save()
 
-        with patch('requests.Session.send') as mock:
-            # run a user through this flow
-            flow.start([], [self.joe])
+        # run a user through this flow
+        flow.start([], [self.joe])
 
-            # have joe reply with mauve, which will put him in the other category that triggers the API Action
-            sms = self.create_msg(contact=self.joe, direction='I', status='H', text="Mauve")
+        # have joe reply with mauve, which will put him in the other category that triggers the API Action
+        sms = self.create_msg(contact=self.joe, direction='I', status='H', text="Mauve",
+                              attachments=["image/jpeg:http://s3.com/text.jpg", "audio/mp4:http://s3.com/text.mp4"])
 
-            mock.return_value = MockResponse(200, "{}")
-            Flow.find_and_handle(sms)
+        mock_send.return_value = MockResponse(200, "{}")
+        Flow.find_and_handle(sms)
 
-            # should have one event created
-            event = WebHookEvent.objects.get()
+        # should have one event created
+        event = WebHookEvent.objects.get()
 
-            self.assertEquals('C', event.status)
-            self.assertEquals(1, event.try_count)
-            self.assertFalse(event.next_attempt)
+        self.assertEquals('C', event.status)
+        self.assertEquals(1, event.try_count)
+        self.assertFalse(event.next_attempt)
 
-            result = WebHookResult.objects.get()
-            self.assertIn("successfully", result.message)
-            self.assertEquals(200, result.status_code)
+        result = WebHookResult.objects.get()
+        self.assertIn("successfully", result.message)
+        self.assertEquals(200, result.status_code)
 
-            self.assertTrue(mock.called)
+        self.assertTrue(mock_send.called)
 
-            args = mock.call_args_list[0][0]
-            prepared_request = args[0]
-            self.assertIn(self.channel.org.get_webhook_url(), prepared_request.url)
+        args = mock_send.call_args_list[0][0]
+        prepared_request = args[0]
+        self.assertIn(self.channel.org.get_webhook_url(), prepared_request.url)
 
-            data = parse_qs(prepared_request.body)
+        data = parse_qs(prepared_request.body)
 
-            self.assertEqual(data['channel'], [str(self.channel.id)])
-            self.assertEqual(data['channel_uuid'], [self.channel.uuid])
-            self.assertEqual(data['step'], [actionset.uuid])
-            self.assertEqual(data['flow'], [str(flow.id)])
-            self.assertEqual(data['flow_uuid'], [flow.uuid])
-            self.assertEqual(data['contact'], [self.joe.uuid])
-            self.assertEqual(data['contact_name'], [self.joe.name])
-            self.assertEqual(data['urn'], [six.text_type(self.joe.get_urn('tel'))])
+        self.assertEqual(data['channel'], [str(self.channel.id)])
+        self.assertEqual(data['channel_uuid'], [self.channel.uuid])
+        self.assertEqual(data['step'], [actionset.uuid])
+        self.assertEqual(data['text'], ["Mauve"])
+        self.assertEqual(data['attachments'], ["http://s3.com/text.jpg", "http://s3.com/text.mp4"])
+        self.assertEqual(data['flow'], [str(flow.id)])
+        self.assertEqual(data['flow_uuid'], [flow.uuid])
+        self.assertEqual(data['contact'], [self.joe.uuid])
+        self.assertEqual(data['contact_name'], [self.joe.name])
+        self.assertEqual(data['urn'], [six.text_type(self.joe.get_urn('tel'))])
 
-            values = json.loads(data['values'][0])
+        values = json.loads(data['values'][0])
 
-            self.assertEquals('Other', values[0]['category']['base'])
-            self.assertEquals('color', values[0]['label'])
-            self.assertEquals('Mauve', values[0]['text'])
-            self.assertTrue(values[0]['time'])
-            self.assertTrue(data['time'])
+        self.assertEquals('Other', values[0]['category']['base'])
+        self.assertEquals('color', values[0]['label'])
+        self.assertEquals('Mauve', values[0]['text'])
+        self.assertTrue(values[0]['time'])
+        self.assertTrue(data['time'])
 
     @patch('temba.api.models.time.time')
     def test_webhook_result_timing(self, mock_time):

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -569,13 +569,11 @@ class APITest(TembaTest):
         msg = step.messages.all().first()
         self.assertTrue(msg.attachments[0].startswith('image/jpeg:http'))
         self.assertTrue(msg.attachments[0].endswith('.jpg'))
-        self.assertTrue(msg.is_media_type_image())
 
         step = FlowStep.objects.filter(step_uuid=ruleset_video.uuid).first()
         msg = step.messages.all().first()
         self.assertTrue(msg.attachments[0].startswith('video/mp4:http'))
         self.assertTrue(msg.attachments[0].endswith('.mp4'))
-        self.assertTrue(msg.is_media_type_video())
 
     def test_api_steps(self):
         url = reverse('api.v1.steps')

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -791,11 +791,12 @@ class MsgReadSerializer(ReadSerializer):
     channel = fields.ChannelField()
     direction = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
-    media = serializers.SerializerMethodField()
+    attachments = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
     archived = serializers.SerializerMethodField()
     visibility = serializers.SerializerMethodField()
     labels = fields.LabelField(many=True)
+    media = serializers.SerializerMethodField()  # deprecated
 
     def get_broadcast(self, obj):
         return obj.broadcast_id
@@ -810,6 +811,9 @@ class MsgReadSerializer(ReadSerializer):
         # PENDING and QUEUED are same as far as users are concerned
         return self.STATUSES.get(QUEUED if obj.status == PENDING else obj.status)
 
+    def get_attachments(self, obj):
+        return [{'content_type': a.content_type, 'url': a.url} for a in obj.get_attachments()]
+
     def get_media(self, obj):
         return obj.attachments[0] if obj.attachments else None
 
@@ -823,7 +827,7 @@ class MsgReadSerializer(ReadSerializer):
         model = Msg
         fields = ('id', 'broadcast', 'contact', 'urn', 'channel',
                   'direction', 'type', 'status', 'archived', 'visibility', 'text', 'labels',
-                  'media', 'created_on', 'sent_on', 'modified_on')
+                  'attachments', 'created_on', 'sent_on', 'modified_on', 'media')
 
 
 class MsgBulkActionSerializer(WriteSerializer):

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -812,7 +812,7 @@ class MsgReadSerializer(ReadSerializer):
         return self.STATUSES.get(QUEUED if obj.status == PENDING else obj.status)
 
     def get_attachments(self, obj):
-        return [{'content_type': a.content_type, 'url': a.url} for a in obj.get_attachments()]
+        return [a.as_json() for a in obj.get_attachments()]
 
     def get_media(self, obj):
         return obj.attachments[0] if obj.attachments else None

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1842,7 +1842,7 @@ class APITest(TembaTest):
 
     def assertMsgEqual(self, msg_json, msg, msg_type, msg_status, msg_visibility):
         self.assertEqual(msg_json, {
-            'id': msg.pk,
+            'id': msg.id,
             'broadcast': msg.broadcast,
             'contact': {'uuid': msg.contact.uuid, 'name': msg.contact.name},
             'urn': msg.contact_urn.urn,
@@ -1854,10 +1854,11 @@ class APITest(TembaTest):
             'visibility': msg_visibility,
             'text': msg.text,
             'labels': [dict(name=l.name, uuid=l.uuid) for l in msg.labels.all()],
-            'media': msg.attachments[0] if msg.attachments else None,
+            'attachments': [{'content_type': a.content_type, 'url': a.url} for a in msg.get_attachments()],
             'created_on': format_datetime(msg.created_on),
             'sent_on': format_datetime(msg.sent_on),
-            'modified_on': format_datetime(msg.modified_on)
+            'modified_on': format_datetime(msg.modified_on),
+            'media': msg.attachments[0] if msg.attachments else None
         })
 
     def test_messages(self):
@@ -1876,7 +1877,8 @@ class APITest(TembaTest):
         frank_msg1 = self.create_msg(direction='I', msg_type='I', text="Bonjour", contact=self.frank, channel=self.twitter)
         joe_msg2 = self.create_msg(direction='O', msg_type='I', text="How are you?", contact=self.joe, status='Q')
         frank_msg2 = self.create_msg(direction='O', msg_type='I', text="Ça va?", contact=self.frank, status='D')
-        joe_msg3 = self.create_msg(direction='I', msg_type='F', text="Good", contact=self.joe)
+        joe_msg3 = self.create_msg(direction='I', msg_type='F', text="Good", contact=self.joe,
+                                   attachments=['image/jpeg:https://example.com/test.jpg'])
         frank_msg3 = self.create_msg(direction='I', msg_type='I', text="Bien", contact=self.frank, channel=self.twitter, visibility='A')
 
         # add a surveyor message (no URN etc)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -2624,8 +2624,8 @@ class Channel(TembaModel):
 
         if msg.attachments:
             # for now we only support sending one attachment per message but this could change in future
-            media_type, media_url = Msg.get_attachments(msg)[0]
-            media_urls = [media_url]
+            attachment = Msg.Attachment.parse(msg.attachments)[0]
+            media_urls = [attachment.url]
 
         if channel.channel_type == Channel.TYPE_TWIML:  # pragma: no cover
             config = channel.config
@@ -2984,9 +2984,8 @@ class Channel(TembaModel):
 
         if msg.attachments and not Channel.supports_media(channel):
             # for now we only support sending one attachment per message but this could change in future
-            media_type, media_url = Msg.get_attachments(msg)[0]
-            if media_type and media_url:
-                text = '%s\n%s' % (text, media_url)
+            attachment = Msg.Attachment.parse(msg.attachments)[0]
+            text = '%s\n%s' % (text, attachment.url)
 
             # don't send as media
             msg.attachments = None

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -2613,7 +2613,7 @@ class Channel(TembaModel):
 
     @classmethod
     def send_twilio_message(cls, channel, msg, text):
-        from temba.msgs.models import Msg, WIRED
+        from temba.msgs.models import Attachment, WIRED
         from temba.orgs.models import ACCOUNT_SID, ACCOUNT_TOKEN
         from temba.utils.twilio import TembaTwilioRestClient
 
@@ -2624,7 +2624,7 @@ class Channel(TembaModel):
 
         if msg.attachments:
             # for now we only support sending one attachment per message but this could change in future
-            attachment = Msg.Attachment.parse(msg.attachments)[0]
+            attachment = Attachment.parse_all(msg.attachments)[0]
             media_urls = [attachment.url]
 
         if channel.channel_type == Channel.TYPE_TWIML:  # pragma: no cover
@@ -2921,7 +2921,7 @@ class Channel(TembaModel):
 
     @classmethod
     def send_message(cls, msg):  # pragma: no cover
-        from temba.msgs.models import Msg, QUEUED, WIRED, MSG_SENT_KEY
+        from temba.msgs.models import Msg, Attachment, QUEUED, WIRED, MSG_SENT_KEY
         r = get_redis_connection()
 
         # check whether this message was already sent somehow
@@ -2984,7 +2984,7 @@ class Channel(TembaModel):
 
         if msg.attachments and not Channel.supports_media(channel):
             # for now we only support sending one attachment per message but this could change in future
-            attachment = Msg.Attachment.parse(msg.attachments)[0]
+            attachment = Attachment.parse_all(msg.attachments)[0]
             text = '%s\n%s' % (text, attachment.url)
 
             # don't send as media

--- a/temba/channels/types/facebook/__init__.py
+++ b/temba/channels/types/facebook/__init__.py
@@ -7,7 +7,7 @@ import time
 
 from django.utils.translation import ugettext_lazy as _
 from temba.contacts.models import Contact, ContactURN, URN, FACEBOOK_SCHEME
-from temba.msgs.models import Msg, WIRED
+from temba.msgs.models import Attachment, WIRED
 from temba.orgs.models import Org
 from temba.triggers.models import Trigger
 from temba.utils.http import HttpEvent
@@ -76,7 +76,7 @@ class FacebookType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         # for now we only support sending one attachment per message but this could change in future
-        attachments = Msg.Attachment.parse(msg.attachments)
+        attachments = Attachment.parse_all(msg.attachments)
         attachment = attachments[0] if attachments else None
 
         if attachment:

--- a/temba/channels/types/facebook/__init__.py
+++ b/temba/channels/types/facebook/__init__.py
@@ -76,14 +76,14 @@ class FacebookType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         # for now we only support sending one attachment per message but this could change in future
-        attachments = Msg.get_attachments(msg)
-        media_type, media_url = attachments[0] if attachments else (None, None)
+        attachments = Msg.Attachment.parse(msg.attachments)
+        attachment = attachments[0] if attachments else None
 
-        if media_type and media_url:
-            media_type = media_type.split('/')[0]
+        if attachment:
+            category = attachment.content_type.split('/')[0]
 
             payload = json.loads(payload)
-            payload['message'] = {'attachment': {'type': media_type, 'payload': {'url': media_url}}}
+            payload['message'] = {'attachment': {'type': category, 'payload': {'url': attachment.url}}}
             payload = json.dumps(payload)
 
             event = HttpEvent('POST', url, payload)

--- a/temba/channels/types/telegram/__init__.py
+++ b/temba/channels/types/telegram/__init__.py
@@ -53,24 +53,24 @@ class TelegramType(ChannelType):
         start = time.time()
 
         # for now we only support sending one attachment per message but this could change in future
-        attachments = Msg.get_attachments(msg)
-        media_type, media_url = attachments[0] if attachments else (None, None)
+        attachments = Msg.Attachment.parse(msg.attachments)
+        attachment = attachments[0] if attachments else None
 
-        if media_type and media_url:
-            media_type = media_type.split('/')[0]
-            if media_type == 'image':
+        if attachment:
+            category = attachment.content_type.split('/')[0]
+            if category == 'image':
                 send_url = 'https://api.telegram.org/bot%s/sendPhoto' % auth_token
-                post_body['photo'] = media_url
+                post_body['photo'] = attachment.url
                 post_body['caption'] = text
                 del post_body['text']
-            elif media_type == 'video':
+            elif category == 'video':
                 send_url = 'https://api.telegram.org/bot%s/sendVideo' % auth_token
-                post_body['video'] = media_url
+                post_body['video'] = attachment.url
                 post_body['caption'] = text
                 del post_body['text']
-            elif media_type == 'audio':
+            elif category == 'audio':
                 send_url = 'https://api.telegram.org/bot%s/sendAudio' % auth_token
-                post_body['audio'] = media_url
+                post_body['audio'] = attachment.url
                 post_body['caption'] = text
                 del post_body['text']
 

--- a/temba/channels/types/telegram/__init__.py
+++ b/temba/channels/types/telegram/__init__.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 from temba.contacts.models import TELEGRAM_SCHEME
-from temba.msgs.models import Msg, WIRED
+from temba.msgs.models import Attachment, WIRED
 from temba.utils.http import HttpEvent
 from .views import ClaimView
 from ...models import Channel, ChannelType, SendException
@@ -53,7 +53,7 @@ class TelegramType(ChannelType):
         start = time.time()
 
         # for now we only support sending one attachment per message but this could change in future
-        attachments = Msg.Attachment.parse(msg.attachments)
+        attachments = Attachment.parse_all(msg.attachments)
         attachment = attachments[0] if attachments else None
 
         if attachment:

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3748,7 +3748,7 @@ class ActionTest(TembaTest):
                 'contact_name': self.contact.name,
                 'urn': u'tel:+250788382382',
                 'text': "Green is my favorite",
-                'attachments': [{'content_type': "image/jpeg", 'url': "http://example.com/test.jpg"}],
+                'attachments': ["http://example.com/test.jpg"],
                 'flow': self.flow.pk,
                 'flow_uuid': self.flow.uuid,
                 'flow_name': self.flow.name,

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3701,62 +3701,69 @@ class ActionTest(TembaTest):
         self.execute_action(action, run, None)
 
         # check webhook was called with correct payload
-        mock_requests_post.assert_called_once_with('http://example.com/callback.php',
-                                                   headers={'Authorization': 'Token 12345',
-                                                            'User-agent': 'RapidPro'},
-                                                   data={'run': run.pk,
-                                                         'phone': u'+250788382382',
-                                                         'contact': self.contact.uuid,
-                                                         'contact_name': self.contact.name,
-                                                         'urn': u'tel:+250788382382',
-                                                         'text': None,
-                                                         'flow': self.flow.pk,
-                                                         'flow_uuid': self.flow.uuid,
-                                                         'flow_name': self.flow.name,
-                                                         'flow_base_language': self.flow.base_language,
-                                                         'relayer': -1,
-                                                         'step': 'None',
-                                                         'values': '[]',
-                                                         'time': '2015-10-27T14:07:30.000006Z',
-                                                         'steps': '[]',
-                                                         'channel': -1,
-                                                         'channel_uuid': None,
-                                                         'header': {'Authorization': 'Token 12345'}
-                                                         },
-                                                   timeout=10)
+        mock_requests_post.assert_called_once_with(
+            'http://example.com/callback.php',
+            headers={'Authorization': 'Token 12345', 'User-agent': 'RapidPro'},
+            data={
+                'run': run.pk,
+                'phone': u'+250788382382',
+                'contact': self.contact.uuid,
+                'contact_name': self.contact.name,
+                'urn': u'tel:+250788382382',
+                'text': None,
+                'attachments': [],
+                'flow': self.flow.pk,
+                'flow_uuid': self.flow.uuid,
+                'flow_name': self.flow.name,
+                'flow_base_language': self.flow.base_language,
+                'relayer': -1,
+                'step': 'None',
+                'values': '[]',
+                'time': '2015-10-27T14:07:30.000006Z',
+                'steps': '[]',
+                'channel': -1,
+                'channel_uuid': None,
+                'header': {'Authorization': 'Token 12345'}
+            },
+            timeout=10
+        )
         mock_requests_post.reset_mock()
 
         # check that run @extra was updated
         self.assertEqual(json.loads(run.fields), {'coupon': "NEXUS4"})
 
         # test with an incoming message
-        msg = self.create_msg(direction=INCOMING, contact=self.contact, text="Green is my favorite")
+        msg = self.create_msg(direction=INCOMING, contact=self.contact, text="Green is my favorite",
+                              attachments=['image/jpeg:http://example.com/test.jpg'])
         self.execute_action(action, run, msg)
 
         # check webhook was called with correct payload
-        mock_requests_post.assert_called_once_with('http://example.com/callback.php',
-                                                   headers={'User-agent': 'RapidPro',
-                                                            'Authorization': 'Token 12345'},
-                                                   data={'run': run.pk,
-                                                         'phone': u'+250788382382',
-                                                         'contact': self.contact.uuid,
-                                                         'contact_name': self.contact.name,
-                                                         'urn': u'tel:+250788382382',
-                                                         'text': "Green is my favorite",
-                                                         'flow': self.flow.pk,
-                                                         'flow_uuid': self.flow.uuid,
-                                                         'flow_name': self.flow.name,
-                                                         'flow_base_language': self.flow.base_language,
-                                                         'relayer': msg.channel.pk,
-                                                         'step': 'None',
-                                                         'values': '[]',
-                                                         'time': '2015-10-27T14:07:30.000006Z',
-                                                         'steps': '[]',
-                                                         'channel': msg.channel.pk,
-                                                         'channel_uuid': msg.channel.uuid,
-                                                         'header': {'Authorization': 'Token 12345'}
-                                                         },
-                                                   timeout=10)
+        mock_requests_post.assert_called_once_with(
+            'http://example.com/callback.php',
+            headers={'User-agent': 'RapidPro', 'Authorization': 'Token 12345'},
+            data={
+                'run': run.pk,
+                'phone': u'+250788382382',
+                'contact': self.contact.uuid,
+                'contact_name': self.contact.name,
+                'urn': u'tel:+250788382382',
+                'text': "Green is my favorite",
+                'attachments': [{'content_type': "image/jpeg", 'url': "http://example.com/test.jpg"}],
+                'flow': self.flow.pk,
+                'flow_uuid': self.flow.uuid,
+                'flow_name': self.flow.name,
+                'flow_base_language': self.flow.base_language,
+                'relayer': msg.channel.pk,
+                'step': 'None',
+                'values': '[]',
+                'time': '2015-10-27T14:07:30.000006Z',
+                'steps': '[]',
+                'channel': msg.channel.pk,
+                'channel_uuid': msg.channel.uuid,
+                'header': {'Authorization': 'Token 12345'}
+            },
+            timeout=10
+        )
 
         # check simulator warns of webhook URL errors
         action = WebhookAction('http://example.com/callback.php?@contact.xyz')

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -600,6 +600,9 @@ class Msg(models.Model):
         def parse(cls, attachments):
             return [cls(*a.split(':', 1)) for a in attachments] if attachments else []
 
+        def as_json(self):
+            return {'content_type': self.content_type, 'url': self.url}
+
         def __eq__(self, other):
             return self.content_type == other.content_type and self.url == other.url
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -16,7 +16,7 @@ from temba.contacts.models import Contact, ContactField, ContactURN, TEL_SCHEME
 from temba.channels.models import Channel, ChannelCount, ChannelEvent, ChannelLog
 from temba.msgs.models import Msg, ExportMessagesTask, RESENT, FAILED, OUTGOING, PENDING, WIRED, DELIVERED, ERRORED
 from temba.msgs.models import Broadcast, BroadcastRecipient, Label, SystemLabel, SystemLabelCount, UnreachableException
-from temba.msgs.models import HANDLED, QUEUED, SENT, INCOMING, INBOX, FLOW
+from temba.msgs.models import Attachment, HANDLED, QUEUED, SENT, INCOMING, INBOX, FLOW
 from temba.orgs.models import Language, Debit, Org
 from temba.schedules.models import Schedule
 from temba.tests import TembaTest, AnonymousOrg
@@ -712,7 +712,7 @@ class MsgTest(TembaTest):
         msg9 = self.create_msg(contact=self.joe, text="Hey out 9", direction='O', status=FAILED,
                                created_on=datetime(2017, 1, 9, 10, tzinfo=pytz.UTC))
 
-        self.assertEqual(msg5.get_attachments(), [Msg.Attachment('audio', 'http://rapidpro.io/audio/sound.mp3')])
+        self.assertEqual(msg5.get_attachments(), [Attachment('audio', 'http://rapidpro.io/audio/sound.mp3')])
 
         # label first message
         folder = Label.get_or_create_folder(self.org, self.user, "Folder")

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -712,8 +712,7 @@ class MsgTest(TembaTest):
         msg9 = self.create_msg(contact=self.joe, text="Hey out 9", direction='O', status=FAILED,
                                created_on=datetime(2017, 1, 9, 10, tzinfo=pytz.UTC))
 
-        self.assertTrue(msg5.is_media_type_audio())
-        self.assertEqual('http://rapidpro.io/audio/sound.mp3', msg5.get_media_path())
+        self.assertEqual(msg5.get_attachments(), [Msg.Attachment('audio', 'http://rapidpro.io/audio/sound.mp3')])
 
         # label first message
         folder = Label.get_or_create_folder(self.org, self.user, "Folder")


### PR DESCRIPTION
Since we no longer include urls in the message text. This PR also tries to clean up the attachment support code a bit and remove methods we no longer use.