### PR TITLE
@step.contact and @contact should both be the run contact

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1708,15 +1708,12 @@ class Flow(TembaModel):
 
             # and add each contact and message to each broadcast
             for broadcast in broadcasts:
-                # create our message context
-                message_context = message_context_base.copy()
-
                 # provide the broadcast with a partial recipient list
                 partial_recipients = list(), Contact.objects.filter(org=self.org, pk__in=batch_contact_ids)
 
                 # create the sms messages
                 created_on = timezone.now()
-                broadcast.send(message_context=message_context, trigger_send=False,
+                broadcast.send(message_context=message_context_base, trigger_send=False,
                                response_to=start_msg, status=INITIALIZING, msg_type=FLOW,
                                created_on=created_on, partial_recipients=partial_recipients, run_map=run_map)
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1215,15 +1215,13 @@ class Flow(TembaModel):
 
         # add our message context
         if msg:
-            message_context = msg.build_expressions_context(contact_context=contact_context)
+            message_context = msg.build_expressions_context()
 
             # some fake channel deets for simulation
             if msg.contact.is_test:
                 channel_context = Channel.SIMULATOR_CONTEXT
             elif msg.channel:
                 channel_context = msg.channel.build_expressions_context()
-        elif contact:
-            message_context = dict(__default__='', contact=contact_context)
         else:
             message_context = dict(__default__='')
 
@@ -1711,8 +1709,7 @@ class Flow(TembaModel):
             # and add each contact and message to each broadcast
             for broadcast in broadcasts:
                 # create our message context
-                message_context = dict()
-                message_context.update(message_context_base)
+                message_context = message_context_base.copy()
 
                 # provide the broadcast with a partial recipient list
                 partial_recipients = list(), Contact.objects.filter(org=self.org, pk__in=batch_contact_ids)
@@ -5770,9 +5767,6 @@ class SendAction(VariableContactAction):
                 for group in groups:
                     for contact in group.contacts.all():
                         unique_contacts.add(contact.pk)
-
-                # contact refers to each contact this message is being sent to so evaluate without it for logging
-                del context['contact']
 
                 text = run.flow.get_localized_text(self.msg, run.contact)
                 (message, errors) = Msg.substitute_variables(text, context, org=run.flow.org, partial_vars=True)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3127,6 +3127,8 @@ class ActionTest(TembaTest):
         self.assertFalse(self.other_group.pk in [g.pk for g in updated_action.groups])
 
     def test_send_action(self):
+        # previously @step.contact was the run contact and @contact would become the recipient but that has been
+        # changed so that both are the run contact
         msg_body = "Hi @contact.name (@contact.state). @step.contact (@step.contact.state) is in the flow"
 
         self.contact.set_field(self.user, 'state', "WA", label="State")
@@ -3148,7 +3150,7 @@ class ActionTest(TembaTest):
         self.assertEqual(broadcast.get_messages().count(), 1)
         msg = broadcast.get_messages().first()
         self.assertEqual(msg.contact, self.contact2)
-        self.assertEqual(msg.text, "Hi Nic (GA). Eric (WA) is in the flow")
+        self.assertEqual(msg.text, "Hi Eric (WA). Eric (WA) is in the flow")
 
         # empty message should be a no-op
         action = SendAction(dict(base=""), [], [self.contact], [])
@@ -3171,7 +3173,7 @@ class ActionTest(TembaTest):
         self.assertEqual(Broadcast.objects.all().count(), 1)
 
         # but we should have logged instead
-        logged = "Sending &#39;Hi @contact.name (@contact.state). Mr Test (IN) is in the flow&#39; to 2 contacts"
+        logged = "Sending &#39;Hi Mr Test (IN). Mr Test (IN) is in the flow&#39; to 2 contacts"
         self.assertEqual(ActionLog.objects.all().first().text, logged)
 
         # delete the group

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -5515,7 +5515,7 @@ class FlowsTest(FlowFileTest):
 
         self.assertEquals("Thanks, you typed +250788123123", self.send_message(flow, "0788123123"))
         sms = Msg.objects.get(org=flow.org, contact__urns__path="+250788123123")
-        self.assertEquals("Hi from Ben Haggerty! Your phone is 0788 123 123.", sms.text)
+        self.assertEquals("Hi from Ben Haggerty! Your phone is (206) 555-2020.", sms.text)
 
     def test_group_send(self):
         # create an inactive group with the same name, to test that this doesn't blow up our import

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1391,9 +1391,9 @@ class Msg(models.Model):
         if not text or text.find('@') < 0:
             return text, []
 
-        # add 'step.contact' if it isn't already populated (like in flow batch starts)
+        # add 'step.contact' if it isn't populated for backwards compatibility
         if 'step' not in context:
-            context['step'] = dict(contact=context['contact'])
+            context['step'] = dict()
         if 'contact' not in context['step']:
             context['step']['contact'] = context.get('contact')
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -1197,7 +1197,8 @@ class BroadcastTest(TembaTest):
         self.joe.set_field(self.user, 'dob', "28/5/1981")
 
         def substitute(s, context):
-            return Msg.substitute_variables(s, context, contact=self.joe)
+            context['contact'] = self.joe.build_expressions_context()
+            return Msg.substitute_variables(s, context)
 
         self.assertEquals(("Hello World", []), substitute("Hello World", dict()))
         self.assertEquals(("Hello World Joe", []), substitute("Hello World @contact.first_name", dict()))
@@ -1283,8 +1284,6 @@ class BroadcastTest(TembaTest):
         self.assertEqual(context['value'], "keyword remainder-remainder")
         self.assertEqual(context['text'], "keyword remainder-remainder")
         self.assertEqual(context['attachments'], {})
-        self.assertEqual(context['contact']['__default__'], "Joe Blow")
-        self.assertEqual(context['contact']['superhero_name'], "batman")
 
         # time should be in org format and timezone
         self.assertEqual(context['time'], datetime_to_str(msg.created_on, '%d-%m-%Y %H:%M', tz=self.org.timezone))


### PR DESCRIPTION
Previously `@contact` would become the recipient in a send_msg action. Now `@step.contact` and `@contact` will both refer to the run contact, and when we migrate flows to the new world, we'll map both to just `@contact`.

We sent an email to users about this change a while back.