### PR TITLE
Use a real but mockable HTTP server to test webhooks in flows 

### DIFF
--- a/media/test_flows/dual_webhook.json
+++ b/media/test_flows/dual_webhook.json
@@ -56,7 +56,7 @@
               "destination_type": "A"
             }
           ], 
-          "webhook": "http://foo.bar/", 
+          "webhook": "http://localhost:49999/echo?content=%7B%20%22code%22%3A%20%22ABABUUDDLRS%22%20%7D",
           "ruleset_type": "webhook", 
           "label": "Webhook", 
           "operand": "@step.value", 
@@ -108,7 +108,7 @@
               "uuid": "4dd0f3e7-cc15-41fa-8a84-d53d76d46d66"
             }
           ], 
-          "webhook": "http://bar.foo/", 
+          "webhook": "http://localhost:49999/echo?content=Success",
           "ruleset_type": "webhook", 
           "label": "Webhook 2", 
           "operand": "@step.value", 

--- a/media/test_flows/stacked_webhook_exits.json
+++ b/media/test_flows/stacked_webhook_exits.json
@@ -266,7 +266,7 @@
           "y": 0, 
           "x": 160, 
           "config": {
-            "webhook": "http://foo.bar/", 
+            "webhook": "http://localhost:49999/echo?content=Success",
             "webhook_action": "GET"
           }
         }, 

--- a/media/test_flows/triggered.json
+++ b/media/test_flows/triggered.json
@@ -83,7 +83,7 @@
               "destination_type": "A"
             }
           ],
-          "webhook": "http://catfacts-api.appspot.com/api/facts?number=1",
+          "webhook": "http://localhost:49999/echo?content=%7B%20%22text%22%3A%20%22%28I%20came%20from%20a%20webhook%29%22%20%7D",
           "ruleset_type": "webhook",
           "label": "Response 1",
           "operand": "@step.value",

--- a/media/test_flows/webhook_loop.json
+++ b/media/test_flows/webhook_loop.json
@@ -15,7 +15,7 @@
             "actions": [
               {
                 "action": "GET",
-                "webhook": "http://foo.com/",
+                "webhook": "http://localhost:49999/echo?content=%7B%20%22text%22%3A%20%22first%20message%22%20%7D",
                 "type": "api"
               },
               {

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4006,17 +4006,15 @@ class WebhookTest(TembaTest):
         substitutions = dict(contact_id=contact1.id)
         flow = self.get_flow('triggered', substitutions)
 
-        with patch('requests.get') as get:
-            get.return_value = MockResponse(200, '{ "text": "(I came from a webhook)" }')
-            flow.start(groups=[], contacts=[contact1], restart_participants=True)
+        flow.start(groups=[], contacts=[contact1], restart_participants=True)
 
-            # first message from our trigger flow action
-            msg = Msg.objects.all().order_by('-created_on')[0]
-            self.assertEqual('Honey, I triggered the flow! (I came from a webhook)', msg.text)
+        # first message from our trigger flow action
+        msg = Msg.objects.all().order_by('-created_on')[0]
+        self.assertEqual('Honey, I triggered the flow! (I came from a webhook)', msg.text)
 
-            # second message from our start flow action
-            msg = Msg.objects.all().order_by('-created_on')[1]
-            self.assertEqual('Honey, I triggered the flow! (I came from a webhook)', msg.text)
+        # second message from our start flow action
+        msg = Msg.objects.all().order_by('-created_on')[1]
+        self.assertEqual('Honey, I triggered the flow! (I came from a webhook)', msg.text)
 
     def test_webhook(self):
         self.flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
@@ -6382,31 +6380,28 @@ class FlowMigrationTest(FlowFileTest):
             self.assertFalse('webhook' in ruleset)
             self.assertFalse('webhook_action' in ruleset)
 
-        with patch('requests.post') as mock_post:
-            mock_post.return_value = MockResponse(200, '{ "code": "ABABUUDDLRS" }')
+        webhook_flow.start([], [self.contact])
 
-            webhook_flow.start([], [self.contact])
-            self.assertEqual(mock_post.call_args[0][0], 'http://foo.bar/')
+        self.assertMockedRequests([{'method': 'POST', 'url': "http://localhost:49999/echo?content=%7B%20%22code%22%3A%20%22ABABUUDDLRS%22%20%7D"}])
 
-            # assert the code we received was right
-            msg = Msg.objects.filter(direction='O', contact=self.contact).first()
-            self.assertEqual("Great, your code is ABABUUDDLRS. Enter your name", msg.text)
+        # assert the code we received was right
+        msg = Msg.objects.filter(direction='O', contact=self.contact).first()
+        self.assertEqual(msg.text, "Great, your code is ABABUUDDLRS. Enter your name")
 
-            with patch('requests.get') as mock_get:
-                mock_get.return_value = MockResponse(400, "Error")
-                self.send_message(webhook_flow, "Ryan Lewis", assert_reply=False)
-                self.assertEqual(mock_get.call_args[0][0], 'http://bar.foo/')
+        self.send_message(webhook_flow, "Ryan Lewis", assert_reply=False)
+        self.assertMockedRequests([{'method': 'GET', 'url': "http://localhost:49999/echo?content=Success"}])
 
         # startover have our first webhook fail, check that routing still works with failure
-        with patch('requests.post') as mock_post:
-            mock_post.return_value = MockResponse(400, 'Error')
+        error_url = self.mockedServerURL("Error", 400)
+        flow_def['rule_sets'][0]['config']['webhook'] = error_url
+        webhook_flow.update(flow_def)
 
-            webhook_flow.start([], [self.contact], restart_participants=True)
-            self.assertEqual(mock_post.call_args[0][0], 'http://foo.bar/')
+        webhook_flow.start([], [self.contact], restart_participants=True)
+        self.assertMockedRequests([{'method': 'POST', 'url': error_url}])
 
-            # assert the code we received was right
-            msg = Msg.objects.filter(direction='O', contact=self.contact).first()
-            self.assertEqual("Great, your code is @extra.code. Enter your name", msg.text)
+        # assert the code we received was right
+        msg = Msg.objects.filter(direction='O', contact=self.contact).first()
+        self.assertEqual("Great, your code is @extra.code. Enter your name", msg.text)
 
     def test_migrate_to_9(self):
 
@@ -6628,7 +6623,7 @@ class FlowMigrationTest(FlowFileTest):
 
         # pretend our current ruleset was stopped at a webhook with a passive rule
         ruleset = RuleSet.objects.get(flow=flow, uuid=step.step_uuid)
-        ruleset.webhook_url = 'http://www.mywebhook.com/lookup'
+        ruleset.webhook_url = 'http://localhost:49999/echo?content=%7B%20%22status%22%3A%20%22valid%22%20%7D'
         ruleset.webhook_action = 'POST'
         ruleset.operand = '@extra.value'
         ruleset.save()
@@ -6649,7 +6644,7 @@ class FlowMigrationTest(FlowFileTest):
         # we should be pointing to a newly created webhook rule
         webhook = RuleSet.objects.get(flow=flow, uuid=ruleset.get_rules()[0].destination)
         self.assertEquals('webhook', webhook.ruleset_type)
-        self.assertEquals('http://www.mywebhook.com/lookup', webhook.config_json()[RuleSet.CONFIG_WEBHOOK])
+        self.assertEquals('http://localhost:49999/echo?content=%7B%20%22status%22%3A%20%22valid%22%20%7D', webhook.config_json()[RuleSet.CONFIG_WEBHOOK])
         self.assertEquals('POST', webhook.config_json()[RuleSet.CONFIG_WEBHOOK_ACTION])
         self.assertEquals('@step.value', webhook.operand)
         self.assertEquals('Color Webhook', webhook.label)
@@ -6679,22 +6674,19 @@ class FlowMigrationTest(FlowFileTest):
         expression.operand = '@step.value'
         expression.save()
 
-        with patch('requests.post') as mock:
-            mock.return_value = MockResponse(200, '{ "status": "valid" }')
+        # now move our straggler forward with a message, should get a reply
 
-            # now move our straggler forward with a message, should get a reply
+        first_response = ActionSet.objects.get(flow=flow, x=131)
+        actions = first_response.get_actions_dict()
+        actions[0]['msg'][flow.base_language] = 'I like @flow.color.category too! What is your favorite beer? @flow.color_webhook'
+        first_response.set_actions_dict(actions)
+        first_response.save()
 
-            first_response = ActionSet.objects.get(flow=flow, x=131)
-            actions = first_response.get_actions_dict()
-            actions[0]['msg'][flow.base_language] = 'I like @flow.color.category too! What is your favorite beer? @flow.color_webhook'
-            first_response.set_actions_dict(actions)
-            first_response.save()
+        reply = self.send_message(flow, 'red')
+        self.assertEquals('I like Red too! What is your favorite beer? { "status": "valid" }', reply)
 
-            reply = self.send_message(flow, 'red')
-            self.assertEquals('I like Red too! What is your favorite beer? { "status": "valid" }', reply)
-
-            reply = self.send_message(flow, 'Turbo King')
-            self.assertEquals('Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?', reply)
+        reply = self.send_message(flow, 'Turbo King')
+        self.assertEquals('Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?', reply)
 
     def test_migrate_sample_flows(self):
         self.org.create_sample_flows('https://app.rapidpro.io')
@@ -6788,24 +6780,17 @@ class ChannelSplitTest(FlowFileTest):
 
 class WebhookLoopTest(FlowFileTest):
 
-    def setUp(self):
-        super(WebhookLoopTest, self).setUp()
-        settings.SEND_WEBHOOKS = True
-
-    def tearDown(self):
-        super(WebhookLoopTest, self).tearDown()
-        settings.SEND_WEBHOOKS = False
-
+    @override_settings(SEND_WEBHOOKS=True)
     def test_webhook_loop(self):
         flow = self.get_flow('webhook_loop')
 
-        with patch('requests.get') as mock:
-            mock.return_value = MockResponse(200, '{ "text": "first message" }')
-            self.assertEquals("first message", self.send_message(flow, "first", initiate_flow=True))
+        self.assertEquals("first message", self.send_message(flow, "first", initiate_flow=True))
 
-        with patch('requests.get') as mock:
-            mock.return_value = MockResponse(200, '{ "text": "second message" }')
-            self.assertEquals("second message", self.send_message(flow, "second"))
+        flow_def = flow.as_json()
+        flow_def['action_sets'][0]['actions'][0]['webhook'] = self.mockedServerURL('{ "text": "second message" }')
+        flow.update(flow_def)
+
+        self.assertEquals("second message", self.send_message(flow, "second"))
 
 
 class MissedCallChannelTest(FlowFileTest):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -850,9 +850,9 @@ AUTHENTICATION_BACKENDS = (
 ANONYMOUS_USER_NAME = 'AnonymousUser'
 
 # -----------------------------------------------------------------------------------
-# Our test runner is standard but with ability to exclude apps
+# Our test runner includes a mocked HTTP server and the ability to exclude apps
 # -----------------------------------------------------------------------------------
-TEST_RUNNER = 'temba.tests.ExcludeTestRunner'
+TEST_RUNNER = 'temba.tests.TembaTestRunner'
 TEST_EXCLUDE = ('smartmin',)
 
 # -----------------------------------------------------------------------------------

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -11,6 +11,7 @@ import shutil
 import string
 import six
 import time
+import urlparse
 
 from datetime import datetime, timedelta
 from django.conf import settings
@@ -20,7 +21,9 @@ from django.db import connection
 from django.test import LiveServerTestCase
 from django.test.runner import DiscoverRunner
 from django.utils import timezone
+from django.utils.http import quote_plus
 from HTMLParser import HTMLParser
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from selenium.webdriver.firefox.webdriver import WebDriver
 from smartmin.tests import SmartminTest
 from temba.contacts.models import Contact, ContactGroup, ContactField, URN
@@ -32,18 +35,58 @@ from temba.ivr.clients import TwilioClient
 from temba.msgs.models import Msg, INCOMING
 from temba.utils import dict_to_struct, get_anonymous_user
 from temba.values.models import Value
+from threading import Thread
 from twilio.util import RequestValidator
 from uuid import uuid4
 
 
-class ExcludeTestRunner(DiscoverRunner):
+class MockServerRequestHandler(BaseHTTPRequestHandler):
+    """
+    A simple HTTP server for mocking external services. For example:
+
+    GET http://localhost:49999/echo?content=OK
+        ->  content: 'OK', status_code: 200
+    POST http://localhost:49999/echo?content=%7B%20%22status%22%3A%20%22valid%22%20%7D&status=400
+        ->  content: '{ "status": "valid" }', status_code: 400
+    """
+    def _handle_request(self, method):
+        # record this request so calling test can verify it was made
+        TembaTestRunner.MOCKED_REQUESTS.append({'method': method, 'url': 'http://localhost:49999%s' % self.path})
+
+        parsed = urlparse.urlparse(self.path)
+        params = urlparse.parse_qs(parsed.query)
+        if parsed.path == '/echo':
+            return self._handle_echo(params)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_echo(self, params):
+        content = params['content'][0]
+        status = int(params.get('status', [200])[0])
+
+        self.send_response(status)
+        self.end_headers()
+        self.wfile.write(content.encode('utf-8'))
+
+    def do_GET(self):
+        return self._handle_request('GET')
+
+    def do_POST(self):
+        return self._handle_request('POST')
+
+
+class TembaTestRunner(DiscoverRunner):
+    MOCKED_SERVER_URL = 'http://localhost:49999'
+    MOCKED_REQUESTS = []
+
     def __init__(self, *args, **kwargs):
-        from django.conf import settings
         settings.TESTING = True
-        super(ExcludeTestRunner, self).__init__(*args, **kwargs)
+
+        super(TembaTestRunner, self).__init__(*args, **kwargs)
 
     def build_suite(self, *args, **kwargs):
-        suite = super(ExcludeTestRunner, self).build_suite(*args, **kwargs)
+        suite = super(TembaTestRunner, self).build_suite(*args, **kwargs)
         excluded = getattr(settings, 'TEST_EXCLUDE', [])
         if not getattr(settings, 'RUN_ALL_TESTS', False):
             tests = []
@@ -53,6 +96,15 @@ class ExcludeTestRunner(DiscoverRunner):
                     tests.append(case)
             suite._tests = tests
         return suite
+
+    def run_suite(self, suite, **kwargs):
+        # start running mock server in a daemon thread which will automatically shut down when the main process exits
+        mock_server = HTTPServer(('localhost', 49999), MockServerRequestHandler)
+        mock_server_thread = Thread(target=mock_server.serve_forever)
+        mock_server_thread.setDaemon(True)
+        mock_server_thread.start()
+
+        return super(TembaTestRunner, self).run_suite(suite, **kwargs)
 
 
 def add_testing_flag_to_context(*args):
@@ -360,6 +412,14 @@ class TembaTest(SmartminTest):
             ruleset.save()
         else:
             self.fail("Couldn't find node with uuid: %s" % node)
+
+    def mockedServerURL(self, content, status=200):
+        return '%s/echo?content=%s&status=%d' % (TembaTestRunner.MOCKED_SERVER_URL, quote_plus(content), status)
+
+    def assertMockedRequests(self, requests, reset=True):
+        self.assertEqual(TembaTestRunner.MOCKED_REQUESTS, requests)
+        if reset:
+            TembaTestRunner.MOCKED_REQUESTS = []
 
     def assertExcelRow(self, sheet, row_num, values, tz=None):
         """


### PR DESCRIPTION
Because some tests will use goflow to run flows in the future - we can't rely on mocking at the level of the python request. This PR adds a simple HTTP server to our test runner setup, which can generate a particular response based on the parameters passed to it.