### PR TITLE
remove duplicate excellent includes

### DIFF
--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -49,8 +49,6 @@
     %script{type:'text/javascript', src:"{{ STATIC_URL }}bower/angular-ui-sortable/sortable.js"}
     %script{type:'text/javascript', src:"{{ STATIC_URL }}js/temba-ui-bootstrap-tpls.js"}
 
-  %script{src:"{{ STATIC_URL }}js/excellent.js"}
-
   :javascript
     window.flowId = {{ object.pk }};
     window.simulateURL = '{% url "flows.flow_simulate" object.pk %}';

--- a/templates/msgs/msg_send_modal.haml
+++ b/templates/msgs/msg_send_modal.haml
@@ -50,8 +50,6 @@
       %a.btn.btn-primary{href:"{% url 'channels.channel_list' %}", tabindex:3}
         -trans "Add Channel"
 
-  %script{src:"{{ STATIC_URL }}js/excellent.js"}
-
   -load compress
 
   :javascript


### PR DESCRIPTION
Since these weren't compressed, these were overwriting signatures of newer compressed versions of excellent (that is in frame.haml). This remove all other includes since they are already present.