### PR TITLE
Twilio channel removal fix

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1168,10 +1168,11 @@ class Channel(TembaModel):
                         if matching:
                             client.phone_numbers.update(matching[0].sid, **number_update_args)
 
-                try:
-                    client.applications.delete(sid=config['application_sid'])
-                except TwilioRestException:  # pragma: no cover
-                    pass
+                if 'application_sid' in config:
+                    try:
+                        client.applications.delete(sid=config['application_sid'])
+                    except TwilioRestException:  # pragma: no cover
+                        pass
 
         # save off our org and gcm id before nullifying
         org = self.org


### PR DESCRIPTION
Fixes the case where a user tries to delete a Twilio channel which we weren't able to migrate to a channel-specific-app, i.e. https://sentry.io/nyaruka/textit/issues/311552652/