### PR TITLE
Add /c/kn/uuid-uuid-uuid/receive style endpoints for all channel types

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -1844,6 +1844,8 @@ class MageHandler(BaseChannelHandler):
 
 class StartHandler(BaseChannelHandler):
     courier_url = r'^st/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive)$'
+    courier_name = 'courier.st'
+
     handler_url = r'^start/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
     handler_name = 'handlers.start_handler'
 

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -44,16 +44,26 @@ class BaseChannelHandler(View):
     """
     Base class for all channel handlers
     """
-    url = None
-    url_name = None
+
+    # the url pattern for this handler on courier
+    courier_url = None
+    courier_name = None
+
+    # the url pattern for this handler on rapidpro (legacy)
+    handler_url = None
+    handler_name = None
 
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
         return super(BaseChannelHandler, self).dispatch(request, *args, **kwargs)
 
     @classmethod
-    def get_url(cls):
-        return cls.url, cls.url_name
+    def get_courier_url(cls):
+        return cls.courier_url, cls.courier_name
+
+    @classmethod
+    def get_handler_url(cls):
+        return cls.handler_url, cls.handler_name
 
     def get_param(self, name, default=None):
         """
@@ -80,8 +90,8 @@ def get_channel_handlers():
 
 class TwimlAPIHandler(BaseChannelHandler):
 
-    url = r'^twiml_api/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.twiml_api_handler'
+    handler_url = r'^twiml_api/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.twiml_api_handler'
 
     def get(self, request, *args, **kwargs):  # pragma: no cover
         return HttpResponse("ILLEGAL METHOD")
@@ -272,8 +282,11 @@ class TwimlAPIHandler(BaseChannelHandler):
 
 class TwilioHandler(TwimlAPIHandler):
 
-    url = r'^twilio/(?P<action>receive|status|voice)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.twilio_handler'
+    courier_url = r'^t/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive|status|voice)$'
+    courier_name = 'courier.t'
+
+    handler_url = r'^twilio/(?P<action>receive|status|voice)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.twilio_handler'
 
     def get_channel_type(self):
         return Channel.TYPE_TWILIO
@@ -281,8 +294,11 @@ class TwilioHandler(TwimlAPIHandler):
 
 class TwilioMessagingServiceHandler(BaseChannelHandler):
 
-    url = r'^twilio_messaging_service/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.twilio_messaging_service_handler'
+    courier_url = r'^tms/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive)$'
+    courier_name = 'courier.tms'
+
+    handler_url = r'^twilio_messaging_service/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.twilio_messaging_service_handler'
 
     def get(self, request, *args, **kwargs):  # pragma: no cover
         return self.post(request, *args, **kwargs)
@@ -323,8 +339,11 @@ class TwilioMessagingServiceHandler(BaseChannelHandler):
 
 class AfricasTalkingHandler(BaseChannelHandler):
 
-    url = r'^africastalking/(?P<action>delivery|callback)/(?P<uuid>[a-z0-9\-]+)/$'
-    url_name = 'handlers.africas_talking_handler'
+    courier_url = r'^at/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive|delivery|callback|status)$'
+    courier_name = 'courier.at'
+
+    handler_url = r'^africastalking/(?P<action>receive|delivery|callback|status)/(?P<uuid>[a-z0-9\-]+)/$'
+    handler_name = 'handlers.africas_talking_handler'
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("ILLEGAL METHOD", status=400)
@@ -340,7 +359,7 @@ class AfricasTalkingHandler(BaseChannelHandler):
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
 
         # this is a callback for a message we sent
-        if action == 'delivery':
+        if action in ['delivery', 'status']:
             if 'status' not in request.POST or 'id' not in request.POST:
                 return HttpResponse("Missing status or id parameters", status=400)
 
@@ -364,7 +383,7 @@ class AfricasTalkingHandler(BaseChannelHandler):
             return HttpResponse("SMS Status Updated")
 
         # this is a new incoming message
-        elif action == 'callback':
+        elif action in ['receive', 'callback']:
             if 'from' not in request.POST or 'text' not in request.POST:
                 return HttpResponse("Missing from or text parameters", status=400)
 
@@ -378,8 +397,11 @@ class AfricasTalkingHandler(BaseChannelHandler):
 
 class ZenviaHandler(BaseChannelHandler):
 
-    url = r'^zenvia/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$'
-    url_name = 'handlers.zenvia_handler'
+    courier_url = r'^zv/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.zv'
+
+    handler_url = r'^zenvia/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$'
+    handler_name = 'handlers.zenvia_handler'
 
     def get(self, request, *args, **kwargs):
         return self.post(request, *args, **kwargs)
@@ -445,8 +467,11 @@ class ZenviaHandler(BaseChannelHandler):
 
 class ExternalHandler(BaseChannelHandler):
 
-    url = r'^external/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/$'
-    url_name = 'handlers.external_handler'
+    courier_url = r'^ex/(?P<uuid>[a-z0-9\-]+)/(?P<action>sent|delivered|failed|received|receive)$'
+    courier_name = 'courier.ex'
+
+    handler_url = r'^external/(?P<action>sent|delivered|failed|received|receive)/(?P<uuid>[a-z0-9\-]+)/$'
+    handler_name = 'handlers.external_handler'
 
     def get_channel_type(self):
         return 'EX'
@@ -492,7 +517,7 @@ class ExternalHandler(BaseChannelHandler):
             return HttpResponse("SMS Status Updated")
 
         # this is a new incoming message
-        elif action == 'received':
+        elif action in ['received', 'receive']:
             sender = self.get_param('from', self.get_param('sender'))
             if not sender:
                 return HttpResponse("Missing 'from' or 'sender' parameter, invalid call.", status=400)
@@ -522,8 +547,11 @@ class ShaqodoonHandler(ExternalHandler):
     """
     Overloaded external channel for accepting Shaqodoon messages
     """
-    url = r'^shaqodoon/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/$'
-    url_name = 'handlers.shaqodoon_handler'
+    courier_url = r'^sq/(?P<uuid>[a-z0-9\-]+)/(?P<action>sent|delivered|failed|received|receive)$'
+    courier_name = 'courier.sq'
+
+    handler_url = r'^shaqodoon/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/$'
+    handler_name = 'handlers.shaqodoon_handler'
 
     def get_channel_type(self):
         return Channel.TYPE_SHAQODOON
@@ -533,17 +561,22 @@ class YoHandler(ExternalHandler):
     """
     Overloaded external channel for accepting Yo! Messages.
     """
-    url = r'^yo/(?P<action>received)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.yo_handler'
+    courier_url = r'^yo/(?P<uuid>[a-z0-9\-]+)/(?P<action>received)$'
+    courier_name = 'courier.yo'
+
+    handler_url = r'^yo/(?P<action>received)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.yo_handler'
 
     def get_channel_type(self):
         return Channel.TYPE_YO
 
 
 class TelegramHandler(BaseChannelHandler):
+    courier_url = r'^tg/(?P<uuid>[a-z0-9\-]+)/receive$'
+    courier_name = 'courier.tg'
 
-    url = r'^telegram/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.telegram_handler'
+    handler_url = r'^telegram/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.telegram_handler'
 
     @classmethod
     def download_file(cls, channel, file_id):
@@ -683,8 +716,11 @@ class TelegramHandler(BaseChannelHandler):
 
 class InfobipHandler(BaseChannelHandler):
 
-    url = r'^infobip/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.infobip_handler'
+    courier_url = r'^ib/(?P<uuid>[a-z0-9\-]+)/(?P<action>sent|delivered|failed|received|receive)$'
+    courier_name = 'courier.ib'
+
+    handler_url = r'^infobip/(?P<action>sent|delivered|failed|received|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.infobip_handler'
 
     def get_channel_type(self):
         return 'IB'
@@ -761,9 +797,11 @@ class InfobipHandler(BaseChannelHandler):
 
 
 class Hub9Handler(BaseChannelHandler):
+    courier_url = r'^h9/(?P<uuid>[a-z0-9\-]+)/(?P<action>sent|delivered|failed|receive|received)$'
+    courier_name = 'courier.h9'
 
-    url = r'^hub9/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.hub9_handler'
+    handler_url = r'^hub9/(?P<action>sent|delivered|failed|receive|received)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.hub9_handler'
 
     def get_channel_type(self):
         return Channel.TYPE_HUB9
@@ -808,7 +846,7 @@ class Hub9Handler(BaseChannelHandler):
             return HttpResponse("000")
 
         # An MO message
-        if action == 'received':
+        if action in ['received', 'receive']:
 
             if message is None or from_number is None or to_number is None:
                 return HttpResponse("Parameters message, original and sendto should not be null.",
@@ -825,18 +863,22 @@ class Hub9Handler(BaseChannelHandler):
 
 
 class DartMediaHandler(Hub9Handler):
+    courier_url = r'^da/(?P<uuid>[a-z0-9\-]+)/(?P<action>delivered|received|receive)$'
+    courier_name = 'courier.da'
 
-    url = r'^dartmedia/(?P<action>delivered|received)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.dartmedia_handler'
+    handler_url = r'^dartmedia/(?P<action>delivered|received|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.dartmedia_handler'
 
     def get_channel_type(self):
         return Channel.TYPE_DARTMEDIA
 
 
 class HighConnectionHandler(BaseChannelHandler):
+    courier_url = r'^hx/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.hx'
 
-    url = r'^hcnx/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.hcnx_handler'
+    handler_url = r'^hcnx/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.hcnx_handler'
 
     def post(self, request, *args, **kwargs):
         return self.get(request, *args, **kwargs)
@@ -894,9 +936,11 @@ class HighConnectionHandler(BaseChannelHandler):
 
 
 class BlackmynaHandler(BaseChannelHandler):
+    courier_url = r'^bm/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.bm'
 
-    url = r'^blackmyna/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.blackmyna_handler'
+    handler_url = r'^blackmyna/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.blackmyna_handler'
 
     def post(self, request, *args, **kwargs):  # pragma: needs cover
         return self.get(request, *args, **kwargs)
@@ -950,9 +994,11 @@ class BlackmynaHandler(BaseChannelHandler):
 
 
 class SMSCentralHandler(BaseChannelHandler):
+    courier_url = r'^sc/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive)$'
+    courier_name = 'courier.sc'
 
-    url = r'^smscentral/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.smscentral_handler'
+    handler_url = r'^smscentral/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.smscentral_handler'
 
     def post(self, request, *args, **kwargs):  # pragma: needs cover
         return self.get(request, *args, **kwargs)
@@ -982,9 +1028,11 @@ class SMSCentralHandler(BaseChannelHandler):
 
 
 class MacroKioskHandler(BaseChannelHandler):
+    courier_url = r'^mk/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.mk'
 
-    url = r'^macrokiosk/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.macrokiosk_handler'
+    handler_url = r'^macrokiosk/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.macrokiosk_handler'
 
     def get(self, request, *args, **kwargs):
         return self.post(request, *args, **kwargs)
@@ -1050,8 +1098,11 @@ class M3TechHandler(ExternalHandler):
     """
     Exposes our API for handling and receiving messages, same as external handlers.
     """
-    url = r'^m3tech/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.m3tech_handler'
+    courier_url = r'^m3/(?P<uuid>[a-z0-9\-]+)/(?P<action>sent|delivered|failed|received|receive)$'
+    courier_name = 'courier.m3'
+
+    handler_url = r'^m3tech/(?P<action>sent|delivered|failed|received|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.m3tech_handler'
 
     def get_channel_type(self):
         return Channel.TYPE_M3TECH
@@ -1059,8 +1110,8 @@ class M3TechHandler(ExternalHandler):
 
 class NexmoCallHandler(BaseChannelHandler):
 
-    url = r'^nexmo/(?P<action>answer|event)/(?P<uuid>[a-z0-9\-]+)/$'
-    url_name = 'handlers.nexmo_call_handler'
+    handler_url = r'^nexmo/(?P<action>answer|event)/(?P<uuid>[a-z0-9\-]+)/$'
+    handler_name = 'handlers.nexmo_call_handler'
 
     def post(self, request, *args, **kwargs):
         return self.get(request, *args, **kwargs)
@@ -1181,9 +1232,11 @@ class NexmoCallHandler(BaseChannelHandler):
 
 
 class NexmoHandler(BaseChannelHandler):
+    courier_url = r'^nx/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.nx'
 
-    url = r'^nexmo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$'
-    url_name = 'handlers.nexmo_handler'
+    handler_url = r'^nexmo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$'
+    handler_name = 'handlers.nexmo_handler'
 
     def post(self, request, *args, **kwargs):  # pragma: needs cover
         return self.get(request, *args, **kwargs)
@@ -1244,9 +1297,8 @@ class NexmoHandler(BaseChannelHandler):
 
 
 class VerboiceHandler(BaseChannelHandler):
-
-    url = r'^verboice/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.verboice_handler'
+    handler_url = r'^verboice/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.verboice_handler'
 
     def post(self, request, *args, **kwargs):
         return HttpResponse("Illegal method, must be GET", status=405)
@@ -1279,9 +1331,11 @@ class VerboiceHandler(BaseChannelHandler):
 
 
 class VumiHandler(BaseChannelHandler):
+    courier_url = r'^vm/(?P<uuid>[a-z0-9\-]+)/(?P<action>event|receive)$'
+    courier_name = 'courier.vm'
 
-    url = r'^vumi/(?P<action>event|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.vumi_handler'
+    handler_url = r'^vumi/(?P<action>event|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.vumi_handler'
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("Illegal method, must be POST", status=405)
@@ -1414,9 +1468,11 @@ class VumiHandler(BaseChannelHandler):
 
 
 class KannelHandler(BaseChannelHandler):
+    courier_url = r'^kn/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.kn'
 
-    url = r'^kannel/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.kannel_handler'
+    handler_url = r'^kannel/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.kannel_handler'
 
     def get(self, request, *args, **kwargs):  # pragma: needs cover
         return self.post(request, *args, **kwargs)
@@ -1499,9 +1555,11 @@ class KannelHandler(BaseChannelHandler):
 
 
 class ClickatellHandler(BaseChannelHandler):
+    courier_url = r'^ct/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.ct'
 
-    url = r'^clickatell/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.clickatell_handler'
+    handler_url = r'^clickatell/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.clickatell_handler'
 
     def get(self, request, *args, **kwargs):
         return self.post(request, *args, **kwargs)
@@ -1622,9 +1680,11 @@ class ClickatellHandler(BaseChannelHandler):
 
 
 class PlivoHandler(BaseChannelHandler):
+    courier_url = r'^pl/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.pl'
 
-    url = r'^plivo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.plivo_handler'
+    handler_url = r'^plivo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.plivo_handler'
 
     def get(self, request, *args, **kwargs):
         return self.post(request, *args, **kwargs)
@@ -1731,8 +1791,8 @@ class PlivoHandler(BaseChannelHandler):
 
 class MageHandler(BaseChannelHandler):
 
-    url = r'^mage/(?P<action>handle_message|follow_notification|stop_contact)$'
-    url_name = 'handlers.mage_handler'
+    handler_url = r'^mage/(?P<action>handle_message|follow_notification|stop_contact)$'
+    handler_name = 'handlers.mage_handler'
 
     def get(self, request, *args, **kwargs):
         return JsonResponse(dict(error="Illegal method, must be POST"), status=405)
@@ -1783,9 +1843,9 @@ class MageHandler(BaseChannelHandler):
 
 
 class StartHandler(BaseChannelHandler):
-
-    url = r'^start/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.start_handler'
+    courier_url = r'^st/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive)$'
+    handler_url = r'^start/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.start_handler'
 
     def post(self, request, *args, **kwargs):
         from temba.msgs.models import Msg
@@ -1829,9 +1889,11 @@ class StartHandler(BaseChannelHandler):
 
 
 class ChikkaHandler(BaseChannelHandler):
+    courier_url = r'^ck/(?P<uuid>[a-z0-9\-]+)/receive$'
+    courier_name = 'courier.ck'
 
-    url = r'^chikka/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.chikka_handler'
+    handler_url = r'^chikka/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.chikka_handler'
 
     def get(self, request, *args, **kwargs):  # pragma: needs cover
         return self.post(request, *args, **kwargs)
@@ -1907,9 +1969,11 @@ class ChikkaHandler(BaseChannelHandler):
 
 
 class JasminHandler(BaseChannelHandler):
+    courier_url = r'^js/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.js'
 
-    url = r'^jasmin/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.jasmin_handler'
+    handler_url = r'^jasmin/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.jasmin_handler'
 
     def get(self, request, *args, **kwargs):  # pragma: needs cover
         return HttpResponse("Must be called as a POST", status=400)
@@ -1970,9 +2034,11 @@ class JasminHandler(BaseChannelHandler):
 
 
 class JunebugHandler(BaseChannelHandler):
+    courier_url = r'^jn/(?P<uuid>[a-z0-9\-]+)/(?P<action>event|inbound)$'
+    courier_name = 'courier.jn'
 
-    url = r'^junebug/(?P<action>event|inbound)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.junebug_handler'
+    handler_url = r'^junebug/(?P<action>event|inbound)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.junebug_handler'
     ACK = 'ack'
     NACK = 'nack'
 
@@ -2128,9 +2194,11 @@ class JunebugHandler(BaseChannelHandler):
 
 
 class MbloxHandler(BaseChannelHandler):
+    courier_url = r'^mb/(?P<uuid>[a-z0-9\-]+)/receive$'
+    courier_name = 'courier.mb'
 
-    url = r'^mblox/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.mblox_handler'
+    handler_url = r'^mblox/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.mblox_handler'
 
     def get(self, request, *args, **kwargs):  # pragma: needs cover
         return HttpResponse("Must be called as a POST", status=400)
@@ -2201,8 +2269,11 @@ class JioChatHandler(BaseChannelHandler):
     # Jiochat expected the URL to receive message on CONFIG_URL/rcv/msg/message
     # and for event message on CONFIG_URL/rcv/event/menu
     # and for follow event on CONFIG_URL/rcv/event/follow
-    url = r'^jiochat/(?P<uuid>[a-z0-9\-]+)(/rcv/msg/message|/rcv/event/menu|/rcv/event/follow)?/?$'
-    url_name = 'handlers.jiochat_handler'
+    courier_url = r'^jc/(?P<uuid>[a-z0-9\-]+)(/rcv/msg/message|/rcv/event/menu|/rcv/event/follow)?/?$'
+    courier_name = 'courier.jc'
+
+    handler_url = r'^jiochat/(?P<uuid>[a-z0-9\-]+)(/rcv/msg/message|/rcv/event/menu|/rcv/event/follow)?/?$'
+    handler_name = 'handlers.jiochat_handler'
 
     def lookup_channel(self, kwargs):
         # look up the channel
@@ -2283,9 +2354,11 @@ class JioChatHandler(BaseChannelHandler):
 
 
 class FacebookHandler(BaseChannelHandler):
+    courier_url = r'^fb/(?P<uuid>[a-z0-9\-]+)/receive'
+    courier_name = 'courier.fb'
 
-    url = r'^facebook/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.facebook_handler'
+    handler_url = r'^facebook/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.facebook_handler'
 
     def lookup_channel(self, kwargs):
         # look up the channel
@@ -2509,9 +2582,11 @@ class FacebookHandler(BaseChannelHandler):
 
 
 class GlobeHandler(BaseChannelHandler):
+    courier_url = r'^gl/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive)$'
+    courier_name = 'courier.gl'
 
-    url = r'^globe/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.globe_handler'
+    handler_url = r'^globe/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.globe_handler'
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("Illegal method, must be POST", status=405)
@@ -2590,9 +2665,11 @@ class GlobeHandler(BaseChannelHandler):
 
 
 class ViberHandler(BaseChannelHandler):
+    courier_url = r'^vi/(?P<uuid>[a-z0-9\-]+)/(?P<action>status|receive)$'
+    courier_name = 'courier.vi'
 
-    url = r'^viber/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.viber_handler'
+    handler_url = r'^viber/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.viber_handler'
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("Must be called as a POST", status=405)
@@ -2658,9 +2735,11 @@ class ViberHandler(BaseChannelHandler):
 
 
 class LineHandler(BaseChannelHandler):
+    courier_url = r'^ln/(?P<uuid>[a-z0-9\-]+)/receive$'
+    courier_name = 'courier.ln'
 
-    url = r'^line/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.line_handler'
+    handler_url = r'^line/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.line_handler'
 
     def get(self, request, *args, **kwargs):
         return self.post(request, *args, **kwargs)
@@ -2700,9 +2779,11 @@ class LineHandler(BaseChannelHandler):
 
 
 class ViberPublicHandler(BaseChannelHandler):
+    courier_url = r'^vp/(?P<uuid>[a-z0-9\-]+)/receive$'
+    courier_name = 'courier.vp'
 
-    url = r'^viber_public/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.viber_public_handler'
+    handler_url = r'^viber_public/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.viber_public_handler'
 
     @classmethod
     def calculate_sig(cls, request_body, auth_token):
@@ -2909,9 +2990,8 @@ class ViberPublicHandler(BaseChannelHandler):
 
 
 class FCMHandler(BaseChannelHandler):
-
-    url = r'^fcm/(?P<action>register|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.fcm_handler'
+    handler_url = r'^fcm/(?P<action>register|receive)/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.fcm_handler'
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("Must be called as a POST", status=405)
@@ -2969,9 +3049,11 @@ class FCMHandler(BaseChannelHandler):
 
 
 class TwitterHandler(BaseChannelHandler):
+    courier_url = r'^twt/(?P<uuid>[a-z0-9\-]+)/receive$'
+    courier_name = 'courier.twt'
 
-    url = r'^twitter/(?P<uuid>[a-z0-9\-]+)/?$'
-    url_name = 'handlers.twitter_handler'
+    handler_url = r'^twitter/(?P<uuid>[a-z0-9\-]+)/?$'
+    handler_name = 'handlers.twitter_handler'
 
     def get(self, request, *args, **kwargs):
         crc_token = request.GET['crc_token']

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1383,7 +1383,7 @@ class Channel(TembaModel):
         from temba.utils import gsm7
 
         # build our callback dlr url, jasmin will call this when our message is sent or delivered
-        dlr_url = 'https://%s%s' % (settings.HOSTNAME, reverse('courier.ja', args=[channel.uuid, 'status']))
+        dlr_url = 'https://%s%s' % (settings.HOSTNAME, reverse('courier.js', args=[channel.uuid, 'status']))
 
         # encode to GSM7
         encoded = gsm7.encode(text, 'replace')[0]

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -582,7 +582,7 @@ class Channel(TembaModel):
                                   "Note that you can only claim numbers after "
                                   "adding credit to your Nexmo account.") + "\n" + str(e))
 
-        mo_path = reverse('handlers.nexmo_handler', args=['receive', org_uuid])
+        mo_path = reverse('courier.nx', args=[org_uuid, 'receive'])
 
         channel_uuid = generate_uuid()
 
@@ -627,8 +627,8 @@ class Channel(TembaModel):
         channel_uuid = uuid4()
 
         # create new TwiML app
-        new_receive_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['receive', channel_uuid])
-        new_status_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['status', channel_uuid])
+        new_receive_url = "https://" + settings.TEMBA_HOST + reverse('courier.t', args=[channel_uuid, 'receive'])
+        new_status_url = "https://" + settings.TEMBA_HOST + reverse('courier.t', args=[channel_uuid, 'status'])
         new_voice_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['voice', channel_uuid])
 
         new_app = client.applications.create(
@@ -649,7 +649,7 @@ class Channel(TembaModel):
             if short_codes:
                 short_code = short_codes[0]
                 number_sid = short_code.sid
-                app_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('handlers.twilio_handler', args=['receive', channel_uuid])
+                app_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('courier.t', args=[channel_uuid, 'receive'])
                 client.sms.short_codes.update(number_sid, sms_url=app_url, sms_method='POST')
 
                 role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE
@@ -1383,7 +1383,7 @@ class Channel(TembaModel):
         from temba.utils import gsm7
 
         # build our callback dlr url, jasmin will call this when our message is sent or delivered
-        dlr_url = 'https://%s%s' % (settings.HOSTNAME, reverse('handlers.jasmin_handler', args=['status', channel.uuid]))
+        dlr_url = 'https://%s%s' % (settings.HOSTNAME, reverse('courier.ja', args=[channel.uuid, 'status']))
 
         # encode to GSM7
         encoded = gsm7.encode(text, 'replace')[0]
@@ -1441,10 +1441,7 @@ class Channel(TembaModel):
         event_hostname = channel.config.get(Channel.CONFIG_RP_HOSTNAME_OVERRIDE, settings.HOSTNAME)
 
         # the event url Junebug will relay events to
-        event_url = 'http://%s%s' % (
-            event_hostname,
-            reverse('handlers.junebug_handler',
-                    args=['event', channel.uuid]))
+        event_url = 'http://%s%s' % (event_hostname, reverse('courier.jn', args=[channel.uuid, 'event']))
 
         is_ussd = channel.channel_type == Channel.TYPE_JUNEBUG_USSD
 
@@ -1575,7 +1572,7 @@ class Channel(TembaModel):
         from temba.msgs.models import WIRED
 
         # build our callback dlr url, kannel will call this when our message is sent or delivered
-        dlr_url = 'https://%s%s?id=%d&status=%%d' % (settings.HOSTNAME, reverse('handlers.kannel_handler', args=['status', channel.uuid]), msg.id)
+        dlr_url = 'https://%s%s?id=%d&status=%%d' % (settings.HOSTNAME, reverse('courier.kn', args=[channel.uuid, 'status']), msg.id)
         dlr_mask = 31
 
         # build our payload
@@ -1777,8 +1774,8 @@ class Channel(TembaModel):
             'ret_id': msg.id,
             'datacoding': 8,
             'userdata': 'textit',
-            'ret_url': 'https://%s%s' % (settings.HOSTNAME, reverse('handlers.hcnx_handler', args=['status', channel.uuid])),
-            'ret_mo_url': 'https://%s%s' % (settings.HOSTNAME, reverse('handlers.hcnx_handler', args=['receive', channel.uuid]))
+            'ret_url': 'https://%s%s' % (settings.HOSTNAME, reverse('courier.hx', args=[channel.uuid, 'status'])),
+            'ret_mo_url': 'https://%s%s' % (settings.HOSTNAME, reverse('courier.hx', args=[channel.uuid, 'receive']))
         }
 
         # build our send URL
@@ -2458,8 +2455,7 @@ class Channel(TembaModel):
         url = 'https://api.plivo.com/v1/Account/%s/Message/' % channel.config[Channel.CONFIG_PLIVO_AUTH_ID]
 
         client = plivo.RestAPI(channel.config[Channel.CONFIG_PLIVO_AUTH_ID], channel.config[Channel.CONFIG_PLIVO_AUTH_TOKEN])
-        status_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('handlers.plivo_handler',
-                                                                       args=['status', channel.uuid])
+        status_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('courier.pl', args=[channel.uuid, 'status'])
 
         payload = {'src': channel.address.lstrip('+'),
                    'dst': msg.urn_path.lstrip('+'),

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1685,8 +1685,8 @@ class ChannelTest(TembaTest):
                 response = self.client.get(config_url)
                 self.assertEquals(200, response.status_code)
 
-                self.assertContains(response, reverse('handlers.nexmo_handler', args=['receive', channel.org.nexmo_uuid()]))
-                self.assertContains(response, reverse('handlers.nexmo_handler', args=['status', channel.org.nexmo_uuid()]))
+                self.assertContains(response, reverse('courier.nx', args=[channel.org.nexmo_uuid(), 'receive']))
+                self.assertContains(response, reverse('courier.nx', args=[channel.org.nexmo_uuid(), 'status']))
                 self.assertContains(response, reverse('handlers.nexmo_call_handler', args=['answer', channel.uuid]))
 
                 call_handler_event_url = reverse('handlers.nexmo_call_handler', args=['event', channel.uuid])
@@ -2563,8 +2563,8 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.clickatell_handler', args=['status', channel.uuid]))
-        self.assertContains(response, reverse('handlers.clickatell_handler', args=['receive', channel.uuid]))
+        self.assertContains(response, reverse('courier.ct', args=[channel.uuid, 'status']))
+        self.assertContains(response, reverse('courier.ct', args=[channel.uuid, 'receive']))
 
     def test_high_connection(self):
         Channel.objects.all().delete()
@@ -2597,7 +2597,7 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.hcnx_handler', args=['receive', channel.uuid]))
+        self.assertContains(response, reverse('courier.hx', args=[channel.uuid, 'receive']))
 
     @override_settings(IP_ADDRESSES=('10.10.10.10', '172.16.20.30'))
     def test_claim_dart_media(self):
@@ -2633,7 +2633,7 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.dartmedia_handler', args=['received', channel.uuid]))
+        self.assertContains(response, reverse('courier.da', args=[channel.uuid, 'receive']))
 
         # check we show the IP to whitelist
         self.assertContains(response, "10.10.10.10")
@@ -2671,7 +2671,7 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.shaqodoon_handler', args=['received', channel.uuid]))
+        self.assertContains(response, reverse('courier.sq', args=[channel.uuid, 'receive']))
 
     def test_kannel(self):
         Channel.objects.all().delete()
@@ -2715,7 +2715,7 @@ class ChannelClaimTest(TembaTest):
         self.assertEquals(200, response.status_code)
 
         # our configuration page should list our receive URL
-        self.assertContains(response, reverse('handlers.kannel_handler', args=['receive', channel.uuid]))
+        self.assertContains(response, reverse('courier.kn', args=[channel.uuid, 'receive']))
 
     def test_zenvia(self):
         Channel.objects.all().delete()
@@ -2757,8 +2757,8 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.zenvia_handler', args=['status', channel.uuid]))
-        self.assertContains(response, reverse('handlers.zenvia_handler', args=['receive', channel.uuid]))
+        self.assertContains(response, reverse('courier.zv', args=[channel.uuid, 'status']))
+        self.assertContains(response, reverse('courier.zv', args=[channel.uuid, 'receive']))
 
     def test_claim_africa(self):
         Channel.objects.all().delete()
@@ -2790,8 +2790,8 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.africas_talking_handler', args=['callback', channel.uuid]))
-        self.assertContains(response, reverse('handlers.africas_talking_handler', args=['delivery', channel.uuid]))
+        self.assertContains(response, reverse('courier.at', args=[channel.uuid, 'receive']))
+        self.assertContains(response, reverse('courier.at', args=[channel.uuid, 'status']))
 
     def test_claim_viber(self):
         Channel.objects.all().delete()
@@ -2815,8 +2815,8 @@ class ChannelClaimTest(TembaTest):
 
         response = self.client.get(claim_url)
 
-        self.assertContains(response, reverse('handlers.viber_handler', args=['status', channel.uuid]))
-        self.assertContains(response, reverse('handlers.viber_handler', args=['receive', channel.uuid]))
+        self.assertContains(response, reverse('courier.vi', args=[channel.uuid, 'status']))
+        self.assertContains(response, reverse('courier.vi', args=[channel.uuid, 'receive']))
 
         # going to our account home should link to our claim page
         response = self.client.get(reverse('orgs.org_home'))
@@ -2836,8 +2836,8 @@ class ChannelClaimTest(TembaTest):
 
         response = self.client.get(config_url)
 
-        self.assertContains(response, reverse('handlers.viber_handler', args=['status', channel.uuid]))
-        self.assertContains(response, reverse('handlers.viber_handler', args=['receive', channel.uuid]))
+        self.assertContains(response, reverse('courier.vi', args=[channel.uuid, 'status']))
+        self.assertContains(response, reverse('courier.vi', args=[channel.uuid, 'receive']))
 
         # once claimed, account page should go to read page
         response = self.client.get(reverse('orgs.org_home'))
@@ -2873,7 +2873,7 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.chikka_handler', args=[channel.uuid]))
+        self.assertContains(response, reverse('courier.ck', args=[channel.uuid]))
 
     def test_claim_junebug(self):
         Channel.objects.all().delete()
@@ -2909,7 +2909,7 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.junebug_handler', args=['inbound', channel.uuid]))
+        self.assertContains(response, reverse('courier.jn', args=[channel.uuid, 'inbound']))
 
     def test_claim_junebug_with_secret(self):
         Channel.objects.all().delete()
@@ -2947,7 +2947,7 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.junebug_handler', args=['inbound', channel.uuid]))
+        self.assertContains(response, reverse('courier.jn', args=[channel.uuid, 'inbound']))
 
     def test_claim_junebug_ussd(self):
         Channel.objects.all().delete()
@@ -3004,8 +3004,8 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.vumi_handler', args=['receive', channel.uuid]))
-        self.assertContains(response, reverse('handlers.vumi_handler', args=['event', channel.uuid]))
+        self.assertContains(response, reverse('courier.vm', args=[channel.uuid, 'receive']))
+        self.assertContains(response, reverse('courier.vm', args=[channel.uuid, 'event']))
 
     def test_claim_vumi_ussd_custom_api(self):
         Channel.objects.all().delete()
@@ -3127,8 +3127,8 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.macrokiosk_handler', args=['receive', channel.uuid]))
-        self.assertContains(response, reverse('handlers.macrokiosk_handler', args=['status', channel.uuid]))
+        self.assertContains(response, reverse('courier.mk', args=[channel.uuid, 'receive']))
+        self.assertContains(response, reverse('courier.mk', args=[channel.uuid, 'status']))
 
     def test_m3tech(self):
         Channel.objects.all().delete()
@@ -3160,10 +3160,10 @@ class ChannelClaimTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.m3tech_handler', args=['received', channel.uuid]))
-        self.assertContains(response, reverse('handlers.m3tech_handler', args=['sent', channel.uuid]))
-        self.assertContains(response, reverse('handlers.m3tech_handler', args=['failed', channel.uuid]))
-        self.assertContains(response, reverse('handlers.m3tech_handler', args=['delivered', channel.uuid]))
+        self.assertContains(response, reverse('courier.m3', args=[channel.uuid, 'receive']))
+        self.assertContains(response, reverse('courier.m3', args=[channel.uuid, 'sent']))
+        self.assertContains(response, reverse('courier.m3', args=[channel.uuid, 'failed']))
+        self.assertContains(response, reverse('courier.m3', args=[channel.uuid, 'delivered']))
 
     @override_settings(SEND_EMAILS=True)
     def test_sms_alert(self):

--- a/temba/channels/types/blackmyna/tests.py
+++ b/temba/channels/types/blackmyna/tests.py
@@ -49,8 +49,8 @@ class BlackmynaTypeTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.blackmyna_handler', args=['status', channel.uuid]))
-        self.assertContains(response, reverse('handlers.blackmyna_handler', args=['receive', channel.uuid]))
+        self.assertContains(response, reverse('courier.bm', args=[channel.uuid, 'status']))
+        self.assertContains(response, reverse('courier.bm', args=[channel.uuid, 'receive']))
 
         Channel.objects.all().delete()
 

--- a/temba/channels/types/external/tests.py
+++ b/temba/channels/types/external/tests.py
@@ -49,10 +49,10 @@ class ExternalTypeTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertContains(response, reverse('handlers.external_handler', args=['sent', channel.uuid]))
-        self.assertContains(response, reverse('handlers.external_handler', args=['delivered', channel.uuid]))
-        self.assertContains(response, reverse('handlers.external_handler', args=['failed', channel.uuid]))
-        self.assertContains(response, reverse('handlers.external_handler', args=['received', channel.uuid]))
+        self.assertContains(response, reverse('courier.ex', args=[channel.uuid, 'sent']))
+        self.assertContains(response, reverse('courier.ex', args=[channel.uuid, 'delivered']))
+        self.assertContains(response, reverse('courier.ex', args=[channel.uuid, 'failed']))
+        self.assertContains(response, reverse('courier.ex', args=[channel.uuid, 'receive']))
 
         # test substitution in our url
         self.assertEqual('http://test.com/send.php?from=5080&text=test&to=%2B250788383383',

--- a/temba/channels/types/facebook/tests.py
+++ b/temba/channels/types/facebook/tests.py
@@ -57,12 +57,12 @@ class FacebookTypeTest(TembaTest):
         self.assertContains(response, channel.secret)
 
         # test validating our secret
-        handler_url = reverse('handlers.facebook_handler', args=['invalid'])
+        handler_url = reverse('courier.fb', args=['invalid'])
         response = self.client.get(handler_url)
         self.assertEqual(response.status_code, 400)
 
         # test invalid token
-        handler_url = reverse('handlers.facebook_handler', args=[channel.uuid])
+        handler_url = reverse('courier.fb', args=[channel.uuid])
         payload = {'hub.mode': 'subscribe', 'hub.verify_token': 'invalid', 'hub.challenge': 'challenge'}
         response = self.client.get(handler_url, payload)
         self.assertEqual(response.status_code, 400)

--- a/temba/channels/types/infobip/tests.py
+++ b/temba/channels/types/infobip/tests.py
@@ -43,8 +43,8 @@ class InfobipTypeTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.infobip_handler', args=['received', channel.uuid]))
-        self.assertContains(response, reverse('handlers.infobip_handler', args=['delivered', channel.uuid]))
+        self.assertContains(response, reverse('courier.ib', args=[channel.uuid, 'receive']))
+        self.assertContains(response, reverse('courier.ib', args=[channel.uuid, 'delivered']))
 
         Channel.objects.all().delete()
 

--- a/temba/channels/types/jiochat/tests.py
+++ b/temba/channels/types/jiochat/tests.py
@@ -34,7 +34,7 @@ class JioChatTypeTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEquals(200, response.status_code)
 
-        self.assertContains(response, reverse('handlers.jiochat_handler', args=[channel.uuid]))
+        self.assertContains(response, reverse('courier.jc', args=[channel.uuid]))
         self.assertContains(response, channel.secret)
 
         contact = self.create_contact('Jiochat User', urn=URN.from_jiochat('1234'))

--- a/temba/channels/types/telegram/type.py
+++ b/temba/channels/types/telegram/type.py
@@ -39,7 +39,7 @@ class TelegramType(ChannelType):
     def activate(self, channel):
         config = channel.config_json()
         bot = telegram.Bot(config['auth_token'])
-        bot.set_webhook("https://" + settings.TEMBA_HOST + reverse('handlers.telegram_handler', args=[channel.uuid]))
+        bot.set_webhook("https://" + settings.TEMBA_HOST + reverse('courier.tg', args=[channel.uuid]))
 
     def deactivate(self, channel):
         config = channel.config_json()

--- a/temba/channels/types/twitter_activity/tests.py
+++ b/temba/channels/types/twitter_activity/tests.py
@@ -85,7 +85,7 @@ class TwitterActivityTypeTest(TembaTest):
         self.assertEqual(json.loads(channel.config), {'handle_id': '87654', 'api_key': 'ak', 'api_secret': 'as',
                                                       'access_token': 'at', 'access_token_secret': 'ats', 'webhook_id': '1234567'})
 
-        mock_register_webhook.assert_called_once_with('https://temba.ngrok.io/handlers/twitter/%s' % channel.uuid)
+        mock_register_webhook.assert_called_once_with('https://temba.ngrok.io/c/twt/%s/receive' % channel.uuid)
         mock_subscribe_to_webhook.assert_called_once_with("1234567")
 
     @override_settings(IS_PROD=True)

--- a/temba/channels/types/twitter_activity/type.py
+++ b/temba/channels/types/twitter_activity/type.py
@@ -41,7 +41,7 @@ class TwitterActivityType(ChannelType):
         config = channel.config_json()
         client = TembaTwython(config['api_key'], config['api_secret'], config['access_token'], config['access_token_secret'])
 
-        callback_url = 'https://%s%s' % (settings.HOSTNAME, reverse('handlers.twitter_handler', args=[channel.uuid]))
+        callback_url = 'https://%s%s' % (settings.HOSTNAME, reverse('courier.twt', args=[channel.uuid]))
         webhook = client.register_webhook(callback_url)
         client.subscribe_to_webhook(webhook['id'])
 

--- a/temba/channels/types/viber_public/type.py
+++ b/temba/channels/types/viber_public/type.py
@@ -37,7 +37,7 @@ class ViberPublicType(ChannelType):
 
     def activate(self, channel):
         auth_token = channel.config_json()['auth_token']
-        handler_url = "https://" + settings.TEMBA_HOST + reverse('handlers.viber_public_handler', args=[channel.uuid])
+        handler_url = "https://" + settings.TEMBA_HOST + reverse('courier.vp', args=[channel.uuid])
 
         requests.post('https://chatapi.viber.com/pa/set_webhook', json={
             'auth_token': auth_token,

--- a/temba/channels/urls.py
+++ b/temba/channels/urls.py
@@ -16,10 +16,12 @@ handler_urls = []
 
 for handler in get_channel_handlers():
     rel_url, url_name = handler.get_courier_url()
-    courier_urls.append(url(rel_url, handler.as_view(), name=url_name))
+    if rel_url:
+        courier_urls.append(url(rel_url, handler.as_view(), name=url_name))
 
     rel_url, url_name = handler.get_handler_url()
-    handler_urls.append(url(rel_url, handler.as_view(), name=url_name))
+    if rel_url:
+        handler_urls.append(url(rel_url, handler.as_view(), name=url_name))
 
 urlpatterns = [
     url(r'^', include(ChannelEventCRUDL().as_urlpatterns())),

--- a/temba/channels/urls.py
+++ b/temba/channels/urls.py
@@ -11,11 +11,15 @@ from .views import ChannelCRUDL, ChannelEventCRUDL, ChannelLogCRUDL
 
 claim_page_urls = [ch_type.get_claim_url() for ch_type in Channel.get_types() if ch_type.claim_view]
 
+courier_urls = []
 handler_urls = []
-for handler in get_channel_handlers():
-    rel_url, url_name = handler.get_url()
-    handler_urls.append(url(rel_url, handler.as_view(), name=url_name))
 
+for handler in get_channel_handlers():
+    rel_url, url_name = handler.get_courier_url()
+    courier_urls.append(url(rel_url, handler.as_view(), name=url_name))
+
+    rel_url, url_name = handler.get_handler_url()
+    handler_urls.append(url(rel_url, handler.as_view(), name=url_name))
 
 urlpatterns = [
     url(r'^', include(ChannelEventCRUDL().as_urlpatterns())),
@@ -24,6 +28,7 @@ urlpatterns = [
 
     url(r'^channels/', include(claim_page_urls)),
 
+    url(r'^c/', include(courier_urls)),
     url(r'^handlers/', include(handler_urls)),
 
     # for backwards compatibility these channel handlers are exposed at /api/v1 as well

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -653,8 +653,8 @@ class OrgCRUDL(SmartCRUDL):
                 return HttpResponseRedirect(reverse("orgs.org_nexmo_connect"))
 
             nexmo_uuid = org.nexmo_uuid()
-            mo_path = reverse('handlers.nexmo_handler', args=['receive', nexmo_uuid])
-            dl_path = reverse('handlers.nexmo_handler', args=['status', nexmo_uuid])
+            mo_path = reverse('courier.nx', args=[nexmo_uuid, 'receive'])
+            dl_path = reverse('courier.nx', args=[nexmo_uuid, 'status'])
             try:
                 from temba.settings import TEMBA_HOST
                 nexmo_client.update_account('http://%s%s' % (TEMBA_HOST, mo_path),
@@ -675,8 +675,8 @@ class OrgCRUDL(SmartCRUDL):
             context['nexmo_api_secret'] = config[NEXMO_SECRET]
 
             nexmo_uuid = config.get(NEXMO_UUID, None)
-            mo_path = reverse('handlers.nexmo_handler', args=['receive', nexmo_uuid])
-            dl_path = reverse('handlers.nexmo_handler', args=['status', nexmo_uuid])
+            mo_path = reverse('courier.nx', args=[nexmo_uuid, 'receive'])
+            dl_path = reverse('courier.nx', args=[nexmo_uuid, 'status'])
             context['mo_path'] = 'https://%s%s' % (TEMBA_HOST, mo_path)
             context['dl_path'] = 'https://%s%s' % (TEMBA_HOST, dl_path)
 

--- a/templates/channels/channel_claim_viber.haml
+++ b/templates/channels/channel_claim_viber.haml
@@ -40,13 +40,13 @@
     -trans "Status URL"
 
   %code
-    https://{{ domain }}{% url 'handlers.viber_handler' 'status' object.uuid %}
+    https://{{ domain }}{% url 'courier.vi' object.uuid 'status' %}
 
   %h4
     -trans "Receive URL"
 
   %code
-    https://{{ domain }}{% url 'handlers.viber_handler' 'receive' object.uuid %}
+    https://{{ domain }}{% url 'courier.vi' object.uuid 'receive' %}
 
   %hr
 

--- a/templates/channels/channel_configuration.haml
+++ b/templates/channels/channel_configuration.haml
@@ -45,7 +45,7 @@
         <a href="http://www.africastalking.com/account/sms/smscallback" target="africastalking">Callback URL</a>.
 
     %code
-      https://{{ domain }}{% url 'handlers.africas_talking_handler' 'callback' object.uuid %}
+      https://{{ domain }}{% url 'courier.at' object.uuid 'receive' %}
 
     %hr
 
@@ -57,7 +57,7 @@
       <a href="http://www.africastalking.com/account/sms/dlrcallback" target="africastalking">Delivery Reports</a>.
 
     %code
-      https://{{ domain }}{% url 'handlers.africas_talking_handler' 'delivery' object.uuid %}
+      https://{{ domain }}{% url 'courier.at' object.uuid 'status' %}
 
     %hr
 
@@ -76,7 +76,7 @@
         path to HTTP GET and your target address to the URL below. (leave username and password blank)
 
     %code
-      https://{{ domain }}{% url 'handlers.clickatell_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.ct' object.uuid 'receive' %}
 
     %hr
 
@@ -89,7 +89,7 @@
         account and set the message delivery notifications to the URL below. (pick HTTP Get as the Method)
 
     %code
-      https://{{ domain }}{% url 'handlers.clickatell_handler' 'status' object.uuid %}
+      https://{{ domain }}{% url 'courier.ct' object.uuid 'status' %}
 
     %hr
 
@@ -101,7 +101,7 @@
         URL for incoming messages to {{ number }}.
 
     %code
-      https://{{ domain }}{% url 'handlers.shaqodoon_handler' 'received' object.uuid %}
+      https://{{ domain }}{% url 'courier.sq' object.uuid 'receive' %}
 
     %hr
 
@@ -131,7 +131,7 @@
         for your Zenvia account.
 
     %code
-      https://{{ domain }}{% url 'handlers.zenvia_handler' 'status' object.uuid %}
+      https://{{ domain }}{% url 'courier.zv' object.uuid 'status' %}
 
     %hr
 
@@ -142,7 +142,7 @@
       -trans "To receive incoming messages, you need to set the receive URL for your Zenvia account."
 
     %code
-      https://{{ domain }}{% url 'handlers.zenvia_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.zv' object.uuid 'receive' %}
 
     %hr
 
@@ -158,7 +158,7 @@
         The callback URL is called by Nexmo when you receive new incoming messages.
 
     %code
-      https://{{ domain }}{% url 'handlers.nexmo_handler' 'receive' object.org.nexmo_uuid %}
+      https://{{ domain }}{% url 'courier.nx' object.org.nexmo_uuid 'receive' %}
 
     %h4
       -trans "Callback URL for Delivery Receipt"
@@ -168,7 +168,7 @@
         The delivery URL is called by Nexmo when a message is successfully delivered to a recipient.
 
     %code
-      https://{{ domain }}{% url 'handlers.nexmo_handler' 'status' object.org.nexmo_uuid %}
+      https://{{ domain }}{% url 'courier.nx' object.org.nexmo_uuid 'status' %}
 
 
     %h4
@@ -211,7 +211,7 @@
         This endpoint should be called by Infobip when new messages are received to your number. You can set the receive URL on your Infobip account by contacting your sales agent.
 
     %code
-      https://{{ domain }}{% url 'handlers.infobip_handler' 'received' object.uuid %}
+      https://{{ domain }}{% url 'courier.ib' object.uuid 'receive' %}
 
     %hr
 
@@ -224,7 +224,7 @@
         You can set the delivery callback URL on your Infobip account by contacting your sales agent.
 
     %code
-      https://{{ domain }}{% url 'handlers.infobip_handler' 'delivered' object.uuid %}
+      https://{{ domain }}{% url 'courier.ib' object.uuid 'delivered' %}
 
   -elif object.channel_type == 'MK'
     %h4
@@ -241,7 +241,7 @@
         This endpoint should be called by MACROKIOSK when new messages are received to your number.
 
     %code
-      https://{{ domain }}{% url 'handlers.macrokiosk_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.mk' object.uuid 'receive' %}
 
     %hr
 
@@ -253,7 +253,7 @@
         This endpoint should be called by MACROKIOSK when the message status changes. (delivery reports)
 
     %code
-      https://{{ domain }}{% url 'handlers.macrokiosk_handler' 'status' object.uuid %}
+      https://{{ domain }}{% url 'courier.mk' object.uuid 'status' %}
 
   -elif object.channel_type == 'BM'
     %h4
@@ -270,7 +270,7 @@
         This endpoint should be called by Blackmyna when new messages are received to your number.
 
     %code
-      https://{{ domain }}{% url 'handlers.blackmyna_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.bm' object.uuid 'receive' %}
 
     %hr
 
@@ -282,7 +282,7 @@
         This endpoint should be called by Blackmyna when the message status changes. (delivery reports)
 
     %code
-      https://{{ domain }}{% url 'handlers.blackmyna_handler' 'status' object.uuid %}
+      https://{{ domain }}{% url 'courier.bm' object.uuid 'status' %}
 
   -elif object.channel_type == 'TMS'
     %h4
@@ -299,7 +299,7 @@
         This endpoint should be called by Twilio when new messages are received by your Messaging Service.
 
     %code
-      https://{{ domain }}{% url 'handlers.twilio_messaging_service_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.tms' object.uuid 'receive' %}
 
     %hr
 
@@ -347,7 +347,7 @@
         This endpoint should be called by SMSCentral when new messages are received to your number.
 
     %code
-      https://{{ domain }}{% url 'handlers.smscentral_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.sc' object.uuid 'receive' %}
 
   -elif object.channel_type == 'ST'
     %h4
@@ -364,7 +364,7 @@
         This endpoint should be called by Start when new messages are received to your number.
 
     %code
-      https://{{ domain }}{% url 'handlers.start_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.st' object.uuid 'receive' %}
 
   -elif object.channel_type == 'M3'
     %h4
@@ -374,7 +374,7 @@
     %h4
       -trans "Received URL"
     %code
-      https://{{ domain }}{% url 'handlers.m3tech_handler' 'received' object.uuid %}
+      https://{{ domain }}{% url 'courier.m3' object.uuid 'receive' %}
 
     %p
       -blocktrans
@@ -382,14 +382,14 @@
         the following parameters: 'from' and 'text'
     %pre.prettyprint.example<
       :plain
-        POST https://{{ domain }}{% url 'handlers.m3tech_handler' 'received' object.uuid %}
+        POST https://{{ domain }}{% url 'courier.m3' object.uuid 'receive' %}
         from=%2B250788123123&text=Love+is+patient.+Love+is+kind.
     %hr
 
     %h4
       -trans "Sent URL"
     %code
-      https://{{ domain }}{% url 'handlers.m3tech_handler' 'sent' object.uuid %}
+      https://{{ domain }}{% url 'courier.m3' object.uuid 'sent' %}
 
     %p
       -blocktrans
@@ -397,14 +397,14 @@
         the id of the message as the parameter 'id' (reporting sent messages is optional)
     %pre.prettyprint.example<
       :plain
-        POST https://{{ domain }}{% url 'handlers.m3tech_handler' 'sent' object.uuid %}
+        POST https://{{ domain }}{% url 'courier.m3' object.uuid 'sent' %}
         id=2599235
     %hr
 
     %h4
       -trans "Delivered URL"
     %code
-      https://{{ domain }}{% url 'handlers.m3tech_handler' 'delivered' object.uuid %}
+      https://{{ domain }}{% url 'courier.m3' object.uuid 'delivered' %}
 
     %p
       -blocktrans
@@ -412,14 +412,14 @@
         the id of the message as the parameter 'id' (reporting deliveries is optional)
     %pre.prettyprint.example<
       :plain
-        POST https://{{ domain }}{% url 'handlers.m3tech_handler' 'delivered' object.uuid %}
+        POST https://{{ domain }}{% url 'courier.m3' object.uuid 'delivered' %}
         id=2599235
     %hr
 
     %h4
       -trans "Failed URL"
     %code
-      https://{{ domain }}{% url 'handlers.m3tech_handler' 'failed' object.uuid %}
+      https://{{ domain }}{% url 'courier.m3' object.uuid 'failed' %}
 
     %p
       -blocktrans
@@ -427,7 +427,7 @@
         the id of the message as the parameter 'id' (reporting failed sends is optional)
     %pre.prettyprint.example<
       :plain
-        POST https://{{ domain }}{% url 'handlers.m3tech_handler' 'failed' object.uuid %}
+        POST https://{{ domain }}{% url 'courier.m3' object.uuid 'failed' %}
         id=2599235
     %hr
 
@@ -458,7 +458,7 @@
         This endpoint should be called by Hub9 when new messages are received to your number. You can set the receive URL on your Hub9 account by contacting your sales agent.
 
     %code
-      https://{{ domain }}{% url 'handlers.hub9_handler' 'received' object.uuid %}
+      https://{{ domain }}{% url 'courier.h9' object.uuid 'receive' %}
 
     %hr
 
@@ -471,7 +471,7 @@
         You can set the delivery callback URL on your Hub9 account by contacting your sales agent.
 
     %code
-      https://{{ domain }}{% url 'handlers.hub9_handler' 'delivered' object.uuid %}
+      https://{{ domain }}{% url 'courier.h9' object.uuid 'delivered' %}
 
     %hr
 
@@ -512,7 +512,7 @@
         This endpoint should be called by Dart Media when new messages are received to your number. You can set the receive URL on your Dart Media account by contacting your sales agent.
 
     %code
-      https://{{ domain }}{% url 'handlers.dartmedia_handler' 'received' object.uuid %}
+      https://{{ domain }}{% url 'courier.da' object.uuid 'receive' %}
 
     %hr
 
@@ -525,7 +525,7 @@
         You can set the delivery callback URL on your Dart Media account by contacting your sales agent.
 
     %code
-      https://{{ domain }}{% url 'handlers.dartmedia_handler' 'delivered' object.uuid %}
+      https://{{ domain }}{% url 'courier.da' object.uuid 'delivered' %}
 
     %hr
 
@@ -608,7 +608,7 @@
         This endpoint will be called by Vumi when new messages are received to your number.
 
     %code
-      https://{{ domain }}{% url 'handlers.vumi_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.vm' object.uuid 'receive' %}
 
     %hr
 
@@ -620,7 +620,7 @@
         This endpoint will be called by Vumi when sent messages are sent or delivered.
 
     %code
-      https://{{ domain }}{% url 'handlers.vumi_handler' 'event' object.uuid %}
+      https://{{ domain }}{% url 'courier.vm' object.uuid 'event' %}
 
   -elif object.channel_type == 'KN'
     %h4
@@ -651,7 +651,7 @@
         keyword = default
         allowed-receiver-prefix = {{channel.address}}
         max-messages = 0
-        post-url = "https://{{domain}}{% url 'handlers.kannel_handler' 'receive' object.uuid %}/?backend=%i&sender=%p&message=%b&ts=%T&id=%I&to=%P"
+        post-url = "https://{{domain}}{% url 'courier.kn' object.uuid 'receive' %}?backend=%i&sender=%p&message=%b&ts=%T&id=%I&to=%P"
         concatenation = true
         assume-plain-text = true
         accept-x-kannel-headers = true
@@ -674,7 +674,7 @@
         to be called as a POST
 
     %code
-      https://{{ domain }}{% url 'handlers.jasmin_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.js' object.uuid 'receive' %}
 
   -elif object.channel_type == 'JN' or object.channel_type == 'JNU'
     %h4
@@ -692,7 +692,7 @@
         to be called as a POST
 
     %code
-      https://{{ domain }}{% url 'handlers.junebug_handler' 'inbound' object.uuid %}
+      https://{{ domain }}{% url 'courier.jn' object.uuid 'inbound' %}
 
   -elif object.channel_type == 'MB'
     %h4
@@ -709,7 +709,7 @@
         This endpoint will be called by Mblox when new messages are received to your number and for delivery reports.
 
     %code
-      https://{{ domain }}{% url 'handlers.mblox_handler' object.uuid %}
+      https://{{ domain }}{% url 'courier.mb' object.uuid 'receive' %}
 
   -elif object.channel_type == 'VB'
     %h4
@@ -722,7 +722,7 @@
       -trans "Status Callback URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.verboice_handler' 'status' object.uuid %}
+      https://{{ domain }}{% url 'courier.vb' object.uuid 'status' %}
 
   -elif object.channel_type == 'FB'
     %h4
@@ -750,7 +750,7 @@
       -trans "Webhook URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.facebook_handler' object.uuid %}
+      https://{{ domain }}{% url 'courier.fb' object.uuid %}
 
     %h4
       -trans "Verify Token"
@@ -769,7 +769,7 @@
       -trans "Webhook URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.jiochat_handler' object.uuid %}
+      https://{{ domain }}{% url 'courier.jc' object.uuid %}
 
     %h4
       -trans "Token"
@@ -795,18 +795,18 @@
       -trans "Status URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.viber_handler' 'status' object.uuid %}
+      https://{{ domain }}{% url 'courier.vi' object.uuid 'status' %}
 
     %h4
       -trans "Receive URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.viber_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.vi' object.uuid 'receive'  %}
 
-  -elif object.channel_type == 'VI'
+  -elif object.channel_type == 'VP'
     %h4
       -blocktrans
-        Your Viber public channel is connected. If needed the webhook endpoints are listed below.
+        Your Viber channel is connected. If needed the webhook endpoints are listed below.
 
     %hr
 
@@ -814,7 +814,7 @@
       -trans "Webhook URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.viber_public_handler' object.uuid %}
+      https://{{ domain }}{% url 'courier.vp' object.uuid %}
 
   -elif object.channel_type == 'LN'
     %h4
@@ -838,7 +838,7 @@
       -trans "Callback URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.line_handler' object.uuid %}
+      https://{{ domain }}{% url 'courier.ln' object.uuid %}
 
     %hr
 
@@ -860,7 +860,7 @@
       -trans "Notify URI"
 
     %code
-      https://{{ domain }}{% url 'handlers.globe_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.gl' object.uuid 'receive' %}
 
   -elif object.channel_type == 'HX'
     %h4
@@ -874,7 +874,7 @@
       -trans "Receive URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.hcnx_handler' 'receive' object.uuid %}
+      https://{{ domain }}{% url 'courier.hx' object.uuid 'receive' %}
 
   -elif object.channel_type == 'YO'
     %h4
@@ -889,7 +889,7 @@
         This URL should be called with a GET by Yo! when new incoming messages are received on your shortcode.
 
     %code
-      https://{{ domain }}{% url 'handlers.yo_handler' 'received' object.uuid %}
+      https://{{ domain }}{% url 'courier.yo' object.uuid 'receive' %}
 
   -elif object.channel_type == 'CK'
     %h4
@@ -902,7 +902,7 @@
       -trans "Notification Receiver URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.chikka_handler' object.uuid %}
+      https://{{ domain }}{% url 'courier.ck' object.uuid %}
 
     %hr
 
@@ -910,7 +910,7 @@
       -trans "Message Receiver URL"
 
     %code
-      https://{{ domain }}{% url 'handlers.chikka_handler' object.uuid %}
+      https://{{ domain }}{% url 'courier.ck' object.uuid %}
 
   -elif object.channel_type == 'EX'
     %h4
@@ -956,7 +956,7 @@
       %h4
         -trans "Received URL"
         %code
-          https://{{ domain }}{% url 'handlers.external_handler' 'received' object.uuid %}
+          https://{{ domain }}{% url 'courier.ex' object.uuid 'receive' %}
 
       %p
         -blocktrans
@@ -965,14 +965,14 @@
           (ex: 2012-04-23T18:25:43.511Z) format to specify the time the message was received.
       %pre.prettyprint.example<
         :plain
-          POST https://{{ domain }}{% url 'handlers.external_handler' 'received' object.uuid %}
+          POST https://{{ domain }}{% url 'courier.ex' object.uuid 'receive' %}
           from=%2B250788123123&text=Love+is+patient.+Love+is+kind.&date=2012-04-23T18:25:43.511Z
       %hr
 
     %h4
       -trans "Sent URL"
       %code
-        https://{{ domain }}{% url 'handlers.external_handler' 'sent' object.uuid %}
+        https://{{ domain }}{% url 'courier.ex' object.uuid 'sent' %}
 
     %p
       -blocktrans
@@ -980,14 +980,14 @@
         the id of the message as the parameter 'id' (reporting sent messages is optional)
     %pre.prettyprint.example<
       :plain
-        POST https://{{ domain }}{% url 'handlers.external_handler' 'sent' object.uuid %}
+        POST https://{{ domain }}{% url 'courier.ex' object.uuid 'sent' %}
         id=2599235
     %hr
 
     %h4
       -trans "Delivered URL"
       %code
-        https://{{ domain }}{% url 'handlers.external_handler' 'delivered' object.uuid %}
+        https://{{ domain }}{% url 'courier.ex' object.uuid 'delivered' %}
 
     %p
       -blocktrans
@@ -995,14 +995,14 @@
         the id of the message as the parameter 'id' (reporting deliveries is optional)
     %pre.prettyprint.example<
       :plain
-        POST https://{{ domain }}{% url 'handlers.external_handler' 'delivered' object.uuid %}
+        POST https://{{ domain }}{% url 'courier.ex' object.uuid 'delivered' %}
         id=2599235
     %hr
 
     %h4
       -trans "Failed URL"
       %code
-        https://{{ domain }}{% url 'handlers.external_handler' 'failed' object.uuid %}
+        https://{{ domain }}{% url 'courier.ex' object.uuid 'failed' %}
 
     %p
       -blocktrans
@@ -1010,7 +1010,7 @@
         the id of the message as the parameter 'id' (reporting failed sends is optional)
     %pre.prettyprint.example<
       :plain
-        POST https://{{ domain }}{% url 'handlers.external_handler' 'failed' object.uuid %}
+        POST https://{{ domain }}{% url 'courier.ex' object.uuid 'failed' %}
         id=2599235
     %hr
 


### PR DESCRIPTION
We'll still have to do nginx remappings ourselves, but future peeps will be able to just reroute all of /c/ to courier via a application level load balancer.