### PR TITLE
RegexTest match groups should only be accessible by index and not name

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -6813,8 +6813,8 @@ class RegexTest(Test):  # pragma: needs cover
             if match:
                 return_match = match.group(0)
 
-                # build up a dictionary that contains indexed values
-                group_dict = match.groupdict()
+                # build up a dictionary that contains indexed group matches
+                group_dict = {}
                 for idx in range(rexp.groups + 1):
                     group_dict[str(idx)] = match.group(idx)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1685,7 +1685,6 @@ class FlowTest(TembaTest):
         self.assertEquals("Isaac Newton", extra['0'])
         self.assertEquals("Isaac", extra['1'])
         self.assertEquals("Newton", extra['2'])
-        self.assertEquals("Isaac", extra['first_name'])
 
         # find that arabic unicode is handled right
         sms.text = "مرحبا العالم"
@@ -1694,7 +1693,6 @@ class FlowTest(TembaTest):
         self.assertEquals("مرحبا العالم", extra['0'])
         self.assertEquals("مرحبا", extra['1'])
         self.assertEquals("العالم", extra['2'])
-        self.assertEquals("مرحبا", extra['first_name'])
 
         # no matching groups, should return whole string as match
         test = RegexTest(dict(base="\w+ \w+"))


### PR DESCRIPTION
Named groups was never documented and doesn't appear to have been used so removing it now before someone does