### PR TITLE
Remove TEMBA_HOST, always use HOSTNAME

### DIFF
--- a/temba/channels/migrations/0059_update_nexmo_channels_roles.py
+++ b/temba/channels/migrations/0059_update_nexmo_channels_roles.py
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
                         mo_path = reverse('handlers.nexmo_handler', args=['receive', org_uuid])
 
                         nexmo_client.update_nexmo_number(channel.country, channel.address,
-                                                         'http://%s%s' % (settings.TEMBA_HOST, mo_path),
+                                                         'http://%s%s' % (settings.HOSTNAME, mo_path),
                                                          app_id)
 
                     updated.append(channel.id)

--- a/temba/channels/migrations/0072_migrate_twilio_apps.py
+++ b/temba/channels/migrations/0072_migrate_twilio_apps.py
@@ -21,12 +21,12 @@ def migrate_twilio_app(channel):
     number_sid = channel.bod
     is_short_code = len(channel.address) <= 6
 
-    new_receive_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['receive', channel.uuid])
-    new_status_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['status', channel.uuid])
-    new_voice_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['voice', channel.uuid])
+    new_receive_url = "https://" + settings.HOSTNAME + reverse('handlers.twilio_handler', args=['receive', channel.uuid])
+    new_status_url = "https://" + settings.HOSTNAME + reverse('handlers.twilio_handler', args=['status', channel.uuid])
+    new_voice_url = "https://" + settings.HOSTNAME + reverse('handlers.twilio_handler', args=['voice', channel.uuid])
 
     new_app = client.applications.create(
-        friendly_name="%s/%s" % (settings.TEMBA_HOST.lower(), channel.uuid),
+        friendly_name="%s/%s" % (settings.HOSTNAME.lower(), channel.uuid),
         sms_url=new_receive_url,
         sms_method="POST",
         voice_url=new_voice_url,

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1241,7 +1241,7 @@ class Channel(TembaModel):
         elif channel_type == 'TW':
             url = reverse('courier.tw', args=[channel_uuid, 'status'])
 
-        url = "https://" + settings.TEMBA_HOST + url + "?action=callback&id=%d" % sms_id
+        url = "https://" + settings.HOSTNAME + url + "?action=callback&id=%d" % sms_id
         return url
 
     def __str__(self):  # pragma: no cover

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -5360,7 +5360,7 @@ class TwilioTest(TembaTest):
 
         client = self.org.get_twilio_client()
         validator = RequestValidator(client.auth[1])
-        signature = validator.compute_signature('https://' + settings.TEMBA_HOST + twilio_url, post_data)
+        signature = validator.compute_signature('https://' + settings.HOSTNAME + twilio_url, post_data)
 
         with patch('requests.get') as response:
             mock = MockResponse(200, 'Fake Recording Bits')
@@ -5387,7 +5387,7 @@ class TwilioTest(TembaTest):
             response.return_value = mock
 
             post_data['Body'] = ''
-            signature = validator.compute_signature('https://' + settings.TEMBA_HOST + '/handlers/twilio/', post_data)
+            signature = validator.compute_signature('https://' + settings.HOSTNAME + '/handlers/twilio/', post_data)
             self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
         # should have a single message with an attachment but no text
@@ -5407,7 +5407,7 @@ class TwilioTest(TembaTest):
             response.side_effect = (mock1, mock2)
 
             post_data['Body'] = ''
-            signature = validator.compute_signature('https://' + settings.TEMBA_HOST + '/handlers/twilio/', post_data)
+            signature = validator.compute_signature('https://' + settings.HOSTNAME + '/handlers/twilio/', post_data)
             response = self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
         msg = Msg.objects.get()
@@ -5435,7 +5435,7 @@ class TwilioTest(TembaTest):
         self.channel.org.config = json.dumps({})
         self.channel.org.save()
 
-        signature = validator.compute_signature('https://' + settings.TEMBA_HOST + '/handlers/twilio/', post_data)
+        signature = validator.compute_signature('https://' + settings.HOSTNAME + '/handlers/twilio/', post_data)
         response = self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
         self.assertEqual(400, response.status_code)
@@ -5582,7 +5582,7 @@ class TwilioTest(TembaTest):
 
         joe = self.create_contact("Joe", "+250788383383")
 
-        with self.settings(SEND_MESSAGES=True, TEMBA_HOST='testserver'):
+        with self.settings(SEND_MESSAGES=True, HOSTNAME='testserver'):
             with patch('twilio.rest.resources.base.make_request') as mock:
                 for channel_type in ['T', 'TMS', 'TW']:
                     ChannelLog.objects.all().delete()
@@ -5723,7 +5723,7 @@ class TwilioTest(TembaTest):
             self.assertEqual(0, self.channel.get_error_log_count())
             self.assertEqual(1, self.channel.get_success_log_count())
 
-    @override_settings(SEND_MESSAGES=True, TEMBA_HOST='testserver')
+    @override_settings(SEND_MESSAGES=True, HOSTNAME='testserver')
     def test_send_media(self):
         from temba.orgs.models import ACCOUNT_SID, ACCOUNT_TOKEN, APPLICATION_SID
         org_config = self.org.config_json()

--- a/temba/channels/types/nexmo/views.py
+++ b/temba/channels/types/nexmo/views.py
@@ -126,9 +126,9 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             role += Channel.ROLE_ANSWER + Channel.ROLE_CALL
 
         # update the delivery URLs for it
-        from temba.settings import TEMBA_HOST
+        from temba.settings import HOSTNAME
         try:
-            client.update_nexmo_number(country, phone_number, 'https://%s%s' % (TEMBA_HOST, mo_path), app_id)
+            client.update_nexmo_number(country, phone_number, 'https://%s%s' % (HOSTNAME, mo_path), app_id)
 
         except Exception as e:  # pragma: no cover
             # shortcodes don't seem to claim right on nexmo, move forward anyways

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -46,8 +46,8 @@ class PlivoType(ChannelType):
         url = 'https://api.plivo.com/v1/Account/%s/Message/' % channel.config[Channel.CONFIG_PLIVO_AUTH_ID]
 
         client = plivo.RestAPI(channel.config[Channel.CONFIG_PLIVO_AUTH_ID], channel.config[Channel.CONFIG_PLIVO_AUTH_TOKEN])
-        status_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('handlers.plivo_handler',
-                                                                       args=['status', channel.uuid])
+        status_url = "https://" + settings.HOSTNAME + "%s" % reverse('handlers.plivo_handler',
+                                                                     args=['status', channel.uuid])
 
         payload = {'src': channel.address.lstrip('+'),
                    'dst': msg.urn_path.lstrip('+'),

--- a/temba/channels/types/plivo/views.py
+++ b/temba/channels/types/plivo/views.py
@@ -109,11 +109,11 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         org = user.get_org()
 
         plivo_uuid = generate_uuid()
-        app_name = "%s/%s" % (settings.TEMBA_HOST.lower(), plivo_uuid)
+        app_name = "%s/%s" % (settings.HOSTNAME.lower(), plivo_uuid)
 
         client = plivo.RestAPI(auth_id, auth_token)
 
-        message_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('handlers.plivo_handler', args=['receive', plivo_uuid])
+        message_url = "https://" + settings.HOSTNAME + "%s" % reverse('handlers.plivo_handler', args=['receive', plivo_uuid])
         answer_url = "https://" + settings.AWS_BUCKET_DOMAIN + "/plivo_voice_unavailable.xml"
 
         plivo_response_status, plivo_response = client.create_application(params=dict(app_name=app_name,

--- a/temba/channels/types/telegram/type.py
+++ b/temba/channels/types/telegram/type.py
@@ -39,7 +39,7 @@ class TelegramType(ChannelType):
     def activate(self, channel):
         config = channel.config_json()
         bot = telegram.Bot(config['auth_token'])
-        bot.set_webhook("https://" + settings.TEMBA_HOST + reverse('courier.tg', args=[channel.uuid]))
+        bot.set_webhook("https://" + settings.HOSTNAME + reverse('courier.tg', args=[channel.uuid]))
 
     def deactivate(self, channel):
         config = channel.config_json()

--- a/temba/channels/types/twilio/views.py
+++ b/temba/channels/types/twilio/views.py
@@ -101,12 +101,12 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         channel_uuid = uuid4()
 
         # create new TwiML app
-        new_receive_url = "https://" + settings.TEMBA_HOST + reverse('courier.t', args=[channel_uuid, 'receive'])
-        new_status_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['status', channel_uuid])
-        new_voice_url = "https://" + settings.TEMBA_HOST + reverse('handlers.twilio_handler', args=['voice', channel_uuid])
+        new_receive_url = "https://" + settings.HOSTNAME + reverse('courier.t', args=[channel_uuid, 'receive'])
+        new_status_url = "https://" + settings.HOSTNAME + reverse('handlers.twilio_handler', args=['status', channel_uuid])
+        new_voice_url = "https://" + settings.HOSTNAME + reverse('handlers.twilio_handler', args=['voice', channel_uuid])
 
         new_app = client.applications.create(
-            friendly_name="%s/%s" % (settings.TEMBA_HOST.lower(), channel_uuid),
+            friendly_name="%s/%s" % (settings.HOSTNAME.lower(), channel_uuid),
             sms_url=new_receive_url,
             sms_method="POST",
             voice_url=new_voice_url,
@@ -123,7 +123,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             if short_codes:
                 short_code = short_codes[0]
                 number_sid = short_code.sid
-                app_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('handlers.twilio_handler', args=['receive', channel_uuid])
+                app_url = "https://" + settings.HOSTNAME + "%s" % reverse('handlers.twilio_handler', args=['receive', channel_uuid])
                 client.sms.short_codes.update(number_sid, sms_url=app_url, sms_method='POST')
 
                 role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE

--- a/temba/channels/types/viber_public/type.py
+++ b/temba/channels/types/viber_public/type.py
@@ -37,7 +37,7 @@ class ViberPublicType(ChannelType):
 
     def activate(self, channel):
         auth_token = channel.config_json()['auth_token']
-        handler_url = "https://" + settings.TEMBA_HOST + reverse('courier.vp', args=[channel.uuid])
+        handler_url = "https://" + settings.HOSTNAME + reverse('courier.vp', args=[channel.uuid])
 
         requests.post('https://chatapi.viber.com/pa/set_webhook', json={
             'auth_token': auth_token,

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -508,7 +508,7 @@ class Flow(TembaModel):
         destination = Flow.get_node(run.flow, step.step_uuid, step.step_type)
         if isinstance(destination, RuleSet):
             response = call.channel.generate_ivr_response()
-            callback = 'https://%s%s' % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[call.pk]))
+            callback = 'https://%s%s' % (settings.HOSTNAME, reverse('ivr.ivrcall_handle', args=[call.pk]))
             gather = destination.get_voice_input(response, action=callback)
 
             # recordings have to be tacked on last
@@ -2955,7 +2955,7 @@ class FlowRun(models.Model):
             self.save(update_fields=('exit_type', 'exited_on', 'modified_on', 'is_active'))
 
         if hasattr(self, 'voice_response') and self.parent and self.parent.is_active:
-            callback = 'https://%s%s' % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[self.connection.pk]))
+            callback = 'https://%s%s' % (settings.HOSTNAME, reverse('ivr.ivrcall_handle', args=[self.connection.pk]))
             self.voice_response.redirect(url=callback + '?resume=1')
         else:
             # if we have a parent to continue
@@ -5839,7 +5839,7 @@ class StartFlowAction(Action):
         if run.flow.flow_type == Flow.VOICE and self.flow.flow_type == Flow.VOICE:
             new_run = self.flow.start([], [run.contact], started_flows=started_flows,
                                       restart_participants=True, extra=extra, parent_run=run)[0]
-            url = "https://%s%s" % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[new_run.connection.pk]))
+            url = "https://%s%s" % (settings.HOSTNAME, reverse('ivr.ivrcall_handle', args=[new_run.connection.pk]))
             run.voice_response.redirect(url)
         else:
             child_runs = self.flow.start([], [run.contact], started_flows=started_flows, restart_participants=True,

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1421,8 +1421,8 @@ class FlowCRUDL(SmartCRUDL):
             new_message = json_dict.get('new_message', '')
             media = None
 
-            from temba.settings import TEMBA_HOST, STATIC_URL
-            media_url = 'http://%s%simages' % (TEMBA_HOST, STATIC_URL)
+            from temba.settings import HOSTNAME, STATIC_URL
+            media_url = 'http://%s%simages' % (HOSTNAME, STATIC_URL)
 
             if 'new_photo' in json_dict:  # pragma: needs cover
                 media = '%s/png:%s/simulator_photo.png' % (Msg.MEDIA_IMAGE, media_url)

--- a/temba/ivr/clients.py
+++ b/temba/ivr/clients.py
@@ -56,7 +56,7 @@ class NexmoClient(NexmoCli):
             raise ServerError(message)
 
     def start_call(self, call, to, from_, status_callback):
-        url = 'https://%s%s' % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[call.pk]))
+        url = 'https://%s%s' % (settings.HOSTNAME, reverse('ivr.ivrcall_handle', args=[call.pk]))
 
         params = dict()
         params['answer_url'] = [url]

--- a/temba/ivr/migrations/0014_add_twilio_status_callback.py
+++ b/temba/ivr/migrations/0014_add_twilio_status_callback.py
@@ -33,8 +33,8 @@ def fix_twilio_twiml_apps(Org):
             client = get_twilio_client(twilio_org)
 
             if client:
-                app_name = "%s/%d" % (settings.TEMBA_HOST.lower(), twilio_org.pk)
-                app_url = "https://" + settings.TEMBA_HOST + "%s" % reverse('handlers.twilio_handler')
+                app_name = "%s/%d" % (settings.HOSTNAME.lower(), twilio_org.pk)
+                app_url = "https://" + settings.HOSTNAME + "%s" % reverse('handlers.twilio_handler')
 
                 try:
                     apps = client.applications.list(friendly_name=app_name)

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -66,7 +66,7 @@ class IVRCall(ChannelSession):
         from temba.flows.models import ActionLog, FlowRun
         if client:
             try:
-                url = "https://%s%s" % (settings.TEMBA_HOST, reverse('ivr.ivrcall_handle', args=[self.pk]))
+                url = "https://%s%s" % (settings.HOSTNAME, reverse('ivr.ivrcall_handle', args=[self.pk]))
                 if qs:  # pragma: no cover
                     url = "%s?%s" % (url, qs)
 

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -335,12 +335,12 @@ class IVRTests(FlowFileTest):
 
         # we have a record action
         self.assertContains(response, '"action": "record"')
-        self.assertContains(response, '"eventUrl": ["https://%s%s"]' % (settings.TEMBA_HOST, callback_url))
+        self.assertContains(response, '"eventUrl": ["https://%s%s"]' % (settings.HOSTNAME, callback_url))
 
         # we have an input to redirect so we save the recording
         # hack to make the recording look synchronous for our flows
         self.assertContains(response, '"action": "input"')
-        self.assertContains(response, '"eventUrl": ["https://%s%s?save_media=1"]' % (settings.TEMBA_HOST, callback_url))
+        self.assertContains(response, '"eventUrl": ["https://%s%s?save_media=1"]' % (settings.HOSTNAME, callback_url))
 
         # any request with has_event params return empty content response
         response = self.client.get("%s?has_event=1" % callback_url)
@@ -741,7 +741,7 @@ class IVRTests(FlowFileTest):
         # make sure we set submitOnHash to true nexmo
         self.assertContains(response, '"submitOnHash": true,')
 
-        self.assertContains(response, '"eventUrl": ["https://%s%s"]}]' % (settings.TEMBA_HOST, callback_url))
+        self.assertContains(response, '"eventUrl": ["https://%s%s"]}]' % (settings.HOSTNAME, callback_url))
 
     @patch('jwt.encode')
     @patch('requests.put')

--- a/temba/orgs/migrations/0032_fix_org_with_nexmo_config.py
+++ b/temba/orgs/migrations/0032_fix_org_with_nexmo_config.py
@@ -32,7 +32,7 @@ def update_nexmo_config(Org):
 
                 nx_client = nx.Client(key=nexmo_api_key, secret=nexmo_secret)
 
-                app_name = "%s/%s" % (settings.TEMBA_HOST.lower(), nexmo_uuid)
+                app_name = "%s/%s" % (settings.HOSTNAME.lower(), nexmo_uuid)
                 answer_url = reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid])
 
                 event_url = reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid])
@@ -66,7 +66,7 @@ def update_nexmo_config(Org):
                     mo_path = reverse('handlers.nexmo_handler', args=['receive', nexmo_uuid])
 
                     nexmo_client.update_nexmo_number(six.text_type(channel.country), channel.address,
-                                                     'https://%s%s' % (settings.TEMBA_HOST, mo_path),
+                                                     'https://%s%s' % (settings.HOSTNAME, mo_path),
                                                      app_id)
 
                     nexmo_phones = nexmo_client.get_numbers(channel.address)

--- a/temba/orgs/migrations/0033_fix_org_with_nexmo_config_absolute_urls.py
+++ b/temba/orgs/migrations/0033_fix_org_with_nexmo_config_absolute_urls.py
@@ -32,14 +32,14 @@ def update_nexmo_config(Org):
 
                 nx_client = nx.Client(key=nexmo_api_key, secret=nexmo_secret)
 
-                temba_host = settings.TEMBA_HOST.lower()
+                hostname = settings.HOSTNAME.lower()
 
-                app_name = "%s/%s" % (temba_host, nexmo_uuid)
+                app_name = "%s/%s" % (hostname, nexmo_uuid)
 
-                answer_url = "https://%s%s" % (temba_host,
+                answer_url = "https://%s%s" % (hostname,
                                                reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]))
 
-                event_url = "https://%s%s" % (temba_host,
+                event_url = "https://%s%s" % (hostname,
                                               reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]))
 
                 params = dict(name=app_name, type='voice', answer_url=answer_url, answer_method='POST',
@@ -70,7 +70,7 @@ def update_nexmo_config(Org):
                     mo_path = reverse('handlers.nexmo_handler', args=['receive', nexmo_uuid])
 
                     nexmo_client.update_nexmo_number(six.text_type(channel.country), channel.address,
-                                                     'https://%s%s' % (temba_host, mo_path),
+                                                     'https://%s%s' % (hostname, mo_path),
                                                      app_id)
 
                     nexmo_phones = nexmo_client.get_numbers(channel.address)

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -787,13 +787,13 @@ class Org(SmartModel):
         nexmo_uuid = str(uuid4())
         nexmo_config = {NEXMO_KEY: api_key.strip(), NEXMO_SECRET: api_secret.strip(), NEXMO_UUID: nexmo_uuid}
         client = NexmoClient(key=nexmo_config[NEXMO_KEY], secret=nexmo_config[NEXMO_SECRET])
-        temba_host = settings.TEMBA_HOST.lower()
+        hostname = settings.HOSTNAME.lower()
 
-        app_name = "%s/%s" % (temba_host, nexmo_uuid)
+        app_name = "%s/%s" % (hostname, nexmo_uuid)
 
-        answer_url = "https://%s%s" % (temba_host, reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]))
+        answer_url = "https://%s%s" % (hostname, reverse('handlers.nexmo_call_handler', args=['answer', nexmo_uuid]))
 
-        event_url = "https://%s%s" % (temba_host, reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]))
+        event_url = "https://%s%s" % (hostname, reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]))
 
         params = dict(name=app_name, type='voice', answer_url=answer_url, answer_method='POST',
                       event_url=event_url, event_method='POST')

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1603,12 +1603,12 @@ class OrgTest(TembaTest):
                 nexmo_uuid = self.org.config_json()['NEXMO_UUID']
 
                 self.assertEqual(mock_create_application.call_args_list[0][1]['params']['answer_url'],
-                                 "https://%s%s" % (settings.TEMBA_HOST.lower(),
+                                 "https://%s%s" % (settings.HOSTNAME.lower(),
                                                    reverse('handlers.nexmo_call_handler', args=['answer',
                                                                                                 nexmo_uuid])))
 
                 self.assertEqual(mock_create_application.call_args_list[0][1]['params']['event_url'],
-                                 "https://%s%s" % (settings.TEMBA_HOST.lower(),
+                                 "https://%s%s" % (settings.HOSTNAME.lower(),
                                                    reverse('handlers.nexmo_call_handler', args=['event',
                                                                                                 nexmo_uuid])))
 
@@ -1617,7 +1617,7 @@ class OrgTest(TembaTest):
 
                 self.assertEqual(mock_create_application.call_args_list[0][1]['params']['type'], 'voice')
                 self.assertEqual(mock_create_application.call_args_list[0][1]['params']['name'],
-                                 "%s/%s" % (settings.TEMBA_HOST.lower(), nexmo_uuid))
+                                 "%s/%s" % (settings.HOSTNAME.lower(), nexmo_uuid))
 
                 nexmo_account_url = reverse('orgs.org_nexmo_account')
                 response = self.client.get(nexmo_account_url)

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -652,9 +652,9 @@ class OrgCRUDL(SmartCRUDL):
             mo_path = reverse('courier.nx', args=[nexmo_uuid, 'receive'])
             dl_path = reverse('courier.nx', args=[nexmo_uuid, 'status'])
             try:
-                from temba.settings import TEMBA_HOST
-                nexmo_client.update_account('http://%s%s' % (TEMBA_HOST, mo_path),
-                                            'http://%s%s' % (TEMBA_HOST, dl_path))
+                from temba.settings import HOSTNAME
+                nexmo_client.update_account('http://%s%s' % (HOSTNAME, mo_path),
+                                            'http://%s%s' % (HOSTNAME, dl_path))
 
                 return HttpResponseRedirect(reverse("channels.claim_nexmo"))
 
@@ -664,7 +664,7 @@ class OrgCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super(OrgCRUDL.NexmoConfiguration, self).get_context_data(**kwargs)
 
-            from temba.settings import TEMBA_HOST
+            from temba.settings import HOSTNAME
             org = self.get_object()
             config = org.config_json()
             context['nexmo_api_key'] = config[NEXMO_KEY]
@@ -673,8 +673,8 @@ class OrgCRUDL(SmartCRUDL):
             nexmo_uuid = config.get(NEXMO_UUID, None)
             mo_path = reverse('courier.nx', args=[nexmo_uuid, 'receive'])
             dl_path = reverse('courier.nx', args=[nexmo_uuid, 'status'])
-            context['mo_path'] = 'https://%s%s' % (TEMBA_HOST, mo_path)
-            context['dl_path'] = 'https://%s%s' % (TEMBA_HOST, dl_path)
+            context['mo_path'] = 'https://%s%s' % (HOSTNAME, mo_path)
+            context['dl_path'] = 'https://%s%s' % (HOSTNAME, dl_path)
 
             return context
 

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -20,7 +20,6 @@ DEBUG_TOOLBAR = False
 # Used when creating callbacks for Twilio, Nexmo etc..
 # -----------------------------------------------------------------------------------
 HOSTNAME = 'temba.ngrok.io'
-TEMBA_HOST = 'temba.ngrok.io'
 ALLOWED_HOSTS = ['localhost', 'temba.ngrok.io']
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
We've been running with both of these being the same for the past few days so I think we are safe on this.

Next up, use brand specific hosts for whitelabels.