### PR TITLE
Remove step.contact from completion options

### DIFF
--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -879,7 +879,6 @@ class FlowCRUDL(SmartCRUDL):
                 dict(name='step', display=six.text_type(_('Sent to'))),
                 dict(name='step.value', display=six.text_type(_('Sent to')))
             ]
-            flow_variables += [dict(name='step.%s' % v['name'], display=v['display']) for v in contact_variables]
 
             parent_variables = [dict(name='parent.%s' % v['name'], display=v['display']) for v in contact_variables]
             parent_variables += [dict(name='parent.%s' % v['name'], display=v['display']) for v in flow_variables]


### PR DESCRIPTION
Just removes @step.contact from completion. I've also updated the knowledge base with details for October 1st changes to @contact inside Send Message to somebody else.