### PR TITLE
Mage handler shouldn't be accessible using example token

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -1860,6 +1860,9 @@ class MageHandler(BaseChannelHandler):
     def post(self, request, *args, **kwargs):
         from temba.triggers.tasks import fire_follow_triggers
 
+        if not settings.MAGE_AUTH_TOKEN:  # pragma: no cover
+            return JsonResponse(dict(error="Authentication not configured"), status=401)
+
         authorization = request.META.get('HTTP_AUTHORIZATION', '').split(' ')
 
         if len(authorization) != 2 or authorization[0] != 'Token' or authorization[1] != settings.MAGE_AUTH_TOKEN:

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -7544,6 +7544,7 @@ class MageHandlerTest(TembaTest):
                                   direction=INCOMING, created_on=timezone.now(),
                                   channel=self.channel, contact=contact, contact_urn=contact_urn)
 
+    @override_settings(MAGE_AUTH_TOKEN='abc123')
     def test_handle_message(self):
         url = reverse('handlers.mage_handler', args=['handle_message'])
         headers = dict(HTTP_AUTHORIZATION='Token %s' % settings.MAGE_AUTH_TOKEN)
@@ -7637,6 +7638,7 @@ class MageHandlerTest(TembaTest):
         response = self.client.post(url, dict(message_id='xx'), **headers)
         self.assertEqual(400, response.status_code)
 
+    @override_settings(MAGE_AUTH_TOKEN='abc123')
     def test_follow_notification(self):
         url = reverse('handlers.mage_handler', args=['follow_notification'])
         headers = dict(HTTP_AUTHORIZATION='Token %s' % settings.MAGE_AUTH_TOKEN)
@@ -7699,6 +7701,7 @@ class MageHandlerTest(TembaTest):
         self.assertEqual(200, response.status_code)
         self.assertEqual(ChannelEvent.objects.filter(channel=channel).count(), channel_events_count)
 
+    @override_settings(MAGE_AUTH_TOKEN='abc123')
     def test_stop_contact(self):
         url = reverse('handlers.mage_handler', args=['stop_contact'])
         headers = dict(HTTP_AUTHORIZATION='Token %s' % settings.MAGE_AUTH_TOKEN)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1071,7 +1071,7 @@ for brand in BRANDING.values():
     COMPRESS_OFFLINE_CONTEXT.append(context)
 
 MAGE_API_URL = 'http://localhost:8026/api/v1'
-MAGE_AUTH_TOKEN = '___MAGE_TOKEN_YOU_PICK__'
+MAGE_AUTH_TOKEN = None  # should be same token as configured on Mage side
 
 # -----------------------------------------------------------------------------------
 # RapidPro configuration settings


### PR DESCRIPTION
Since not everyone uses Mage, seems like we should only allow access to the MageHandler endpoint if they have configured an access token