### PR TITLE
strip matched string in test not empty

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -6187,7 +6187,7 @@ class NotEmptyTest(Test):
 
     def evaluate(self, run, sms, context, text):  # pragma: needs cover
         if text and len(text.strip()):
-            return 1, text
+            return 1, text.strip()
         return 0, None
 
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1780,7 +1780,7 @@ class FlowTest(TembaTest):
         self.assertTest(False, None, NotEmptyTest())
         sms.text = " "
         self.assertTest(False, None, NotEmptyTest())
-        sms.text = "it works"
+        sms.text = "it works "
         self.assertTest(True, "it works", NotEmptyTest())
 
         def perform_date_tests(sms, dayfirst):


### PR DESCRIPTION
This makes it match the behavior of our other string matching tests.