### PR TITLE
Fix surveyor submissions across brands

### DIFF
--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -581,7 +581,7 @@ class FlowRunWriteSerializer(WriteSerializer):
     def validate_submitted_by(self, value):
         if value:
             user = User.objects.filter(username__iexact=value).first()
-            if user and self.org in user.get_user_orgs():
+            if user and self.org in user.get_user_orgs(self.org.brand):
                 self.submitted_by_obj = user
             else:  # pragma: needs cover
                 raise serializers.ValidationError("Invalid submitter id, user doesn't exist")

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -610,7 +610,7 @@ class APITest(TembaTest):
         data = dict(flow=flow.uuid,
                     revision=2,
                     contact=self.joe.uuid,
-                    submitted_by=self.admin.username,
+                    submitted_by=self.surveyor.username,
                     started='2015-08-25T11:09:29.088Z',
                     steps=[
                         dict(node='d51ec25f-04e6-4349-a448-e7c4d93d4597',
@@ -620,6 +620,12 @@ class APITest(TembaTest):
                              ])
                     ],
                     completed=False)
+
+        # make our org brand different from the default brand
+        # this is to make sure surveyor submissions work when
+        # they deviate from DEFAULT_BRAND
+        self.org.brand = 'other_brand'
+        self.org.save()
 
         with patch.object(timezone, 'now', return_value=datetime(2015, 9, 15, 0, 0, 0, 0, pytz.UTC)):
             self.postJSON(url, data)
@@ -663,7 +669,7 @@ class APITest(TembaTest):
                     revision=2,
                     contact=self.joe.uuid,
                     started='2015-08-25T11:09:29.088Z',
-                    submitted_by=self.admin.username,
+                    submitted_by=self.surveyor.username,
                     steps=[
                         dict(node='bd531ace-911e-4722-8e53-6730d6122fe1',
                              arrived_on='2015-08-25T11:11:30.088Z',
@@ -691,7 +697,7 @@ class APITest(TembaTest):
         # run should be complete now
         run = FlowRun.objects.get()
 
-        self.assertEqual(run.submitted_by, self.admin)
+        self.assertEqual(run.submitted_by, self.surveyor)
         self.assertEqual(run.modified_on, datetime(2015, 9, 16, 0, 0, 0, 0, pytz.UTC))
         self.assertEqual(run.is_active, False)
         self.assertEqual(run.is_completed(), True)

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1903,7 +1903,7 @@ class Org(SmartModel):
 # ===================== monkey patch User class with a few extra functions ========================
 
 def get_user_orgs(user, brand=None):
-    org = user.get_org()
+    org = Org.get_org(user)
     if not brand:
         brand = org.brand if org else settings.DEFAULT_BRAND
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1903,8 +1903,8 @@ class Org(SmartModel):
 # ===================== monkey patch User class with a few extra functions ========================
 
 def get_user_orgs(user, brand=None):
-    org = Org.get_org(user)
     if not brand:
+        org = Org.get_org(user)
         brand = org.brand if org else settings.DEFAULT_BRAND
 
     if user.is_superuser:

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -77,11 +77,6 @@ class OrgTest(TembaTest):
         self.assertEqual(self.surveyor, org_users[2])
         self.assertEqual(self.user, org_users[3])
 
-    def test_get_user_orgs(self):
-        delattr(self.admin, '_org')
-        settings.DEFAULT_BRAND = None
-        self.assertIsNotNone(self.admin.get_user_orgs().first())
-
     def test_get_unique_slug(self):
         self.org.slug = 'allo'
         self.org.save()

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -77,6 +77,11 @@ class OrgTest(TembaTest):
         self.assertEqual(self.surveyor, org_users[2])
         self.assertEqual(self.user, org_users[3])
 
+    def test_get_user_orgs(self):
+        delattr(self.admin, '_org')
+        settings.DEFAULT_BRAND = None
+        self.assertIsNotNone(self.admin.get_user_orgs().first())
+
     def test_get_unique_slug(self):
         self.org.slug = 'allo'
         self.org.save()


### PR DESCRIPTION
This fixes some failed Surveyor submissions due to not being able to identify the brand of a submitter's org.