### PR TITLE
Never use category field for value of contact fields

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -669,8 +669,6 @@ class Contact(TembaModel):
             return format_decimal(value.decimal_value)
         elif field.value_type in [Value.TYPE_STATE, Value.TYPE_DISTRICT, Value.TYPE_WARD] and value.location_value:
             return value.location_value.name
-        elif value.category:
-            return value.category
         else:
             return value.string_value
 
@@ -688,8 +686,6 @@ class Contact(TembaModel):
             return format_decimal(value.decimal_value)
         elif field.value_type in [Value.TYPE_STATE, Value.TYPE_DISTRICT, Value.TYPE_WARD] and value.location_value:
             return value.location_value.name
-        elif value.category:
-            return value.category
         else:
             return value.string_value
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3533,10 +3533,7 @@ class ContactTest(TembaTest):
         self.assertEqual(Contact.serialize_field_value(state_field, value), 'Kigali City')
 
         value = joe.get_field(color_field.key)
-        value.category = "Dark"
-        value.save()
-
-        self.assertEqual(Contact.serialize_field_value(color_field, value), 'Dark')
+        self.assertEqual(Contact.serialize_field_value(color_field, value), 'green')
 
     def test_set_location_fields(self):
         district_field = ContactField.get_or_create(self.org, self.admin, 'district', 'District', None, Value.TYPE_DISTRICT)
@@ -3559,8 +3556,8 @@ class ContactTest(TembaTest):
         value = Value.objects.filter(contact=joe, contact_field=state_field).first()
         self.assertTrue(value.location_value)
         self.assertEqual(value.location_value.name, "Kigali City")
-        self.assertEqual("Kigali City", joe.get_field_display_for_value(not_state_field, value))
-        self.assertEqual("Kigali City", joe.serialize_field_value(not_state_field, value))
+        self.assertEqual("Kigali City", joe.get_field_display_for_value(state_field, value))
+        self.assertEqual("Kigali City", joe.serialize_field_value(state_field, value))
 
         # test that we don't normalize non-location fields
         joe.set_field(self.user, 'not_state', 'kigali city')

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -2371,12 +2371,12 @@ class ContactTest(TembaTest):
         state.value_type = Value.TYPE_TEXT
         state.save()
         value = self.joe.get_field('state')
-        value.category = "Rwama Category"
+        value.string_value = "Rwama Value"
         value.save()
 
-        # should now be using stored category as value
+        # should now be using stored string_value instead of state name
         response = self.client.get(reverse('contacts.contact_read', args=[self.joe.uuid]))
-        self.assertContains(response, 'Rwama Category')
+        self.assertContains(response, 'Rwama Value')
 
         # bad field
         contact_field = ContactField.objects.create(org=self.org, key='language', label='User Language',

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3540,6 +3540,7 @@ class ContactTest(TembaTest):
 
     def test_set_location_fields(self):
         district_field = ContactField.get_or_create(self.org, self.admin, 'district', 'District', None, Value.TYPE_DISTRICT)
+        not_state_field = ContactField.get_or_create(self.org, self.admin, 'not_state', 'Not State', None, Value.TYPE_TEXT)
 
         # add duplicate district in different states
         east_province = AdminBoundary.objects.create(osm_id='R005', name='East Province', level=1, parent=self.country)
@@ -3558,6 +3559,14 @@ class ContactTest(TembaTest):
         value = Value.objects.filter(contact=joe, contact_field=state_field).first()
         self.assertTrue(value.location_value)
         self.assertEqual(value.location_value.name, "Kigali City")
+        self.assertEqual("Kigali City", joe.get_field_display_for_value(not_state_field, value))
+        self.assertEqual("Kigali City", joe.serialize_field_value(not_state_field, value))
+
+        # test that we don't normalize non-location fields
+        joe.set_field(self.user, 'not_state', 'kigali city')
+        value = Value.objects.filter(contact=joe, contact_field=not_state_field).first()
+        self.assertEqual("kigali city", joe.get_field_display_for_value(not_state_field, value))
+        self.assertEqual("kigali city", joe.serialize_field_value(not_state_field, value))
 
         joe.set_field(self.user, 'district', 'Remera')
         value = Value.objects.filter(contact=joe, contact_field=district_field).first()


### PR DESCRIPTION
I don't think we actually need to keep category long term, so we can drop writing it entirely when we migrate to a new contact value store, but in the meantime this fixes an issue where we were using and displaying state location names for `TYPE_TEXT` contact fields. This was especially confusing when that remapping was taking place due to a string matching a location alias.