### PR TITLE
Import the color flow used in tests so it's always migrated to latest version

### DIFF
--- a/media/test_flows/color.json
+++ b/media/test_flows/color.json
@@ -1,139 +1,152 @@
 {
   "version": 8,
-  "flow_type": "F",
-  "base_language": "base",
-  "metadata": {
-    "author": "Ryan Lewis"
-  },
-  "entry": "d51ec25f-04e6-4349-a448-e7c4d93d4597",
-  "action_sets": [
+  "site": "http://rapidpro.io",
+  "flows": [
     {
-      "y": 1,
-      "x": 1,
-      "destination": "bd531ace-911e-4722-8e53-6730d6122fe1",
-      "uuid": "d51ec25f-04e6-4349-a448-e7c4d93d4597",
-      "actions": [
+      "version": 8,
+      "flow_type": "F",
+      "base_language": "base",
+      "metadata": {
+        "uuid": "2a385c5b-e27c-43ac-bbc6-49653fede421",
+        "author": "Ryan Lewis",
+        "name": "Color Flow"
+      },
+      "entry": "d51ec25f-04e6-4349-a448-e7c4d93d4597",
+      "action_sets": [
         {
-          "msg": {
-            "base": "What is your favorite color?",
-            "fre": "Quelle est votre couleur pr\u00e9f\u00e9r\u00e9e?"
-          },
-          "media": {},
-          "send_all": false,
-          "type": "reply"
+          "y": 1,
+          "x": 1,
+          "destination": "bd531ace-911e-4722-8e53-6730d6122fe1",
+          "uuid": "d51ec25f-04e6-4349-a448-e7c4d93d4597",
+          "actions": [
+            {
+              "msg": {
+                "base": "What is your favorite color?",
+                "fre": "Quelle est votre couleur pr\u00e9f\u00e9r\u00e9e?"
+              },
+              "media": {},
+              "send_all": false,
+              "type": "reply",
+              "uuid": "98388930-7a0f-4eb8-9a0a-09be2f006420"
+            }
+          ]
+        },
+        {
+          "y": 2,
+          "x": 2,
+          "destination": null,
+          "uuid": "7d40faea-723b-473d-8999-59fb7d3c3ca2",
+          "actions": [
+            {
+              "msg": {
+                "base": "I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow"
+              },
+              "media": {},
+              "send_all": false,
+              "type": "reply",
+              "uuid": "cf57f270-c9d7-4826-b3cc-7bfc22ac4ef6"
+            }
+          ]
+        },
+        {
+          "y": 3,
+          "x": 3,
+          "destination": null,
+          "uuid": "c12f37e2-8e6c-4c81-ba6d-941bb3caf93f",
+          "actions": [
+            {
+              "msg": {
+                "base": "Blue is sad. :("
+              },
+              "media": {},
+              "send_all": false,
+              "type": "reply",
+              "uuid": "d6aee40b-3710-4358-b0a6-c0ddc1d7734e"
+            }
+          ]
+        },
+        {
+          "y": 4,
+          "x": 4,
+          "destination": "bd531ace-911e-4722-8e53-6730d6122fe1",
+          "uuid": "1cb6d8da-3749-45b2-9382-3f756e3ca71f",
+          "actions": [
+            {
+              "msg": {
+                "base": "That is a funny color. Try again."
+              },
+              "media": {},
+              "send_all": false,
+              "type": "reply",
+              "uuid": "ca798d2d-2c95-468a-a857-74797a4d5301"
+            }
+          ]
         }
-      ]
-    },
-    {
-      "y": 2,
-      "x": 2,
-      "destination": null,
-      "uuid": "7d40faea-723b-473d-8999-59fb7d3c3ca2",
-      "actions": [
+      ],
+      "rule_sets": [
         {
-          "msg": {
-            "base": "I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow"
-          },
-          "media": {},
-          "send_all": false,
-          "type": "reply"
-        }
-      ]
-    },
-    {
-      "y": 3,
-      "x": 3,
-      "destination": null,
-      "uuid": "c12f37e2-8e6c-4c81-ba6d-941bb3caf93f",
-      "actions": [
-        {
-          "msg": {
-            "base": "Blue is sad. :("
-          },
-          "media": {},
-          "send_all": false,
-          "type": "reply"
-        }
-      ]
-    },
-    {
-      "y": 4,
-      "x": 4,
-      "destination": "bd531ace-911e-4722-8e53-6730d6122fe1",
-      "uuid": "1cb6d8da-3749-45b2-9382-3f756e3ca71f",
-      "actions": [
-        {
-          "msg": {
-            "base": "That is a funny color. Try again."
-          },
-          "media": {},
-          "send_all": false,
-          "type": "reply"
+          "uuid": "bd531ace-911e-4722-8e53-6730d6122fe1",
+          "rules": [
+            {
+              "category": {
+                "base": "Orange"
+              },
+              "test": {
+                "test": {
+                  "base": "orange"
+                },
+                "type": "contains"
+              },
+              "destination": "7d40faea-723b-473d-8999-59fb7d3c3ca2",
+              "uuid": "1c75fd71-027b-40e8-a819-151a0f8140e6",
+              "destination_type": "A"
+            },
+            {
+              "category": {
+                "base": "Blue"
+              },
+              "test": {
+                "test": {
+                  "base": "blue"
+                },
+                "type": "contains"
+              },
+              "destination": "c12f37e2-8e6c-4c81-ba6d-941bb3caf93f",
+              "uuid": "40cc7c36-b7c8-4f05-ae82-25275607e5aa",
+              "destination_type": "A"
+            },
+            {
+              "category": {
+                "base": "Other"
+              },
+              "test": {
+                "type": "true"
+              },
+              "destination": "1cb6d8da-3749-45b2-9382-3f756e3ca71f",
+              "uuid": "93998b50-6580-4574-8f60-74654df7d243",
+              "destination_type": "A"
+            },
+            {
+              "category": {
+                "base": "Nothing"
+              },
+              "test": {
+                "type": "true"
+              },
+              "uuid": "a51ff58e-17c2-4b00-8c8f-a6b6948aaa0b"
+            }
+          ],
+          "ruleset_type": "wait_message",
+          "label": "color",
+          "y": 5,
+          "finished_key": null,
+          "response_type": "",
+          "operand": null,
+          "x": 5,
+          "config": {}
         }
       ]
     }
   ],
-  "rule_sets": [
-    {
-      "uuid": "bd531ace-911e-4722-8e53-6730d6122fe1",
-      "rules": [
-        {
-          "category": {
-            "base": "Orange"
-          },
-          "test": {
-            "test": {
-              "base": "orange"
-            },
-            "type": "contains"
-          },
-          "destination": "7d40faea-723b-473d-8999-59fb7d3c3ca2",
-          "uuid": "1c75fd71-027b-40e8-a819-151a0f8140e6",
-          "destination_type": "A"
-        },
-        {
-          "category": {
-            "base": "Blue"
-          },
-          "test": {
-            "test": {
-              "base": "blue"
-            },
-            "type": "contains"
-          },
-          "destination": "c12f37e2-8e6c-4c81-ba6d-941bb3caf93f",
-          "uuid": "40cc7c36-b7c8-4f05-ae82-25275607e5aa",
-          "destination_type": "A"
-        },
-        {
-          "category": {
-            "base": "Other"
-          },
-          "test": {
-            "type": "true"
-          },
-          "destination": "1cb6d8da-3749-45b2-9382-3f756e3ca71f",
-          "uuid": "93998b50-6580-4574-8f60-74654df7d243",
-          "destination_type": "A"
-        },
-        {
-          "category": {
-            "base": "Nothing"
-          },
-          "test": {
-            "type": "true"
-          },
-          "uuid": "a51ff58e-17c2-4b00-8c8f-a6b6948aaa0b"
-        }
-      ],
-      "ruleset_type": "wait_message",
-      "label": "color",
-      "y": 5,
-      "finished_key": null,
-      "response_type": "",
-      "operand": null,
-      "x": 5,
-      "config": {}
-    }
-  ]
+  "triggers": []
 }

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -230,7 +230,7 @@ class WebHookTest(TembaTest):
         org = self.channel.org
         org.save()
 
-        flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow = self.get_flow('color')
 
         # replace our uuid of 4 with the right thing
         actionset = ActionSet.objects.get(x=4)

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -340,7 +340,7 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         # create our test flow
-        flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow = self.get_flow('color')
         flow_ruleset1 = RuleSet.objects.get(flow=flow)
 
         # this time, a 200
@@ -430,7 +430,7 @@ class APITest(TembaTest):
         url = reverse('api.v1.steps')
         self.login(self.surveyor)
 
-        flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow = self.get_flow('color')
 
         # remove our entry node
         ActionSet.objects.get(uuid=flow.entry_uuid).delete()
@@ -590,7 +590,11 @@ class APITest(TembaTest):
         # login as surveyor
         self.login(self.surveyor)
 
-        flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow = self.get_flow('color')
+        color_prompt = ActionSet.objects.get(x=1, y=1)
+        color_ruleset = RuleSet.objects.get(label="color")
+        orange_rule = color_ruleset.get_rules()[0]
+        color_reply = ActionSet.objects.get(x=2, y=2)
 
         # add an update action
         definition = flow.as_json()
@@ -613,7 +617,7 @@ class APITest(TembaTest):
                     submitted_by=self.surveyor.username,
                     started='2015-08-25T11:09:29.088Z',
                     steps=[
-                        dict(node='d51ec25f-04e6-4349-a448-e7c4d93d4597',
+                        dict(node=color_prompt.uuid,
                              arrived_on='2015-08-25T11:09:30.088Z',
                              actions=[
                                  dict(type="reply", msg="What is your favorite color?")
@@ -640,7 +644,7 @@ class APITest(TembaTest):
 
         steps = list(run.steps.order_by('pk'))
         self.assertEqual(len(steps), 1)
-        self.assertEqual(steps[0].step_uuid, "d51ec25f-04e6-4349-a448-e7c4d93d4597")
+        self.assertEqual(steps[0].step_uuid, color_prompt.uuid)
         self.assertEqual(steps[0].step_type, 'A')
         self.assertEqual(steps[0].rule_uuid, None)
         self.assertEqual(steps[0].rule_category, None)
@@ -663,7 +667,7 @@ class APITest(TembaTest):
                          {'total': 1, 'active': 1, 'completed': 0, 'expired': 0, 'interrupted': 0, 'completion': 0})
 
         # check flow activity
-        self.assertEqual(flow.get_activity(), ({'d51ec25f-04e6-4349-a448-e7c4d93d4597': 1}, {}))
+        self.assertEqual(flow.get_activity(), ({color_prompt.uuid: 1}, {}))
 
         data = dict(flow=flow.uuid,
                     revision=2,
@@ -671,13 +675,13 @@ class APITest(TembaTest):
                     started='2015-08-25T11:09:29.088Z',
                     submitted_by=self.surveyor.username,
                     steps=[
-                        dict(node='bd531ace-911e-4722-8e53-6730d6122fe1',
+                        dict(node=color_ruleset.uuid,
                              arrived_on='2015-08-25T11:11:30.088Z',
-                             rule=dict(uuid='1c75fd71-027b-40e8-a819-151a0f8140e6',
+                             rule=dict(uuid=orange_rule.uuid,
                                        value="orange",
                                        category="Orange",
                                        text="I like orange")),
-                        dict(node='7d40faea-723b-473d-8999-59fb7d3c3ca2',
+                        dict(node=color_reply.uuid,
                              arrived_on='2015-08-25T11:13:30.088Z',
                              actions=[
                                  dict(type="reply", msg="I love orange too!")
@@ -708,15 +712,15 @@ class APITest(TembaTest):
 
         steps = list(run.steps.order_by('pk'))
         self.assertEqual(steps[0].left_on, datetime(2015, 8, 25, 11, 11, 30, 88000, pytz.UTC))
-        self.assertEqual(steps[0].next_uuid, 'bd531ace-911e-4722-8e53-6730d6122fe1')
+        self.assertEqual(steps[0].next_uuid, color_ruleset.uuid)
 
-        self.assertEqual(steps[1].step_uuid, 'bd531ace-911e-4722-8e53-6730d6122fe1')
+        self.assertEqual(steps[1].step_uuid, color_ruleset.uuid)
         self.assertEqual(steps[1].step_type, 'R')
-        self.assertEqual(steps[1].rule_uuid, '1c75fd71-027b-40e8-a819-151a0f8140e6')
+        self.assertEqual(steps[1].rule_uuid, orange_rule.uuid)
         self.assertEqual(steps[1].rule_category, 'Orange')
         self.assertEqual(steps[1].rule_value, "orange")
         self.assertEqual(steps[1].rule_decimal_value, None)
-        self.assertEqual(steps[1].next_uuid, '7d40faea-723b-473d-8999-59fb7d3c3ca2')
+        self.assertEqual(steps[1].next_uuid, color_reply.uuid)
         self.assertEqual(steps[1].arrived_on, datetime(2015, 8, 25, 11, 11, 30, 88000, pytz.UTC))
         self.assertEqual(steps[1].left_on, datetime(2015, 8, 25, 11, 13, 30, 88000, pytz.UTC))
         self.assertEqual(steps[1].messages.count(), 1)
@@ -725,8 +729,8 @@ class APITest(TembaTest):
         value = Value.objects.get(org=self.org)
         self.assertEqual(value.contact, self.joe)
         self.assertEqual(value.run, run)
-        self.assertEqual(value.ruleset, RuleSet.objects.get(uuid='bd531ace-911e-4722-8e53-6730d6122fe1'))
-        self.assertEqual(value.rule_uuid, '1c75fd71-027b-40e8-a819-151a0f8140e6')
+        self.assertEqual(value.ruleset, RuleSet.objects.get(label="color"))
+        self.assertEqual(value.rule_uuid, orange_rule.uuid)
         self.assertEqual(value.string_value, 'orange')
         self.assertEqual(value.decimal_value, None)
         self.assertEqual(value.datetime_value, None)
@@ -739,7 +743,7 @@ class APITest(TembaTest):
         self.assertEqual(step1_msgs[0].contact_urn, None)
         self.assertEqual(step1_msgs[0].text, "I like orange")
 
-        self.assertEqual(steps[2].step_uuid, '7d40faea-723b-473d-8999-59fb7d3c3ca2')
+        self.assertEqual(steps[2].step_uuid, color_reply.uuid)
         self.assertEqual(steps[2].step_type, 'A')
         self.assertEqual(steps[2].rule_uuid, None)
         self.assertEqual(steps[2].rule_category, None)
@@ -764,9 +768,9 @@ class APITest(TembaTest):
 
         # check flow activity
         self.assertEqual(flow.get_activity(), ({},
-                                               {'7d40faea-723b-473d-8999-59fb7d3c3ca2:' + new_node_uuid: 1,
-                                                '1c75fd71-027b-40e8-a819-151a0f8140e6:7d40faea-723b-473d-8999-59fb7d3c3ca2': 1,
-                                                'd51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1': 1}))
+                                               {color_reply.uuid + ':' + new_node_uuid: 1,
+                                                orange_rule.uuid + ':' + color_reply.uuid: 1,
+                                                color_prompt.uuid + ':' + color_ruleset.uuid: 1}))
 
         # now lets remove our last action set
         definition['action_sets'].pop()
@@ -824,13 +828,13 @@ class APITest(TembaTest):
                         started='2015-08-25T11:09:29.088Z',
                         submitted_by=self.admin.username,
                         steps=[
-                            dict(node='bd531ace-911e-4722-8e53-6730d6122fe1',
+                            dict(node=color_ruleset.uuid,
                                  arrived_on='2015-08-25T11:11:30.088Z',
                                  rule=dict(uuid='abc5fd71-027b-40e8-a819-151a0f8140e6',
                                            value="orange",
                                            category="Orange",
                                            text="I like orange")),
-                            dict(node='7d40faea-723b-473d-8999-59fb7d3c3ca2',
+                            dict(node=color_reply.uuid,
                                  arrived_on='2015-08-25T11:13:30.088Z',
                                  actions=[
                                      dict(type="reply", msg="I love orange too!")

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1333,7 +1333,7 @@ class APITest(TembaTest):
         self.create_group("Developers", query="isdeveloper = YES")
 
         # start contacts in a flow
-        flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow = self.get_flow('color')
         flow.start([], [contact1, contact2, contact3])
 
         self.create_msg(direction='I', contact=contact1, text="Hello")
@@ -1636,17 +1636,17 @@ class APITest(TembaTest):
         self.assertEndpointAccess(url)
 
         registration = self.create_flow(name="Registration")
-        survey = self.create_flow(name="Survey", definition=self.COLOR_FLOW_DEFINITION)
+        color = self.get_flow('color')
 
         # add a campaign message flow that should be filtered out
         Flow.create_single_message(self.org, self.admin, dict(eng="Hello world"), 'eng')
 
         # add a flow label
         reporting = FlowLabel.objects.create(org=self.org, name="Reporting")
-        survey.labels.add(reporting)
+        color.labels.add(reporting)
 
         # run joe through through a flow
-        survey.start([], [self.joe])
+        color.start([], [self.joe])
         self.create_msg(direction='I', contact=self.joe, text="it is blue").handle()
 
         # flow belong to other org
@@ -1661,14 +1661,14 @@ class APITest(TembaTest):
         self.assertEqual(resp_json['next'], None)
         self.assertEqual(resp_json['results'], [
             {
-                'uuid': survey.uuid,
-                'name': "Survey",
+                'uuid': color.uuid,
+                'name': "Color Flow",
                 'archived': False,
                 'labels': [{'uuid': reporting.uuid, 'name': "Reporting"}],
                 'expires': 720,
                 'runs': {'active': 0, 'completed': 1, 'interrupted': 0, 'expired': 0},
-                'created_on': format_datetime(survey.created_on),
-                'modified_on': format_datetime(survey.modified_on)
+                'created_on': format_datetime(color.created_on),
+                'modified_on': format_datetime(color.modified_on)
             },
             {
                 'uuid': registration.uuid,
@@ -1683,16 +1683,16 @@ class APITest(TembaTest):
         ])
 
         # filter by UUID
-        response = self.fetchJSON(url, 'uuid=%s' % survey.uuid)
-        self.assertResultsByUUID(response, [survey])
+        response = self.fetchJSON(url, 'uuid=%s' % color.uuid)
+        self.assertResultsByUUID(response, [color])
 
         # filter by before
         response = self.fetchJSON(url, 'before=%s' % format_datetime(registration.modified_on))
         self.assertResultsByUUID(response, [registration])
 
         # filter by after
-        response = self.fetchJSON(url, 'after=%s' % format_datetime(survey.modified_on))
-        self.assertResultsByUUID(response, [survey])
+        response = self.fetchJSON(url, 'after=%s' % format_datetime(color.modified_on))
+        self.assertResultsByUUID(response, [color])
 
     @patch.object(ContactGroup, "MAX_ORG_CONTACTGROUPS", new=10)
     def test_groups(self):
@@ -2138,7 +2138,7 @@ class APITest(TembaTest):
         self.frank.language = 'fre'
         self.frank.save()
 
-        flow1 = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow1 = self.get_flow('color')
         flow2 = Flow.copy(flow1, self.user)
 
         start1 = FlowStart.create(flow1, self.admin, contacts=[self.joe], restart_participants=True)

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -20,7 +20,7 @@ from rest_framework.test import APIClient
 from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent
 from temba.contacts.models import Contact, ContactGroup, ContactField
-from temba.flows.models import Flow, FlowRun, FlowLabel, FlowStart, ReplyAction
+from temba.flows.models import Flow, FlowRun, FlowLabel, FlowStart, ReplyAction, ActionSet, RuleSet
 from temba.locations.models import BoundaryAlias
 from temba.msgs.models import Broadcast, Label, Msg
 from temba.orgs.models import Language
@@ -2141,6 +2141,10 @@ class APITest(TembaTest):
         flow1 = self.get_flow('color')
         flow2 = Flow.copy(flow1, self.user)
 
+        color_prompt = ActionSet.objects.get(flow=flow1, x=1, y=1)
+        color_ruleset = RuleSet.objects.get(flow=flow1, label="color")
+        blue_reply = ActionSet.objects.get(flow=flow1, x=3, y=3)
+
         start1 = FlowStart.create(flow1, self.admin, contacts=[self.joe], restart_participants=True)
 
         joe_run1, = start1.start()
@@ -2186,8 +2190,8 @@ class APITest(TembaTest):
             'start': None,
             'responded': False,
             'path': [
-                {'node': "d51ec25f-04e6-4349-a448-e7c4d93d4597", 'time': format_datetime(frank_run2_steps[0].arrived_on)},
-                {'node': "bd531ace-911e-4722-8e53-6730d6122fe1", 'time': format_datetime(frank_run2_steps[1].arrived_on)}
+                {'node': color_prompt.uuid, 'time': format_datetime(frank_run2_steps[0].arrived_on)},
+                {'node': color_ruleset.uuid, 'time': format_datetime(frank_run2_steps[1].arrived_on)}
             ],
             'values': {},
             'created_on': format_datetime(frank_run2.created_on),
@@ -2202,16 +2206,16 @@ class APITest(TembaTest):
             'start': {'uuid': str(joe_run1.start.uuid)},
             'responded': True,
             'path': [
-                {'node': "d51ec25f-04e6-4349-a448-e7c4d93d4597", 'time': format_datetime(joe_run1_steps[0].arrived_on)},
-                {'node': "bd531ace-911e-4722-8e53-6730d6122fe1", 'time': format_datetime(joe_run1_steps[1].arrived_on)},
-                {'node': "c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", 'time': format_datetime(joe_run1_steps[2].arrived_on)}
+                {'node': color_prompt.uuid, 'time': format_datetime(joe_run1_steps[0].arrived_on)},
+                {'node': color_ruleset.uuid, 'time': format_datetime(joe_run1_steps[1].arrived_on)},
+                {'node': blue_reply.uuid, 'time': format_datetime(joe_run1_steps[2].arrived_on)}
             ],
             'values': {
                 'color': {
                     'value': "blue",
                     'category': "Blue",
-                    'node': "bd531ace-911e-4722-8e53-6730d6122fe1",
-                    'time': format_datetime(self.joe.values.get(ruleset__uuid="bd531ace-911e-4722-8e53-6730d6122fe1").modified_on)
+                    'node': color_ruleset.uuid,
+                    'time': format_datetime(self.joe.values.get(ruleset=color_ruleset).modified_on)
                 }
             },
             'created_on': format_datetime(joe_run1.created_on),

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -576,7 +576,7 @@ class ContactTest(TembaTest):
     def create_campaign(self):
         # create a campaign with a future event and add joe
         self.farmers = self.create_group("Farmers", [self.joe])
-        self.reminder_flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        self.reminder_flow = self.get_flow('color')
         self.planting_date = ContactField.get_or_create(self.org, self.admin, 'planting_date', "Planting Date")
         self.campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -60,7 +60,7 @@ class FlowTest(TembaTest):
         self.contact2 = self.create_contact('Nic', '+250788383383')
         self.contact3 = self.create_contact('Norbert', '+250788123456')
 
-        self.flow = self.create_flow(name="Color Flow", base_language='base', definition=self.COLOR_FLOW_DEFINITION)
+        self.flow = self.get_flow('color')
 
         self.other_group = self.create_group("Other", [])
 
@@ -442,7 +442,10 @@ class FlowTest(TembaTest):
 
     def test_states(self):
         # set our flow
-        entry = ActionSet.objects.filter(uuid=self.flow.entry_uuid)[0]
+        color_prompt = ActionSet.objects.get(x=1, y=1)
+        color_ruleset = RuleSet.objects.get(label="color")
+        orange_rule = color_ruleset.get_rules()[0]
+        color_reply = ActionSet.objects.get(x=2, y=2)
 
         # how many people in the flow?
         self.assertEqual(self.flow.get_run_stats(),
@@ -484,18 +487,18 @@ class FlowTest(TembaTest):
         self.assertEqual(len(contact2_steps), 2)
 
         # check our steps for contact #1
-        self.assertEqual(six.text_type(contact1_steps[0]), "Eric - A:d51ec25f-04e6-4349-a448-e7c4d93d4597")
-        self.assertEqual(contact1_steps[0].step_uuid, entry.uuid)
+        self.assertEqual(six.text_type(contact1_steps[0]), "Eric - A:" + color_prompt.uuid)
+        self.assertEqual(contact1_steps[0].step_uuid, color_prompt.uuid)
         self.assertEqual(contact1_steps[0].step_type, FlowStep.TYPE_ACTION_SET)
         self.assertEqual(contact1_steps[0].contact, self.contact)
         self.assertTrue(contact1_steps[0].arrived_on)
         self.assertTrue(contact1_steps[0].left_on)
         self.assertEqual(set(contact1_steps[0].broadcasts.all()), {broadcast})
         self.assertEqual(set(contact1_steps[0].messages.all()), {contact1_msg})
-        self.assertEqual(contact1_steps[0].next_uuid, entry.destination)
+        self.assertEqual(contact1_steps[0].next_uuid, color_prompt.destination)
 
-        self.assertEqual(six.text_type(contact1_steps[1]), "Eric - R:bd531ace-911e-4722-8e53-6730d6122fe1")
-        self.assertEqual(contact1_steps[1].step_uuid, entry.destination)
+        self.assertEqual(six.text_type(contact1_steps[1]), "Eric - R:" + color_ruleset.uuid)
+        self.assertEqual(contact1_steps[1].step_uuid, color_ruleset.uuid)
         self.assertEqual(contact1_steps[1].step_type, FlowStep.TYPE_RULE_SET)
         self.assertEqual(contact1_steps[1].contact, self.contact)
         self.assertTrue(contact1_steps[1].arrived_on)
@@ -506,10 +509,10 @@ class FlowTest(TembaTest):
         # check equivalent "steps" in the path fields
         contact1_path = contact1_run.get_path()
         self.assertEqual(len(contact1_path), 2)
-        self.assertEqual(contact1_path[0]['node_uuid'], entry.uuid)
+        self.assertEqual(contact1_path[0]['node_uuid'], color_prompt.uuid)
         self.assertEqual(contact1_path[0]['arrived_on'], contact1_steps[0].arrived_on.isoformat())
-        self.assertNotIn('exit_uuid', contact1_path[0])
-        self.assertEqual(contact1_path[1]['node_uuid'], entry.destination)
+        self.assertEqual(contact1_path[0]['exit_uuid'], color_prompt.exit_uuid)
+        self.assertEqual(contact1_path[1]['node_uuid'], color_ruleset.uuid)
         self.assertEqual(contact1_path[1]['arrived_on'], contact1_steps[1].arrived_on.isoformat())
         self.assertNotIn('exit_uuid', contact1_path[1])
 
@@ -524,15 +527,15 @@ class FlowTest(TembaTest):
         test_message = self.create_msg(contact=test_contact, text='Hi')
 
         activity = json.loads(self.client.get(reverse('flows.flow_activity', args=[self.flow.pk])).content)
-        self.assertEqual(2, activity['visited']["d51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1"])
-        self.assertEqual(2, activity['activity']["bd531ace-911e-4722-8e53-6730d6122fe1"])
+        self.assertEqual(2, activity['visited'][color_prompt.uuid + ":" + color_ruleset.uuid])
+        self.assertEqual(2, activity['activity'][color_ruleset.uuid])
         self.assertEqual(activity['messages'], [])
 
         # check activity with IVR test call
         IVRCall.create_incoming(self.channel, test_contact, test_contact.get_urn(), self.admin, 'CallSid')
         activity = json.loads(self.client.get(reverse('flows.flow_activity', args=[self.flow.pk])).content)
-        self.assertEqual(2, activity['visited']["d51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1"])
-        self.assertEqual(2, activity['activity']["bd531ace-911e-4722-8e53-6730d6122fe1"])
+        self.assertEqual(2, activity['visited'][color_prompt.uuid + ":" + color_ruleset.uuid])
+        self.assertEqual(2, activity['activity'][color_ruleset.uuid])
         self.assertTrue(activity['messages'], [test_message.as_json()])
 
         # set the flow as inactive, shouldn't react to replies
@@ -574,16 +577,16 @@ class FlowTest(TembaTest):
         self.assertEqual(step.messages.all()[0].msg_type, 'F')
 
         # it should contain what rule matched and what came next
-        self.assertEqual("1c75fd71-027b-40e8-a819-151a0f8140e6", step.rule_uuid)
+        self.assertEqual(orange_rule.uuid, step.rule_uuid)
         self.assertEqual("Orange", step.rule_category)
         self.assertEqual("orange", step.rule_value)
         self.assertFalse(step.rule_decimal_value)
-        self.assertEqual("7d40faea-723b-473d-8999-59fb7d3c3ca2", step.next_uuid)
+        self.assertEqual(color_reply.uuid, step.next_uuid)
         self.assertTrue(incoming in step.messages.all())
 
         # we should also have a Value for this RuleSet
         value = Value.objects.get(run=step.run, ruleset__label="color")
-        self.assertEqual("1c75fd71-027b-40e8-a819-151a0f8140e6", value.rule_uuid)
+        self.assertEqual(orange_rule.uuid, value.rule_uuid)
         self.assertEqual("Orange", value.category)
         self.assertEqual("orange", value.string_value)
         self.assertEqual(None, value.decimal_value)
@@ -666,7 +669,7 @@ class FlowTest(TembaTest):
         self.assertEqual('color', color['label'])
         self.assertEqual('Orange', color['category']['base'])
         self.assertEqual('orange', color['value'])
-        self.assertEqual("bd531ace-911e-4722-8e53-6730d6122fe1", color['node'])
+        self.assertEqual(color_ruleset.uuid, color['node'])
         self.assertEqual(incoming.text, color['text'])
 
     def test_anon_export_results(self):
@@ -1249,31 +1252,28 @@ class FlowTest(TembaTest):
         # our flow should have the appropriate RuleSet and ActionSet objects
         self.assertEqual(4, ActionSet.objects.all().count())
 
-        entry = ActionSet.objects.get(uuid="d51ec25f-04e6-4349-a448-e7c4d93d4597")
+        entry = ActionSet.objects.get(x=1, y=1)
         actions = entry.get_actions()
         self.assertEqual(len(actions), 1)
         self.assertIsInstance(actions[0], ReplyAction)
         self.assertEqual(actions[0].msg, dict(base="What is your favorite color?", fre="Quelle est votre couleur préférée?"))
         self.assertEqual(entry.uuid, self.flow.entry_uuid)
 
-        orange = ActionSet.objects.get(uuid="7d40faea-723b-473d-8999-59fb7d3c3ca2")
+        orange = ActionSet.objects.get(x=2, y=2)
         actions = orange.get_actions()
         self.assertEqual(1, len(actions))
         self.assertEqual(ReplyAction(actions[0].uuid, dict(base='I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow')).as_json(), actions[0].as_json())
 
         self.assertEqual(1, RuleSet.objects.all().count())
-        ruleset = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
+        ruleset = RuleSet.objects.get(label="color")
         self.assertEqual(entry.destination, ruleset.uuid)
         rules = ruleset.get_rules()
         self.assertEqual(4, len(rules))
 
         # check ordering
-        self.assertEqual("7d40faea-723b-473d-8999-59fb7d3c3ca2", rules[0].destination)
-        self.assertEqual("1c75fd71-027b-40e8-a819-151a0f8140e6", rules[0].uuid)
-        self.assertEqual("c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", rules[1].destination)
-        self.assertEqual("40cc7c36-b7c8-4f05-ae82-25275607e5aa", rules[1].uuid)
-        self.assertEqual("1cb6d8da-3749-45b2-9382-3f756e3ca71f", rules[2].destination)
-        self.assertEqual("93998b50-6580-4574-8f60-74654df7d243", rules[2].uuid)
+        self.assertEqual(rules[0].category['base'], "Orange")
+        self.assertEqual(rules[1].category['base'], "Blue")
+        self.assertEqual(rules[2].category['base'], "Other")
 
         # check routing
         self.assertEqual(ContainsTest(test=dict(base="orange")).as_json(), rules[0].test.as_json())
@@ -1307,27 +1307,27 @@ class FlowTest(TembaTest):
 
         self.assertEqual(3, ActionSet.objects.all().count())
 
-        entry = ActionSet.objects.get(uuid="d51ec25f-04e6-4349-a448-e7c4d93d4597")
+        entry = ActionSet.objects.get(x=1, y=1)
         actions = entry.get_actions()
         self.assertEqual(len(actions), 1)
         self.assertIsInstance(actions[0], ReplyAction)
         self.assertEqual(actions[0].msg, dict(base="What is your favorite color?", fre="Quelle est votre couleur préférée?"))
         self.assertEqual(entry.uuid, self.flow.entry_uuid)
 
-        orange = ActionSet.objects.get(uuid="7d40faea-723b-473d-8999-59fb7d3c3ca2")
+        orange = ActionSet.objects.get(x=2, y=2)
         actions = orange.get_actions()
         self.assertEqual(1, len(actions))
         self.assertEqual(ReplyAction(actions[0].uuid, dict(base='I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow')).as_json(), actions[0].as_json())
 
         self.assertEqual(1, RuleSet.objects.all().count())
-        ruleset = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
+        ruleset = RuleSet.objects.get(label="color")
         self.assertEqual(entry.destination, ruleset.uuid)
         rules = ruleset.get_rules()
         self.assertEqual(3, len(rules))
 
         # check ordering
-        self.assertEqual("7d40faea-723b-473d-8999-59fb7d3c3ca2", rules[0].destination)
-        self.assertEqual("c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", rules[1].destination)
+        self.assertEqual(rules[0].category['base'], "Orange")
+        self.assertEqual(rules[1].category['base'], "Blue")
 
         # check routing
         self.assertEqual(ContainsTest(test=dict(base="orange")).as_json(), rules[0].test.as_json())
@@ -1339,13 +1339,13 @@ class FlowTest(TembaTest):
         self.flow.update(json_dict)
 
         # now check they are truncated to the max lengths
-        ruleset = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
+        ruleset = RuleSet.objects.get()
         self.assertEqual(64, len(ruleset.label))
         self.assertEqual(128, len(ruleset.operand))
 
     def test_expanding(self):
         # add actions for adding to a group and messaging a contact, we'll test how these expand
-        action_set = ActionSet.objects.get(uuid="1cb6d8da-3749-45b2-9382-3f756e3ca71f")
+        action_set = ActionSet.objects.get(x=4, y=4)
 
         actions = [AddToGroupAction(str(uuid4()), [self.other_group]).as_json(),
                    SendAction(str(uuid4()), "Outgoing Message", [self.other_group], [self.contact], []).as_json()]
@@ -1918,7 +1918,7 @@ class FlowTest(TembaTest):
         self.assertEqual(SendAction, Action.from_json(org, dict(type='send', msg=dict(base="hello world"), contacts=[], groups=[], variables=[])).__class__)
 
     def test_decimal_values(self):
-        rules = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
+        rules = RuleSet.objects.get(label="color")
 
         # update our rule to include decimal parsing
         rules.set_rules_dict([
@@ -1945,7 +1945,7 @@ class FlowTest(TembaTest):
         sms = self.create_msg(direction=INCOMING, contact=self.contact, text="My answer is 15")
         self.assertTrue(Flow.find_and_handle(sms)[0])
 
-        step = FlowStep.objects.get(step_uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
+        step = FlowStep.objects.get(step_uuid=rules.uuid)
         self.assertEqual("> 10", step.rule_category)
         self.assertEqual("40cc7c36-b7c8-4f05-ae82-25275607e5aa", step.rule_uuid)
         self.assertEqual("15", step.rule_value)
@@ -1955,13 +1955,13 @@ class FlowTest(TembaTest):
         run = FlowRun.objects.get(flow=self.flow, contact=self.contact)
         results = run.get_results()
         self.assertEqual("15", results['color']['value'])
-        self.assertEqual("bd531ace-911e-4722-8e53-6730d6122fe1", results['color']['node_uuid'])
+        self.assertEqual(rules.uuid, results['color']['node_uuid'])
         self.assertEqual("> 10", results['color']['category'])
         self.assertEqual("color", results['color']['name'])
         self.assertIsNotNone(results['color']['created_on'])
 
         # and that the category counts have been updated
-        self.assertIsNotNone(FlowCategoryCount.objects.filter(node_uuid='bd531ace-911e-4722-8e53-6730d6122fe1', category_name='> 10',
+        self.assertIsNotNone(FlowCategoryCount.objects.filter(node_uuid=rules.uuid, category_name='> 10',
                                                               result_name='color', result_key='color', count=1).first())
 
     def test_location_entry_test(self):
@@ -2863,7 +2863,7 @@ class ActionTest(TembaTest):
         self.contact = self.create_contact('Eric', '+250788382382')
         self.contact2 = self.create_contact('Nic', '+250788383383')
 
-        self.flow = self.create_flow(name="Empty Flow", base_language='base', definition=self.COLOR_FLOW_DEFINITION)
+        self.flow = self.get_flow('color')
 
         self.other_group = self.create_group("Other", [])
 
@@ -3497,7 +3497,6 @@ class ActionTest(TembaTest):
         self.assertIsNone(Contact.objects.get(pk=self.contact.pk).language)
 
     def test_start_flow_action(self):
-        self.flow.update(self.COLOR_FLOW_DEFINITION)
         self.flow.name = 'Parent'
         self.flow.save()
 
@@ -3805,7 +3804,7 @@ class ActionTest(TembaTest):
             'time': ['2015-10-27T14:07:30.000006Z'],
             'steps': ['[]'],
             'contact_name': ['Eric'],
-            'flow_name': ['Empty Flow'],
+            'flow_name': ['Color Flow'],
             'channel': ['-1']
         }, authorization='Token 12345', user_agent='RapidPro')
 
@@ -3837,7 +3836,7 @@ class ActionTest(TembaTest):
             'time': ['2015-10-27T14:07:30.000006Z'],
             'steps': ['[]'],
             'contact_name': ['Eric'],
-            'flow_name': ['Empty Flow'],
+            'flow_name': ['Color Flow'],
             'relayer': [str(msg.channel.id)]
         }, authorization='Token 12345', user_agent='RapidPro')
 
@@ -3866,7 +3865,7 @@ class FlowRunTest(TembaTest):
     def setUp(self):
         super(FlowRunTest, self).setUp()
 
-        self.flow = self.create_flow()
+        self.flow = self.get_flow('color')
         self.contact = self.create_contact("Ben Haggerty", "+250788123123")
 
     def test_field_normalization(self):
@@ -3940,7 +3939,6 @@ class FlowRunTest(TembaTest):
         self.assertEqual(run.field_dict(), {"0": "zero", "1": "one", "2": "two"})
 
     def test_is_completed(self):
-        self.flow.update(self.COLOR_FLOW_DEFINITION)
         self.flow.start([], [self.contact])
 
         self.assertFalse(FlowRun.objects.get(contact=self.contact).is_completed())
@@ -4122,7 +4120,7 @@ class WebhookTest(TembaTest):
         self.assertAllRequestsMade()
 
     def test_webhook(self):
-        self.flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        self.flow = self.get_flow('color')
         self.contact = self.create_contact("Ben Haggerty", '+250788383383')
 
         run = FlowRun.create(self.flow, self.contact.pk)

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -1880,7 +1880,7 @@ class ConsoleTest(TembaTest):
         self.john = self.create_contact("John Doe", "0788123123")
 
         # create a flow and set "color" as its trigger
-        self.flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        self.flow = self.get_flow('color')
         Trigger.objects.create(flow=self.flow, keyword="color", created_by=self.admin, modified_by=self.admin, org=self.org)
 
     def assertEchoed(self, needle, clear=True):

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1981,7 +1981,7 @@ class AnonOrgTest(TembaTest):
         self.assertNotContains(response, "123123")
 
         # create a flow
-        flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow = self.get_flow('color')
 
         # start the contact down it
         flow.start([], [contact])

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -157,13 +157,6 @@ def add_testing_flag_to_context(*args):
 
 
 class TembaTest(SmartminTest):
-    @classmethod
-    def setUpClass(cls):
-        super(TembaTest, cls).setUpClass()
-
-        with open('%s/test_flows/color.json' % settings.MEDIA_ROOT, 'r') as f:
-            cls.COLOR_FLOW_DEFINITION = json.load(f)
-
     def setUp(self):
         self.mock_server = mock_server
 

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -809,7 +809,7 @@ class TriggerTest(TembaTest):
     def test_catch_all_trigger(self):
         self.login(self.admin)
         catch_all_trigger = Trigger.get_triggers_of_type(self.org, Trigger.TYPE_CATCH_ALL).first()
-        flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
+        flow = self.get_flow('color')
 
         contact = self.create_contact("Ali", "250788739305")
 


### PR DESCRIPTION
Currently this test flow is loaded as a static definition, assumed to be at the latest export version. This PR changes it to be like every other test flow.