### PR TITLE
Remove the duplicated Plivo number block row

### DIFF
--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -24,6 +24,7 @@ class PlivoTypeTest(TembaTest):
         response = self.client.get(reverse('channels.channel_claim'))
         self.assertContains(response, "Connect plivo")
         self.assertContains(response, reverse('orgs.org_plivo_connect'))
+        self.assertNotContains(response, reverse('channels.claim_plivo'))
 
         with patch('requests.get') as plivo_get:
             plivo_get.return_value = MockResponse(400, json.dumps(dict()))

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -35,6 +35,9 @@ class PlivoType(ChannelType):
     schemes = [TEL_SCHEME]
     max_length = 1600
 
+    def is_available_to(self, user):
+        return False
+
     def deactivate(self, channel):
         config = channel.config_json()
         client = plivo.RestAPI(config[Channel.CONFIG_PLIVO_AUTH_ID],


### PR DESCRIPTION
Plivo channel claim view is a redirection after org plivo connect which really puts the credentials on the session.

This will prevent the the having two 'Plivo number' on the claim page while the one from dynamic channel can not work