### PR TITLE
Fixes for Twitter Activity channels

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -2922,7 +2922,7 @@ class TwitterHandler(BaseChannelHandler):
         crc_token = request.GET['crc_token']
 
         channel = Channel.objects.filter(uuid=kwargs['uuid'], is_active=True,
-                                         channel_type='TT').exclude(org=None).first()
+                                         channel_type='TWT').exclude(org=None).first()
         if not channel:
             return HttpResponse("No such Twitter channel", status=400)
 
@@ -2933,7 +2933,7 @@ class TwitterHandler(BaseChannelHandler):
 
     def post(self, request, *args, **kwargs):
         channel = Channel.objects.filter(uuid=kwargs['uuid'], is_active=True,
-                                         channel_type='TT').exclude(org=None).first()
+                                         channel_type='TWT').exclude(org=None).first()
         if not channel:
             return HttpResponse("No such Twitter channel", status=400)
 

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1163,7 +1163,7 @@ class Channel(TembaModel):
             try:
                 # if channel is a new style type, deactivate it
                 channel_type.deactivate(self)
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 # proceed with removing this channel but log the problem
                 logger.exception(six.text_type(e))
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -7826,7 +7826,7 @@ class TwitterTest(TembaTest):
                                       uuid='00000000-0000-0000-0000-000000002345')
 
         # a new style Twitter channel configured for the Webhooks API
-        self.twitter_beta = Channel.create(self.org, self.user, None, 'TT', None, 'cuenca_facts',
+        self.twitter_beta = Channel.create(self.org, self.user, None, 'TWT', None, 'cuenca_facts',
                                            config={'handle_id': 10001,
                                                    'api_key': 'APIKEY',
                                                    'api_secret': 'APISECRET',

--- a/temba/channels/types/twitter_activity/__init__.py
+++ b/temba/channels/types/twitter_activity/__init__.py
@@ -51,6 +51,6 @@ class TwitterActivityType(ChannelType):
 
         client.delete_webhook(config['webhook_id'])
 
-    def send(self, channel, msg, text):  # pragma: no cover
+    def send(self, channel, msg, text):
         # use regular Twitter channel sending
-        return Channel.get_type_for_code('TT').send(channel, msg, text)
+        return Channel.get_type_from_code('TT').send(channel, msg, text)

--- a/temba/channels/types/twitter_activity/__init__.py
+++ b/temba/channels/types/twitter_activity/__init__.py
@@ -26,6 +26,7 @@ class TwitterActivityType(ChannelType):
     claim_view = ClaimView
 
     scheme = TWITTER_SCHEME
+    show_config_page = False
     free_sending = True
 
     def is_available_to(self, user):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -985,7 +985,7 @@ class BroadcastTest(TembaTest):
     def test_send(self):
         # remove all channels first
         for channel in Channel.objects.all():
-            channel.release(notify_mage=False)
+            channel.release()
 
         send_url = reverse('msgs.broadcast_send')
         self.login(self.admin)
@@ -1032,7 +1032,7 @@ class BroadcastTest(TembaTest):
 
         # test with one channel now
         for channel in Channel.objects.all():
-            channel.release(notify_mage=False)
+            channel.release()
 
         Channel.create(self.org, self.user, None, 'A', None, secret="12345", gcm_id="123")
 
@@ -1103,7 +1103,7 @@ class BroadcastTest(TembaTest):
         self.assertTrue(msgs[0].contact, twitter_contact)
 
         # remove twitter relayer
-        self.twitter.release(trigger_sync=False, notify_mage=False)
+        self.twitter.release(trigger_sync=False)
 
         # send another broadcast to all
         broadcast = Broadcast.create(self.org, self.admin, "Want to go thrift shopping?", recipients)

--- a/temba/utils/management/commands/test_db.py
+++ b/temba/utils/management/commands/test_db.py
@@ -166,7 +166,7 @@ class Command(BaseCommand):
         r.flushdb()
         self._log(self.style.SUCCESS("OK") + '\n')
 
-        superuser = User.objects.create_superuser("root", "root@example.com", "password")
+        superuser = User.objects.create_superuser("root", "root@example.com", USER_PASSWORD)
 
         country, locations = self.load_locations(LOCATIONS_DUMP)
         orgs = self.create_orgs(superuser, country, num_orgs)

--- a/temba/utils/twitter.py
+++ b/temba/utils/twitter.py
@@ -169,7 +169,7 @@ class TembaTwython(Twython):  # pragma: no cover
 
         Docs: https://dev.twitter.com/webhooks/reference/post/account_activity/webhooks/subscriptions
         """
-        return self.post('account_activity/webhooks/%s/subscriptions.json' % webhook_id)
+        return self.post('account_activity/webhooks/%s/subscriptions' % webhook_id)
 
 
 def generate_twitter_signature(content, consumer_secret):


### PR DESCRIPTION
* Remove a channel even if deactivating it throws an exception
* Remove no longer used `notify_mage` param for `Channel.release` - Mage is notified based on `settings.IS_PROD`
* Fix channel type in Twitter Activity API handler
* Update endpoint used to subscribe to a Twitter Activity API webhook (this appears to have changed)