### PR TITLE
yapf formatting and fixes

### DIFF
--- a/temba/airtime/models.py
+++ b/temba/airtime/models.py
@@ -23,17 +23,17 @@ class AirtimeTransfer(SmartModel):
     SUCCESS = 'S'
     FAILED = 'F'
 
-    STATUS_CHOICES = ((PENDING, "Pending"),
-                      (SUCCESS, "Success"),
-                      (FAILED, "Failed"))
+    STATUS_CHOICES = ((PENDING, "Pending"), (SUCCESS, "Success"), (FAILED, "Failed"))
 
     org = models.ForeignKey(Org, help_text="The organization that this airtime was triggered for")
 
-    status = models.CharField(max_length=1, choices=STATUS_CHOICES, default='P',
-                              help_text="The state this event is currently in")
+    status = models.CharField(
+        max_length=1, choices=STATUS_CHOICES, default='P', help_text="The state this event is currently in"
+    )
 
-    channel = models.ForeignKey(Channel, null=True, blank=True,
-                                help_text="The channel that this airtime is relating to")
+    channel = models.ForeignKey(
+        Channel, null=True, blank=True, help_text="The channel that this airtime is relating to"
+    )
 
     contact = models.ForeignKey(Contact, help_text="The contact that this airtime is sent to")
 
@@ -47,8 +47,9 @@ class AirtimeTransfer(SmartModel):
 
     response = models.TextField(null=True, blank=True, default="")
 
-    message = models.CharField(max_length=255, null=True, blank=True,
-                               help_text="A message describing the end status, error messages go here")
+    message = models.CharField(
+        max_length=255, null=True, blank=True, help_text="A message describing the end status, error messages go here"
+    )
 
     @classmethod
     def post_transferto_api_response(cls, login, token, airtime_obj=None, **kwargs):
@@ -109,8 +110,15 @@ class AirtimeTransfer(SmartModel):
         if not contact_urn:
             contact_urn = contact.get_urn(TEL_SCHEME)
 
-        airtime = AirtimeTransfer.objects.create(org=org, channel=channel, contact=contact, recipient=contact_urn.path,
-                                                 amount=0, created_by=api_user, modified_by=api_user)
+        airtime = AirtimeTransfer.objects.create(
+            org=org,
+            channel=channel,
+            contact=contact,
+            recipient=contact_urn.path,
+            amount=0,
+            created_by=api_user,
+            modified_by=api_user
+        )
 
         message = "None"
         try:
@@ -128,8 +136,12 @@ class AirtimeTransfer(SmartModel):
                 account_currency = config.get(TRANSFERTO_ACCOUNT_CURRENCY, '')
 
             action = 'msisdn_info'
-            request_kwargs = dict(action=action, destination_msisdn=airtime.recipient, currency=account_currency,
-                                  delivered_amount_info='1')
+            request_kwargs = dict(
+                action=action,
+                destination_msisdn=airtime.recipient,
+                currency=account_currency,
+                delivered_amount_info='1'
+            )
             response = airtime.get_transferto_response(**request_kwargs)
             content_json = AirtimeTransfer.parse_transferto_response(response.content)
 
@@ -215,12 +227,14 @@ class AirtimeTransfer(SmartModel):
             transaction_id = content_json.get('reserved_id')
 
             action = 'topup'
-            request_kwargs = dict(action=action,
-                                  reserved_id=transaction_id,
-                                  msisdn=channel.address if channel else '',
-                                  destination_msisdn=airtime.recipient,
-                                  currency=account_currency,
-                                  product=airtime.denomination)
+            request_kwargs = dict(
+                action=action,
+                reserved_id=transaction_id,
+                msisdn=channel.address if channel else '',
+                destination_msisdn=airtime.recipient,
+                currency=account_currency,
+                product=airtime.denomination
+            )
 
             if skuid:
                 request_kwargs['skuid'] = skuid

--- a/temba/airtime/views.py
+++ b/temba/airtime/views.py
@@ -13,9 +13,9 @@ class AirtimeCRUDL(SmartCRUDL):
     class List(OrgPermsMixin, SmartListView):
         fields = ('status', 'message', 'amount', 'contact', 'created_on')
         title = _("Recent Airtime Transfers")
-        default_order = ('-created_on',)
+        default_order = ('-created_on', )
         field_config = dict(created_on=dict(label="Time"))
-        link_fields = ('message',)
+        link_fields = ('message', )
 
         def get_status(self, obj):
             return obj.get_status_display()
@@ -52,8 +52,7 @@ class AirtimeCRUDL(SmartCRUDL):
 
         def derive_fields(self):
             if self.show_logs():
-                return ('contact', 'status', 'channel', 'amount', 'message',
-                        'recipient', 'denomination', 'created_on')
+                return ('contact', 'status', 'channel', 'amount', 'message', 'recipient', 'denomination', 'created_on')
 
             return ('contact', 'status', 'channel', 'amount', 'message', 'created_on')  # pragma: needs cover
 

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -46,6 +46,7 @@ class OrgRateThrottle(ScopedRateThrottle):
     """
     Throttle class which rate limits across an org
     """
+
     def get_cache_key(self, request, view):
         ident = None
         if request.user.is_authenticated():
@@ -61,6 +62,7 @@ class DocumentationRenderer(BrowsableAPIRenderer):
     The regular REST framework browsable API renderer includes a form on each endpoint. We don't provide that and
     instead have a separate API explorer page. This render then just displays the endpoint docs.
     """
+
     def get_context(self, data, accepted_media_type, renderer_context):
         view = renderer_context['view']
         request = renderer_context['request']

--- a/temba/api/tasks.py
+++ b/temba/api/tasks.py
@@ -39,17 +39,23 @@ def retry_events_task():  # pragma: no cover
 
     # get all events that have an error and need to be retried
     now = timezone.now()
-    for event in WebHookEvent.objects.filter(status=WebHookEvent.STATUS_ERRORED, next_attempt__lte=now).exclude(event=WebHookEvent.TYPE_FLOW):
+    for event in WebHookEvent.objects.filter(
+        status=WebHookEvent.STATUS_ERRORED, next_attempt__lte=now
+    ).exclude(event=WebHookEvent.TYPE_FLOW):
         deliver_event_task.delay(event.pk)
 
     # also get those over five minutes old that are still pending
     five_minutes_ago = now - timedelta(minutes=5)
-    for event in WebHookEvent.objects.filter(status=WebHookEvent.STATUS_PENDING, created_on__lte=five_minutes_ago).exclude(event=WebHookEvent.TYPE_FLOW):
+    for event in WebHookEvent.objects.filter(
+        status=WebHookEvent.STATUS_PENDING, created_on__lte=five_minutes_ago
+    ).exclude(event=WebHookEvent.TYPE_FLOW):
         deliver_event_task.delay(event.pk)
 
     # and any that were errored and haven't been retried for some reason
     fifteen_minutes_ago = now - timedelta(minutes=15)
-    for event in WebHookEvent.objects.filter(status=WebHookEvent.STATUS_ERRORED, modified_on__lte=fifteen_minutes_ago).exclude(event=WebHookEvent.TYPE_FLOW):
+    for event in WebHookEvent.objects.filter(
+        status=WebHookEvent.STATUS_ERRORED, modified_on__lte=fifteen_minutes_ago
+    ).exclude(event=WebHookEvent.TYPE_FLOW):
         deliver_event_task.delay(event.pk)
 
 

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -69,10 +69,13 @@ class APITokenTest(TembaTest):
         self.assertEqual(set(APIToken.get_orgs_for_role(self.admin, self.surveyors_group)), {self.org, self.org2})
 
     def test_get_allowed_roles(self):
-        self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.admin)),
-                         {self.admins_group, self.editors_group, self.surveyors_group})
-        self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.editor)),
-                         {self.editors_group, self.surveyors_group})
+        self.assertEqual(
+            set(APIToken.get_allowed_roles(self.org, self.admin)),
+            {self.admins_group, self.editors_group, self.surveyors_group}
+        )
+        self.assertEqual(
+            set(APIToken.get_allowed_roles(self.org, self.editor)), {self.editors_group, self.surveyors_group}
+        )
         self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.surveyor)), {self.surveyors_group})
         self.assertEqual(set(APIToken.get_allowed_roles(self.org, self.user)), set())
 
@@ -90,7 +93,6 @@ class APITokenTest(TembaTest):
 
 
 class WebHookTest(TembaTest):
-
     def setUp(self):
         super(WebHookTest, self).setUp()
         self.joe = self.create_contact("Joe Blow", "0788123123")
@@ -112,12 +114,14 @@ class WebHookTest(TembaTest):
     def test_call_deliveries(self):
         self.setupChannel()
         now = timezone.now()
-        call = ChannelEvent.objects.create(org=self.org,
-                                           channel=self.channel,
-                                           contact=self.joe,
-                                           contact_urn=self.joe.get_urn(),
-                                           event_type=ChannelEvent.TYPE_CALL_IN_MISSED,
-                                           occurred_on=now)
+        call = ChannelEvent.objects.create(
+            org=self.org,
+            channel=self.channel,
+            contact=self.joe,
+            contact_urn=self.joe.get_urn(),
+            event_type=ChannelEvent.TYPE_CALL_IN_MISSED,
+            occurred_on=now
+        )
 
         self.setupChannel()
 
@@ -167,16 +171,18 @@ class WebHookTest(TembaTest):
             self.assertEqual(self.channel.pk, int(data['channel'][0]))
 
     def test_alarm_deliveries(self):
-        sync_event = SyncEvent.objects.create(channel=self.channel,
-                                              power_source='AC',
-                                              power_status='CHARGING',
-                                              power_level=85,
-                                              network_type='WIFI',
-                                              pending_message_count=5,
-                                              retry_message_count=4,
-                                              incoming_command_count=0,
-                                              created_by=self.admin,
-                                              modified_by=self.admin)
+        sync_event = SyncEvent.objects.create(
+            channel=self.channel,
+            power_source='AC',
+            power_status='CHARGING',
+            power_level=85,
+            network_type='WIFI',
+            pending_message_count=5,
+            retry_message_count=4,
+            incoming_command_count=0,
+            created_by=self.admin,
+            modified_by=self.admin
+        )
 
         self.setupChannel()
 
@@ -241,8 +247,13 @@ class WebHookTest(TembaTest):
         flow.start([], [self.joe])
 
         # have joe reply with mauve, which will put him in the other category that triggers the API Action
-        sms = self.create_msg(contact=self.joe, direction='I', status='H', text="Mauve",
-                              attachments=["image/jpeg:http://s3.com/text.jpg", "audio/mp4:http://s3.com/text.mp4"])
+        sms = self.create_msg(
+            contact=self.joe,
+            direction='I',
+            status='H',
+            text="Mauve",
+            attachments=["image/jpeg:http://s3.com/text.jpg", "audio/mp4:http://s3.com/text.mp4"]
+        )
 
         mock_send.return_value = MockResponse(200, "{}")
         Flow.find_and_handle(sms)
@@ -510,7 +521,9 @@ class WebHookTest(TembaTest):
             self.assertTrue(mock.called)
 
             broadcast = Broadcast.objects.get()
-            contact = Contact.get_or_create(self.org, self.admin, name=None, urns=["tel:+250788123123"], channel=self.channel)
+            contact = Contact.get_or_create(
+                self.org, self.admin, name=None, urns=["tel:+250788123123"], channel=self.channel
+            )
             self.assertTrue(broadcast.text, {'base': "I am success"})
             self.assertTrue(contact, broadcast.contacts.all())
 
@@ -587,10 +600,8 @@ class WebHookTest(TembaTest):
         # check that our webhook settings have saved
         self.assertEqual('http://fake.com/webhook.php', self.channel.org.get_webhook_url())
         self.assertDictEqual({
-            'X-My-Header':
-            'foobar',
-            'Authorization':
-            'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
+            'X-My-Header': 'foobar',
+            'Authorization': 'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
         }, self.channel.org.get_webhook_headers())
 
         with patch('requests.Session.send') as mock:
@@ -626,8 +637,10 @@ class WebHookTest(TembaTest):
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(200, '{ "phone": "+250788123123", "text": "I am success" }')
 
-            response = self.client.post(reverse('api.webhook_tunnel'),
-                                        dict(url="http://webhook.url/", data="phone=250788383383&values=foo&bogus=2"))
+            response = self.client.post(
+                reverse('api.webhook_tunnel'),
+                dict(url="http://webhook.url/", data="phone=250788383383&values=foo&bogus=2")
+            )
             self.assertEqual(200, response.status_code)
             self.assertContains(response, "I am success")
             self.assertTrue('values' in mock.call_args[1]['data'])

--- a/temba/api/urls.py
+++ b/temba/api/urls.py
@@ -7,21 +7,25 @@ from django.views.generic import RedirectView
 from .views import RefreshAPITokenView, ResthookList
 from .views import WebHookEventListView, WebHookEventReadView, WebHookView, WebHookSimulatorView, WebHookTunnelView
 
-
 urlpatterns = [
     url(r'^api/$', RedirectView.as_view(pattern_name='api.v2', permanent=False), name='api'),
     url(r'^api/v1/', include('temba.api.v1.urls')),
     url(r'^api/v2/', include('temba.api.v2.urls')),
     url(r'^api/apitoken/refresh/$', RefreshAPITokenView.as_view(), name='api.apitoken_refresh'),
-
-    url(r'^webhooks/', include([
-        url(r'^log/$', WebHookEventListView.as_view(), name='api.log'),
-        url(r'^log/(?P<pk>\d+)/$', WebHookEventReadView.as_view(), name='api.log_read'),
-        url(r'^webhook/$', WebHookView.as_view(), name='api.webhook'),
-        url(r'^webhook/simulator/$', WebHookSimulatorView.as_view(), name='api.webhook_simulator'),
-        url(r'^webhook/tunnel/$', login_required(csrf_protect(WebHookTunnelView.as_view())), name='api.webhook_tunnel')
-    ])),
-
+    url(
+        r'^webhooks/',
+        include([
+            url(r'^log/$', WebHookEventListView.as_view(), name='api.log'),
+            url(r'^log/(?P<pk>\d+)/$', WebHookEventReadView.as_view(), name='api.log_read'),
+            url(r'^webhook/$', WebHookView.as_view(), name='api.webhook'),
+            url(r'^webhook/simulator/$', WebHookSimulatorView.as_view(), name='api.webhook_simulator'),
+            url(
+                r'^webhook/tunnel/$',
+                login_required(csrf_protect(WebHookTunnelView.as_view())),
+                name='api.webhook_tunnel'
+            )
+        ])
+    ),
     url(r'^api/resthooks/', include([
         url(r'^$', ResthookList.as_view(), name='api.resthook_list'),
     ])),

--- a/temba/api/v1/__init__.py
+++ b/temba/api/v1/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, unicode_literals
-
 """
 A subset of the former API v1 retained for Android Surveyor clients
 """

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -32,20 +32,22 @@ from .serializers import MsgCreateSerializer
 
 
 class APITest(TembaTest):
-
     def setUp(self):
         super(APITest, self).setUp()
 
         self.joe = self.create_contact("Joe Blow", "0788123123")
 
-        self.channel2 = Channel.create(None, self.admin, 'RW', 'A', "Unclaimed Channel",
-                                       claim_code="123123123", secret="123456", gcm_id="1234")
+        self.channel2 = Channel.create(
+            None, self.admin, 'RW', 'A', "Unclaimed Channel", claim_code="123123123", secret="123456", gcm_id="1234"
+        )
 
-        self.call1 = ChannelEvent.objects.create(contact=self.joe,
-                                                 channel=self.channel,
-                                                 org=self.org,
-                                                 event_type=ChannelEvent.TYPE_CALL_OUT_MISSED,
-                                                 occurred_on=timezone.now())
+        self.call1 = ChannelEvent.objects.create(
+            contact=self.joe,
+            channel=self.channel,
+            org=self.org,
+            event_type=ChannelEvent.TYPE_CALL_OUT_MISSED,
+            occurred_on=timezone.now()
+        )
 
         # this is needed to prevent REST framework from rolling back transaction created around each unit test
         connection.settings_dict['ATOMIC_REQUESTS'] = False
@@ -73,7 +75,9 @@ class APITest(TembaTest):
         return response
 
     def postJSON(self, url, data):
-        return self.client.post(url + ".json", json.dumps(data), content_type="application/json", HTTP_X_FORWARDED_HTTPS='https')
+        return self.client.post(
+            url + ".json", json.dumps(data), content_type="application/json", HTTP_X_FORWARDED_HTTPS='https'
+        )
 
     def deleteJSON(self, url, query=None):
         url = url + ".json"
@@ -151,7 +155,9 @@ class APITest(TembaTest):
 
         self.assertEqual(dict_field.to_internal_value({'a': '123'}), {'a': '123'})
         self.assertRaises(ValidationError, dict_field.to_internal_value, [])  # must be a dict
-        self.assertRaises(ValidationError, dict_field.to_internal_value, {123: '456'})  # keys and values must be strings
+        self.assertRaises(ValidationError, dict_field.to_internal_value, {
+            123: '456'
+        })  # keys and values must be strings
 
         strings_field = StringArrayField(source='test')
 
@@ -183,21 +189,33 @@ class APITest(TembaTest):
         url = reverse('api.v1.org') + '.json'
 
         # can't fetch endpoint with invalid token
-        response = self.client.get(url, content_type="application/json",
-                                   HTTP_X_FORWARDED_HTTPS='https', HTTP_AUTHORIZATION="Token 1234567890")
+        response = self.client.get(
+            url,
+            content_type="application/json",
+            HTTP_X_FORWARDED_HTTPS='https',
+            HTTP_AUTHORIZATION="Token 1234567890"
+        )
         self.assertEqual(response.status_code, 403)
 
         # can fetch endpoint with valid token
-        response = self.client.get(url, content_type="application/json",
-                                   HTTP_X_FORWARDED_HTTPS='https', HTTP_AUTHORIZATION="Token %s" % self.surveyor.api_token)
+        response = self.client.get(
+            url,
+            content_type="application/json",
+            HTTP_X_FORWARDED_HTTPS='https',
+            HTTP_AUTHORIZATION="Token %s" % self.surveyor.api_token
+        )
         self.assertEqual(response.status_code, 200)
 
         # but not if user is inactive
         self.surveyor.is_active = False
         self.surveyor.save()
 
-        response = self.client.get(url, content_type="application/json",
-                                   HTTP_X_FORWARDED_HTTPS='https', HTTP_AUTHORIZATION="Token %s" % self.surveyor.api_token)
+        response = self.client.get(
+            url,
+            content_type="application/json",
+            HTTP_X_FORWARDED_HTTPS='https',
+            HTTP_AUTHORIZATION="Token %s" % self.surveyor.api_token
+        )
         self.assertEqual(response.status_code, 403)
 
     def test_api_org(self):
@@ -220,13 +238,18 @@ class APITest(TembaTest):
         # fetch as JSON
         response = self.fetchJSON(url)
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.json(), dict(name="Temba",
-                                               country="RW",
-                                               languages=[],
-                                               primary_language=None,
-                                               timezone="Africa/Kigali",
-                                               date_style="day_first",
-                                               anon=False))
+        self.assertEqual(
+            response.json(),
+            dict(
+                name="Temba",
+                country="RW",
+                languages=[],
+                primary_language=None,
+                timezone="Africa/Kigali",
+                date_style="day_first",
+                anon=False
+            )
+        )
 
         eng = Language.create(self.org, self.admin, "English", 'eng')
         Language.create(self.org, self.admin, "French", 'fre')
@@ -235,13 +258,18 @@ class APITest(TembaTest):
 
         response = self.fetchJSON(url)
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.json(), dict(name="Temba",
-                                               country="RW",
-                                               languages=["eng", "fre"],
-                                               primary_language="eng",
-                                               timezone="Africa/Kigali",
-                                               date_style="day_first",
-                                               anon=False))
+        self.assertEqual(
+            response.json(),
+            dict(
+                name="Temba",
+                country="RW",
+                languages=["eng", "fre"],
+                primary_language="eng",
+                timezone="Africa/Kigali",
+                date_style="day_first",
+                anon=False
+            )
+        )
 
     def test_api_boundaries(self):
         url = reverse('api.v1.boundaries')
@@ -275,39 +303,33 @@ class APITest(TembaTest):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()['results']), 10)
-        self.assertEqual(response.json()['results'][2], {
-            'boundary': "1708283",
-            'name': "Kigali City",
-            'parent': "171496",
-            'level': 1,
-            'geometry': {
-                'type': "MultiPolygon",
-                'coordinates': [
-                    [
-                        [
-                            [1.0, 1.0],
-                            [1.0, -1.0],
-                            [-1.0, -1.0],
-                            [-1.0, 1.0],
-                            [1.0, 1.0]
-                        ]
-                    ]
-                ],
-            },
-        })
+        self.assertEqual(
+            response.json()['results'][2], {
+                'boundary': "1708283",
+                'name': "Kigali City",
+                'parent': "171496",
+                'level': 1,
+                'geometry': {
+                    'type': "MultiPolygon",
+                    'coordinates': [[[[1.0, 1.0], [1.0, -1.0], [-1.0, -1.0], [-1.0, 1.0], [1.0, 1.0]]]],
+                },
+            }
+        )
 
         # test with aliases instead of geometry
         response = self.fetchJSON(url, 'aliases=true')
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()['results']), 10)
-        self.assertEqual(response.json()['results'][2], {
-            'boundary': "1708283",
-            'name': "Kigali City",
-            'parent': "171496",
-            'level': 1,
-            'aliases': ["Kigali", "Kigari"],
-        })
+        self.assertEqual(
+            response.json()['results'][2], {
+                'boundary': "1708283",
+                'name': "Kigali City",
+                'parent': "171496",
+                'level': 1,
+                'aliases': ["Kigali", "Kigari"],
+            }
+        )
 
     def test_api_flows(self):
         url = reverse('api.v1.flows')
@@ -348,21 +370,30 @@ class APITest(TembaTest):
         self.assertEqual(200, response.status_code)
 
         # should contain our single flow in the response
-        self.assertEqual(response.json()['results'][0], dict(flow=flow.pk,
-                                                             uuid=flow.uuid,
-                                                             name='Color Flow',
-                                                             labels=[],
-                                                             runs=0,
-                                                             completed_runs=0,
-                                                             participants=None,
-                                                             rulesets=[dict(node=flow_ruleset1.uuid,
-                                                                            id=flow_ruleset1.pk,
-                                                                            response_type='C',
-                                                                            ruleset_type='wait_message',
-                                                                            label='color')],
-                                                             created_on=datetime_to_json_date(flow.created_on),
-                                                             expires=flow.expires_after_minutes,
-                                                             archived=False))
+        self.assertEqual(
+            response.json()['results'][0],
+            dict(
+                flow=flow.pk,
+                uuid=flow.uuid,
+                name='Color Flow',
+                labels=[],
+                runs=0,
+                completed_runs=0,
+                participants=None,
+                rulesets=[
+                    dict(
+                        node=flow_ruleset1.uuid,
+                        id=flow_ruleset1.pk,
+                        response_type='C',
+                        ruleset_type='wait_message',
+                        label='color'
+                    )
+                ],
+                created_on=datetime_to_json_date(flow.created_on),
+                expires=flow.expires_after_minutes,
+                archived=False
+            )
+        )
 
         # filter by archived
         flow.is_archived = True
@@ -441,17 +472,14 @@ class APITest(TembaTest):
         flow.save()
 
         # post that someone arrived at this ruleset, but never replied
-        data = dict(flow=flow.uuid,
-                    revision=1,
-                    contact=self.joe.uuid,
-                    started='2015-08-25T11:09:29.088Z',
-                    steps=[
-                        dict(node=flow.entry_uuid,
-                             arrived_on='2015-08-25T11:09:30.088Z',
-                             actions=[],
-                             rule=None)
-                    ],
-                    completed=False)
+        data = dict(
+            flow=flow.uuid,
+            revision=1,
+            contact=self.joe.uuid,
+            started='2015-08-25T11:09:29.088Z',
+            steps=[dict(node=flow.entry_uuid, arrived_on='2015-08-25T11:09:30.088Z', actions=[], rule=None)],
+            completed=False
+        )
 
         with patch.object(timezone, 'now', return_value=datetime(2015, 9, 15, 0, 0, 0, 0, pytz.UTC)):
             self.postJSON(url, data)
@@ -477,8 +505,16 @@ class APITest(TembaTest):
         self.assertEqual(steps[0].next_uuid, None)
 
         # check flow stats
-        self.assertEqual(flow.get_run_stats(),
-                         {'total': 1, 'active': 1, 'completed': 0, 'expired': 0, 'interrupted': 0, 'completion': 0})
+        self.assertEqual(
+            flow.get_run_stats(), {
+                'total': 1,
+                'active': 1,
+                'completed': 0,
+                'expired': 0,
+                'interrupted': 0,
+                'completion': 0
+            }
+        )
 
         # check flow activity
         self.assertEqual(flow.get_activity(), ({flow.entry_uuid: 1}, {}))
@@ -506,35 +542,52 @@ class APITest(TembaTest):
             steps=[
 
                 # the contact name
-                dict(node=ruleset_name.uuid,
-                     arrived_on='2015-08-25T11:11:30.000Z',
-                     rule=dict(uuid=ruleset_name.get_rules()[0].uuid,
-                               value="Marshawn",
-                               category="All Responses",
-                               text="Marshawn")),
+                dict(
+                    node=ruleset_name.uuid,
+                    arrived_on='2015-08-25T11:11:30.000Z',
+                    rule=dict(
+                        uuid=ruleset_name.get_rules()[0].uuid,
+                        value="Marshawn",
+                        category="All Responses",
+                        text="Marshawn"
+                    )
+                ),
 
                 # location ruleset
-                dict(node=ruleset_location.uuid,
-                     arrived_on='2015-08-25T11:12:30.000Z',
-                     rule=dict(uuid=ruleset_location.get_rules()[0].uuid,
-                               category="All Responses",
-                               media="geo:47.7579804,-121.0821648")),
+                dict(
+                    node=ruleset_location.uuid,
+                    arrived_on='2015-08-25T11:12:30.000Z',
+                    rule=dict(
+                        uuid=ruleset_location.get_rules()[0].uuid,
+                        category="All Responses",
+                        media="geo:47.7579804,-121.0821648"
+                    )
+                ),
 
                 # a picture of steve
-                dict(node=ruleset_photo.uuid,
-                     arrived_on='2015-08-25T11:13:30.000Z',
-                     rule=dict(uuid=ruleset_photo.get_rules()[0].uuid,
-                               category="All Responses",
-                               media="image/jpeg:http://testserver/media/steve.jpg")),
+                dict(
+                    node=ruleset_photo.uuid,
+                    arrived_on='2015-08-25T11:13:30.000Z',
+                    rule=dict(
+                        uuid=ruleset_photo.get_rules()[0].uuid,
+                        category="All Responses",
+                        media="image/jpeg:http://testserver/media/steve.jpg"
+                    )
+                ),
 
                 # a video
-                dict(node=ruleset_video.uuid,
-                     arrived_on='2015-08-25T11:13:30.000Z',
-                     rule=dict(uuid=ruleset_video.get_rules()[0].uuid,
-                               category="All Responses",
-                               media="video/mp4:http://testserver/media/snow.mp4")),
+                dict(
+                    node=ruleset_video.uuid,
+                    arrived_on='2015-08-25T11:13:30.000Z',
+                    rule=dict(
+                        uuid=ruleset_video.get_rules()[0].uuid,
+                        category="All Responses",
+                        media="video/mp4:http://testserver/media/snow.mp4"
+                    )
+                ),
             ],
-            completed=False)
+            completed=False
+        )
 
         with patch.object(timezone, 'now', return_value=datetime(2015, 9, 16, 0, 0, 0, 0, pytz.UTC)):
 
@@ -597,29 +650,38 @@ class APITest(TembaTest):
         new_node_uuid = str(uuid4())
 
         # add a new action set
-        definition['action_sets'].append(dict(uuid=new_node_uuid, x=100, y=4, destination=None,
-                                              actions=[
-                                                  dict(type='save', field='tel_e164', value='+12065551212'),
-                                                  dict(type='del_group', group=dict(name='Remove Me'))
-                                              ]))
+        definition['action_sets'].append(
+            dict(
+                uuid=new_node_uuid,
+                x=100,
+                y=4,
+                destination=None,
+                actions=[
+                    dict(type='save', field='tel_e164', value='+12065551212'),
+                    dict(type='del_group', group=dict(name='Remove Me'))
+                ]
+            )
+        )
 
         # point one of our nodes to it
         definition['action_sets'][1]['destination'] = new_node_uuid
 
         flow.update(definition)
-        data = dict(flow=flow.uuid,
-                    revision=2,
-                    contact=self.joe.uuid,
-                    submitted_by=self.surveyor.username,
-                    started='2015-08-25T11:09:29.088Z',
-                    steps=[
-                        dict(node='d51ec25f-04e6-4349-a448-e7c4d93d4597',
-                             arrived_on='2015-08-25T11:09:30.088Z',
-                             actions=[
-                                 dict(type="reply", msg="What is your favorite color?")
-                             ])
-                    ],
-                    completed=False)
+        data = dict(
+            flow=flow.uuid,
+            revision=2,
+            contact=self.joe.uuid,
+            submitted_by=self.surveyor.username,
+            started='2015-08-25T11:09:29.088Z',
+            steps=[
+                dict(
+                    node='d51ec25f-04e6-4349-a448-e7c4d93d4597',
+                    arrived_on='2015-08-25T11:09:30.088Z',
+                    actions=[dict(type="reply", msg="What is your favorite color?")]
+                )
+            ],
+            completed=False
+        )
 
         # make our org brand different from the default brand
         # this is to make sure surveyor submissions work when
@@ -659,37 +721,53 @@ class APITest(TembaTest):
         self.assertEqual(out_msgs[0].created_on, datetime(2015, 8, 25, 11, 9, 30, 88000, pytz.UTC))
 
         # check flow stats
-        self.assertEqual(flow.get_run_stats(),
-                         {'total': 1, 'active': 1, 'completed': 0, 'expired': 0, 'interrupted': 0, 'completion': 0})
+        self.assertEqual(
+            flow.get_run_stats(), {
+                'total': 1,
+                'active': 1,
+                'completed': 0,
+                'expired': 0,
+                'interrupted': 0,
+                'completion': 0
+            }
+        )
 
         # check flow activity
         self.assertEqual(flow.get_activity(), ({'d51ec25f-04e6-4349-a448-e7c4d93d4597': 1}, {}))
 
-        data = dict(flow=flow.uuid,
-                    revision=2,
-                    contact=self.joe.uuid,
-                    started='2015-08-25T11:09:29.088Z',
-                    submitted_by=self.surveyor.username,
-                    steps=[
-                        dict(node='bd531ace-911e-4722-8e53-6730d6122fe1',
-                             arrived_on='2015-08-25T11:11:30.088Z',
-                             rule=dict(uuid='1c75fd71-027b-40e8-a819-151a0f8140e6',
-                                       value="orange",
-                                       category="Orange",
-                                       text="I like orange")),
-                        dict(node='7d40faea-723b-473d-8999-59fb7d3c3ca2',
-                             arrived_on='2015-08-25T11:13:30.088Z',
-                             actions=[
-                                 dict(type="reply", msg="I love orange too!")
-                             ]),
-                        dict(node=new_node_uuid,
-                             arrived_on='2015-08-25T11:15:30.088Z',
-                             actions=[
-                                 dict(type="save", field="tel_e164", value="+12065551212"),
-                                 dict(type="del_group", group=dict(name="Remove Me"))
-                             ]),
-                    ],
-                    completed=True)
+        data = dict(
+            flow=flow.uuid,
+            revision=2,
+            contact=self.joe.uuid,
+            started='2015-08-25T11:09:29.088Z',
+            submitted_by=self.surveyor.username,
+            steps=[
+                dict(
+                    node='bd531ace-911e-4722-8e53-6730d6122fe1',
+                    arrived_on='2015-08-25T11:11:30.088Z',
+                    rule=dict(
+                        uuid='1c75fd71-027b-40e8-a819-151a0f8140e6',
+                        value="orange",
+                        category="Orange",
+                        text="I like orange"
+                    )
+                ),
+                dict(
+                    node='7d40faea-723b-473d-8999-59fb7d3c3ca2',
+                    arrived_on='2015-08-25T11:13:30.088Z',
+                    actions=[dict(type="reply", msg="I love orange too!")]
+                ),
+                dict(
+                    node=new_node_uuid,
+                    arrived_on='2015-08-25T11:15:30.088Z',
+                    actions=[
+                        dict(type="save", field="tel_e164", value="+12065551212"),
+                        dict(type="del_group", group=dict(name="Remove Me"))
+                    ]
+                ),
+            ],
+            completed=True
+        )
 
         with patch.object(timezone, 'now', return_value=datetime(2015, 9, 16, 0, 0, 0, 0, pytz.UTC)):
             self.postJSON(url, data)
@@ -759,14 +837,25 @@ class APITest(TembaTest):
         self.assertEqual(out_msgs[1].response_to, step1_msgs[0])
 
         # check flow stats
-        self.assertEqual(flow.get_run_stats(),
-                         {'total': 1, 'active': 0, 'completed': 1, 'expired': 0, 'interrupted': 0, 'completion': 100})
+        self.assertEqual(
+            flow.get_run_stats(), {
+                'total': 1,
+                'active': 0,
+                'completed': 1,
+                'expired': 0,
+                'interrupted': 0,
+                'completion': 100
+            }
+        )
 
         # check flow activity
-        self.assertEqual(flow.get_activity(), ({},
-                                               {'7d40faea-723b-473d-8999-59fb7d3c3ca2:' + new_node_uuid: 1,
-                                                '1c75fd71-027b-40e8-a819-151a0f8140e6:7d40faea-723b-473d-8999-59fb7d3c3ca2': 1,
-                                                'd51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1': 1}))
+        self.assertEqual(
+            flow.get_activity(), ({}, {
+                '7d40faea-723b-473d-8999-59fb7d3c3ca2:' + new_node_uuid: 1,
+                '1c75fd71-027b-40e8-a819-151a0f8140e6:7d40faea-723b-473d-8999-59fb7d3c3ca2': 1,
+                'd51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1': 1
+            })
+        )
 
         # now lets remove our last action set
         definition['action_sets'].pop()
@@ -774,18 +863,20 @@ class APITest(TembaTest):
         flow.update(definition)
 
         # update a value for our missing node
-        data = dict(flow=flow.uuid,
-                    revision=2,
-                    contact=self.joe.uuid,
-                    started='2015-08-26T11:09:29.088Z',
-                    steps=[
-                        dict(node=new_node_uuid,
-                             arrived_on='2015-08-26T11:15:30.088Z',
-                             actions=[
-                                 dict(type="save", field="tel_e164", value="+13605551212")
-                             ]),
-                    ],
-                    completed=True)
+        data = dict(
+            flow=flow.uuid,
+            revision=2,
+            contact=self.joe.uuid,
+            started='2015-08-26T11:09:29.088Z',
+            steps=[
+                dict(
+                    node=new_node_uuid,
+                    arrived_on='2015-08-26T11:15:30.088Z',
+                    actions=[dict(type="save", field="tel_e164", value="+13605551212")]
+                ),
+            ],
+            completed=True
+        )
 
         with patch.object(timezone, 'now', return_value=datetime(2015, 9, 16, 0, 0, 0, 0, pytz.UTC)):
 
@@ -793,7 +884,9 @@ class APITest(TembaTest):
             data['revision'] = 3
             response = self.postJSON(url, data)
             self.assertEqual(400, response.status_code)
-            self.assertResponseError(response, 'non_field_errors', "No such node with UUID %s in flow 'Color Flow'" % new_node_uuid)
+            self.assertResponseError(
+                response, 'non_field_errors', "No such node with UUID %s in flow 'Color Flow'" % new_node_uuid
+            )
 
             # this version doesn't exist
             data['revision'] = 12
@@ -818,31 +911,39 @@ class APITest(TembaTest):
             self.assertIsNotNone(self.joe.urns.filter(path='+13605551212').first())
 
             # rule uuid not existing we should find the actual matching rule
-            data = dict(flow=flow.uuid,
-                        revision=2,
-                        contact=self.joe.uuid,
-                        started='2015-08-25T11:09:29.088Z',
-                        submitted_by=self.admin.username,
-                        steps=[
-                            dict(node='bd531ace-911e-4722-8e53-6730d6122fe1',
-                                 arrived_on='2015-08-25T11:11:30.088Z',
-                                 rule=dict(uuid='abc5fd71-027b-40e8-a819-151a0f8140e6',
-                                           value="orange",
-                                           category="Orange",
-                                           text="I like orange")),
-                            dict(node='7d40faea-723b-473d-8999-59fb7d3c3ca2',
-                                 arrived_on='2015-08-25T11:13:30.088Z',
-                                 actions=[
-                                     dict(type="reply", msg="I love orange too!")
-                                 ]),
-                            dict(node=new_node_uuid,
-                                 arrived_on='2015-08-25T11:15:30.088Z',
-                                 actions=[
-                                     dict(type="save", field="tel_e164", value="+12065551212"),
-                                     dict(type="del_group", group=dict(name="Remove Me"))
-                                 ]),
-                        ],
-                        completed=True)
+            data = dict(
+                flow=flow.uuid,
+                revision=2,
+                contact=self.joe.uuid,
+                started='2015-08-25T11:09:29.088Z',
+                submitted_by=self.admin.username,
+                steps=[
+                    dict(
+                        node='bd531ace-911e-4722-8e53-6730d6122fe1',
+                        arrived_on='2015-08-25T11:11:30.088Z',
+                        rule=dict(
+                            uuid='abc5fd71-027b-40e8-a819-151a0f8140e6',
+                            value="orange",
+                            category="Orange",
+                            text="I like orange"
+                        )
+                    ),
+                    dict(
+                        node='7d40faea-723b-473d-8999-59fb7d3c3ca2',
+                        arrived_on='2015-08-25T11:13:30.088Z',
+                        actions=[dict(type="reply", msg="I love orange too!")]
+                    ),
+                    dict(
+                        node=new_node_uuid,
+                        arrived_on='2015-08-25T11:15:30.088Z',
+                        actions=[
+                            dict(type="save", field="tel_e164", value="+12065551212"),
+                            dict(type="del_group", group=dict(name="Remove Me"))
+                        ]
+                    ),
+                ],
+                completed=True
+            )
 
             response = self.postJSON(url, data)
             self.assertEqual(201, response.status_code)
@@ -950,7 +1051,9 @@ class APITest(TembaTest):
 
         # try to update with both phone and urns field
         response = self.postJSON(url, dict(name='Eminem', phone='+250788123456', urns=['tel:+250788123456']))
-        self.assertResponseError(response, 'non_field_errors', "Cannot provide both urns and phone parameters together")
+        self.assertResponseError(
+            response, 'non_field_errors', "Cannot provide both urns and phone parameters together"
+        )
 
         # clearing the contact name is allowed
         response = self.postJSON(url, dict(name="", uuid=contact.uuid))
@@ -998,11 +1101,15 @@ class APITest(TembaTest):
 
             # but can't update phone
             response = self.postJSON(url, dict(name="Anon", uuid=contact.uuid, phone='+250788123456'))
-            self.assertResponseError(response, 'non_field_errors', "Cannot update contact URNs on anonymous organizations")
+            self.assertResponseError(
+                response, 'non_field_errors', "Cannot update contact URNs on anonymous organizations"
+            )
 
             # or URNs
             response = self.postJSON(url, dict(name="Anon", uuid=contact.uuid, urns=['tel:+250788123456']))
-            self.assertResponseError(response, 'non_field_errors', "Cannot update contact URNs on anonymous organizations")
+            self.assertResponseError(
+                response, 'non_field_errors', "Cannot update contact URNs on anonymous organizations"
+            )
 
         # finally try clearing our language
         response = self.postJSON(url, dict(phone='+250788123456', language=None))
@@ -1110,13 +1217,15 @@ class APITest(TembaTest):
         state.save()
         response = self.postJSON(url, dict(phone='+250788123456', fields={"state": "VA"}))
         self.assertEqual(response.status_code, 201)
-        self.assertEqual("VA", Value.objects.get(contact=contact, contact_field=state).string_value)   # unchanged
+        self.assertEqual("VA", Value.objects.get(contact=contact, contact_field=state).string_value)  # unchanged
 
         drdre = Contact.objects.get()
 
         # add another contact
         jay_z = self.create_contact("Jay-Z", number="+250784444444")
-        ContactField.get_or_create(self.org, self.admin, 'registration_date', "Registration Date", None, Value.TYPE_DATETIME)
+        ContactField.get_or_create(
+            self.org, self.admin, 'registration_date', "Registration Date", None, Value.TYPE_DATETIME
+        )
         jay_z.set_field(self.user, 'registration_date', "2014-12-31 03:04:00")
 
         # try to update using URNs from two different contacts
@@ -1141,17 +1250,26 @@ class APITest(TembaTest):
 
         self.assertEqual(resp_json['results'][1]['name'], "Dr Dre")
         self.assertEqual(resp_json['results'][1]['urns'], ['tel:+250788123456', 'twitter:drdre'])
-        self.assertEqual(resp_json['results'][1]['fields'], {'real_name': "Andre", 'registration_date': None,
-                                                             'state': 'VA'})
+        self.assertEqual(
+            resp_json['results'][1]['fields'], {
+                'real_name': "Andre",
+                'registration_date': None,
+                'state': 'VA'
+            }
+        )
         self.assertEqual(resp_json['results'][1]['group_uuids'], [artists.uuid])
         self.assertEqual(resp_json['results'][1]['groups'], ["Music Artists"])
         self.assertEqual(resp_json['results'][1]['blocked'], False)
         self.assertEqual(resp_json['results'][1]['failed'], False)
 
         self.assertEqual(resp_json['results'][0]['name'], "Jay-Z")
-        self.assertEqual(resp_json['results'][0]['fields'], {'real_name': None,
-                                                             'registration_date': "2014-12-31T01:04:00.000000Z",
-                                                             'state': None})
+        self.assertEqual(
+            resp_json['results'][0]['fields'], {
+                'real_name': None,
+                'registration_date': "2014-12-31T01:04:00.000000Z",
+                'state': None
+            }
+        )
 
         # search using deprecated phone field
         response = self.fetchJSON(url, "phone=%2B250788123456")
@@ -1168,7 +1286,9 @@ class APITest(TembaTest):
         self.assertContains(response, "Dr Dre")
 
         # search using urns list
-        response = self.fetchJSON(url, 'urns=%s&urns=%s' % (urlquote_plus("tel:+250788123456"), urlquote_plus("tel:+250785555555")))
+        response = self.fetchJSON(
+            url, 'urns=%s&urns=%s' % (urlquote_plus("tel:+250788123456"), urlquote_plus("tel:+250785555555"))
+        )
         self.assertResultCount(response, 2)
 
         # search deleted contacts
@@ -1206,8 +1326,9 @@ class APITest(TembaTest):
         self.assertResultCount(response, 1)
         self.assertContains(response, "Dr Dre")
 
-        response = self.fetchJSON(url, 'after=%s&before=%s' % (datetime_to_json_date(after_dre),
-                                                               datetime_to_json_date(before_jayz)))
+        response = self.fetchJSON(
+            url, 'after=%s&before=%s' % (datetime_to_json_date(after_dre), datetime_to_json_date(before_jayz))
+        )
         self.assertResultCount(response, 0)
 
         # check anon org case
@@ -1280,8 +1401,9 @@ class APITest(TembaTest):
         # bulk create more contacts than fits on one page
         contacts = []
         for c in range(0, 300):
-            contacts.append(Contact(org=self.org, name="Minion %d" % (c + 1),
-                                    created_by=self.admin, modified_by=self.admin))
+            contacts.append(
+                Contact(org=self.org, name="Minion %d" % (c + 1), created_by=self.admin, modified_by=self.admin)
+            )
         Contact.objects.all().delete()
         Contact.objects.bulk_create(contacts)
 
@@ -1383,7 +1505,9 @@ class APITest(TembaTest):
         # create with label that would be an invalid key
         response = self.postJSON(url, dict(label='Name', value_type='T'))
         self.assertEqual(400, response.status_code)
-        self.assertResponseError(response, 'non_field_errors', "Generated key for 'Name' is invalid or a reserved name")
+        self.assertResponseError(
+            response, 'non_field_errors', "Generated key for 'Name' is invalid or a reserved name"
+        )
 
         # create with key specified
         response = self.postJSON(url, dict(key='real_age_2', label="Actual Age 2", value_type='N'))
@@ -1403,9 +1527,10 @@ class APITest(TembaTest):
             ContactField.get_or_create(self.org, self.admin, 'field%d' % i, 'Field%d' % i)
 
         response = self.postJSON(url, dict(label='Real Age', value_type='T'))
-        self.assertResponseError(response, 'non_field_errors',
-                                 "This org has 10 contact fields and the limit is 10. "
-                                 "You must delete existing ones before you can create new ones.")
+        self.assertResponseError(
+            response, 'non_field_errors', "This org has 10 contact fields and the limit is 10. "
+            "You must delete existing ones before you can create new ones."
+        )
 
     def test_api_authenticate(self):
         url = reverse('api.v1.authenticate')
@@ -1417,13 +1542,17 @@ class APITest(TembaTest):
         surveyor_group = Group.objects.get(name='Surveyors')
 
         # login an admin as an admin
-        admin = json.loads(self.client.post(url, dict(email='Administrator', password='Administrator', role='A')).content)
+        admin = json.loads(
+            self.client.post(url, dict(email='Administrator', password='Administrator', role='A')).content
+        )
         self.assertEqual(1, len(admin))
         self.assertEqual('Temba', admin[0]['name'])
         self.assertIsNotNone(APIToken.objects.filter(key=admin[0]['token'], role=admin_group).first())
 
         # login an admin as a surveyor
-        surveyor = json.loads(self.client.post(url, dict(email='Administrator', password='Administrator', role='S')).content)
+        surveyor = json.loads(
+            self.client.post(url, dict(email='Administrator', password='Administrator', role='S')).content
+        )
         self.assertEqual(1, len(surveyor))
         self.assertEqual('Temba', surveyor[0]['name'])
         self.assertIsNotNone(APIToken.objects.filter(key=surveyor[0]['token'], role=surveyor_group).first())
@@ -1460,11 +1589,15 @@ class APITest(TembaTest):
         API v1 no longer has a messages endpoint but serializer is still used for creating messages from webhook
         responses
         """
-        serializer = MsgCreateSerializer(org=self.org, user=self.admin, data={
-            'urn': ["tel:+250964150000"],
-            'contact': [self.joe.uuid],
-            'text': "Hello1"
-        })
+        serializer = MsgCreateSerializer(
+            org=self.org,
+            user=self.admin,
+            data={
+                'urn': ["tel:+250964150000"],
+                'contact': [self.joe.uuid],
+                'text': "Hello1"
+            }
+        )
         self.assertTrue(serializer.is_valid())
 
         broadcast = serializer.save()
@@ -1473,11 +1606,15 @@ class APITest(TembaTest):
         self.assertEqual(broadcast.text, {'base': 'Hello1'})
 
         # try again with explicit channel
-        serializer = MsgCreateSerializer(org=self.org, user=self.admin, data={
-            'urn': ["tel:+250964150000"],
-            'text': "Hello2",
-            'channel': self.channel.id
-        })
+        serializer = MsgCreateSerializer(
+            org=self.org,
+            user=self.admin,
+            data={
+                'urn': ["tel:+250964150000"],
+                'text': "Hello2",
+                'channel': self.channel.id
+            }
+        )
         self.assertTrue(serializer.is_valid())
 
         broadcast = serializer.save()
@@ -1485,16 +1622,17 @@ class APITest(TembaTest):
         self.assertEqual(broadcast.text, {'base': 'Hello2'})
 
         # try with channel that isn't ours
-        serializer = MsgCreateSerializer(org=self.org, user=self.admin, data={
-            'contact': [self.joe.uuid],
-            'text': "Hello2",
-            'channel': self.channel2.id
-        })
+        serializer = MsgCreateSerializer(
+            org=self.org,
+            user=self.admin,
+            data={
+                'contact': [self.joe.uuid],
+                'text': "Hello2",
+                'channel': self.channel2.id
+            }
+        )
         self.assertFalse(serializer.is_valid())
 
         # try with invalid phone number
-        serializer = MsgCreateSerializer(org=self.org, user=self.admin, data={
-            'text': "Hello2",
-            'phone': '12'
-        })
+        serializer = MsgCreateSerializer(org=self.org, user=self.admin, data={'text': "Hello2", 'phone': '12'})
         self.assertFalse(serializer.is_valid())

--- a/temba/api/v1/views.py
+++ b/temba/api/v1/views.py
@@ -33,7 +33,6 @@ class RootView(views.APIView):
 
 
 class AuthenticateEndpoint(SmartFormView):
-
     class LoginForm(forms.Form):
         email = forms.CharField()
         password = forms.CharField()
@@ -294,20 +293,24 @@ class ContactEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
 
         groups = self.request.query_params.getlist('group', None)  # deprecated, use group_uuids
         if groups:
-            queryset = queryset.filter(all_groups__name__in=groups,
-                                       all_groups__group_type=ContactGroup.TYPE_USER_DEFINED)
+            queryset = queryset.filter(
+                all_groups__name__in=groups, all_groups__group_type=ContactGroup.TYPE_USER_DEFINED
+            )
 
         group_uuids = self.request.query_params.getlist('group_uuids', None)
         if group_uuids:
-            queryset = queryset.filter(all_groups__uuid__in=group_uuids,
-                                       all_groups__group_type=ContactGroup.TYPE_USER_DEFINED)
+            queryset = queryset.filter(
+                all_groups__uuid__in=group_uuids, all_groups__group_type=ContactGroup.TYPE_USER_DEFINED
+            )
 
         uuids = self.request.query_params.getlist('uuid', None)
         if uuids:
             queryset = queryset.filter(uuid__in=uuids)
 
         # can't prefetch a custom manager directly, so here we prefetch user groups as new attribute
-        user_groups_prefetch = Prefetch('all_groups', queryset=ContactGroup.user_groups.all(), to_attr='prefetched_user_groups')
+        user_groups_prefetch = Prefetch(
+            'all_groups', queryset=ContactGroup.user_groups.all(), to_attr='prefetched_user_groups'
+        )
 
         return queryset.select_related('org').prefetch_related(user_groups_prefetch).order_by('-modified_on', 'pk')
 
@@ -730,13 +733,15 @@ class OrgEndpoint(BaseAPIView):
     def get(self, request, *args, **kwargs):
         org = request.user.get_org()
 
-        data = dict(name=org.name,
-                    country=org.get_country_code(),
-                    languages=[l.iso_code for l in org.languages.order_by('iso_code')],
-                    primary_language=org.primary_language.iso_code if org.primary_language else None,
-                    timezone=six.text_type(org.timezone),
-                    date_style=('day_first' if org.get_dayfirst() else 'month_first'),
-                    anon=org.is_anon)
+        data = dict(
+            name=org.name,
+            country=org.get_country_code(),
+            languages=[l.iso_code for l in org.languages.order_by('iso_code')],
+            primary_language=org.primary_language.iso_code if org.primary_language else None,
+            timezone=six.text_type(org.timezone),
+            date_style=('day_first' if org.get_dayfirst() else 'month_first'),
+            anon=org.is_anon
+        )
 
         return Response(data, status=status.HTTP_200_OK)
 

--- a/temba/api/v2/__init__.py
+++ b/temba/api/v2/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, unicode_literals
-
 """
 API v2: The current official API version
 """

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -51,6 +51,7 @@ class TranslatableField(serializers.Field):
     """
     A field which is either a simple string or a translations dict
     """
+
     def __init__(self, **kwargs):
         self.max_length = kwargs.pop('max_length', None)
         super(TranslatableField, self).__init__(**kwargs)
@@ -64,7 +65,9 @@ class TranslatableField(serializers.Field):
 
         if isinstance(data, six.string_types):
             if len(data) > self.max_length:
-                raise serializers.ValidationError("Ensure this field has no more than %d characters." % self.max_length)
+                raise serializers.ValidationError(
+                    "Ensure this field has no more than %d characters." % self.max_length
+                )
 
             data = {base_language: data}
 
@@ -80,6 +83,7 @@ class LimitedListField(serializers.ListField):
     """
     A list field which can be only be written to with a limited number of items
     """
+
     def to_internal_value(self, data):
         validate_size(data, DEFAULT_MAX_LIST_ITEMS)
 
@@ -90,6 +94,7 @@ class LimitedDictField(serializers.DictField):
     """
     A dict field which can be only be written to with a limited number of items
     """
+
     def to_internal_value(self, data):
         validate_size(data, DEFAULT_MAX_DICT_ITEMS)
 
@@ -116,7 +121,7 @@ class URNListField(LimitedListField):
 class TembaModelField(serializers.RelatedField):
     model = None
     model_manager = 'objects'
-    lookup_fields = ('uuid',)
+    lookup_fields = ('uuid', )
     ignore_case_for_fields = ()
 
     class LimitedSizeList(serializers.ManyRelatedField):
@@ -200,7 +205,7 @@ class ContactField(TembaModelField):
 
 class ContactFieldField(TembaModelField):
     model = ContactFieldModel
-    lookup_fields = ('key',)
+    lookup_fields = ('key', )
 
     def to_representation(self, obj):
         return {'key': obj.key, 'label': obj.label}
@@ -210,7 +215,7 @@ class ContactGroupField(TembaModelField):
     model = ContactGroup
     model_manager = 'user_groups'
     lookup_fields = ('uuid', 'name')
-    ignore_case_for_fields = ('name',)
+    ignore_case_for_fields = ('name', )
 
     def __init__(self, **kwargs):
         self.allow_dynamic = kwargs.pop('allow_dynamic', True)
@@ -233,12 +238,14 @@ class LabelField(TembaModelField):
     model = Label
     model_manager = 'label_objects'
     lookup_fields = ('uuid', 'name')
-    ignore_case_for_fields = ('name',)
+    ignore_case_for_fields = ('name', )
 
 
 class MessageField(TembaModelField):
     model = Msg
-    lookup_fields = ('id',)
+    lookup_fields = ('id', )
 
     def get_queryset(self):
-        return self.model.objects.filter(org=self.context['org'], contact__is_test=False).exclude(visibility=Msg.VISIBILITY_DELETED)
+        return self.model.objects.filter(
+            org=self.context['org'], contact__is_test=False
+        ).exclude(visibility=Msg.VISIBILITY_DELETED)

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -32,12 +32,10 @@ from temba.api.models import APIToken, Resthook, WebHookEvent
 from . import fields
 from .serializers import format_datetime
 
-
 NUM_BASE_REQUEST_QUERIES = 7  # number of db queries required for any API request
 
 
 class APITest(TembaTest):
-
     def setUp(self):
         super(APITest, self).setUp()
 
@@ -45,8 +43,9 @@ class APITest(TembaTest):
         self.frank = self.create_contact("Frank", twitter="franky")
         self.test_contact = Contact.get_test_contact(self.user)
 
-        self.twitter = Channel.create(self.org, self.user, None, 'TT', name="Twitter Channel",
-                                      address="billy_bob", role="SR")
+        self.twitter = Channel.create(
+            self.org, self.user, None, 'TT', name="Twitter Channel", address="billy_bob", role="SR"
+        )
 
         self.create_secondary_org()
         self.hans = self.create_contact("Hans Gruber", "+4921551511", org=self.org2)
@@ -154,8 +153,9 @@ class APITest(TembaTest):
 
         self.login(self.admin)
 
-        response = self.client.get(reverse('api.v2.fields') + '.json', content_type="application/json",
-                                   HTTP_X_FORWARDED_HTTPS='https')
+        response = self.client.get(
+            reverse('api.v2.fields') + '.json', content_type="application/json", HTTP_X_FORWARDED_HTTPS='https'
+        )
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.content, "Server Error. Site administrators have been notified.")
 
@@ -164,8 +164,9 @@ class APITest(TembaTest):
         field_obj = ContactField.get_or_create(self.org, self.admin, 'registered', "Registered On")
         flow = self.create_flow()
         campaign = Campaign.create(self.org, self.admin, "Reminders #1", group)
-        event = CampaignEvent.create_flow_event(self.org, self.admin, campaign, field_obj,
-                                                6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12)
+        event = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, field_obj, 6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12
+        )
 
         field = fields.LimitedListField(child=serializers.IntegerField(), source='test')
 
@@ -240,20 +241,36 @@ class APITest(TembaTest):
         self.org.save()
 
         self.assertEqual(field.to_internal_value("Hello"), ({'kin': "Hello"}, 'kin'))
-        self.assertEqual(field.to_internal_value({'eng': "Hello", 'kin': "Muraho"}), ({'eng': "Hello", 'kin': "Muraho"}, 'kin'))
+        self.assertEqual(
+            field.to_internal_value({
+                'eng': "Hello",
+                'kin': "Muraho"
+            }), ({
+                'eng': "Hello",
+                'kin': "Muraho"
+            }, 'kin')
+        )
 
         self.assertRaises(serializers.ValidationError, field.to_internal_value, 123)  # not a string or dict
         self.assertRaises(serializers.ValidationError, field.to_internal_value, {'kin': 123})
         self.assertRaises(serializers.ValidationError, field.to_internal_value, {})
         self.assertRaises(serializers.ValidationError, field.to_internal_value, {123: "Hello", 'kin': "Muraho"})
         self.assertRaises(serializers.ValidationError, field.to_internal_value, "HelloHello1")  # too long
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, {'kin': "HelloHello1"})  # also too long
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, {'eng': "HelloHello1"})  # base lang not provided
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, {
+            'kin': "HelloHello1"
+        })  # also too long
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, {
+            'eng': "HelloHello1"
+        })  # base lang not provided
 
     def test_authentication(self):
         def api_request(endpoint, token):
-            return self.client.get(endpoint + '.json', content_type="application/json",
-                                   HTTP_X_FORWARDED_HTTPS='https', HTTP_AUTHORIZATION="Token %s" % token)
+            return self.client.get(
+                endpoint + '.json',
+                content_type="application/json",
+                HTTP_X_FORWARDED_HTTPS='https',
+                HTTP_AUTHORIZATION="Token %s" % token
+            )
 
         contacts_url = reverse('api.v2.contacts')
         campaigns_url = reverse('api.v2.campaigns')
@@ -494,40 +511,40 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertEqual(len(resp_json['results']), 10)
-        self.assertEqual(resp_json['results'][0], {
-            'osm_id': "1708283",
-            'name': "Kigali City",
-            'parent': {'osm_id': "171496", 'name': "Rwanda"},
-            'level': 1,
-            'aliases': ["Kigali", "Kigari"],
-            'geometry': None
-        })
+        self.assertEqual(
+            resp_json['results'][0], {
+                'osm_id': "1708283",
+                'name': "Kigali City",
+                'parent': {
+                    'osm_id': "171496",
+                    'name': "Rwanda"
+                },
+                'level': 1,
+                'aliases': ["Kigali", "Kigari"],
+                'geometry': None
+            }
+        )
 
         # test without geometry
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 3):
             response = self.fetchJSON(url, 'geometry=true')
 
-        self.assertEqual(response.json()['results'][0], {
-            'osm_id': "1708283",
-            'name': "Kigali City",
-            'parent': {'osm_id': "171496", 'name': "Rwanda"},
-            'level': 1,
-            'aliases': ["Kigali", "Kigari"],
-            'geometry': {
-                'type': "MultiPolygon",
-                'coordinates': [
-                    [
-                        [
-                            [1.0, 1.0],
-                            [1.0, -1.0],
-                            [-1.0, -1.0],
-                            [-1.0, 1.0],
-                            [1.0, 1.0]
-                        ]
-                    ]
-                ],
+        self.assertEqual(
+            response.json()['results'][0], {
+                'osm_id': "1708283",
+                'name': "Kigali City",
+                'parent': {
+                    'osm_id': "171496",
+                    'name': "Rwanda"
+                },
+                'level': 1,
+                'aliases': ["Kigali", "Kigari"],
+                'geometry': {
+                    'type': "MultiPolygon",
+                    'coordinates': [[[[1.0, 1.0], [1.0, -1.0], [-1.0, -1.0], [-1.0, 1.0], [1.0, 1.0]]]],
+                }
             }
-        })
+        )
 
         # if org doesn't have a country, just return no results
         self.org.country = None
@@ -546,8 +563,9 @@ class APITest(TembaTest):
         bcast1 = Broadcast.create(self.org, self.admin, "Hello 1", [self.frank.get_urn('twitter')])
         bcast2 = Broadcast.create(self.org, self.admin, "Hello 2", [self.joe])
         bcast3 = Broadcast.create(self.org, self.admin, "Hello 3", [self.frank], status='S')
-        bcast4 = Broadcast.create(self.org, self.admin, "Hello 4",
-                                  [self.frank.get_urn('twitter'), self.joe, reporters], status='F')
+        bcast4 = Broadcast.create(
+            self.org, self.admin, "Hello 4", [self.frank.get_urn('twitter'), self.joe, reporters], status='F'
+        )
         Broadcast.create(self.org2, self.admin2, "Different org...", [self.hans])
 
         # no filtering
@@ -558,14 +576,24 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsById(response, [bcast4, bcast3, bcast2, bcast1])
-        self.assertEqual(resp_json['results'][0], {
-            'id': bcast4.pk,
-            'urns': ["twitter:franky"],
-            'contacts': [{'uuid': self.joe.uuid, 'name': self.joe.name}],
-            'groups': [{'uuid': reporters.uuid, 'name': reporters.name}],
-            'text': {'base': "Hello 4"},
-            'created_on': format_datetime(bcast4.created_on)
-        })
+        self.assertEqual(
+            resp_json['results'][0], {
+                'id': bcast4.pk,
+                'urns': ["twitter:franky"],
+                'contacts': [{
+                    'uuid': self.joe.uuid,
+                    'name': self.joe.name
+                }],
+                'groups': [{
+                    'uuid': reporters.uuid,
+                    'name': reporters.name
+                }],
+                'text': {
+                    'base': "Hello 4"
+                },
+                'created_on': format_datetime(bcast4.created_on)
+            }
+        )
 
         # filter by id
         response = self.fetchJSON(url, 'id=%d' % bcast3.pk)
@@ -593,13 +621,15 @@ class APITest(TembaTest):
         self.assertResponseError(response, 'non_field_errors', "Must provide either urns, contacts or groups")
 
         # create new broadcast with all fields
-        response = self.postJSON(url, None, {
-            'text': "Hi @contact",
-            'urns': ["twitter:franky"],
-            'contacts': [self.joe.uuid, self.frank.uuid],
-            'groups': [reporters.uuid],
-            'channel': self.channel.uuid
-        })
+        response = self.postJSON(
+            url, None, {
+                'text': "Hi @contact",
+                'urns': ["twitter:franky"],
+                'contacts': [self.joe.uuid, self.frank.uuid],
+                'groups': [reporters.uuid],
+                'channel': self.channel.uuid
+            }
+        )
 
         broadcast = Broadcast.objects.get(pk=response.json()['id'])
         self.assertEqual(broadcast.text, {'base': "Hi @contact"})
@@ -612,10 +642,15 @@ class APITest(TembaTest):
         self.assertEqual({m.text for m in broadcast.msgs.all()}, {"Hi Joe Blow"})
 
         # create new broadcast with translations
-        response = self.postJSON(url, None, {
-            'text': {'base': "Hello", 'fre': "Bonjour"},
-            'contacts': [self.joe.uuid, self.frank.uuid],
-        })
+        response = self.postJSON(
+            url, None, {
+                'text': {
+                    'base': "Hello",
+                    'fre': "Bonjour"
+                },
+                'contacts': [self.joe.uuid, self.frank.uuid],
+            }
+        )
 
         broadcast = Broadcast.objects.get(pk=response.json()['id'])
         self.assertEqual(broadcast.text, {'base': "Hello", 'fre': "Bonjour"})
@@ -624,8 +659,10 @@ class APITest(TembaTest):
         # try sending as a suspended org
         self.org.set_suspended()
         response = self.postJSON(url, None, {'text': "Hello", 'urns': ["twitter:franky"]})
-        self.assertResponseError(response, 'non_field_errors', "Sorry, your account is currently suspended. To enable "
-                                                               "sending messages, please contact support.")
+        self.assertResponseError(
+            response, 'non_field_errors', "Sorry, your account is currently suspended. To enable "
+            "sending messages, please contact support."
+        )
 
     def test_campaigns(self):
         url = reverse('api.v2.campaigns')
@@ -649,13 +686,18 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsByUUID(response, [campaign2, campaign1])
-        self.assertEqual(resp_json['results'][0], {
-            'uuid': campaign2.uuid,
-            'name': "Reminders #2",
-            'archived': False,
-            'group': {'uuid': reporters.uuid, 'name': "Reporters"},
-            'created_on': format_datetime(campaign2.created_on)
-        })
+        self.assertEqual(
+            resp_json['results'][0], {
+                'uuid': campaign2.uuid,
+                'name': "Reminders #2",
+                'archived': False,
+                'group': {
+                    'uuid': reporters.uuid,
+                    'name': "Reporters"
+                },
+                'created_on': format_datetime(campaign2.created_on)
+            }
+        )
 
         # filter by UUID
         response = self.fetchJSON(url, 'uuid=%s' % campaign1.uuid)
@@ -671,13 +713,18 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 201)
 
         campaign3 = Campaign.objects.get(name="Reminders #3")
-        self.assertEqual(response.json(), {
-            'uuid': campaign3.uuid,
-            'name': "Reminders #3",
-            'archived': False,
-            'group': {'uuid': reporters.uuid, 'name': "Reporters"},
-            'created_on': format_datetime(campaign3.created_on)
-        })
+        self.assertEqual(
+            response.json(), {
+                'uuid': campaign3.uuid,
+                'name': "Reminders #3",
+                'archived': False,
+                'group': {
+                    'uuid': reporters.uuid,
+                    'name': "Reporters"
+                },
+                'created_on': format_datetime(campaign3.created_on)
+            }
+        )
 
         # try to create another campaign with same name
         response = self.postJSON(url, None, {'name': "Reminders #3", 'group': reporters.uuid})
@@ -718,19 +765,23 @@ class APITest(TembaTest):
         contact.set_field(self.admin, "registration", timezone.now())
 
         campaign1 = Campaign.create(self.org, self.admin, "Reminders", reporters)
-        event1 = CampaignEvent.create_message_event(self.org, self.admin, campaign1, registration,
-                                                    1, CampaignEvent.UNIT_DAYS, "Don't forget to brush your teeth")
+        event1 = CampaignEvent.create_message_event(
+            self.org, self.admin, campaign1, registration, 1, CampaignEvent.UNIT_DAYS,
+            "Don't forget to brush your teeth"
+        )
 
         campaign2 = Campaign.create(self.org, self.admin, "Notifications", reporters)
-        event2 = CampaignEvent.create_flow_event(self.org, self.admin, campaign2, registration,
-                                                 6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12)
+        event2 = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign2, registration, 6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12
+        )
 
         # create event for another org
         joined = ContactField.get_or_create(self.org2, self.admin2, 'joined', "Joined On")
         spammers = ContactGroup.get_or_create(self.org2, self.admin2, "Spammers")
         spam = Campaign.create(self.org2, self.admin2, "Cool stuff", spammers)
-        CampaignEvent.create_flow_event(self.org2, self.admin2, spam, joined,
-                                        6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12)
+        CampaignEvent.create_flow_event(
+            self.org2, self.admin2, spam, joined, 6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12
+        )
 
         # no filtering
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 4):
@@ -740,27 +791,46 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsByUUID(response, [event2, event1])
-        self.assertEqual(resp_json['results'], [{
-            'uuid': event2.uuid,
-            'campaign': {'uuid': campaign2.uuid, 'name': "Notifications"},
-            'relative_to': {'key': "registration", 'label': "Registration"},
-            'offset': 6,
-            'unit': 'hours',
-            'delivery_hour': 12,
-            'flow': {'uuid': flow.uuid, 'name': "Color Flow"},
-            'message': None,
-            'created_on': format_datetime(event2.created_on)
-        }, {
-            'uuid': event1.uuid,
-            'campaign': {'uuid': campaign1.uuid, 'name': "Reminders"},
-            'relative_to': {'key': "registration", 'label': "Registration"},
-            'offset': 1,
-            'unit': 'days',
-            'delivery_hour': -1,
-            'flow': None,
-            'message': {'base': "Don't forget to brush your teeth"},
-            'created_on': format_datetime(event1.created_on)
-        }])
+        self.assertEqual(
+            resp_json['results'], [{
+                'uuid': event2.uuid,
+                'campaign': {
+                    'uuid': campaign2.uuid,
+                    'name': "Notifications"
+                },
+                'relative_to': {
+                    'key': "registration",
+                    'label': "Registration"
+                },
+                'offset': 6,
+                'unit': 'hours',
+                'delivery_hour': 12,
+                'flow': {
+                    'uuid': flow.uuid,
+                    'name': "Color Flow"
+                },
+                'message': None,
+                'created_on': format_datetime(event2.created_on)
+            }, {
+                'uuid': event1.uuid,
+                'campaign': {
+                    'uuid': campaign1.uuid,
+                    'name': "Reminders"
+                },
+                'relative_to': {
+                    'key': "registration",
+                    'label': "Registration"
+                },
+                'offset': 1,
+                'unit': 'days',
+                'delivery_hour': -1,
+                'flow': None,
+                'message': {
+                    'base': "Don't forget to brush your teeth"
+                },
+                'created_on': format_datetime(event1.created_on)
+            }]
+        )
 
         # filter by UUID
         response = self.fetchJSON(url, 'uuid=%s' % event1.uuid)
@@ -787,35 +857,41 @@ class APITest(TembaTest):
         self.assertResponseError(response, 'delivery_hour', "This field is required.")
 
         # try again with some invalid values
-        response = self.postJSON(url, None, {
-            'campaign': campaign1.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'epocs',
-            'delivery_hour': 25
-        })
+        response = self.postJSON(
+            url, None, {
+                'campaign': campaign1.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'epocs',
+                'delivery_hour': 25
+            }
+        )
         self.assertResponseError(response, 'unit', "\"epocs\" is not a valid choice.")
         self.assertResponseError(response, 'delivery_hour', "Ensure this value is less than or equal to 23.")
 
         # provide valid values for those fields.. but not a message or flow
-        response = self.postJSON(url, None, {
-            'campaign': campaign1.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'weeks',
-            'delivery_hour': -1
-        })
+        response = self.postJSON(
+            url, None, {
+                'campaign': campaign1.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'weeks',
+                'delivery_hour': -1
+            }
+        )
         self.assertResponseError(response, 'non_field_errors', "Flow UUID or a message text required.")
 
         # create a message event
-        response = self.postJSON(url, None, {
-            'campaign': campaign1.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'weeks',
-            'delivery_hour': -1,
-            'message': "Nice job"
-        })
+        response = self.postJSON(
+            url, None, {
+                'campaign': campaign1.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'weeks',
+                'delivery_hour': -1,
+                'message': "Nice job"
+            }
+        )
         self.assertEqual(response.status_code, 201)
 
         event1 = CampaignEvent.objects.filter(campaign=campaign1).order_by('-id').first()
@@ -828,14 +904,16 @@ class APITest(TembaTest):
         self.assertIsNotNone(event1.flow)
 
         # create a flow event
-        response = self.postJSON(url, None, {
-            'campaign': campaign1.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'weeks',
-            'delivery_hour': -1,
-            'flow': flow.uuid
-        })
+        response = self.postJSON(
+            url, None, {
+                'campaign': campaign1.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'weeks',
+                'delivery_hour': -1,
+                'flow': flow.uuid
+            }
+        )
         self.assertEqual(response.status_code, 201)
 
         event2 = CampaignEvent.objects.filter(campaign=campaign1).order_by('-id').first()
@@ -851,14 +929,16 @@ class APITest(TembaTest):
         self.assertEqual(1, EventFire.objects.filter(contact=contact, event=event2).count())
 
         # update the message event to be a flow event
-        response = self.postJSON(url, 'uuid=%s' % event1.uuid, {
-            'campaign': campaign1.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'weeks',
-            'delivery_hour': -1,
-            'flow': flow.uuid
-        })
+        response = self.postJSON(
+            url, 'uuid=%s' % event1.uuid, {
+                'campaign': campaign1.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'weeks',
+                'delivery_hour': -1,
+                'flow': flow.uuid
+            }
+        )
         self.assertEqual(response.status_code, 200)
 
         event1.refresh_from_db()
@@ -867,14 +947,19 @@ class APITest(TembaTest):
         self.assertEqual(event1.flow, flow)
 
         # and update the flow event to be a message event
-        response = self.postJSON(url, 'uuid=%s' % event2.uuid, {
-            'campaign': campaign1.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'weeks',
-            'delivery_hour': -1,
-            'message': {'base': "OK", 'fre': "D'accord"}
-        })
+        response = self.postJSON(
+            url, 'uuid=%s' % event2.uuid, {
+                'campaign': campaign1.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'weeks',
+                'delivery_hour': -1,
+                'message': {
+                    'base': "OK",
+                    'fre': "D'accord"
+                }
+            }
+        )
         self.assertEqual(response.status_code, 200)
 
         event2.refresh_from_db()
@@ -882,14 +967,20 @@ class APITest(TembaTest):
         self.assertEqual(event2.message, {'base': "OK", 'fre': "D'accord"})
 
         # and update update it's message again
-        response = self.postJSON(url, 'uuid=%s' % event2.uuid, {
-            'campaign': campaign1.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'weeks',
-            'delivery_hour': -1,
-            'message': {'base': "OK", 'fre': "D'accord", 'kin': "Sawa"}
-        })
+        response = self.postJSON(
+            url, 'uuid=%s' % event2.uuid, {
+                'campaign': campaign1.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'weeks',
+                'delivery_hour': -1,
+                'message': {
+                    'base': "OK",
+                    'fre': "D'accord",
+                    'kin': "Sawa"
+                }
+            }
+        )
         self.assertEqual(response.status_code, 200)
 
         event2.refresh_from_db()
@@ -897,14 +988,16 @@ class APITest(TembaTest):
         self.assertEqual(event2.message, {'base': "OK", 'fre': "D'accord", 'kin': "Sawa"})
 
         # try to change an existing event's campaign
-        response = self.postJSON(url, 'uuid=%s' % event1.uuid, {
-            'campaign': campaign2.uuid,
-            'relative_to': 'registration',
-            'offset': 15,
-            'unit': 'weeks',
-            'delivery_hour': -1,
-            'flow': flow.uuid
-        })
+        response = self.postJSON(
+            url, 'uuid=%s' % event1.uuid, {
+                'campaign': campaign2.uuid,
+                'relative_to': 'registration',
+                'offset': 15,
+                'unit': 'weeks',
+                'delivery_hour': -1,
+                'flow': flow.uuid
+            }
+        )
         self.assertResponseError(response, 'campaign', "Cannot change campaign for existing events")
 
         # try an empty delete request
@@ -927,8 +1020,7 @@ class APITest(TembaTest):
         self.assertEndpointAccess(url)
 
         # create channel for other org
-        Channel.create(self.org2, self.admin2, None, 'TT', name="Twitter Channel",
-                       address="nyaruka", role="SR")
+        Channel.create(self.org2, self.admin2, None, 'TT', name="Twitter Channel", address="nyaruka", role="SR")
 
         # no filtering
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 2):
@@ -938,21 +1030,23 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsByUUID(response, [self.twitter, self.channel])
-        self.assertEqual(resp_json['results'][1], {
-            'uuid': self.channel.uuid,
-            'name': "Test Channel",
-            'address': "+250785551212",
-            'country': "RW",
-            'device': {
-                'name': "Nexus 5X",
-                'network_type': None,
-                'power_level': -1,
-                'power_source': None,
-                'power_status': None
-            },
-            'last_seen': format_datetime(self.channel.last_seen),
-            'created_on': format_datetime(self.channel.created_on)
-        })
+        self.assertEqual(
+            resp_json['results'][1], {
+                'uuid': self.channel.uuid,
+                'name': "Test Channel",
+                'address': "+250785551212",
+                'country': "RW",
+                'device': {
+                    'name': "Nexus 5X",
+                    'network_type': None,
+                    'power_level': -1,
+                    'power_source': None,
+                    'power_status': None
+                },
+                'last_seen': format_datetime(self.channel.last_seen),
+                'created_on': format_datetime(self.channel.created_on)
+            }
+        )
 
         # filter by UUID
         response = self.fetchJSON(url, 'uuid=%s' % self.twitter.uuid)
@@ -968,9 +1062,13 @@ class APITest(TembaTest):
         self.assertEndpointAccess(url)
 
         call1 = ChannelEvent.create(self.channel, "tel:0788123123", ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now())
-        call2 = ChannelEvent.create(self.channel, "tel:0788124124", ChannelEvent.TYPE_CALL_IN, timezone.now(), dict(duration=36))
+        call2 = ChannelEvent.create(
+            self.channel, "tel:0788124124", ChannelEvent.TYPE_CALL_IN, timezone.now(), dict(duration=36)
+        )
         call3 = ChannelEvent.create(self.channel, "tel:0788124124", ChannelEvent.TYPE_CALL_OUT_MISSED, timezone.now())
-        call4 = ChannelEvent.create(self.channel, "tel:0788123123", ChannelEvent.TYPE_CALL_OUT, timezone.now(), dict(duration=15))
+        call4 = ChannelEvent.create(
+            self.channel, "tel:0788123123", ChannelEvent.TYPE_CALL_OUT, timezone.now(), dict(duration=15)
+        )
 
         # no filtering
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 3):
@@ -980,15 +1078,23 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsById(response, [call4, call3, call2, call1])
-        self.assertEqual(resp_json['results'][0], {
-            'id': call4.pk,
-            'channel': {'uuid': self.channel.uuid, 'name': "Test Channel"},
-            'type': "call-out",
-            'contact': {'uuid': self.joe.uuid, 'name': self.joe.name},
-            'occurred_on': format_datetime(call4.occurred_on),
-            'extra': dict(duration=15),
-            'created_on': format_datetime(call4.created_on),
-        })
+        self.assertEqual(
+            resp_json['results'][0], {
+                'id': call4.pk,
+                'channel': {
+                    'uuid': self.channel.uuid,
+                    'name': "Test Channel"
+                },
+                'type': "call-out",
+                'contact': {
+                    'uuid': self.joe.uuid,
+                    'name': self.joe.name
+                },
+                'occurred_on': format_datetime(call4.occurred_on),
+                'extra': dict(duration=15),
+                'created_on': format_datetime(call4.created_on),
+            }
+        )
 
         # filter by id
         response = self.fetchJSON(url, 'id=%d' % call1.pk)
@@ -1048,18 +1154,25 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsByUUID(response, [contact4, self.joe, contact2, contact1, self.frank])
-        self.assertEqual(resp_json['results'][0], {
-            'uuid': contact4.uuid,
-            'name': "Don",
-            'language': "fre",
-            'urns': ["tel:+250788000004"],
-            'groups': [{'uuid': group.uuid, 'name': group.name}],
-            'fields': {'nickname': "Donnie"},
-            'blocked': False,
-            'stopped': False,
-            'created_on': format_datetime(contact4.created_on),
-            'modified_on': format_datetime(contact4.modified_on)
-        })
+        self.assertEqual(
+            resp_json['results'][0], {
+                'uuid': contact4.uuid,
+                'name': "Don",
+                'language': "fre",
+                'urns': ["tel:+250788000004"],
+                'groups': [{
+                    'uuid': group.uuid,
+                    'name': group.name
+                }],
+                'fields': {
+                    'nickname': "Donnie"
+                },
+                'blocked': False,
+                'stopped': False,
+                'created_on': format_datetime(contact4.created_on),
+                'modified_on': format_datetime(contact4.modified_on)
+            }
+        )
 
         # filter by UUID
         response = self.fetchJSON(url, 'uuid=%s' % contact2.uuid)
@@ -1096,18 +1209,20 @@ class APITest(TembaTest):
         # view the deleted contact
         response = self.fetchJSON(url, 'deleted=true')
         self.assertResultsByUUID(response, [contact3])
-        self.assertEqual(response.json()['results'][0], {
-            'uuid': contact3.uuid,
-            'name': None,
-            'language': None,
-            'urns': [],
-            'groups': [],
-            'fields': {},
-            'blocked': None,
-            'stopped': None,
-            'created_on': format_datetime(contact3.created_on),
-            'modified_on': format_datetime(contact3.modified_on)
-        })
+        self.assertEqual(
+            response.json()['results'][0], {
+                'uuid': contact3.uuid,
+                'name': None,
+                'language': None,
+                'urns': [],
+                'groups': [],
+                'fields': {},
+                'blocked': None,
+                'stopped': None,
+                'created_on': format_datetime(contact3.created_on),
+                'modified_on': format_datetime(contact3.modified_on)
+            }
+        )
 
         with AnonymousOrg(self.org):
             # can't filter by URN
@@ -1128,18 +1243,22 @@ class APITest(TembaTest):
 
         empty = Contact.objects.get(name=None)
 
-        self.assertEqual(response.json(), {
-            'uuid': empty.uuid,
-            'name': None,
-            'language': None,
-            'urns': [],
-            'groups': [],
-            'fields': {'nickname': None},
-            'blocked': False,
-            'stopped': False,
-            'created_on': format_datetime(empty.created_on),
-            'modified_on': format_datetime(empty.modified_on)
-        })
+        self.assertEqual(
+            response.json(), {
+                'uuid': empty.uuid,
+                'name': None,
+                'language': None,
+                'urns': [],
+                'groups': [],
+                'fields': {
+                    'nickname': None
+                },
+                'blocked': False,
+                'stopped': False,
+                'created_on': format_datetime(empty.created_on),
+                'modified_on': format_datetime(empty.modified_on)
+            }
+        )
 
         # create with all fields but empty
         response = self.postJSON(url, None, {'name': None, 'language': None, 'urns': [], 'groups': [], 'fields': {}})
@@ -1153,13 +1272,17 @@ class APITest(TembaTest):
         dyn_group = self.create_group("Dynamic Group", query="nickname is jado")
 
         # create with all fields
-        response = self.postJSON(url, None, {
-            'name': "Jean",
-            'language': "fre",
-            'urns': ["tel:+250783333333", "twitter:JEAN"],
-            'groups': [group.uuid],
-            'fields': {'nickname': "Jado"}
-        })
+        response = self.postJSON(
+            url, None, {
+                'name': "Jean",
+                'language': "fre",
+                'urns': ["tel:+250783333333", "twitter:JEAN"],
+                'groups': [group.uuid],
+                'fields': {
+                    'nickname': "Jado"
+                }
+            }
+        )
         self.assertEqual(response.status_code, 201)
 
         # URNs will be normalized
@@ -1169,15 +1292,21 @@ class APITest(TembaTest):
         self.assertEqual(jean.get_field('nickname').string_value, "Jado")
 
         # create with invalid fields
-        response = self.postJSON(url, None, {
-            'name': "Jim",
-            'language': "english",
-            'urns': ["1234556789"],
-            'groups': ["59686b4e-14bc-4160-9376-b649b218c806"],
-            'fields': {'hmmm': "X"}
-        })
+        response = self.postJSON(
+            url, None, {
+                'name': "Jim",
+                'language': "english",
+                'urns': ["1234556789"],
+                'groups': ["59686b4e-14bc-4160-9376-b649b218c806"],
+                'fields': {
+                    'hmmm': "X"
+                }
+            }
+        )
         self.assertResponseError(response, 'language', "Ensure this field has no more than 3 characters.")
-        self.assertResponseError(response, 'urns', "Invalid URN: 1234556789. Ensure phone numbers contain country codes.")
+        self.assertResponseError(
+            response, 'urns', "Invalid URN: 1234556789. Ensure phone numbers contain country codes."
+        )
         self.assertResponseError(response, 'groups', "No such object: 59686b4e-14bc-4160-9376-b649b218c806")
         self.assertResponseError(response, 'fields', "Invalid contact field key: hmmm")
 
@@ -1194,13 +1323,17 @@ class APITest(TembaTest):
         self.assertEqual(jean.get_field('nickname').string_value, "Jado")
 
         # update by UUID and change all fields
-        response = self.postJSON(url, 'uuid=%s' % jean.uuid, {
-            'name': "Jean II",
-            'language': "eng",
-            'urns': ["tel:+250784444444"],
-            'groups': [],
-            'fields': {'nickname': "John"}
-        })
+        response = self.postJSON(
+            url, 'uuid=%s' % jean.uuid, {
+                'name': "Jean II",
+                'language': "eng",
+                'urns': ["tel:+250784444444"],
+                'groups': [],
+                'fields': {
+                    'nickname': "John"
+                }
+            }
+        )
         self.assertEqual(response.status_code, 200)
 
         jean = Contact.objects.get(pk=jean.pk)
@@ -1284,7 +1417,9 @@ class APITest(TembaTest):
             # TODO should UUID be masked in response??
 
             xavier = Contact.objects.get(name="Xavier")
-            self.assertEqual(set(xavier.urns.values_list('identity', flat=True)), {"tel:+250787777777", "twitter:xavier"})
+            self.assertEqual(
+                set(xavier.urns.values_list('identity', flat=True)), {"tel:+250787777777", "twitter:xavier"}
+            )
 
         # try an empty delete request
         response = self.deleteJSON(url, None)
@@ -1342,43 +1477,51 @@ class APITest(TembaTest):
         self.create_msg(direction='I', contact=contact4, text="Hello")
 
         # try adding more contacts to group than this endpoint is allowed to operate on at one time
-        response = self.postJSON(url, None, {'contacts': [six.text_type(x) for x in range(101)], 'action': 'add', 'group': "Testers"})
+        response = self.postJSON(
+            url, None, {
+                'contacts': [six.text_type(x) for x in range(101)],
+                'action': 'add',
+                'group': "Testers"
+            }
+        )
         self.assertResponseError(response, 'contacts', "This field can only contain up to 100 items.")
 
         # try adding all contacts to a group by its name
-        response = self.postJSON(url, None, {
-            'contacts': [
-                contact1.uuid,
-                'tel:+250788000002',
-                contact3.uuid,
-                contact4.uuid,
-                contact5.uuid,
-                test_contact.uuid
-            ],
-            'action': 'add',
-            'group': "Testers"
-        })
+        response = self.postJSON(
+            url, None, {
+                'contacts': [
+                    contact1.uuid, 'tel:+250788000002', contact3.uuid, contact4.uuid, contact5.uuid, test_contact.uuid
+                ],
+                'action': 'add',
+                'group': "Testers"
+            }
+        )
 
         # error reporting that at least one of the UUIDs is not a valid contact
         self.assertResponseError(response, 'contacts', "No such object: %s" % contact5.uuid)
 
         # try adding a blocked contact to a group
-        response = self.postJSON(url, None, {
-            'contacts': [contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid],
-            'action': 'add',
-            'group': "Testers"
-        })
+        response = self.postJSON(
+            url, None, {
+                'contacts': [contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid],
+                'action': 'add',
+                'group': "Testers"
+            }
+        )
 
         # error reporting that the deleted and test contacts are invalid
-        self.assertResponseError(response, 'non_field_errors',
-                                 "Blocked or stopped contacts cannot be added to groups: %s" % contact4.uuid)
+        self.assertResponseError(
+            response, 'non_field_errors', "Blocked or stopped contacts cannot be added to groups: %s" % contact4.uuid
+        )
 
         # add valid contacts to the group by name
-        response = self.postJSON(url, None, {
-            'contacts': [contact1.uuid, 'tel:+250788000002'],
-            'action': 'add',
-            'group': "Testers"
-        })
+        response = self.postJSON(
+            url, None, {
+                'contacts': [contact1.uuid, 'tel:+250788000002'],
+                'action': 'add',
+                'group': "Testers"
+            }
+        )
         self.assertEqual(response.status_code, 204)
         self.assertEqual(set(group.contacts.all()), {contact1, contact2})
 
@@ -1416,17 +1559,21 @@ class APITest(TembaTest):
         self.assertResponseError(response, 'group', "This field may not be null.")
 
         # try to block all contacts
-        response = self.postJSON(url, None, {
-            'contacts': [contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid, test_contact.uuid],
-            'action': 'block'
-        })
+        response = self.postJSON(
+            url, None, {
+                'contacts': [contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid, test_contact.uuid],
+                'action': 'block'
+            }
+        )
         self.assertResponseError(response, 'contacts', "No such object: %s" % test_contact.uuid)
 
         # block all valid contacts
-        response = self.postJSON(url, None, {
-            'contacts': [contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid],
-            'action': 'block'
-        })
+        response = self.postJSON(
+            url, None, {
+                'contacts': [contact1.uuid, contact2.uuid, contact3.uuid, contact4.uuid],
+                'action': 'block'
+            }
+        )
         self.assertEqual(response.status_code, 204)
         self.assertEqual(set(Contact.objects.filter(is_blocked=True)), {contact1, contact2, contact3, contact4})
 
@@ -1575,14 +1722,27 @@ class APITest(TembaTest):
         resp_json = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
-        self.assertEqual(resp_json['results'], [
-            {'key': 'registered', 'label': "Registered On", 'value_type': "datetime"},
-            {'key': 'nick_name', 'label': "Nick Name", 'value_type': "text"}
-        ])
+        self.assertEqual(
+            resp_json['results'], [{
+                'key': 'registered',
+                'label': "Registered On",
+                'value_type': "datetime"
+            }, {
+                'key': 'nick_name',
+                'label': "Nick Name",
+                'value_type': "text"
+            }]
+        )
 
         # filter by key
         response = self.fetchJSON(url, 'key=nick_name')
-        self.assertEqual(response.json()['results'], [{'key': 'nick_name', 'label': "Nick Name", 'value_type': "text"}])
+        self.assertEqual(
+            response.json()['results'], [{
+                'key': 'nick_name',
+                'label': "Nick Name",
+                'value_type': "text"
+            }]
+        )
 
         # try to create empty field
         response = self.postJSON(url, None, {})
@@ -1626,9 +1786,10 @@ class APITest(TembaTest):
             ContactField.get_or_create(self.org, self.admin, 'field%d' % i, 'Field%d' % i)
 
         response = self.postJSON(url, None, {'label': "Age", 'value_type': "numeric"})
-        self.assertResponseError(response, 'non_field_errors',
-                                 "This org has 10 contact fields and the limit is 10. "
-                                 "You must delete existing ones before you can create new ones.")
+        self.assertResponseError(
+            response, 'non_field_errors', "This org has 10 contact fields and the limit is 10. "
+            "You must delete existing ones before you can create new ones."
+        )
 
     def test_flows(self):
         url = reverse('api.v2.flows')
@@ -1659,28 +1820,40 @@ class APITest(TembaTest):
         resp_json = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
-        self.assertEqual(resp_json['results'], [
-            {
+        self.assertEqual(
+            resp_json['results'], [{
                 'uuid': survey.uuid,
                 'name': "Survey",
                 'archived': False,
-                'labels': [{'uuid': reporting.uuid, 'name': "Reporting"}],
+                'labels': [{
+                    'uuid': reporting.uuid,
+                    'name': "Reporting"
+                }],
                 'expires': 720,
-                'runs': {'active': 0, 'completed': 1, 'interrupted': 0, 'expired': 0},
+                'runs': {
+                    'active': 0,
+                    'completed': 1,
+                    'interrupted': 0,
+                    'expired': 0
+                },
                 'created_on': format_datetime(survey.created_on),
                 'modified_on': format_datetime(survey.modified_on)
-            },
-            {
+            }, {
                 'uuid': registration.uuid,
                 'name': "Registration",
                 'archived': False,
                 'labels': [],
                 'expires': 720,
-                'runs': {'active': 0, 'completed': 0, 'interrupted': 0, 'expired': 0},
+                'runs': {
+                    'active': 0,
+                    'completed': 0,
+                    'interrupted': 0,
+                    'expired': 0
+                },
                 'created_on': format_datetime(registration.created_on),
                 'modified_on': format_datetime(registration.modified_on)
-            }
-        ])
+            }]
+        )
 
         # filter by UUID
         response = self.fetchJSON(url, 'uuid=%s' % survey.uuid)
@@ -1714,10 +1887,19 @@ class APITest(TembaTest):
         resp_json = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
-        self.assertEqual(resp_json['results'], [
-            {'uuid': developers.uuid, 'name': "Developers", 'query': "isdeveloper = YES", 'count': 0},
-            {'uuid': customers.uuid, 'name': "Customers", 'query': None, 'count': 1}
-        ])
+        self.assertEqual(
+            resp_json['results'], [{
+                'uuid': developers.uuid,
+                'name': "Developers",
+                'query': "isdeveloper = YES",
+                'count': 0
+            }, {
+                'uuid': customers.uuid,
+                'name': "Customers",
+                'query': None,
+                'count': 1
+            }]
+        )
 
         # filter by UUID
         response = self.fetchJSON(url, 'uuid=%s' % customers.uuid)
@@ -1798,9 +1980,10 @@ class APITest(TembaTest):
             ContactGroup.create_static(self.org, self.admin, 'group%d' % i)
 
         response = self.postJSON(url, None, {'name': "Reporters"})
-        self.assertResponseError(response, 'non_field_errors',
-                                 "This org has 10 groups and the limit is 10. "
-                                 "You must delete existing ones before you can create new ones.")
+        self.assertResponseError(
+            response, 'non_field_errors', "This org has 10 groups and the limit is 10. "
+            "You must delete existing ones before you can create new ones."
+        )
 
         group1 = ContactGroup.user_groups.filter(org=self.org, name='group1').first()
         response = self.deleteJSON(url, 'uuid=%s' % group1.uuid)
@@ -1826,10 +2009,17 @@ class APITest(TembaTest):
         resp_json = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
-        self.assertEqual(resp_json['results'], [
-            {'uuid': feedback.uuid, 'name': "Feedback", 'count': 0},
-            {'uuid': important.uuid, 'name': "Important", 'count': 1}
-        ])
+        self.assertEqual(
+            resp_json['results'], [{
+                'uuid': feedback.uuid,
+                'name': "Feedback",
+                'count': 0
+            }, {
+                'uuid': important.uuid,
+                'name': "Important",
+                'count': 1
+            }]
+        )
 
         # filter by UUID
         response = self.fetchJSON(url, 'uuid=%s' % feedback.uuid)
@@ -1901,31 +2091,42 @@ class APITest(TembaTest):
             Label.get_or_create(self.org, self.user, "label%d" % i)
 
         response = self.postJSON(url, None, {'name': "Interesting"})
-        self.assertResponseError(response, 'non_field_errors',
-                                 "This org has 10 labels and the limit is 10. "
-                                 "You must delete existing ones before you can create new ones."
-                                 )
+        self.assertResponseError(
+            response, 'non_field_errors', "This org has 10 labels and the limit is 10. "
+            "You must delete existing ones before you can create new ones."
+        )
 
     def assertMsgEqual(self, msg_json, msg, msg_type, msg_status, msg_visibility):
-        self.assertEqual(msg_json, {
-            'id': msg.id,
-            'broadcast': msg.broadcast,
-            'contact': {'uuid': msg.contact.uuid, 'name': msg.contact.name},
-            'urn': six.text_type(msg.contact_urn),
-            'channel': {'uuid': msg.channel.uuid, 'name': msg.channel.name},
-            'direction': "in" if msg.direction == 'I' else "out",
-            'type': msg_type,
-            'status': msg_status,
-            'archived': msg.visibility == 'A',
-            'visibility': msg_visibility,
-            'text': msg.text,
-            'labels': [dict(name=l.name, uuid=l.uuid) for l in msg.labels.all()],
-            'attachments': [{'content_type': a.content_type, 'url': a.url} for a in msg.get_attachments()],
-            'created_on': format_datetime(msg.created_on),
-            'sent_on': format_datetime(msg.sent_on),
-            'modified_on': format_datetime(msg.modified_on),
-            'media': msg.attachments[0] if msg.attachments else None
-        })
+        self.assertEqual(
+            msg_json, {
+                'id': msg.id,
+                'broadcast': msg.broadcast,
+                'contact': {
+                    'uuid': msg.contact.uuid,
+                    'name': msg.contact.name
+                },
+                'urn': six.text_type(msg.contact_urn),
+                'channel': {
+                    'uuid': msg.channel.uuid,
+                    'name': msg.channel.name
+                },
+                'direction': "in" if msg.direction == 'I' else "out",
+                'type': msg_type,
+                'status': msg_status,
+                'archived': msg.visibility == 'A',
+                'visibility': msg_visibility,
+                'text': msg.text,
+                'labels': [dict(name=l.name, uuid=l.uuid) for l in msg.labels.all()],
+                'attachments': [{
+                    'content_type': a.content_type,
+                    'url': a.url
+                } for a in msg.get_attachments()],
+                'created_on': format_datetime(msg.created_on),
+                'sent_on': format_datetime(msg.sent_on),
+                'modified_on': format_datetime(msg.modified_on),
+                'media': msg.attachments[0] if msg.attachments else None
+            }
+        )
 
     def test_messages(self):
         url = reverse('api.v2.messages')
@@ -1935,21 +2136,39 @@ class APITest(TembaTest):
 
         # make sure you have to pass in something to filter by
         response = self.fetchJSON(url)
-        self.assertResponseError(response, None,
-                                 "You must specify one of the contact, folder, label, broadcast, id parameters")
+        self.assertResponseError(
+            response, None, "You must specify one of the contact, folder, label, broadcast, id parameters"
+        )
 
         # create some messages
         joe_msg1 = self.create_msg(direction='I', msg_type='F', text="Howdy", contact=self.joe)
-        frank_msg1 = self.create_msg(direction='I', msg_type='I', text="Bonjour", contact=self.frank, channel=self.twitter)
+        frank_msg1 = self.create_msg(
+            direction='I', msg_type='I', text="Bonjour", contact=self.frank, channel=self.twitter
+        )
         joe_msg2 = self.create_msg(direction='O', msg_type='I', text="How are you?", contact=self.joe, status='Q')
         frank_msg2 = self.create_msg(direction='O', msg_type='I', text="Ça va?", contact=self.frank, status='D')
-        joe_msg3 = self.create_msg(direction='I', msg_type='F', text="Good", contact=self.joe,
-                                   attachments=['image/jpeg:https://example.com/test.jpg'])
-        frank_msg3 = self.create_msg(direction='I', msg_type='I', text="Bien", contact=self.frank, channel=self.twitter, visibility='A')
+        joe_msg3 = self.create_msg(
+            direction='I',
+            msg_type='F',
+            text="Good",
+            contact=self.joe,
+            attachments=['image/jpeg:https://example.com/test.jpg']
+        )
+        frank_msg3 = self.create_msg(
+            direction='I', msg_type='I', text="Bien", contact=self.frank, channel=self.twitter, visibility='A'
+        )
 
         # add a surveyor message (no URN etc)
-        joe_msg4 = self.create_msg(direction='O', msg_type='F', text="Surveys!", contact=self.joe, contact_urn=None,
-                                   status='S', channel=None, sent_on=timezone.now())
+        joe_msg4 = self.create_msg(
+            direction='O',
+            msg_type='F',
+            text="Surveys!",
+            contact=self.joe,
+            contact_urn=None,
+            status='S',
+            channel=None,
+            sent_on=timezone.now()
+        )
 
         # add a deleted message
         deleted_msg = self.create_msg(direction='I', msg_type='I', text="!@$!%", contact=self.frank, visibility='D')
@@ -1968,8 +2187,8 @@ class APITest(TembaTest):
         label.toggle_label([frank_msg1], add=True)
         label.toggle_label([joe_msg3], add=True)
 
-        frank_msg1.refresh_from_db(fields=('modified_on',))
-        joe_msg3.refresh_from_db(fields=('modified_on',))
+        frank_msg1.refresh_from_db(fields=('modified_on', ))
+        joe_msg3.refresh_from_db(fields=('modified_on', ))
 
         # filter by inbox
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
@@ -1979,7 +2198,9 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsById(response, [frank_msg1])
-        self.assertMsgEqual(resp_json['results'][0], frank_msg1, msg_type='inbox', msg_status='queued', msg_visibility='visible')
+        self.assertMsgEqual(
+            resp_json['results'][0], frank_msg1, msg_type='inbox', msg_status='queued', msg_visibility='visible'
+        )
 
         # filter by incoming, should get deleted messages too
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
@@ -1989,7 +2210,9 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
         self.assertResultsById(response, [joe_msg3, frank_msg1, frank_msg3, deleted_msg, joe_msg1])
-        self.assertMsgEqual(resp_json['results'][0], joe_msg3, msg_type='flow', msg_status='queued', msg_visibility='visible')
+        self.assertMsgEqual(
+            resp_json['results'][0], joe_msg3, msg_type='flow', msg_status='queued', msg_visibility='visible'
+        )
 
         # filter by folder (flow)
         response = self.fetchJSON(url, 'folder=flows')
@@ -2057,11 +2280,14 @@ class APITest(TembaTest):
         self.assertResponseError(response, None, "Value for id must be an integer")
 
         # can't filter by more than one of contact, folder, label or broadcast together
-        for query in ('contact=%s&label=Spam' % self.joe.uuid, 'label=Spam&folder=inbox',
-                      'broadcast=12345&folder=inbox', 'broadcast=12345&label=Spam'):
+        for query in (
+            'contact=%s&label=Spam' % self.joe.uuid, 'label=Spam&folder=inbox', 'broadcast=12345&folder=inbox',
+            'broadcast=12345&label=Spam'
+        ):
             response = self.fetchJSON(url, query)
-            self.assertResponseError(response, None,
-                                     "You may only specify one of the contact, folder, label, broadcast parameters")
+            self.assertResponseError(
+                response, None, "You may only specify one of the contact, folder, label, broadcast parameters"
+            )
 
         with AnonymousOrg(self.org):
             # for anon orgs, don't return URN values
@@ -2076,30 +2302,40 @@ class APITest(TembaTest):
         # fetch as JSON
         response = self.fetchJSON(url)
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.json(), {
-            'name': "Temba",
-            'country': "RW",
-            'languages': [],
-            'primary_language': None,
-            'timezone': "Africa/Kigali",
-            'date_style': "day_first",
-            'credits': {'used': 0, 'remaining': 1000},
-            'anon': False
-        })
+        self.assertEqual(
+            response.json(), {
+                'name': "Temba",
+                'country': "RW",
+                'languages': [],
+                'primary_language': None,
+                'timezone': "Africa/Kigali",
+                'date_style': "day_first",
+                'credits': {
+                    'used': 0,
+                    'remaining': 1000
+                },
+                'anon': False
+            }
+        )
 
         self.org.set_languages(self.admin, ['eng', 'fre'], 'eng')
 
         response = self.fetchJSON(url)
-        self.assertEqual(response.json(), {
-            'name': "Temba",
-            'country': "RW",
-            'languages': ["eng", "fre"],
-            'primary_language': "eng",
-            'timezone': "Africa/Kigali",
-            'date_style': "day_first",
-            'credits': {'used': 0, 'remaining': 1000},
-            'anon': False
-        })
+        self.assertEqual(
+            response.json(), {
+                'name': "Temba",
+                'country': "RW",
+                'languages': ["eng", "fre"],
+                'primary_language': "eng",
+                'timezone': "Africa/Kigali",
+                'date_style': "day_first",
+                'credits': {
+                    'used': 0,
+                    'remaining': 1000
+                },
+                'anon': False
+            }
+        )
 
     def test_media(self):
         url = reverse('api.v2.media') + '.json'
@@ -2116,7 +2352,9 @@ class APITest(TembaTest):
                 location = response.json().get('location', None)
                 self.assertIsNotNone(location)
 
-                starts_with = 'https://%s/%s/%d/media/' % (settings.AWS_BUCKET_DOMAIN, settings.STORAGE_ROOT_DIR, self.org.pk)
+                starts_with = 'https://%s/%s/%d/media/' % (
+                    settings.AWS_BUCKET_DOMAIN, settings.STORAGE_ROOT_DIR, self.org.pk
+                )
                 self.assertEqual(starts_with, location[0:len(starts_with)])
                 self.assertEqual('.%s' % ext, location[-4:])
 
@@ -2179,46 +2417,74 @@ class APITest(TembaTest):
         frank_run2_steps = list(frank_run2.steps.order_by('pk'))
 
         resp_json = response.json()
-        self.assertEqual(resp_json['results'][2], {
-            'id': frank_run2.pk,
-            'flow': {'uuid': flow1.uuid, 'name': "Color Flow"},
-            'contact': {'uuid': self.frank.uuid, 'name': self.frank.name},
-            'start': None,
-            'responded': False,
-            'path': [
-                {'node': "d51ec25f-04e6-4349-a448-e7c4d93d4597", 'time': format_datetime(frank_run2_steps[0].arrived_on)},
-                {'node': "bd531ace-911e-4722-8e53-6730d6122fe1", 'time': format_datetime(frank_run2_steps[1].arrived_on)}
-            ],
-            'values': {},
-            'created_on': format_datetime(frank_run2.created_on),
-            'modified_on': format_datetime(frank_run2.modified_on),
-            'exited_on': None,
-            'exit_type': None
-        })
-        self.assertEqual(resp_json['results'][4], {
-            'id': joe_run1.pk,
-            'flow': {'uuid': flow1.uuid, 'name': "Color Flow"},
-            'contact': {'uuid': self.joe.uuid, 'name': self.joe.name},
-            'start': {'uuid': str(joe_run1.start.uuid)},
-            'responded': True,
-            'path': [
-                {'node': "d51ec25f-04e6-4349-a448-e7c4d93d4597", 'time': format_datetime(joe_run1_steps[0].arrived_on)},
-                {'node': "bd531ace-911e-4722-8e53-6730d6122fe1", 'time': format_datetime(joe_run1_steps[1].arrived_on)},
-                {'node': "c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", 'time': format_datetime(joe_run1_steps[2].arrived_on)}
-            ],
-            'values': {
-                'color': {
-                    'value': "blue",
-                    'category': "Blue",
+        self.assertEqual(
+            resp_json['results'][2], {
+                'id': frank_run2.pk,
+                'flow': {
+                    'uuid': flow1.uuid,
+                    'name': "Color Flow"
+                },
+                'contact': {
+                    'uuid': self.frank.uuid,
+                    'name': self.frank.name
+                },
+                'start': None,
+                'responded': False,
+                'path': [{
+                    'node': "d51ec25f-04e6-4349-a448-e7c4d93d4597",
+                    'time': format_datetime(frank_run2_steps[0].arrived_on)
+                }, {
                     'node': "bd531ace-911e-4722-8e53-6730d6122fe1",
-                    'time': format_datetime(self.joe.values.get(ruleset__uuid="bd531ace-911e-4722-8e53-6730d6122fe1").modified_on)
-                }
-            },
-            'created_on': format_datetime(joe_run1.created_on),
-            'modified_on': format_datetime(joe_run1.modified_on),
-            'exited_on': format_datetime(joe_run1.exited_on),
-            'exit_type': 'completed'
-        })
+                    'time': format_datetime(frank_run2_steps[1].arrived_on)
+                }],
+                'values': {},
+                'created_on': format_datetime(frank_run2.created_on),
+                'modified_on': format_datetime(frank_run2.modified_on),
+                'exited_on': None,
+                'exit_type': None
+            }
+        )
+        self.assertEqual(
+            resp_json['results'][4], {
+                'id': joe_run1.pk,
+                'flow': {
+                    'uuid': flow1.uuid,
+                    'name': "Color Flow"
+                },
+                'contact': {
+                    'uuid': self.joe.uuid,
+                    'name': self.joe.name
+                },
+                'start': {
+                    'uuid': str(joe_run1.start.uuid)
+                },
+                'responded': True,
+                'path': [{
+                    'node': "d51ec25f-04e6-4349-a448-e7c4d93d4597",
+                    'time': format_datetime(joe_run1_steps[0].arrived_on)
+                }, {
+                    'node': "bd531ace-911e-4722-8e53-6730d6122fe1",
+                    'time': format_datetime(joe_run1_steps[1].arrived_on)
+                }, {
+                    'node': "c12f37e2-8e6c-4c81-ba6d-941bb3caf93f",
+                    'time': format_datetime(joe_run1_steps[2].arrived_on)
+                }],
+                'values': {
+                    'color': {
+                        'value': "blue",
+                        'category': "Blue",
+                        'node': "bd531ace-911e-4722-8e53-6730d6122fe1",
+                        'time': format_datetime(
+                            self.joe.values.get(ruleset__uuid="bd531ace-911e-4722-8e53-6730d6122fe1").modified_on
+                        )
+                    }
+                },
+                'created_on': format_datetime(joe_run1.created_on),
+                'modified_on': format_datetime(joe_run1.modified_on),
+                'exited_on': format_datetime(joe_run1.exited_on),
+                'exit_type': 'completed'
+            }
+        )
 
         # check when all broadcasts have been purged
         Broadcast.objects.all().update(purged=True)
@@ -2281,8 +2547,7 @@ class APITest(TembaTest):
 
         # can't filter by both contact and flow together
         response = self.fetchJSON(url, 'contact=%s&flow=%s' % (self.joe.uuid, flow1.uuid))
-        self.assertResponseError(response, None,
-                                 "You may only specify one of the contact, flow parameters")
+        self.assertResponseError(response, None, "You may only specify one of the contact, flow parameters")
 
     def test_message_actions(self):
         url = reverse('api.v2.message_actions')
@@ -2353,7 +2618,14 @@ class APITest(TembaTest):
         self.assertResponseError(response, 'label', "This field may not be null.")
 
         # try to provide both label and label_name
-        response = self.postJSON(url, None, {'messages': [msg1.id], 'action': 'label', 'label': "Test", 'label_name': "Test"})
+        response = self.postJSON(
+            url, None, {
+                'messages': [msg1.id],
+                'action': 'label',
+                'label': "Test",
+                'label_name': "Test"
+            }
+        )
         self.assertResponseError(response, 'non_field_errors', "Can't specify both label and label_name.")
 
         # archive all messages
@@ -2412,18 +2684,17 @@ class APITest(TembaTest):
         resp_json = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(resp_json['next'], None)
-        self.assertEqual(resp_json['results'], [
-            {
+        self.assertEqual(
+            resp_json['results'], [{
                 'resthook': 'new-father',
                 'created_on': format_datetime(resthook2.created_on),
                 'modified_on': format_datetime(resthook2.modified_on),
-            },
-            {
+            }, {
                 'resthook': 'new-mother',
                 'created_on': format_datetime(resthook1.created_on),
                 'modified_on': format_datetime(resthook1.modified_on),
-            }
-        ])
+            }]
+        )
 
         # ok, let's look at subscriptions
         url = reverse('api.v2.resthook_subscribers')
@@ -2447,12 +2718,14 @@ class APITest(TembaTest):
         hook1_subscriber = resthook1.subscribers.get()
         hook2_subscriber = resthook2.subscribers.get()
 
-        self.assertEqual(response.json(), {
-            'id': hook2_subscriber.id,
-            'resthook': "new-father",
-            'target_url': "https://foo.bar/fathers",
-            'created_on': format_datetime(hook2_subscriber.created_on),
-        })
+        self.assertEqual(
+            response.json(), {
+                'id': hook2_subscriber.id,
+                'resthook': "new-father",
+                'target_url': "https://foo.bar/fathers",
+                'created_on': format_datetime(hook2_subscriber.created_on),
+            }
+        )
 
         # create a subscriber on our other resthook
         other_org_subscriber = other_org_resthook.add_subscriber('https://bar.foo', self.admin2)
@@ -2461,20 +2734,19 @@ class APITest(TembaTest):
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 1):
             response = self.fetchJSON(url)
 
-        self.assertEqual(response.json()['results'], [
-            {
+        self.assertEqual(
+            response.json()['results'], [{
                 'id': hook2_subscriber.id,
                 'resthook': "new-father",
                 'target_url': "https://foo.bar/fathers",
                 'created_on': format_datetime(hook2_subscriber.created_on),
-            },
-            {
+            }, {
                 'id': hook1_subscriber.id,
                 'resthook': "new-mother",
                 'target_url': "https://foo.bar/mothers",
                 'created_on': format_datetime(hook1_subscriber.created_on),
-            }
-        ])
+            }]
+        )
 
         # filter by id
         response = self.fetchJSON(url, 'id=%d' % hook1_subscriber.id)
@@ -2505,34 +2777,43 @@ class APITest(TembaTest):
         self.assertEndpointAccess(url)
 
         # create some events on our resthooks
-        event1 = WebHookEvent.objects.create(org=self.org, resthook=resthook1, event='F',
-                                             data=json.dumps(dict(event='new mother',
-                                                                  values=json.dumps(dict(name="Greg")),
-                                                                  steps=json.dumps(dict(uuid='abcde')))),
-                                             created_by=self.admin, modified_by=self.admin)
-        event2 = WebHookEvent.objects.create(org=self.org, resthook=resthook2, event='F',
-                                             data=json.dumps(dict(event='new father',
-                                                                  values=json.dumps(dict(name="Yo")),
-                                                                  steps=json.dumps(dict(uuid='12345')))),
-                                             created_by=self.admin, modified_by=self.admin)
+        event1 = WebHookEvent.objects.create(
+            org=self.org,
+            resthook=resthook1,
+            event='F',
+            data=json.dumps(
+                dict(event='new mother', values=json.dumps(dict(name="Greg")), steps=json.dumps(dict(uuid='abcde')))
+            ),
+            created_by=self.admin,
+            modified_by=self.admin
+        )
+        event2 = WebHookEvent.objects.create(
+            org=self.org,
+            resthook=resthook2,
+            event='F',
+            data=json.dumps(
+                dict(event='new father', values=json.dumps(dict(name="Yo")), steps=json.dumps(dict(uuid='12345')))
+            ),
+            created_by=self.admin,
+            modified_by=self.admin
+        )
 
         # no filtering
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 1):
             response = self.fetchJSON(url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()['results'], [
-            {
+        self.assertEqual(
+            response.json()['results'], [{
                 'resthook': "new-father",
                 'created_on': format_datetime(event2.created_on),
                 'data': dict(event='new father', values=dict(name="Yo"), steps=dict(uuid='12345'))
-            },
-            {
+            }, {
                 'resthook': "new-mother",
                 'created_on': format_datetime(event1.created_on),
                 'data': dict(event='new mother', values=dict(name="Greg"), steps=dict(uuid='abcde'))
-            }
-        ])
+            }]
+        )
 
     def test_flow_starts(self):
         url = reverse('api.v2.flow_starts')
@@ -2542,9 +2823,12 @@ class APITest(TembaTest):
 
         # update our flow to use @extra.first_name and @extra.last_name
         first_action = flow.action_sets.all().order_by('y')[0]
-        first_action.actions = json.dumps([ReplyAction(str(uuid4()),
-                                                       dict(base="Hi @extra.first_name @extra.last_name, "
-                                                                 "what's your favorite color?")).as_json()])
+        first_action.actions = json.dumps([
+            ReplyAction(
+                str(uuid4()), dict(base="Hi @extra.first_name @extra.last_name, "
+                                   "what's your favorite color?")
+            ).as_json()
+        ])
         first_action.save()
 
         # try to create an empty flow start
@@ -2569,12 +2853,17 @@ class APITest(TembaTest):
         # start a flow with all parameters
         extra = dict(first_name="Ryan", last_name="Lewis")
         hans_group = self.create_group("hans", contacts=[self.hans])
-        response = self.postJSON(url, None, dict(urns=['tel:+12067791212'],
-                                                 contacts=[self.joe.uuid],
-                                                 groups=[hans_group.uuid],
-                                                 flow=flow.uuid,
-                                                 restart_participants=False,
-                                                 extra=extra))
+        response = self.postJSON(
+            url, None,
+            dict(
+                urns=['tel:+12067791212'],
+                contacts=[self.joe.uuid],
+                groups=[hans_group.uuid],
+                flow=flow.uuid,
+                restart_participants=False,
+                extra=extra
+            )
+        )
 
         self.assertEqual(response.status_code, 201)
 
@@ -2595,18 +2884,21 @@ class APITest(TembaTest):
         self.assertResponseError(response, 'non_field_errors', "Must specify at least one group, contact or URN")
 
         # invalid URN
-        response = self.postJSON(url, None, dict(flow=flow.uuid, restart_participants=True, urns=['foo:bar'],
-                                                 contacts=[self.joe.uuid]))
+        response = self.postJSON(
+            url, None, dict(flow=flow.uuid, restart_participants=True, urns=['foo:bar'], contacts=[self.joe.uuid])
+        )
         self.assertEqual(response.status_code, 400)
 
         # invalid contact uuid
-        response = self.postJSON(url, None, dict(flow=flow.uuid, restart_participants=True, urns=['tel:+12067791212'],
-                                                 contacts=['abcde']))
+        response = self.postJSON(
+            url, None, dict(flow=flow.uuid, restart_participants=True, urns=['tel:+12067791212'], contacts=['abcde'])
+        )
         self.assertEqual(response.status_code, 400)
 
         # invalid group uuid
-        response = self.postJSON(url, None, dict(flow=flow.uuid, restart_participants=True, urns=['tel:+12067791212'],
-                                                 groups=['abcde']))
+        response = self.postJSON(
+            url, None, dict(flow=flow.uuid, restart_participants=True, urns=['tel:+12067791212'], groups=['abcde'])
+        )
         self.assertResponseError(response, 'groups', "No such object: abcde")
 
         # invalid flow uuid
@@ -2629,23 +2921,35 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['next'], None)
         self.assertResultsById(response, [start2, start1])
-        self.assertEqual(response.json()['results'][0], {
-            'id': start2.id,
-            'uuid': six.text_type(start2.uuid),
-            'flow': {'uuid': flow.uuid, 'name': 'Favorites'},
-            'contacts': [
-                {'uuid': self.joe.uuid, 'name': 'Joe Blow'},
-                {'uuid': anon_contact.uuid, 'name': None}
-            ],
-            'groups': [
-                {'uuid': hans_group.uuid, 'name': 'hans'}
-            ],
-            'restart_participants': False,
-            'status': 'complete',
-            'extra': {"first_name": "Ryan", "last_name": "Lewis"},
-            'created_on': format_datetime(start2.created_on),
-            'modified_on': format_datetime(start2.modified_on),
-        })
+        self.assertEqual(
+            response.json()['results'][0], {
+                'id': start2.id,
+                'uuid': six.text_type(start2.uuid),
+                'flow': {
+                    'uuid': flow.uuid,
+                    'name': 'Favorites'
+                },
+                'contacts': [{
+                    'uuid': self.joe.uuid,
+                    'name': 'Joe Blow'
+                }, {
+                    'uuid': anon_contact.uuid,
+                    'name': None
+                }],
+                'groups': [{
+                    'uuid': hans_group.uuid,
+                    'name': 'hans'
+                }],
+                'restart_participants': False,
+                'status': 'complete',
+                'extra': {
+                    "first_name": "Ryan",
+                    "last_name": "Lewis"
+                },
+                'created_on': format_datetime(start2.created_on),
+                'modified_on': format_datetime(start2.modified_on),
+            }
+        )
 
         # check filtering by UUID
         response = self.fetchJSON(url, "uuid=%s" % str(start2.uuid))

--- a/temba/api/v2/urls.py
+++ b/temba/api/v2/urls.py
@@ -8,7 +8,6 @@ from .views import FieldsEndpoint, FlowStartsEndpoint, GroupsEndpoint, LabelsEnd
 from .views import OrgEndpoint, ResthooksEndpoint, ResthookEventsEndpoint, ResthookSubscribersEndpoint, RunsEndpoint
 from .views import BoundariesEndpoint, ContactActionsEndpoint, MessageActionsEndpoint
 
-
 urlpatterns = [
     url(r'^$', RootView.as_view(), name='api.v2'),
     url(r'^explorer/$', ExplorerView.as_view(), name='api.v2.explorer'),

--- a/temba/api/v2/validators.py
+++ b/temba/api/v2/validators.py
@@ -8,6 +8,7 @@ class UniqueForOrgValidator(UniqueValidator):
     UniqueValidator requires a queryset at compile time but we always need to include org, which isn't known until
     request time. So this subclass reads org from the field's context and applies it to the queryset at runtime.
     """
+
     def __init__(self, queryset, ignore_case=True, message=None):
         lookup = 'iexact' if ignore_case else 'exact'
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -219,6 +219,7 @@ class AuthenticateView(SmartFormView):
     """
     Provides a login form view for app users to generate and access their API tokens
     """
+
     class LoginForm(forms.Form):
         ROLE_CHOICES = (('A', _("Administrator")), ('E', _("Editor")), ('S', _("Surveyor")))
 
@@ -309,7 +310,9 @@ class BaseAPIView(generics.GenericAPIView):
                 lookup_values[field] = param_value
 
         if len(lookup_values) > 1:
-            raise InvalidQueryError("URL can only contain one of the following parameters: " + ", ".join(self.lookup_params.keys()))
+            raise InvalidQueryError(
+                "URL can only contain one of the following parameters: " + ", ".join(self.lookup_params.keys())
+            )
 
         return lookup_values
 
@@ -464,6 +467,7 @@ class BulkWriteAPIMixin(object):
     """
     Mixin for a bulk action endpoint which writes multiple objects in response to a POST but returns nothing.
     """
+
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data, context=self.get_serializer_context())
 
@@ -478,11 +482,14 @@ class DeleteAPIMixin(mixins.DestroyModelMixin):
     """
     Mixin for any endpoint that can delete objects with a DELETE request
     """
+
     def delete(self, request, *args, **kwargs):
         self.lookup_values = self.get_lookup_values()
 
         if not self.lookup_values:
-            raise InvalidQueryError("URL must contain one of the following parameters: " + ", ".join(self.lookup_params.keys()))
+            raise InvalidQueryError(
+                "URL must contain one of the following parameters: " + ", ".join(self.lookup_params.keys())
+            )
 
         instance = self.get_object()
         self.perform_destroy(instance)
@@ -548,8 +555,9 @@ class BoundariesEndpoint(ListAPIMixin, BaseAPIView):
         }
 
     """
+
     class Pagination(CursorPagination):
-        ordering = ('osm_id',)
+        ordering = ('osm_id', )
 
     permission = 'locations.adminboundary_api'
     model = AdminBoundary
@@ -672,7 +680,9 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
         )
 
         if not org.is_anon:
-            queryset = queryset.prefetch_related(Prefetch('urns', queryset=ContactURN.objects.only('scheme', 'path', 'display').order_by('pk')))
+            queryset = queryset.prefetch_related(
+                Prefetch('urns', queryset=ContactURN.objects.only('scheme', 'path', 'display').order_by('pk'))
+            )
 
         return self.filter_before_after(queryset, 'created_on')
 
@@ -683,11 +693,19 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "List Broadcasts",
             'url': reverse('api.v2.broadcasts'),
             'slug': 'broadcast-list',
-            'params': [
-                {'name': 'id', 'required': False, 'help': "A broadcast ID to filter by, ex: 123456"},
-                {'name': 'before', 'required': False, 'help': "Only return broadcasts created before this date, ex: 2015-01-28T18:00:00.000"},
-                {'name': 'after', 'required': False, 'help': "Only return broadcasts created after this date, ex: 2015-01-28T18:00:00.000"}
-            ]
+            'params': [{
+                'name': 'id',
+                'required': False,
+                'help': "A broadcast ID to filter by, ex: 123456"
+            }, {
+                'name': 'before',
+                'required': False,
+                'help': "Only return broadcasts created before this date, ex: 2015-01-28T18:00:00.000"
+            }, {
+                'name': 'after',
+                'required': False,
+                'help': "Only return broadcasts created after this date, ex: 2015-01-28T18:00:00.000"
+            }]
         }
 
     @classmethod
@@ -697,13 +715,27 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "Send Broadcasts",
             'url': reverse('api.v2.broadcasts'),
             'slug': 'broadcast-write',
-            'fields': [
-                {'name': 'text', 'required': True, 'help': "The text of the message you want to send"},
-                {'name': 'urns', 'required': False, 'help': "The URNs of contacts you want to send to"},
-                {'name': 'contacts', 'required': False, 'help': "The UUIDs of contacts you want to send to"},
-                {'name': 'groups', 'required': False, 'help': "The UUIDs of contact groups you want to send to"},
-                {'name': 'channel', 'required': False, 'help': "The UUID of the channel you want to use for sending"}
-            ]
+            'fields': [{
+                'name': 'text',
+                'required': True,
+                'help': "The text of the message you want to send"
+            }, {
+                'name': 'urns',
+                'required': False,
+                'help': "The URNs of contacts you want to send to"
+            }, {
+                'name': 'contacts',
+                'required': False,
+                'help': "The UUIDs of contacts you want to send to"
+            }, {
+                'name': 'groups',
+                'required': False,
+                'help': "The UUIDs of contact groups you want to send to"
+            }, {
+                'name': 'channel',
+                'required': False,
+                'help': "The UUID of the channel you want to use for sending"
+            }]
         }
 
 
@@ -809,7 +841,11 @@ class CampaignsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.campaigns'),
             'slug': 'campaign-list',
             'params': [
-                {'name': "uuid", 'required': False, 'help': "A campaign UUID to filter by"},
+                {
+                    'name': "uuid",
+                    'required': False,
+                    'help': "A campaign UUID to filter by"
+                },
             ]
         }
 
@@ -821,12 +857,21 @@ class CampaignsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.campaigns'),
             'slug': 'campaign-write',
             'params': [
-                {'name': "uuid", 'required': False, 'help': "UUID of the campaign to be updated"},
+                {
+                    'name': "uuid",
+                    'required': False,
+                    'help': "UUID of the campaign to be updated"
+                },
             ],
-            'fields': [
-                {'name': "name", 'required': True, 'help': "The name of the campaign"},
-                {'name': "group", 'required': True, 'help': "The UUID of the contact group operated on by the campaign"}
-            ]
+            'fields': [{
+                'name': "name",
+                'required': True,
+                'help': "The name of the campaign"
+            }, {
+                'name': "group",
+                'required': True,
+                'help': "The UUID of the contact group operated on by the campaign"
+            }]
         }
 
 
@@ -981,8 +1026,16 @@ class CampaignEventsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAP
             'url': reverse('api.v2.campaign_events'),
             'slug': 'campaign-event-list',
             'params': [
-                {'name': "uuid", 'required': False, 'help': "A campaign event UUID to filter by"},
-                {'name': "campaign", 'required': False, 'help': "A campaign UUID or name to filter"},
+                {
+                    'name': "uuid",
+                    'required': False,
+                    'help': "A campaign event UUID to filter by"
+                },
+                {
+                    'name': "campaign",
+                    'required': False,
+                    'help': "A campaign UUID or name to filter"
+                },
             ]
         }
 
@@ -994,17 +1047,41 @@ class CampaignEventsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAP
             'url': reverse('api.v2.campaign_events'),
             'slug': 'campaign-event-write',
             'params': [
-                {'name': "uuid", 'required': False, 'help': "The UUID of the campaign event to update"},
+                {
+                    'name': "uuid",
+                    'required': False,
+                    'help': "The UUID of the campaign event to update"
+                },
             ],
-            'fields': [
-                {'name': "campaign", 'required': False, 'help': "The UUID of the campaign this event belongs to"},
-                {'name': "relative_to", 'required': True, 'help': "The key of the contact field this event is relative to. (string)"},
-                {'name': "offset", 'required': True, 'help': "The offset from the relative_to field value (integer, positive or negative)"},
-                {'name': "unit", 'required': True, 'help': 'The unit of the offset (one of "minutes, "hours", "days", "weeks")'},
-                {'name': "delivery_hour", 'required': True, 'help': "The hour this event should be triggered, or -1 if the event should be sent at the same hour as our date (integer, -1 or 0-23)"},
-                {'name': "message", 'required': False, 'help': "The message that should be sent to the contact when this event is triggered (string)"},
-                {'name': "flow", 'required': False, 'help': "The UUID of the flow that the contact should start when this event is triggered (string)"}
-            ]
+            'fields': [{
+                'name': "campaign",
+                'required': False,
+                'help': "The UUID of the campaign this event belongs to"
+            }, {
+                'name': "relative_to",
+                'required': True,
+                'help': "The key of the contact field this event is relative to. (string)"
+            }, {
+                'name': "offset",
+                'required': True,
+                'help': "The offset from the relative_to field value (integer, positive or negative)"
+            }, {
+                'name': "unit",
+                'required': True,
+                'help': 'The unit of the offset (one of "minutes, "hours", "days", "weeks")'
+            }, {
+                'name': "delivery_hour",
+                'required': True,
+                'help': "The hour this event should be triggered, or -1 if the event should be sent at the same hour as our date (integer, -1 or 0-23)"
+            }, {
+                'name': "message",
+                'required': False,
+                'help': "The message that should be sent to the contact when this event is triggered (string)"
+            }, {
+                'name': "flow",
+                'required': False,
+                'help': "The UUID of the flow that the contact should start when this event is triggered (string)"
+            }]
         }
 
     @classmethod
@@ -1015,9 +1092,11 @@ class CampaignEventsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAP
             'url': reverse('api.v2.campaign_events'),
             'slug': 'campaign-event-delete',
             'request': '',
-            'params': [
-                {'name': "uuid", 'required': False, 'help': "The UUID of the campaign event to delete"}
-            ],
+            'params': [{
+                'name': "uuid",
+                'required': False,
+                'help': "The UUID of the campaign event to delete"
+            }],
         }
 
 
@@ -1100,8 +1179,16 @@ class ChannelsEndpoint(ListAPIMixin, BaseAPIView):
             'url': reverse('api.v2.channels'),
             'slug': 'channel-list',
             'params': [
-                {'name': "uuid", 'required': False, 'help': "A channel UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
-                {'name': "address", 'required': False, 'help': "A channel address to filter by. ex: +250783530001"},
+                {
+                    'name': "uuid",
+                    'required': False,
+                    'help': "A channel UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"
+                },
+                {
+                    'name': "address",
+                    'required': False,
+                    'help': "A channel address to filter by. ex: +250783530001"
+                },
             ]
         }
 
@@ -1181,12 +1268,23 @@ class ChannelEventsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Channel Events",
             'url': reverse('api.v2.channel_events'),
             'slug': 'channel-event-list',
-            'params': [
-                {'name': "id", 'required': False, 'help': "An event ID to filter by. ex: 12345"},
-                {'name': "contact", 'required': False, 'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
-                {'name': 'before', 'required': False, 'help': "Only return events created before this date, ex: 2015-01-28T18:00:00.000"},
-                {'name': 'after', 'required': False, 'help': "Only return events created after this date, ex: 2015-01-28T18:00:00.000"}
-            ]
+            'params': [{
+                'name': "id",
+                'required': False,
+                'help': "An event ID to filter by. ex: 12345"
+            }, {
+                'name': "contact",
+                'required': False,
+                'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"
+            }, {
+                'name': 'before',
+                'required': False,
+                'help': "Only return events created before this date, ex: 2015-01-28T18:00:00.000"
+            }, {
+                'name': 'after',
+                'required': False,
+                'help': "Only return events created after this date, ex: 2015-01-28T18:00:00.000"
+            }]
         }
 
 
@@ -1352,8 +1450,11 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
 
         # use prefetch rather than select_related for foreign keys to avoid joins
         queryset = queryset.prefetch_related(
-            Prefetch('all_groups', queryset=ContactGroup.user_groups.only('uuid', 'name').order_by('pk'),
-                     to_attr='prefetched_user_groups')
+            Prefetch(
+                'all_groups',
+                queryset=ContactGroup.user_groups.only('uuid', 'name').order_by('pk'),
+                to_attr='prefetched_user_groups'
+            )
         )
 
         return self.filter_before_after(queryset, 'modified_on')
@@ -1390,15 +1491,34 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'title': "List Contacts",
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-list',
-            'params': [
-                {'name': "uuid", 'required': False, 'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
-                {'name': "urn", 'required': False, 'help': "A contact URN to filter by. ex: tel:+250788123123"},
-                {'name': "group", 'required': False, 'help': "A group name or UUID to filter by. ex: Customers"},
-                {'name': "deleted", 'required': False, 'help': "Whether to return only deleted contacts. ex: false"},
-                {'name': 'before', 'required': False, 'help': "Only return contacts modified before this date, ex: 2015-01-28T18:00:00.000"},
-                {'name': 'after', 'required': False, 'help': "Only return contacts modified after this date, ex: 2015-01-28T18:00:00.000"}
-            ],
-            'example': {'query': "urn=tel%3A%2B250788123123"},
+            'params': [{
+                'name': "uuid",
+                'required': False,
+                'help': "A contact UUID to filter by. ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"
+            }, {
+                'name': "urn",
+                'required': False,
+                'help': "A contact URN to filter by. ex: tel:+250788123123"
+            }, {
+                'name': "group",
+                'required': False,
+                'help': "A group name or UUID to filter by. ex: Customers"
+            }, {
+                'name': "deleted",
+                'required': False,
+                'help': "Whether to return only deleted contacts. ex: false"
+            }, {
+                'name': 'before',
+                'required': False,
+                'help': "Only return contacts modified before this date, ex: 2015-01-28T18:00:00.000"
+            }, {
+                'name': 'after',
+                'required': False,
+                'help': "Only return contacts modified after this date, ex: 2015-01-28T18:00:00.000"
+            }],
+            'example': {
+                'query': "urn=tel%3A%2B250788123123"
+            },
         }
 
     @classmethod
@@ -1409,17 +1529,47 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-write',
             'params': [
-                {'name': "uuid", 'required': False, 'help': "UUID of the contact to be updated"},
-                {'name': "urn", 'required': False, 'help': "URN of the contact to be updated. ex: tel:+250788123123"},
+                {
+                    'name': "uuid",
+                    'required': False,
+                    'help': "UUID of the contact to be updated"
+                },
+                {
+                    'name': "urn",
+                    'required': False,
+                    'help': "URN of the contact to be updated. ex: tel:+250788123123"
+                },
             ],
             'fields': [
-                {'name': "name", 'required': False, 'help': "List of UUIDs of this contact's groups."},
-                {'name': "language", 'required': False, 'help': "Preferred language of the contact (3-letter ISO code). ex: fre, eng"},
-                {'name': "urns", 'required': False, 'help': "List of URNs belonging to the contact."},
-                {'name': "groups", 'required': False, 'help': "List of UUIDs of groups that the contact belongs to."},
-                {'name': "fields", 'required': False, 'help': "Custom fields as a JSON dictionary."},
+                {
+                    'name': "name",
+                    'required': False,
+                    'help': "List of UUIDs of this contact's groups."
+                },
+                {
+                    'name': "language",
+                    'required': False,
+                    'help': "Preferred language of the contact (3-letter ISO code). ex: fre, eng"
+                },
+                {
+                    'name': "urns",
+                    'required': False,
+                    'help': "List of URNs belonging to the contact."
+                },
+                {
+                    'name': "groups",
+                    'required': False,
+                    'help': "List of UUIDs of groups that the contact belongs to."
+                },
+                {
+                    'name': "fields",
+                    'required': False,
+                    'help': "Custom fields as a JSON dictionary."
+                },
             ],
-            'example': {'body': '{"name": "Ben Haggerty", "groups": [], "urns": ["tel:+250788123123"]}'},
+            'example': {
+                'body': '{"name": "Ben Haggerty", "groups": [], "urns": ["tel:+250788123123"]}'
+            },
         }
 
     @classmethod
@@ -1429,10 +1579,15 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
             'title': "Delete Contacts",
             'url': reverse('api.v2.contacts'),
             'slug': 'contact-delete',
-            'params': [
-                {'name': "uuid", 'required': False, 'help': "UUID of the contact to be deleted"},
-                {'name': "urn", 'required': False, 'help': "URN of the contact to be deleted. ex: tel:+250788123123"}
-            ],
+            'params': [{
+                'name': "uuid",
+                'required': False,
+                'help': "UUID of the contact to be deleted"
+            }, {
+                'name': "urn",
+                'required': False,
+                'help': "URN of the contact to be deleted. ex: tel:+250788123123"
+            }],
         }
 
 
@@ -1479,9 +1634,21 @@ class ContactActionsEndpoint(BulkWriteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.contact_actions'),
             'slug': 'contact-actions',
             'fields': [
-                {'name': "contacts", 'required': True, 'help': "The UUIDs of the contacts to update"},
-                {'name': "action", 'required': True, 'help': "One of the following strings: " + ", ".join(actions)},
-                {'name': "group", 'required': False, 'help': "The UUID or name of a contact group"},
+                {
+                    'name': "contacts",
+                    'required': True,
+                    'help': "The UUIDs of the contacts to update"
+                },
+                {
+                    'name': "action",
+                    'required': True,
+                    'help': "One of the following strings: " + ", ".join(actions)
+                },
+                {
+                    'name': "group",
+                    'required': False,
+                    'help': "The UUID or name of a contact group"
+                },
             ]
         }
 
@@ -1592,7 +1759,9 @@ class DefinitionsEndpoint(BaseAPIView):
 
         include = params.get('dependencies', 'all')
         if include not in DefinitionsEndpoint.Depends.__members__:
-            raise InvalidQueryError("dependencies must be one of %s" % ', '.join(DefinitionsEndpoint.Depends.__members__))
+            raise InvalidQueryError(
+                "dependencies must be one of %s" % ', '.join(DefinitionsEndpoint.Depends.__members__)
+            )
 
         include = DefinitionsEndpoint.Depends[include]
 
@@ -1624,11 +1793,19 @@ class DefinitionsEndpoint(BaseAPIView):
             'title': "Export Definitions",
             'url': reverse('api.v2.definitions'),
             'slug': 'definition-list',
-            'params': [
-                {'name': "flow", 'required': False, 'help': "One or more flow UUIDs to include"},
-                {'name': "campaign", 'required': False, 'help': "One or more campaign UUIDs to include"},
-                {'name': "dependencies", 'required': False, 'help': "Whether to include dependencies of the requested items. ex: false"}
-            ]
+            'params': [{
+                'name': "flow",
+                'required': False,
+                'help': "One or more flow UUIDs to include"
+            }, {
+                'name': "campaign",
+                'required': False,
+                'help': "One or more campaign UUIDs to include"
+            }, {
+                'name': "dependencies",
+                'required': False,
+                'help': "Whether to include dependencies of the requested items. ex: false"
+            }]
         }
 
 
@@ -1730,10 +1907,14 @@ class FieldsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "List Fields",
             'url': reverse('api.v2.fields'),
             'slug': 'field-list',
-            'params': [
-                {'name': "key", 'required': False, 'help': "A field key to filter by. ex: nick_name"}
-            ],
-            'example': {'query': "key=nick_name"},
+            'params': [{
+                'name': "key",
+                'required': False,
+                'help': "A field key to filter by. ex: nick_name"
+            }],
+            'example': {
+                'query': "key=nick_name"
+            },
         }
 
     @classmethod
@@ -1743,14 +1924,23 @@ class FieldsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "Add or Update Fields",
             'url': reverse('api.v2.fields'),
             'slug': 'field-write',
-            'params': [
-                {'name': "key", 'required': False, 'help': "Key of an existing field to update"}
-            ],
-            'fields': [
-                {'name': "label", 'required': True, 'help': "The label of the field"},
-                {'name': "value_type", 'required': True, 'help': "The value type of the field"}
-            ],
-            'example': {'query': "key=nick_name"},
+            'params': [{
+                'name': "key",
+                'required': False,
+                'help': "Key of an existing field to update"
+            }],
+            'fields': [{
+                'name': "label",
+                'required': True,
+                'help': "The label of the field"
+            }, {
+                'name': "value_type",
+                'required': True,
+                'help': "The value type of the field"
+            }],
+            'example': {
+                'query': "key=nick_name"
+            },
         }
 
 
@@ -1826,11 +2016,19 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Flows",
             'url': reverse('api.v2.flows'),
             'slug': 'flow-list',
-            'params': [
-                {'name': "uuid", 'required': False, 'help': "A flow UUID filter by. ex: 5f05311e-8f81-4a67-a5b5-1501b6d6496a"},
-                {'name': 'before', 'required': False, 'help': "Only return flows modified before this date, ex: 2017-01-28T18:00:00.000"},
-                {'name': 'after', 'required': False, 'help': "Only return flows modified after this date, ex: 2017-01-28T18:00:00.000"}
-            ]
+            'params': [{
+                'name': "uuid",
+                'required': False,
+                'help': "A flow UUID filter by. ex: 5f05311e-8f81-4a67-a5b5-1501b6d6496a"
+            }, {
+                'name': 'before',
+                'required': False,
+                'help': "Only return flows modified before this date, ex: 2017-01-28T18:00:00.000"
+            }, {
+                'name': 'after',
+                'required': False,
+                'help': "Only return flows modified after this date, ex: 2017-01-28T18:00:00.000"
+            }]
         }
 
 
@@ -1953,10 +2151,15 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "List Contact Groups",
             'url': reverse('api.v2.groups'),
             'slug': 'group-list',
-            'params': [
-                {'name': "uuid", 'required': False, 'help': "A contact group UUID to filter by"},
-                {'name': "name", 'required': False, 'help': "A contact group name to filter by"}
-            ]
+            'params': [{
+                'name': "uuid",
+                'required': False,
+                'help': "A contact group UUID to filter by"
+            }, {
+                'name': "name",
+                'required': False,
+                'help': "A contact group name to filter by"
+            }]
         }
 
     @classmethod
@@ -1966,12 +2169,16 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "Add or Update Contact Groups",
             'url': reverse('api.v2.groups'),
             'slug': 'group-write',
-            'params': [
-                {'name': "uuid", 'required': False, 'help': "The UUID of the contact group to update"}
-            ],
-            'fields': [
-                {'name': "name", 'required': True, 'help': "The name of the contact group"}
-            ]
+            'params': [{
+                'name': "uuid",
+                'required': False,
+                'help': "The UUID of the contact group to update"
+            }],
+            'fields': [{
+                'name': "name",
+                'required': True,
+                'help': "The name of the contact group"
+            }]
         }
 
     @classmethod
@@ -1981,9 +2188,11 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "Delete Contact Groups",
             'url': reverse('api.v2.groups'),
             'slug': 'group-delete',
-            'params': [
-                {'name': "uuid", 'required': True, 'help': "The UUID of the contact group to delete"}
-            ],
+            'params': [{
+                'name': "uuid",
+                'required': True,
+                'help': "The UUID of the contact group to delete"
+            }],
         }
 
 
@@ -2103,10 +2312,15 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "List Message Labels",
             'url': reverse('api.v2.labels'),
             'slug': 'label-list',
-            'params': [
-                {'name': "uuid", 'required': False, 'help': "A message label UUID to filter by"},
-                {'name': "name", 'required': False, 'help': "A message label name to filter by"}
-            ]
+            'params': [{
+                'name': "uuid",
+                'required': False,
+                'help': "A message label UUID to filter by"
+            }, {
+                'name': "name",
+                'required': False,
+                'help': "A message label name to filter by"
+            }]
         }
 
     @classmethod
@@ -2117,11 +2331,17 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.labels'),
             'slug': 'label-write',
             'params': [
-                {'name': "uuid", 'required': False, 'help': "The UUID of the message label to update"},
+                {
+                    'name': "uuid",
+                    'required': False,
+                    'help': "The UUID of the message label to update"
+                },
             ],
-            'fields': [
-                {'name': "name", 'required': True, 'help': "The name of the message label"}
-            ]
+            'fields': [{
+                'name': "name",
+                'required': True,
+                'help': "The name of the message label"
+            }]
         }
 
     @classmethod
@@ -2131,9 +2351,11 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             'title': "Delete Message Labels",
             'url': reverse('api.v2.labels'),
             'slug': 'label-delete',
-            'params': [
-                {'name': "uuid", 'required': True, 'help': "The UUID of the message label to delete"}
-            ],
+            'params': [{
+                'name': "uuid",
+                'required': True,
+                'help': "The UUID of the message label to delete"
+            }],
         }
 
 
@@ -2145,7 +2367,10 @@ class MediaEndpoint(BaseAPIView):
 
     By making a `POST` request to the endpoint you can add a new media files
     """
-    parser_classes = (MultiPartParser, FormParser,)
+    parser_classes = (
+        MultiPartParser,
+        FormParser,
+    )
     permission = 'msgs.msg_api'
 
     def post(self, request, format=None, *args, **kwargs):
@@ -2221,11 +2446,13 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
             ...
         }
     """
+
     class Pagination(CreatedOnCursorPagination):
         """
         Overridden paginator for Msg endpoint that switches from created_on to modified_on when looking
         at all incoming messages.
         """
+
         def get_ordering(self, request, queryset, view=None):
             if request.query_params.get('folder', '').lower() == 'incoming':
                 return ModifiedOnCursorPagination.ordering
@@ -2240,11 +2467,13 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
     required_params = ('contact', 'folder', 'label', 'broadcast', 'id')
     throttle_scope = 'v2.messages'
 
-    FOLDER_FILTERS = {'inbox': SystemLabel.TYPE_INBOX,
-                      'flows': SystemLabel.TYPE_FLOWS,
-                      'archived': SystemLabel.TYPE_ARCHIVED,
-                      'outbox': SystemLabel.TYPE_OUTBOX,
-                      'sent': SystemLabel.TYPE_SENT}
+    FOLDER_FILTERS = {
+        'inbox': SystemLabel.TYPE_INBOX,
+        'flows': SystemLabel.TYPE_FLOWS,
+        'archived': SystemLabel.TYPE_ARCHIVED,
+        'outbox': SystemLabel.TYPE_OUTBOX,
+        'sent': SystemLabel.TYPE_SENT
+    }
 
     def get_queryset(self):
         org = self.request.user.get_org()
@@ -2320,16 +2549,38 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Messages",
             'url': reverse('api.v2.messages'),
             'slug': 'msg-list',
-            'params': [
-                {'name': 'id', 'required': False, 'help': "A message ID to filter by, ex: 123456"},
-                {'name': 'broadcast', 'required': False, 'help': "A broadcast ID to filter by, ex: 12345"},
-                {'name': 'contact', 'required': False, 'help': "A contact UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
-                {'name': 'folder', 'required': False, 'help': "A folder name to filter by, one of: inbox, flows, archived, outbox, sent, incoming"},
-                {'name': 'label', 'required': False, 'help': "A label name or UUID to filter by, ex: Spam"},
-                {'name': 'before', 'required': False, 'help': "Only return messages created before this date, ex: 2015-01-28T18:00:00.000"},
-                {'name': 'after', 'required': False, 'help': "Only return messages created after this date, ex: 2015-01-28T18:00:00.000"}
-            ],
-            'example': {'query': "folder=incoming&after=2014-01-01T00:00:00.000"},
+            'params': [{
+                'name': 'id',
+                'required': False,
+                'help': "A message ID to filter by, ex: 123456"
+            }, {
+                'name': 'broadcast',
+                'required': False,
+                'help': "A broadcast ID to filter by, ex: 12345"
+            }, {
+                'name': 'contact',
+                'required': False,
+                'help': "A contact UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"
+            }, {
+                'name': 'folder',
+                'required': False,
+                'help': "A folder name to filter by, one of: inbox, flows, archived, outbox, sent, incoming"
+            }, {
+                'name': 'label',
+                'required': False,
+                'help': "A label name or UUID to filter by, ex: Spam"
+            }, {
+                'name': 'before',
+                'required': False,
+                'help': "Only return messages created before this date, ex: 2015-01-28T18:00:00.000"
+            }, {
+                'name': 'after',
+                'required': False,
+                'help': "Only return messages created after this date, ex: 2015-01-28T18:00:00.000"
+            }],
+            'example': {
+                'query': "folder=incoming&after=2014-01-01T00:00:00.000"
+            },
         }
 
 
@@ -2379,9 +2630,21 @@ class MessageActionsEndpoint(BulkWriteAPIMixin, BaseAPIView):
             'url': reverse('api.v2.message_actions'),
             'slug': 'message-actions',
             'fields': [
-                {'name': "messages", 'required': True, 'help': "The ids of the messages to update"},
-                {'name': "action", 'required': True, 'help': "One of the following strings: " + ", ".join(actions)},
-                {'name': "label", 'required': False, 'help': "The UUID or name of a message label"},
+                {
+                    'name': "messages",
+                    'required': True,
+                    'help': "The ids of the messages to update"
+                },
+                {
+                    'name': "action",
+                    'required': True,
+                    'help': "One of the following strings: " + ", ".join(actions)
+                },
+                {
+                    'name': "label",
+                    'required': False,
+                    'help': "The UUID or name of a message label"
+                },
             ]
         }
 
@@ -2423,7 +2686,10 @@ class OrgEndpoint(BaseAPIView):
             'primary_language': org.primary_language.iso_code if org.primary_language else None,
             'timezone': six.text_type(org.timezone),
             'date_style': ('day_first' if org.get_dayfirst() else 'month_first'),
-            'credits': {'used': org.get_credits_used(), 'remaining': org.get_credits_remaining()},
+            'credits': {
+                'used': org.get_credits_used(),
+                'remaining': org.get_credits_remaining()
+            },
             'anon': org.is_anon
         }
 
@@ -2431,12 +2697,7 @@ class OrgEndpoint(BaseAPIView):
 
     @classmethod
     def get_read_explorer(cls):
-        return {
-            'method': "GET",
-            'title': "View Current Org",
-            'url': reverse('api.v2.org'),
-            'slug': 'org-read'
-        }
+        return {'method': "GET", 'title': "View Current Org", 'url': reverse('api.v2.org'), 'slug': 'org-read'}
 
 
 class ResthooksEndpoint(ListAPIMixin, BaseAPIView):
@@ -2602,23 +2863,31 @@ class ResthookSubscribersEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, B
 
     @classmethod
     def get_write_explorer(cls):
-        return dict(method="POST",
-                    title="Add Resthook Subscriber",
-                    url=reverse('api.v2.resthook_subscribers'),
-                    slug='resthooksubscriber-write',
-                    fields=[dict(name='resthook', required=True,
-                                 help="The slug for the resthook you want to subscribe to"),
-                            dict(name='target_url', required=True,
-                                 help="The URL that will be called when the resthook is triggered.")],
-                    example=dict(body='{"resthook": "new-report", "target_url": "https://zapier.com/handle/1515155"}'))
+        return dict(
+            method="POST",
+            title="Add Resthook Subscriber",
+            url=reverse('api.v2.resthook_subscribers'),
+            slug='resthooksubscriber-write',
+            fields=[
+                dict(name='resthook', required=True, help="The slug for the resthook you want to subscribe to"),
+                dict(
+                    name='target_url',
+                    required=True,
+                    help="The URL that will be called when the resthook is triggered."
+                )
+            ],
+            example=dict(body='{"resthook": "new-report", "target_url": "https://zapier.com/handle/1515155"}')
+        )
 
     @classmethod
     def get_delete_explorer(cls):
-        return dict(method="DELETE",
-                    title="Delete Resthook Subscriber",
-                    url=reverse('api.v2.resthook_subscribers'),
-                    slug='resthooksubscriber-delete',
-                    params=[dict(name='id', required=True, help="The id of the subscriber to delete")])
+        return dict(
+            method="DELETE",
+            title="Delete Resthook Subscriber",
+            url=reverse('api.v2.resthook_subscribers'),
+            slug='resthooksubscriber-delete',
+            params=[dict(name='id', required=True, help="The id of the subscriber to delete")]
+        )
 
 
 class ResthookEventsEndpoint(ListAPIMixin, BaseAPIView):
@@ -2844,15 +3113,34 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
             'title': "List Flow Runs",
             'url': reverse('api.v2.runs'),
             'slug': 'run-list',
-            'params': [
-                {'name': 'id', 'required': False, 'help': "A run ID to filter by, ex: 123456"},
-                {'name': 'flow', 'required': False, 'help': "A flow UUID to filter by, ex: f5901b62-ba76-4003-9c62-72fdacc1b7b7"},
-                {'name': 'contact', 'required': False, 'help': "A contact UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"},
-                {'name': 'responded', 'required': False, 'help': "Whether to only return runs with contact responses"},
-                {'name': 'before', 'required': False, 'help': "Only return runs modified before this date, ex: 2015-01-28T18:00:00.000"},
-                {'name': 'after', 'required': False, 'help': "Only return runs modified after this date, ex: 2015-01-28T18:00:00.000"}
-            ],
-            'example': {'query': "after=2016-01-01T00:00:00.000"}
+            'params': [{
+                'name': 'id',
+                'required': False,
+                'help': "A run ID to filter by, ex: 123456"
+            }, {
+                'name': 'flow',
+                'required': False,
+                'help': "A flow UUID to filter by, ex: f5901b62-ba76-4003-9c62-72fdacc1b7b7"
+            }, {
+                'name': 'contact',
+                'required': False,
+                'help': "A contact UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab"
+            }, {
+                'name': 'responded',
+                'required': False,
+                'help': "Whether to only return runs with contact responses"
+            }, {
+                'name': 'before',
+                'required': False,
+                'help': "Only return runs modified before this date, ex: 2015-01-28T18:00:00.000"
+            }, {
+                'name': 'after',
+                'required': False,
+                'help': "Only return runs modified after this date, ex: 2015-01-28T18:00:00.000"
+            }],
+            'example': {
+                'query': "after=2016-01-01T00:00:00.000"
+            }
         }
 
 
@@ -2993,30 +3281,42 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             'title': "List Flow Starts",
             'url': reverse('api.v2.flow_starts'),
             'slug': 'flow-start-list',
-            'params': [
-                {'name': 'id', 'required': False, 'help': "Only return the flow start with this id"},
-                {'name': 'after', 'required': False, 'help': "Only return flow starts modified after this date"},
-                {'name': 'before', 'required': False, 'help': "Only return flow starts modified before this date"}
-            ],
-            'example': {'query': "after=2016-01-01T00:00:00.000"}
+            'params': [{
+                'name': 'id',
+                'required': False,
+                'help': "Only return the flow start with this id"
+            }, {
+                'name': 'after',
+                'required': False,
+                'help': "Only return flow starts modified after this date"
+            }, {
+                'name': 'before',
+                'required': False,
+                'help': "Only return flow starts modified before this date"
+            }],
+            'example': {
+                'query': "after=2016-01-01T00:00:00.000"
+            }
         }
 
     @classmethod
     def get_write_explorer(cls):
-        return dict(method="POST",
-                    title="Start Contacts in a Flow",
-                    url=reverse('api.v2.flow_starts'),
-                    slug='flow-start-write',
-                    fields=[dict(name='flow', required=True,
-                                 help="The UUID of the flow to start"),
-                            dict(name='groups', required=False,
-                                 help="The UUIDs of any contact groups you want to start"),
-                            dict(name='contacts', required=False,
-                                 help="The UUIDs of any contacts you want to start"),
-                            dict(name='urns', required=False,
-                                 help="The URNS of any contacts you want to start"),
-                            dict(name='restart_participants', required=False,
-                                 help="Whether to restart any participants already in the flow"),
-                            dict(name='extra', required=False,
-                                 help="Any extra parameters to pass to the flow start")],
-                    example=dict(body='{"flow":"f5901b62-ba76-4003-9c62-72fdacc1b7b7","urns":["twitter:sirmixalot"]}'))
+        return dict(
+            method="POST",
+            title="Start Contacts in a Flow",
+            url=reverse('api.v2.flow_starts'),
+            slug='flow-start-write',
+            fields=[
+                dict(name='flow', required=True, help="The UUID of the flow to start"),
+                dict(name='groups', required=False, help="The UUIDs of any contact groups you want to start"),
+                dict(name='contacts', required=False, help="The UUIDs of any contacts you want to start"),
+                dict(name='urns', required=False, help="The URNS of any contacts you want to start"),
+                dict(
+                    name='restart_participants',
+                    required=False,
+                    help="Whether to restart any participants already in the flow"
+                ),
+                dict(name='extra', required=False, help="Any extra parameters to pass to the flow start")
+            ],
+            example=dict(body='{"flow":"f5901b62-ba76-4003-9c62-72fdacc1b7b7","urns":["twitter:sirmixalot"]}')
+        )

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -40,7 +40,7 @@ class WebHookEventListView(WebHookEventMixin, SmartListView):
     fields = ('event', 'status', 'channel', 'tries', 'created_on')
     title = _("Recent WebHook Events")
     template_name = 'api/webhookevent_list.html'
-    default_order = ('-created_on',)
+    default_order = ('-created_on', )
     permission = 'api.webhookevent_list'
 
     def get_context_data(self, *args, **kwargs):  # pragma: needs cover
@@ -90,9 +90,11 @@ class WebHookTunnelView(View):
             incoming_data = parse_qs(data)
             outgoing_data = dict()
             for key in incoming_data.keys():
-                if key in ['relayer', 'channel', 'sms', 'phone', 'text', 'time', 'call', 'duration', 'power_level', 'power_status',
-                           'power_source', 'network_type', 'pending_message_count', 'retry_message_count', 'last_seen', 'event',
-                           'step', 'values', 'flow', 'relayer_phone']:
+                if key in [
+                    'relayer', 'channel', 'sms', 'phone', 'text', 'time', 'call', 'duration', 'power_level',
+                    'power_status', 'power_source', 'network_type', 'pending_message_count', 'retry_message_count',
+                    'last_seen', 'event', 'step', 'values', 'flow', 'relayer_phone'
+                ]:
                     outgoing_data[key] = incoming_data[key]
 
             response = requests.post(url, data=outgoing_data, timeout=3)
@@ -118,17 +120,45 @@ class WebHookSimulatorView(SmartTemplateView):
 
         fields = list()
         fields.append(dict(name="relayer", help="The id of the channel which received an SMS", default=5))
-        fields.append(dict(name="relayer_phone", help="The phone number of the channel which received an SMS", default="+250788123123"))
+        fields.append(
+            dict(
+                name="relayer_phone",
+                help="The phone number of the channel which received an SMS",
+                default="+250788123123"
+            )
+        )
         fields.append(dict(name="sms", help="The id of the incoming SMS message", default=1))
-        fields.append(dict(name="phone", help="The phone number of the sender in E164 format", default="+250788123123"))
+        fields.append(
+            dict(name="phone", help="The phone number of the sender in E164 format", default="+250788123123")
+        )
         fields.append(dict(name="text", help="The text of the SMS message", default="That gucci is hella tight"))
         fields.append(dict(name="status", help="The status of this SMS message, one of P,H,S,D,E,F", default="D"))
-        fields.append(dict(name="direction", help="The direction of the SMS, either I for incoming or O for outgoing", default="I"))
-        fields.append(dict(name="time", help="When this event occurred in ECMA-162 format", default="2013-01-21T22:34:00.123"))
+        fields.append(
+            dict(
+                name="direction",
+                help="The direction of the SMS, either I for incoming or O for outgoing",
+                default="I"
+            )
+        )
+        fields.append(
+            dict(name="time", help="When this event occurred in ECMA-162 format", default="2013-01-21T22:34:00.123")
+        )
 
-        mo_sms = dict(event="mo_sms", title="Sent when your channel receives a new SMS message", fields=fields, color='green')
-        mt_sent = dict(event="mt_sent", title="Sent when your channel has confirmed it has sent an outgoing SMS", fields=fields, color='green')
-        mt_dlvd = dict(event="mt_dlvd", title="Sent when your channel receives a delivery report for an outgoing SMS", fields=fields, color='green')
+        mo_sms = dict(
+            event="mo_sms", title="Sent when your channel receives a new SMS message", fields=fields, color='green'
+        )
+        mt_sent = dict(
+            event="mt_sent",
+            title="Sent when your channel has confirmed it has sent an outgoing SMS",
+            fields=fields,
+            color='green'
+        )
+        mt_dlvd = dict(
+            event="mt_dlvd",
+            title="Sent when your channel receives a delivery report for an outgoing SMS",
+            fields=fields,
+            color='green'
+        )
 
         endpoints.append(mo_sms)
         endpoints.append(mt_sent)
@@ -136,16 +166,52 @@ class WebHookSimulatorView(SmartTemplateView):
 
         fields = list()
         fields.append(dict(name="relayer", help="The id of the channel which received a call", default=5))
-        fields.append(dict(name="relayer_phone", help="The phone number of the channel which received an SMS", default="+250788123123"))
+        fields.append(
+            dict(
+                name="relayer_phone",
+                help="The phone number of the channel which received an SMS",
+                default="+250788123123"
+            )
+        )
         fields.append(dict(name="call", help="The id of the call", default=1))
-        fields.append(dict(name="phone", help="The phone number of the caller or callee in E164 format", default="+250788123123"))
+        fields.append(
+            dict(
+                name="phone", help="The phone number of the caller or callee in E164 format", default="+250788123123"
+            )
+        )
         fields.append(dict(name="duration", help="The duration of the call (always 0 for missed calls)", default="0"))
-        fields.append(dict(name="time", help="When this event was received by the channel in ECMA-162 format", default="2013-01-21T22:34:00.123"))
+        fields.append(
+            dict(
+                name="time",
+                help="When this event was received by the channel in ECMA-162 format",
+                default="2013-01-21T22:34:00.123"
+            )
+        )
 
-        mo_call = dict(event=ChannelEvent.TYPE_CALL_IN, title="Sent when your channel receives an incoming call that was picked up", fields=fields, color='blue')
-        mo_miss = dict(event=ChannelEvent.TYPE_CALL_IN_MISSED, title="Sent when your channel receives an incoming call that was missed", fields=fields, color='blue')
-        mt_call = dict(event=ChannelEvent.TYPE_CALL_OUT, title="Sent when your channel places an outgoing call that was connected", fields=fields, color='blue')
-        mt_miss = dict(event=ChannelEvent.TYPE_CALL_OUT_MISSED, title="Sent when your channel places an outgoing call that was not connected", fields=fields, color='blue')
+        mo_call = dict(
+            event=ChannelEvent.TYPE_CALL_IN,
+            title="Sent when your channel receives an incoming call that was picked up",
+            fields=fields,
+            color='blue'
+        )
+        mo_miss = dict(
+            event=ChannelEvent.TYPE_CALL_IN_MISSED,
+            title="Sent when your channel receives an incoming call that was missed",
+            fields=fields,
+            color='blue'
+        )
+        mt_call = dict(
+            event=ChannelEvent.TYPE_CALL_OUT,
+            title="Sent when your channel places an outgoing call that was connected",
+            fields=fields,
+            color='blue'
+        )
+        mt_miss = dict(
+            event=ChannelEvent.TYPE_CALL_OUT_MISSED,
+            title="Sent when your channel places an outgoing call that was not connected",
+            fields=fields,
+            color='blue'
+        )
 
         endpoints.append(mo_call)
         endpoints.append(mo_miss)
@@ -156,14 +222,41 @@ class WebHookSimulatorView(SmartTemplateView):
         fields.append(dict(name="relayer", help="The id of the channel which this alarm is for", default=1))
         fields.append(dict(name="relayer_phone", help="The phone number of the channel", default="+250788123123"))
         fields.append(dict(name="power_level", help="The current power level of the channel", default=65))
-        fields.append(dict(name="power_status", help="The current power status, either CHARGING or DISCHARGING", default="CHARGING"))
+        fields.append(
+            dict(
+                name="power_status",
+                help="The current power status, either CHARGING or DISCHARGING",
+                default="CHARGING"
+            )
+        )
         fields.append(dict(name="power_source", help="The source of power, ex: BATTERY, AC, USB", default="AC"))
-        fields.append(dict(name="network_type", help="The type of network the device is connected to. ex: WIFI", default="WIFI"))
-        fields.append(dict(name="pending_message_count", help="The number of unsent messages for this channel", default=0))
-        fields.append(dict(name="retry_message_count", help="The number of messages that had send errors and are being retried", default=0))
-        fields.append(dict(name="last_seen", help="The time that this channel last synced in ECMA-162 format", default="2013-01-21T22:34:00.123"))
+        fields.append(
+            dict(name="network_type", help="The type of network the device is connected to. ex: WIFI", default="WIFI")
+        )
+        fields.append(
+            dict(name="pending_message_count", help="The number of unsent messages for this channel", default=0)
+        )
+        fields.append(
+            dict(
+                name="retry_message_count",
+                help="The number of messages that had send errors and are being retried",
+                default=0
+            )
+        )
+        fields.append(
+            dict(
+                name="last_seen",
+                help="The time that this channel last synced in ECMA-162 format",
+                default="2013-01-21T22:34:00.123"
+            )
+        )
 
-        alarm = dict(event="alarm", title="Sent when we detects either a low battery, unsent messages, or lack of connectivity for your channel", fields=fields, color='red')
+        alarm = dict(
+            event="alarm",
+            title="Sent when we detects either a low battery, unsent messages, or lack of connectivity for your channel",
+            fields=fields,
+            color='red'
+        )
 
         endpoints.append(alarm)
 
@@ -172,13 +265,30 @@ class WebHookSimulatorView(SmartTemplateView):
         fields.append(dict(name="relayer_phone", help="The phone number of the channel", default="+250788123123"))
         fields.append(dict(name="phone", help="The phone number of the contact", default="+250788788123"))
         fields.append(dict(name="flow", help="The id of the flow (reference the URL on your flow page)", default=504))
-        fields.append(dict(name="step", help="The uuid of the step which triggered this event (reference your flow)", default="15121251-15121241-15145152-12541241"))
-        fields.append(dict(name="time", help="The time that this step was reached by the user in ECMA-162 format", default="2013-01-21T22:34:00.123"))
-        fields.append(dict(name="values", help="The values that have been collected for this contact thus far through the flow",
-                           default='[{ "label": "Water Source", "category": "Stream", "text": "from stream", "time": "2013-01-01T05:35:32.012" },'
-                                   ' { "label": "Boil", "category": "Yes", "text": "yego", "time": "2013-01-01T05:36:54.012" }]'))
+        fields.append(
+            dict(
+                name="step",
+                help="The uuid of the step which triggered this event (reference your flow)",
+                default="15121251-15121241-15145152-12541241"
+            )
+        )
+        fields.append(
+            dict(
+                name="time",
+                help="The time that this step was reached by the user in ECMA-162 format",
+                default="2013-01-21T22:34:00.123"
+            )
+        )
+        fields.append(dict(
+            name="values",
+            help="The values that have been collected for this contact thus far through the flow",
+            default='[{ "label": "Water Source", "category": "Stream", "text": "from stream", "time": "2013-01-01T05:35:32.012" },'
+                    ' { "label": "Boil", "category": "Yes", "text": "yego", "time": "2013-01-01T05:36:54.012" }]'
+        ))
 
-        flow = dict(event="flow", title="Sent when a user reaches an API node in a flow", fields=fields, color='purple')
+        flow = dict(
+            event="flow", title="Sent when a user reaches an API node in a flow", fields=fields, color='purple'
+        )
 
         endpoints.append(flow)
 

--- a/temba/assets/models.py
+++ b/temba/assets/models.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
 
-
 ASSET_STORES_BY_KEY = {}
 ASSET_STORES_BY_MODEL = {}
 
@@ -82,13 +81,17 @@ class BaseAssetStore(object):
         # if our storage backend is S3
         if settings.DEFAULT_FILE_STORAGE == 'storages.backends.s3boto.S3BotoStorage':  # pragma: needs cover
             # generate our URL manually so that we can force the download name for the user
-            url = default_storage.connection.generate_url(default_storage.querystring_expire,
-                                                          method='GET', bucket=default_storage.bucket.name,
-                                                          key=default_storage._encode_name(path),
-                                                          query_auth=default_storage.querystring_auth,
-                                                          force_http=not default_storage.secure_urls,
-                                                          response_headers={'response-content-disposition':
-                                                                            'attachment;filename=%s' % filename})
+            url = default_storage.connection.generate_url(
+                default_storage.querystring_expire,
+                method='GET',
+                bucket=default_storage.bucket.name,
+                key=default_storage._encode_name(path),
+                query_auth=default_storage.querystring_auth,
+                force_http=not default_storage.secure_urls,
+                response_headers={
+                    'response-content-disposition': 'attachment;filename=%s' % filename
+                }
+            )
 
         # otherwise, let the backend generate the URL
         else:

--- a/temba/assets/tests.py
+++ b/temba/assets/tests.py
@@ -8,7 +8,6 @@ from temba.tests import TembaTest
 
 
 class AssetTest(TembaTest):
-
     def tearDown(self):
         self.clear_storage()
 
@@ -16,50 +15,59 @@ class AssetTest(TembaTest):
         # create a message export
         message_export_task = ExportMessagesTask.create(self.org, self.admin, SystemLabel.TYPE_INBOX)
 
-        response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.download', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertLoginRedirect(response)
 
         self.login(self.admin)
 
         # asset doesn't exist yet
-        response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.download', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertContains(response, "File not found", status_code=200)
 
         # specify wrong asset type so db object won't exist
-        response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='contact_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.download', kwargs=dict(type='contact_export', pk=message_export_task.pk))
+        )
         self.assertContains(response, "File not found", status_code=200)
 
         # create asset and request again with correct type
         message_export_task.perform()
 
-        response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.download', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # check direct download stream
-        response = self.client.get(reverse('assets.stream',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.stream', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertEqual(response.status_code, 200)
 
         # create contact export and check that we can access it
         contact_export_task = ExportContactsTask.create(self.org, self.admin)
         contact_export_task.perform()
 
-        response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='contact_export', pk=contact_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.download', kwargs=dict(type='contact_export', pk=contact_export_task.pk))
+        )
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # create flow results export and check that we can access it
         flow = self.create_flow()
-        results_export_task = ExportFlowResultsTask.objects.create(org=self.org, created_by=self.admin, modified_by=self.admin)
+        results_export_task = ExportFlowResultsTask.objects.create(
+            org=self.org, created_by=self.admin, modified_by=self.admin
+        )
         results_export_task.flows.add(flow)
         results_export_task.perform()
 
-        response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='results_export', pk=results_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.download', kwargs=dict(type='results_export', pk=results_export_task.pk))
+        )
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # add our admin to another org
@@ -72,8 +80,9 @@ class AssetTest(TembaTest):
         s.save()
 
         # as this asset belongs to org #1, request will have that context
-        response = self.client.get(reverse('assets.download',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.download', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertEqual(200, response.status_code)
         user = response.context_data['view'].request.user
         self.assertEqual(user, self.admin)
@@ -84,8 +93,9 @@ class AssetTest(TembaTest):
         message_export_task = ExportMessagesTask.create(self.org, self.admin, SystemLabel.TYPE_INBOX)
 
         # try as anon
-        response = self.client.get(reverse('assets.stream',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.stream', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertLoginRedirect(response)
 
         self.login(self.admin)
@@ -95,13 +105,15 @@ class AssetTest(TembaTest):
         self.assertEqual(response.status_code, 404)
 
         # try before asset is generated
-        response = self.client.get(reverse('assets.stream',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.stream', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertEqual(response.status_code, 404)
 
         # create asset and request again
         message_export_task.perform()
 
-        response = self.client.get(reverse('assets.stream',
-                                           kwargs=dict(type='message_export', pk=message_export_task.pk)))
+        response = self.client.get(
+            reverse('assets.stream', kwargs=dict(type='message_export', pk=message_export_task.pk))
+        )
         self.assertEqual(response.status_code, 200)

--- a/temba/assets/urls.py
+++ b/temba/assets/urls.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import url
 from .views import AssetDownloadView, AssetStreamView
 
-
 urlpatterns = [
     url(r'download/(?P<type>\w+)/(?P<pk>\d+)/$', AssetDownloadView.as_view(), name='assets.download'),
     url(r'stream/(?P<type>\w+)/(?P<pk>\d+)/$', AssetStreamView.as_view(), name='assets.stream'),

--- a/temba/assets/views.py
+++ b/temba/assets/views.py
@@ -71,6 +71,7 @@ class AssetStreamView(SmartView, View):
     """
     Provides a direct download stream to an asset, e.g. /assets/stream/contact_export/123/
     """
+
     def has_permission(self, request, *args, **kwargs):
         return self.request.user.is_authenticated()
 

--- a/temba/campaigns/tasks.py
+++ b/temba/campaigns/tasks.py
@@ -14,7 +14,6 @@ from temba.utils import chunk_list
 from temba.utils.cache import QueueRecord
 from temba.utils.queues import push_task, nonoverlapping_task
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -50,7 +49,9 @@ def check_campaigns_task():
 
             if queued_fire_ids:
                 try:
-                    push_task(flow.org_id, HANDLER_QUEUE, HANDLE_EVENT_TASK, dict(type=FIRE_EVENT, fires=queued_fire_ids))
+                    push_task(
+                        flow.org_id, HANDLER_QUEUE, HANDLE_EVENT_TASK, dict(type=FIRE_EVENT, fires=queued_fire_ids)
+                    )
 
                     queued_fires.set_queued(queued_fire_ids)
                 except Exception:  # pragma: no cover

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -18,7 +18,6 @@ from .models import Campaign, CampaignEvent, EventFire
 
 
 class CampaignTest(TembaTest):
-
     def setUp(self):
         super(CampaignTest, self).setUp()
 
@@ -39,13 +38,19 @@ class CampaignTest(TembaTest):
         self.planting_date = ContactField.get_or_create(self.org, self.admin, 'planting_date', "Planting Date")
 
     def test_get_unique_name(self):
-        campaign1 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
+        campaign1 = Campaign.create(
+            self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers
+        )
         self.assertEqual(campaign1.name, "Reminders")
 
-        campaign2 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
+        campaign2 = Campaign.create(
+            self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers
+        )
         self.assertEqual(campaign2.name, "Reminders 2")
 
-        campaign3 = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
+        campaign3 = Campaign.create(
+            self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers
+        )
         self.assertEqual(campaign3.name, "Reminders 3")
 
         self.create_secondary_org()
@@ -57,26 +62,45 @@ class CampaignTest(TembaTest):
 
         flow = self.create_flow()
 
-        event1 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, self.planting_date,
-                                                 offset=1, unit='W', flow=flow, delivery_hour='13')
-        event2 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, self.planting_date,
-                                                 offset=1, unit='W', flow=flow, delivery_hour='9')
-        event3 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, self.planting_date,
-                                                 offset=2, unit='W', flow=flow, delivery_hour='1')
+        event1 = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, self.planting_date, offset=1, unit='W', flow=flow, delivery_hour='13'
+        )
+        event2 = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, self.planting_date, offset=1, unit='W', flow=flow, delivery_hour='9'
+        )
+        event3 = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, self.planting_date, offset=2, unit='W', flow=flow, delivery_hour='1'
+        )
 
         self.assertEqual(campaign.get_sorted_events(), [event2, event1, event3])
 
         flow_json = self.get_flow_json('call_me_maybe')['definition']
-        flow = Flow.create_instance(dict(name='Call Me Maybe', org=self.org, flow_type=Flow.MESSAGE,
-                                         created_by=self.admin, modified_by=self.admin,
-                                         saved_by=self.admin, version_number=3))
+        flow = Flow.create_instance(
+            dict(
+                name='Call Me Maybe',
+                org=self.org,
+                flow_type=Flow.MESSAGE,
+                created_by=self.admin,
+                modified_by=self.admin,
+                saved_by=self.admin,
+                version_number=3
+            )
+        )
 
-        FlowRevision.create_instance(dict(flow=flow, definition=json.dumps(flow_json),
-                                          spec_version=3, revision=1,
-                                          created_by=self.admin, modified_by=self.admin))
+        FlowRevision.create_instance(
+            dict(
+                flow=flow,
+                definition=json.dumps(flow_json),
+                spec_version=3,
+                revision=1,
+                created_by=self.admin,
+                modified_by=self.admin
+            )
+        )
 
-        event4 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, self.planting_date,
-                                                 offset=2, unit='W', flow=flow, delivery_hour='5')
+        event4 = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, self.planting_date, offset=2, unit='W', flow=flow, delivery_hour='5'
+        )
 
         self.assertEqual(flow.version_number, 3)
         self.assertEqual(campaign.get_sorted_events(), [event2, event1, event3, event4])
@@ -103,8 +127,9 @@ class CampaignTest(TembaTest):
         self.assertNotContains(response, 'show_language')
 
         # set our primary language to Achinese
-        ace = Language.objects.create(org=self.org, name='Achinese', iso_code='ace',
-                                      created_by=self.admin, modified_by=self.admin)
+        ace = Language.objects.create(
+            org=self.org, name='Achinese', iso_code='ace', created_by=self.admin, modified_by=self.admin
+        )
 
         self.org.primary_language = ace
         self.org.save()
@@ -115,8 +140,9 @@ class CampaignTest(TembaTest):
         self.assertTrue('ace' in response.context['form'].fields)
 
         # add second language
-        spa = Language.objects.create(org=self.org, name='Spanish', iso_code='spa',
-                                      created_by=self.admin, modified_by=self.admin)
+        spa = Language.objects.create(
+            org=self.org, name='Spanish', iso_code='spa', created_by=self.admin, modified_by=self.admin
+        )
 
         response = self.client.get(url)
         self.assertFalse('base' in response.context['form'].fields)
@@ -134,9 +160,20 @@ class CampaignTest(TembaTest):
         self.assertTrue('spa' in response.context['form'].fields)
         self.assertTrue('ace' in response.context['form'].fields)
 
-        post_data = dict(relative_to=self.planting_date.pk, event_type='M', base="This is my message", spa="hola",
-                         direction='B', offset=1, unit='W', flow_to_start='', delivery_hour=13)
-        response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            event_type='M',
+            base="This is my message",
+            spa="hola",
+            direction='B',
+            offset=1,
+            unit='W',
+            flow_to_start='',
+            delivery_hour=13
+        )
+        response = self.client.post(
+            reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data
+        )
 
         # should be redirected back to our campaign read page
         self.assertRedirect(response, reverse('campaigns.campaign_read', args=[campaign.pk]))
@@ -179,8 +216,18 @@ class CampaignTest(TembaTest):
         self.assertEqual('', response.context['form'].fields['ace'].initial)
 
         # now we save our new settings
-        post_data = dict(relative_to=self.planting_date.pk, event_type='M', base='Required', spa="This is my spanish @contact.planting_date", ace='',
-                         direction='B', offset=1, unit='W', flow_to_start='', delivery_hour=13)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            event_type='M',
+            base='Required',
+            spa="This is my spanish @contact.planting_date",
+            ace='',
+            direction='B',
+            offset=1,
+            unit='W',
+            flow_to_start='',
+            delivery_hour=13
+        )
         response = self.client.post(url, post_data)
         self.assertEqual(302, response.status_code)
         flow.refresh_from_db()
@@ -295,28 +342,73 @@ class CampaignTest(TembaTest):
         self.assertContains(response, self.voice_flow.name)
         self.assertEqual(200, response.status_code)
 
-        post_data = dict(relative_to=self.planting_date.pk, delivery_hour=-1, base='', direction='A', offset=2, unit='D', event_type='M', flow_to_start=self.reminder_flow.pk)
-        response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            delivery_hour=-1,
+            base='',
+            direction='A',
+            offset=2,
+            unit='D',
+            event_type='M',
+            flow_to_start=self.reminder_flow.pk
+        )
+        response = self.client.post(
+            reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data
+        )
 
         self.assertTrue(response.context['form'].errors)
         self.assertTrue('A message is required' in six.text_type(response.context['form'].errors['__all__']))
 
-        post_data = dict(relative_to=self.planting_date.pk, delivery_hour=-1, base='allo!' * 500, direction='A',
-                         offset=2, unit='D', event_type='M', flow_to_start=self.reminder_flow.pk)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            delivery_hour=-1,
+            base='allo!' * 500,
+            direction='A',
+            offset=2,
+            unit='D',
+            event_type='M',
+            flow_to_start=self.reminder_flow.pk
+        )
 
-        response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
+        response = self.client.post(
+            reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data
+        )
 
         self.assertTrue(response.context['form'].errors)
-        self.assertTrue("Translation for &#39;Default&#39; exceeds the %d character limit." % Msg.MAX_TEXT_LEN in six.text_type(response.context['form'].errors['__all__']))
+        self.assertTrue(
+            "Translation for &#39;Default&#39; exceeds the %d character limit." % Msg.MAX_TEXT_LEN in
+            six.text_type(response.context['form'].errors['__all__'])
+        )
 
-        post_data = dict(relative_to=self.planting_date.pk, delivery_hour=-1, base='', direction='A', offset=2, unit='D', event_type='F')
-        response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            delivery_hour=-1,
+            base='',
+            direction='A',
+            offset=2,
+            unit='D',
+            event_type='F'
+        )
+        response = self.client.post(
+            reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data
+        )
 
         self.assertTrue(response.context['form'].errors)
         self.assertTrue('Please select a flow' in response.context['form'].errors['flow_to_start'])
 
-        post_data = dict(relative_to=self.planting_date.pk, delivery_hour=-1, base='', direction='A', offset=2, unit='D', event_type='F', flow_to_start=self.reminder_flow.pk)
-        response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            delivery_hour=-1,
+            base='',
+            direction='A',
+            offset=2,
+            unit='D',
+            event_type='F',
+            flow_to_start=self.reminder_flow.pk
+        )
+        response = self.client.post(
+            reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data
+        )
 
         # should be redirected back to our campaign read page
         self.assertRedirect(response, reverse('campaigns.campaign_read', args=[campaign.pk]))
@@ -345,7 +437,16 @@ class CampaignTest(TembaTest):
         self.assertEqual(scheduled_date.year, fire.scheduled.year)
         self.assertEqual(event, fire.event)
 
-        post_data = dict(relative_to=self.planting_date.pk, delivery_hour=15, base='', direction='A', offset=1, unit='D', event_type='F', flow_to_start=self.reminder_flow.pk)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            delivery_hour=15,
+            base='',
+            direction='A',
+            offset=1,
+            unit='D',
+            event_type='F',
+            flow_to_start=self.reminder_flow.pk
+        )
         response = self.client.post(reverse('campaigns.campaignevent_update', args=[event.pk]), post_data)
 
         # should be redirected back to our campaign event read page
@@ -368,8 +469,16 @@ class CampaignTest(TembaTest):
         self.assertEqual(2020, fire.scheduled.year)
         self.assertEqual(event, fire.event)
 
-        post_data = dict(relative_to=self.planting_date.pk, delivery_hour=15, base='', direction='A', offset=2,
-                         unit='D', event_type='F', flow_to_start=self.reminder2_flow.pk)
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            delivery_hour=15,
+            base='',
+            direction='A',
+            offset=2,
+            unit='D',
+            event_type='F',
+            flow_to_start=self.reminder2_flow.pk
+        )
         self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
 
         # trying to archive our flow should fail since it belongs to a campaign
@@ -377,11 +486,17 @@ class CampaignTest(TembaTest):
         response = self.client.post(reverse('flows.flow_list'), post_data)
         self.reminder_flow.refresh_from_db()
         self.assertFalse(self.reminder_flow.is_archived)
-        self.assertEqual('Reminder Flow is used inside a campaign. To archive it, first remove it from your campaigns.', response.get('Temba-Toast'))
+        self.assertEqual(
+            'Reminder Flow is used inside a campaign. To archive it, first remove it from your campaigns.',
+            response.get('Temba-Toast')
+        )
 
         post_data = dict(action='archive', objects=[self.reminder_flow.pk, self.reminder2_flow.pk])
         response = self.client.post(reverse('flows.flow_list'), post_data)
-        self.assertEqual('Planting Reminder and Reminder Flow are used inside a campaign. To archive them, first remove them from your campaigns.', response.get('Temba-Toast'))
+        self.assertEqual(
+            'Planting Reminder and Reminder Flow are used inside a campaign. To archive them, first remove them from your campaigns.',
+            response.get('Temba-Toast')
+        )
         CampaignEvent.objects.filter(flow=self.reminder2_flow.pk).delete()
 
         # archive the campaign
@@ -424,8 +539,10 @@ class CampaignTest(TembaTest):
         self.assertEqual(2, EventFire.objects.all().count())
 
         # remove one of the farmers from the group
-        response = self.client.post(reverse('contacts.contact_read', args=[self.farmer1.uuid]),
-                                    dict(contact=self.farmer1.pk, group=self.farmers.pk))
+        response = self.client.post(
+            reverse('contacts.contact_read', args=[self.farmer1.uuid]),
+            dict(contact=self.farmer1.pk, group=self.farmers.pk)
+        )
         self.assertEqual(200, response.status_code)
 
         # should only be one event now (on farmer 2)
@@ -436,14 +553,14 @@ class CampaignTest(TembaTest):
         self.assertEqual(event, fire.event)
 
         # but if we add him back in, should be updated
-        post_data = dict(name=self.farmer1.name,
-                         groups=[self.farmers.id],
-                         __urn__tel=self.farmer1.get_urn('tel').path)
+        post_data = dict(name=self.farmer1.name, groups=[self.farmers.id], __urn__tel=self.farmer1.get_urn('tel').path)
 
         self.client.post(reverse('contacts.contact_update', args=[self.farmer1.id]), post_data)
         planting_date = ContactField.objects.filter(key='planting_date').first()
-        response = self.client.post(reverse('contacts.contact_update_fields', args=[self.farmer1.id]),
-                                    dict(contact_field=planting_date.id, field_value='4/8/2020'))
+        response = self.client.post(
+            reverse('contacts.contact_update_fields', args=[self.farmer1.id]),
+            dict(contact_field=planting_date.id, field_value='4/8/2020')
+        )
         self.assertRedirect(response, reverse('contacts.contact_read', args=[self.farmer1.uuid]))
 
         fires = EventFire.objects.all()
@@ -474,8 +591,15 @@ class CampaignTest(TembaTest):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
 
         # create a reminder for our first planting event
-        planting_reminder = CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
-                                                            offset=3, unit='D', flow=self.reminder_flow)
+        planting_reminder = CampaignEvent.create_flow_event(
+            self.org,
+            self.admin,
+            campaign,
+            relative_to=self.planting_date,
+            offset=3,
+            unit='D',
+            flow=self.reminder_flow
+        )
 
         self.assertEqual(0, EventFire.objects.all().count())
         self.farmer1.set_field(self.user, 'planting_date', "10-05-2020 12:30:10")
@@ -504,14 +628,24 @@ class CampaignTest(TembaTest):
         # now import the group again
         filename = 'farmers.csv'
         extra_fields = [dict(key='planting_date', header='planting_date', label='Planting Date', type='D')]
-        import_params = dict(org_id=self.org.id, timezone=six.text_type(self.org.timezone), extra_fields=extra_fields, original_filename=filename)
+        import_params = dict(
+            org_id=self.org.id,
+            timezone=six.text_type(self.org.timezone),
+            extra_fields=extra_fields,
+            original_filename=filename
+        )
 
         from temba.contacts.models import ImportTask, Contact
         import json
         task = ImportTask.objects.create(
-            created_by=self.admin, modified_by=self.admin,
+            created_by=self.admin,
+            modified_by=self.admin,
             csv_file='test_imports/' + filename,
-            model_class="Contact", import_params=json.dumps(import_params), import_log="", task_id="A")
+            model_class="Contact",
+            import_params=json.dumps(import_params),
+            import_log="",
+            task_id="A"
+        )
         Contact.import_csv(task, log=None)
 
         # check that we have new planting dates
@@ -562,8 +696,15 @@ class CampaignTest(TembaTest):
 
         # create our campaign and event
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
-        CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
-                                        offset=2, unit='D', flow=self.reminder_flow)
+        CampaignEvent.create_flow_event(
+            self.org,
+            self.admin,
+            campaign,
+            relative_to=self.planting_date,
+            offset=2,
+            unit='D',
+            flow=self.reminder_flow
+        )
 
         # set the time to something pre-dst (fall back on November 4th at 2am to 1am)
         self.farmer1.set_field(self.user, 'planting_date', "03-11-2029 12:30:00")
@@ -577,7 +718,9 @@ class CampaignTest(TembaTest):
         self.assertEqual(12, fire.scheduled.astimezone(eastern).hour)
 
         # assert our offsets are different (we crossed DST)
-        self.assertNotEqual(fire.scheduled.utcoffset(), self.farmer1.get_field('planting_date').datetime_value.utcoffset())
+        self.assertNotEqual(
+            fire.scheduled.utcoffset(), self.farmer1.get_field('planting_date').datetime_value.utcoffset()
+        )
 
         # the number of hours between these two events should be 49 (two days 1 hour)
         delta = fire.scheduled - self.farmer1.get_field('planting_date').datetime_value
@@ -595,7 +738,9 @@ class CampaignTest(TembaTest):
         self.assertEqual(2, fire.scheduled.astimezone(eastern).hour)
 
         # assert our offsets changed (we crossed DST)
-        self.assertNotEqual(fire.scheduled.utcoffset(), self.farmer1.get_field('planting_date').datetime_value.utcoffset())
+        self.assertNotEqual(
+            fire.scheduled.utcoffset(), self.farmer1.get_field('planting_date').datetime_value.utcoffset()
+        )
 
         # delta should be 47 hours exactly
         delta = fire.scheduled - self.farmer1.get_field('planting_date').datetime_value
@@ -607,8 +752,16 @@ class CampaignTest(TembaTest):
         self.assertEqual("Planting Reminders", six.text_type(campaign))
 
         # create a reminder for our first planting event
-        planting_reminder = CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
-                                                            offset=0, unit='D', flow=self.reminder_flow, delivery_hour=17)
+        planting_reminder = CampaignEvent.create_flow_event(
+            self.org,
+            self.admin,
+            campaign,
+            relative_to=self.planting_date,
+            offset=0,
+            unit='D',
+            flow=self.reminder_flow,
+            delivery_hour=17
+        )
 
         self.assertEqual("Planting Date == 0 -> Reminder Flow", six.text_type(planting_reminder))
 
@@ -666,8 +819,15 @@ class CampaignTest(TembaTest):
         self.assertEqual(planting_reminder, fire.event)
 
         # create another reminder
-        planting_reminder2 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
-                                                             offset=1, unit='D', flow=self.reminder2_flow)
+        planting_reminder2 = CampaignEvent.create_flow_event(
+            self.org,
+            self.admin,
+            campaign,
+            relative_to=self.planting_date,
+            offset=1,
+            unit='D',
+            flow=self.reminder2_flow
+        )
 
         self.assertEqual(1, planting_reminder2.abs_offset())
 
@@ -731,10 +891,16 @@ class CampaignTest(TembaTest):
     def test_translations(self):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
 
-        event1 = CampaignEvent.create_message_event(self.org, self.admin, campaign,
-                                                    relative_to=self.planting_date,
-                                                    offset=0, unit='D', message={'eng': "hello"},
-                                                    base_language='eng')
+        event1 = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign,
+            relative_to=self.planting_date,
+            offset=0,
+            unit='D',
+            message={'eng': "hello"},
+            base_language='eng'
+        )
 
         with self.assertRaises(ValidationError):
             event1.message = {'ddddd': "x"}
@@ -754,13 +920,24 @@ class CampaignTest(TembaTest):
 
         flow = self.create_flow()
 
-        CampaignEvent.create_flow_event(self.org, self.admin, campaign, self.planting_date,
-                                        offset=1, unit='W', flow=flow, delivery_hour='13')
-        CampaignEvent.create_flow_event(self.org, self.admin, campaign, self.planting_date,
-                                        offset=1, unit='W', flow=self.reminder_flow, delivery_hour='9')
+        CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, self.planting_date, offset=1, unit='W', flow=flow, delivery_hour='13'
+        )
+        CampaignEvent.create_flow_event(
+            self.org,
+            self.admin,
+            campaign,
+            self.planting_date,
+            offset=1,
+            unit='W',
+            flow=self.reminder_flow,
+            delivery_hour='9'
+        )
 
-        CampaignEvent.create_message_event(self.org, self.admin, campaign, self.planting_date,
-                                           1, CampaignEvent.UNIT_DAYS, "Don't forget to brush your teeth")
+        CampaignEvent.create_message_event(
+            self.org, self.admin, campaign, self.planting_date, 1, CampaignEvent.UNIT_DAYS,
+            "Don't forget to brush your teeth"
+        )
 
         flow.archive()
         campaign.is_archived = True

--- a/temba/channels/courier.py
+++ b/temba/channels/courier.py
@@ -38,31 +38,30 @@ def msg_as_task(msg):
     """
     Used to serialize msgs as tasks to courier
     """
-    msg_json = dict(id=msg.id,
-                    uuid=str(msg.uuid) if msg.uuid else "",
-                    org_id=msg.org_id,
-                    channel_id=msg.channel_id,
-                    channel_uuid=msg.channel.uuid,
-                    contact_id=msg.contact_id,
-                    contact_urn_id=msg.contact_urn_id,
-
-                    status=msg.status,
-                    direction=msg.direction,
-                    text=msg.text,
-                    high_priority=msg.high_priority,
-                    urn=msg.contact_urn.urn,
-                    error_count=msg.error_count,
-                    attachments=msg.attachments,
-                    response_to_id=msg.response_to_id,
-                    external_id=msg.external_id,
-
-                    tps_cost=msg.channel.calculate_tps_cost(msg),
-
-                    next_attempt=datetime_to_str(msg.next_attempt, ms=True),
-                    created_on=datetime_to_str(msg.created_on, ms=True),
-                    modified_on=datetime_to_str(msg.modified_on, ms=True),
-                    queued_on=datetime_to_str(msg.queued_on, ms=True),
-                    sent_on=datetime_to_str(msg.sent_on, ms=True))
+    msg_json = dict(
+        id=msg.id,
+        uuid=str(msg.uuid) if msg.uuid else "",
+        org_id=msg.org_id,
+        channel_id=msg.channel_id,
+        channel_uuid=msg.channel.uuid,
+        contact_id=msg.contact_id,
+        contact_urn_id=msg.contact_urn_id,
+        status=msg.status,
+        direction=msg.direction,
+        text=msg.text,
+        high_priority=msg.high_priority,
+        urn=msg.contact_urn.urn,
+        error_count=msg.error_count,
+        attachments=msg.attachments,
+        response_to_id=msg.response_to_id,
+        external_id=msg.external_id,
+        tps_cost=msg.channel.calculate_tps_cost(msg),
+        next_attempt=datetime_to_str(msg.next_attempt, ms=True),
+        created_on=datetime_to_str(msg.created_on, ms=True),
+        modified_on=datetime_to_str(msg.modified_on, ms=True),
+        queued_on=datetime_to_str(msg.queued_on, ms=True),
+        sent_on=datetime_to_str(msg.sent_on, ms=True)
+    )
 
     if msg.contact_urn.auth:  # pragma: no cover
         msg_json['contact_urn_auth'] = msg.contact_urn.auth
@@ -73,7 +72,6 @@ def msg_as_task(msg):
 COURIER_HIGH_PRIORITY = 1
 COURIER_LOW_PRIORITY = 0
 COURIER_DEFAULT_TPS = 10
-
 
 # Our lua script for properly inserting items to a courier queue
 # from https://github.com/nyaruka/courier/blob/master/queue/queue.go

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -88,6 +88,7 @@ def get_channel_handlers():
     """
     Gets all known channel handler classes, i.e. subclasses of BaseChannelHandler
     """
+
     def all_subclasses(cls):
         return cls.__subclasses__() + [g for s in cls.__subclasses__() for g in all_subclasses(s)]
 
@@ -172,9 +173,9 @@ class TwimlAPIHandler(BaseChannelHandler):
                     call = IVRCall.create_incoming(channel, contact, urn_obj, channel.created_by, call_sid)
                     session = FlowSession.create(contact, connection=call)
 
-                    call.update_status(request.POST.get('CallStatus', None),
-                                       request.POST.get('CallDuration', None),
-                                       'T')
+                    call.update_status(
+                        request.POST.get('CallStatus', None), request.POST.get('CallDuration', None), 'T'
+                    )
                     call.save()
 
                     FlowRun.create(flow, contact.pk, session=session, connection=call)
@@ -206,8 +207,9 @@ class TwimlAPIHandler(BaseChannelHandler):
                 from temba.ivr.models import IVRCall
                 call = IVRCall.objects.filter(external_id=call_sid).first()
                 if call:
-                    call.update_status(request.POST.get('CallStatus', None), request.POST.get('CallDuration', None),
-                                       'TW')
+                    call.update_status(
+                        request.POST.get('CallStatus', None), request.POST.get('CallDuration', None), 'TW'
+                    )
                     call.save()
                     return HttpResponse("Call status updated")
             return HttpResponse("No call found")
@@ -283,10 +285,14 @@ class TwimlAPIHandler(BaseChannelHandler):
         return HttpResponse("Not Handled, unknown action", status=400)  # pragma: no cover
 
     def get_ringing_channel(self, uuid):
-        return Channel.objects.filter(uuid=uuid, channel_type=self.get_channel_type(), role__contains='A', is_active=True).exclude(org=None).first()
+        return Channel.objects.filter(
+            uuid=uuid, channel_type=self.get_channel_type(), role__contains='A', is_active=True
+        ).exclude(org=None).first()
 
     def get_receive_channel(self, uuid=None):
-        return Channel.objects.filter(uuid=uuid, is_active=True, channel_type=self.get_channel_type()).exclude(org=None).first()
+        return Channel.objects.filter(
+            uuid=uuid, is_active=True, channel_type=self.get_channel_type()
+        ).exclude(org=None).first()
 
     def get_client(self, channel):
         return channel.get_ivr_client()
@@ -328,7 +334,9 @@ class TwilioMessagingServiceHandler(BaseChannelHandler):
         action = kwargs['action']
         channel_uuid = kwargs['uuid']
 
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='TMS').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='TMS'
+        ).exclude(org=None).first()
         if not channel:  # pragma: needs cover
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
 
@@ -410,7 +418,9 @@ class AfricasTalkingHandler(BaseChannelHandler):
         action = kwargs['action']
         channel_uuid = kwargs['uuid']
 
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='AT').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='AT'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
 
@@ -470,7 +480,9 @@ class ZenviaHandler(BaseChannelHandler):
         action = kwargs['action']
         channel_uuid = kwargs['uuid']
 
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='ZV').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='ZV'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
 
@@ -547,7 +559,9 @@ class ExternalHandler(BaseChannelHandler):
         else:
             channel_q = Q(address=uuid_or_address) | Q(address=('+' + uuid_or_address))
 
-        channel = Channel.objects.filter(channel_q).filter(is_active=True, channel_type=self.get_channel_type()).exclude(org=None).first()
+        channel = Channel.objects.filter(channel_q).filter(
+            is_active=True, channel_type=self.get_channel_type()
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid or address %s not found." % uuid_or_address, status=400)
 
@@ -689,7 +703,9 @@ class TelegramHandler(BaseChannelHandler):
             ChannelLog.log_message(msg, description, event)
 
         channel_uuid = kwargs['uuid']
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='TG').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='TG'
+        ).exclude(org=None).first()
 
         if not channel:  # pragma: needs cover
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
@@ -711,7 +727,9 @@ class TelegramHandler(BaseChannelHandler):
             # "first_name": "Eric",
             # "last_name": "Newcomer",
             # "username": "ericn" }
-            name = " ".join((body['message']['from'].get('first_name', ''), body['message']['from'].get('last_name', '')))
+            name = " ".join(
+                (body['message']['from'].get('first_name', ''), body['message']['from'].get('last_name', ''))
+            )
             name = name.strip()
 
             username = body['message']['from'].get('username', '')
@@ -807,7 +825,9 @@ class InfobipHandler(BaseChannelHandler):
         channel_uuid = kwargs['uuid']
         action = kwargs['action']
 
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type=self.get_channel_type()).exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type=self.get_channel_type()
+        ).exclude(org=None).first()
         if not channel:  # pragma: needs cover
             return make_response("Channel with uuid: %s not found." % channel_uuid, status_code=404)
 
@@ -891,7 +911,9 @@ class Hub9Handler(BaseChannelHandler):
         from temba.msgs.models import Msg
 
         channel_uuid = kwargs['uuid']
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type=self.get_channel_type()).exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type=self.get_channel_type()
+        ).exclude(org=None).first()
         if not channel:  # pragma: needs cover
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
 
@@ -930,8 +952,7 @@ class Hub9Handler(BaseChannelHandler):
         if action in ['received', 'receive']:
 
             if message is None or from_number is None or to_number is None:
-                return HttpResponse("Parameters message, original and sendto should not be null.",
-                                    status=401)
+                return HttpResponse("Parameters message, original and sendto should not be null.", status=401)
 
             # make sure the channel number matches the receiver
             if channel.address not in ['+' + to_number, to_number]:
@@ -968,7 +989,9 @@ class HighConnectionHandler(BaseChannelHandler):
         from temba.msgs.models import Msg
 
         channel_uuid = kwargs['uuid']
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='HX').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='HX'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=400)
 
@@ -1030,7 +1053,9 @@ class BlackmynaHandler(BaseChannelHandler):
         from temba.msgs.models import Msg
 
         channel_uuid = kwargs['uuid']
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='BM').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='BM'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=400)
 
@@ -1066,7 +1091,9 @@ class BlackmynaHandler(BaseChannelHandler):
                 return HttpResponse("Missing to, from or text parameters", status=400)
 
             if channel.address != to_number:
-                return HttpResponse("Invalid to number [%s], expecting [%s]" % (to_number, channel.address), status=400)
+                return HttpResponse(
+                    "Invalid to number [%s], expecting [%s]" % (to_number, channel.address), status=400
+                )
 
             Msg.create_incoming(channel, URN.from_tel(from_number), message)
             return HttpResponse("")
@@ -1088,7 +1115,9 @@ class SMSCentralHandler(BaseChannelHandler):
         from temba.msgs.models import Msg
 
         channel_uuid = kwargs['uuid']
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='SC').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='SC'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=400)
 
@@ -1122,7 +1151,9 @@ class MacroKioskHandler(BaseChannelHandler):
         from temba.msgs.models import Msg
 
         channel_uuid = kwargs['uuid']
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='MK').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='MK'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=400)
 
@@ -1167,7 +1198,9 @@ class MacroKioskHandler(BaseChannelHandler):
                 return HttpResponse("Missing shortcode, longcode, from, msisdn or text parameters", status=400)
 
             if channel.address != to_number:
-                return HttpResponse("Invalid to number [%s], expecting [%s]" % (to_number, channel.address), status=400)
+                return HttpResponse(
+                    "Invalid to number [%s], expecting [%s]" % (to_number, channel.address), status=400
+                )
 
             Msg.create_incoming(channel, URN.from_tel(from_number), text, date=gmt_date, external_id=external_id)
             return HttpResponse("-1")
@@ -1238,8 +1271,9 @@ class NexmoCallHandler(BaseChannelHandler):
             call.update_status(status, duration, channel_type)
             call.save()
 
-            response = dict(description="Updated call status",
-                            call=dict(status=call.get_status_display(), duration=call.duration))
+            response = dict(
+                description="Updated call status", call=dict(status=call.get_status_display(), duration=call.duration)
+            )
 
             event = HttpEvent(request_method, request_path, request_body, 200, json.dumps(response))
             ChannelLog.log_ivr_interaction(call, "Updated call status", event)
@@ -1268,8 +1302,9 @@ class NexmoCallHandler(BaseChannelHandler):
 
             # look up the channel
             address_q = Q(address=channel_number) | Q(address=('+' + channel_number))
-            channel = Channel.objects.filter(address_q).filter(is_active=True,
-                                                               channel_type='NX').exclude(org=None).first()
+            channel = Channel.objects.filter(address_q).filter(
+                is_active=True, channel_type='NX'
+            ).exclude(org=None).first()
 
             # make sure we got one, and that it matches the key for our org
             org_uuid = None
@@ -1389,7 +1424,9 @@ class VerboiceHandler(BaseChannelHandler):
         action = kwargs['action'].lower()
         request_uuid = kwargs['uuid']
 
-        channel = Channel.objects.filter(uuid__iexact=request_uuid, is_active=True, channel_type=Channel.TYPE_VERBOICE).exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid__iexact=request_uuid, is_active=True, channel_type=Channel.TYPE_VERBOICE
+        ).exclude(org=None).first()
         if not channel:  # pragma: needs cover
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=404)
 
@@ -1438,8 +1475,9 @@ class VumiHandler(BaseChannelHandler):
         channel_type = 'VMU' if is_ussd else 'VM'
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type=channel_type).exclude(
-            org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type=channel_type
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=404)
 
@@ -1493,8 +1531,7 @@ class VumiHandler(BaseChannelHandler):
         elif action == 'receive':
 
             if any(attr not in body for attr in ('timestamp', 'from_addr', 'message_id')):
-                return HttpResponse("Missing one of timestamp, from_addr or message_id, ignoring message",
-                                    status=400)
+                return HttpResponse("Missing one of timestamp, from_addr or message_id, ignoring message", status=400)
 
             # dates come in the format "2014-04-18 03:54:20.570618" GMT
             message_date = datetime.strptime(body['timestamp'], "%Y-%m-%d %H:%M:%S.%f")
@@ -1524,9 +1561,16 @@ class VumiHandler(BaseChannelHandler):
 
                 session_id = str(session_id_part1 + session_id_part2)
 
-                connection = USSDSession.handle_incoming(channel=channel, urn=body['from_addr'], content=content,
-                                                         status=status, date=gmt_date, external_id=session_id,
-                                                         message_id=body['message_id'], starcode=body.get('to_addr'))
+                connection = USSDSession.handle_incoming(
+                    channel=channel,
+                    urn=body['from_addr'],
+                    content=content,
+                    status=status,
+                    date=gmt_date,
+                    external_id=session_id,
+                    message_id=body['message_id'],
+                    starcode=body.get('to_addr')
+                )
 
                 if connection:
                     return HttpResponse("Accepted: %d" % connection.id)
@@ -1537,7 +1581,9 @@ class VumiHandler(BaseChannelHandler):
                 if not content:
                     return HttpResponse("No content, ignoring message", status=400)
 
-                message = Msg.create_incoming(channel, URN.from_tel(body['from_addr']), content, date=gmt_date, status=PENDING)
+                message = Msg.create_incoming(
+                    channel, URN.from_tel(body['from_addr']), content, date=gmt_date, status=PENDING
+                )
 
                 # use an update so there is no race with our handling
                 Msg.objects.filter(pk=message.id).update(external_id=body['message_id'])
@@ -1565,7 +1611,9 @@ class KannelHandler(BaseChannelHandler):
         request_uuid = kwargs['uuid']
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type='KN').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type='KN'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
@@ -1585,11 +1633,7 @@ class KannelHandler(BaseChannelHandler):
                 return HttpResponse("Message with external id of '%s' not found" % sms_id, status=400)
 
             # possible status codes kannel will send us
-            STATUS_CHOICES = {'1': DELIVERED,
-                              '2': FAILED,
-                              '4': SENT,
-                              '8': SENT,
-                              '16': FAILED}
+            STATUS_CHOICES = {'1': DELIVERED, '2': FAILED, '4': SENT, '8': SENT, '16': FAILED}
 
             # check our status
             status = STATUS_CHOICES.get(status_code, None)
@@ -1619,7 +1663,9 @@ class KannelHandler(BaseChannelHandler):
             sms_sender = self.get_param('sender')
 
             if sms_id is None or sms_ts is None or sms_message is None or sms_sender is None:  # pragma: needs cover
-                return HttpResponse("Missing one of 'message', 'sender', 'id' or 'ts' in request parameters.", status=400)
+                return HttpResponse(
+                    "Missing one of 'message', 'sender', 'id' or 'ts' in request parameters.", status=400
+                )
 
             # dates come in the format of a timestamp
             sms_date = datetime.utcfromtimestamp(int(sms_ts))
@@ -1652,7 +1698,9 @@ class ClickatellHandler(BaseChannelHandler):
         request_uuid = kwargs['uuid']
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type='CT').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type='CT'
+        ).exclude(org=None).first()
         if not channel:  # pragma: needs cover
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
@@ -1677,19 +1725,21 @@ class ClickatellHandler(BaseChannelHandler):
                 return HttpResponse("Message with external id of '%s' not found" % sms_id, status=400)
 
             # possible status codes Clickatell will send us
-            STATUS_CHOICES = {'001': FAILED,      # incorrect msg id
-                              '002': WIRED,       # queued
-                              '003': SENT,        # delivered to upstream gateway
-                              '004': DELIVERED,   # received by handset
-                              '005': FAILED,      # error in message
-                              '006': FAILED,      # terminated by user
-                              '007': FAILED,      # error delivering
-                              '008': WIRED,       # msg received
-                              '009': FAILED,      # error routing
-                              '010': FAILED,      # expired
-                              '011': WIRED,       # delayed but queued
-                              '012': FAILED,      # out of credit
-                              '014': FAILED}      # too long
+            STATUS_CHOICES = {
+                '001': FAILED,  # incorrect msg id
+                '002': WIRED,  # queued
+                '003': SENT,  # delivered to upstream gateway
+                '004': DELIVERED,  # received by handset
+                '005': FAILED,  # error in message
+                '006': FAILED,  # terminated by user
+                '007': FAILED,  # error delivering
+                '008': WIRED,  # msg received
+                '009': FAILED,  # error routing
+                '010': FAILED,  # expired
+                '011': WIRED,  # delayed but queued
+                '012': FAILED,  # out of credit
+                '014': FAILED
+            }  # too long
 
             # check our status
             status = STATUS_CHOICES.get(status_code, None)
@@ -1729,7 +1779,9 @@ class ClickatellHandler(BaseChannelHandler):
 
             if sms_from is None or sms_text is None or sms_id is None or sms_timestamp is None:  # pragma: needs cover
                 # return 200 as clickatell pings our endpoint during configuration
-                return HttpResponse("Missing one of 'from', 'text', 'moMsgId' or 'timestamp' in request parameters.", status=200)
+                return HttpResponse(
+                    "Missing one of 'from', 'text', 'moMsgId' or 'timestamp' in request parameters.", status=200
+                )
 
             # dates come in the format "2014-04-18 03:54:20" GMT+2
             sms_date = parse_datetime(sms_timestamp)
@@ -1811,11 +1863,13 @@ class PlivoHandler(BaseChannelHandler):
             if not sms:
                 return HttpResponse("Message with external id of '%s' not found" % sms_id, status=400)
 
-            STATUS_CHOICES = {'queued': WIRED,
-                              'sent': SENT,
-                              'delivered': DELIVERED,
-                              'undelivered': SENT,
-                              'rejected': FAILED}
+            STATUS_CHOICES = {
+                'queued': WIRED,
+                'sent': SENT,
+                'delivered': DELIVERED,
+                'undelivered': SENT,
+                'rejected': FAILED
+            }
 
             status = STATUS_CHOICES.get(plivo_status)
 
@@ -1900,8 +1954,10 @@ class MageHandler(BaseChannelHandler):
 
             msg = Msg.objects.select_related('org').get(pk=msg_id)
 
-            push_task(msg.org, HANDLER_QUEUE, HANDLE_EVENT_TASK,
-                      dict(type=MSG_EVENT, id=msg.id, from_mage=True, new_contact=new_contact))
+            push_task(
+                msg.org, HANDLER_QUEUE, HANDLE_EVENT_TASK,
+                dict(type=MSG_EVENT, id=msg.id, from_mage=True, new_contact=new_contact)
+            )
 
             # fire an event off for this message
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, msg, msg.created_on)
@@ -1938,7 +1994,9 @@ class StartHandler(BaseChannelHandler):
 
         channel_uuid = kwargs['uuid']
 
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='ST').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='ST'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=400)
 
@@ -1991,7 +2049,9 @@ class ChikkaHandler(BaseChannelHandler):
         action = self.get_param('message_type').lower()
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type='CK').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type='CK'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Error, channel not found for id: %s" % request_uuid, status=400)
 
@@ -2001,7 +2061,9 @@ class ChikkaHandler(BaseChannelHandler):
             status_code = self.get_param('status')
 
             if sms_id is None or status_code is None:  # pragma: needs cover
-                return HttpResponse("Error, missing one of 'message_id' or 'status' in request parameters.", status=400)
+                return HttpResponse(
+                    "Error, missing one of 'message_id' or 'status' in request parameters.", status=400
+                )
 
             # look up the message
             sms = Msg.objects.filter(channel=channel, id=sms_id).select_related('channel')
@@ -2036,8 +2098,11 @@ class ChikkaHandler(BaseChannelHandler):
             sms_timestamp = self.get_param('timestamp')
 
             if sms_id is None or sms_from is None or sms_text is None or sms_timestamp is None:  # pragma: needs cover
-                return HttpResponse("Error, missing one of 'mobile_number', 'request_id', "
-                                    "'message' or 'timestamp' in request parameters.", status=400)
+                return HttpResponse(
+                    "Error, missing one of 'mobile_number', 'request_id', "
+                    "'message' or 'timestamp' in request parameters.",
+                    status=400
+                )
 
             # dates come as timestamps
             sms_date = datetime.utcfromtimestamp(float(sms_timestamp))
@@ -2072,7 +2137,9 @@ class JasminHandler(BaseChannelHandler):
         request_uuid = kwargs['uuid']
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type='JS').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type='JS'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
@@ -2103,8 +2170,9 @@ class JasminHandler(BaseChannelHandler):
         # this is a new incoming message
         elif action == 'receive':
             if not all(k in request.POST for k in ['content', 'coding', 'from', 'to', 'id']):  # pragma: needs cover
-                return HttpResponse("Missing one of 'content', 'coding', 'from', 'to' or 'id' in request parameters.",
-                                    status=400)
+                return HttpResponse(
+                    "Missing one of 'content', 'coding', 'from', 'to' or 'id' in request parameters.", status=400
+                )
 
             # if we are GSM7 coded, decode it
             content = request.POST['content']
@@ -2142,9 +2210,16 @@ class JunebugHandler(BaseChannelHandler):
         request_path = request.get_full_path()
 
         def log_channel(channel, description, event, is_error=False):
-            return ChannelLog.objects.create(channel_id=channel.pk, is_error=is_error, request=event.request_body,
-                                             response=event.response_body, url=event.url, method=event.method,
-                                             response_status=event.status_code, description=description)
+            return ChannelLog.objects.create(
+                channel_id=channel.pk,
+                is_error=is_error,
+                request=event.request_body,
+                response=event.response_body,
+                url=event.url,
+                method=event.method,
+                response_status=event.status_code,
+                description=description
+            )
 
         action = kwargs['action'].lower()
         request_uuid = kwargs['uuid']
@@ -2156,9 +2231,8 @@ class JunebugHandler(BaseChannelHandler):
 
         # look up the channel
         channel = Channel.objects.filter(
-            uuid=request_uuid,
-            is_active=True,
-            channel_type__in=channel_types).exclude(org=None).first()
+            uuid=request_uuid, is_active=True, channel_type__in=channel_types
+        ).exclude(org=None).first()
 
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
@@ -2166,8 +2240,8 @@ class JunebugHandler(BaseChannelHandler):
         authorization = request.META.get('HTTP_AUTHORIZATION', '').split(' ')
 
         if channel.secret is not None and (
-                len(authorization) != 2 or authorization[0] != 'Token' or
-                authorization[1] != channel.secret):
+            len(authorization) != 2 or authorization[0] != 'Token' or authorization[1] != channel.secret
+        ):
             return JsonResponse(dict(error="Incorrect authentication token"), status=401)
 
         # Junebug is sending an event
@@ -2187,7 +2261,7 @@ class JunebugHandler(BaseChannelHandler):
             message = Msg.objects.filter(channel=channel, external_id=message_id).select_related('channel')
             if not message:
                 status = 400
-                response_body = "Message with external id of '%s' not found" % (message_id,)
+                response_body = "Message with external id of '%s' not found" % (message_id, )
                 event = HttpEvent(request_method, request_path, request_body, status, response_body)
                 log_channel(channel, 'Failed to handle %s event_type.' % (event_type), event)
                 return HttpResponse(response_body, status=status)
@@ -2202,10 +2276,7 @@ class JunebugHandler(BaseChannelHandler):
                 for message_obj in message:
                     message_obj.status_fail()
 
-            response_body = {
-                'status': self.ACK,
-                'message_ids': [message_obj.pk for message_obj in message]
-            }
+            response_body = {'status': self.ACK, 'message_ids': [message_obj.pk for message_obj in message]}
             event = HttpEvent(request_method, request_path, request_body, 200, json.dumps(response_body))
             log_channel(channel, 'Handled %s event_type.' % (event_type), event)
             # Let Junebug know we're happy
@@ -2241,9 +2312,16 @@ class JunebugHandler(BaseChannelHandler):
                 # Use a session id if provided, otherwise fall back to using the `from` address as the identifier
                 session_id = channel_data.get('session_id') or data['from']
 
-                connection = USSDSession.handle_incoming(channel=channel, urn=data['from'], content=data['content'],
-                                                         status=status, date=gmt_date, external_id=session_id,
-                                                         message_id=data['message_id'], starcode=data['to'])
+                connection = USSDSession.handle_incoming(
+                    channel=channel,
+                    urn=data['from'],
+                    content=data['content'],
+                    status=status,
+                    date=gmt_date,
+                    external_id=session_id,
+                    message_id=data['message_id'],
+                    starcode=data['to']
+                )
 
                 if connection:
                     status = 200
@@ -2252,18 +2330,18 @@ class JunebugHandler(BaseChannelHandler):
                         'session_id': connection.pk,
                     }
                     event = HttpEvent(request_method, request_path, request_body, status, json.dumps(response_body))
-                    log_channel(channel, 'Handled USSD message of %s session_event' % (
-                        channel_data['session_event'],), event)
+                    log_channel(
+                        channel, 'Handled USSD message of %s session_event' % (channel_data['session_event'], ), event
+                    )
                     return JsonResponse(response_body, status=status)
                 else:
                     status = 400
-                    response_body = {
-                        'status': self.NACK,
-                        'reason': 'No suitable session found for this message.'
-                    }
+                    response_body = {'status': self.NACK, 'reason': 'No suitable session found for this message.'}
                     event = HttpEvent(request_method, request_path, request_body, status, json.dumps(response_body))
-                    log_channel(channel, 'Failed to handle USSD message of %s session_event' % (
-                        channel_data['session_event'],), event)
+                    log_channel(
+                        channel,
+                        'Failed to handle USSD message of %s session_event' % (channel_data['session_event'], ), event
+                    )
                     return JsonResponse(response_body, status=status)
             else:
                 content = data['content']
@@ -2295,8 +2373,9 @@ class MbloxHandler(BaseChannelHandler):
         request_uuid = kwargs['uuid']
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True,
-                                         channel_type='MB').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type='MB'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
@@ -2338,8 +2417,9 @@ class MbloxHandler(BaseChannelHandler):
         # this is a new incoming message
         elif body['type'] == 'mo_text':
             if not all(k in body for k in ['id', 'from', 'to', 'body', 'received_at']):  # pragma: needs cover
-                return HttpResponse("Missing one of 'id', 'from', 'to', 'body' or 'received_at' in request body.",
-                                    status=400)
+                return HttpResponse(
+                    "Missing one of 'id', 'from', 'to', 'body' or 'received_at' in request body.", status=400
+                )
 
             msg_date = parse_datetime(body['received_at'])
             msg = Msg.create_incoming(channel, URN.from_tel(body['from']), body['body'], date=msg_date)
@@ -2363,8 +2443,7 @@ class JioChatHandler(BaseChannelHandler):
 
     def lookup_channel(self, kwargs):
         # look up the channel
-        return Channel.objects.filter(uuid=kwargs['uuid'], is_active=True,
-                                      channel_type='JC').exclude(org=None).first()
+        return Channel.objects.filter(uuid=kwargs['uuid'], is_active=True, channel_type='JC').exclude(org=None).first()
 
     def get(self, request, *args, **kwargs):
         channel = self.lookup_channel(kwargs)
@@ -2410,8 +2489,9 @@ class JioChatHandler(BaseChannelHandler):
             contact_detail = client.get_user_detail(sender_id, channel.id)
             contact_name = contact_detail.get('nickname')
 
-        contact = Contact.get_or_create(channel.org, channel.created_by, name=contact_name,
-                                        urns=[urn], channel=channel)
+        contact = Contact.get_or_create(
+            channel.org, channel.created_by, name=contact_name, urns=[urn], channel=channel
+        )
 
         if msg_type == 'event':
             event = body.get('Event')
@@ -2432,8 +2512,9 @@ class JioChatHandler(BaseChannelHandler):
             attachments.append('%s:%s' % (content_type, downloaded_url))
 
         if text or attachments:
-            msg = Msg.create_incoming(channel, urn, text, date=msg_date, contact=contact, attachments=attachments,
-                                      external_id=external_id)
+            msg = Msg.create_incoming(
+                channel, urn, text, date=msg_date, contact=contact, attachments=attachments, external_id=external_id
+            )
             return HttpResponse("Msgs Accepted: %s" % msg.id)
 
         return HttpResponse("Not handled", status=400)
@@ -2448,8 +2529,9 @@ class FacebookHandler(BaseChannelHandler):
 
     def lookup_channel(self, kwargs):
         # look up the channel
-        channel = Channel.objects.filter(uuid=kwargs['uuid'], is_active=True,
-                                         channel_type='FB').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=kwargs['uuid'], is_active=True, channel_type='FB'
+        ).exclude(org=None).first()
         return channel
 
     def get(self, request, *args, **kwargs):
@@ -2546,11 +2628,13 @@ class FacebookHandler(BaseChannelHandler):
                             continue
 
                         if not contact:
-                            contact = Contact.get_or_create(channel.org, channel.created_by,
-                                                            urns=[urn], channel=channel)
+                            contact = Contact.get_or_create(
+                                channel.org, channel.created_by, urns=[urn], channel=channel
+                            )
 
-                        event = ChannelEvent.create(channel, urn, ChannelEvent.TYPE_REFERRAL, timezone.now(),
-                                                    extra=trigger_extra)
+                        event = ChannelEvent.create(
+                            channel, urn, ChannelEvent.TYPE_REFERRAL, timezone.now(), extra=trigger_extra
+                        )
                         caught = event.handle()
 
                         if caught:
@@ -2610,21 +2694,29 @@ class FacebookHandler(BaseChannelHandler):
                                 # if this isn't an anonymous org, look up their name from the Facebook API
                                 if not channel.org.is_anon:
                                     try:
-                                        response = requests.get('https://graph.facebook.com/v2.5/' + six.text_type(sender_id),
-                                                                params=dict(fields='first_name,last_name',
-                                                                            access_token=channel.config_json()[Channel.CONFIG_AUTH_TOKEN]))
+                                        response = requests.get(
+                                            'https://graph.facebook.com/v2.5/' + six.text_type(sender_id),
+                                            params=dict(
+                                                fields='first_name,last_name',
+                                                access_token=channel.config_json()[Channel.CONFIG_AUTH_TOKEN]
+                                            )
+                                        )
 
                                         if response.status_code == 200:
                                             user_stats = response.json()
-                                            name = ' '.join([user_stats.get('first_name', ''), user_stats.get('last_name', '')])
+                                            name = ' '.join([
+                                                user_stats.get('first_name', ''),
+                                                user_stats.get('last_name', '')
+                                            ])
 
                                     except Exception as e:
                                         # something went wrong trying to look up the user's attributes, oh well, move on
                                         import traceback
                                         traceback.print_exc()
 
-                                    contact = Contact.get_or_create(channel.org, channel.created_by,
-                                                                    name=name, urns=[urn], channel=channel)
+                                    contact = Contact.get_or_create(
+                                        channel.org, channel.created_by, name=name, urns=[urn], channel=channel
+                                    )
 
                         # we received a new message, create and handle it
                         if content:
@@ -2635,15 +2727,18 @@ class FacebookHandler(BaseChannelHandler):
 
                         # conversation started with a referrer_id that catches a trigger
                         elif referrer_id:
-                            event = ChannelEvent.create(channel, urn, ChannelEvent.TYPE_REFERRAL, timezone.now(),
-                                                        extra=trigger_extra)
+                            event = ChannelEvent.create(
+                                channel, urn, ChannelEvent.TYPE_REFERRAL, timezone.now(), extra=trigger_extra
+                            )
                             event.handle()
 
                             status.append("Referral posted with referral id: %s" % referrer_id)
 
                         # a contact pressed "Get Started", trigger any new conversation triggers
                         elif postback == 'get_started':
-                            event = ChannelEvent.create(channel, urn, ChannelEvent.TYPE_NEW_CONVERSATION, timezone.now())
+                            event = ChannelEvent.create(
+                                channel, urn, ChannelEvent.TYPE_NEW_CONVERSATION, timezone.now()
+                            )
                             event.handle()
                             status.append("Postback handled.")
 
@@ -2652,7 +2747,9 @@ class FacebookHandler(BaseChannelHandler):
 
                     elif 'delivery' in envelope and 'mids' in envelope['delivery']:
                         for external_id in envelope['delivery']['mids']:
-                            msg = Msg.objects.filter(channel=channel, external_id=external_id, direction=OUTGOING).first()
+                            msg = Msg.objects.filter(
+                                channel=channel, external_id=external_id, direction=OUTGOING
+                            ).first()
                             if msg:
                                 msg.status_delivered()
                                 status.append("Msg %d updated." % msg.id)
@@ -2701,7 +2798,9 @@ class GlobeHandler(BaseChannelHandler):
         request_uuid = kwargs['uuid']
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type='GL').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type='GL'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
@@ -2719,8 +2818,14 @@ class GlobeHandler(BaseChannelHandler):
         if action == 'receive':
             msgs = []
             for inbound_msg in body['inboundSMSMessageList']['inboundSMSMessage']:
-                if not all(field in inbound_msg for field in ('dateTime', 'senderAddress', 'message', 'messageId', 'destinationAddress')):
-                    return HttpResponse("Missing one of dateTime, senderAddress, message, messageId or destinationAddress in message", status=400)
+                if not all(
+                    field in inbound_msg
+                    for field in ('dateTime', 'senderAddress', 'message', 'messageId', 'destinationAddress')
+                ):
+                    return HttpResponse(
+                        "Missing one of dateTime, senderAddress, message, messageId or destinationAddress in message",
+                        status=400
+                    )
 
                 try:
                     scheme, destination, display = URN.to_parts(inbound_msg['destinationAddress'])
@@ -2765,7 +2870,9 @@ class ViberHandler(BaseChannelHandler):
         request_uuid = kwargs['uuid']
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type=Channel.TYPE_VIBER).exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type=Channel.TYPE_VIBER
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
@@ -2783,7 +2890,9 @@ class ViberHandler(BaseChannelHandler):
             # }
             external_id = body['message_token']
 
-            msg = Msg.objects.filter(channel=channel, external_id=external_id, direction=OUTGOING).select_related('channel').first()
+            msg = Msg.objects.filter(
+                channel=channel, external_id=external_id, direction=OUTGOING
+            ).select_related('channel').first()
             if not msg:
                 # viber is hammers us incessantly if we give 400s for non-existant message_ids
                 return HttpResponse("Message with external id of '%s' not found" % external_id)
@@ -2803,14 +2912,15 @@ class ViberHandler(BaseChannelHandler):
             #      "tracking_data": "tracking_id:100035"}
             #  }
             if not all(k in body for k in ['message_token', 'phone_number', 'time', 'message']):
-                return HttpResponse("Missing one of 'message_token', 'phone_number', 'time', or 'message' in request parameters.",
-                                    status=400)
+                return HttpResponse(
+                    "Missing one of 'message_token', 'phone_number', 'time', or 'message' in request parameters.",
+                    status=400
+                )
 
             msg_date = datetime.utcfromtimestamp(body['time']).replace(tzinfo=pytz.utc)
-            msg = Msg.create_incoming(channel,
-                                      URN.from_tel(body['phone_number']),
-                                      body['message']['text'],
-                                      date=msg_date)
+            msg = Msg.create_incoming(
+                channel, URN.from_tel(body['phone_number']), body['message']['text'], date=msg_date
+            )
             Msg.objects.filter(pk=msg.id).update(external_id=body['message_token'])
             return HttpResponse('Msg Accepted: %d' % msg.id)
 
@@ -2833,7 +2943,9 @@ class LineHandler(BaseChannelHandler):
 
         channel_uuid = kwargs['uuid']
 
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='LN').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='LN'
+        ).exclude(org=None).first()
         if not channel:  # pragma: needs cover
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
 
@@ -2871,8 +2983,7 @@ class ViberPublicHandler(BaseChannelHandler):
 
     @classmethod
     def calculate_sig(cls, request_body, auth_token):
-        return hmac.new(bytes(auth_token.encode('ascii')),
-                        msg=request_body, digestmod=hashlib.sha256).hexdigest()
+        return hmac.new(bytes(auth_token.encode('ascii')), msg=request_body, digestmod=hashlib.sha256).hexdigest()
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("Must be called as a POST", status=405)
@@ -2882,7 +2993,9 @@ class ViberPublicHandler(BaseChannelHandler):
         request_uuid = kwargs['uuid']
 
         # look up the channel
-        channel = Channel.objects.filter(uuid=request_uuid, is_active=True, channel_type='VP').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=request_uuid, is_active=True, channel_type='VP'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=200)
 
@@ -2893,8 +3006,7 @@ class ViberPublicHandler(BaseChannelHandler):
             return HttpResponse("Invalid JSON in POST body: %s" % str(e), status=400)
 
         # calculate our signature
-        signature = ViberPublicHandler.calculate_sig(request.body,
-                                                     channel.config_json()[Channel.CONFIG_AUTH_TOKEN])
+        signature = ViberPublicHandler.calculate_sig(request.body, channel.config_json()[Channel.CONFIG_AUTH_TOKEN])
 
         # check it against the Viber header
         if signature != request.META.get('HTTP_X_VIBER_CONTENT_SIGNATURE'):
@@ -2980,7 +3092,9 @@ class ViberPublicHandler(BaseChannelHandler):
             #    "message_token": 4912661846655238145,
             #    "user_id": "01234567890A="
             # }
-            msg = Msg.objects.filter(channel=channel, direction=OUTGOING, external_id=body['message_token']).select_related('channel').first()
+            msg = Msg.objects.filter(
+                channel=channel, direction=OUTGOING, external_id=body['message_token']
+            ).select_related('channel').first()
             if not msg:
                 return HttpResponse("Message with external id of '%s' not found" % body['message_token'])
 
@@ -3012,8 +3126,9 @@ class ViberPublicHandler(BaseChannelHandler):
             #    }
             # }
             if not all(k in body for k in ['timestamp', 'message_token', 'sender', 'message']):  # pragma: needs cover
-                return HttpResponse("Missing one of 'timestamp', 'message_token', 'sender' or 'message' in request body.",
-                                    status=400)
+                return HttpResponse(
+                    "Missing one of 'timestamp', 'message_token', 'sender' or 'message' in request body.", status=400
+                )
 
             message = body['message']
             msg_date = datetime.utcfromtimestamp(body['timestamp'] / 1000).replace(tzinfo=pytz.utc)
@@ -3051,7 +3166,9 @@ class ViberPublicHandler(BaseChannelHandler):
 
             elif message_type == 'location':
                 # "location": {"lat": "37.7898", "lon": "-122.3942"}
-                attachments.append('%s:%s,%s' % (Msg.MEDIA_GPS, message['location']['lat'], message['location']['lon']))
+                attachments.append(
+                    '%s:%s,%s' % (Msg.MEDIA_GPS, message['location']['lat'], message['location']['lon'])
+                )
 
             else:  # pragma: needs cover
                 return HttpResponse("Unknown message type: %s" % message_type, status=400)
@@ -3065,8 +3182,15 @@ class ViberPublicHandler(BaseChannelHandler):
             contact_name = None if channel.org.is_anon else body['sender'].get('name')
             contact = Contact.get_or_create(channel.org, channel.created_by, contact_name, urns=[urn])
 
-            msg = Msg.create_incoming(channel, urn, text, contact=contact, date=msg_date,
-                                      external_id=body['message_token'], attachments=attachments)
+            msg = Msg.create_incoming(
+                channel,
+                urn,
+                text,
+                contact=contact,
+                date=msg_date,
+                external_id=body['message_token'],
+                attachments=attachments
+            )
             return HttpResponse('Msg Accepted: %d' % msg.id)
 
         else:  # pragma: no cover
@@ -3085,8 +3209,9 @@ class FCMHandler(BaseChannelHandler):
 
         channel_uuid = kwargs['uuid']
 
-        channel = Channel.objects.filter(uuid=channel_uuid, is_active=True, channel_type='FCM').exclude(
-            org=None).first()
+        channel = Channel.objects.filter(
+            uuid=channel_uuid, is_active=True, channel_type='FCM'
+        ).exclude(org=None).first()
 
         if not channel:
             return HttpResponse("Channel with uuid: %s not found." % channel_uuid, status=404)
@@ -3105,8 +3230,9 @@ class FCMHandler(BaseChannelHandler):
                 fcm_urn = URN.from_fcm(self.get_param('from'))
                 fcm_token = self.get_param('fcm_token')
                 name = self.get_param('name', None)
-                contact = Contact.get_or_create(channel.org, channel.created_by, name=name, urns=[fcm_urn],
-                                                channel=channel, auth=fcm_token)
+                contact = Contact.get_or_create(
+                    channel.org, channel.created_by, name=name, urns=[fcm_urn], channel=channel, auth=fcm_token
+                )
 
                 sms = Msg.create_incoming(channel, fcm_urn, self.get_param('msg'), date=date, contact=contact)
                 return HttpResponse("Msg Accepted: %d" % sms.id)
@@ -3120,8 +3246,15 @@ class FCMHandler(BaseChannelHandler):
                 name = self.get_param('name', None)
                 contact_uuid = self.get_param('contact_uuid', None)
 
-                contact = Contact.get_or_create(channel.org, channel.created_by, name=name, urns=[fcm_urn],
-                                                channel=channel, auth=fcm_token, uuid=contact_uuid)
+                contact = Contact.get_or_create(
+                    channel.org,
+                    channel.created_by,
+                    name=name,
+                    urns=[fcm_urn],
+                    channel=channel,
+                    auth=fcm_token,
+                    uuid=contact_uuid
+                )
 
                 return HttpResponse(json.dumps({'contact_uuid': contact.uuid}), content_type='application/json')
 
@@ -3142,8 +3275,9 @@ class TwitterHandler(BaseChannelHandler):
     def get(self, request, *args, **kwargs):
         crc_token = request.GET['crc_token']
 
-        channel = Channel.objects.filter(uuid=kwargs['uuid'], is_active=True,
-                                         channel_type='TWT').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=kwargs['uuid'], is_active=True, channel_type='TWT'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("No such Twitter channel", status=400)
 
@@ -3153,8 +3287,9 @@ class TwitterHandler(BaseChannelHandler):
         return JsonResponse({'response_token': resp_token}, status=200)
 
     def post(self, request, *args, **kwargs):
-        channel = Channel.objects.filter(uuid=kwargs['uuid'], is_active=True,
-                                         channel_type='TWT').exclude(org=None).first()
+        channel = Channel.objects.filter(
+            uuid=kwargs['uuid'], is_active=True, channel_type='TWT'
+        ).exclude(org=None).first()
         if not channel:
             return HttpResponse("No such Twitter channel", status=400)
 
@@ -3182,12 +3317,16 @@ class TwitterHandler(BaseChannelHandler):
 
                 urn = URN.from_twitterid(users[sender_id]['id'], users[sender_id]['screen_name'])
                 name = None if channel.org.is_anon else users[sender_id]['name']
-                contact = Contact.get_or_create(channel.org, channel.created_by, name=name, urns=[urn], channel=channel)
+                contact = Contact.get_or_create(
+                    channel.org, channel.created_by, name=name, urns=[urn], channel=channel
+                )
 
                 external_id = dm_event['id']
                 created_on = ms_to_datetime(int(dm_event['created_timestamp']))
                 text = dm_event['message_create']['message_data']['text']
 
-                msgs.append(Msg.create_incoming(channel, urn, text, date=created_on, contact=contact, external_id=external_id))
+                msgs.append(
+                    Msg.create_incoming(channel, urn, text, date=created_on, contact=contact, external_id=external_id)
+                )
 
         return HttpResponse("Accepted %d messages" % len(msgs), status=200)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -67,6 +67,7 @@ class ChannelType(six.with_metaclass(ABCMeta)):
     """
     Base class for all dynamic channel types
     """
+
     class Category(Enum):
         PHONE = 1
         SOCIAL_MEDIA = 2
@@ -220,8 +221,7 @@ class Channel(TembaModel):
     ENCODING_SMART = 'S'  # we try simple substitutions to GSM7 then go to unicode if it still isn't GSM7
     ENCODING_UNICODE = 'U'  # we send everything as unicode
 
-    ENCODING_CHOICES = ((ENCODING_DEFAULT, _("Default Encoding")),
-                        (ENCODING_SMART, _("Smart Encoding")),
+    ENCODING_CHOICES = ((ENCODING_DEFAULT, _("Default Encoding")), (ENCODING_SMART, _("Smart Encoding")),
                         (ENCODING_UNICODE, _("Unicode Encoding")))
 
     # the role types for our channels
@@ -256,8 +256,8 @@ class Channel(TembaModel):
     }
 
     CONTENT_TYPE_CHOICES = ((CONTENT_TYPE_URLENCODED, _("URL Encoded - application/x-www-form-urlencoded")),
-                            (CONTENT_TYPE_JSON, _("JSON - application/json")),
-                            (CONTENT_TYPE_XML, _("XML - text/xml; charset=utf-8")))
+                            (CONTENT_TYPE_JSON,
+                             _("JSON - application/json")), (CONTENT_TYPE_XML, _("XML - text/xml; charset=utf-8")))
 
     # our default max tps is 50
     DEFAULT_TPS = 50
@@ -270,15 +270,10 @@ class Channel(TembaModel):
         TYPE_VIBER: dict(schemes=['tel'], max_length=1000)
     }
 
-    TYPE_CHOICES = ((TYPE_ANDROID, "Android"),
-                    (TYPE_DUMMY, "Dummy"),
-                    (TYPE_VERBOICE, "Verboice"),
+    TYPE_CHOICES = ((TYPE_ANDROID, "Android"), (TYPE_DUMMY, "Dummy"), (TYPE_VERBOICE, "Verboice"),
                     (TYPE_VIBER, "Viber"))
 
-    TYPE_ICONS = {
-        TYPE_ANDROID: "icon-channel-android",
-        TYPE_VIBER: "icon-viber"
-    }
+    TYPE_ICONS = {TYPE_ANDROID: "icon-channel-android", TYPE_VIBER: "icon-viber"}
 
     FREE_SENDING_CHANNEL_TYPES = [TYPE_VIBER]
 
@@ -288,63 +283,140 @@ class Channel(TembaModel):
 
     VIBER_NO_SERVICE_ID = 'no_service_id'
 
-    SIMULATOR_CONTEXT = dict(__default__='(800) 555-1212', name='Simulator', tel='(800) 555-1212', tel_e164='+18005551212')
+    SIMULATOR_CONTEXT = dict(
+        __default__='(800) 555-1212', name='Simulator', tel='(800) 555-1212', tel_e164='+18005551212'
+    )
 
     channel_type = models.CharField(verbose_name=_("Channel Type"), max_length=3)
 
-    name = models.CharField(verbose_name=_("Name"), max_length=64, blank=True, null=True,
-                            help_text=_("Descriptive label for this channel"))
+    name = models.CharField(
+        verbose_name=_("Name"),
+        max_length=64,
+        blank=True,
+        null=True,
+        help_text=_("Descriptive label for this channel")
+    )
 
-    address = models.CharField(verbose_name=_("Address"), max_length=255, blank=True, null=True,
-                               help_text=_("Address with which this channel communicates"))
+    address = models.CharField(
+        verbose_name=_("Address"),
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text=_("Address with which this channel communicates")
+    )
 
-    country = CountryField(verbose_name=_("Country"), null=True, blank=True,
-                           help_text=_("Country which this channel is for"))
+    country = CountryField(
+        verbose_name=_("Country"), null=True, blank=True, help_text=_("Country which this channel is for")
+    )
 
-    org = models.ForeignKey(Org, verbose_name=_("Org"), related_name="channels", blank=True, null=True,
-                            help_text=_("Organization using this channel"))
+    org = models.ForeignKey(
+        Org,
+        verbose_name=_("Org"),
+        related_name="channels",
+        blank=True,
+        null=True,
+        help_text=_("Organization using this channel")
+    )
 
-    gcm_id = models.CharField(verbose_name=_("GCM ID"), max_length=255, blank=True, null=True,
-                              help_text=_("The registration id for using Google Cloud Messaging"))
+    gcm_id = models.CharField(
+        verbose_name=_("GCM ID"),
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text=_("The registration id for using Google Cloud Messaging")
+    )
 
-    claim_code = models.CharField(verbose_name=_("Claim Code"), max_length=16, blank=True, null=True, unique=True,
-                                  help_text=_("The token the user will us to claim this channel"))
+    claim_code = models.CharField(
+        verbose_name=_("Claim Code"),
+        max_length=16,
+        blank=True,
+        null=True,
+        unique=True,
+        help_text=_("The token the user will us to claim this channel")
+    )
 
-    secret = models.CharField(verbose_name=_("Secret"), max_length=64, blank=True, null=True, unique=True,
-                              help_text=_("The secret token this channel should use when signing requests"))
+    secret = models.CharField(
+        verbose_name=_("Secret"),
+        max_length=64,
+        blank=True,
+        null=True,
+        unique=True,
+        help_text=_("The secret token this channel should use when signing requests")
+    )
 
-    last_seen = models.DateTimeField(verbose_name=_("Last Seen"), auto_now_add=True,
-                                     help_text=_("The last time this channel contacted the server"))
+    last_seen = models.DateTimeField(
+        verbose_name=_("Last Seen"), auto_now_add=True, help_text=_("The last time this channel contacted the server")
+    )
 
-    device = models.CharField(verbose_name=_("Device"), max_length=255, null=True, blank=True,
-                              help_text=_("The type of Android device this channel is running on"))
+    device = models.CharField(
+        verbose_name=_("Device"),
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text=_("The type of Android device this channel is running on")
+    )
 
-    os = models.CharField(verbose_name=_("OS"), max_length=255, null=True, blank=True,
-                          help_text=_("What Android OS version this channel is running on"))
+    os = models.CharField(
+        verbose_name=_("OS"),
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text=_("What Android OS version this channel is running on")
+    )
 
-    alert_email = models.EmailField(verbose_name=_("Alert Email"), null=True, blank=True,
-                                    help_text=_("We will send email alerts to this address if experiencing issues sending"))
+    alert_email = models.EmailField(
+        verbose_name=_("Alert Email"),
+        null=True,
+        blank=True,
+        help_text=_("We will send email alerts to this address if experiencing issues sending")
+    )
 
-    config = models.TextField(verbose_name=_("Config"), null=True,
-                              help_text=_("Any channel specific configuration, used for the various aggregators"))
+    config = models.TextField(
+        verbose_name=_("Config"),
+        null=True,
+        help_text=_("Any channel specific configuration, used for the various aggregators")
+    )
 
-    schemes = ArrayField(models.CharField(max_length=16), default=['tel'],
-                         verbose_name="URN Schemes", help_text=_("The URN schemes this channel supports"))
+    schemes = ArrayField(
+        models.CharField(max_length=16),
+        default=['tel'],
+        verbose_name="URN Schemes",
+        help_text=_("The URN schemes this channel supports")
+    )
 
-    role = models.CharField(verbose_name="Channel Role", max_length=4, default=DEFAULT_ROLE,
-                            help_text=_("The roles this channel can fulfill"))
+    role = models.CharField(
+        verbose_name="Channel Role",
+        max_length=4,
+        default=DEFAULT_ROLE,
+        help_text=_("The roles this channel can fulfill")
+    )
 
-    parent = models.ForeignKey('self', blank=True, null=True,
-                               help_text=_("The channel this channel is working on behalf of"))
+    parent = models.ForeignKey(
+        'self', blank=True, null=True, help_text=_("The channel this channel is working on behalf of")
+    )
 
-    bod = models.TextField(verbose_name=_("Optional Data"), null=True,
-                           help_text=_("Any channel specific state data"))
+    bod = models.TextField(verbose_name=_("Optional Data"), null=True, help_text=_("Any channel specific state data"))
 
-    tps = models.IntegerField(verbose_name=_("Maximum Transactions per Second"), null=True,
-                              help_text=_("The max number of messages that will be sent per second"))
+    tps = models.IntegerField(
+        verbose_name=_("Maximum Transactions per Second"),
+        null=True,
+        help_text=_("The max number of messages that will be sent per second")
+    )
 
     @classmethod
-    def create(cls, org, user, country, channel_type, name=None, address=None, config=None, role=DEFAULT_ROLE, schemes=None, **kwargs):
+    def create(
+        cls,
+        org,
+        user,
+        country,
+        channel_type,
+        name=None,
+        address=None,
+        config=None,
+        role=DEFAULT_ROLE,
+        schemes=None,
+        **kwargs
+    ):
         if isinstance(channel_type, six.string_types):
             channel_type = cls.get_type_from_code(channel_type)
 
@@ -363,12 +435,18 @@ class Channel(TembaModel):
         if config is None:
             config = {}
 
-        create_args = dict(org=org, created_by=user, modified_by=user,
-                           country=country,
-                           channel_type=channel_type.code,
-                           name=name, address=address,
-                           config=json.dumps(config),
-                           role=role, schemes=schemes)
+        create_args = dict(
+            org=org,
+            created_by=user,
+            modified_by=user,
+            country=country,
+            channel_type=channel_type.code,
+            name=name,
+            address=address,
+            config=json.dumps(config),
+            role=role,
+            schemes=schemes
+        )
         create_args.update(kwargs)
 
         if 'uuid' not in create_args:
@@ -411,8 +489,9 @@ class Channel(TembaModel):
         return Channel.create(org, user, None, Channel.TYPE_VIBER, name=name, address=Channel.VIBER_NO_SERVICE_ID)
 
     @classmethod
-    def add_authenticated_external_channel(cls, org, user, country, phone_number,
-                                           username, password, channel_type, url, role=DEFAULT_ROLE):
+    def add_authenticated_external_channel(
+        cls, org, user, country, phone_number, username, password, channel_type, url, role=DEFAULT_ROLE
+    ):
         try:
             parsed = phonenumbers.parse(phone_number, None)
             phone = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
@@ -421,14 +500,26 @@ class Channel(TembaModel):
             phone = phone_number
 
         config = dict(username=username, password=password, send_url=url)
-        return Channel.create(org, user, country, channel_type, name=phone, address=phone_number, config=config,
-                              role=role)
+        return Channel.create(
+            org, user, country, channel_type, name=phone, address=phone_number, config=config, role=role
+        )
 
     @classmethod
-    def add_config_external_channel(cls, org, user, country, address, channel_type, config, role=DEFAULT_ROLE,
-                                    schemes=['tel'], parent=None):
-        return Channel.create(org, user, country, channel_type, name=address, address=address,
-                              config=config, role=role, schemes=schemes, parent=parent)
+    def add_config_external_channel(
+        cls, org, user, country, address, channel_type, config, role=DEFAULT_ROLE, schemes=['tel'], parent=None
+    ):
+        return Channel.create(
+            org,
+            user,
+            country,
+            channel_type,
+            name=address,
+            address=address,
+            config=config,
+            role=role,
+            schemes=schemes,
+            parent=parent
+        )
 
     @classmethod
     def add_send_channel(cls, user, channel):
@@ -436,13 +527,30 @@ class Channel(TembaModel):
         parsed = phonenumbers.parse(channel.address, None)
         nexmo_phone_number = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164).strip('+')
 
-        return Channel.create(user.get_org(), user, channel.country, 'NX', name="Nexmo Sender",
-                              address=channel.address, role=Channel.ROLE_SEND, parent=channel, bod=nexmo_phone_number)
+        return Channel.create(
+            user.get_org(),
+            user,
+            channel.country,
+            'NX',
+            name="Nexmo Sender",
+            address=channel.address,
+            role=Channel.ROLE_SEND,
+            parent=channel,
+            bod=nexmo_phone_number
+        )
 
     @classmethod
     def add_call_channel(cls, org, user, channel):
-        return Channel.create(org, user, channel.country, 'T', name="Twilio Caller",
-                              address=channel.address, role=Channel.ROLE_CALL, parent=channel)
+        return Channel.create(
+            org,
+            user,
+            channel.country,
+            'T',
+            name="Twilio Caller",
+            address=channel.address,
+            role=Channel.ROLE_CALL,
+            parent=channel
+        )
 
     @classmethod
     def refresh_all_jiochat_access_token(cls, channel_id=None):
@@ -496,7 +604,7 @@ class Channel(TembaModel):
         # if any inactive channel has this UUID, we can steal it
         for ch in Channel.objects.filter(uuid=uuid, is_active=False):
             ch.uuid = generate_uuid()
-            ch.save(update_fields=('uuid',))
+            ch.save(update_fields=('uuid', ))
 
         # generate random secret and claim code
         claim_code = cls.generate_claim_code()
@@ -504,8 +612,20 @@ class Channel(TembaModel):
         anon = get_anonymous_user()
         config = {Channel.CONFIG_FCM_ID: fcm_id}
 
-        return Channel.create(None, anon, country, Channel.TYPE_ANDROID, None, None, gcm_id=gcm_id, config=config,
-                              uuid=uuid, device=device, claim_code=claim_code, secret=secret)
+        return Channel.create(
+            None,
+            anon,
+            country,
+            Channel.TYPE_ANDROID,
+            None,
+            None,
+            gcm_id=gcm_id,
+            config=config,
+            uuid=uuid,
+            device=device,
+            claim_code=claim_code,
+            secret=secret
+        )
 
     @classmethod
     def generate_claim_code(cls):
@@ -723,26 +843,32 @@ class Channel(TembaModel):
         # also save our org config, as it has twilio and nexmo keys
         org_config = self.org.config_json()
 
-        return dict(id=self.id, org=self.org_id, country=six.text_type(self.country), address=self.address,
-                    uuid=self.uuid, secret=self.secret, channel_type=self.channel_type, name=self.name,
-                    config=self.config_json(), org_config=org_config)
+        return dict(
+            id=self.id,
+            org=self.org_id,
+            country=six.text_type(self.country),
+            address=self.address,
+            uuid=self.uuid,
+            secret=self.secret,
+            channel_type=self.channel_type,
+            name=self.name,
+            config=self.config_json(),
+            org_config=org_config
+        )
 
     def build_registration_command(self):
         # create a claim code if we don't have one
         if not self.claim_code:
             self.claim_code = self.generate_claim_code()
-            self.save(update_fields=('claim_code',))
+            self.save(update_fields=('claim_code', ))
 
         # create a secret if we don't have one
         if not self.secret:
             self.secret = self.generate_secret()
-            self.save(update_fields=('secret',))
+            self.save(update_fields=('secret', ))
 
         # return our command
-        return dict(cmd='reg',
-                    relayer_claim_code=self.claim_code,
-                    relayer_secret=self.secret,
-                    relayer_id=self.id)
+        return dict(cmd='reg', relayer_claim_code=self.claim_code, relayer_secret=self.secret, relayer_id=self.id)
 
     def get_latest_sent_message(self):
         # all message states that are successfully sent
@@ -809,8 +935,11 @@ class Channel(TembaModel):
     def get_unsent_messages(self):
         # use our optimized index for our org outbox
         from temba.msgs.models import Msg
-        return Msg.objects.filter(org=self.org.id, status__in=['P', 'Q'], direction='O',
-                                  visibility='V').filter(channel=self, contact__is_test=False)
+        return Msg.objects.filter(
+            org=self.org.id, status__in=['P', 'Q'], direction='O', visibility='V'
+        ).filter(
+            channel=self, contact__is_test=False
+        )
 
     def is_new(self):
         # is this channel newer than an hour
@@ -900,7 +1029,9 @@ class Channel(TembaModel):
 
         # mark any messages in sending mode as failed for this channel
         from temba.msgs.models import Msg, OUTGOING, PENDING, QUEUED, ERRORED, FAILED
-        Msg.objects.filter(channel=self, direction=OUTGOING, status__in=[QUEUED, PENDING, ERRORED]).update(status=FAILED)
+        Msg.objects.filter(
+            channel=self, direction=OUTGOING, status__in=[QUEUED, PENDING, ERRORED]
+        ).update(status=FAILED)
 
         # trigger the orphaned channel
         if trigger_sync and self.channel_type == Channel.TYPE_ANDROID:  # pragma: no cover
@@ -1011,26 +1142,33 @@ class Channel(TembaModel):
 
         for event in events:
             # write to our log file
-            print(u"[%d] %0.3fs SENT - %s %s \"%s\" %s \"%s\"" %
-                  (msg.id, request_time, event.method, event.url, event.request_body, event.status_code, event.response_body))
+            print(
+                u"[%d] %0.3fs SENT - %s %s \"%s\" %s \"%s\"" % (
+                    msg.id, request_time, event.method, event.url, event.request_body, event.status_code,
+                    event.response_body
+                )
+            )
 
             # lastly store a ChannelLog object for the user
-            ChannelLog.objects.create(channel_id=msg.channel,
-                                      msg_id=msg.id,
-                                      is_error=False,
-                                      description='Successfully delivered',
-                                      method=event.method,
-                                      url=event.url,
-                                      request=event.request_body,
-                                      response=event.response_body,
-                                      response_status=event.status_code,
-                                      request_time=request_time_ms)
+            ChannelLog.objects.create(
+                channel_id=msg.channel,
+                msg_id=msg.id,
+                is_error=False,
+                description='Successfully delivered',
+                method=event.method,
+                url=event.url,
+                request=event.request_body,
+                response=event.response_body,
+                response_status=event.status_code,
+                request_time=request_time_ms
+            )
 
             # Sending data to Chatbase API
             if hasattr(msg, 'is_org_connected_to_chatbase'):
                 chatbase_version = msg.chatbase_version if hasattr(msg, 'chatbase_version') else None
-                Msg.send_chatbase_log(msg.chatbase_api_key, chatbase_version, channel.name, msg.text, msg.contact,
-                                      CHATBASE_TYPE_AGENT)
+                Msg.send_chatbase_log(
+                    msg.chatbase_api_key, chatbase_version, channel.name, msg.text, msg.contact, CHATBASE_TYPE_AGENT
+                )
 
     @classmethod
     def send_dummy_message(cls, channel, msg, text):  # pragma: no cover
@@ -1052,13 +1190,16 @@ class Channel(TembaModel):
         from temba.msgs.models import WIRED
 
         url = 'https://services.viber.com/vibersrvc/1/send_message'
-        payload = {'service_id': int(channel.address),
-                   'dest': msg.urn_path.lstrip('+'),
-                   'seq': msg.id,
-                   'type': 206,
-                   'message': {
-                       '#txt': text,
-                       '#tracking_data': 'tracking_id:%d' % msg.id}}
+        payload = {
+            'service_id': int(channel.address),
+            'dest': msg.urn_path.lstrip('+'),
+            'seq': msg.id,
+            'type': 206,
+            'message': {
+                '#txt': text,
+                '#tracking_data': 'tracking_id:%d' % msg.id
+            }
+        }
 
         event = HttpEvent('POST', url, json.dumps(payload))
         start = time.time()
@@ -1074,13 +1215,13 @@ class Channel(TembaModel):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code not in [200, 201, 202]:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         # success is 0, everything else is a failure
         if response_json['status'] != 0:
-            raise SendException("Got non-0 status [%d] from API" % response_json['status'],
-                                event=event, fatal=True, start=start)
+            raise SendException(
+                "Got non-0 status [%d] from API" % response_json['status'], event=event, fatal=True, start=start
+            )
 
         external_id = response.json().get('message_token', None)
         Channel.success(channel, msg, WIRED, start, event=event, external_id=external_id)
@@ -1100,9 +1241,10 @@ class Channel(TembaModel):
         five_minutes_ago = now - timedelta(minutes=5)
 
         pending = Msg.objects.filter(org=org, direction=OUTGOING)
-        pending = pending.filter(Q(status=PENDING, created_on__lte=five_minutes_ago) |
-                                 Q(status=QUEUED, queued_on__lte=hours_ago) |
-                                 Q(status=ERRORED, next_attempt__lte=now))
+        pending = pending.filter(
+            Q(status=PENDING, created_on__lte=five_minutes_ago) | Q(status=QUEUED, queued_on__lte=hours_ago) |
+            Q(status=ERRORED, next_attempt__lte=now)
+        )
         pending = pending.exclude(channel__channel_type=Channel.TYPE_ANDROID)
 
         # only SMS'es that have a topup and aren't the test contact
@@ -1276,7 +1418,8 @@ class Channel(TembaModel):
         return self.get_count([ChannelCount.SUCCESS_LOG_TYPE])
 
     def get_ivr_log_count(self):
-        return ChannelLog.objects.filter(channel=self).exclude(connection=None).order_by('connection').distinct('connection').count()
+        return ChannelLog.objects.filter(channel=self).exclude(connection=None
+                                                               ).order_by('connection').distinct('connection').count()
 
     def get_non_ivr_log_count(self):
         return self.get_log_count() - self.get_ivr_log_count()
@@ -1296,8 +1439,7 @@ STATUS_DISCHARGING = "DIS"
 STATUS_NOT_CHARGING = "NOT"
 STATUS_FULL = "FUL"
 
-SEND_FUNCTIONS = {Channel.TYPE_DUMMY: Channel.send_dummy_message,
-                  Channel.TYPE_VIBER: Channel.send_viber_message}
+SEND_FUNCTIONS = {Channel.TYPE_DUMMY: Channel.send_dummy_message, Channel.TYPE_VIBER: Channel.send_viber_message}
 
 
 @six.python_2_unicode_compatible
@@ -1313,23 +1455,19 @@ class ChannelCount(SquashableModel):
     OUTGOING_MSG_TYPE = 'OM'  # Outgoing message
     INCOMING_IVR_TYPE = 'IV'  # Incoming IVR step
     OUTGOING_IVR_TYPE = 'OV'  # Outgoing IVR step
-    SUCCESS_LOG_TYPE = 'LS'   # ChannelLog record
-    ERROR_LOG_TYPE = 'LE'     # ChannelLog record that is an error
+    SUCCESS_LOG_TYPE = 'LS'  # ChannelLog record
+    ERROR_LOG_TYPE = 'LE'  # ChannelLog record that is an error
 
-    COUNT_TYPE_CHOICES = ((INCOMING_MSG_TYPE, _("Incoming Message")),
-                          (OUTGOING_MSG_TYPE, _("Outgoing Message")),
-                          (INCOMING_IVR_TYPE, _("Incoming Voice")),
-                          (OUTGOING_IVR_TYPE, _("Outgoing Voice")),
-                          (SUCCESS_LOG_TYPE, _("Success Log Record")),
-                          (ERROR_LOG_TYPE, _("Error Log Record")))
+    COUNT_TYPE_CHOICES = ((INCOMING_MSG_TYPE, _("Incoming Message")), (OUTGOING_MSG_TYPE, _("Outgoing Message")),
+                          (INCOMING_IVR_TYPE, _("Incoming Voice")), (OUTGOING_IVR_TYPE, _("Outgoing Voice")),
+                          (SUCCESS_LOG_TYPE, _("Success Log Record")), (ERROR_LOG_TYPE, _("Error Log Record")))
 
-    channel = models.ForeignKey(Channel,
-                                help_text=_("The channel this is a daily summary count for"))
-    count_type = models.CharField(choices=COUNT_TYPE_CHOICES, max_length=2,
-                                  help_text=_("What type of message this row is counting"))
+    channel = models.ForeignKey(Channel, help_text=_("The channel this is a daily summary count for"))
+    count_type = models.CharField(
+        choices=COUNT_TYPE_CHOICES, max_length=2, help_text=_("What type of message this row is counting")
+    )
     day = models.DateField(null=True, help_text=_("The day this count is for"))
-    count = models.IntegerField(default=0,
-                                help_text=_("The count of messages on this day and type"))
+    count = models.IntegerField(default=0, help_text=_("The count of messages on this day and type"))
 
     @classmethod
     def get_day_count(cls, channel, count_type, day):
@@ -1347,7 +1485,9 @@ class ChannelCount(SquashableModel):
             )
             INSERT INTO %(table)s("channel_id", "count_type", "day", "count", "is_squashed")
             VALUES (%%s, %%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-            """ % {'table': cls._meta.db_table}
+            """ % {
+                'table': cls._meta.db_table
+            }
 
             params = (distinct_set.channel_id, distinct_set.count_type, distinct_set.day) * 2
         else:
@@ -1357,7 +1497,9 @@ class ChannelCount(SquashableModel):
             )
             INSERT INTO %(table)s("channel_id", "count_type", "day", "count", "is_squashed")
             VALUES (%%s, %%s, NULL, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-            """ % {'table': cls._meta.db_table}
+            """ % {
+                'table': cls._meta.db_table
+            }
 
             params = (distinct_set.channel_id, distinct_set.count_type) * 2
 
@@ -1386,35 +1528,45 @@ class ChannelEvent(models.Model):
     EXTRA_REFERRER_ID = 'referrer_id'
 
     # single char flag, human readable name, API readable name
-    TYPE_CONFIG = ((TYPE_UNKNOWN, _("Unknown Call Type"), 'unknown'),
-                   (TYPE_CALL_OUT, _("Outgoing Call"), 'call-out'),
-                   (TYPE_CALL_OUT_MISSED, _("Missed Outgoing Call"), 'call-out-missed'),
-                   (TYPE_CALL_IN, _("Incoming Call"), 'call-in'),
-                   (TYPE_CALL_IN_MISSED, _("Missed Incoming Call"), 'call-in-missed'),
-                   (TYPE_NEW_CONVERSATION, _("New Conversation"), 'new-conversation'),
-                   (TYPE_REFERRAL, _("Referral"), 'referral'),
-                   (TYPE_FOLLOW, _("Follow"), 'follow'))
+    TYPE_CONFIG = ((TYPE_UNKNOWN, _("Unknown Call Type"), 'unknown'), (TYPE_CALL_OUT, _("Outgoing Call"), 'call-out'),
+                   (TYPE_CALL_OUT_MISSED, _("Missed Outgoing Call"),
+                    'call-out-missed'), (TYPE_CALL_IN, _("Incoming Call"), 'call-in'),
+                   (TYPE_CALL_IN_MISSED, _("Missed Incoming Call"),
+                    'call-in-missed'), (TYPE_NEW_CONVERSATION, _("New Conversation"),
+                                        'new-conversation'), (TYPE_REFERRAL, _("Referral"),
+                                                              'referral'), (TYPE_FOLLOW, _("Follow"), 'follow'))
 
     TYPE_CHOICES = [(t[0], t[1]) for t in TYPE_CONFIG]
 
     CALL_TYPES = {TYPE_CALL_OUT, TYPE_CALL_OUT_MISSED, TYPE_CALL_IN, TYPE_CALL_IN_MISSED}
 
-    org = models.ForeignKey(Org, verbose_name=_("Org"),
-                            help_text=_("The org this event is connected to"))
-    channel = models.ForeignKey(Channel, verbose_name=_("Channel"),
-                                help_text=_("The channel on which this event took place"))
-    event_type = models.CharField(max_length=16, choices=TYPE_CHOICES, verbose_name=_("Event Type"),
-                                  help_text=_("The type of event"))
-    contact = models.ForeignKey('contacts.Contact', verbose_name=_("Contact"), related_name='channel_events',
-                                help_text=_("The contact associated with this event"))
-    contact_urn = models.ForeignKey('contacts.ContactURN', null=True, verbose_name=_("URN"), related_name='channel_events',
-                                    help_text=_("The contact URN associated with this event"))
-    extra = models.TextField(verbose_name=_("Extra"), null=True,
-                             help_text=_("Any extra properties on this event as JSON"))
-    occurred_on = models.DateTimeField(verbose_name=_("Occurred On"),
-                                       help_text=_("When this event took place"))
-    created_on = models.DateTimeField(verbose_name=_("Created On"), default=timezone.now,
-                                      help_text=_("When this event was created"))
+    org = models.ForeignKey(Org, verbose_name=_("Org"), help_text=_("The org this event is connected to"))
+    channel = models.ForeignKey(
+        Channel, verbose_name=_("Channel"), help_text=_("The channel on which this event took place")
+    )
+    event_type = models.CharField(
+        max_length=16, choices=TYPE_CHOICES, verbose_name=_("Event Type"), help_text=_("The type of event")
+    )
+    contact = models.ForeignKey(
+        'contacts.Contact',
+        verbose_name=_("Contact"),
+        related_name='channel_events',
+        help_text=_("The contact associated with this event")
+    )
+    contact_urn = models.ForeignKey(
+        'contacts.ContactURN',
+        null=True,
+        verbose_name=_("URN"),
+        related_name='channel_events',
+        help_text=_("The contact URN associated with this event")
+    )
+    extra = models.TextField(
+        verbose_name=_("Extra"), null=True, help_text=_("Any extra properties on this event as JSON")
+    )
+    occurred_on = models.DateTimeField(verbose_name=_("Occurred On"), help_text=_("When this event took place"))
+    created_on = models.DateTimeField(
+        verbose_name=_("Created On"), default=timezone.now, help_text=_("When this event was created")
+    )
 
     @classmethod
     def create(cls, channel, urn, event_type, occurred_on, extra=None):
@@ -1429,8 +1581,15 @@ class ChannelEvent(models.Model):
         contact_urn = contact.urn_objects[urn]
 
         extra_json = None if not extra else json.dumps(extra)
-        event = cls.objects.create(org=org, channel=channel, contact=contact, contact_urn=contact_urn,
-                                   occurred_on=occurred_on, event_type=event_type, extra=extra_json)
+        event = cls.objects.create(
+            org=org,
+            channel=channel,
+            contact=contact,
+            contact_urn=contact_urn,
+            occurred_on=occurred_on,
+            event_type=event_type,
+            extra=extra_json
+        )
 
         if event_type in cls.CALL_TYPES:
             analytics.gauge('temba.call_%s' % event.get_event_type_display().lower().replace(' ', '_'))
@@ -1457,8 +1616,13 @@ class ChannelEvent(models.Model):
             handled = Trigger.catch_triggers(self, Trigger.TYPE_NEW_CONVERSATION, self.channel)
 
         elif self.event_type == ChannelEvent.TYPE_REFERRAL:
-            handled = Trigger.catch_triggers(self, Trigger.TYPE_REFERRAL, self.channel,
-                                             referrer_id=self.extra_json().get('referrer_id'), extra=self.extra_json())
+            handled = Trigger.catch_triggers(
+                self,
+                Trigger.TYPE_REFERRAL,
+                self.channel,
+                referrer_id=self.extra_json().get('referrer_id'),
+                extra=self.extra_json()
+            )
 
         elif self.event_type == ChannelEvent.TYPE_FOLLOW:
             handled = Trigger.catch_triggers(self, Trigger.TYPE_FOLLOW, self.channel)
@@ -1476,7 +1640,6 @@ class ChannelEvent(models.Model):
 
 
 class SendException(Exception):
-
     def __init__(self, description, event=None, events=None, fatal=False, start=None):
         super(SendException, self).__init__(description)
 
@@ -1490,30 +1653,30 @@ class SendException(Exception):
 
 
 class ChannelLog(models.Model):
-    channel = models.ForeignKey(Channel, related_name='logs',
-                                help_text=_("The channel the message was sent on"))
-    msg = models.ForeignKey('msgs.Msg', related_name='channel_logs', null=True,
-                            help_text=_("The message that was sent"))
+    channel = models.ForeignKey(Channel, related_name='logs', help_text=_("The channel the message was sent on"))
+    msg = models.ForeignKey(
+        'msgs.Msg', related_name='channel_logs', null=True, help_text=_("The message that was sent")
+    )
 
-    connection = models.ForeignKey('channels.ChannelSession', related_name='channel_logs', null=True,
-                                   help_text=_("The channel session for this log"))
+    connection = models.ForeignKey(
+        'channels.ChannelSession',
+        related_name='channel_logs',
+        null=True,
+        help_text=_("The channel session for this log")
+    )
 
-    description = models.CharField(max_length=255,
-                                   help_text=_("A description of the status of this message send"))
-    is_error = models.BooleanField(default=None,
-                                   help_text=_("Whether an error was encountered when sending the message"))
-    url = models.TextField(null=True,
-                           help_text=_("The URL used when sending the message"))
-    method = models.CharField(max_length=16, null=True,
-                              help_text=_("The HTTP method used when sending the message"))
-    request = models.TextField(null=True,
-                               help_text=_("The body of the request used when sending the message"))
-    response = models.TextField(null=True,
-                                help_text=_("The body of the response received when sending the message"))
-    response_status = models.IntegerField(null=True,
-                                          help_text=_("The response code received when sending the message"))
-    created_on = models.DateTimeField(auto_now_add=True,
-                                      help_text=_("When this log message was logged"))
+    description = models.CharField(max_length=255, help_text=_("A description of the status of this message send"))
+    is_error = models.BooleanField(
+        default=None, help_text=_("Whether an error was encountered when sending the message")
+    )
+    url = models.TextField(null=True, help_text=_("The URL used when sending the message"))
+    method = models.CharField(max_length=16, null=True, help_text=_("The HTTP method used when sending the message"))
+    request = models.TextField(null=True, help_text=_("The body of the request used when sending the message"))
+    response = models.TextField(null=True, help_text=_("The body of the response received when sending the message"))
+    response_status = models.IntegerField(
+        null=True, help_text=_("The response code received when sending the message")
+    )
+    created_on = models.DateTimeField(auto_now_add=True, help_text=_("When this log message was logged"))
     request_time = models.IntegerField(null=True, help_text=_('Time it took to process this request'))
 
     @classmethod
@@ -1522,22 +1685,28 @@ class ChannelLog(models.Model):
         request_time = 0 if not e.start else time.time() - e.start
 
         for event in e.events:
-            print(u"[%d] %0.3fs ERROR - %s %s \"%s\" %s \"%s\"" %
-                  (msg.id, request_time, event.method, event.url, event.request_body, event.status_code, event.response_body))
+            print(
+                u"[%d] %0.3fs ERROR - %s %s \"%s\" %s \"%s\"" % (
+                    msg.id, request_time, event.method, event.url, event.request_body, event.status_code,
+                    event.response_body
+                )
+            )
 
             # log our request time in ms
             request_time_ms = request_time * 1000
 
-            ChannelLog.objects.create(channel_id=msg.channel,
-                                      msg_id=msg.id,
-                                      is_error=True,
-                                      description=six.text_type(e.description)[:255],
-                                      method=event.method,
-                                      url=event.url,
-                                      request=event.request_body,
-                                      response=event.response_body,
-                                      response_status=event.status_code,
-                                      request_time=request_time_ms)
+            ChannelLog.objects.create(
+                channel_id=msg.channel,
+                msg_id=msg.id,
+                is_error=True,
+                description=six.text_type(e.description)[:255],
+                method=event.method,
+                url=event.url,
+                request=event.request_body,
+                response=event.response_body,
+                response_status=event.status_code,
+                request_time=request_time_ms
+            )
 
         if request_time > 0:
             analytics.gauge('temba.msg_sent_%s' % channel.channel_type.lower(), request_time)
@@ -1545,49 +1714,52 @@ class ChannelLog(models.Model):
     @classmethod
     def log_error(cls, msg, description):
         print(u"[%d] ERROR - %s" % (msg.id, description))
-        ChannelLog.objects.create(channel_id=msg.channel,
-                                  msg_id=msg.id,
-                                  is_error=True,
-                                  description=description[:255])
+        ChannelLog.objects.create(channel_id=msg.channel, msg_id=msg.id, is_error=True, description=description[:255])
 
     @classmethod
     def log_message(cls, msg, description, event, is_error=False):
-        ChannelLog.objects.create(channel_id=msg.channel_id,
-                                  msg=msg,
-                                  request=event.request_body,
-                                  response=event.response_body,
-                                  url=event.url,
-                                  method=event.method,
-                                  is_error=is_error,
-                                  response_status=event.status_code,
-                                  description=description[:255])
+        ChannelLog.objects.create(
+            channel_id=msg.channel_id,
+            msg=msg,
+            request=event.request_body,
+            response=event.response_body,
+            url=event.url,
+            method=event.method,
+            is_error=is_error,
+            response_status=event.status_code,
+            description=description[:255]
+        )
 
     @classmethod
     def log_ivr_interaction(cls, call, description, event, is_error=False):
-        ChannelLog.objects.create(channel_id=call.channel_id,
-                                  connection_id=call.id,
-                                  request=six.text_type(event.request_body),
-                                  response=six.text_type(event.response_body),
-                                  url=event.url,
-                                  method=event.method,
-                                  is_error=is_error,
-                                  response_status=event.status_code,
-                                  description=description[:255])
+        ChannelLog.objects.create(
+            channel_id=call.channel_id,
+            connection_id=call.id,
+            request=six.text_type(event.request_body),
+            response=six.text_type(event.response_body),
+            url=event.url,
+            method=event.method,
+            is_error=is_error,
+            response_status=event.status_code,
+            description=description[:255]
+        )
 
     @classmethod
     def log_channel_request(cls, channel_id, description, event, start, is_error=False):
         request_time = 0 if not start else time.time() - start
         request_time_ms = request_time * 1000
 
-        ChannelLog.objects.create(channel_id=channel_id,
-                                  request=six.text_type(event.request_body),
-                                  response=six.text_type(event.response_body),
-                                  url=event.url,
-                                  method=event.method,
-                                  is_error=is_error,
-                                  response_status=event.status_code,
-                                  description=description[:255],
-                                  request_time=request_time_ms)
+        ChannelLog.objects.create(
+            channel_id=channel_id,
+            request=six.text_type(event.request_body),
+            response=six.text_type(event.response_body),
+            url=event.url,
+            method=event.method,
+            is_error=is_error,
+            response_status=event.status_code,
+            description=description[:255],
+            request_time=request_time_ms
+        )
 
     def get_url_host(self):
         parsed = urlparse.urlparse(self.url)
@@ -1618,24 +1790,45 @@ class ChannelLog(models.Model):
 
 
 class SyncEvent(SmartModel):
-    channel = models.ForeignKey(Channel, verbose_name=_("Channel"),
-                                help_text=_("The channel that synced to the server"))
-    power_source = models.CharField(verbose_name=_("Power Source"), max_length=64,
-                                    help_text=_("The power source the device is using"))
-    power_status = models.CharField(verbose_name=_("Power Status"), max_length=64, default="STATUS_UNKNOWN",
-                                    help_text=_("The power status. eg: Charging, Full or Discharging"))
+    channel = models.ForeignKey(
+        Channel, verbose_name=_("Channel"), help_text=_("The channel that synced to the server")
+    )
+    power_source = models.CharField(
+        verbose_name=_("Power Source"), max_length=64, help_text=_("The power source the device is using")
+    )
+    power_status = models.CharField(
+        verbose_name=_("Power Status"),
+        max_length=64,
+        default="STATUS_UNKNOWN",
+        help_text=_("The power status. eg: Charging, Full or Discharging")
+    )
     power_level = models.IntegerField(verbose_name=_("Power Level"), help_text=_("The power level of the battery"))
-    network_type = models.CharField(verbose_name=_("Network Type"), max_length=128,
-                                    help_text=_("The data network type to which the channel is connected"))
+    network_type = models.CharField(
+        verbose_name=_("Network Type"),
+        max_length=128,
+        help_text=_("The data network type to which the channel is connected")
+    )
     lifetime = models.IntegerField(verbose_name=_("Lifetime"), null=True, blank=True, default=0)
-    pending_message_count = models.IntegerField(verbose_name=_("Pending Messages Count"),
-                                                help_text=_("The number of messages on the channel in PENDING state"), default=0)
-    retry_message_count = models.IntegerField(verbose_name=_("Retry Message Count"),
-                                              help_text=_("The number of messages on the channel in RETRY state"), default=0)
-    incoming_command_count = models.IntegerField(verbose_name=_("Incoming Command Count"),
-                                                 help_text=_("The number of commands that the channel gave us"), default=0)
-    outgoing_command_count = models.IntegerField(verbose_name=_("Outgoing Command Count"),
-                                                 help_text=_("The number of commands that we gave the channel"), default=0)
+    pending_message_count = models.IntegerField(
+        verbose_name=_("Pending Messages Count"),
+        help_text=_("The number of messages on the channel in PENDING state"),
+        default=0
+    )
+    retry_message_count = models.IntegerField(
+        verbose_name=_("Retry Message Count"),
+        help_text=_("The number of messages on the channel in RETRY state"),
+        default=0
+    )
+    incoming_command_count = models.IntegerField(
+        verbose_name=_("Incoming Command Count"),
+        help_text=_("The number of commands that the channel gave us"),
+        default=0
+    )
+    outgoing_command_count = models.IntegerField(
+        verbose_name=_("Outgoing Command Count"),
+        help_text=_("The number of commands that we gave the channel"),
+        default=0
+    )
 
     @classmethod
     def create(cls, channel, cmd, incoming_commands):
@@ -1705,32 +1898,44 @@ class Alert(SmartModel):
     TYPE_POWER = 'P'
     TYPE_SMS = 'S'
 
-    TYPE_CHOICES = ((TYPE_POWER, _("Power")),                 # channel has low power
-                    (TYPE_DISCONNECTED, _("Disconnected")),   # channel hasn't synced in a while
-                    (TYPE_SMS, _("SMS")))                     # channel has many unsent messages
+    TYPE_CHOICES = (
+        (TYPE_POWER, _("Power")),  # channel has low power
+        (TYPE_DISCONNECTED, _("Disconnected")),  # channel hasn't synced in a while
+        (TYPE_SMS, _("SMS"))
+    )  # channel has many unsent messages
 
-    channel = models.ForeignKey(Channel, verbose_name=_("Channel"),
-                                help_text=_("The channel that this alert is for"))
-    sync_event = models.ForeignKey(SyncEvent, verbose_name=_("Sync Event"), null=True,
-                                   help_text=_("The sync event that caused this alert to be sent (if any)"))
-    alert_type = models.CharField(verbose_name=_("Alert Type"), max_length=1, choices=TYPE_CHOICES,
-                                  help_text=_("The type of alert the channel is sending"))
+    channel = models.ForeignKey(Channel, verbose_name=_("Channel"), help_text=_("The channel that this alert is for"))
+    sync_event = models.ForeignKey(
+        SyncEvent,
+        verbose_name=_("Sync Event"),
+        null=True,
+        help_text=_("The sync event that caused this alert to be sent (if any)")
+    )
+    alert_type = models.CharField(
+        verbose_name=_("Alert Type"),
+        max_length=1,
+        choices=TYPE_CHOICES,
+        help_text=_("The type of alert the channel is sending")
+    )
     ended_on = models.DateTimeField(verbose_name=_("Ended On"), blank=True, null=True)
 
     @classmethod
     def check_power_alert(cls, sync):
         alert_user = get_alert_user()
 
-        if sync.power_status in (STATUS_DISCHARGING, STATUS_UNKNOWN, STATUS_NOT_CHARGING) and int(sync.power_level) < 25:
+        if sync.power_status in (STATUS_DISCHARGING, STATUS_UNKNOWN,
+                                 STATUS_NOT_CHARGING) and int(sync.power_level) < 25:
 
             alerts = Alert.objects.filter(sync_event__channel=sync.channel, alert_type=cls.TYPE_POWER, ended_on=None)
 
             if not alerts:
-                new_alert = Alert.objects.create(channel=sync.channel,
-                                                 sync_event=sync,
-                                                 alert_type=cls.TYPE_POWER,
-                                                 created_by=alert_user,
-                                                 modified_by=alert_user)
+                new_alert = Alert.objects.create(
+                    channel=sync.channel,
+                    sync_event=sync,
+                    alert_type=cls.TYPE_POWER,
+                    created_by=alert_user,
+                    modified_by=alert_user
+                )
                 new_alert.send_alert()
 
         if sync.power_status == STATUS_CHARGING or sync.power_status == STATUS_FULL:
@@ -1760,11 +1965,14 @@ class Alert(SmartModel):
                 alert.save()
                 alert.send_resolved()
 
-        for channel in Channel.objects.filter(channel_type=Channel.TYPE_ANDROID, is_active=True).exclude(org=None).exclude(last_seen__gte=thirty_minutes_ago):
+        for channel in Channel.objects.filter(
+            channel_type=Channel.TYPE_ANDROID, is_active=True
+        ).exclude(org=None).exclude(last_seen__gte=thirty_minutes_ago):
             # have we already sent an alert for this channel
             if not Alert.objects.filter(channel=channel, alert_type=cls.TYPE_DISCONNECTED, ended_on=None):
-                alert = Alert.objects.create(channel=channel, alert_type=cls.TYPE_DISCONNECTED,
-                                             modified_by=alert_user, created_by=alert_user)
+                alert = Alert.objects.create(
+                    channel=channel, alert_type=cls.TYPE_DISCONNECTED, modified_by=alert_user, created_by=alert_user
+                )
                 alert.send_alert()
 
         day_ago = timezone.now() - timedelta(days=1)
@@ -1774,13 +1982,28 @@ class Alert(SmartModel):
         for alert in Alert.objects.filter(alert_type=cls.TYPE_SMS, ended_on=None):
             # are there still queued messages?
 
-            if not Msg.objects.filter(status__in=['Q', 'P'], channel=alert.channel, contact__is_test=False, created_on__lte=thirty_minutes_ago).exclude(created_on__lte=day_ago):
+            if not Msg.objects.filter(
+                status__in=['Q', 'P'],
+                channel=alert.channel,
+                contact__is_test=False,
+                created_on__lte=thirty_minutes_ago
+            ).exclude(created_on__lte=day_ago):
                 alert.ended_on = timezone.now()
                 alert.save()
 
         # now look for channels that have many unsent messages
-        queued_messages = Msg.objects.filter(status__in=['Q', 'P'], contact__is_test=False).order_by('channel', 'created_on').exclude(created_on__gte=thirty_minutes_ago).exclude(created_on__lte=day_ago).exclude(channel=None).values('channel').annotate(latest_queued=Max('created_on'))
-        sent_messages = Msg.objects.filter(status__in=['S', 'D'], contact__is_test=False).exclude(created_on__lte=day_ago).exclude(channel=None).order_by('channel', 'sent_on').values('channel').annotate(latest_sent=Max('sent_on'))
+        queued_messages = Msg.objects.filter(
+            status__in=['Q', 'P'], contact__is_test=False
+        ).order_by(
+            'channel', 'created_on'
+        ).exclude(created_on__gte=thirty_minutes_ago
+                  ).exclude(created_on__lte=day_ago
+                            ).exclude(channel=None).values('channel').annotate(latest_queued=Max('created_on'))
+        sent_messages = Msg.objects.filter(
+            status__in=['S', 'D'], contact__is_test=False
+        ).exclude(created_on__lte=day_ago).exclude(channel=None).order_by(
+            'channel', 'sent_on'
+        ).values('channel').annotate(latest_sent=Max('sent_on'))
 
         channels = dict()
         for queued in queued_messages:
@@ -1802,8 +2025,9 @@ class Alert(SmartModel):
 
                 # if we haven't sent an alert in the past six ours
                 if not Alert.objects.filter(channel=channel).filter(Q(created_on__gt=six_hours_ago)):
-                    alert = Alert.objects.create(channel=channel, alert_type=cls.TYPE_SMS,
-                                                 modified_by=alert_user, created_by=alert_user)
+                    alert = Alert.objects.create(
+                        channel=channel, alert_type=cls.TYPE_SMS, modified_by=alert_user, created_by=alert_user
+                    )
                     alert.send_alert()
 
     def send_alert(self):
@@ -1847,9 +2071,16 @@ class Alert(SmartModel):
         else:  # pragma: no cover
             raise Exception(_("Unknown alert type: %(alert)s") % {'alert': self.alert_type})
 
-        context = dict(org=self.channel.org, channel=self.channel, now=timezone.now(),
-                       last_seen=self.channel.last_seen, sync=self.sync_event)
-        context['unsent_count'] = Msg.objects.filter(channel=self.channel, status__in=['Q', 'P'], contact__is_test=False).count()
+        context = dict(
+            org=self.channel.org,
+            channel=self.channel,
+            now=timezone.now(),
+            last_seen=self.channel.last_seen,
+            sync=self.sync_event
+        )
+        context['unsent_count'] = Msg.objects.filter(
+            channel=self.channel, status__in=['Q', 'P'], contact__is_test=False
+        ).count()
         context['subject'] = subject
 
         send_template_email(self.channel.alert_email, subject, template, context, self.channel.org.get_branding())
@@ -1888,51 +2119,42 @@ class ChannelSession(SmartModel):
     IVR = 'F'
     USSD = 'U'
 
-    DIRECTION_CHOICES = ((INCOMING, "Incoming"),
-                         (OUTGOING, "Outgoing"))
+    DIRECTION_CHOICES = ((INCOMING, "Incoming"), (OUTGOING, "Outgoing"))
 
-    TYPE_CHOICES = ((IVR, "IVR"), (USSD, "USSD"),)
+    TYPE_CHOICES = (
+        (IVR, "IVR"),
+        (USSD, "USSD"),
+    )
 
-    STATUS_CHOICES = ((PENDING, "Pending"),
-                      (QUEUED, "Queued"),
-                      (RINGING, "Ringing"),
-                      (IN_PROGRESS, "In Progress"),
-                      (COMPLETED, "Complete"),
-                      (BUSY, "Busy"),
-                      (FAILED, "Failed"),
-                      (NO_ANSWER, "No Answer"),
-                      (CANCELED, "Canceled"),
-                      (INTERRUPTED, "Interrupted"),
-                      (TRIGGERED, "Triggered"),
-                      (INITIATED, "Initiated"),
-                      (ENDING, "Ending"))
+    STATUS_CHOICES = ((PENDING, "Pending"), (QUEUED, "Queued"), (RINGING, "Ringing"), (IN_PROGRESS, "In Progress"),
+                      (COMPLETED, "Complete"), (BUSY, "Busy"), (FAILED, "Failed"), (NO_ANSWER, "No Answer"),
+                      (CANCELED, "Canceled"), (INTERRUPTED, "Interrupted"), (TRIGGERED, "Triggered"),
+                      (INITIATED, "Initiated"), (ENDING, "Ending"))
 
-    external_id = models.CharField(max_length=255,
-                                   help_text="The external id for this session, our twilio id usually")
-    status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=PENDING,
-                              help_text="The status of this session")
-    channel = models.ForeignKey('Channel',
-                                help_text="The channel that created this session")
-    contact = models.ForeignKey('contacts.Contact', related_name='sessions',
-                                help_text="Who this session is with")
-    contact_urn = models.ForeignKey('contacts.ContactURN', verbose_name=_("Contact URN"),
-                                    help_text=_("The URN this session is communicating with"))
-    direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES,
-                                 help_text="The direction of this session, either incoming or outgoing")
-    started_on = models.DateTimeField(null=True, blank=True,
-                                      help_text="When this session was connected and started")
-    ended_on = models.DateTimeField(null=True, blank=True,
-                                    help_text="When this session ended")
-    org = models.ForeignKey(Org,
-                            help_text="The organization this session belongs to")
-    session_type = models.CharField(max_length=1, choices=TYPE_CHOICES,
-                                    help_text="What sort of session this is")
-    duration = models.IntegerField(default=0, null=True,
-                                   help_text="The length of this session in seconds")
+    external_id = models.CharField(max_length=255, help_text="The external id for this session, our twilio id usually")
+    status = models.CharField(
+        max_length=1, choices=STATUS_CHOICES, default=PENDING, help_text="The status of this session"
+    )
+    channel = models.ForeignKey('Channel', help_text="The channel that created this session")
+    contact = models.ForeignKey('contacts.Contact', related_name='sessions', help_text="Who this session is with")
+    contact_urn = models.ForeignKey(
+        'contacts.ContactURN',
+        verbose_name=_("Contact URN"),
+        help_text=_("The URN this session is communicating with")
+    )
+    direction = models.CharField(
+        max_length=1,
+        choices=DIRECTION_CHOICES,
+        help_text="The direction of this session, either incoming or outgoing"
+    )
+    started_on = models.DateTimeField(null=True, blank=True, help_text="When this session was connected and started")
+    ended_on = models.DateTimeField(null=True, blank=True, help_text="When this session ended")
+    org = models.ForeignKey(Org, help_text="The organization this session belongs to")
+    session_type = models.CharField(max_length=1, choices=TYPE_CHOICES, help_text="What sort of session this is")
+    duration = models.IntegerField(default=0, null=True, help_text="The length of this session in seconds")
 
     def __init__(self, *args, **kwargs):
         super(ChannelSession, self).__init__(*args, **kwargs)
-
         """ This is needed when referencing `session` from `FlowRun`. Since
         the FK is bound to ChannelSession, when it initializes an instance from
         DB we need to specify the class based on `session_type` so we can access

--- a/temba/channels/tasks.py
+++ b/temba/channels/tasks.py
@@ -17,7 +17,6 @@ from temba.utils.mage import MageClient
 from temba.temba_celery import app as celery_app
 from .models import Channel, Alert, ChannelLog, ChannelCount
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -74,9 +73,11 @@ def send_msg_task():
             # send each of our msgs
             while msg_tasks:
                 msg_task = msg_tasks.pop(0)
-                msg = dict_to_struct('MockMsg', msg_task,
-                                     datetime_fields=['modified_on', 'sent_on', 'created_on', 'queued_on',
-                                                      'next_attempt'])
+                msg = dict_to_struct(
+                    'MockMsg',
+                    msg_task,
+                    datetime_fields=['modified_on', 'sent_on', 'created_on', 'queued_on', 'next_attempt']
+                )
                 Channel.send_message(msg)
 
                 # if there are more messages to send for this contact, sleep a second before moving on
@@ -163,8 +164,9 @@ def fb_channel_subscribe(channel_id):
         page_access_token = channel.config_json()[Channel.CONFIG_AUTH_TOKEN]
 
         # subscribe to messaging events for this channel
-        response = requests.post('https://graph.facebook.com/v2.6/me/subscribed_apps',
-                                 params=dict(access_token=page_access_token))
+        response = requests.post(
+            'https://graph.facebook.com/v2.6/me/subscribed_apps', params=dict(access_token=page_access_token)
+        )
 
         if response.status_code != 200 or not response.json()['success']:
             print("Unable to subscribe for delivery of events: %s" % response.content)

--- a/temba/channels/types/__init__.py
+++ b/temba/channels/types/__init__.py
@@ -32,21 +32,24 @@ def reload_channel_types():
     # create types on the fly for each type not yet converted to a dynamic type
     for code, name in Channel.TYPE_CHOICES:
         type_settings = Channel.CHANNEL_SETTINGS[code]
-        dyn_type_class = type(str(code + 'Type'), (ChannelType,), dict(
-            code=code,
-            name=name,
-            slug=code.lower(),
-            icon=Channel.TYPE_ICONS.get(code, 'icon-channel-external'),
-            show_config_page=code not in Channel.HIDE_CONFIG_PAGE,
-            schemes=type_settings.get('schemes'),
-            max_length=type_settings.get('max_length'),
-            max_tps=type_settings.get('max_tps'),
-            attachment_support=False,
-            free_sending=code in Channel.FREE_SENDING_CHANNEL_TYPES,
-            update_form=TYPE_UPDATE_FORM_CLASSES.get(code),
-            send=SEND_FUNCTIONS.get(code),
-            ivr_protocol=ChannelType.IVRProtocol.IVR_PROTOCOL_TWIML if code in Channel.TWIML_CHANNELS else None
-        ))
+        dyn_type_class = type(
+            str(code + 'Type'), (ChannelType, ),
+            dict(
+                code=code,
+                name=name,
+                slug=code.lower(),
+                icon=Channel.TYPE_ICONS.get(code, 'icon-channel-external'),
+                show_config_page=code not in Channel.HIDE_CONFIG_PAGE,
+                schemes=type_settings.get('schemes'),
+                max_length=type_settings.get('max_length'),
+                max_tps=type_settings.get('max_tps'),
+                attachment_support=False,
+                free_sending=code in Channel.FREE_SENDING_CHANNEL_TYPES,
+                update_form=TYPE_UPDATE_FORM_CLASSES.get(code),
+                send=SEND_FUNCTIONS.get(code),
+                ivr_protocol=ChannelType.IVRProtocol.IVR_PROTOCOL_TWIML if code in Channel.TWIML_CHANNELS else None
+            )
+        )
         register_channel_type(dyn_type_class)
 
 

--- a/temba/channels/types/africastalking/tests.py
+++ b/temba/channels/types/africastalking/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class AfricastalkingTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/africastalking/type.py
+++ b/temba/channels/types/africastalking/type.py
@@ -4,7 +4,6 @@ import requests
 import six
 import time
 
-
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 
@@ -25,9 +24,11 @@ class AfricasTalkingType(ChannelType):
     name = "Africa's Talking"
     icon = 'icon-channel-external'
 
-    claim_blurb = _("""If you are based in Kenya, Uganda or Malawi you can purchase a short
+    claim_blurb = _(
+        """If you are based in Kenya, Uganda or Malawi you can purchase a short
     code from <a href="http://africastalking.com">Africa's Talking</a> and connect it
-    in a few simple steps.""")
+    in a few simple steps."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -43,9 +44,7 @@ class AfricasTalkingType(ChannelType):
 
     def send(self, channel, msg, text):
 
-        payload = dict(username=channel.config['username'],
-                       to=msg.urn_path,
-                       message=text)
+        payload = dict(username=channel.config['username'], to=msg.urn_path, message=text)
 
         # if this isn't a shared shortcode, send the from address
         if not channel.config.get('is_shared', False):
@@ -57,25 +56,21 @@ class AfricasTalkingType(ChannelType):
         start = time.time()
 
         try:
-            response = requests.post(api_url,
-                                     data=payload, headers=headers, timeout=5)
+            response = requests.post(api_url, data=payload, headers=headers, timeout=5)
             event.status_code = response.status_code
             event.response_body = response.text
         except Exception as e:
-            raise SendException(u"Unable to send message: %s" % six.text_type(e),
-                                event=event, start=start)
+            raise SendException(u"Unable to send message: %s" % six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201:
-            raise SendException("Got non-200 response from API: %d" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response from API: %d" % response.status_code, event=event, start=start)
 
         response_data = response.json()
 
         # grab the status out of our response
         status = response_data['SMSMessageData']['Recipients'][0]['status']
         if status != 'Success':
-            raise SendException("Got non success status from API: %s" % status,
-                                event=event, start=start)
+            raise SendException("Got non success status from API: %s" % status, event=event, start=start)
 
         # set our external id so we know when it is actually sent, this is missing in cases where
         # it wasn't sent, in which case we'll become an errored message

--- a/temba/channels/types/africastalking/views.py
+++ b/temba/channels/types/africastalking/views.py
@@ -9,15 +9,13 @@ from ...views import ClaimViewMixin
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
-        shortcode = forms.CharField(max_length=6, min_length=1,
-                                    help_text=_("Your short code on Africa's Talking"))
+        shortcode = forms.CharField(max_length=6, min_length=1, help_text=_("Your short code on Africa's Talking"))
         country = forms.ChoiceField(choices=(('KE', _("Kenya")), ('UG', _("Uganda")), ('MW', _("Malawi"))))
-        is_shared = forms.BooleanField(initial=False, required=False,
-                                       help_text=_("Whether this short code is shared with others"))
-        username = forms.CharField(max_length=32,
-                                   help_text=_("Your username on Africa's Talking"))
-        api_key = forms.CharField(max_length=64,
-                                  help_text=_("Your api key, should be 64 characters"))
+        is_shared = forms.BooleanField(
+            initial=False, required=False, help_text=_("Whether this short code is shared with others")
+        )
+        username = forms.CharField(max_length=32, help_text=_("Your username on Africa's Talking"))
+        api_key = forms.CharField(max_length=64, help_text=_("Your api key, should be 64 characters"))
 
     form_class = Form
 
@@ -32,8 +30,14 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         config = dict(username=data['username'], api_key=data['api_key'], is_shared=data['is_shared'])
 
-        self.object = Channel.create(org, user, data['country'], 'AT',
-                                     name="Africa's Talking: %s" % data['shortcode'], address=data['shortcode'],
-                                     config=config)
+        self.object = Channel.create(
+            org,
+            user,
+            data['country'],
+            'AT',
+            name="Africa's Talking: %s" % data['shortcode'],
+            address=data['shortcode'],
+            config=config
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/blackmyna/tests.py
+++ b/temba/channels/types/blackmyna/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class BlackmynaTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/blackmyna/type.py
+++ b/temba/channels/types/blackmyna/type.py
@@ -23,7 +23,9 @@ class BlackmynaType(ChannelType):
 
     name = "Blackmyna"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="http://blackmyna.com">Blackmyna</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="http://blackmyna.com">Blackmyna</a> using their APIs."""
+    )
     claim_view = AuthenticatedExternalClaimView
 
     schemes = [TEL_SCHEME]
@@ -52,8 +54,13 @@ class BlackmynaType(ChannelType):
         event = HttpEvent('POST', url, payload)
 
         try:
-            response = requests.post(url, data=payload, headers=http_headers(), timeout=30,
-                                     auth=(channel.config[Channel.CONFIG_USERNAME], channel.config[Channel.CONFIG_PASSWORD]))
+            response = requests.post(
+                url,
+                data=payload,
+                headers=http_headers(),
+                timeout=30,
+                auth=(channel.config[Channel.CONFIG_USERNAME], channel.config[Channel.CONFIG_PASSWORD])
+            )
             # parse our response, should be JSON that looks something like:
             # [{
             #   "recipient" : recipient_number_1,
@@ -72,7 +79,6 @@ class BlackmynaType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:  # pragma: needs cover
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event, external_id=external_id)

--- a/temba/channels/types/chikka/tests.py
+++ b/temba/channels/types/chikka/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class ChikkaTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/chikka/type.py
+++ b/temba/channels/types/chikka/type.py
@@ -26,8 +26,10 @@ class ChikkaType(ChannelType):
 
     name = "Chikka"
 
-    claim_blurb = _("""If you are based in the Phillipines, you can integrate with Chikka to send
-                       and receive messages on your shortcode.""")
+    claim_blurb = _(
+        """If you are based in the Phillipines, you can integrate with Chikka to send
+                       and receive messages on your shortcode."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -80,7 +82,8 @@ class ChikkaType(ChannelType):
         # if they reject our request_id, send it as a normal send
         if response.status_code == 400 and 'request_id' in payload:
             error = response.json()
-            if error.get('message', None) == 'BAD REQUEST' and error.get('description', None) == 'Invalid/Used Request ID':
+            if error.get('message', None
+                         ) == 'BAD REQUEST' and error.get('description', None) == 'Invalid/Used Request ID':
                 try:
 
                     # operate on a copy so we can still inspect our original call
@@ -102,7 +105,8 @@ class ChikkaType(ChannelType):
                     raise SendException(six.text_type(e), events=events, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                events=events, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from API" % response.status_code, events=events, start=start
+            )
 
         Channel.success(channel, msg, WIRED, start, events=events)

--- a/temba/channels/types/chikka/views.py
+++ b/temba/channels/types/chikka/views.py
@@ -9,14 +9,18 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class ChikkaForm(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=4, label=_("Number"),
-                                 help_text=_("The short code you are connecting."))
-        username = forms.CharField(label=_("Client Id"),
-                                   help_text=_("The Client Id found on your Chikka API credentials page"))
-        password = forms.CharField(label=_("Secret Key"),
-                                   help_text=_("The Secret Key found on your Chikka API credentials page"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14, min_length=4, label=_("Number"), help_text=_("The short code you are connecting.")
+        )
+        username = forms.CharField(
+            label=_("Client Id"), help_text=_("The Client Id found on your Chikka API credentials page")
+        )
+        password = forms.CharField(
+            label=_("Secret Key"), help_text=_("The Secret Key found on your Chikka API credentials page")
+        )
 
     form_class = ChikkaForm
 

--- a/temba/channels/types/clickatell/__init__.py
+++ b/temba/channels/types/clickatell/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals, absolute_import
 
-from .type import ClickatellType # noqa
+from .type import ClickatellType  # noqa

--- a/temba/channels/types/clickatell/tests.py
+++ b/temba/channels/types/clickatell/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class ClickatellTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/clickatell/type.py
+++ b/temba/channels/types/clickatell/type.py
@@ -25,8 +25,10 @@ class ClickatellType(ChannelType):
     name = "Clickatell"
     icon = "icon-channel-clickatell"
 
-    claim_blurb = _("""Connect your <a href="http://clickatell.com/" target="_blank">Clickatell</a> number, we'll walk you
-                           through the steps necessary to get your Clickatell connection working in a few minutes.""")
+    claim_blurb = _(
+        """Connect your <a href="http://clickatell.com/" target="_blank">Clickatell</a> number, we'll walk you
+                           through the steps necessary to get your Clickatell connection working in a few minutes."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -44,16 +46,18 @@ class ClickatellType(ChannelType):
             unicode_switch = 0
 
         url = 'https://api.clickatell.com/http/sendmsg'
-        payload = {'api_id': channel.config[Channel.CONFIG_API_ID],
-                   'user': channel.config[Channel.CONFIG_USERNAME],
-                   'password': channel.config[Channel.CONFIG_PASSWORD],
-                   'from': channel.address.lstrip('+'),
-                   'concat': 3,
-                   'callback': 7,
-                   'mo': 1,
-                   'unicode': unicode_switch,
-                   'to': msg.urn_path.lstrip('+'),
-                   'text': text}
+        payload = {
+            'api_id': channel.config[Channel.CONFIG_API_ID],
+            'user': channel.config[Channel.CONFIG_USERNAME],
+            'password': channel.config[Channel.CONFIG_PASSWORD],
+            'from': channel.address.lstrip('+'),
+            'concat': 3,
+            'callback': 7,
+            'mo': 1,
+            'unicode': unicode_switch,
+            'to': msg.urn_path.lstrip('+'),
+            'text': text
+        }
 
         event = HttpEvent('GET', url + "?" + urlencode(payload))
 
@@ -68,8 +72,7 @@ class ClickatellType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         # parse out the external id for the message, comes in the format: "ID: id12312312312"
         external_id = None

--- a/temba/channels/types/clickatell/views.py
+++ b/temba/channels/types/clickatell/views.py
@@ -11,17 +11,20 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class ClickatellForm(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_(
-                                     "The phone number with country code or short code you are connecting. ex: +250788123124 or 15543"))
-        api_id = forms.CharField(label=_("API ID"),
-                                 help_text=_("Your API ID as provided by Clickatell"))
-        username = forms.CharField(label=_("Username"),
-                                   help_text=_("The username for your Clickatell account"))
-        password = forms.CharField(label=_("Password"),
-                                   help_text=_("The password for your Clickatell account"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_(
+                "The phone number with country code or short code you are connecting. ex: +250788123124 or 15543"
+            )
+        )
+        api_id = forms.CharField(label=_("API ID"), help_text=_("Your API ID as provided by Clickatell"))
+        username = forms.CharField(label=_("Username"), help_text=_("The username for your Clickatell account"))
+        password = forms.CharField(label=_("Password"), help_text=_("The password for your Clickatell account"))
 
         def clean_number(self):
             # if this is a long number, try to normalize it
@@ -32,7 +35,8 @@ class ClaimView(AuthenticatedExternalClaimView):
                     return phonenumbers.format_number(cleaned, phonenumbers.PhoneNumberFormat.E164)
                 except Exception:  # pragma: needs cover
                     raise forms.ValidationError(
-                        _("Invalid phone number, please include the country code. ex: +250788123123"))
+                        _("Invalid phone number, please include the country code. ex: +250788123123")
+                    )
             else:  # pragma: needs cover
                 return number
 
@@ -45,10 +49,9 @@ class ClaimView(AuthenticatedExternalClaimView):
             raise Exception(_("No org for this user, cannot claim"))
 
         data = form.cleaned_data
-        self.object = Channel.add_config_external_channel(org, self.request.user,
-                                                          data['country'], data['number'], 'CT',
-                                                          dict(api_id=data['api_id'],
-                                                               username=data['username'],
-                                                               password=data['password']))
+        self.object = Channel.add_config_external_channel(
+            org, self.request.user, data['country'], data['number'], 'CT',
+            dict(api_id=data['api_id'], username=data['username'], password=data['password'])
+        )
 
         return super(AuthenticatedExternalClaimView, self).form_valid(form)

--- a/temba/channels/types/dartmedia/tests.py
+++ b/temba/channels/types/dartmedia/tests.py
@@ -7,7 +7,6 @@ from ...models import Channel
 
 
 class DartMediaTypeTest(TembaTest):
-
     @override_settings(IP_ADDRESSES=('10.10.10.10', '172.16.20.30'))
     def test_claim(self):
         Channel.objects.all().delete()

--- a/temba/channels/types/dartmedia/type.py
+++ b/temba/channels/types/dartmedia/type.py
@@ -13,7 +13,6 @@ from temba.msgs.models import SENT
 from temba.utils.http import HttpEvent, http_headers
 from ...models import Channel, ChannelType, SendException
 
-
 # DartMedia is an aggregator in Indonesia, set this to the endpoint for your service
 # and make sure you send from a whitelisted IP Address
 DART_MEDIA_ENDPOINT = 'http://202.43.169.11/APIhttpU/receive2waysms.php'
@@ -29,7 +28,9 @@ class DartMediaType(ChannelType):
 
     name = "DartMedia"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="http://dartmedia.biz/">Dart Media</a> in Indonesia.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="http://dartmedia.biz/">Dart Media</a> in Indonesia."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -56,9 +57,16 @@ class DartMediaType(ChannelType):
         #   &udhl=0&charset=utf-8
         #
         url = DART_MEDIA_ENDPOINT
-        payload = dict(userid=channel.config['username'], password=channel.config['password'],
-                       original=channel.address.lstrip('+'), sendto=msg.urn_path.lstrip('+'),
-                       messageid=msg.id, message=text, dcs=0, udhl=0)
+        payload = dict(
+            userid=channel.config['username'],
+            password=channel.config['password'],
+            original=channel.address.lstrip('+'),
+            sendto=msg.urn_path.lstrip('+'),
+            messageid=msg.id,
+            message=text,
+            dcs=0,
+            udhl=0
+        )
 
         # build up our querystring and send it as a get
         send_url = "%s?%s" % (url, urlencode(payload))
@@ -74,12 +82,10 @@ class DartMediaType(ChannelType):
             event.status_code = response.status_code
             event.response_body = response.text
             if not response:  # pragma: no cover
-                raise SendException("Unable to send message",
-                                    event=event, start=start)
+                raise SendException("Unable to send message", event=event, start=start)
 
             if response.status_code != 200 and response.status_code != 201:
-                raise SendException("Received non 200 status: %d" % response.status_code,
-                                    event=event, start=start)
+                raise SendException("Received non 200 status: %d" % response.status_code, event=event, start=start)
 
             # if it wasn't successfully delivered, throw
             if response.text != "000":  # pragma: no cover

--- a/temba/channels/types/dartmedia/views.py
+++ b/temba/channels/types/dartmedia/views.py
@@ -2,7 +2,6 @@ from temba.channels.views import AuthenticatedExternalClaimView
 
 
 class ClaimView(AuthenticatedExternalClaimView):
-
     def get_country(self, obj):
         return "Indonesia"
 

--- a/temba/channels/types/dmark/tests.py
+++ b/temba/channels/types/dmark/tests.py
@@ -8,7 +8,6 @@ from ...models import Channel
 
 
 class DMarkTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/dmark/type.py
+++ b/temba/channels/types/dmark/type.py
@@ -19,9 +19,11 @@ class DMarkType(ChannelType):
     name = "DMark"
     icon = 'icon-channel-external'
 
-    claim_blurb = _("""If you are based in Uganda or DRC you can purchase a short
+    claim_blurb = _(
+        """If you are based in Uganda or DRC you can purchase a short
     code from <a href="http://dmarkmobile.com/">DMark Mobile</a> and connect it
-    in a few simple steps.""")
+    in a few simple steps."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]

--- a/temba/channels/types/dmark/views.py
+++ b/temba/channels/types/dmark/views.py
@@ -13,16 +13,15 @@ class ClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
         shortcode = forms.IntegerField(help_text=_("Your short code on DMark Mobile"))
         country = forms.ChoiceField(choices=(('UG', _("Uganda")), ('CD', _("DRC"))))
-        username = forms.CharField(max_length=32,
-                                   help_text=_("Your username on DMark Mobile"))
-        password = forms.CharField(max_length=64,
-                                   help_text=_("Your password on DMark Mobile"))
+        username = forms.CharField(max_length=32, help_text=_("Your username on DMark Mobile"))
+        password = forms.CharField(max_length=64, help_text=_("Your password on DMark Mobile"))
 
         def clean(self):
             try:
-                resp = requests.post("http://smsapi1.dmarkmobile.com/get-token/",
-                                     data=dict(username=self.cleaned_data['username'],
-                                               password=self.cleaned_data['password']))
+                resp = requests.post(
+                    "http://smsapi1.dmarkmobile.com/get-token/",
+                    data=dict(username=self.cleaned_data['username'], password=self.cleaned_data['password'])
+                )
 
                 if resp.status_code == 200:
                     self.cleaned_data['token'] = resp.json()['token']
@@ -51,8 +50,14 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             Channel.CONFIG_AUTH_TOKEN: data['token'],
         }
 
-        self.object = Channel.create(org, user, data['country'], 'DK',
-                                     name="DMark Mobile: %s" % data['shortcode'], address=data['shortcode'],
-                                     config=config)
+        self.object = Channel.create(
+            org,
+            user,
+            data['country'],
+            'DK',
+            name="DMark Mobile: %s" % data['shortcode'],
+            address=data['shortcode'],
+            config=config
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/external/tests.py
+++ b/temba/channels/types/external/tests.py
@@ -55,8 +55,14 @@ class ExternalTypeTest(TembaTest):
         self.assertContains(response, reverse('courier.ex', args=[channel.uuid, 'receive']))
 
         # test substitution in our url
-        self.assertEqual('http://test.com/send.php?from=5080&text=test&to=%2B250788383383',
-                         channel.replace_variables(ext_url, {'from': "5080", 'text': "test", 'to': "+250788383383"}))
+        self.assertEqual(
+            'http://test.com/send.php?from=5080&text=test&to=%2B250788383383',
+            channel.replace_variables(ext_url, {
+                'from': "5080",
+                'text': "test",
+                'to': "+250788383383"
+            })
+        )
 
         # test substitution with unicode
         self.assertEqual(
@@ -65,17 +71,23 @@ class ExternalTypeTest(TembaTest):
                 'from': "5080",
                 'text': "Reply “1” for good",
                 'to': "+250788383383"
-            }))
+            })
+        )
 
         # test substitution with XML encoding
         body = "<xml>{{text}}</xml>"
-        self.assertEqual("<xml>Hello &amp; World</xml>",
-                         channel.replace_variables(body, {'text': "Hello & World"}, Channel.CONTENT_TYPE_XML))
+        self.assertEqual(
+            "<xml>Hello &amp; World</xml>",
+            channel.replace_variables(body, {'text': "Hello & World"}, Channel.CONTENT_TYPE_XML)
+        )
 
-        self.assertEqual("<xml>التوطين</xml>",
-                         channel.replace_variables(body, {'text': "التوطين"}, Channel.CONTENT_TYPE_XML))
+        self.assertEqual(
+            "<xml>التوطين</xml>", channel.replace_variables(body, {'text': "التوطين"}, Channel.CONTENT_TYPE_XML)
+        )
 
         # test substitution with JSON encoding
         body = "{ body: {{text}} }"
-        self.assertEqual("{ body: \"this is \\\"quote\\\"\" }",
-                         channel.replace_variables(body, {'text': "this is \"quote\""}, Channel.CONTENT_TYPE_JSON))
+        self.assertEqual(
+            "{ body: \"this is \\\"quote\\\"\" }",
+            channel.replace_variables(body, {'text': "this is \"quote\""}, Channel.CONTENT_TYPE_JSON)
+        )

--- a/temba/channels/types/external/type.py
+++ b/temba/channels/types/external/type.py
@@ -70,7 +70,6 @@ class ExternalType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event)

--- a/temba/channels/types/external/views.py
+++ b/temba/channels/types/external/views.py
@@ -11,44 +11,86 @@ from ...views import ClaimViewMixin, ALL_COUNTRIES
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class ClaimForm(ClaimViewMixin.Form):
-        scheme = forms.ChoiceField(choices=ContactURN.SCHEME_CHOICES, label=_("URN Type"),
-                                   help_text=_("The type of URNs handled by this channel"))
+        scheme = forms.ChoiceField(
+            choices=ContactURN.SCHEME_CHOICES,
+            label=_("URN Type"),
+            help_text=_("The type of URNs handled by this channel")
+        )
 
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"), required=False,
-                                 help_text=_("The phone number or that this channel will send from"))
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            required=False,
+            help_text=_("The phone number or that this channel will send from")
+        )
 
-        handle = forms.CharField(max_length=32, min_length=1, label=_("Handle"), required=False,
-                                 help_text=_("The Twitter handle that this channel will send from"))
+        handle = forms.CharField(
+            max_length=32,
+            min_length=1,
+            label=_("Handle"),
+            required=False,
+            help_text=_("The Twitter handle that this channel will send from")
+        )
 
-        address = forms.CharField(max_length=64, min_length=1, label=_("Address"), required=False,
-                                  help_text=_("The external address that this channel will send from"))
+        address = forms.CharField(
+            max_length=64,
+            min_length=1,
+            label=_("Address"),
+            required=False,
+            help_text=_("The external address that this channel will send from")
+        )
 
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"), required=False,
-                                    help_text=_("The country this phone number is used in"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES,
+            label=_("Country"),
+            required=False,
+            help_text=_("The country this phone number is used in")
+        )
 
-        method = forms.ChoiceField(choices=(('POST', "HTTP POST"), ('GET', "HTTP GET"), ('PUT', "HTTP PUT")),
-                                   help_text=_("What HTTP method to use when calling the URL"))
+        method = forms.ChoiceField(
+            choices=(('POST', "HTTP POST"), ('GET', "HTTP GET"), ('PUT', "HTTP PUT")),
+            help_text=_("What HTTP method to use when calling the URL")
+        )
 
-        content_type = forms.ChoiceField(choices=Channel.CONTENT_TYPE_CHOICES,
-                                         help_text=_("The content type used when sending the request"))
+        content_type = forms.ChoiceField(
+            choices=Channel.CONTENT_TYPE_CHOICES, help_text=_("The content type used when sending the request")
+        )
 
-        max_length = forms.IntegerField(initial=160, validators=[MaxValueValidator(640), MinValueValidator(60)],
-                                        help_text=_("The maximum length of any single message on this channel. "
-                                                    "(longer messages will be split)"))
+        max_length = forms.IntegerField(
+            initial=160,
+            validators=[MaxValueValidator(640), MinValueValidator(60)],
+            help_text=_(
+                "The maximum length of any single message on this channel. "
+                "(longer messages will be split)"
+            )
+        )
 
-        url = forms.URLField(max_length=1024, label=_("Send URL"),
-                             help_text=_("The URL we will call when sending messages, with variable substitutions"))
+        url = forms.URLField(
+            max_length=1024,
+            label=_("Send URL"),
+            help_text=_("The URL we will call when sending messages, with variable substitutions")
+        )
 
-        body = forms.CharField(max_length=2048, label=_("Request Body"), required=False, widget=forms.Textarea,
-                               help_text=_(
-                                   "The request body if any, with variable substitutions (only used for PUT or POST)"))
+        body = forms.CharField(
+            max_length=2048,
+            label=_("Request Body"),
+            required=False,
+            widget=forms.Textarea,
+            help_text=_("The request body if any, with variable substitutions (only used for PUT or POST)")
+        )
 
     class SendClaimForm(ClaimViewMixin.Form):
-        url = forms.URLField(max_length=1024, label=_("Send URL"),
-                             help_text=_("The URL we will POST to when sending messages, with variable substitutions"))
+        url = forms.URLField(
+            max_length=1024,
+            label=_("Send URL"),
+            help_text=_("The URL we will POST to when sending messages, with variable substitutions")
+        )
 
-        method = forms.ChoiceField(choices=(('POST', "HTTP POST"), ('GET', "HTTP GET"), ('PUT', "HTTP PUT")),
-                                   help_text=_("What HTTP method to use when calling the URL"))
+        method = forms.ChoiceField(
+            choices=(('POST', "HTTP POST"), ('GET', "HTTP GET"), ('PUT', "HTTP PUT")),
+            help_text=_("What HTTP method to use when calling the URL")
+        )
 
     title = "Connect External Service"
     permission = 'channels.channel_claim'
@@ -100,8 +142,8 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             Channel.CONFIG_CONTENT_TYPE: data['content_type'],
             Channel.CONFIG_MAX_LENGTH: data['max_length']
         }
-        self.object = Channel.add_config_external_channel(org, self.request.user, country, address,
-                                                          self.channel_type,
-                                                          config, role, [scheme], parent=channel)
+        self.object = Channel.add_config_external_channel(
+            org, self.request.user, country, address, self.channel_type, config, role, [scheme], parent=channel
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/facebook/tests.py
+++ b/temba/channels/types/facebook/tests.py
@@ -14,8 +14,19 @@ class FacebookTypeTest(TembaTest):
     def setUp(self):
         super(FacebookTypeTest, self).setUp()
 
-        self.channel = Channel.create(self.org, self.user, None, 'FB', name="Facebook", address="12345",
-                                      role="SR", schemes=['facebook'], config={'auth_token': '09876543'})
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'FB',
+            name="Facebook",
+            address="12345",
+            role="SR",
+            schemes=['facebook'],
+            config={
+                'auth_token': '09876543'
+            }
+        )
 
     @override_settings(IS_PROD=True)
     @patch('requests.get')
@@ -97,8 +108,11 @@ class FacebookTypeTest(TembaTest):
         mock_delete.return_value = MockResponse(200, json.dumps({'success': True}))
         self.channel.release()
 
-        mock_delete.assert_called_once_with('https://graph.facebook.com/v2.5/me/subscribed_apps',
-                                            params={'access_token': '09876543'})
+        mock_delete.assert_called_once_with(
+            'https://graph.facebook.com/v2.5/me/subscribed_apps', params={
+                'access_token': '09876543'
+            }
+        )
 
     @override_settings(IS_PROD=True)
     @patch('requests.post')
@@ -109,27 +123,50 @@ class FacebookTypeTest(TembaTest):
 
         trigger = Trigger.create(self.org, self.admin, Trigger.TYPE_NEW_CONVERSATION, flow, self.channel)
 
-        mock_post.assert_called_once_with('https://graph.facebook.com/v2.6/12345/thread_settings', json={
-            'setting_type': 'call_to_actions',
-            'thread_state': 'new_thread',
-            'call_to_actions': [{"payload": "get_started"}]
-        }, headers={'Content-Type': 'application/json'}, params={'access_token': '09876543'})
+        mock_post.assert_called_once_with(
+            'https://graph.facebook.com/v2.6/12345/thread_settings',
+            json={
+                'setting_type': 'call_to_actions',
+                'thread_state': 'new_thread',
+                'call_to_actions': [{
+                    "payload": "get_started"
+                }]
+            },
+            headers={'Content-Type': 'application/json'},
+            params={
+                'access_token': '09876543'
+            }
+        )
         mock_post.reset_mock()
 
         trigger.archive(self.admin)
 
-        mock_post.assert_called_once_with('https://graph.facebook.com/v2.6/12345/thread_settings', json={
-            'setting_type': 'call_to_actions',
-            'thread_state': 'new_thread',
-            'call_to_actions': []
-        }, headers={'Content-Type': 'application/json'}, params={'access_token': '09876543'})
+        mock_post.assert_called_once_with(
+            'https://graph.facebook.com/v2.6/12345/thread_settings',
+            json={'setting_type': 'call_to_actions',
+                  'thread_state': 'new_thread',
+                  'call_to_actions': []},
+            headers={'Content-Type': 'application/json'},
+            params={
+                'access_token': '09876543'
+            }
+        )
         mock_post.reset_mock()
 
         trigger.restore(self.admin)
 
-        mock_post.assert_called_once_with('https://graph.facebook.com/v2.6/12345/thread_settings', json={
-            'setting_type': 'call_to_actions',
-            'thread_state': 'new_thread',
-            'call_to_actions': [{"payload": "get_started"}]
-        }, headers={'Content-Type': 'application/json'}, params={'access_token': '09876543'})
+        mock_post.assert_called_once_with(
+            'https://graph.facebook.com/v2.6/12345/thread_settings',
+            json={
+                'setting_type': 'call_to_actions',
+                'thread_state': 'new_thread',
+                'call_to_actions': [{
+                    "payload": "get_started"
+                }]
+            },
+            headers={'Content-Type': 'application/json'},
+            params={
+                'access_token': '09876543'
+            }
+        )
         mock_post.reset_mock()

--- a/temba/channels/types/facebook/type.py
+++ b/temba/channels/types/facebook/type.py
@@ -25,9 +25,11 @@ class FacebookType(ChannelType):
     name = "Facebook"
     icon = 'icon-facebook-official'
 
-    claim_blurb = _("""Add a <a href="http://facebook.com">Facebook</a> bot to send and receive messages on behalf
+    claim_blurb = _(
+        """Add a <a href="http://facebook.com">Facebook</a> bot to send and receive messages on behalf
     of one of your Facebook pages for free. You will need to create a Facebook application on their
-    <a href="http://developers.facebook.com">developers</a> site first.""")
+    <a href="http://developers.facebook.com">developers</a> site first."""
+    )
     claim_view = ClaimView
 
     schemes = [FACEBOOK_SCHEME]
@@ -37,9 +39,12 @@ class FacebookType(ChannelType):
 
     def deactivate(self, channel):
         config = channel.config_json()
-        requests.delete('https://graph.facebook.com/v2.5/me/subscribed_apps', params={
-            'access_token': config[Channel.CONFIG_AUTH_TOKEN]
-        })
+        requests.delete(
+            'https://graph.facebook.com/v2.5/me/subscribed_apps',
+            params={
+                'access_token': config[Channel.CONFIG_AUTH_TOKEN]
+            }
+        )
 
     def activate_trigger(self, trigger):
         # if this is new conversation trigger, register for the FB callback
@@ -97,8 +102,9 @@ class FacebookType(ChannelType):
                 raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200:
-            raise SendException("Got non-200 response [%d] from Facebook" % response.status_code,
-                                event=event, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from Facebook" % response.status_code, event=event, start=start
+            )
 
         # grab our external id out, Facebook response is in format:
         # "{"recipient_id":"997011467086879","message_id":"mid.1459532331848:2534ddacc3993a4b78"}"
@@ -145,8 +151,11 @@ class FacebookType(ChannelType):
 
         access_token = channel.config_json()[Channel.CONFIG_AUTH_TOKEN]
 
-        response = requests.post(url, json=body, params={'access_token': access_token},
-                                 headers={'Content-Type': 'application/json'})
+        response = requests.post(
+            url, json=body, params={'access_token': access_token}, headers={
+                'Content-Type': 'application/json'
+            }
+        )
 
         if response.status_code != 200:  # pragma: no cover
             raise Exception(_("Unable to update call to action: %s" % response.text))

--- a/temba/channels/types/facebook/views.py
+++ b/temba/channels/types/facebook/views.py
@@ -12,8 +12,9 @@ from ...views import ClaimViewMixin
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
-        page_access_token = forms.CharField(min_length=43, required=True,
-                                            help_text=_("The Page Access Token for your Application"))
+        page_access_token = forms.CharField(
+            min_length=43, required=True, help_text=_("The Page Access Token for your Application")
+        )
 
         def clean_page_access_token(self):
             value = self.cleaned_data['page_access_token']
@@ -37,7 +38,15 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         config = {'auth_token': auth_token, 'page_name': page['name']}
 
-        self.object = Channel.create(org, self.request.user, None, self.channel_type, name=page['name'],
-                                     address=page['id'], config=config, secret=Channel.generate_secret())
+        self.object = Channel.create(
+            org,
+            self.request.user,
+            None,
+            self.channel_type,
+            name=page['name'],
+            address=page['id'],
+            config=config,
+            secret=Channel.generate_secret()
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/firebase/tests.py
+++ b/temba/channels/types/firebase/tests.py
@@ -12,9 +12,20 @@ class FirebaseCloudMessagingTypeTest(TembaTest):
     def setUp(self):
         super(FirebaseCloudMessagingTypeTest, self).setUp()
 
-        self.channel = Channel.create(self.org, self.user, None, 'FCM', name="Firebase", address="87654",
-                                      role="SR", schemes=['fcm'],
-                                      config={'FCM_TITLE': 'Title', 'FCM_KEY': '87654'})
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'FCM',
+            name="Firebase",
+            address="87654",
+            role="SR",
+            schemes=['fcm'],
+            config={
+                'FCM_TITLE': 'Title',
+                'FCM_KEY': '87654'
+            }
+        )
 
     @patch('requests.get')
     def test_claim(self, mock_get):
@@ -26,15 +37,27 @@ class FirebaseCloudMessagingTypeTest(TembaTest):
         response = self.client.get(reverse('channels.channel_claim'))
         self.assertContains(response, url)
 
-        mock_get.return_value = MockResponse(200, json.dumps({'title': 'FCM Channel', 'key': 'abcde12345', 'send_notification': 'True'}))
+        mock_get.return_value = MockResponse(
+            200, json.dumps({
+                'title': 'FCM Channel',
+                'key': 'abcde12345',
+                'send_notification': 'True'
+            })
+        )
 
-        response = self.client.post(url, {
-            'title': 'FCM Channel',
-            'key': 'abcde12345',
-            'send_notification': 'True'
-        }, follow=True)
+        response = self.client.post(
+            url, {'title': 'FCM Channel',
+                  'key': 'abcde12345',
+                  'send_notification': 'True'}, follow=True
+        )
 
         channel = Channel.objects.get(address='abcde12345')
         self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.id]))
         self.assertEqual(channel.channel_type, "FCM")
-        self.assertEqual(channel.config_json(), {'FCM_KEY': 'abcde12345', 'FCM_TITLE': 'FCM Channel', 'FCM_NOTIFICATION': True})
+        self.assertEqual(
+            channel.config_json(), {
+                'FCM_KEY': 'abcde12345',
+                'FCM_TITLE': 'FCM Channel',
+                'FCM_NOTIFICATION': True
+            }
+        )

--- a/temba/channels/types/firebase/type.py
+++ b/temba/channels/types/firebase/type.py
@@ -23,8 +23,10 @@ class FirebaseCloudMessagingType(ChannelType):
     name = "Firebase Cloud Messaging"
     icon = 'icon-fcm'
 
-    claim_blurb = _("""Add a <a href="https://firebase.google.com/docs/cloud-messaging/" target="_blank"> Firebase Cloud
-    Messaging Channel</a> to send and receive messages. Your users will need an App to send and receive messages.""")
+    claim_blurb = _(
+        """Add a <a href="https://firebase.google.com/docs/cloud-messaging/" target="_blank"> Firebase Cloud
+    Messaging Channel</a> to send and receive messages. Your users will need an App to send and receive messages."""
+    )
     claim_view = ClaimView
 
     schemes = [FCM_SCHEME]
@@ -50,14 +52,16 @@ class FirebaseCloudMessagingType(ChannelType):
         }
 
         if channel.config.get('FCM_NOTIFICATION'):
-            data['notification'] = {
-                'title': title,
-                'body': text
-            }
+            data['notification'] = {'title': title, 'body': text}
             data['content_available'] = True
 
         payload = json.dumps(data)
-        headers = http_headers(extra={'Content-Type': 'application/json', 'Authorization': 'key=%s' % channel.config.get('FCM_KEY')})
+        headers = http_headers(
+            extra={
+                'Content-Type': 'application/json',
+                'Authorization': 'key=%s' % channel.config.get('FCM_KEY')
+            }
+        )
 
         event = HttpEvent('POST', url, payload)
 
@@ -74,5 +78,6 @@ class FirebaseCloudMessagingType(ChannelType):
             external_id = result.get('multicast_id')
             Channel.success(channel, msg, WIRED, start, events=[event], external_id=external_id)
         else:
-            raise SendException("Got non-200 response [%d] from Firebase Cloud Messaging" % response.status_code,
-                                event, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from Firebase Cloud Messaging" % response.status_code, event, start=start
+            )

--- a/temba/channels/types/firebase/views.py
+++ b/temba/channels/types/firebase/views.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, absolute_import
 
-
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from smartmin.views import SmartFormView
@@ -11,12 +10,16 @@ from ...views import ClaimViewMixin
 class ClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
         title = forms.CharField(label=_('Notification Title'))
-        key = forms.CharField(label=_('FCM Key'),
-                              help_text=_("The key provided on the the Firebase Console when you created your app."))
-        send_notification = forms.CharField(label=_('Send notification'), required=False,
-                                            help_text=_("Check if you want this channel to send notifications "
-                                                        "to contacts."),
-                                            widget=forms.CheckboxInput())
+        key = forms.CharField(
+            label=_('FCM Key'), help_text=_("The key provided on the the Firebase Console when you created your app.")
+        )
+        send_notification = forms.CharField(
+            label=_('Send notification'),
+            required=False,
+            help_text=_("Check if you want this channel to send notifications "
+                        "to contacts."),
+            widget=forms.CheckboxInput()
+        )
 
     form_class = Form
 
@@ -29,6 +32,8 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         if form.cleaned_data.get('send_notification') == 'True':
             config['FCM_NOTIFICATION'] = True
 
-        self.object = Channel.create(org, self.request.user, None, self.channel_type, name=title, address=key, config=config)
+        self.object = Channel.create(
+            org, self.request.user, None, self.channel_type, name=title, address=key, config=config
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/globe/tests.py
+++ b/temba/channels/types/globe/tests.py
@@ -27,10 +27,11 @@ class GlobeTypeTest(TembaTest):
         response = self.client.get(claim_url)
         self.assertEqual(200, response.status_code)
 
-        response = self.client.post(claim_url,
-                                    dict(number=21586380, app_id="AppId",
-                                         app_secret="AppSecret", passphrase="Passphrase"),
-                                    follow=True)
+        response = self.client.post(
+            claim_url,
+            dict(number=21586380, app_id="AppId", app_secret="AppSecret", passphrase="Passphrase"),
+            follow=True
+        )
         self.assertEqual(200, response.status_code)
 
         channel = Channel.objects.get(channel_type='GL')

--- a/temba/channels/types/globe/type.py
+++ b/temba/channels/types/globe/type.py
@@ -24,8 +24,10 @@ class GlobeType(ChannelType):
 
     name = "Globe Labs"
 
-    claim_blurb = _("""If you are based in the Phillipines, you can integrate {{ brand.name }} with Globe Labs to send
-                       and receive messages on your shortcode.""")
+    claim_blurb = _(
+        """If you are based in the Phillipines, you can integrate {{ brand.name }} with Globe Labs to send
+                       and receive messages on your shortcode."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -53,10 +55,7 @@ class GlobeType(ChannelType):
         start = time.time()
 
         try:
-            response = requests.post(url,
-                                     data=payload,
-                                     headers=http_headers(),
-                                     timeout=5)
+            response = requests.post(url, data=payload, headers=http_headers(), timeout=5)
             event.status_code = response.status_code
             event.response_body = response.text
 
@@ -64,8 +63,7 @@ class GlobeType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         # parse our response
         response.json()

--- a/temba/channels/types/globe/views.py
+++ b/temba/channels/types/globe/views.py
@@ -9,15 +9,20 @@ from temba.channels.views import ClaimViewMixin, AuthenticatedExternalClaimView
 
 class ClaimView(AuthenticatedExternalClaimView):
     class GlobeClaimForm(ClaimViewMixin.Form):
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_("The shortcode you have been assigned by Globe Labs "
-                                             "ex: 15543"))
-        app_id = forms.CharField(label=_("Application Id"),
-                                 help_text=_("The id of your Globe Labs application"))
-        app_secret = forms.CharField(label=_("Application Secret"),
-                                     help_text=_("The secret assigned to your Globe Labs application"))
-        passphrase = forms.CharField(label=_("Passphrase"),
-                                     help_text=_("The passphrase assigned to you by Globe Labs to support sending"))
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_("The shortcode you have been assigned by Globe Labs "
+                        "ex: 15543")
+        )
+        app_id = forms.CharField(label=_("Application Id"), help_text=_("The id of your Globe Labs application"))
+        app_secret = forms.CharField(
+            label=_("Application Secret"), help_text=_("The secret assigned to your Globe Labs application")
+        )
+        passphrase = forms.CharField(
+            label=_("Passphrase"), help_text=_("The passphrase assigned to you by Globe Labs to support sending")
+        )
 
     form_class = GlobeClaimForm
 
@@ -31,11 +36,14 @@ class ClaimView(AuthenticatedExternalClaimView):
             raise Exception(_("No org for this user, cannot claim"))
 
         data = form.cleaned_data
-        self.object = Channel.add_config_external_channel(org, self.request.user,
-                                                          'PH', data['number'], 'GL',
-                                                          dict(app_id=data['app_id'],
-                                                               app_secret=data['app_secret'],
-                                                               passphrase=data['passphrase']),
-                                                          role=Channel.ROLE_SEND + Channel.ROLE_RECEIVE)
+        self.object = Channel.add_config_external_channel(
+            org,
+            self.request.user,
+            'PH',
+            data['number'],
+            'GL',
+            dict(app_id=data['app_id'], app_secret=data['app_secret'], passphrase=data['passphrase']),
+            role=Channel.ROLE_SEND + Channel.ROLE_RECEIVE
+        )
 
         return super(AuthenticatedExternalClaimView, self).form_valid(form)

--- a/temba/channels/types/highconnection/tests.py
+++ b/temba/channels/types/highconnection/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class HighConnectionTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/highconnection/type.py
+++ b/temba/channels/types/highconnection/type.py
@@ -27,8 +27,10 @@ class HighConnectionType(ChannelType):
     name = "High Connection"
     slug = "high_connection"
 
-    claim_blurb = _("""If you are based in France, you can purchase a number from High Connexion
-                  <a href="http://www.highconnexion.com/en/">High Connection</a> and connect it in a few simple steps.""")
+    claim_blurb = _(
+        """If you are based in France, you can purchase a number from High Connexion
+                  <a href="http://www.highconnexion.com/en/">High Connection</a> and connect it in a few simple steps."""
+    )
     claim_view = AuthenticatedExternalClaimView
 
     schemes = [TEL_SCHEME]
@@ -49,8 +51,10 @@ class HighConnectionType(ChannelType):
             'ret_id': msg.id,
             'datacoding': 8,
             'userdata': 'textit',
-            'ret_url': 'https://%s%s' % (settings.HOSTNAME, reverse('handlers.hcnx_handler', args=['status', channel.uuid])),
-            'ret_mo_url': 'https://%s%s' % (settings.HOSTNAME, reverse('handlers.hcnx_handler', args=['receive', channel.uuid]))
+            'ret_url': 'https://%s%s' %
+            (settings.HOSTNAME, reverse('handlers.hcnx_handler', args=['status', channel.uuid])),
+            'ret_mo_url': 'https://%s%s' %
+            (settings.HOSTNAME, reverse('handlers.hcnx_handler', args=['receive', channel.uuid]))
         }
 
         # build our send URL
@@ -68,7 +72,6 @@ class HighConnectionType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event)

--- a/temba/channels/types/hub9/__init__.py
+++ b/temba/channels/types/hub9/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals, absolute_import
 
-from .type import Hub9Type # noqa
+from .type import Hub9Type  # noqa

--- a/temba/channels/types/hub9/tests.py
+++ b/temba/channels/types/hub9/tests.py
@@ -7,7 +7,6 @@ from ...models import Channel
 
 
 class Hub9TypeTest(TembaTest):
-
     @override_settings(IP_ADDRESSES=('10.10.10.10', '172.16.20.30'))
     def test_claim(self):
         Channel.objects.all().delete()

--- a/temba/channels/types/hub9/type.py
+++ b/temba/channels/types/hub9/type.py
@@ -12,7 +12,6 @@ from temba.msgs.models import SENT
 from temba.utils.http import HttpEvent, http_headers
 from ...models import Channel, ChannelType, SendException
 
-
 # Hub9 is an aggregator in Indonesia, set this to the endpoint for your service
 # and make sure you send from a whitelisted IP Address
 HUB9_ENDPOINT = 'http://175.103.48.29:28078/testing/smsmt.php'
@@ -55,9 +54,16 @@ class Hub9Type(ChannelType):
         #   &udhl=0&charset=utf-8
         #
         url = HUB9_ENDPOINT
-        payload = dict(userid=channel.config['username'], password=channel.config['password'],
-                       original=channel.address.lstrip('+'), sendto=msg.urn_path.lstrip('+'),
-                       messageid=msg.id, message=text, dcs=0, udhl=0)
+        payload = dict(
+            userid=channel.config['username'],
+            password=channel.config['password'],
+            original=channel.address.lstrip('+'),
+            sendto=msg.urn_path.lstrip('+'),
+            messageid=msg.id,
+            message=text,
+            dcs=0,
+            udhl=0
+        )
 
         # build up our querystring and send it as a get
         send_url = "%s?%s" % (url, urlencode(payload))
@@ -73,12 +79,10 @@ class Hub9Type(ChannelType):
             event.status_code = response.status_code
             event.response_body = response.text
             if not response:  # pragma: no cover
-                raise SendException("Unable to send message",
-                                    event=event, start=start)
+                raise SendException("Unable to send message", event=event, start=start)
 
             if response.status_code != 200 and response.status_code != 201:
-                raise SendException("Received non 200 status: %d" % response.status_code,
-                                    event=event, start=start)
+                raise SendException("Received non 200 status: %d" % response.status_code, event=event, start=start)
 
             # if it wasn't successfully delivered, throw
             if response.text != "000":  # pragma: no cover

--- a/temba/channels/types/infobip/tests.py
+++ b/temba/channels/types/infobip/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class InfobipTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/jasmin/tests.py
+++ b/temba/channels/types/jasmin/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class JasminTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/jasmin/type.py
+++ b/temba/channels/types/jasmin/type.py
@@ -28,8 +28,10 @@ class JasminType(ChannelType):
 
     name = "Jasmin"
 
-    claim_blurb = _("""Connect your <a href="http://www.jasminsms.com/" target="_blank">Jasmin</a> instance that you have
-                       already connected to an SMSC.""")
+    claim_blurb = _(
+        """Connect your <a href="http://www.jasminsms.com/" target="_blank">Jasmin</a> instance that you have
+                       already connected to an SMSC."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -39,16 +41,25 @@ class JasminType(ChannelType):
     def send(self, channel, msg, text):
 
         # build our callback dlr url, jasmin will call this when our message is sent or delivered
-        dlr_url = 'https://%s%s' % (settings.HOSTNAME, reverse('handlers.jasmin_handler', args=['status', channel.uuid]))
+        dlr_url = 'https://%s%s' % (
+            settings.HOSTNAME, reverse('handlers.jasmin_handler', args=['status', channel.uuid])
+        )
 
         # encode to GSM7
         encoded = gsm7.encode(text, 'replace')[0]
 
         # build our payload
-        payload = {'from': channel.address.lstrip('+'), 'to': msg.urn_path.lstrip('+'),
-                   'username': channel.config[Channel.CONFIG_USERNAME],
-                   'password': channel.config[Channel.CONFIG_PASSWORD], 'dlr': dlr_url, 'dlr-level': '2',
-                   'dlr-method': 'POST', 'coding': '0', 'content': encoded}
+        payload = {
+            'from': channel.address.lstrip('+'),
+            'to': msg.urn_path.lstrip('+'),
+            'username': channel.config[Channel.CONFIG_USERNAME],
+            'password': channel.config[Channel.CONFIG_PASSWORD],
+            'dlr': dlr_url,
+            'dlr-level': '2',
+            'dlr-method': 'POST',
+            'coding': '0',
+            'content': encoded
+        }
 
         log_payload = payload.copy()
         log_payload['password'] = 'x' * len(log_payload['password'])
@@ -64,12 +75,12 @@ class JasminType(ChannelType):
             event.response_body = response.text
 
         except Exception as e:
-            raise SendException(six.text_type(e),
-                                event=event, start=start)
+            raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from Jasmin" % response.status_code,
-                                event=event, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from Jasmin" % response.status_code, event=event, start=start
+            )
 
         # save the external id, response should be in format:
         # Success "07033084-5cfd-4812-90a4-e4d24ffb6e3d"

--- a/temba/channels/types/jasmin/views.py
+++ b/temba/channels/types/jasmin/views.py
@@ -10,16 +10,24 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class JasminForm(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=4, label=_("Number"),
-                                 help_text=_("The short code or phone number you are connecting."))
-        url = forms.URLField(label=_("URL"),
-                             help_text=_("The URL for the Jasmin server send path. ex: https://jasmin.gateway.io/send"))
-        username = forms.CharField(label=_("Username"),
-                                   help_text=_("The username to be used to authenticate to Jasmin"))
-        password = forms.CharField(label=_("Password"),
-                                   help_text=_("The password to be used to authenticate to Jasmin"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=4,
+            label=_("Number"),
+            help_text=_("The short code or phone number you are connecting.")
+        )
+        url = forms.URLField(
+            label=_("URL"), help_text=_("The URL for the Jasmin server send path. ex: https://jasmin.gateway.io/send")
+        )
+        username = forms.CharField(
+            label=_("Username"), help_text=_("The username to be used to authenticate to Jasmin")
+        )
+        password = forms.CharField(
+            label=_("Password"), help_text=_("The password to be used to authenticate to Jasmin")
+        )
 
         def clean_number(self):
             number = self.data['number']
@@ -37,6 +45,7 @@ class ClaimView(AuthenticatedExternalClaimView):
                 return phonenumbers.format_number(cleaned, phonenumbers.PhoneNumberFormat.E164)
             except Exception:  # pragma: needs cover
                 raise forms.ValidationError(
-                    _("Invalid phone number, please include the country code. ex: +250788123123"))
+                    _("Invalid phone number, please include the country code. ex: +250788123123")
+                )
 
     form_class = JasminForm

--- a/temba/channels/types/jiochat/tests.py
+++ b/temba/channels/types/jiochat/tests.py
@@ -26,7 +26,12 @@ class JioChatTypeTest(TembaTest):
 
         channel = Channel.objects.get(channel_type='JC')
 
-        self.assertEqual(channel.config_json(), {'jiochat_app_id': post_data['app_id'], 'jiochat_app_secret': post_data['app_secret']})
+        self.assertEqual(
+            channel.config_json(), {
+                'jiochat_app_id': post_data['app_id'],
+                'jiochat_app_secret': post_data['app_secret']
+            }
+        )
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)

--- a/temba/channels/types/jiochat/type.py
+++ b/temba/channels/types/jiochat/type.py
@@ -20,9 +20,11 @@ class JioChatType(ChannelType):
     name = "JioChat"
     icon = 'icon-jiochat'
 
-    claim_blurb = _("""Add a <a href="https://jiochat.me">JioChat</a> bot to send and receive messages to JioChat users
+    claim_blurb = _(
+        """Add a <a href="https://jiochat.me">JioChat</a> bot to send and receive messages to JioChat users
                 for free. Your users will need an Android, Windows or iOS device and a JioChat account to send
-                and receive messages.""")
+                and receive messages."""
+    )
     claim_view = ClaimView
 
     schemes = [JIOCHAT_SCHEME]
@@ -33,9 +35,9 @@ class JioChatType(ChannelType):
     def send(self, channel, msg, text):
         data = {'msgtype': 'text', 'touser': msg.urn_path, 'text': {'content': text}}
 
-        client = JiochatClient(channel.uuid,
-                               channel.config.get('jiochat_app_id'),
-                               channel.config.get('jiochat_app_secret'))
+        client = JiochatClient(
+            channel.uuid, channel.config.get('jiochat_app_id'), channel.config.get('jiochat_app_secret')
+        )
 
         start = time.time()
 

--- a/temba/channels/types/jiochat/views.py
+++ b/temba/channels/types/jiochat/views.py
@@ -18,12 +18,17 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         org = self.request.user.get_org()
         cleaned_data = form.cleaned_data
 
-        config = {
-            'jiochat_app_id': cleaned_data.get('app_id'),
-            'jiochat_app_secret': cleaned_data.get('app_secret')
-        }
+        config = {'jiochat_app_id': cleaned_data.get('app_id'), 'jiochat_app_secret': cleaned_data.get('app_secret')}
 
-        self.object = Channel.create(org, self.request.user, None, self.channel_type, name='', address='',
-                                     config=config, secret=Channel.generate_secret(32))
+        self.object = Channel.create(
+            org,
+            self.request.user,
+            None,
+            self.channel_type,
+            name='',
+            address='',
+            config=config,
+            secret=Channel.generate_secret(32)
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/junebug/type.py
+++ b/temba/channels/types/junebug/type.py
@@ -30,7 +30,9 @@ class JunebugType(ChannelType):
     name = "Junebug"
     icon = "icon-junebug"
 
-    claim_blurb = _("""Connect your <a href="https://junebug.praekelt.org/" target="_blank">Junebug</a> instance that you have already set up and configured.""")
+    claim_blurb = _(
+        """Connect your <a href="https://junebug.praekelt.org/" target="_blank">Junebug</a> instance that you have already set up and configured."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -80,10 +82,13 @@ class JunebugType(ChannelType):
 
         try:
             response = requests.post(
-                channel.config[Channel.CONFIG_SEND_URL], verify=True,
-                json=payload, timeout=15, headers=headers,
-                auth=(channel.config[Channel.CONFIG_USERNAME],
-                      channel.config[Channel.CONFIG_PASSWORD]))
+                channel.config[Channel.CONFIG_SEND_URL],
+                verify=True,
+                json=payload,
+                timeout=15,
+                headers=headers,
+                auth=(channel.config[Channel.CONFIG_USERNAME], channel.config[Channel.CONFIG_PASSWORD])
+            )
 
             event.status_code = response.status_code
             event.response_body = response.text
@@ -92,8 +97,9 @@ class JunebugType(ChannelType):
             raise SendException(text_type(e), event=event, start=start)
 
         if not (200 <= response.status_code < 300):
-            raise SendException("Received a non 200 response %d from Junebug" % response.status_code,
-                                event=event, start=start)
+            raise SendException(
+                "Received a non 200 response %d from Junebug" % response.status_code, event=event, start=start
+            )
 
         data = response.json()
 
@@ -104,8 +110,10 @@ class JunebugType(ChannelType):
             message_id = data['result']['message_id']
             Channel.success(channel, msg, WIRED, start, event=event, external_id=message_id)
         except KeyError as e:
-            raise SendException("Unable to read external message_id: %r" % (e,),
-                                event=HttpEvent('POST', log_url,
-                                                request_body=json.dumps(json.dumps(payload)),
-                                                response_body=json.dumps(data)),
-                                start=start)
+            raise SendException(
+                "Unable to read external message_id: %r" % (e, ),
+                event=HttpEvent(
+                    'POST', log_url, request_body=json.dumps(json.dumps(payload)), response_body=json.dumps(data)
+                ),
+                start=start
+            )

--- a/temba/channels/types/junebug/views.py
+++ b/temba/channels/types/junebug/views.py
@@ -9,22 +9,30 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class Form(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=4, label=_("Number"),
-                                 help_text=("The shortcode or phone number you are connecting."))
-        url = forms.URLField(label=_("URL"),
-                             help_text=_(
-                                 "The URL for the Junebug channel. ex: https://junebug.praekelt.org/jb/channels/3853bb51-d38a-4bca-b332-8a57c00f2a48/messages.json"))
-        username = forms.CharField(label=_("Username"),
-                                   help_text=_("The username to be used to authenticate to Junebug"),
-                                   required=False)
-        password = forms.CharField(label=_("Password"),
-                                   help_text=_("The password to be used to authenticate to Junebug"),
-                                   required=False)
-        secret = forms.CharField(label=_("Secret"),
-                                 help_text=_("The token Junebug should use to authenticate"),
-                                 required=False)
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=4,
+            label=_("Number"),
+            help_text=("The shortcode or phone number you are connecting.")
+        )
+        url = forms.URLField(
+            label=_("URL"),
+            help_text=_(
+                "The URL for the Junebug channel. ex: https://junebug.praekelt.org/jb/channels/3853bb51-d38a-4bca-b332-8a57c00f2a48/messages.json"
+            )
+        )
+        username = forms.CharField(
+            label=_("Username"), help_text=_("The username to be used to authenticate to Junebug"), required=False
+        )
+        password = forms.CharField(
+            label=_("Password"), help_text=_("The password to be used to authenticate to Junebug"), required=False
+        )
+        secret = forms.CharField(
+            label=_("Secret"), help_text=_("The token Junebug should use to authenticate"), required=False
+        )
 
     form_class = Form
 
@@ -32,12 +40,17 @@ class ClaimView(AuthenticatedExternalClaimView):
         org = self.request.user.get_org()
         data = form.cleaned_data
 
-        self.object = Channel.add_authenticated_external_channel(org, self.request.user,
-                                                                 self.get_submitted_country(data),
-                                                                 data['number'], data['username'],
-                                                                 data['password'], 'JN',
-                                                                 data.get('url'),
-                                                                 role=Channel.DEFAULT_ROLE)
+        self.object = Channel.add_authenticated_external_channel(
+            org,
+            self.request.user,
+            self.get_submitted_country(data),
+            data['number'],
+            data['username'],
+            data['password'],
+            'JN',
+            data.get('url'),
+            role=Channel.DEFAULT_ROLE
+        )
         if data['secret']:
             self.object.secret = data['secret']
             self.object.save()

--- a/temba/channels/types/junebug_ussd/tests.py
+++ b/temba/channels/types/junebug_ussd/tests.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals, absolute_import
 
-
 from django.urls import reverse
 from temba.tests import TembaTest
 from ...models import Channel
 
 
 class JunebugTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
         self.login(self.admin)

--- a/temba/channels/types/junebug_ussd/type.py
+++ b/temba/channels/types/junebug_ussd/type.py
@@ -19,7 +19,9 @@ class JunebugUSSDType(ChannelType):
     slug = "junebug_ussd"
     icon = "icon-junebug"
 
-    claim_blurb = _("""Connect your <a href="https://junebug.praekelt.org/" target="_blank">Junebug</a> instance that you have already set up and configured.""")
+    claim_blurb = _(
+        """Connect your <a href="https://junebug.praekelt.org/" target="_blank">Junebug</a> instance that you have already set up and configured."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]

--- a/temba/channels/types/junebug_ussd/views.py
+++ b/temba/channels/types/junebug_ussd/views.py
@@ -9,22 +9,30 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class Form(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=4, label=_("Number"),
-                                 help_text=("The shortcode or phone number you are connecting."))
-        url = forms.URLField(label=_("URL"),
-                             help_text=_(
-                                 "The URL for the Junebug channel. ex: https://junebug.praekelt.org/jb/channels/3853bb51-d38a-4bca-b332-8a57c00f2a48/messages.json"))
-        username = forms.CharField(label=_("Username"),
-                                   help_text=_("The username to be used to authenticate to Junebug"),
-                                   required=False)
-        password = forms.CharField(label=_("Password"),
-                                   help_text=_("The password to be used to authenticate to Junebug"),
-                                   required=False)
-        secret = forms.CharField(label=_("Secret"),
-                                 help_text=_("The token Junebug should use to authenticate"),
-                                 required=False)
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=4,
+            label=_("Number"),
+            help_text=("The shortcode or phone number you are connecting.")
+        )
+        url = forms.URLField(
+            label=_("URL"),
+            help_text=_(
+                "The URL for the Junebug channel. ex: https://junebug.praekelt.org/jb/channels/3853bb51-d38a-4bca-b332-8a57c00f2a48/messages.json"
+            )
+        )
+        username = forms.CharField(
+            label=_("Username"), help_text=_("The username to be used to authenticate to Junebug"), required=False
+        )
+        password = forms.CharField(
+            label=_("Password"), help_text=_("The password to be used to authenticate to Junebug"), required=False
+        )
+        secret = forms.CharField(
+            label=_("Secret"), help_text=_("The token Junebug should use to authenticate"), required=False
+        )
 
     form_class = Form
 
@@ -32,12 +40,17 @@ class ClaimView(AuthenticatedExternalClaimView):
         org = self.request.user.get_org()
         data = form.cleaned_data
 
-        self.object = Channel.add_authenticated_external_channel(org, self.request.user,
-                                                                 self.get_submitted_country(data),
-                                                                 data['number'], data['username'],
-                                                                 data['password'], 'JNU',
-                                                                 data.get('url'),
-                                                                 role=Channel.ROLE_USSD)
+        self.object = Channel.add_authenticated_external_channel(
+            org,
+            self.request.user,
+            self.get_submitted_country(data),
+            data['number'],
+            data['username'],
+            data['password'],
+            'JNU',
+            data.get('url'),
+            role=Channel.ROLE_USSD
+        )
         if data['secret']:
             self.object.secret = data['secret']
             self.object.save()

--- a/temba/channels/types/kannel/tests.py
+++ b/temba/channels/types/kannel/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class KannelTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/kannel/type.py
+++ b/temba/channels/types/kannel/type.py
@@ -29,8 +29,10 @@ class KannelType(ChannelType):
     name = "Kannel"
     icon = "icon-channel-kannel"
 
-    claim_blurb = _("""Connect your <a href="http://www.kannel.org/" target="_blank">Kannel</a> instance, we'll walk you through
-                       the steps necessary to get your SMSC connection working in a few minutes.""")
+    claim_blurb = _(
+        """Connect your <a href="http://www.kannel.org/" target="_blank">Kannel</a> instance, we'll walk you through
+                       the steps necessary to get your SMSC connection working in a few minutes."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -40,7 +42,9 @@ class KannelType(ChannelType):
 
     def send(self, channel, msg, text):
         # build our callback dlr url, kannel will call this when our message is sent or delivered
-        dlr_url = 'https://%s%s?id=%d&status=%%d' % (settings.HOSTNAME, reverse('courier.kn', args=[channel.uuid, 'status']), msg.id)
+        dlr_url = 'https://%s%s?id=%d&status=%%d' % (
+            settings.HOSTNAME, reverse('courier.kn', args=[channel.uuid, 'status']), msg.id
+        )
         dlr_mask = 31
 
         # build our payload
@@ -107,7 +111,8 @@ class KannelType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from Kannel" % response.status_code,
-                                event=event, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from Kannel" % response.status_code, event=event, start=start
+            )
 
         Channel.success(channel, msg, WIRED, start, event=event)

--- a/temba/channels/types/kannel/views.py
+++ b/temba/channels/types/kannel/views.py
@@ -12,26 +12,55 @@ from ...views import ClaimViewMixin, ALL_COUNTRIES
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class KannelClaimForm(ClaimViewMixin.Form):
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_("The phone number or short code you are connecting"))
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        url = forms.URLField(max_length=1024, label=_("Send URL"),
-                             help_text=_("The publicly accessible URL for your Kannel instance for sending. "
-                                         "ex: https://kannel.macklemore.co/cgi-bin/sendsms"))
-        username = forms.CharField(max_length=64, required=False,
-                                   help_text=_("The username to use to authenticate to Kannel, if left blank we "
-                                               "will generate one for you"))
-        password = forms.CharField(max_length=64, required=False,
-                                   help_text=_("The password to use to authenticate to Kannel, if left blank we "
-                                               "will generate one for you"))
-        encoding = forms.ChoiceField(Channel.ENCODING_CHOICES, label=_("Encoding"),
-                                     help_text=_("What encoding to use for outgoing messages"))
-        verify_ssl = forms.BooleanField(initial=True, required=False, label=_("Verify SSL"),
-                                        help_text=_("Whether to verify the SSL connection (recommended)"))
-        use_national = forms.BooleanField(initial=False, required=False, label=_("Use National Numbers"),
-                                          help_text=_("Use only the national number (no country code) when "
-                                                      "sending (not recommended)"))
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_("The phone number or short code you are connecting")
+        )
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        url = forms.URLField(
+            max_length=1024,
+            label=_("Send URL"),
+            help_text=_(
+                "The publicly accessible URL for your Kannel instance for sending. "
+                "ex: https://kannel.macklemore.co/cgi-bin/sendsms"
+            )
+        )
+        username = forms.CharField(
+            max_length=64,
+            required=False,
+            help_text=_(
+                "The username to use to authenticate to Kannel, if left blank we "
+                "will generate one for you"
+            )
+        )
+        password = forms.CharField(
+            max_length=64,
+            required=False,
+            help_text=_(
+                "The password to use to authenticate to Kannel, if left blank we "
+                "will generate one for you"
+            )
+        )
+        encoding = forms.ChoiceField(
+            Channel.ENCODING_CHOICES, label=_("Encoding"), help_text=_("What encoding to use for outgoing messages")
+        )
+        verify_ssl = forms.BooleanField(
+            initial=True,
+            required=False,
+            label=_("Verify SSL"),
+            help_text=_("Whether to verify the SSL connection (recommended)")
+        )
+        use_national = forms.BooleanField(
+            initial=False,
+            required=False,
+            label=_("Use National Numbers"),
+            help_text=_("Use only the national number (no country code) when "
+                        "sending (not recommended)")
+        )
 
     form_class = KannelClaimForm
 
@@ -44,14 +73,17 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         number = data['number']
         role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE
 
-        config = {Channel.CONFIG_SEND_URL: url,
-                  Channel.CONFIG_VERIFY_SSL: data.get('verify_ssl', False),
-                  Channel.CONFIG_USE_NATIONAL: data.get('use_national', False),
-                  Channel.CONFIG_USERNAME: data.get('username', None),
-                  Channel.CONFIG_PASSWORD: data.get('password', None),
-                  Channel.CONFIG_ENCODING: data.get('encoding', Channel.ENCODING_DEFAULT)}
-        self.object = Channel.add_config_external_channel(org, self.request.user, country, number, 'KN',
-                                                          config, role=role, parent=None)
+        config = {
+            Channel.CONFIG_SEND_URL: url,
+            Channel.CONFIG_VERIFY_SSL: data.get('verify_ssl', False),
+            Channel.CONFIG_USE_NATIONAL: data.get('use_national', False),
+            Channel.CONFIG_USERNAME: data.get('username', None),
+            Channel.CONFIG_PASSWORD: data.get('password', None),
+            Channel.CONFIG_ENCODING: data.get('encoding', Channel.ENCODING_DEFAULT)
+        }
+        self.object = Channel.add_config_external_channel(
+            org, self.request.user, country, number, 'KN', config, role=role, parent=None
+        )
 
         # if they didn't set a username or password, generate them, we do this after the addition above
         # because we use the channel id in the configuration

--- a/temba/channels/types/line/tests.py
+++ b/temba/channels/types/line/tests.py
@@ -12,9 +12,20 @@ class LineTypeTest(TembaTest):
     def setUp(self):
         super(LineTypeTest, self).setUp()
 
-        self.channel = Channel.create(self.org, self.user, None, 'LN', name="LINE", address="12345",
-                                      role="SR", schemes=['line'],
-                                      config={'auth_token': 'abcdef098765', 'channel_secret': '87654'})
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'LN',
+            name="LINE",
+            address="12345",
+            role="SR",
+            schemes=['line'],
+            config={
+                'auth_token': 'abcdef098765',
+                'channel_secret': '87654'
+            }
+        )
 
     @patch('requests.get')
     def test_claim(self, mock_get):
@@ -34,12 +45,14 @@ class LineTypeTest(TembaTest):
 
         channel = Channel.objects.get(address='u1234567890')
         self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.id]))
-        self.assertEqual(channel.config_json(), {
-            'auth_token': 'abcdef123456',
-            'channel_secret': '123456',
-            'channel_id': 123456789,
-            'channel_mid': 'u1234567890'
-        })
+        self.assertEqual(
+            channel.config_json(), {
+                'auth_token': 'abcdef123456',
+                'channel_secret': '123456',
+                'channel_id': 123456789,
+                'channel_mid': 'u1234567890'
+            }
+        )
 
         response = self.client.post(url, payload, follow=True)
         self.assertContains(response, "A channel with this configuration already exists.")

--- a/temba/channels/types/line/type.py
+++ b/temba/channels/types/line/type.py
@@ -23,9 +23,11 @@ class LineType(ChannelType):
     name = "LINE"
     icon = 'icon-line'
 
-    claim_blurb = _("""Add a <a href="https://line.me">LINE</a> bot to send and receive messages to LINE users
+    claim_blurb = _(
+        """Add a <a href="https://line.me">LINE</a> bot to send and receive messages to LINE users
                 for free. Your users will need an Android, Windows or iOS device and a LINE account to send
-                and receive messages.""")
+                and receive messages."""
+    )
     claim_view = ClaimView
 
     schemes = [LINE_SCHEME]
@@ -39,10 +41,12 @@ class LineType(ChannelType):
         data = json.dumps({'to': msg.urn_path, 'messages': [{'type': 'text', 'text': text}]})
 
         start = time.time()
-        headers = http_headers(extra={
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer %s' % channel_access_token
-        })
+        headers = http_headers(
+            extra={
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer %s' % channel_access_token
+            }
+        )
         send_url = 'https://api.line.me/v2/bot/message/push'
 
         event = HttpEvent('POST', send_url, data)
@@ -57,7 +61,6 @@ class LineType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code not in [200, 201, 202]:  # pragma: needs cover
-            raise SendException("Got non-200 response [%d] from Line" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from Line" % response.status_code, event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event)

--- a/temba/channels/types/line/views.py
+++ b/temba/channels/types/line/views.py
@@ -15,18 +15,21 @@ from ...views import ClaimViewMixin
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
-        access_token = forms.CharField(label=_("Access Token"), required=True,
-                                       help_text=_("The Access Token of the LINE Bot"))
+        access_token = forms.CharField(
+            label=_("Access Token"), required=True, help_text=_("The Access Token of the LINE Bot")
+        )
         secret = forms.CharField(label=_("Secret"), required=True, help_text=_("The Secret of the LINE Bot"))
 
         def clean(self):
             access_token = self.cleaned_data.get('access_token')
             secret = self.cleaned_data.get('secret')
 
-            headers = http_headers(extra={
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer %s' % access_token
-            })
+            headers = http_headers(
+                extra={
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer %s' % access_token
+                }
+            )
 
             response = requests.get('https://api.line.me/v1/oauth/verify', headers=headers)
             content = response.json()
@@ -45,9 +48,11 @@ class ClaimView(ClaimViewMixin, SmartFormView):
                 }
 
                 existing = Channel.objects.filter(
-                    Q(config__contains=channel_id) | Q(config__contains=secret) | Q(
-                        config__contains=access_token), channel_type=self.channel_type.code, address=channel_mid,
-                    is_active=True).first()
+                    Q(config__contains=channel_id) | Q(config__contains=secret) | Q(config__contains=access_token),
+                    channel_type=self.channel_type.code,
+                    address=channel_mid,
+                    is_active=True
+                ).first()
                 if existing:
                     raise ValidationError(_("A channel with this configuration already exists."))
 
@@ -82,7 +87,14 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             'channel_mid': channel_mid
         }
 
-        self.object = Channel.create(org, self.request.user, None, self.channel_type,
-                                     name=profile.get('display_name'), address=channel_mid, config=config)
+        self.object = Channel.create(
+            org,
+            self.request.user,
+            None,
+            self.channel_type,
+            name=profile.get('display_name'),
+            address=channel_mid,
+            config=config
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/m3tech/tests.py
+++ b/temba/channels/types/m3tech/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class M3TechTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/m3tech/type.py
+++ b/temba/channels/types/m3tech/type.py
@@ -25,7 +25,9 @@ class M3TechType(ChannelType):
 
     name = "M3 Tech"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="http://m3techservice.com">M3 Tech</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="http://m3techservice.com">M3 Tech</a> using their APIs."""
+    )
     claim_view = AuthenticatedExternalClaimView
 
     schemes = [TEL_SCHEME]
@@ -48,17 +50,19 @@ class M3TechType(ChannelType):
             sms_type = '0'
 
         url = 'https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS'
-        payload = {'AuthKey': 'm3-Tech',
-                   'UserId': channel.config[Channel.CONFIG_USERNAME],
-                   'Password': channel.config[Channel.CONFIG_PASSWORD],
-                   'MobileNo': msg.urn_path.lstrip('+'),
-                   'MsgId': msg.id,
-                   'SMS': text,
-                   'MsgHeader': channel.address.lstrip('+'),
-                   'SMSType': sms_type,
-                   'HandsetPort': '0',
-                   'SMSChannel': '0',
-                   'Telco': '0'}
+        payload = {
+            'AuthKey': 'm3-Tech',
+            'UserId': channel.config[Channel.CONFIG_USERNAME],
+            'Password': channel.config[Channel.CONFIG_PASSWORD],
+            'MobileNo': msg.urn_path.lstrip('+'),
+            'MsgId': msg.id,
+            'SMS': text,
+            'MsgHeader': channel.address.lstrip('+'),
+            'SMSType': sms_type,
+            'HandsetPort': '0',
+            'SMSChannel': '0',
+            'Telco': '0'
+        }
 
         event = HttpEvent('GET', url + "?" + urlencode(payload))
 
@@ -73,8 +77,7 @@ class M3TechType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         # our response is JSON and should contain a 0 as a status code:
         # [{"Response":"0"}]
@@ -85,7 +88,6 @@ class M3TechType(ChannelType):
 
         # <Response>0</Response>
         if response_code != "0":
-            raise SendException("Received non-zero status from API: %s" % str(response_code),
-                                event=event, start=start)
+            raise SendException("Received non-zero status from API: %s" % str(response_code), event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event)

--- a/temba/channels/types/macrokiosk/tests.py
+++ b/temba/channels/types/macrokiosk/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class MacrokioskTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/macrokiosk/type.py
+++ b/temba/channels/types/macrokiosk/type.py
@@ -24,7 +24,9 @@ class MacrokioskType(ChannelType):
 
     name = "Macrokiosk"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="http://macrokiosk.com/">Macrokiosk</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="http://macrokiosk.com/">Macrokiosk</a> using their APIs."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -50,9 +52,13 @@ class MacrokioskType(ChannelType):
         recipient = msg.urn_path[1:] if msg.urn_path.startswith('+') else msg.urn_path
 
         data = {
-            'user': channel.config[Channel.CONFIG_USERNAME], 'pass': channel.config[Channel.CONFIG_PASSWORD],
-            'to': recipient, 'text': text, 'from': channel.config[Channel.CONFIG_MACROKIOSK_SENDER_ID],
-            'servid': channel.config[Channel.CONFIG_MACROKIOSK_SERVICE_ID], 'type': message_type
+            'user': channel.config[Channel.CONFIG_USERNAME],
+            'pass': channel.config[Channel.CONFIG_PASSWORD],
+            'to': recipient,
+            'text': text,
+            'from': channel.config[Channel.CONFIG_MACROKIOSK_SENDER_ID],
+            'servid': channel.config[Channel.CONFIG_MACROKIOSK_SERVICE_ID],
+            'type': message_type
         }
 
         url = 'https://www.etracker.cc/bulksms/send'
@@ -74,7 +80,6 @@ class MacrokioskType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code not in [200, 201, 202]:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event, external_id=external_id)

--- a/temba/channels/types/macrokiosk/views.py
+++ b/temba/channels/types/macrokiosk/views.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, absolute_import
 
-
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from smartmin.views import SmartFormView
@@ -10,20 +9,29 @@ from ...views import ClaimViewMixin, ALL_COUNTRIES
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class MacrokioskClaimForm(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_("The phone number or short code you are connecting with country code. "
-                                             "ex: +250788123124"))
-        sender_id = forms.CharField(label=_("Sender ID"),
-                                    help_text=_("The sender ID provided by Macrokiosk to use their API"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_("The phone number or short code you are connecting with country code. "
+                        "ex: +250788123124")
+        )
+        sender_id = forms.CharField(
+            label=_("Sender ID"), help_text=_("The sender ID provided by Macrokiosk to use their API")
+        )
 
-        username = forms.CharField(label=_("Username"),
-                                   help_text=_("The username provided by Macrokiosk to use their API"))
-        password = forms.CharField(label=_("Password"),
-                                   help_text=_("The password provided by Macrokiosk to use their API"))
-        service_id = forms.CharField(label=_("Service ID"),
-                                     help_text=_("The Service ID provided by Macrokiosk to use their API"))
+        username = forms.CharField(
+            label=_("Username"), help_text=_("The username provided by Macrokiosk to use their API")
+        )
+        password = forms.CharField(
+            label=_("Password"), help_text=_("The password provided by Macrokiosk to use their API")
+        )
+        service_id = forms.CharField(
+            label=_("Service ID"), help_text=_("The Service ID provided by Macrokiosk to use their API")
+        )
 
     form_class = MacrokioskClaimForm
 
@@ -44,10 +52,14 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             Channel.CONFIG_MACROKIOSK_SENDER_ID: data.get('sender_id', data['number']),
             Channel.CONFIG_MACROKIOSK_SERVICE_ID: data.get('service_id', None)
         }
-        self.object = Channel.add_config_external_channel(org, self.request.user,
-                                                          self.get_submitted_country(data),
-                                                          data['number'], 'MK',
-                                                          config,
-                                                          role=Channel.ROLE_SEND + Channel.ROLE_RECEIVE)
+        self.object = Channel.add_config_external_channel(
+            org,
+            self.request.user,
+            self.get_submitted_country(data),
+            data['number'],
+            'MK',
+            config,
+            role=Channel.ROLE_SEND + Channel.ROLE_RECEIVE
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/mblox/tests.py
+++ b/temba/channels/types/mblox/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class MbloxTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/mblox/type.py
+++ b/temba/channels/types/mblox/type.py
@@ -24,7 +24,9 @@ class MbloxType(ChannelType):
 
     name = "Mblox"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="https://www.mblox.com/">Mblox</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="https://www.mblox.com/">Mblox</a> using their APIs."""
+    )
 
     claim_view = AuthenticatedExternalClaimView
 
@@ -43,8 +45,10 @@ class MbloxType(ChannelType):
         request_body = json.dumps(payload)
 
         url = 'https://api.mblox.com/xms/v1/%s/batches' % channel.config[Channel.CONFIG_USERNAME]
-        headers = {'Content-Type': 'application/json',
-                   'Authorization': 'Bearer %s' % channel.config[Channel.CONFIG_PASSWORD]}
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer %s' % channel.config[Channel.CONFIG_PASSWORD]
+        }
 
         start = time.time()
 
@@ -58,8 +62,9 @@ class MbloxType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from MBlox" % response.status_code,
-                                event=event, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from MBlox" % response.status_code, event=event, start=start
+            )
 
         # response in format:
         # {
@@ -80,7 +85,6 @@ class MbloxType(ChannelType):
             response_json = response.json()
             external_id = response_json['id']
         except Exception:  # pragma: no cover
-            raise SendException("Unable to parse response body from MBlox",
-                                event=event, start=start)
+            raise SendException("Unable to parse response body from MBlox", event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event, external_id=external_id)

--- a/temba/channels/types/nexmo/type.py
+++ b/temba/channels/types/nexmo/type.py
@@ -27,7 +27,9 @@ class NexmoType(ChannelType):
     name = "Nexmo"
     icon = "icon-channel-nexmo"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="https://www.nexmo.com/">Nexmo</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="https://www.nexmo.com/">Nexmo</a> using their APIs."""
+    )
     claim_view = ClaimView
 
     update_form = UpdateNexmoForm
@@ -39,16 +41,19 @@ class NexmoType(ChannelType):
     ivr_protocol = ChannelType.IVRProtocol.IVR_PROTOCOL_NCCO
 
     def is_recommended_to(self, user):
-        NEXMO_RECOMMENDED_COUNTRIES = ['US', 'CA', 'GB', 'AU', 'AT', 'FI', 'DE', 'HK', 'HU',
-                                       'LT', 'NL', 'NO', 'PL', 'SE', 'CH', 'BE', 'ES', 'ZA']
+        NEXMO_RECOMMENDED_COUNTRIES = [
+            'US', 'CA', 'GB', 'AU', 'AT', 'FI', 'DE', 'HK', 'HU', 'LT', 'NL', 'NO', 'PL', 'SE', 'CH', 'BE', 'ES', 'ZA'
+        ]
         org = user.get_org()
         countrycode = timezone_to_country_code(org.timezone)
         return countrycode in NEXMO_RECOMMENDED_COUNTRIES
 
     def send(self, channel, msg, text):
 
-        client = NexmoClient(channel.org_config[NEXMO_KEY], channel.org_config[NEXMO_SECRET],
-                             channel.org_config[NEXMO_APP_ID], channel.org_config[NEXMO_APP_PRIVATE_KEY])
+        client = NexmoClient(
+            channel.org_config[NEXMO_KEY], channel.org_config[NEXMO_SECRET], channel.org_config[NEXMO_APP_ID],
+            channel.org_config[NEXMO_APP_PRIVATE_KEY]
+        )
         start = time.time()
 
         event = None
@@ -57,7 +62,9 @@ class NexmoType(ChannelType):
             try:
                 (message_id, event) = client.send_message_via_nexmo(channel.address, msg.urn_path, text)
             except SendException as e:
-                match = regex.match(r'.*Throughput Rate Exceeded - please wait \[ (\d+) \] and retry.*', e.events[0].response_body)
+                match = regex.match(
+                    r'.*Throughput Rate Exceeded - please wait \[ (\d+) \] and retry.*', e.events[0].response_body
+                )
 
                 # this is a throughput failure, attempt to wait up to three times
                 if match and attempts < 3:

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -10,7 +10,6 @@ from temba.tests import TembaTest, MockResponse
 
 
 class PlivoTypeTest(TembaTest):
-
     def test_claim(self):
         self.login(self.admin)
 
@@ -41,11 +40,17 @@ class PlivoTypeTest(TembaTest):
         # let's add a number already connected to the account
         with patch('requests.get') as plivo_get:
             with patch('requests.post') as plivo_post:
-                plivo_get.return_value = MockResponse(200,
-                                                      json.dumps(dict(objects=[dict(number='16062681435',
-                                                                                    region="California, UNITED STATES"),
-                                                                               dict(number='8080',
-                                                                                    region='GUADALAJARA, MEXICO')])))
+                plivo_get.return_value = MockResponse(
+                    200,
+                    json.dumps(
+                        dict(
+                            objects=[
+                                dict(number='16062681435', region="California, UNITED STATES"),
+                                dict(number='8080', region='GUADALAJARA, MEXICO')
+                            ]
+                        )
+                    )
+                )
 
                 plivo_post.return_value = MockResponse(202, json.dumps(dict(status='changed', app_id='app-id')))
 
@@ -71,9 +76,13 @@ class PlivoTypeTest(TembaTest):
                 # make sure it is actually connected
                 channel = Channel.objects.get(channel_type='PL', org=self.org)
                 self.assertEqual(channel.role, Channel.ROLE_SEND + Channel.ROLE_RECEIVE)
-                self.assertEqual(channel.config_json(), {Channel.CONFIG_PLIVO_AUTH_ID: 'auth-id',
-                                                         Channel.CONFIG_PLIVO_AUTH_TOKEN: 'auth-token',
-                                                         Channel.CONFIG_PLIVO_APP_ID: 'app-id'})
+                self.assertEqual(
+                    channel.config_json(), {
+                        Channel.CONFIG_PLIVO_AUTH_ID: 'auth-id',
+                        Channel.CONFIG_PLIVO_AUTH_TOKEN: 'auth-token',
+                        Channel.CONFIG_PLIVO_APP_ID: 'app-id'
+                    }
+                )
                 self.assertEqual(channel.address, "+16062681435")
                 # no more credential in the session
                 self.assertFalse(Channel.CONFIG_PLIVO_AUTH_ID in self.client.session)
@@ -86,7 +95,9 @@ class PlivoTypeTest(TembaTest):
             with patch('temba.channels.views.plivo.RestAPI.create_application') as mock_plivo_create_application:
 
                 with patch('temba.channels.types.plivo.views.plivo.RestAPI.get_number') as mock_plivo_get_number:
-                    with patch('temba.channels.types.plivo.views.plivo.RestAPI.buy_phone_number') as mock_plivo_buy_phone_number:
+                    with patch(
+                        'temba.channels.types.plivo.views.plivo.RestAPI.buy_phone_number'
+                    ) as mock_plivo_buy_phone_number:
                         mock_plivo_get_account.return_value = (200, MockResponse(200, json.dumps(dict())))
 
                         mock_plivo_create_application.return_value = (200, dict(app_id='app-id'))
@@ -96,7 +107,10 @@ class PlivoTypeTest(TembaTest):
                         response_body = json.dumps({
                             'status': 'fulfilled',
                             'message': 'created',
-                            'numbers': [{'status': 'Success', 'number': '27816855210'}],
+                            'numbers': [{
+                                'status': 'Success',
+                                'number': '27816855210'
+                            }],
                             'api_id': '4334c747-9e83-11e5-9147-22000acb8094'
                         })
                         mock_plivo_buy_phone_number.return_value = (201, MockResponse(201, response_body))
@@ -110,16 +124,20 @@ class PlivoTypeTest(TembaTest):
                         self.assertTrue(Channel.CONFIG_PLIVO_AUTH_ID in self.client.session)
                         self.assertTrue(Channel.CONFIG_PLIVO_AUTH_TOKEN in self.client.session)
 
-                        response = self.client.post(claim_plivo_url, dict(phone_number='+1 606-268-1440', country='US'))
+                        response = self.client.post(
+                            claim_plivo_url, dict(phone_number='+1 606-268-1440', country='US')
+                        )
                         self.assertRedirects(response, reverse('public.public_welcome') + "?success")
 
                         # make sure it is actually connected
                         channel = Channel.objects.get(channel_type='PL', org=self.org)
-                        self.assertEqual(channel.config_json(), {
-                            Channel.CONFIG_PLIVO_AUTH_ID: 'auth-id',
-                            Channel.CONFIG_PLIVO_AUTH_TOKEN: 'auth-token',
-                            Channel.CONFIG_PLIVO_APP_ID: 'app-id'
-                        })
+                        self.assertEqual(
+                            channel.config_json(), {
+                                Channel.CONFIG_PLIVO_AUTH_ID: 'auth-id',
+                                Channel.CONFIG_PLIVO_AUTH_TOKEN: 'auth-token',
+                                Channel.CONFIG_PLIVO_APP_ID: 'app-id'
+                            }
+                        )
                         self.assertEqual(channel.address, "+16062681440")
                         # no more credential in the session
                         self.assertFalse(Channel.CONFIG_PLIVO_AUTH_ID in self.client.session)

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -27,7 +27,9 @@ class PlivoType(ChannelType):
     name = "Plivo"
     icon = "icon-channel-plivo"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="https://www.plivo.com/">Plivo</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="https://www.plivo.com/">Plivo</a> using their APIs."""
+    )
     claim_view = ClaimView
 
     show_config_page = False
@@ -37,23 +39,27 @@ class PlivoType(ChannelType):
 
     def deactivate(self, channel):
         config = channel.config_json()
-        client = plivo.RestAPI(config[Channel.CONFIG_PLIVO_AUTH_ID],
-                               config[Channel.CONFIG_PLIVO_AUTH_TOKEN])
+        client = plivo.RestAPI(config[Channel.CONFIG_PLIVO_AUTH_ID], config[Channel.CONFIG_PLIVO_AUTH_TOKEN])
         client.delete_application(params=dict(app_id=config[Channel.CONFIG_PLIVO_APP_ID]))
 
     def send(self, channel, msg, text):
         # url used for logs and exceptions
         url = 'https://api.plivo.com/v1/Account/%s/Message/' % channel.config[Channel.CONFIG_PLIVO_AUTH_ID]
 
-        client = plivo.RestAPI(channel.config[Channel.CONFIG_PLIVO_AUTH_ID], channel.config[Channel.CONFIG_PLIVO_AUTH_TOKEN])
-        status_url = "https://" + settings.HOSTNAME + "%s" % reverse('handlers.plivo_handler',
-                                                                     args=['status', channel.uuid])
+        client = plivo.RestAPI(
+            channel.config[Channel.CONFIG_PLIVO_AUTH_ID], channel.config[Channel.CONFIG_PLIVO_AUTH_TOKEN]
+        )
+        status_url = "https://" + settings.HOSTNAME + "%s" % reverse(
+            'handlers.plivo_handler', args=['status', channel.uuid]
+        )
 
-        payload = {'src': channel.address.lstrip('+'),
-                   'dst': msg.urn_path.lstrip('+'),
-                   'text': text,
-                   'url': status_url,
-                   'method': 'POST'}
+        payload = {
+            'src': channel.address.lstrip('+'),
+            'dst': msg.urn_path.lstrip('+'),
+            'text': text,
+            'url': status_url,
+            'method': 'POST'
+        }
 
         event = HttpEvent('POST', url, json.dumps(payload))
 
@@ -69,8 +75,7 @@ class PlivoType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if plivo_response_status != 200 and plivo_response_status != 201 and plivo_response_status != 202:
-            raise SendException("Got non-200 response [%d] from API" % plivo_response_status,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % plivo_response_status, event=event, start=start)
 
         external_id = plivo_response['message_uuid'][0]
         Channel.success(channel, msg, WIRED, start, event=event, external_id=external_id)

--- a/temba/channels/types/redrabbit/tests.py
+++ b/temba/channels/types/redrabbit/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class RedRabbitTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/redrabbit/type.py
+++ b/temba/channels/types/redrabbit/type.py
@@ -24,7 +24,9 @@ class RedRabbitType(ChannelType):
 
     name = "Red Rabbit"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="http://www.redrabbitsms.com/">Red Rabbit</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="http://www.redrabbitsms.com/">Red Rabbit</a> using their APIs."""
+    )
 
     claim_view = AuthenticatedExternalClaimView
 

--- a/temba/channels/types/shaqodoon/tests.py
+++ b/temba/channels/types/shaqodoon/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class ShaqodoonTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/shaqodoon/type.py
+++ b/temba/channels/types/shaqodoon/type.py
@@ -24,8 +24,10 @@ class ShaqodoonType(ChannelType):
 
     name = "Shaqodoon"
 
-    claim_blurb = _("""If you are based in Somalia, you can integrate with Shaqodoon to send
-                       and receive messages on your shortcode.""")
+    claim_blurb = _(
+        """If you are based in Somalia, you can integrate with Shaqodoon to send
+                       and receive messages on your shortcode."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -43,9 +45,13 @@ class ShaqodoonType(ChannelType):
         # requests are signed with a key built as follows:
         # signing_key = md5(username|password|from|to|msg|key|current_date)
         # where current_date is in the format: d/m/y H
-        payload = {'from': channel.address.lstrip('+'), 'to': msg.urn_path.lstrip('+'),
-                   'username': channel.config[Channel.CONFIG_USERNAME], 'password': channel.config[Channel.CONFIG_PASSWORD],
-                   'msg': text}
+        payload = {
+            'from': channel.address.lstrip('+'),
+            'to': msg.urn_path.lstrip('+'),
+            'username': channel.config[Channel.CONFIG_USERNAME],
+            'password': channel.config[Channel.CONFIG_PASSWORD],
+            'msg': text
+        }
 
         # build our send URL
         url = channel.config[Channel.CONFIG_SEND_URL] + "?" + urlencode(payload)
@@ -63,7 +69,6 @@ class ShaqodoonType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event)

--- a/temba/channels/types/shaqodoon/views.py
+++ b/temba/channels/types/shaqodoon/views.py
@@ -9,16 +9,15 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class ShaqodoonForm(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_("The short code you are connecting with."))
-        url = forms.URLField(label=_("URL"),
-                             help_text=_("The url provided to deliver messages"))
-        username = forms.CharField(label=_("Username"),
-                                   help_text=_("The username provided to use their API"))
-        password = forms.CharField(label=_("Password"),
-                                   help_text=_("The password provided to use their API"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14, min_length=1, label=_("Number"), help_text=_("The short code you are connecting with.")
+        )
+        url = forms.URLField(label=_("URL"), help_text=_("The url provided to deliver messages"))
+        username = forms.CharField(label=_("Username"), help_text=_("The username provided to use their API"))
+        password = forms.CharField(label=_("Password"), help_text=_("The password provided to use their API"))
 
     form_class = ShaqodoonForm
 
@@ -35,10 +34,9 @@ class ClaimView(AuthenticatedExternalClaimView):
             raise Exception(_("No org for this user, cannot claim"))
 
         data = form.cleaned_data
-        self.object = Channel.add_config_external_channel(org, self.request.user,
-                                                          'SO', data['number'], 'SQ',
-                                                          dict(send_url=data['url'],
-                                                               username=data['username'],
-                                                               password=data['password']))
+        self.object = Channel.add_config_external_channel(
+            org, self.request.user, 'SO', data['number'], 'SQ',
+            dict(send_url=data['url'], username=data['username'], password=data['password'])
+        )
 
         return super(AuthenticatedExternalClaimView, self).form_valid(form)

--- a/temba/channels/types/smscentral/tests.py
+++ b/temba/channels/types/smscentral/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class SMSCentralTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/smscentral/type.py
+++ b/temba/channels/types/smscentral/type.py
@@ -25,7 +25,9 @@ class SMSCentralType(ChannelType):
     name = "SMSCentral"
     icon = 'icon-channel-external'
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="http://smscentral.com.np/">SMSCentral</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="http://smscentral.com.np/">SMSCentral</a> using their APIs."""
+    )
     claim_view = AuthenticatedExternalClaimView
 
     schemes = [TEL_SCHEME]
@@ -44,7 +46,10 @@ class SMSCentralType(ChannelType):
         mobile = msg.urn_path[1:] if msg.urn_path.startswith('+') else msg.urn_path
 
         payload = {
-            'user': channel.config[Channel.CONFIG_USERNAME], 'pass': channel.config[Channel.CONFIG_PASSWORD], 'mobile': mobile, 'content': text,
+            'user': channel.config[Channel.CONFIG_USERNAME],
+            'pass': channel.config[Channel.CONFIG_PASSWORD],
+            'mobile': mobile,
+            'content': text,
         }
 
         url = 'http://smail.smscentral.com.np/bp/ApiSms.php'
@@ -63,7 +68,6 @@ class SMSCentralType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         Channel.success(channel, msg, WIRED, start, event=event)

--- a/temba/channels/types/start/tests.py
+++ b/temba/channels/types/start/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class StartTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/start/type.py
+++ b/temba/channels/types/start/type.py
@@ -24,7 +24,9 @@ class StartType(ChannelType):
 
     name = "Start Mobile"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="https://bulk.startmobile.ua/">Start Mobile</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="https://bulk.startmobile.ua/">Start Mobile</a> using their APIs."""
+    )
     claim_view = AuthenticatedExternalClaimView
 
     schemes = [TEL_SCHEME]
@@ -59,11 +61,13 @@ class StartType(ChannelType):
         try:
             headers = http_headers(extra={'Content-Type': 'application/xml; charset=utf8'})
 
-            response = requests.post(url,
-                                     data=post_body,
-                                     headers=headers,
-                                     auth=(channel.config[Channel.CONFIG_USERNAME], channel.config[Channel.CONFIG_PASSWORD]),
-                                     timeout=30)
+            response = requests.post(
+                url,
+                data=post_body,
+                headers=headers,
+                auth=(channel.config[Channel.CONFIG_USERNAME], channel.config[Channel.CONFIG_PASSWORD]),
+                timeout=30
+            )
 
             event.status_code = response.status_code
             event.response_body = response.text

--- a/temba/channels/types/telegram/tests.py
+++ b/temba/channels/types/telegram/tests.py
@@ -14,9 +14,19 @@ class TelegramTypeTest(TembaTest):
     def setUp(self):
         super(TelegramTypeTest, self).setUp()
 
-        self.channel = Channel.create(self.org, self.user, None, 'TG', name="Telegram", address="12345",
-                                      role="SR", schemes=['telegram'],
-                                      config={'auth_token': '123456789:BAEKbsOKAL23CXufXG4ksNV7Dq7e_1qi3j8'})
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'TG',
+            name="Telegram",
+            address="12345",
+            role="SR",
+            schemes=['telegram'],
+            config={
+                'auth_token': '123456789:BAEKbsOKAL23CXufXG4ksNV7Dq7e_1qi3j8'
+            }
+        )
 
     @override_settings(IS_PROD=True)
     @patch('telegram.Bot.get_me')
@@ -38,8 +48,10 @@ class TelegramTypeTest(TembaTest):
         mock_get_me.side_effect = telegram.TelegramError('Boom')
         response = self.client.post(url, {'auth_token': 'invalid'})
         self.assertEqual(200, response.status_code)
-        self.assertEqual('Your authentication token is invalid, please check and try again',
-                         response.context['form'].errors['auth_token'][0])
+        self.assertEqual(
+            'Your authentication token is invalid, please check and try again',
+            response.context['form'].errors['auth_token'][0]
+        )
 
         user = telegram.User(123, 'Rapid', True)
         user.last_name = 'Bot'
@@ -58,8 +70,10 @@ class TelegramTypeTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         response = self.client.post(url, {'auth_token': '184875172:BAEKbsOKAL23CXufXG4ksNV7Dq7e_1qi3j8'})
-        self.assertEqual('A telegram channel for this bot already exists on your account.',
-                         response.context['form'].errors['auth_token'][0])
+        self.assertEqual(
+            'A telegram channel for this bot already exists on your account.',
+            response.context['form'].errors['auth_token'][0]
+        )
 
         contact = self.create_contact('Telegram User', urn=URN.from_telegram('1234'))
 

--- a/temba/channels/types/telegram/type.py
+++ b/temba/channels/types/telegram/type.py
@@ -26,9 +26,11 @@ class TelegramType(ChannelType):
     icon = 'icon-telegram'
     show_config_page = False
 
-    claim_blurb = _("""Add a <a href="https://telegram.org">Telegram</a> bot to send and receive messages to Telegram
+    claim_blurb = _(
+        """Add a <a href="https://telegram.org">Telegram</a> bot to send and receive messages to Telegram
     users for free. Your users will need an Android, Windows or iOS device and a Telegram account to send and receive
-    messages.""")
+    messages."""
+    )
     claim_view = ClaimView
 
     schemes = [TELEGRAM_SCHEME]

--- a/temba/channels/types/telegram/views.py
+++ b/temba/channels/types/telegram/views.py
@@ -12,8 +12,9 @@ from ...views import ClaimViewMixin
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
-        auth_token = forms.CharField(label=_("Authentication Token"),
-                                     help_text=_("The Authentication token for your Telegram Bot"))
+        auth_token = forms.CharField(
+            label=_("Authentication Token"), help_text=_("The Authentication token for your Telegram Bot")
+        )
 
         def clean_auth_token(self):
             org = self.request.user.get_org()
@@ -41,7 +42,16 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         bot = telegram.Bot(auth_token)
         me = bot.get_me()
 
-        self.object = Channel.create(org, self.request.user, None, self.channel_type,
-                                     name=me.first_name, address=me.username, config={'auth_token': auth_token})
+        self.object = Channel.create(
+            org,
+            self.request.user,
+            None,
+            self.channel_type,
+            name=me.first_name,
+            address=me.username,
+            config={
+                'auth_token': auth_token
+            }
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/twilio/tests.py
+++ b/temba/channels/types/twilio/tests.py
@@ -12,7 +12,6 @@ from temba.tests import TembaTest, MockTwilioClient, MockRequestValidator
 
 
 class TwilioTypeTest(TembaTest):
-
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
     def test_claim(self):
@@ -50,8 +49,9 @@ class TwilioTypeTest(TembaTest):
             response = self.client.get(claim_twilio)
             self.assertRedirects(response, reverse('orgs.org_twilio_connect'))
 
-            mock_get_twilio_client.side_effect = TwilioRestException(401, 'http://twilio', msg='Authentication Failure',
-                                                                     code=20003)
+            mock_get_twilio_client.side_effect = TwilioRestException(
+                401, 'http://twilio', msg='Authentication Failure', code=20003
+            )
 
             response = self.client.get(claim_twilio)
             self.assertRedirects(response, reverse('orgs.org_twilio_connect'))
@@ -81,8 +81,10 @@ class TwilioTypeTest(TembaTest):
 
             mock_search.return_value = []
             response = self.client.post(search_url, {'country': 'US', 'area_code': ''})
-            self.assertEqual(json.loads(response.content)['error'],
-                             "Sorry, no numbers found, please enter another area code and try again.")
+            self.assertEqual(
+                json.loads(response.content)['error'],
+                "Sorry, no numbers found, please enter another area code and try again."
+            )
 
             # try searching for non-US number
             mock_search.return_value = [MockTwilioClient.MockPhoneNumber('+442812345678')]
@@ -91,8 +93,10 @@ class TwilioTypeTest(TembaTest):
 
             mock_search.return_value = []
             response = self.client.post(search_url, {'country': 'GB', 'area_code': ''})
-            self.assertEqual(json.loads(response.content)['error'],
-                             "Sorry, no numbers found, please enter another pattern and try again.")
+            self.assertEqual(
+                json.loads(response.content)['error'],
+                "Sorry, no numbers found, please enter another pattern and try again."
+            )
 
         with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
             mock_numbers.return_value = [MockTwilioClient.MockPhoneNumber('+12062345678')]
@@ -109,8 +113,9 @@ class TwilioTypeTest(TembaTest):
 
                 # make sure it is actually connected
                 channel = Channel.objects.get(channel_type='T', org=self.org)
-                self.assertEqual(channel.role,
-                                 Channel.ROLE_CALL + Channel.ROLE_ANSWER + Channel.ROLE_SEND + Channel.ROLE_RECEIVE)
+                self.assertEqual(
+                    channel.role, Channel.ROLE_CALL + Channel.ROLE_ANSWER + Channel.ROLE_SEND + Channel.ROLE_RECEIVE
+                )
 
                 channel_config = channel.config_json()
                 self.assertEqual(channel_config[Channel.CONFIG_ACCOUNT_SID], 'account-sid')
@@ -185,8 +190,9 @@ class TwilioTypeTest(TembaTest):
         with self.settings(IS_PROD=True):
             with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.update') as mock_numbers:
                 # our twilio channel removal should fail on bad auth
-                mock_numbers.side_effect = TwilioRestException(401, 'http://twilio', msg='Authentication Failure',
-                                                               code=20003)
+                mock_numbers.side_effect = TwilioRestException(
+                    401, 'http://twilio', msg='Authentication Failure', code=20003
+                )
                 self.client.post(reverse('channels.channel_delete', args=[twilio_channel.pk]))
                 self.assertIsNotNone(self.org.channels.all().first())
 
@@ -199,5 +205,6 @@ class TwilioTypeTest(TembaTest):
                 mock_numbers.side_effect = None
                 self.client.post(reverse('channels.channel_delete', args=[twilio_channel.pk]))
                 self.assertIsNone(self.org.channels.all().first())
-                self.assertEqual(mock_numbers.call_args_list[-1][1], dict(voice_application_sid='',
-                                                                          sms_application_sid=''))
+                self.assertEqual(
+                    mock_numbers.call_args_list[-1][1], dict(voice_application_sid='', sms_application_sid='')
+                )

--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -26,7 +26,9 @@ class TwilioType(ChannelType):
     name = "Twilio"
     icon = "icon-channel-twilio"
 
-    claim_blurb = _("""Easily add a two way number you have configured with <a href="https://www.twilio.com/">Twilio</a> using their APIs.""")
+    claim_blurb = _(
+        """Easily add a two way number you have configured with <a href="https://www.twilio.com/">Twilio</a> using their APIs."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -81,26 +83,35 @@ class TwilioType(ChannelType):
 
         if channel.channel_type == 'TW':  # pragma: no cover
             config = channel.config
-            client = TembaTwilioRestClient(config.get(Channel.CONFIG_ACCOUNT_SID), config.get(Channel.CONFIG_AUTH_TOKEN),
-                                           base=config.get(Channel.CONFIG_SEND_URL))
+            client = TembaTwilioRestClient(
+                config.get(Channel.CONFIG_ACCOUNT_SID),
+                config.get(Channel.CONFIG_AUTH_TOKEN),
+                base=config.get(Channel.CONFIG_SEND_URL)
+            )
         else:
             config = channel.config
-            client = TembaTwilioRestClient(config.get(Channel.CONFIG_ACCOUNT_SID), config.get(Channel.CONFIG_AUTH_TOKEN))
+            client = TembaTwilioRestClient(
+                config.get(Channel.CONFIG_ACCOUNT_SID), config.get(Channel.CONFIG_AUTH_TOKEN)
+            )
 
         try:
             if channel.channel_type == 'TMS':
                 messaging_service_sid = channel.config['messaging_service_sid']
-                client.messages.create(to=msg.urn_path,
-                                       messaging_service_sid=messaging_service_sid,
-                                       body=text,
-                                       media_url=media_urls,
-                                       status_callback=callback_url)
+                client.messages.create(
+                    to=msg.urn_path,
+                    messaging_service_sid=messaging_service_sid,
+                    body=text,
+                    media_url=media_urls,
+                    status_callback=callback_url
+                )
             else:
-                client.messages.create(to=msg.urn_path,
-                                       from_=channel.address,
-                                       body=text,
-                                       media_url=media_urls,
-                                       status_callback=callback_url)
+                client.messages.create(
+                    to=msg.urn_path,
+                    from_=channel.address,
+                    body=text,
+                    media_url=media_urls,
+                    status_callback=callback_url
+                )
 
             Channel.success(channel, msg, WIRED, start, events=client.messages.events)
 

--- a/temba/channels/types/twilio_messaging_service/tests.py
+++ b/temba/channels/types/twilio_messaging_service/tests.py
@@ -12,7 +12,6 @@ from temba.tests import TembaTest, MockTwilioClient, MockRequestValidator
 
 
 class TwilioMessagingServiceTypeTest(TembaTest):
-
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
     def test_claim(self):
@@ -54,7 +53,9 @@ class TwilioMessagingServiceTypeTest(TembaTest):
             response = self.client.get(claim_twilio_ms)
             self.assertRedirects(response, reverse('orgs.org_twilio_connect'))
 
-            mock_get_twilio_client.side_effect = TwilioRestException(401, 'http://twilio', msg='Authentication Failure', code=20003)
+            mock_get_twilio_client.side_effect = TwilioRestException(
+                401, 'http://twilio', msg='Authentication Failure', code=20003
+            )
 
             response = self.client.get(claim_twilio_ms)
             self.assertRedirects(response, reverse('orgs.org_twilio_connect'))

--- a/temba/channels/types/twilio_messaging_service/type.py
+++ b/temba/channels/types/twilio_messaging_service/type.py
@@ -21,7 +21,9 @@ class TwilioMessagingServiceType(ChannelType):
     slug = "twilio_messaging_service"
     icon = "icon-channel-twilio"
 
-    claim_blurb = _("""You can connect a messaging service from your Twilio account to benefit from <a href="https://www.twilio.com/copilot">Twilio Copilot features</a></br>""")
+    claim_blurb = _(
+        """You can connect a messaging service from your Twilio account to benefit from <a href="https://www.twilio.com/copilot">Twilio Copilot features</a></br>"""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]

--- a/temba/channels/types/twilio_messaging_service/views.py
+++ b/temba/channels/types/twilio_messaging_service/views.py
@@ -15,8 +15,9 @@ from ...views import ClaimViewMixin, TWILIO_SUPPORTED_COUNTRIES
 class ClaimView(ClaimViewMixin, SmartFormView):
     class TwilioMessagingServiceForm(ClaimViewMixin.Form):
         country = forms.ChoiceField(choices=TWILIO_SUPPORTED_COUNTRIES)
-        messaging_service_sid = forms.CharField(label=_("Messaging Service SID"),
-                                                help_text=_("The Twilio Messaging Service SID"))
+        messaging_service_sid = forms.CharField(
+            label=_("Messaging Service SID"), help_text=_("The Twilio Messaging Service SID")
+        )
 
     form_class = TwilioMessagingServiceForm
 
@@ -51,11 +52,14 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         data = form.cleaned_data
 
         org_config = org.config_json()
-        config = {Channel.CONFIG_MESSAGING_SERVICE_SID: data['messaging_service_sid'],
-                  Channel.CONFIG_ACCOUNT_SID: org_config[ACCOUNT_SID],
-                  Channel.CONFIG_AUTH_TOKEN: org_config[ACCOUNT_TOKEN]}
+        config = {
+            Channel.CONFIG_MESSAGING_SERVICE_SID: data['messaging_service_sid'],
+            Channel.CONFIG_ACCOUNT_SID: org_config[ACCOUNT_SID],
+            Channel.CONFIG_AUTH_TOKEN: org_config[ACCOUNT_TOKEN]
+        }
 
-        self.object = Channel.create(org, user, data['country'], 'TMS',
-                                     name=data['messaging_service_sid'], address=None, config=config)
+        self.object = Channel.create(
+            org, user, data['country'], 'TMS', name=data['messaging_service_sid'], address=None, config=config
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/twiml_api/tests.py
+++ b/temba/channels/types/twiml_api/tests.py
@@ -7,7 +7,6 @@ from temba.tests import TembaTest, MockTwilioClient, MockRequestValidator
 
 
 class TwimlAPITypeTest(TembaTest):
-
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
     def test_claim(self):
@@ -30,22 +29,61 @@ class TwimlAPITypeTest(TembaTest):
         response = self.client.post(claim_url, dict(number='5512345678', country='AA'))
         self.assertTrue(response.context['form'].errors)
 
-        response = self.client.post(claim_url, dict(country='US', number='12345678', url='https://twilio.com', role='SR', account_sid='abcd1234', account_token='abcd1234'))
+        response = self.client.post(
+            claim_url,
+            dict(
+                country='US',
+                number='12345678',
+                url='https://twilio.com',
+                role='SR',
+                account_sid='abcd1234',
+                account_token='abcd1234'
+            )
+        )
         channel = self.org.channels.all().first()
         self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.pk]))
         self.assertEqual(channel.channel_type, "TW")
-        self.assertEqual(channel.config_json(), dict(ACCOUNT_TOKEN='abcd1234', send_url='https://twilio.com', ACCOUNT_SID='abcd1234'))
+        self.assertEqual(
+            channel.config_json(),
+            dict(ACCOUNT_TOKEN='abcd1234', send_url='https://twilio.com', ACCOUNT_SID='abcd1234')
+        )
 
-        response = self.client.post(claim_url, dict(country='US', number='12345678', url='https://twilio.com', role='SR', account_sid='abcd4321', account_token='abcd4321'))
+        response = self.client.post(
+            claim_url,
+            dict(
+                country='US',
+                number='12345678',
+                url='https://twilio.com',
+                role='SR',
+                account_sid='abcd4321',
+                account_token='abcd4321'
+            )
+        )
         channel = self.org.channels.all().first()
         self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.pk]))
         self.assertEqual(channel.channel_type, "TW")
-        self.assertEqual(channel.config_json(), dict(ACCOUNT_TOKEN='abcd4321', send_url='https://twilio.com', ACCOUNT_SID='abcd4321'))
+        self.assertEqual(
+            channel.config_json(),
+            dict(ACCOUNT_TOKEN='abcd4321', send_url='https://twilio.com', ACCOUNT_SID='abcd4321')
+        )
 
         self.org.channels.update(is_active=False, org=None)
 
-        response = self.client.post(claim_url, dict(country='US', number='8080', url='https://twilio.com', role='SR', account_sid='abcd1234', account_token='abcd1234'))
+        response = self.client.post(
+            claim_url,
+            dict(
+                country='US',
+                number='8080',
+                url='https://twilio.com',
+                role='SR',
+                account_sid='abcd1234',
+                account_token='abcd1234'
+            )
+        )
         channel = self.org.channels.all().first()
         self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.pk]))
         self.assertEqual(channel.channel_type, "TW")
-        self.assertEqual(channel.config_json(), dict(ACCOUNT_TOKEN='abcd1234', send_url='https://twilio.com', ACCOUNT_SID='abcd1234'))
+        self.assertEqual(
+            channel.config_json(),
+            dict(ACCOUNT_TOKEN='abcd1234', send_url='https://twilio.com', ACCOUNT_SID='abcd1234')
+        )

--- a/temba/channels/types/twiml_api/type.py
+++ b/temba/channels/types/twiml_api/type.py
@@ -19,7 +19,9 @@ class TwimlAPIType(ChannelType):
     slug = "twiml_api"
     icon = "icon-channel-twilio"
 
-    claim_blurb = _("""Connect to a service that speaks TwiML. You can use this to connect to TwiML compatible services outside of Twilio.""")
+    claim_blurb = _(
+        """Connect to a service that speaks TwiML. You can use this to connect to TwiML compatible services outside of Twilio."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]

--- a/temba/channels/types/twiml_api/views.py
+++ b/temba/channels/types/twiml_api/views.py
@@ -20,20 +20,39 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             (Channel.ROLE_CALL + Channel.ROLE_ANSWER, _('Voice')),
             (Channel.ROLE_SEND + Channel.ROLE_RECEIVE + Channel.ROLE_CALL + Channel.ROLE_ANSWER, _('Both')),
         )
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_("The phone number without country code or short code you are connecting."))
-        url = forms.URLField(max_length=1024, label=_("TwiML REST API Host"), help_text=_(
-            "The publicly accessible URL for your TwiML REST API instance ex: https://api.twilio.com"))
-        role = forms.ChoiceField(choices=ROLES, label=_("Role"),
-                                 help_text=_("Choose the role that this channel supports"))
-        account_sid = forms.CharField(max_length=64, required=False,
-                                      help_text=_("The Account SID to use to authenticate to the TwiML REST API"),
-                                      widget=forms.TextInput(attrs={'autocomplete': 'off'}))
-        account_token = forms.CharField(max_length=64, required=False,
-                                        help_text=_("The Account Token to use to authenticate to the TwiML REST API"),
-                                        widget=forms.TextInput(attrs={'autocomplete': 'off'}))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_("The phone number without country code or short code you are connecting.")
+        )
+        url = forms.URLField(
+            max_length=1024,
+            label=_("TwiML REST API Host"),
+            help_text=_("The publicly accessible URL for your TwiML REST API instance ex: https://api.twilio.com")
+        )
+        role = forms.ChoiceField(
+            choices=ROLES, label=_("Role"), help_text=_("Choose the role that this channel supports")
+        )
+        account_sid = forms.CharField(
+            max_length=64,
+            required=False,
+            help_text=_("The Account SID to use to authenticate to the TwiML REST API"),
+            widget=forms.TextInput(attrs={
+                'autocomplete': 'off'
+            })
+        )
+        account_token = forms.CharField(
+            max_length=64,
+            required=False,
+            help_text=_("The Account Token to use to authenticate to the TwiML REST API"),
+            widget=forms.TextInput(attrs={
+                'autocomplete': 'off'
+            })
+        )
 
     form_class = TwimlApiClaimForm
 
@@ -47,9 +66,11 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         url = data.get('url')
         role = data.get('role')
 
-        config = {Channel.CONFIG_SEND_URL: url,
-                  ACCOUNT_SID: data.get('account_sid', None),
-                  ACCOUNT_TOKEN: data.get('account_token', None)}
+        config = {
+            Channel.CONFIG_SEND_URL: url,
+            ACCOUNT_SID: data.get('account_sid', None),
+            ACCOUNT_TOKEN: data.get('account_token', None)
+        }
 
         is_short_code = len(number) <= 6
 
@@ -67,7 +88,9 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE
         else:
             address = "+%s" % address
-            name = phonenumbers.format_number(phonenumbers.parse(address, None), phonenumbers.PhoneNumberFormat.NATIONAL)
+            name = phonenumbers.format_number(
+                phonenumbers.parse(address, None), phonenumbers.PhoneNumberFormat.NATIONAL
+            )
 
         existing = Channel.objects.filter(address=address, org=org, channel_type='TW').first()
         if existing:
@@ -79,7 +102,9 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             existing.save()
             self.object = existing
         else:
-            self.object = Channel.create(org, user, country, 'TW', name=name, address=address, config=config, role=role)
+            self.object = Channel.create(
+                org, user, country, 'TW', name=name, address=address, config=config, role=role
+            )
 
         # if they didn't set a username or password, generate them, we do this after the addition above
         # because we use the channel id in the configuration

--- a/temba/channels/types/twitter/tests.py
+++ b/temba/channels/types/twitter/tests.py
@@ -13,8 +13,9 @@ class TwitterTypeTest(TembaTest):
     def setUp(self):
         super(TwitterTypeTest, self).setUp()
 
-        self.channel = Channel.create(self.org, self.user, None, 'TT', name="Twitter", address="billy_bob",
-                                      role="SR", config={})
+        self.channel = Channel.create(
+            self.org, self.user, None, 'TT', name="Twitter", address="billy_bob", role="SR", config={}
+        )
 
     @override_settings(IS_PROD=True)
     @patch('twython.Twython.get_authentication_tokens')

--- a/temba/channels/types/twitter/type.py
+++ b/temba/channels/types/twitter/type.py
@@ -34,8 +34,10 @@ class TwitterType(ChannelType):
     show_config_page = False
     free_sending = True
 
-    FATAL_403S = ("messages to this user right now",  # handle is suspended
-                  "users who are not following you")  # handle no longer follows us
+    FATAL_403S = (
+        "messages to this user right now",  # handle is suspended
+        "users who are not following you"
+    )  # handle no longer follows us
 
     def activate(self, channel):
         # tell Mage to activate this channel

--- a/temba/channels/types/twitter/views.py
+++ b/temba/channels/types/twitter/views.py
@@ -10,7 +10,6 @@ from temba.utils.twitter import TembaTwython
 from ...models import Channel
 from ...views import ClaimViewMixin
 
-
 SESSION_TWITTER_API_KEY = 'twitter_api_key'
 SESSION_TWITTER_API_SECRET = 'twitter_api_secret'
 SESSION_TWITTER_OAUTH_TOKEN = 'twitter_oauth_token'
@@ -18,7 +17,6 @@ SESSION_TWITTER_OAUTH_SECRET = 'twitter_oauth_token_secret'
 
 
 class ClaimView(ClaimViewMixin, SmartTemplateView):
-
     def pre_process(self, *args, **kwargs):
         response = super(ClaimView, self).pre_process(*args, **kwargs)
 
@@ -43,9 +41,16 @@ class ClaimView(ClaimViewMixin, SmartTemplateView):
             del self.request.session[SESSION_TWITTER_OAUTH_SECRET]
 
             # check there isn't already a channel for this Twitter account
-            if self.org.channels.filter(channel_type=self.channel_type.code, address=screen_name, is_active=True).exists():
-                messages.error(self.request, _("A Twitter channel for that handle already exists, and must be removed"
-                                               "before another channel can be created for that handle."))
+            if self.org.channels.filter(
+                channel_type=self.channel_type.code, address=screen_name, is_active=True
+            ).exists():
+                messages.error(
+                    self.request,
+                    _(
+                        "A Twitter channel for that handle already exists, and must be removed"
+                        "before another channel can be created for that handle."
+                    )
+                )
                 return response
             else:
                 config = {
@@ -53,8 +58,15 @@ class ClaimView(ClaimViewMixin, SmartTemplateView):
                     'oauth_token': oauth_token,
                     'oauth_token_secret': oauth_token_secret
                 }
-                self.object = Channel.create(org, self.request.user, None, self.channel_type,
-                                             name="@%s" % screen_name, address=screen_name, config=config)
+                self.object = Channel.create(
+                    org,
+                    self.request.user,
+                    None,
+                    self.channel_type,
+                    name="@%s" % screen_name,
+                    address=screen_name,
+                    config=config
+                )
 
             return redirect(self.get_success_url())
 

--- a/temba/channels/types/twitter_activity/tasks.py
+++ b/temba/channels/types/twitter_activity/tasks.py
@@ -20,9 +20,9 @@ def resolve_twitter_ids():
 
     with r.lock('resolve_twitter_ids_task', 1800):
         # look up all 'twitter' URNs, limiting to 30k since that's the most our API would allow anyways
-        twitter_urns = ContactURN.objects.filter(scheme=TWITTER_SCHEME,
-                                                 contact__is_stopped=False,
-                                                 contact__is_blocked=False).exclude(contact=None)
+        twitter_urns = ContactURN.objects.filter(
+            scheme=TWITTER_SCHEME, contact__is_stopped=False, contact__is_blocked=False
+        ).exclude(contact=None)
         twitter_urns = twitter_urns[:30000].only('id', 'org', 'contact', 'path')
         api_key = settings.TWITTER_API_KEY
         api_secret = settings.TWITTER_API_SECRET

--- a/temba/channels/types/twitter_activity/tests.py
+++ b/temba/channels/types/twitter_activity/tests.py
@@ -17,14 +17,23 @@ class TwitterActivityTypeTest(TembaTest):
     def setUp(self):
         super(TwitterActivityTypeTest, self).setUp()
 
-        self.channel = Channel.create(self.org, self.user, None, 'TWT', name="Twitter Beta", address="beta_bob",
-                                      role="SR",
-                                      config={'api_key': 'ak1',
-                                              'api_secret': 'as1',
-                                              'access_token': 'at1',
-                                              'access_token_secret': 'ats1',
-                                              'handle_id': 'h123456',
-                                              'webhook_id': 'wh45678'})
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'TWT',
+            name="Twitter Beta",
+            address="beta_bob",
+            role="SR",
+            config={
+                'api_key': 'ak1',
+                'api_secret': 'as1',
+                'access_token': 'at1',
+                'access_token_secret': 'ats1',
+                'handle_id': 'h123456',
+                'webhook_id': 'wh45678'
+            }
+        )
 
     @override_settings(IS_PROD=True)
     @patch('temba.utils.twitter.TembaTwython.subscribe_to_webhook')
@@ -48,8 +57,10 @@ class TwitterActivityTypeTest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Connect Twitter Activity API")
 
-        self.assertEqual(list(response.context['form'].fields.keys()),
-                         ['api_key', 'api_secret', 'access_token', 'access_token_secret', 'loc'])
+        self.assertEqual(
+            list(response.context['form'].fields.keys()),
+            ['api_key', 'api_secret', 'access_token', 'access_token_secret', 'loc']
+        )
 
         # try submitting empty form
         response = self.client.post(url, {})
@@ -62,7 +73,14 @@ class TwitterActivityTypeTest(TembaTest):
         # try submitting with invalid credentials
         mock_verify_credentials.side_effect = TwythonError("Invalid credentials")
 
-        response = self.client.post(url, {'api_key': 'ak', 'api_secret': 'as', 'access_token': 'at', 'access_token_secret': 'ats'})
+        response = self.client.post(
+            url, {
+                'api_key': 'ak',
+                'api_secret': 'as',
+                'access_token': 'at',
+                'access_token_secret': 'ats'
+            }
+        )
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', None, "The provided Twitter credentials do not appear to be valid.")
 
@@ -70,7 +88,14 @@ class TwitterActivityTypeTest(TembaTest):
         mock_verify_credentials.side_effect = None
         mock_verify_credentials.return_value = {'id': '345678', 'screen_name': "beta_bob"}
 
-        response = self.client.post(url, {'api_key': 'ak', 'api_secret': 'as', 'access_token': 'at', 'access_token_secret': 'ats'})
+        response = self.client.post(
+            url, {
+                'api_key': 'ak',
+                'api_secret': 'as',
+                'access_token': 'at',
+                'access_token_secret': 'ats'
+            }
+        )
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', None, "A Twitter channel already exists for that handle.")
 
@@ -78,12 +103,27 @@ class TwitterActivityTypeTest(TembaTest):
         mock_verify_credentials.return_value = {'id': '87654', 'screen_name': "jimmy"}
         mock_register_webhook.return_value = {'id': "1234567"}
 
-        response = self.client.post(url, {'api_key': 'ak', 'api_secret': 'as', 'access_token': 'at', 'access_token_secret': 'ats'})
+        response = self.client.post(
+            url, {
+                'api_key': 'ak',
+                'api_secret': 'as',
+                'access_token': 'at',
+                'access_token_secret': 'ats'
+            }
+        )
         self.assertEqual(response.status_code, 302)
 
         channel = Channel.objects.get(address='jimmy')
-        self.assertEqual(json.loads(channel.config), {'handle_id': '87654', 'api_key': 'ak', 'api_secret': 'as',
-                                                      'access_token': 'at', 'access_token_secret': 'ats', 'webhook_id': '1234567'})
+        self.assertEqual(
+            json.loads(channel.config), {
+                'handle_id': '87654',
+                'api_key': 'ak',
+                'api_secret': 'as',
+                'access_token': 'at',
+                'access_token_secret': 'ats',
+                'webhook_id': '1234567'
+            }
+        )
 
         mock_register_webhook.assert_called_once_with('https://temba.ngrok.io/c/twt/%s/receive' % channel.uuid)
         mock_subscribe_to_webhook.assert_called_once_with("1234567")
@@ -140,7 +180,9 @@ class TwitterActivityTypeTest(TembaTest):
         self.assertEqual("twitterid:12345", old_fred.urns.all()[0].identity)
 
         self.jane = self.create_contact("jane", twitter="jane10")
-        mock_lookup_user.side_effect = Exception("Twitter API returned a 404 (Not Found), No user matches for specified terms.")
+        mock_lookup_user.side_effect = Exception(
+            "Twitter API returned a 404 (Not Found), No user matches for specified terms."
+        )
         resolve_twitter_ids()
 
         self.jane.refresh_from_db()

--- a/temba/channels/types/twitter_activity/type.py
+++ b/temba/channels/types/twitter_activity/type.py
@@ -23,8 +23,10 @@ class TwitterActivityType(ChannelType):
     name = "Twitter Activity API"
     icon = 'icon-twitter'
 
-    claim_blurb = _("""If you have access to the new <a href="https://dev.twitter.com/webhooks/account-activity">Twitter
-    Activity API</a> which is currently in beta, you can add a Twitter channel for that here.""")
+    claim_blurb = _(
+        """If you have access to the new <a href="https://dev.twitter.com/webhooks/account-activity">Twitter
+    Activity API</a> which is currently in beta, you can add a Twitter channel for that here."""
+    )
     claim_view = ClaimView
 
     update_form = UpdateTwitterForm
@@ -42,7 +44,9 @@ class TwitterActivityType(ChannelType):
 
     def activate(self, channel):
         config = channel.config_json()
-        client = TembaTwython(config['api_key'], config['api_secret'], config['access_token'], config['access_token_secret'])
+        client = TembaTwython(
+            config['api_key'], config['api_secret'], config['access_token'], config['access_token_secret']
+        )
 
         callback_url = 'https://%s%s' % (settings.HOSTNAME, reverse('courier.twt', args=[channel.uuid]))
         webhook = client.register_webhook(callback_url)
@@ -51,11 +55,13 @@ class TwitterActivityType(ChannelType):
         # save this webhook for later so we can delete it
         config['webhook_id'] = webhook['id']
         channel.config = json.dumps(config)
-        channel.save(update_fields=('config',))
+        channel.save(update_fields=('config', ))
 
     def deactivate(self, channel):
         config = channel.config_json()
-        client = TembaTwython(config['api_key'], config['api_secret'], config['access_token'], config['access_token_secret'])
+        client = TembaTwython(
+            config['api_key'], config['api_secret'], config['access_token'], config['access_token_secret']
+        )
 
         client.delete_webhook(config['webhook_id'])
 

--- a/temba/channels/types/twitter_activity/views.py
+++ b/temba/channels/types/twitter_activity/views.py
@@ -31,8 +31,9 @@ class ClaimView(ClaimViewMixin, SmartFormView):
                     user = twitter.verify_credentials()
 
                     # check there isn't already a channel for this Twitter account
-                    if org.channels.filter(channel_type=self.channel_type.code,
-                                           address=user['screen_name'], is_active=True).exists():
+                    if org.channels.filter(
+                        channel_type=self.channel_type.code, address=user['screen_name'], is_active=True
+                    ).exists():
                         raise ValidationError(_("A Twitter channel already exists for that handle."))
 
                 except TwythonError:
@@ -64,7 +65,14 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             'access_token_secret': access_token_secret
         }
 
-        self.object = Channel.create(org, self.request.user, None, self.channel_type, name="@%s" % screen_name,
-                                     address=screen_name, config=config)
+        self.object = Channel.create(
+            org,
+            self.request.user,
+            None,
+            self.channel_type,
+            name="@%s" % screen_name,
+            address=screen_name,
+            config=config
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -13,8 +13,19 @@ class ViberPublicTypeTest(TembaTest):
     def setUp(self):
         super(ViberPublicTypeTest, self).setUp()
 
-        self.channel = Channel.create(self.org, self.user, None, 'VP', name="Viber", address="12345",
-                                      role="SR", schemes=['viber'], config={'auth_token': 'abcd1234'})
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'VP',
+            name="Viber",
+            address="12345",
+            role="SR",
+            schemes=['viber'],
+            config={
+                'auth_token': 'abcd1234'
+            }
+        )
 
     @override_settings(IS_PROD=True)
     @patch('requests.post')
@@ -36,9 +47,22 @@ class ViberPublicTypeTest(TembaTest):
 
         # ok this time claim with a success
         mock_post.side_effect = [
-            MockResponse(200, json.dumps({'status': 0, 'status_message': "ok", 'id': "viberId", 'uri': "viberName"})),
-            MockResponse(200, json.dumps({'status': 0, 'status_message': "ok", 'id': "viberId", 'uri': "viberName"})),
-            MockResponse(200, json.dumps({'status': 0, 'status_message': "ok"}))
+            MockResponse(200, json.dumps({
+                'status': 0,
+                'status_message': "ok",
+                'id': "viberId",
+                'uri': "viberName"
+            })),
+            MockResponse(200, json.dumps({
+                'status': 0,
+                'status_message': "ok",
+                'id': "viberId",
+                'uri': "viberName"
+            })),
+            MockResponse(200, json.dumps({
+                'status': 0,
+                'status_message': "ok"
+            }))
         ]
 
         self.client.post(url, {'auth_token': '123456'}, follow=True)

--- a/temba/channels/types/viber_public/type.py
+++ b/temba/channels/types/viber_public/type.py
@@ -25,9 +25,11 @@ class ViberPublicType(ChannelType):
     name = "Viber"
     icon = 'icon-viber'
 
-    claim_blurb = _("""Connect a <a href="http://viber.com/en/">Viber</a> public channel to send and receive messages to
+    claim_blurb = _(
+        """Connect a <a href="http://viber.com/en/">Viber</a> public channel to send and receive messages to
     Viber users for free. Your users will need an Android, Windows or iOS device and a Viber account to send and receive
-    messages.""")
+    messages."""
+    )
     claim_view = ClaimView
 
     schemes = [VIBER_SCHEME]
@@ -39,11 +41,14 @@ class ViberPublicType(ChannelType):
         auth_token = channel.config_json()['auth_token']
         handler_url = "https://" + settings.HOSTNAME + reverse('courier.vp', args=[channel.uuid])
 
-        requests.post('https://chatapi.viber.com/pa/set_webhook', json={
-            'auth_token': auth_token,
-            'url': handler_url,
-            'event_types': ['delivered', 'failed', 'conversation_started']
-        })
+        requests.post(
+            'https://chatapi.viber.com/pa/set_webhook',
+            json={
+                'auth_token': auth_token,
+                'url': handler_url,
+                'event_types': ['delivered', 'failed', 'conversation_started']
+            }
+        )
 
     def deactivate(self, channel):
         auth_token = channel.config_json()['auth_token']
@@ -73,13 +78,13 @@ class ViberPublicType(ChannelType):
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code not in [200, 201, 202]:
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response [%d] from API" % response.status_code, event=event, start=start)
 
         # success is 0, everything else is a failure
         if response_json['status'] != 0:
-            raise SendException("Got non-0 status [%d] from API" % response_json['status'],
-                                event=event, fatal=True, start=start)
+            raise SendException(
+                "Got non-0 status [%d] from API" % response_json['status'], event=event, fatal=True, start=start
+            )
 
         external_id = response.json().get('message_token', None)
         Channel.success(channel, msg, WIRED, start, event=event, external_id=external_id)

--- a/temba/channels/types/viber_public/views.py
+++ b/temba/channels/types/viber_public/views.py
@@ -34,7 +34,8 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         address = response_json['id']
         config = {'auth_token': auth_token}
 
-        self.object = Channel.create(org, self.request.user, None, self.channel_type,
-                                     name=name, address=address, config=config)
+        self.object = Channel.create(
+            org, self.request.user, None, self.channel_type, name=name, address=address, config=config
+        )
 
         return super(ClaimView, self).form_valid(form)

--- a/temba/channels/types/vumi/tests.py
+++ b/temba/channels/types/vumi/tests.py
@@ -8,7 +8,6 @@ from ...models import Channel
 
 
 class VumiTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
         url = reverse('channels.claim_vumi')

--- a/temba/channels/types/vumi/type.py
+++ b/temba/channels/types/vumi/type.py
@@ -25,7 +25,9 @@ class VumiType(ChannelType):
 
     name = "Vumi"
 
-    claim_blurb = _("""Easily connect your <a href="http://vumi.com/">Vumi</a> account to take advantage of two way texting across different mediums.""")
+    claim_blurb = _(
+        """Easily connect your <a href="http://vumi.com/">Vumi</a> account to take advantage of two way texting across different mediums."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -54,16 +56,18 @@ class VumiType(ChannelType):
         if msg.response_to_id:
             in_reply_to = Msg.objects.values_list('external_id', flat=True).filter(pk=msg.response_to_id).first()
 
-        payload = dict(message_id=msg.id,
-                       in_reply_to=in_reply_to,
-                       session_event=session_event,
-                       to_addr=msg.urn_path,
-                       from_addr=channel.address,
-                       content=text,
-                       transport_name=channel.config['transport_name'],
-                       transport_type='ussd' if is_ussd else 'sms',
-                       transport_metadata={},
-                       helper_metadata={})
+        payload = dict(
+            message_id=msg.id,
+            in_reply_to=in_reply_to,
+            session_event=session_event,
+            to_addr=msg.urn_path,
+            from_addr=channel.address,
+            content=text,
+            transport_name=channel.config['transport_name'],
+            transport_type='ussd' if is_ussd else 'sms',
+            transport_metadata={},
+            helper_metadata={}
+        )
 
         payload = json.dumps(payload)
 
@@ -81,11 +85,13 @@ class VumiType(ChannelType):
         validator(url)
 
         try:
-            response = requests.put(url,
-                                    data=payload,
-                                    headers=headers,
-                                    timeout=30,
-                                    auth=(channel.config['account_key'], channel.config['access_token']))
+            response = requests.put(
+                url,
+                data=payload,
+                headers=headers,
+                timeout=30,
+                auth=(channel.config['account_key'], channel.config['access_token'])
+            )
 
             event.status_code = response.status_code
             event.response_body = response.text
@@ -103,8 +109,9 @@ class VumiType(ChannelType):
                 contact.stop(contact.modified_by)
                 fatal = True
 
-            raise SendException("Got non-200 response [%d] from API" % response.status_code,
-                                event=event, fatal=fatal, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from API" % response.status_code, event=event, fatal=fatal, start=start
+            )
 
         # parse our response
         body = response.json()

--- a/temba/channels/types/vumi/views.py
+++ b/temba/channels/types/vumi/views.py
@@ -11,16 +11,28 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class Form(ClaimViewMixin.Form):
-            country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                        help_text=_("The country this phone number is used in"))
-            number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                     help_text=_("The phone number with country code or short code you are connecting. ex: +250788123124 or 15543"))
-            account_key = forms.CharField(label=_("Account Key"),
-                                          help_text=_("Your Vumi account key as found under Account -> Details"))
-            conversation_key = forms.CharField(label=_("Conversation Key"),
-                                               help_text=_("The key for your Vumi conversation, can be found in the URL"))
-            api_url = forms.URLField(label=_("API URL"), required=False,
-                                     help_text=_("Custom VUMI API Endpoint. Leave blank to use default of: '%s'" % Channel.VUMI_GO_API_URL))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_(
+                "The phone number with country code or short code you are connecting. ex: +250788123124 or 15543"
+            )
+        )
+        account_key = forms.CharField(
+            label=_("Account Key"), help_text=_("Your Vumi account key as found under Account -> Details")
+        )
+        conversation_key = forms.CharField(
+            label=_("Conversation Key"), help_text=_("The key for your Vumi conversation, can be found in the URL")
+        )
+        api_url = forms.URLField(
+            label=_("API URL"),
+            required=False,
+            help_text=_("Custom VUMI API Endpoint. Leave blank to use default of: '%s'" % Channel.VUMI_GO_API_URL)
+        )
 
     form_class = Form
 
@@ -36,12 +48,19 @@ class ClaimView(AuthenticatedExternalClaimView):
         else:
             api_url = data.get('api_url')
 
-        self.object = Channel.add_config_external_channel(org, self.request.user,
-                                                          data['country'], data['number'], 'VM',
-                                                          dict(account_key=data['account_key'],
-                                                               access_token=str(uuid4()),
-                                                               conversation_key=data['conversation_key'],
-                                                               api_url=api_url),
-                                                          role=Channel.DEFAULT_ROLE)
+        self.object = Channel.add_config_external_channel(
+            org,
+            self.request.user,
+            data['country'],
+            data['number'],
+            'VM',
+            dict(
+                account_key=data['account_key'],
+                access_token=str(uuid4()),
+                conversation_key=data['conversation_key'],
+                api_url=api_url
+            ),
+            role=Channel.DEFAULT_ROLE
+        )
 
         return super(AuthenticatedExternalClaimView, self).form_valid(form)

--- a/temba/channels/types/vumi_ussd/tests.py
+++ b/temba/channels/types/vumi_ussd/tests.py
@@ -8,7 +8,6 @@ from ...models import Channel
 
 
 class VumiUSSDTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/vumi_ussd/type.py
+++ b/temba/channels/types/vumi_ussd/type.py
@@ -20,7 +20,9 @@ class VumiUSSDType(ChannelType):
     name = "Vumi USSD"
     slug = 'vumi_ussd'
 
-    claim_blurb = _("""Easily connect your <a href="http://go.vumi.org/">Vumi</a> account to take advantage of session based messaging across USSD transports.""")
+    claim_blurb = _(
+        """Easily connect your <a href="http://go.vumi.org/">Vumi</a> account to take advantage of session based messaging across USSD transports."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]

--- a/temba/channels/types/vumi_ussd/views.py
+++ b/temba/channels/types/vumi_ussd/views.py
@@ -11,16 +11,28 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class Form(ClaimViewMixin.Form):
-            country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                        help_text=_("The country this phone number is used in"))
-            number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                     help_text=_("The phone number with country code or short code you are connecting. ex: +250788123124 or 15543"))
-            account_key = forms.CharField(label=_("Account Key"),
-                                          help_text=_("Your Vumi account key as found under Account -> Details"))
-            conversation_key = forms.CharField(label=_("Conversation Key"),
-                                               help_text=_("The key for your Vumi conversation, can be found in the URL"))
-            api_url = forms.URLField(label=_("API URL"), required=False,
-                                     help_text=_("Custom VUMI API Endpoint. Leave blank to use default of: '%s'" % Channel.VUMI_GO_API_URL))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_(
+                "The phone number with country code or short code you are connecting. ex: +250788123124 or 15543"
+            )
+        )
+        account_key = forms.CharField(
+            label=_("Account Key"), help_text=_("Your Vumi account key as found under Account -> Details")
+        )
+        conversation_key = forms.CharField(
+            label=_("Conversation Key"), help_text=_("The key for your Vumi conversation, can be found in the URL")
+        )
+        api_url = forms.URLField(
+            label=_("API URL"),
+            required=False,
+            help_text=_("Custom VUMI API Endpoint. Leave blank to use default of: '%s'" % Channel.VUMI_GO_API_URL)
+        )
 
     form_class = Form
 
@@ -36,12 +48,19 @@ class ClaimView(AuthenticatedExternalClaimView):
         else:
             api_url = data.get('api_url')
 
-        self.object = Channel.add_config_external_channel(org, self.request.user,
-                                                          data['country'], data['number'], 'VMU',
-                                                          dict(account_key=data['account_key'],
-                                                               access_token=str(uuid4()),
-                                                               conversation_key=data['conversation_key'],
-                                                               api_url=api_url),
-                                                          role=Channel.ROLE_USSD)
+        self.object = Channel.add_config_external_channel(
+            org,
+            self.request.user,
+            data['country'],
+            data['number'],
+            'VMU',
+            dict(
+                account_key=data['account_key'],
+                access_token=str(uuid4()),
+                conversation_key=data['conversation_key'],
+                api_url=api_url
+            ),
+            role=Channel.ROLE_USSD
+        )
 
         return super(AuthenticatedExternalClaimView, self).form_valid(form)

--- a/temba/channels/types/yo/tests.py
+++ b/temba/channels/types/yo/tests.py
@@ -6,7 +6,6 @@ from ...models import Channel
 
 
 class YoTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/yo/type.py
+++ b/temba/channels/types/yo/type.py
@@ -30,8 +30,10 @@ class YoType(ChannelType):
     name = "YO!"
     slug = 'yo'
 
-    claim_blurb = _("""If you are based in Uganda, you can integrate with <a href="http://www.yo.co.ug/">Yo!</a> to send
-                    and receive messages on your shortcode.""")
+    claim_blurb = _(
+        """If you are based in Uganda, you can integrate with <a href="http://www.yo.co.ug/">Yo!</a> to send
+                    and receive messages on your shortcode."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -48,11 +50,13 @@ class YoType(ChannelType):
     def send(self, channel, msg, text):
 
         # build our message dict
-        params = dict(origin=channel.address.lstrip('+'),
-                      sms_content=text,
-                      destinations=msg.urn_path.lstrip('+'),
-                      ybsacctno=channel.config['username'],
-                      password=channel.config['password'])
+        params = dict(
+            origin=channel.address.lstrip('+'),
+            sms_content=text,
+            destinations=msg.urn_path.lstrip('+'),
+            ybsacctno=channel.config['username'],
+            password=channel.config['password']
+        )
         log_params = params.copy()
         log_params['password'] = 'x' * len(log_params['password'])
 
@@ -97,7 +101,6 @@ class YoType(ChannelType):
                 break
 
         if failed:
-            raise SendException("Received error from Yo! API",
-                                events=events, fatal=fatal, start=start)
+            raise SendException("Received error from Yo! API", events=events, fatal=fatal, start=start)
 
         Channel.success(channel, msg, SENT, start, events=events)

--- a/temba/channels/types/yo/views.py
+++ b/temba/channels/types/yo/views.py
@@ -10,15 +10,18 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin, AuthenticatedExt
 
 class ClaimView(AuthenticatedExternalClaimView):
     class YoClaimForm(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_("The phone number or short code you are connecting with country code. "
-                                             "ex: +250788123124"))
-        username = forms.CharField(label=_("Account Number"),
-                                   help_text=_("Your Yo! account YBS account number"))
-        password = forms.CharField(label=_("Gateway Password"),
-                                   help_text=_("Your Yo! SMS Gateway password"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_("The phone number or short code you are connecting with country code. "
+                        "ex: +250788123124")
+        )
+        username = forms.CharField(label=_("Account Number"), help_text=_("Your Yo! account YBS account number"))
+        password = forms.CharField(label=_("Gateway Password"), help_text=_("Your Yo! SMS Gateway password"))
 
         def clean_number(self):
             number = self.data['number']
@@ -36,7 +39,8 @@ class ClaimView(AuthenticatedExternalClaimView):
                 return phonenumbers.format_number(cleaned, phonenumbers.PhoneNumberFormat.E164)
             except Exception:  # pragma: needs cover
                 raise forms.ValidationError(
-                    _("Invalid phone number, please include the country code. ex: +250788123123"))
+                    _("Invalid phone number, please include the country code. ex: +250788123123")
+                )
 
     form_class = YoClaimForm
 

--- a/temba/channels/types/zenvia/tests.py
+++ b/temba/channels/types/zenvia/tests.py
@@ -7,7 +7,6 @@ from ...models import Channel
 
 
 class ZenviaTypeTest(TembaTest):
-
     def test_claim(self):
         Channel.objects.all().delete()
 

--- a/temba/channels/types/zenvia/type.py
+++ b/temba/channels/types/zenvia/type.py
@@ -24,7 +24,9 @@ class ZenviaType(ChannelType):
 
     name = "Zenvia"
 
-    claim_blurb = _("""If you are based in Brazil, you can purchase a short code from <a href="http://www.zenvia.com.br/">Zenvia</a> and connect it in a few simple steps.""")
+    claim_blurb = _(
+        """If you are based in Brazil, you can purchase a short code from <a href="http://www.zenvia.com.br/">Zenvia</a> and connect it in a few simple steps."""
+    )
     claim_view = ClaimView
 
     schemes = [TEL_SCHEME]
@@ -40,13 +42,15 @@ class ZenviaType(ChannelType):
         # Zenvia accepts messages via a GET
         # http://www.zenvia360.com.br/GatewayIntegration/msgSms.do?dispatch=send&account=temba&
         # code=abc123&to=5511996458779&msg=my message content&id=123&callbackOption=1
-        payload = dict(dispatch='send',
-                       account=channel.config['account'],
-                       code=channel.config['code'],
-                       msg=text,
-                       to=msg.urn_path,
-                       id=msg.id,
-                       callbackOption=1)
+        payload = dict(
+            dispatch='send',
+            account=channel.config['account'],
+            code=channel.config['code'],
+            msg=text,
+            to=msg.urn_path,
+            id=msg.id,
+            callbackOption=1
+        )
 
         zenvia_url = "http://www.zenvia360.com.br/GatewayIntegration/msgSms.do"
         headers = http_headers(extra={'Content-Type': "text/html", 'Accept-Charset': 'ISO-8859-1'})
@@ -61,12 +65,10 @@ class ZenviaType(ChannelType):
             event.response_body = response.text
 
         except Exception as e:
-            raise SendException(u"Unable to send message: %s" % six.text_type(e),
-                                event=event, start=start)
+            raise SendException(u"Unable to send message: %s" % six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201:
-            raise SendException("Got non-200 response from API: %d" % response.status_code,
-                                event=event, start=start)
+            raise SendException("Got non-200 response from API: %d" % response.status_code, event=event, start=start)
 
         response_code = int(response.text[:3])
 

--- a/temba/channels/types/zenvia/views.py
+++ b/temba/channels/types/zenvia/views.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, absolute_import
 
-
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from smartmin.views import SmartFormView
@@ -10,12 +9,9 @@ from ...views import ClaimViewMixin
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class ZVClaimForm(ClaimViewMixin.Form):
-        shortcode = forms.CharField(max_length=6, min_length=1,
-                                    help_text=_("The Zenvia short code"))
-        account = forms.CharField(max_length=32,
-                                  help_text=_("Your account name on Zenvia"))
-        code = forms.CharField(max_length=64,
-                               help_text=_("Your api code on Zenvia for authentication"))
+        shortcode = forms.CharField(max_length=6, min_length=1, help_text=_("The Zenvia short code"))
+        account = forms.CharField(max_length=32, help_text=_("Your account name on Zenvia"))
+        code = forms.CharField(max_length=64, help_text=_("Your api code on Zenvia for authentication"))
 
     form_class = ZVClaimForm
 

--- a/temba/channels/urls.py
+++ b/temba/channels/urls.py
@@ -8,7 +8,6 @@ from .handlers import SMSCentralHandler, MageHandler, YoHandler, get_channel_han
 from .models import Channel
 from .views import ChannelCRUDL, ChannelEventCRUDL, ChannelLogCRUDL
 
-
 claim_page_urls = [ch_type.get_claim_url() for ch_type in Channel.get_types() if ch_type.claim_view]
 
 courier_urls = []
@@ -25,33 +24,47 @@ for handler in get_channel_handlers():
 
 urlpatterns = [
     url(r'^', include(ChannelEventCRUDL().as_urlpatterns())),
-
     url(r'^channels/', include(ChannelCRUDL().as_urlpatterns() + ChannelLogCRUDL().as_urlpatterns())),
-
     url(r'^channels/', include(claim_page_urls)),
-
     url(r'^c/', include(courier_urls)),
     url(r'^handlers/', include(handler_urls)),
 
     # for backwards compatibility these channel handlers are exposed at /api/v1 as well
-    url(r'^api/v1/', include([
-        url(r'^verboice/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', VerboiceHandler.as_view()),
-        url(r'^africastalking/(?P<action>delivery|callback)/(?P<uuid>[a-z0-9\-]+)/$', AfricasTalkingHandler.as_view()),
-        url(r'^zenvia/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$', ZenviaHandler.as_view()),
-        url(r'^external/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/$', ExternalHandler.as_view()),
-        url(r'^shaqodoon/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/$', ShaqodoonHandler.as_view()),
-        url(r'^nexmo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$', NexmoHandler.as_view()),
-        url(r'^infobip/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$', InfobipHandler.as_view()),
-        url(r'^hub9/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$', Hub9Handler.as_view()),
-        url(r'^vumi/(?P<action>event|receive)/(?P<uuid>[a-z0-9\-]+)/?$', VumiHandler.as_view()),
-        url(r'^kannel/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', KannelHandler.as_view()),
-        url(r'^clickatell/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', ClickatellHandler.as_view()),
-        url(r'^plivo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', PlivoHandler.as_view()),
-        url(r'^hcnx/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', HighConnectionHandler.as_view()),
-        url(r'^blackmyna/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', BlackmynaHandler.as_view()),
-        url(r'^smscentral/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$', SMSCentralHandler.as_view()),
-        url(r'^m3tech/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$', M3TechHandler.as_view()),
-        url(r'^yo/(?P<action>received)/(?P<uuid>[a-z0-9\-]+)/?$', YoHandler.as_view()),
-        url(r'^mage/(?P<action>handle_message|follow_notification|stop_contact)$', MageHandler.as_view())
-    ]))
+    url(
+        r'^api/v1/',
+        include([
+            url(r'^verboice/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', VerboiceHandler.as_view()),
+            url(
+                r'^africastalking/(?P<action>delivery|callback)/(?P<uuid>[a-z0-9\-]+)/$',
+                AfricasTalkingHandler.as_view()
+            ),
+            url(r'^zenvia/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$', ZenviaHandler.as_view()),
+            url(
+                r'^external/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/$',
+                ExternalHandler.as_view()
+            ),
+            url(
+                r'^shaqodoon/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/$',
+                ShaqodoonHandler.as_view()
+            ),
+            url(r'^nexmo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/$', NexmoHandler.as_view()),
+            url(
+                r'^infobip/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$',
+                InfobipHandler.as_view()
+            ),
+            url(r'^hub9/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$', Hub9Handler.as_view()),
+            url(r'^vumi/(?P<action>event|receive)/(?P<uuid>[a-z0-9\-]+)/?$', VumiHandler.as_view()),
+            url(r'^kannel/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', KannelHandler.as_view()),
+            url(r'^clickatell/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', ClickatellHandler.as_view()),
+            url(r'^plivo/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', PlivoHandler.as_view()),
+            url(r'^hcnx/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', HighConnectionHandler.as_view()),
+            url(r'^blackmyna/(?P<action>status|receive)/(?P<uuid>[a-z0-9\-]+)/?$', BlackmynaHandler.as_view()),
+            url(r'^smscentral/(?P<action>receive)/(?P<uuid>[a-z0-9\-]+)/?$', SMSCentralHandler.as_view()),
+            url(
+                r'^m3tech/(?P<action>sent|delivered|failed|received)/(?P<uuid>[a-z0-9\-]+)/?$', M3TechHandler.as_view()
+            ),
+            url(r'^yo/(?P<action>received)/(?P<uuid>[a-z0-9\-]+)/?$', YoHandler.as_view()),
+            url(r'^mage/(?P<action>handle_message|follow_notification|stop_contact)$', MageHandler.as_view())
+        ])
+    )
 ]

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -37,430 +37,432 @@ from temba.utils import analytics
 from twilio import TwilioRestException
 from .models import Channel, ChannelEvent, SyncEvent, Alert, ChannelLog, ChannelCount
 
-
 COUNTRIES_NAMES = {key: value for key, value in COUNTRIES.iteritems()}
 COUNTRIES_NAMES['GB'] = _("United Kingdom")
 COUNTRIES_NAMES['US'] = _("United States")
-
 
 COUNTRY_CALLING_CODES = {
     "AF": (93, ),  # Afghanistan
     "AX": (35818, ),  # Åland Islands
     "AL": (355, ),  # Albania
-    "DZ": (213,),  # Algeria
-    "AS": (1684,),  # American Samoa
-    "AD": (376,),  # Andorra
-    "AO": (244,),  # Angola
-    "AI": (1264,),  # Anguilla
+    "DZ": (213, ),  # Algeria
+    "AS": (1684, ),  # American Samoa
+    "AD": (376, ),  # Andorra
+    "AO": (244, ),  # Angola
+    "AI": (1264, ),  # Anguilla
     "AQ": (),  # Antarctica
-    "AG": (1268,),  # Antigua and Barbuda
-    "AR": (54,),  # Argentina
-    "AM": (374,),  # Armenia
-    "AW": (297,),  # Aruba
-    "AU": (61,),  # Australia
-    "AT": (43,),  # Austria
-    "AZ": (994,),  # Azerbaijan
-    "BS": (1242,),  # Bahamas
-    "BH": (973,),  # Bahrain
-    "BD": (880,),  # Bangladesh
-    "BB": (1246,),  # Barbados
-    "BY": (375,),  # Belarus
-    "BE": (32,),  # Belgium
-    "BZ": (501,),  # Belize
-    "BJ": (229,),  # Benin
-    "BM": (1441,),  # Bermuda
-    "BT": (975,),  # Bhutan
-    "BO": (591,),  # Bolivia (Plurinational State of)
-    "BQ": (5997,),  # Bonaire, Sint Eustatius and Saba
-    "BA": (387,),  # Bosnia and Herzegovina
-    "BW": (267,),  # Botswana
+    "AG": (1268, ),  # Antigua and Barbuda
+    "AR": (54, ),  # Argentina
+    "AM": (374, ),  # Armenia
+    "AW": (297, ),  # Aruba
+    "AU": (61, ),  # Australia
+    "AT": (43, ),  # Austria
+    "AZ": (994, ),  # Azerbaijan
+    "BS": (1242, ),  # Bahamas
+    "BH": (973, ),  # Bahrain
+    "BD": (880, ),  # Bangladesh
+    "BB": (1246, ),  # Barbados
+    "BY": (375, ),  # Belarus
+    "BE": (32, ),  # Belgium
+    "BZ": (501, ),  # Belize
+    "BJ": (229, ),  # Benin
+    "BM": (1441, ),  # Bermuda
+    "BT": (975, ),  # Bhutan
+    "BO": (591, ),  # Bolivia (Plurinational State of)
+    "BQ": (5997, ),  # Bonaire, Sint Eustatius and Saba
+    "BA": (387, ),  # Bosnia and Herzegovina
+    "BW": (267, ),  # Botswana
     "BV": (),  # Bouvet Island
-    "BR": (55,),  # Brazil
-    "IO": (246,),  # British Indian Ocean Territory
-    "BN": (673,),  # Brunei Darussalam
-    "BG": (359,),  # Bulgaria
-    "BF": (226,),  # Burkina Faso
-    "BI": (257,),  # Burundi
-    "CV": (238,),  # Cabo Verde
-    "KH": (855,),  # Cambodia
-    "CM": (237,),  # Cameroon
-    "CA": (1,),  # Canada
-    "KY": (1345,),  # Cayman Islands
-    "CF": (236,),  # Central African Republic
-    "TD": (235,),  # Chad
-    "CL": (56,),  # Chile
-    "CN": (86,),  # China
-    "CX": (6189164,),  # Christmas Island
-    "CC": (6189162,),  # Cocos (Keeling) Islands
-    "CO": (57,),  # Colombia
-    "KM": (269,),  # Comoros
-    "CD": (243,),  # Congo (the Democratic Republic of the)
-    "CG": (242,),  # Congo
-    "CK": (682,),  # Cook Islands
-    "CR": (506,),  # Costa Rica
-    "CI": (225,),  # Côte d'Ivoire
-    "HR": (385,),  # Croatia
-    "CU": (53,),  # Cuba
-    "CW": (5999,),  # Curaçao
-    "CY": (357,),  # Cyprus
-    "CZ": (420,),  # Czech Republic
-    "DK": (45,),  # Denmark
-    "DJ": (253,),  # Djibouti
-    "DM": (1767,),  # Dominica
+    "BR": (55, ),  # Brazil
+    "IO": (246, ),  # British Indian Ocean Territory
+    "BN": (673, ),  # Brunei Darussalam
+    "BG": (359, ),  # Bulgaria
+    "BF": (226, ),  # Burkina Faso
+    "BI": (257, ),  # Burundi
+    "CV": (238, ),  # Cabo Verde
+    "KH": (855, ),  # Cambodia
+    "CM": (237, ),  # Cameroon
+    "CA": (1, ),  # Canada
+    "KY": (1345, ),  # Cayman Islands
+    "CF": (236, ),  # Central African Republic
+    "TD": (235, ),  # Chad
+    "CL": (56, ),  # Chile
+    "CN": (86, ),  # China
+    "CX": (6189164, ),  # Christmas Island
+    "CC": (6189162, ),  # Cocos (Keeling) Islands
+    "CO": (57, ),  # Colombia
+    "KM": (269, ),  # Comoros
+    "CD": (243, ),  # Congo (the Democratic Republic of the)
+    "CG": (242, ),  # Congo
+    "CK": (682, ),  # Cook Islands
+    "CR": (506, ),  # Costa Rica
+    "CI": (225, ),  # Côte d'Ivoire
+    "HR": (385, ),  # Croatia
+    "CU": (53, ),  # Cuba
+    "CW": (5999, ),  # Curaçao
+    "CY": (357, ),  # Cyprus
+    "CZ": (420, ),  # Czech Republic
+    "DK": (45, ),  # Denmark
+    "DJ": (253, ),  # Djibouti
+    "DM": (1767, ),  # Dominica
     "DO": (1809, 1829, 1849),  # Dominican Republic
-    "EC": (539,),  # Ecuador
-    "EG": (20,),  # Egypt
-    "SV": (503,),  # El Salvador
-    "GQ": (240,),  # Equatorial Guinea
-    "ER": (291,),  # Eritrea
-    "EE": (372,),  # Estonia
-    "ET": (251,),  # Ethiopia
-    "FK": (500,),  # Falkland Islands  [Malvinas]
-    "FO": (298,),  # Faroe Islands
-    "FJ": (679,),  # Fiji
-    "FI": (358,),  # Finland
-    "FR": (33,),  # France
-    "GF": (594,),  # French Guiana
-    "PF": (689,),  # French Polynesia
+    "EC": (539, ),  # Ecuador
+    "EG": (20, ),  # Egypt
+    "SV": (503, ),  # El Salvador
+    "GQ": (240, ),  # Equatorial Guinea
+    "ER": (291, ),  # Eritrea
+    "EE": (372, ),  # Estonia
+    "ET": (251, ),  # Ethiopia
+    "FK": (500, ),  # Falkland Islands  [Malvinas]
+    "FO": (298, ),  # Faroe Islands
+    "FJ": (679, ),  # Fiji
+    "FI": (358, ),  # Finland
+    "FR": (33, ),  # France
+    "GF": (594, ),  # French Guiana
+    "PF": (689, ),  # French Polynesia
     "TF": (),  # French Southern Territories
-    "GA": (241,),  # Gabon
-    "GM": (220,),  # Gambia
-    "GE": (995,),  # Georgia
-    "DE": (49,),  # Germany
-    "GH": (233,),  # Ghana
-    "GI": (350,),  # Gibraltar
-    "GR": (30,),  # Greece
-    "GL": (299,),  # Greenland
-    "GD": (1473,),  # Grenada
-    "GP": (590,),  # Guadeloupe
-    "GU": (1671,),  # Guam
-    "GT": (502,),  # Guatemala
+    "GA": (241, ),  # Gabon
+    "GM": (220, ),  # Gambia
+    "GE": (995, ),  # Georgia
+    "DE": (49, ),  # Germany
+    "GH": (233, ),  # Ghana
+    "GI": (350, ),  # Gibraltar
+    "GR": (30, ),  # Greece
+    "GL": (299, ),  # Greenland
+    "GD": (1473, ),  # Grenada
+    "GP": (590, ),  # Guadeloupe
+    "GU": (1671, ),  # Guam
+    "GT": (502, ),  # Guatemala
     "GG": (441481, 447781, 447839, 447911),  # Guernsey
-    "GN": (224,),  # Guinea
-    "GW": (245,),  # Guinea-Bissau
-    "GY": (592,),  # Guyana
-    "HT": (509,),  # Haiti
+    "GN": (224, ),  # Guinea
+    "GW": (245, ),  # Guinea-Bissau
+    "GY": (592, ),  # Guyana
+    "HT": (509, ),  # Haiti
     "HM": (),  # Heard Island and McDonald Islands
     "VA": (379, 3906698),  # Holy See
-    "HN": (504,),  # Honduras
-    "HK": (852,),  # Hong Kong
-    "HU": (36,),  # Hungary
-    "IS": (354,),  # Iceland
-    "IN": (91,),  # India
-    "ID": (62,),  # Indonesia
-    "IR": (98,),  # Iran (Islamic Republic of)
-    "IQ": (964,),  # Iraq
-    "IE": (353,),  # Ireland
+    "HN": (504, ),  # Honduras
+    "HK": (852, ),  # Hong Kong
+    "HU": (36, ),  # Hungary
+    "IS": (354, ),  # Iceland
+    "IN": (91, ),  # India
+    "ID": (62, ),  # Indonesia
+    "IR": (98, ),  # Iran (Islamic Republic of)
+    "IQ": (964, ),  # Iraq
+    "IE": (353, ),  # Ireland
     "IM": (441624, 447524, 447624, 447924),  # Isle of Man
-    "IL": (972,),  # Israel
-    "IT": (39,),  # Italy
-    "JM": (1876,),  # Jamaica
-    "JP": (81,),  # Japan
-    "JE": (441534,),  # Jersey
-    "JO": (962,),  # Jordan
+    "IL": (972, ),  # Israel
+    "IT": (39, ),  # Italy
+    "JM": (1876, ),  # Jamaica
+    "JP": (81, ),  # Japan
+    "JE": (441534, ),  # Jersey
+    "JO": (962, ),  # Jordan
     "KZ": (76, 77),  # Kazakhstan
-    "KE": (254,),  # Kenya
-    "KI": (686,),  # Kiribati
-    "KP": (850,),  # Korea (the Democratic People's Republic of)
-    "KR": (82,),  # Korea (the Republic of)
-    "KW": (965,),  # Kuwait
-    "KG": (996,),  # Kyrgyzstan
-    "LA": (856,),  # Lao People's Democratic Republic
-    "LV": (371,),  # Latvia
-    "LB": (961,),  # Lebanon
-    "LS": (266,),  # Lesotho
-    "LR": (231,),  # Liberia
-    "LY": (218,),  # Libya
-    "LI": (423,),  # Liechtenstein
-    "LT": (370,),  # Lithuania
-    "LU": (352,),  # Luxembourg
-    "MO": (853,),  # Macao
-    "MK": (389,),  # Macedonia (the former Yugoslav Republic of)
-    "MG": (261,),  # Madagascar
-    "MW": (265,),  # Malawi
-    "MY": (60,),  # Malaysia
-    "MV": (960,),  # Maldives
-    "ML": (223,),   # Mali
-    "MT": (356,),   # Malta
-    "MH": (692,),   # Marshall Islands
-    "MQ": (596,),   # Martinique
-    "MR": (222,),   # Mauritania
-    "MU": (230,),   # Mauritius
-    "YT": (262269, 262639),   # Mayotte
-    "MX": (52,),   # Mexico
-    "FM": (691,),   # Micronesia (Federated States of)
-    "MD": (373,),   # Moldova (the Republic of)
-    "MC": (377,),   # Monaco
-    "MN": (976,),   # Mongolia
-    "ME": (382,),   # Montenegro
-    "MS": (1664,),   # Montserrat
-    "MA": (212,),   # Morocco
-    "MZ": (258,),   # Mozambique
-    "MM": (95,),   # Myanmar
-    "NA": (264,),   # Namibia
-    "NR": (674,),   # Nauru
-    "NP": (977,),   # Nepal
-    "NL": (31,),   # Netherlands
-    "NC": (687,),   # New Caledonia
-    "NZ": (64,),   # New Zealand
-    "NI": (505,),   # Nicaragua
-    "NE": (227,),   # Niger
-    "NG": (243,),   # Nigeria
-    "NU": (683,),   # Niue
-    "NF": (6723,),   # Norfolk Island
-    "MP": (1670,),   # Northern Mariana Islands
-    "NO": (47,),   # Norway
-    "OM": (968,),   # Oman
-    "PK": (92,),   # Pakistan
-    "PW": (680,),   # Palau
-    "PS": (970,),   # Palestine, State of
-    "PA": (507,),   # Panama
-    "PG": (675,),   # Papua New Guinea
-    "PY": (595,),   # Paraguay
-    "PE": (51,),   # Peru
-    "PH": (63,),  # _("Philippines
-    "PN": (64,),   # Pitcairn
-    "PL": (48,),   # Poland
-    "PT": (351,),   # Portugal
-    "PR": (1787, 1939),   # Puerto Rico
-    "QA": (974,),   # Qatar
-    "RE": (262,),   # Réunion
-    "RO": (40,),   # Romania
-    "RU": (7,),   # Russian Federation
-    "RW": (250,),   # Rwanda
-    "BL": (590,),  # _("Saint Barthélemy
-    "SH": (290,),   # Saint Helena, Ascension and Tristan da Cunha
-    "KN": (1869,),   # Saint Kitts and Nevis
-    "LC": (1758,),   # Saint Lucia
-    "MF": (590,),   # Saint Martin (French part)
-    "PM": (508,),   # Saint Pierre and Miquelon
-    "VC": (1784,),   # Saint Vincent and the Grenadines
-    "WS": (685,),   # Samoa
-    "SM": (378,),   # San Marino
-    "ST": (239,),   # Sao Tome and Principe
-    "SA": (966,),   # Saudi Arabia
-    "SN": (221,),   # Senegal
-    "RS": (381,),   # Serbia
-    "SC": (248,),   # Seychelles
-    "SL": (232,),   # Sierra Leone
-    "SG": (65,),   # Singapore
-    "SX": (1721,),   # Sint Maarten (Dutch part)
-    "SK": (421,),   # Slovakia
-    "SI": (386,),  # Slovenia
-    "SB": (677,),   # Solomon Islands
-    "SO": (252,),   # Somalia
-    "ZA": (27,),   # South Africa
-    "GS": (500,),   # South Georgia and the South Sandwich Islands
-    "SS": (211,),   # South Sudan
-    "ES": (34,),   # Spain
-    "LK": (94,),   # Sri Lanka
-    "SD": (249,),   # Sudan
-    "SR": (597,),   # Suriname
-    "SJ": (4779,),   # Svalbard and Jan Mayen
-    "SZ": (268,),   # Swaziland
-    "SE": (46,),   # Sweden
-    "CH": (41,),   # Switzerland
-    "SY": (963,),   # Syrian Arab Republic
-    "TW": (886,),   # Taiwan (Province of China)
-    "TJ": (992,),   # Tajikistan
-    "TZ": (255,),   # Tanzania, United Republic of
-    "TH": (66,),   # Thailand
-    "TL": (),   # Timor-Leste
-    "TG": (228,),   # Togo
-    "TK": (690,),   # Tokelau
-    "TO": (676,),   # Tonga
-    "TT": (1868,),   # Trinidad and Tobago
-    "TN": (216,),   # Tunisia
-    "TR": (90,),   # Turkey
-    "TM": (993,),   # Turkmenistan
-    "TC": (1649,),   # Turks and Caicos Islands
-    "TV": (668,),   # Tuvalu
-    "UG": (256,),   # Uganda
-    "UA": (380,),   # Ukraine
-    "AE": (971,),   # United Arab Emirates
-    "GB": (44,),   # United Kingdom of Great Britain and Northern Ireland
-    "UM": (),   # United States Minor Outlying Islands
-    "US": (1,),   # United States of America
-    "UY": (598,),   # Uruguay
-    "UZ": (998,),   # Uzbekistan
-    "VU": (678,),   # Vanuatu
-    "VE": (58,),   # Venezuela (Bolivarian Republic of)
-    "VN": (84,),   # Viet Nam
-    "VG": (),   # Virgin Islands (British)
-    "VI": (),   # Virgin Islands (U.S.)
-    "WF": (681,),   # Wallis and Futuna
-    "EH": (),   # Western Sahara
-    "YE": (967,),   # Yemen
-    "ZM": (260,),   # Zambia
-    "ZW": (263,),   # Zimbabwe
+    "KE": (254, ),  # Kenya
+    "KI": (686, ),  # Kiribati
+    "KP": (850, ),  # Korea (the Democratic People's Republic of)
+    "KR": (82, ),  # Korea (the Republic of)
+    "KW": (965, ),  # Kuwait
+    "KG": (996, ),  # Kyrgyzstan
+    "LA": (856, ),  # Lao People's Democratic Republic
+    "LV": (371, ),  # Latvia
+    "LB": (961, ),  # Lebanon
+    "LS": (266, ),  # Lesotho
+    "LR": (231, ),  # Liberia
+    "LY": (218, ),  # Libya
+    "LI": (423, ),  # Liechtenstein
+    "LT": (370, ),  # Lithuania
+    "LU": (352, ),  # Luxembourg
+    "MO": (853, ),  # Macao
+    "MK": (389, ),  # Macedonia (the former Yugoslav Republic of)
+    "MG": (261, ),  # Madagascar
+    "MW": (265, ),  # Malawi
+    "MY": (60, ),  # Malaysia
+    "MV": (960, ),  # Maldives
+    "ML": (223, ),  # Mali
+    "MT": (356, ),  # Malta
+    "MH": (692, ),  # Marshall Islands
+    "MQ": (596, ),  # Martinique
+    "MR": (222, ),  # Mauritania
+    "MU": (230, ),  # Mauritius
+    "YT": (262269, 262639),  # Mayotte
+    "MX": (52, ),  # Mexico
+    "FM": (691, ),  # Micronesia (Federated States of)
+    "MD": (373, ),  # Moldova (the Republic of)
+    "MC": (377, ),  # Monaco
+    "MN": (976, ),  # Mongolia
+    "ME": (382, ),  # Montenegro
+    "MS": (1664, ),  # Montserrat
+    "MA": (212, ),  # Morocco
+    "MZ": (258, ),  # Mozambique
+    "MM": (95, ),  # Myanmar
+    "NA": (264, ),  # Namibia
+    "NR": (674, ),  # Nauru
+    "NP": (977, ),  # Nepal
+    "NL": (31, ),  # Netherlands
+    "NC": (687, ),  # New Caledonia
+    "NZ": (64, ),  # New Zealand
+    "NI": (505, ),  # Nicaragua
+    "NE": (227, ),  # Niger
+    "NG": (243, ),  # Nigeria
+    "NU": (683, ),  # Niue
+    "NF": (6723, ),  # Norfolk Island
+    "MP": (1670, ),  # Northern Mariana Islands
+    "NO": (47, ),  # Norway
+    "OM": (968, ),  # Oman
+    "PK": (92, ),  # Pakistan
+    "PW": (680, ),  # Palau
+    "PS": (970, ),  # Palestine, State of
+    "PA": (507, ),  # Panama
+    "PG": (675, ),  # Papua New Guinea
+    "PY": (595, ),  # Paraguay
+    "PE": (51, ),  # Peru
+    "PH": (63, ),  # _("Philippines
+    "PN": (64, ),  # Pitcairn
+    "PL": (48, ),  # Poland
+    "PT": (351, ),  # Portugal
+    "PR": (1787, 1939),  # Puerto Rico
+    "QA": (974, ),  # Qatar
+    "RE": (262, ),  # Réunion
+    "RO": (40, ),  # Romania
+    "RU": (7, ),  # Russian Federation
+    "RW": (250, ),  # Rwanda
+    "BL": (590, ),  # _("Saint Barthélemy
+    "SH": (290, ),  # Saint Helena, Ascension and Tristan da Cunha
+    "KN": (1869, ),  # Saint Kitts and Nevis
+    "LC": (1758, ),  # Saint Lucia
+    "MF": (590, ),  # Saint Martin (French part)
+    "PM": (508, ),  # Saint Pierre and Miquelon
+    "VC": (1784, ),  # Saint Vincent and the Grenadines
+    "WS": (685, ),  # Samoa
+    "SM": (378, ),  # San Marino
+    "ST": (239, ),  # Sao Tome and Principe
+    "SA": (966, ),  # Saudi Arabia
+    "SN": (221, ),  # Senegal
+    "RS": (381, ),  # Serbia
+    "SC": (248, ),  # Seychelles
+    "SL": (232, ),  # Sierra Leone
+    "SG": (65, ),  # Singapore
+    "SX": (1721, ),  # Sint Maarten (Dutch part)
+    "SK": (421, ),  # Slovakia
+    "SI": (386, ),  # Slovenia
+    "SB": (677, ),  # Solomon Islands
+    "SO": (252, ),  # Somalia
+    "ZA": (27, ),  # South Africa
+    "GS": (500, ),  # South Georgia and the South Sandwich Islands
+    "SS": (211, ),  # South Sudan
+    "ES": (34, ),  # Spain
+    "LK": (94, ),  # Sri Lanka
+    "SD": (249, ),  # Sudan
+    "SR": (597, ),  # Suriname
+    "SJ": (4779, ),  # Svalbard and Jan Mayen
+    "SZ": (268, ),  # Swaziland
+    "SE": (46, ),  # Sweden
+    "CH": (41, ),  # Switzerland
+    "SY": (963, ),  # Syrian Arab Republic
+    "TW": (886, ),  # Taiwan (Province of China)
+    "TJ": (992, ),  # Tajikistan
+    "TZ": (255, ),  # Tanzania, United Republic of
+    "TH": (66, ),  # Thailand
+    "TL": (),  # Timor-Leste
+    "TG": (228, ),  # Togo
+    "TK": (690, ),  # Tokelau
+    "TO": (676, ),  # Tonga
+    "TT": (1868, ),  # Trinidad and Tobago
+    "TN": (216, ),  # Tunisia
+    "TR": (90, ),  # Turkey
+    "TM": (993, ),  # Turkmenistan
+    "TC": (1649, ),  # Turks and Caicos Islands
+    "TV": (668, ),  # Tuvalu
+    "UG": (256, ),  # Uganda
+    "UA": (380, ),  # Ukraine
+    "AE": (971, ),  # United Arab Emirates
+    "GB": (44, ),  # United Kingdom of Great Britain and Northern Ireland
+    "UM": (),  # United States Minor Outlying Islands
+    "US": (1, ),  # United States of America
+    "UY": (598, ),  # Uruguay
+    "UZ": (998, ),  # Uzbekistan
+    "VU": (678, ),  # Vanuatu
+    "VE": (58, ),  # Venezuela (Bolivarian Republic of)
+    "VN": (84, ),  # Viet Nam
+    "VG": (),  # Virgin Islands (British)
+    "VI": (),  # Virgin Islands (U.S.)
+    "WF": (681, ),  # Wallis and Futuna
+    "EH": (),  # Western Sahara
+    "YE": (967, ),  # Yemen
+    "ZM": (260, ),  # Zambia
+    "ZW": (263, ),  # Zimbabwe
 }
 
-TWILIO_SEARCH_COUNTRIES_CONFIG = ('BE',  # Belgium
-                                  'CA',  # Canada
-                                  'FI',  # Finland
-                                  'NO',  # Norway
-                                  'PL',  # Poland
-                                  'ES',  # Spain
-                                  'SE',  # Sweden
-                                  'GB',  # United Kingdom
-                                  'US'   # United States
-                                  )
+TWILIO_SEARCH_COUNTRIES_CONFIG = (
+    'BE',  # Belgium
+    'CA',  # Canada
+    'FI',  # Finland
+    'NO',  # Norway
+    'PL',  # Poland
+    'ES',  # Spain
+    'SE',  # Sweden
+    'GB',  # United Kingdom
+    'US'  # United States
+)
 
 TWILIO_SEARCH_COUNTRIES = tuple([(elt, COUNTRIES_NAMES[elt]) for elt in TWILIO_SEARCH_COUNTRIES_CONFIG])
 
-TWILIO_SUPPORTED_COUNTRIES_CONFIG = ('AU',  # Australia
-                                     'AT',  # Austria
-                                     'BE',  # Belgium
-                                     'CA',  # Canada
-                                     'CL',  # Chile  # Beta
-                                     'CZ',  # Czech Republic  # Beta
-                                     'DK',  # Denmark  # Beta
-                                     'EE',  # Estonia
-                                     'FI',  # Finland
-                                     'FR',  # France  # Beta
-                                     'DE',  # Germany
-                                     'HK',  # Hong Kong
-                                     'HU',  # Hungary  # Beta
-                                     'IE',  # Ireland,
-                                     'IL',  # Israel  # Beta
-                                     'LT',  # Lithuania
-                                     'MX',  # Mexico  # Beta
-                                     'NO',  # Norway
-                                     'PL',  # Poland
-                                     'ES',  # Spain
-                                     'SE',  # Sweden
-                                     'CH',  # Switzerland
-                                     'GB',  # United Kingdom
-                                     'US',  # United States
-                                     )
+TWILIO_SUPPORTED_COUNTRIES_CONFIG = (
+    'AU',  # Australia
+    'AT',  # Austria
+    'BE',  # Belgium
+    'CA',  # Canada
+    'CL',  # Chile  # Beta
+    'CZ',  # Czech Republic  # Beta
+    'DK',  # Denmark  # Beta
+    'EE',  # Estonia
+    'FI',  # Finland
+    'FR',  # France  # Beta
+    'DE',  # Germany
+    'HK',  # Hong Kong
+    'HU',  # Hungary  # Beta
+    'IE',  # Ireland,
+    'IL',  # Israel  # Beta
+    'LT',  # Lithuania
+    'MX',  # Mexico  # Beta
+    'NO',  # Norway
+    'PL',  # Poland
+    'ES',  # Spain
+    'SE',  # Sweden
+    'CH',  # Switzerland
+    'GB',  # United Kingdom
+    'US',  # United States
+)
 
 TWILIO_SUPPORTED_COUNTRIES = tuple([(elt, COUNTRIES_NAMES[elt]) for elt in TWILIO_SUPPORTED_COUNTRIES_CONFIG])
 
-TWILIO_SUPPORTED_COUNTRY_CODES = list(set([code
-                                           for elt in TWILIO_SUPPORTED_COUNTRIES_CONFIG
-                                           for code in list(COUNTRY_CALLING_CODES[elt])]))
+TWILIO_SUPPORTED_COUNTRY_CODES = list(
+    set([code for elt in TWILIO_SUPPORTED_COUNTRIES_CONFIG for code in list(COUNTRY_CALLING_CODES[elt])])
+)
 
-NEXMO_SUPPORTED_COUNTRIES_CONFIG = ('DZ',  # Algeria
-                                    'AR',  # Argentina
-                                    'AU',  # Australia
-                                    'AT',  # Austria
-                                    'BH',  # Bahrain
-                                    'BE',  # Belgium
-                                    'BJ',  # Benin
-                                    'BO',  # Bolivia
-                                    'BR',  # Brazil
-                                    'BG',  # Bulgaria
-                                    'KH',  # Cambodia
-                                    'CA',  # Canada
-                                    'KY',  # Cayman Islands
-                                    'CL',  # Chile
-                                    'CN',  # China
-                                    'CO',  # Colombia
-                                    'CR',  # Costa Rica
-                                    'HR',  # Croatia
-                                    'CY',  # Cyprus
-                                    'CZ',  # Czech Republic
-                                    'DK',  # Denmark
-                                    'DO',  # Dominican Republic
-                                    'SV',  # El Salvador
-                                    'EE',  # Estonia
-                                    'FI',  # Finland
-                                    'FR',  # France
-                                    'GE',  # Georgia
-                                    'DE',  # Germany
-                                    'GH',  # Ghana
-                                    'GR',  # Greece
-                                    'GD',  # Grenanda
-                                    'GT',  # Guatemala
-                                    'HN',  # Honduras
-                                    'HK',  # Hong Kong
-                                    'HU',  # Hungary
-                                    'IS',  # Iceland
-                                    'IN',  # India
-                                    'ID',  # Indonesia
-                                    'IE',  # Ireland
-                                    'IL',  # Israel
-                                    'IT',  # Italy
-                                    'JM',  # Jamaica
-                                    'JP',  # Japan
-                                    'KE',  # Kenya
-                                    'LV',  # Latvia
-                                    'LI',  # Liechtenstein
-                                    'LT',  # Lithuania
-                                    'LU',  # Luxembourg
-                                    'MO',  # Macau
-                                    'MY',  # Malaysia
-                                    'MT',  # Malta
-                                    'MX',  # Mexico
-                                    'MD',  # Moldova
-                                    'NL',  # Netherlands
-                                    'NZ',  # New Zealand
-                                    'NG',  # Nigeria
-                                    'NO',  # Norway
-                                    'PK',  # Pakistan
-                                    'PA',  # Panama
-                                    'PE',  # Peru
-                                    'PH',  # Philippines
-                                    'PL',  # Poland
-                                    'PT',  # Portugal
-                                    'PR',  # Puerto Rico
-                                    'RO',  # Romania
-                                    'RU',  # Russia
-                                    'RW',  # Rwanda
-                                    'SA',  # Saudi Arabia
-                                    'SG',  # Singapore
-                                    'SK',  # Slovakia
-                                    'SI',  # Slovenia
-                                    'ZA',  # South Africa
-                                    'KR',  # South Korea
-                                    'ES',  # Spain
-                                    'SE',  # Sweden
-                                    'CH',  # Switzerland
-                                    'TW',  # Taiwan
-                                    'TJ',  # Tajikistan
-                                    'TH',  # Thailand
-                                    'TT',  # Trinidad and Tobago
-                                    'TR',  # Turkey
-                                    'GB',  # United Kingdom
-                                    'US',  # United States
-                                    'UY',  # Uruguay
-                                    'VE',  # Venezuala
-                                    'ZM',  # Zambia
-                                    )
+NEXMO_SUPPORTED_COUNTRIES_CONFIG = (
+    'DZ',  # Algeria
+    'AR',  # Argentina
+    'AU',  # Australia
+    'AT',  # Austria
+    'BH',  # Bahrain
+    'BE',  # Belgium
+    'BJ',  # Benin
+    'BO',  # Bolivia
+    'BR',  # Brazil
+    'BG',  # Bulgaria
+    'KH',  # Cambodia
+    'CA',  # Canada
+    'KY',  # Cayman Islands
+    'CL',  # Chile
+    'CN',  # China
+    'CO',  # Colombia
+    'CR',  # Costa Rica
+    'HR',  # Croatia
+    'CY',  # Cyprus
+    'CZ',  # Czech Republic
+    'DK',  # Denmark
+    'DO',  # Dominican Republic
+    'SV',  # El Salvador
+    'EE',  # Estonia
+    'FI',  # Finland
+    'FR',  # France
+    'GE',  # Georgia
+    'DE',  # Germany
+    'GH',  # Ghana
+    'GR',  # Greece
+    'GD',  # Grenanda
+    'GT',  # Guatemala
+    'HN',  # Honduras
+    'HK',  # Hong Kong
+    'HU',  # Hungary
+    'IS',  # Iceland
+    'IN',  # India
+    'ID',  # Indonesia
+    'IE',  # Ireland
+    'IL',  # Israel
+    'IT',  # Italy
+    'JM',  # Jamaica
+    'JP',  # Japan
+    'KE',  # Kenya
+    'LV',  # Latvia
+    'LI',  # Liechtenstein
+    'LT',  # Lithuania
+    'LU',  # Luxembourg
+    'MO',  # Macau
+    'MY',  # Malaysia
+    'MT',  # Malta
+    'MX',  # Mexico
+    'MD',  # Moldova
+    'NL',  # Netherlands
+    'NZ',  # New Zealand
+    'NG',  # Nigeria
+    'NO',  # Norway
+    'PK',  # Pakistan
+    'PA',  # Panama
+    'PE',  # Peru
+    'PH',  # Philippines
+    'PL',  # Poland
+    'PT',  # Portugal
+    'PR',  # Puerto Rico
+    'RO',  # Romania
+    'RU',  # Russia
+    'RW',  # Rwanda
+    'SA',  # Saudi Arabia
+    'SG',  # Singapore
+    'SK',  # Slovakia
+    'SI',  # Slovenia
+    'ZA',  # South Africa
+    'KR',  # South Korea
+    'ES',  # Spain
+    'SE',  # Sweden
+    'CH',  # Switzerland
+    'TW',  # Taiwan
+    'TJ',  # Tajikistan
+    'TH',  # Thailand
+    'TT',  # Trinidad and Tobago
+    'TR',  # Turkey
+    'GB',  # United Kingdom
+    'US',  # United States
+    'UY',  # Uruguay
+    'VE',  # Venezuala
+    'ZM',  # Zambia
+)
 
 NEXMO_SUPPORTED_COUNTRIES = tuple([(elt, COUNTRIES_NAMES[elt]) for elt in NEXMO_SUPPORTED_COUNTRIES_CONFIG])
 
-NEXMO_SUPPORTED_COUNTRY_CODES = list(set([code
-                                          for elt in NEXMO_SUPPORTED_COUNTRIES_CONFIG
-                                          for code in list(COUNTRY_CALLING_CODES[elt])]))
+NEXMO_SUPPORTED_COUNTRY_CODES = list(
+    set([code for elt in NEXMO_SUPPORTED_COUNTRIES_CONFIG for code in list(COUNTRY_CALLING_CODES[elt])])
+)
 
-PLIVO_SUPPORTED_COUNTRIES_CONFIG = ('AU',  # Australia
-                                    'BE',  # Belgium
-                                    'CA',  # Canada
-                                    'CZ',  # Czech Republic
-                                    'EE',  # Estonia
-                                    'FI',  # Finland
-                                    'DE',  # Germany
-                                    'HK',  # Hong Kong
-                                    'HU',  # Hungary
-                                    'IL',  # Israel
-                                    'LT',  # Lithuania
-                                    'MX',  # Mexico
-                                    'NO',  # Norway
-                                    'PK',  # Pakistan
-                                    'PL',  # Poland
-                                    'ZA',  # South Africa
-                                    'SE',  # Sweden
-                                    'CH',  # Switzerland
-                                    'GB',  # United Kingdom
-                                    'US',  # United States
-                                    )
+PLIVO_SUPPORTED_COUNTRIES_CONFIG = (
+    'AU',  # Australia
+    'BE',  # Belgium
+    'CA',  # Canada
+    'CZ',  # Czech Republic
+    'EE',  # Estonia
+    'FI',  # Finland
+    'DE',  # Germany
+    'HK',  # Hong Kong
+    'HU',  # Hungary
+    'IL',  # Israel
+    'LT',  # Lithuania
+    'MX',  # Mexico
+    'NO',  # Norway
+    'PK',  # Pakistan
+    'PL',  # Poland
+    'ZA',  # South Africa
+    'SE',  # Sweden
+    'CH',  # Switzerland
+    'GB',  # United Kingdom
+    'US',  # United States
+)
 
 PLIVO_SUPPORTED_COUNTRIES = tuple([(elt, COUNTRIES_NAMES[elt]) for elt in PLIVO_SUPPORTED_COUNTRIES_CONFIG])
 
-PLIVO_SUPPORTED_COUNTRY_CODES = list(set([code
-                                          for elt in PLIVO_SUPPORTED_COUNTRIES_CONFIG
-                                          for code in list(COUNTRY_CALLING_CODES[elt])]))
+PLIVO_SUPPORTED_COUNTRY_CODES = list(
+    set([code for elt in PLIVO_SUPPORTED_COUNTRIES_CONFIG for code in list(COUNTRY_CALLING_CODES[elt])])
+)
 
 # django_countries now uses a dict of countries, let's turn it in our tuple
 # list of codes and countries sorted by country name
@@ -573,14 +575,21 @@ def sync(request, channel_id):
         return JsonResponse({"error_id": 3, "error": "Old Request", "cmds": []}, status=401)
 
     # sign the request
-    signature = hmac.new(key=str(channel.secret + request_time), msg=bytes(request.body), digestmod=hashlib.sha256).digest()
+    signature = hmac.new(
+        key=str(channel.secret + request_time), msg=bytes(request.body), digestmod=hashlib.sha256
+    ).digest()
 
     # base64 and url sanitize
     signature = base64.urlsafe_b64encode(signature).strip()
 
     if request_signature != signature:
-        return JsonResponse({"error_id": 1, "error": "Invalid signature: \'%(request)s\'"
-                                                     % {'request': request_signature}, "cmds": []}, status=401)
+        return JsonResponse({
+            "error_id": 1,
+            "error": "Invalid signature: \'%(request)s\'" % {
+                'request': request_signature
+            },
+            "cmds": []
+        }, status=401)
 
     # update our last seen on our channel if we haven't seen this channel in a bit
     if not channel.last_seen or timezone.now() - channel.last_seen > timedelta(minutes=5):
@@ -772,15 +781,21 @@ class ClaimViewMixin(OrgPermsMixin):
 
 class AuthenticatedExternalClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
-        country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                    help_text=_("The country this phone number is used in"))
-        number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                 help_text=_(
-                                     "The phone number or short code you are connecting with country code. ex: +250788123124"))
-        username = forms.CharField(label=_("Username"),
-                                   help_text=_("The username provided by the provider to use their API"))
-        password = forms.CharField(label=_("Password"),
-                                   help_text=_("The password provided by the provider to use their API"))
+        country = forms.ChoiceField(
+            choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+        )
+        number = forms.CharField(
+            max_length=14,
+            min_length=1,
+            label=_("Number"),
+            help_text=_("The phone number or short code you are connecting with country code. ex: +250788123124")
+        )
+        username = forms.CharField(
+            label=_("Username"), help_text=_("The username provided by the provider to use their API")
+        )
+        password = forms.CharField(
+            label=_("Password"), help_text=_("The password provided by the provider to use their API")
+        )
 
         def clean_number(self):
             number = self.data['number']
@@ -798,7 +813,8 @@ class AuthenticatedExternalClaimView(ClaimViewMixin, SmartFormView):
                 return phonenumbers.format_number(cleaned, phonenumbers.PhoneNumberFormat.E164)
             except Exception:  # pragma: needs cover
                 raise forms.ValidationError(
-                    _("Invalid phone number, please include the country code. ex: +250788123123"))
+                    _("Invalid phone number, please include the country code. ex: +250788123123")
+                )
 
     form_class = Form
 
@@ -812,13 +828,11 @@ class AuthenticatedExternalClaimView(ClaimViewMixin, SmartFormView):
             raise Exception("No org for this user, cannot claim")
 
         data = form.cleaned_data
-        self.object = Channel.add_authenticated_external_channel(org, self.request.user,
-                                                                 self.get_submitted_country(data),
-                                                                 data['number'],
-                                                                 data['username'],
-                                                                 data['password'],
-                                                                 self.channel_type,
-                                                                 data.get('url'))
+        self.object = Channel.add_authenticated_external_channel(
+            org, self.request.user,
+            self.get_submitted_country(data), data['number'], data['username'], data['password'], self.channel_type,
+            data.get('url')
+        )
 
         return super(AuthenticatedExternalClaimView, self).form_valid(form)
 
@@ -862,36 +876,52 @@ class BaseClaimNumberMixin(ClaimViewMixin):
         return supported_country_iso_codes
 
     def get_search_countries_tuple(self):  # pragma: no cover
-        raise NotImplementedError('method "get_search_countries_tuple" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "get_search_countries_tuple" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def get_supported_countries_tuple(self):  # pragma: no cover
-        raise NotImplementedError('method "get_supported_countries_tuple" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "get_supported_countries_tuple" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def get_search_url(self):  # pragma: no cover
-        raise NotImplementedError('method "get_search_url" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "get_search_url" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def get_claim_url(self):  # pragma: no cover
-        raise NotImplementedError('method "get_claim_url" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "get_claim_url" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def get_existing_numbers(self, org):  # pragma: no cover
-        raise NotImplementedError('method "get_existing_numbers" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "get_existing_numbers" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def is_valid_country(self, country_code):  # pragma: no cover
-        raise NotImplementedError('method "is_valid_country" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "is_valid_country" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def is_messaging_country(self, country):  # pragma: no cover
-        raise NotImplementedError('method "is_messaging_country" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "is_messaging_country" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def claim_number(self, user, phone_number, country, role):  # pragma: no cover
-        raise NotImplementedError('method "claim_number" should be overridden in %s.%s'
-                                  % (self.crudl.__class__.__name__, self.__class__.__name__))
+        raise NotImplementedError(
+            'method "claim_number" should be overridden in %s.%s' %
+            (self.crudl.__class__.__name__, self.__class__.__name__)
+        )
 
     def remove_api_credentials_from_session(self):
         pass
@@ -902,9 +932,12 @@ class BaseClaimNumberMixin(ClaimViewMixin):
         org = self.request.user.get_org()
         if not org:  # pragma: needs cover
             form._errors['upgrade'] = True
-            form._errors['phone_number'] = form.error_class(
-                [_("Sorry, you need to have an organization to add numbers. "
-                   "You can still test things out for free using an Android phone.")])
+            form._errors['phone_number'] = form.error_class([
+                _(
+                    "Sorry, you need to have an organization to add numbers. "
+                    "You can still test things out for free using an Android phone."
+                )
+            ])
             return self.form_invalid(form)
 
         data = form.cleaned_data
@@ -913,21 +946,31 @@ class BaseClaimNumberMixin(ClaimViewMixin):
         if len(data['phone_number']) > 6:
             phone = phonenumbers.parse(data['phone_number'])
             if not self.is_valid_country(phone.country_code):  # pragma: needs cover
-                form._errors['phone_number'] = form.error_class([_("Sorry, the number you chose is not supported. "
-                                                                   "You can still deploy in any country using your "
-                                                                   "own SIM card and an Android phone.")])
+                form._errors['phone_number'] = form.error_class([
+                    _(
+                        "Sorry, the number you chose is not supported. "
+                        "You can still deploy in any country using your "
+                        "own SIM card and an Android phone."
+                    )
+                ])
                 return self.form_invalid(form)
 
         # don't add the same number twice to the same account
         existing = org.channels.filter(is_active=True, address=data['phone_number']).first()
         if existing:  # pragma: needs cover
-            form._errors['phone_number'] = form.error_class(
-                [_("That number is already connected (%s)" % data['phone_number'])])
+            form._errors['phone_number'] = form.error_class([
+                _("That number is already connected (%s)" % data['phone_number'])
+            ])
             return self.form_invalid(form)
 
         existing = Channel.objects.filter(is_active=True, address=data['phone_number']).first()
         if existing:  # pragma: needs cover
-            form._errors['phone_number'] = form.error_class([_("That number is already connected to another account - %s (%s)" % (existing.org, existing.created_by.username))])
+            form._errors['phone_number'] = form.error_class([
+                _(
+                    "That number is already connected to another account - %s (%s)" %
+                    (existing.org, existing.created_by.username)
+                )
+            ])
             return self.form_invalid(form)
 
         # try to claim the number
@@ -947,7 +990,8 @@ class BaseClaimNumberMixin(ClaimViewMixin):
             else:
                 form._errors['phone_number'] = _(
                     "An error occurred connecting your Twilio number, try removing your "
-                    "Twilio account, reconnecting it and trying again.")
+                    "Twilio account, reconnecting it and trying again."
+                )
             return self.form_invalid(form)
 
 
@@ -1011,14 +1055,17 @@ class UpdateChannelForm(forms.ModelForm):
         model = Channel
         fields = 'name', 'address', 'country', 'alert_email'
         config_fields = []
-        readonly = ('address', 'country',)
+        readonly = (
+            'address',
+            'country',
+        )
         labels = {'address': _('Address')}
         helps = {'address': _('The number or address of this channel')}
 
 
 class UpdateNexmoForm(UpdateChannelForm):
     class Meta(UpdateChannelForm.Meta):
-        readonly = ('country',)
+        readonly = ('country', )
 
 
 class UpdateAndroidForm(UpdateChannelForm):
@@ -1030,7 +1077,7 @@ class UpdateAndroidForm(UpdateChannelForm):
 class UpdateTwitterForm(UpdateChannelForm):
     class Meta(UpdateChannelForm.Meta):
         fields = 'name', 'address', 'alert_email'
-        readonly = ('address',)
+        readonly = ('address', )
         labels = {'address': _('Handle')}
         helps = {'address': _('Twitter handle of this channel')}
 
@@ -1042,11 +1089,11 @@ TYPE_UPDATE_FORM_CLASSES = {
 
 class ChannelCRUDL(SmartCRUDL):
     model = Channel
-    actions = ('list', 'claim', 'update', 'read', 'delete', 'search_numbers',
-               'claim_android', 'configuration',
-               'search_nexmo', 'bulk_sender_options', 'create_bulk_sender',
-               'create_caller', 'claim_verboice', 'search_plivo',
-               'claim_viber', 'create_viber', 'facebook_whitelist')
+    actions = (
+        'list', 'claim', 'update', 'read', 'delete', 'search_numbers', 'claim_android', 'configuration',
+        'search_nexmo', 'bulk_sender_options', 'create_bulk_sender', 'create_caller', 'claim_verboice', 'search_plivo',
+        'claim_viber', 'create_viber', 'facebook_whitelist'
+    )
     permissions = True
 
     class Read(OrgObjPermsMixin, SmartReadView):
@@ -1060,32 +1107,39 @@ class ChannelCRUDL(SmartCRUDL):
             links = []
 
             if self.has_org_perm("channels.channel_update"):
-                links.append(dict(title=_('Edit'),
-                                  style='btn-primary',
-                                  href=reverse('channels.channel_update', args=[self.get_object().id])))
+                links.append(
+                    dict(
+                        title=_('Edit'),
+                        style='btn-primary',
+                        href=reverse('channels.channel_update', args=[self.get_object().id])
+                    )
+                )
 
                 sender = self.get_object().get_sender()
                 if sender and sender.is_delegate_sender():
-                    links.append(dict(title=_('Disable Bulk Sending'),
-                                      style='btn-primary',
-                                      href="#",
-                                      js_class='remove-sender'))
+                    links.append(
+                        dict(title=_('Disable Bulk Sending'), style='btn-primary', href="#", js_class='remove-sender')
+                    )
                 elif self.get_object().channel_type == Channel.TYPE_ANDROID:
-                    links.append(dict(title=_('Enable Bulk Sending'),
-                                      style='btn-primary',
-                                      href="%s?channel=%d" % (reverse("channels.channel_bulk_sender_options"), self.get_object().pk)))
+                    links.append(
+                        dict(
+                            title=_('Enable Bulk Sending'),
+                            style='btn-primary',
+                            href="%s?channel=%d" %
+                            (reverse("channels.channel_bulk_sender_options"), self.get_object().pk)
+                        )
+                    )
 
                 caller = self.get_object().get_caller()
                 if caller and caller.is_delegate_caller():
-                    links.append(dict(title=_('Disable Voice Calling'),
-                                      style='btn-primary',
-                                      href="#",
-                                      js_class='remove-caller'))
+                    links.append(
+                        dict(
+                            title=_('Disable Voice Calling'), style='btn-primary', href="#", js_class='remove-caller'
+                        )
+                    )
 
             if self.has_org_perm("channels.channel_delete"):
-                links.append(dict(title=_('Remove'),
-                                  js_class='remove-channel',
-                                  href="#"))
+                links.append(dict(title=_('Remove'), js_class='remove-channel', href="#"))
 
             if self.object.channel_type == 'FB' and self.has_org_perm('channels.channel_facebook_whitelist'):
                 links.append(dict(title=_("Whitelist Domain"), js_class='facebook-whitelist', href='#'))
@@ -1110,16 +1164,14 @@ class ChannelCRUDL(SmartCRUDL):
 
             # power source stats data
             source_stats = [[event['power_source'], event['count']]
-                            for event in sync_events.order_by('power_source')
-                                                    .values('power_source')
-                                                    .annotate(count=Count('power_source'))]
+                            for event in sync_events.order_by('power_source').values('power_source')
+                            .annotate(count=Count('power_source'))]
             context['source_stats'] = source_stats
 
             # network connected to stats
             network_stats = [[event['network_type'], event['count']]
-                             for event in sync_events.order_by('network_type')
-                                                     .values('network_type')
-                                                     .annotate(count=Count('network_type'))]
+                             for event in sync_events.order_by('network_type').values('network_type')
+                             .annotate(count=Count('network_type'))]
             context['network_stats'] = network_stats
 
             total_network = 0
@@ -1187,14 +1239,14 @@ class ChannelCRUDL(SmartCRUDL):
                 message_stats.append(dict(name=_('Outgoing IVR'), data=ivr_out))
 
             # get all our counts for that period
-            daily_counts = list(ChannelCount.objects.filter(channel__in=channels, day__gte=start_date)
-                                                    .filter(count_type__in=[ChannelCount.INCOMING_MSG_TYPE,
-                                                                            ChannelCount.OUTGOING_MSG_TYPE,
-                                                                            ChannelCount.INCOMING_IVR_TYPE,
-                                                                            ChannelCount.OUTGOING_IVR_TYPE])
-                                                    .values('day', 'count_type')
-                                                    .order_by('day', 'count_type')
-                                                    .annotate(count_sum=Sum('count')))
+            daily_counts = list(
+                ChannelCount.objects.filter(channel__in=channels, day__gte=start_date).filter(
+                    count_type__in=[
+                        ChannelCount.INCOMING_MSG_TYPE, ChannelCount.OUTGOING_MSG_TYPE, ChannelCount.INCOMING_IVR_TYPE,
+                        ChannelCount.OUTGOING_IVR_TYPE
+                    ]
+                ).values('day', 'count_type').order_by('day', 'count_type').annotate(count_sum=Sum('count'))
+            )
 
             current = start_date
             while current <= end_date:
@@ -1221,15 +1273,16 @@ class ChannelCRUDL(SmartCRUDL):
             month_start = channel.created_on.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
             # get our totals grouped by month
-            monthly_totals = list(ChannelCount.objects.filter(channel=channel, day__gte=month_start)
-                                                      .filter(count_type__in=[ChannelCount.INCOMING_MSG_TYPE,
-                                                                              ChannelCount.OUTGOING_MSG_TYPE,
-                                                                              ChannelCount.INCOMING_IVR_TYPE,
-                                                                              ChannelCount.OUTGOING_IVR_TYPE])
-                                                      .extra({'month': "date_trunc('month', day)"})
-                                                      .values('month', 'count_type')
-                                                      .order_by('month', 'count_type')
-                                                      .annotate(count_sum=Sum('count')))
+            monthly_totals = list(
+                ChannelCount.objects.filter(channel=channel, day__gte=month_start).filter(
+                    count_type__in=[
+                        ChannelCount.INCOMING_MSG_TYPE, ChannelCount.OUTGOING_MSG_TYPE, ChannelCount.INCOMING_IVR_TYPE,
+                        ChannelCount.OUTGOING_IVR_TYPE
+                    ]
+                ).extra({
+                    'month': "date_trunc('month', day)"
+                }).values('month', 'count_type').order_by('month', 'count_type').annotate(count_sum=Sum('count'))
+            )
 
             # calculate our summary table for last 12 months
             now = timezone.now()
@@ -1250,11 +1303,15 @@ class ChannelCRUDL(SmartCRUDL):
                     elif monthly_total['count_type'] == ChannelCount.OUTGOING_IVR_TYPE:
                         ivr_out = monthly_total['count_sum']
 
-                message_stats_table.append(dict(month_start=month_start,
-                                                incoming_messages_count=msg_in,
-                                                outgoing_messages_count=msg_out,
-                                                incoming_ivr_count=ivr_in,
-                                                outgoing_ivr_count=ivr_out))
+                message_stats_table.append(
+                    dict(
+                        month_start=month_start,
+                        incoming_messages_count=msg_in,
+                        outgoing_messages_count=msg_out,
+                        incoming_ivr_count=ivr_in,
+                        outgoing_ivr_count=ivr_out
+                    )
+                )
 
                 month_start = (month_start + timedelta(days=32)).replace(day=1)
 
@@ -1266,8 +1323,11 @@ class ChannelCRUDL(SmartCRUDL):
 
     class FacebookWhitelist(ModalMixin, OrgObjPermsMixin, SmartModelActionView):
         class DomainForm(forms.Form):
-            whitelisted_domain = forms.URLField(required=True, initial='https://',
-                                                help_text="The domain to whitelist for Messenger extensions  ex: https://yourdomain.com")
+            whitelisted_domain = forms.URLField(
+                required=True,
+                initial='https://',
+                help_text="The domain to whitelist for Messenger extensions  ex: https://yourdomain.com"
+            )
 
         slug_url_kwarg = 'uuid'
         success_url = 'uuid@channels.channel_read'
@@ -1283,10 +1343,14 @@ class ChannelCRUDL(SmartCRUDL):
             #  "domain_action_type": "add"
             # }' "https://graph.facebook.com/v2.6/me/thread_settings?access_token=PAGE_ACCESS_TOKEN"
             access_token = self.object.config_json()[Channel.CONFIG_AUTH_TOKEN]
-            response = requests.post('https://graph.facebook.com/v2.6/me/thread_settings?access_token=' + access_token,
-                                     json=dict(setting_type='domain_whitelisting',
-                                               whitelisted_domains=[self.form.cleaned_data['whitelisted_domain']],
-                                               domain_action_type='add'))
+            response = requests.post(
+                'https://graph.facebook.com/v2.6/me/thread_settings?access_token=' + access_token,
+                json=dict(
+                    setting_type='domain_whitelisting',
+                    whitelisted_domains=[self.form.cleaned_data['whitelisted_domain']],
+                    domain_action_type='add'
+                )
+            )
 
             if response.status_code != 200:
                 response_json = response.json()
@@ -1297,7 +1361,7 @@ class ChannelCRUDL(SmartCRUDL):
         cancel_url = 'id@channels.channel_read'
         title = _("Remove Android")
         success_message = ''
-        fields = ('id',)
+        fields = ('id', )
 
         def get_success_url(self):
             return reverse('orgs.org_home')
@@ -1309,7 +1373,12 @@ class ChannelCRUDL(SmartCRUDL):
                 channel.release(trigger_sync=self.request.META['SERVER_NAME'] != "testserver")
 
                 if channel.channel_type == 'T' and not channel.is_delegate_sender():
-                    messages.info(request, _("We have disconnected your Twilio number. If you do not need this number you can delete it from the Twilio website."))
+                    messages.info(
+                        request,
+                        _(
+                            "We have disconnected your Twilio number. If you do not need this number you can delete it from the Twilio website."
+                        )
+                    )
                 else:
                     messages.info(request, _("Your phone number has been removed."))
 
@@ -1317,9 +1386,20 @@ class ChannelCRUDL(SmartCRUDL):
 
             except TwilioRestException as e:
                 if e.code == 20003:
-                    messages.error(request, _("We can no longer authenticate with your Twilio Account. To delete this channel please update your Twilio connection settings."))
+                    messages.error(
+                        request,
+                        _(
+                            "We can no longer authenticate with your Twilio Account. To delete this channel please update your Twilio connection settings."
+                        )
+                    )
                 else:
-                    messages.error(request, _("Twilio reported an error removing your channel (Twilio error %s). Please try again later." % e.code))
+                    messages.error(
+                        request,
+                        _(
+                            "Twilio reported an error removing your channel (Twilio error %s). Please try again later."
+                            % e.code
+                        )
+                    )
                 return HttpResponseRedirect(reverse("orgs.org_home"))
 
             except Exception as e:  # pragma: no cover
@@ -1373,7 +1453,8 @@ class ChannelCRUDL(SmartCRUDL):
                 e164_phone_number = None
                 try:
                     parsed = phonenumbers.parse(obj.address, None)
-                    e164_phone_number = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164).strip('+')
+                    e164_phone_number = phonenumbers.format_number(parsed,
+                                                                   phonenumbers.PhoneNumberFormat.E164).strip('+')
                 except Exception:
                     pass
                 for channel in obj.get_delegate_channels():  # pragma: needs cover
@@ -1384,7 +1465,6 @@ class ChannelCRUDL(SmartCRUDL):
             return obj
 
     class Claim(OrgPermsMixin, SmartTemplateView):
-
         def get_context_data(self, **kwargs):
             context = super(ChannelCRUDL.Claim, self).get_context_data(**kwargs)
             user = self.request.user
@@ -1418,7 +1498,6 @@ class ChannelCRUDL(SmartCRUDL):
         pass
 
     class CreateBulkSender(OrgPermsMixin, SmartFormView):
-
         class BulkSenderForm(forms.Form):
             connection = forms.CharField(max_length=2, widget=forms.HiddenInput, required=False)
             channel = forms.IntegerField(widget=forms.HiddenInput, required=False)
@@ -1509,11 +1588,10 @@ class ChannelCRUDL(SmartCRUDL):
 
     class CreateViber(OrgPermsMixin, SmartFormView):
         class ViberCreateForm(forms.Form):
-            name = forms.CharField(max_length=32, min_length=1,
-                                   help_text=_("The name of your Viber bot"))
+            name = forms.CharField(max_length=32, min_length=1, help_text=_("The name of your Viber bot"))
 
         title = _("Connect Viber Bot")
-        fields = ('name',)
+        fields = ('name', )
         form_class = ViberCreateForm
         permission = 'channels.channel_claim'
         success_url = "id@channels.channel_claim_viber"
@@ -1521,9 +1599,7 @@ class ChannelCRUDL(SmartCRUDL):
         def form_valid(self, form):
             org = self.request.user.get_org()
             data = form.cleaned_data
-            self.object = Channel.add_viber_channel(org,
-                                                    self.request.user,
-                                                    data['name'])
+            self.object = Channel.add_viber_channel(org, self.request.user, data['name'])
 
             return super(ChannelCRUDL.CreateViber, self).form_valid(form)
 
@@ -1533,10 +1609,10 @@ class ChannelCRUDL(SmartCRUDL):
 
             class Meta:
                 model = Channel
-                fields = ('service_id',)
+                fields = ('service_id', )
 
         title = _("Connect Viber Bot")
-        fields = ('service_id',)
+        fields = ('service_id', )
         form_class = ViberClaimForm
         permission = 'channels.channel_claim'
         success_url = "id@channels.channel_configuration"
@@ -1557,17 +1633,27 @@ class ChannelCRUDL(SmartCRUDL):
 
     class ClaimVerboice(OrgPermsMixin, SmartFormView):
         class VerboiceClaimForm(forms.Form):
-            country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),
-                                        help_text=_("The country this phone number is used in"))
-            number = forms.CharField(max_length=14, min_length=1, label=_("Number"),
-                                     help_text=_("The phone number with country code or short code you are connecting. "
-                                                 "ex: +250788123124 or 15543"))
-            username = forms.CharField(label=_("Username"),
-                                       help_text=_("The username provided by the provider to use their API"))
-            password = forms.CharField(label=_("Password"),
-                                       help_text=_("The password provided by the provider to use their API"))
-            channel = forms.CharField(label=_("Channel Name"),
-                                      help_text=_("The Verboice channel that will be handling your calls"))
+            country = forms.ChoiceField(
+                choices=ALL_COUNTRIES, label=_("Country"), help_text=_("The country this phone number is used in")
+            )
+            number = forms.CharField(
+                max_length=14,
+                min_length=1,
+                label=_("Number"),
+                help_text=_(
+                    "The phone number with country code or short code you are connecting. "
+                    "ex: +250788123124 or 15543"
+                )
+            )
+            username = forms.CharField(
+                label=_("Username"), help_text=_("The username provided by the provider to use their API")
+            )
+            password = forms.CharField(
+                label=_("Password"), help_text=_("The password provided by the provider to use their API")
+            )
+            channel = forms.CharField(
+                label=_("Channel Name"), help_text=_("The Verboice channel that will be handling your calls")
+            )
 
         title = _("Connect Verboice")
         channel_type = Channel.TYPE_VERBOICE
@@ -1584,16 +1670,18 @@ class ChannelCRUDL(SmartCRUDL):
                 raise Exception(_("No org for this user, cannot claim"))
 
             data = form.cleaned_data
-            self.object = Channel.add_config_external_channel(org, self.request.user,
-                                                              data['country'], data['number'], Channel.TYPE_VERBOICE,
-                                                              dict(username=data['username'],
-                                                                   password=data['password'],
-                                                                   channel=data['channel']),
-                                                              role=Channel.ROLE_CALL + Channel.ROLE_ANSWER)
+            self.object = Channel.add_config_external_channel(
+                org,
+                self.request.user,
+                data['country'],
+                data['number'],
+                Channel.TYPE_VERBOICE,
+                dict(username=data['username'], password=data['password'], channel=data['channel']),
+                role=Channel.ROLE_CALL + Channel.ROLE_ANSWER
+            )
             return super(ChannelCRUDL.ClaimVerboice, self).form_valid(form)
 
     class Configuration(OrgPermsMixin, SmartReadView):
-
         def get_context_data(self, **kwargs):
             context = super(ChannelCRUDL.Configuration, self).get_context_data(**kwargs)
 
@@ -1646,8 +1734,9 @@ class ChannelCRUDL(SmartCRUDL):
             self.object = Channel.objects.filter(claim_code=self.form.cleaned_data['claim_code']).first()
 
             country = self.object.country
-            phone_country = ContactURN.derive_country_from_tel(self.form.cleaned_data['phone_number'],
-                                                               str(self.object.country))
+            phone_country = ContactURN.derive_country_from_tel(
+                self.form.cleaned_data['phone_number'], str(self.object.country)
+            )
 
             # always prefer the country of the phone number they are entering if we have one
             if phone_country and phone_country != country:  # pragma: needs cover
@@ -1715,8 +1804,12 @@ class ChannelCRUDL(SmartCRUDL):
 
     class SearchNumbers(OrgPermsMixin, SmartFormView):
         class SearchNumbersForm(forms.Form):
-            area_code = forms.CharField(max_length=3, min_length=3, required=False,
-                                        help_text=_("The area code you want to search for a new number in"))
+            area_code = forms.CharField(
+                max_length=3,
+                min_length=3,
+                required=False,
+                help_text=_("The area code you want to search for a new number in")
+            )
             country = forms.ChoiceField(choices=TWILIO_SEARCH_COUNTRIES)
 
         form_class = SearchNumbersForm
@@ -1750,30 +1843,54 @@ class ChannelCRUDL(SmartCRUDL):
             if not data['area_code']:
                 available_numbers = self.search_available_numbers(client, country=data['country'])
             elif data['country'] in ['CA', 'US']:
-                available_numbers = self.search_available_numbers(client, area_code=data['area_code'], country=data['country'])
+                available_numbers = self.search_available_numbers(
+                    client, area_code=data['area_code'], country=data['country']
+                )
             else:
-                available_numbers = self.search_available_numbers(client, contains=data['area_code'], country=data['country'])
+                available_numbers = self.search_available_numbers(
+                    client, contains=data['area_code'], country=data['country']
+                )
 
             numbers = []
 
             for number in available_numbers:
-                numbers.append(phonenumbers.format_number(phonenumbers.parse(number.phone_number, None),
-                                                          phonenumbers.PhoneNumberFormat.INTERNATIONAL))
+                numbers.append(
+                    phonenumbers.format_number(
+                        phonenumbers.parse(number.phone_number, None), phonenumbers.PhoneNumberFormat.INTERNATIONAL
+                    )
+                )
 
             if not numbers:
                 if data['country'] in ['CA', 'US']:
-                    return HttpResponse(json.dumps(dict(error=str(_("Sorry, no numbers found, "
-                                                                    "please enter another area code and try again.")))))
+                    return HttpResponse(
+                        json.dumps(
+                            dict(
+                                error=str(
+                                    _("Sorry, no numbers found, "
+                                      "please enter another area code and try again.")
+                                )
+                            )
+                        )
+                    )
                 else:
-                    return HttpResponse(json.dumps(dict(error=str(_("Sorry, no numbers found, "
-                                                                    "please enter another pattern and try again.")))))
+                    return HttpResponse(
+                        json.dumps(
+                            dict(
+                                error=str(
+                                    _("Sorry, no numbers found, "
+                                      "please enter another pattern and try again.")
+                                )
+                            )
+                        )
+                    )
 
             return JsonResponse(numbers, safe=False)
 
     class SearchNexmo(SearchNumbers):
         class SearchNexmoForm(forms.Form):
-            area_code = forms.CharField(max_length=7, required=False,
-                                        help_text=_("The area code you want to search for a new number in"))
+            area_code = forms.CharField(
+                max_length=7, required=False, help_text=_("The area code you want to search for a new number in")
+            )
             country = forms.ChoiceField(choices=NEXMO_SUPPORTED_COUNTRIES)
 
         form_class = SearchNexmoForm
@@ -1788,8 +1905,12 @@ class ChannelCRUDL(SmartCRUDL):
                 numbers = []
 
                 for number in available_numbers:
-                    numbers.append(phonenumbers.format_number(phonenumbers.parse(number['msisdn'], data['country']),
-                                                              phonenumbers.PhoneNumberFormat.INTERNATIONAL))
+                    numbers.append(
+                        phonenumbers.format_number(
+                            phonenumbers.parse(number['msisdn'], data['country']),
+                            phonenumbers.PhoneNumberFormat.INTERNATIONAL
+                        )
+                    )
 
                 return JsonResponse(numbers, safe=False)
             except Exception as e:
@@ -1797,8 +1918,12 @@ class ChannelCRUDL(SmartCRUDL):
 
     class SearchPlivo(SearchNumbers):
         class SearchPlivoForm(forms.Form):
-            area_code = forms.CharField(max_length=3, min_length=3, required=False,
-                                        help_text=_("The area code you want to search for a new number in"))
+            area_code = forms.CharField(
+                max_length=3,
+                min_length=3,
+                required=False,
+                help_text=_("The area code you want to search for a new number in")
+            )
             country = forms.ChoiceField(choices=PLIVO_SUPPORTED_COUNTRIES)
 
         form_class = SearchPlivoForm
@@ -1832,14 +1957,18 @@ class ChannelCRUDL(SmartCRUDL):
 
             results_numbers = []
             try:
-                status, response_data = client.search_phone_numbers(dict(country_iso=data['country'], pattern=data['area_code']))
+                status, response_data = client.search_phone_numbers(
+                    dict(country_iso=data['country'], pattern=data['area_code'])
+                )
 
                 if status == 200:
                     results_numbers = ['+' + number_dict['number'] for number_dict in response_data['objects']]
 
-                numbers = [phonenumbers.format_number(phonenumbers.parse(number, None),
-                                                      phonenumbers.PhoneNumberFormat.INTERNATIONAL)
-                           for number in results_numbers]
+                numbers = [
+                    phonenumbers.format_number(
+                        phonenumbers.parse(number, None), phonenumbers.PhoneNumberFormat.INTERNATIONAL
+                    ) for number in results_numbers
+                ]
                 return JsonResponse(numbers, safe=False)
             except Exception as e:
                 return JsonResponse(dict(error=str(e)))
@@ -1847,7 +1976,7 @@ class ChannelCRUDL(SmartCRUDL):
 
 class ChannelEventCRUDL(SmartCRUDL):
     model = ChannelEvent
-    actions = ('calls',)
+    actions = ('calls', )
 
     class Calls(InboxView):
         title = _("Calls")
@@ -1880,7 +2009,9 @@ class ChannelLogCRUDL(SmartCRUDL):
             channel = Channel.objects.get(pk=self.request.GET['channel'])
 
             if self.request.GET.get('sessions'):
-                logs = ChannelLog.objects.filter(channel=channel).exclude(connection=None).values_list('connection_id', flat=True)
+                logs = ChannelLog.objects.filter(channel=channel).exclude(connection=None).values_list(
+                    'connection_id', flat=True
+                )
                 events = ChannelSession.objects.filter(id__in=logs).order_by('-created_on')
 
                 if self.request.GET.get('errors'):
@@ -1890,7 +2021,9 @@ class ChannelLogCRUDL(SmartCRUDL):
                 events = ChannelLog.objects.filter(channel=channel, connection=None, msg=None).order_by('-created_on')
 
             else:
-                events = ChannelLog.objects.filter(channel=channel, connection=None).exclude(msg=None).order_by('-created_on').select_related('msg__contact', 'msg')
+                events = ChannelLog.objects.filter(
+                    channel=channel, connection=None
+                ).exclude(msg=None).order_by('-created_on').select_related('msg__contact', 'msg')
                 events.count = lambda: channel.get_non_ivr_log_count()
 
             return events

--- a/temba/contacts/fields.py
+++ b/temba/contacts/fields.py
@@ -8,7 +8,6 @@ from .models import Contact, ContactGroup, ContactURN, URN
 
 
 class OmniboxWidget(widgets.TextInput):
-
     @classmethod
     def get_objects_spec(cls, spec, user):
         org = user.get_org()
@@ -49,7 +48,9 @@ class OmniboxWidget(widgets.TextInput):
     def get_json(self, value):
 
         if 'user' not in self.__dict__:  # pragma: no cover
-            raise ValueError("Omnibox requires a user, make sure you set one using field.set_user(user) in your form.__init__")
+            raise ValueError(
+                "Omnibox requires a user, make sure you set one using field.set_user(user) in your form.__init__"
+            )
 
         objects = OmniboxWidget.get_objects_spec(value, self.user)
 
@@ -76,5 +77,7 @@ class OmniboxField(forms.Field):
 
     def to_python(self, value):
         if 'user' not in self.__dict__:  # pragma: no cover
-            raise ValueError("Omnibox requires a user, make sure you set one using field.set_user(user) in your form.__init__")
+            raise ValueError(
+                "Omnibox requires a user, make sure you set one using field.set_user(user) in your form.__init__"
+            )
         return OmniboxWidget.get_objects_spec(value, self.user)

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -32,7 +32,6 @@ from temba.utils.profiler import time_monitor
 from temba.utils.text import clean_string, truncate
 from temba.values.models import Value
 
-
 logger = logging.getLogger(__name__)
 
 # phone number for every org's test contact
@@ -59,18 +58,17 @@ FCM_SCHEME = 'fcm'
 FACEBOOK_PATH_REF_PREFIX = 'ref:'
 
 # Scheme, Label, Export/Import Header, Context Key
-URN_SCHEME_CONFIG = ((TEL_SCHEME, _("Phone number"), 'phone', 'tel_e164'),
-                     (FACEBOOK_SCHEME, _("Facebook identifier"), 'facebook', FACEBOOK_SCHEME),
-                     (TWITTER_SCHEME, _("Twitter handle"), 'twitter', TWITTER_SCHEME),
-                     (TWITTERID_SCHEME, _("Twitter ID"), 'twitterid', TWITTERID_SCHEME),
-                     (VIBER_SCHEME, _("Viber identifier"), 'viber', VIBER_SCHEME),
-                     (LINE_SCHEME, _("LINE identifier"), 'line', LINE_SCHEME),
-                     (TELEGRAM_SCHEME, _("Telegram identifier"), 'telegram', TELEGRAM_SCHEME),
-                     (EMAIL_SCHEME, _("Email address"), 'email', EMAIL_SCHEME),
-                     (EXTERNAL_SCHEME, _("External identifier"), 'external', EXTERNAL_SCHEME),
-                     (JIOCHAT_SCHEME, _("Jiochat identifier"), 'jiochat', JIOCHAT_SCHEME),
+URN_SCHEME_CONFIG = ((TEL_SCHEME, _("Phone number"), 'phone',
+                      'tel_e164'), (FACEBOOK_SCHEME, _("Facebook identifier"), 'facebook',
+                                    FACEBOOK_SCHEME), (TWITTER_SCHEME, _("Twitter handle"), 'twitter', TWITTER_SCHEME),
+                     (TWITTERID_SCHEME, _("Twitter ID"), 'twitterid',
+                      TWITTERID_SCHEME), (VIBER_SCHEME, _("Viber identifier"), 'viber',
+                                          VIBER_SCHEME), (LINE_SCHEME, _("LINE identifier"), 'line', LINE_SCHEME),
+                     (TELEGRAM_SCHEME, _("Telegram identifier"), 'telegram',
+                      TELEGRAM_SCHEME), (EMAIL_SCHEME, _("Email address"), 'email', EMAIL_SCHEME),
+                     (EXTERNAL_SCHEME, _("External identifier"), 'external',
+                      EXTERNAL_SCHEME), (JIOCHAT_SCHEME, _("Jiochat identifier"), 'jiochat', JIOCHAT_SCHEME),
                      (FCM_SCHEME, _("Firebase Cloud Messaging identifier"), 'fcm', FCM_SCHEME))
-
 
 IMPORT_HEADERS = tuple((c[2], c[0]) for c in URN_SCHEME_CONFIG)
 
@@ -340,8 +338,9 @@ class ContactField(SmartModel):
 
     key = models.CharField(verbose_name=_("Key"), max_length=MAX_KEY_LEN)
 
-    value_type = models.CharField(choices=Value.TYPE_CHOICES, max_length=1, default=Value.TYPE_TEXT,
-                                  verbose_name="Field Type")
+    value_type = models.CharField(
+        choices=Value.TYPE_CHOICES, max_length=1, default=Value.TYPE_TEXT, verbose_name="Field Type"
+    )
     show_in_table = models.BooleanField(verbose_name=_("Shown in Tables"), default=False)
 
     @classmethod
@@ -354,7 +353,8 @@ class ContactField(SmartModel):
 
     @classmethod
     def is_valid_key(cls, key):
-        return regex.match(r'^[a-z][a-z0-9_]*$', key, regex.V0) and key not in Contact.RESERVED_FIELDS and len(key) <= cls.MAX_KEY_LEN
+        return regex.match(r'^[a-z][a-z0-9_]*$', key, regex.V0
+                           ) and key not in Contact.RESERVED_FIELDS and len(key) <= cls.MAX_KEY_LEN
 
     @classmethod
     def is_valid_label(cls, label):
@@ -444,9 +444,15 @@ class ContactField(SmartModel):
                 if not ContactField.is_valid_key(key):
                     raise ValueError('Field key %s has invalid characters or is a reserved field name' % key)
 
-                field = ContactField.objects.create(org=org, key=key, label=label,
-                                                    show_in_table=show_in_table, value_type=value_type,
-                                                    created_by=user, modified_by=user)
+                field = ContactField.objects.create(
+                    org=org,
+                    key=key,
+                    label=label,
+                    show_in_table=show_in_table,
+                    value_type=value_type,
+                    created_by=user,
+                    modified_by=user
+                )
 
             return field
 
@@ -468,23 +474,38 @@ MAX_HISTORY = 50
 
 @six.python_2_unicode_compatible
 class Contact(TembaModel):
-    name = models.CharField(verbose_name=_("Name"), max_length=128, blank=True, null=True,
-                            help_text=_("The name of this contact"))
+    name = models.CharField(
+        verbose_name=_("Name"), max_length=128, blank=True, null=True, help_text=_("The name of this contact")
+    )
 
-    org = models.ForeignKey(Org, verbose_name=_("Org"), related_name="org_contacts",
-                            help_text=_("The organization that this contact belongs to"))
+    org = models.ForeignKey(
+        Org,
+        verbose_name=_("Org"),
+        related_name="org_contacts",
+        help_text=_("The organization that this contact belongs to")
+    )
 
-    is_blocked = models.BooleanField(verbose_name=_("Is Blocked"), default=False,
-                                     help_text=_("Whether this contact has been blocked"))
+    is_blocked = models.BooleanField(
+        verbose_name=_("Is Blocked"), default=False, help_text=_("Whether this contact has been blocked")
+    )
 
-    is_test = models.BooleanField(verbose_name=_("Is Test"), default=False,
-                                  help_text=_("Whether this contact is for simulation"))
+    is_test = models.BooleanField(
+        verbose_name=_("Is Test"), default=False, help_text=_("Whether this contact is for simulation")
+    )
 
-    is_stopped = models.BooleanField(verbose_name=_("Is Stopped"), default=False,
-                                     help_text=_("Whether this contact has opted out of receiving messages"))
+    is_stopped = models.BooleanField(
+        verbose_name=_("Is Stopped"),
+        default=False,
+        help_text=_("Whether this contact has opted out of receiving messages")
+    )
 
-    language = models.CharField(max_length=3, verbose_name=_("Language"), null=True, blank=True,
-                                help_text=_("The preferred language for this contact"))
+    language = models.CharField(
+        max_length=3,
+        verbose_name=_("Language"),
+        null=True,
+        blank=True,
+        help_text=_("The preferred language for this contact")
+    )
 
     simulation = False
 
@@ -499,7 +520,21 @@ class Contact(TembaModel):
 
     # reserved contact fields
     RESERVED_FIELDS = [
-        NAME, FIRST_NAME, PHONE, LANGUAGE, GROUPS, UUID, CONTACT_UUID, ID, 'created_by', 'modified_by', 'org', 'is', 'has', 'tel', 'tel_e164',
+        NAME,
+        FIRST_NAME,
+        PHONE,
+        LANGUAGE,
+        GROUPS,
+        UUID,
+        CONTACT_UUID,
+        ID,
+        'created_by',
+        'modified_by',
+        'org',
+        'is',
+        'has',
+        'tel',
+        'tel_e164',
     ] + [c[0] for c in IMPORT_HEADERS]
 
     @property
@@ -552,11 +587,14 @@ class Contact(TembaModel):
         contact_groups = self.user_groups.all()
         now = timezone.now()
 
-        scheduled_broadcasts = SystemLabel.get_queryset(self.org, SystemLabel.TYPE_SCHEDULED, exclude_test_contacts=False)
+        scheduled_broadcasts = SystemLabel.get_queryset(
+            self.org, SystemLabel.TYPE_SCHEDULED, exclude_test_contacts=False
+        )
         scheduled_broadcasts = scheduled_broadcasts.exclude(schedule__next_fire=None)
         scheduled_broadcasts = scheduled_broadcasts.filter(schedule__next_fire__gte=now)
         scheduled_broadcasts = scheduled_broadcasts.filter(
-            Q(contacts__in=[self]) | Q(urns__in=contact_urns) | Q(groups__in=contact_groups))
+            Q(contacts__in=[self]) | Q(urns__in=contact_urns) | Q(groups__in=contact_groups)
+        )
 
         return scheduled_broadcasts.order_by('schedule__next_fire')
 
@@ -570,11 +608,15 @@ class Contact(TembaModel):
         from temba.msgs.models import Msg, BroadcastRecipient
 
         msgs = Msg.objects.filter(contact=self, created_on__gte=after, created_on__lt=before)
-        msgs = msgs.exclude(visibility=Msg.VISIBILITY_DELETED).order_by('-created_on').select_related('channel').prefetch_related('channel_logs')[:MAX_HISTORY]
+        msgs = msgs.exclude(
+            visibility=Msg.VISIBILITY_DELETED
+        ).order_by('-created_on').select_related('channel').prefetch_related('channel_logs')[:MAX_HISTORY]
 
         # we also include in the timeline purged broadcasts with a best guess at the translation used
         recipients = BroadcastRecipient.objects.filter(contact=self)
-        recipients = recipients.filter(broadcast__purged=True, broadcast__created_on__gte=after, broadcast__created_on__lt=before)
+        recipients = recipients.filter(
+            broadcast__purged=True, broadcast__created_on__gte=after, broadcast__created_on__lt=before
+        )
         recipients = recipients.order_by('-broadcast__created_on').select_related('broadcast')[:MAX_HISTORY]
         broadcasts = []
         for recipient in recipients:
@@ -587,10 +629,14 @@ class Contact(TembaModel):
             broadcasts.append(broadcast)
 
         # and all of this contact's runs, channel events such as missed calls, scheduled events
-        started_runs = self.runs.filter(created_on__gte=after, created_on__lt=before).exclude(flow__flow_type=Flow.MESSAGE)
+        started_runs = self.runs.filter(
+            created_on__gte=after, created_on__lt=before
+        ).exclude(flow__flow_type=Flow.MESSAGE)
         started_runs = started_runs.order_by('-created_on').select_related('flow')[:MAX_HISTORY]
 
-        exited_runs = self.runs.filter(exited_on__gte=after, exited_on__lt=before).exclude(flow__flow_type=Flow.MESSAGE)
+        exited_runs = self.runs.filter(
+            exited_on__gte=after, exited_on__lt=before
+        ).exclude(flow__flow_type=Flow.MESSAGE)
         exited_runs = exited_runs.exclude(exit_type=None).order_by('-created_on').select_related('flow')[:MAX_HISTORY]
 
         channel_events = self.channel_events.filter(created_on__gte=after, created_on__lt=before)
@@ -603,21 +649,56 @@ class Contact(TembaModel):
         webhook_results = webhook_results.order_by('-created_on').select_related('event')[:MAX_HISTORY]
 
         # and the contact's failed IVR calls
-        calls = IVRCall.objects.filter(contact=self, created_on__gte=after, created_on__lt=before, status__in=[
-            IVRCall.BUSY, IVRCall.FAILED, IVRCall.NO_ANSWER, IVRCall.CANCELED, IVRCall.COMPLETED
-        ])
+        calls = IVRCall.objects.filter(
+            contact=self,
+            created_on__gte=after,
+            created_on__lt=before,
+            status__in=[IVRCall.BUSY, IVRCall.FAILED, IVRCall.NO_ANSWER, IVRCall.CANCELED, IVRCall.COMPLETED]
+        )
         calls = calls.order_by('-created_on').select_related('channel')[:MAX_HISTORY]
 
         # wrap items, chain and sort by time
         activity = chain(
-            [{'type': 'msg', 'time': m.created_on, 'obj': m} for m in msgs],
-            [{'type': 'broadcast', 'time': b.created_on, 'obj': b} for b in broadcasts],
-            [{'type': 'run-start', 'time': r.created_on, 'obj': r} for r in started_runs],
-            [{'type': 'run-exit', 'time': r.exited_on, 'obj': r} for r in exited_runs],
-            [{'type': 'channel-event', 'time': e.created_on, 'obj': e} for e in channel_events],
-            [{'type': 'event-fire', 'time': f.fired, 'obj': f} for f in event_fires],
-            [{'type': 'webhook-result', 'time': r.created_on, 'obj': r} for r in webhook_results],
-            [{'type': 'call', 'time': c.created_on, 'obj': c} for c in calls],
+            [{
+                'type': 'msg',
+                'time': m.created_on,
+                'obj': m
+            } for m in msgs],
+            [{
+                'type': 'broadcast',
+                'time': b.created_on,
+                'obj': b
+            } for b in broadcasts],
+            [{
+                'type': 'run-start',
+                'time': r.created_on,
+                'obj': r
+            } for r in started_runs],
+            [{
+                'type': 'run-exit',
+                'time': r.exited_on,
+                'obj': r
+            } for r in exited_runs],
+            [{
+                'type': 'channel-event',
+                'time': e.created_on,
+                'obj': e
+            } for e in channel_events],
+            [{
+                'type': 'event-fire',
+                'time': f.fired,
+                'obj': f
+            } for f in event_fires],
+            [{
+                'type': 'webhook-result',
+                'time': r.created_on,
+                'obj': r
+            } for r in webhook_results],
+            [{
+                'type': 'call',
+                'time': c.created_on,
+                'obj': c
+            } for c in calls],
         )
 
         return sorted(activity, key=lambda i: i['time'], reverse=True)[:MAX_HISTORY]
@@ -720,7 +801,9 @@ class Contact(TembaModel):
                 if state_field:
                     state_value = self.get_field(state_field.key)
                     if state_value:
-                        loc_value = self.org.parse_location(value, AdminBoundary.LEVEL_DISTRICT, state_value.location_value)
+                        loc_value = self.org.parse_location(
+                            value, AdminBoundary.LEVEL_DISTRICT, state_value.location_value
+                        )
             else:
                 loc_value = self.org.parse_location(value, AdminBoundary.LEVEL_STATE)
 
@@ -748,8 +831,12 @@ class Contact(TembaModel):
                     existing.location_value = loc_value
                     existing.category = category
 
-                    existing.save(update_fields=['string_value', 'decimal_value', 'datetime_value',
-                                                 'location_value', 'category', 'modified_on'])
+                    existing.save(
+                        update_fields=[
+                            'string_value', 'decimal_value', 'datetime_value', 'location_value', 'category',
+                            'modified_on'
+                        ]
+                    )
                     has_changed = True
 
                 # remove any others on the same field that may exist
@@ -757,9 +844,16 @@ class Contact(TembaModel):
 
             # otherwise, create a new value for it
             else:
-                existing = Value.objects.create(contact=self, contact_field=field, org=self.org,
-                                                string_value=str_value, decimal_value=dec_value, datetime_value=dt_value,
-                                                location_value=loc_value, category=category)
+                existing = Value.objects.create(
+                    contact=self,
+                    contact_field=field,
+                    org=self.org,
+                    string_value=str_value,
+                    decimal_value=dec_value,
+                    datetime_value=dt_value,
+                    location_value=loc_value,
+                    category=category
+                )
                 has_changed = True
 
         # cache this field value
@@ -832,7 +926,19 @@ class Contact(TembaModel):
             return None
 
     @classmethod
-    def get_or_create(cls, org, user, name=None, urns=None, channel=None, uuid=None, language=None, is_test=False, force_urn_update=False, auth=None):
+    def get_or_create(
+        cls,
+        org,
+        user,
+        name=None,
+        urns=None,
+        channel=None,
+        uuid=None,
+        language=None,
+        is_test=False,
+        force_urn_update=False,
+        auth=None
+    ):
         """
         Gets or creates a contact with the given URNs
         """
@@ -956,8 +1062,9 @@ class Contact(TembaModel):
 
             # otherwise create new contact with all URNs
             else:
-                kwargs = dict(org=org, name=name, language=language, is_test=is_test,
-                              created_by=user, modified_by=user)
+                kwargs = dict(
+                    org=org, name=name, language=language, is_test=is_test, created_by=user, modified_by=user
+                )
                 contact = Contact.objects.create(**kwargs)
                 updated_attrs = kwargs.keys()
 
@@ -1122,7 +1229,9 @@ class Contact(TembaModel):
 
         if not urns and not (org.is_anon or uuid):
             error_str = "Missing any valid URNs"
-            error_str += "; at least one among %s should be provided or a Contact UUID" % ", ".join(possible_urn_headers)
+            error_str += "; at least one among %s should be provided or a Contact UUID" % ", ".join(
+                possible_urn_headers
+            )
 
             raise SmartImportRowError(error_str)
 
@@ -1136,7 +1245,9 @@ class Contact(TembaModel):
             language = None  # ignore anything that's not a 3-letter code
 
         # create new contact or fetch existing one
-        contact = Contact.get_or_create(org, user, name, uuid=uuid, urns=urns, language=language, force_urn_update=True)
+        contact = Contact.get_or_create(
+            org, user, name, uuid=uuid, urns=urns, language=language, force_urn_update=True
+        )
 
         # if they exist and are blocked, unblock them
         if contact.is_blocked:
@@ -1229,7 +1340,10 @@ class Contact(TembaModel):
         Contact.validate_org_import_header(headers, org)
 
         # return the column headers which can become contact fields
-        return [header for header in headers if header.strip().lower() and header.strip().lower() not in Contact.RESERVED_FIELDS]
+        return [
+            header for header in headers
+            if header.strip().lower() and header.strip().lower() not in Contact.RESERVED_FIELDS
+        ]
 
     @classmethod
     def validate_org_import_header(cls, headers, org):
@@ -1242,8 +1356,12 @@ class Contact(TembaModel):
             return
 
         if not found_headers:
-            raise Exception(ugettext('The file you provided is missing a required header. At least one of "%s" '
-                                     'or "Contact UUID" should be included.' % capitalized_possible_headers))
+            raise Exception(
+                ugettext(
+                    'The file you provided is missing a required header. At least one of "%s" '
+                    'or "Contact UUID" should be included.' % capitalized_possible_headers
+                )
+            )
 
         if 'name' not in headers:
             raise Exception(ugettext('The file you provided is missing a required header called "Name".'))
@@ -1296,7 +1414,10 @@ class Contact(TembaModel):
 
             # make sure there are same number of fields
             if len(row_data) != len(header):  # pragma: needs cover
-                raise Exception("Line %d: The number of fields for this row is incorrect. Expected %d but found %d." % (line_number, len(header), len(row_data)))
+                raise Exception(
+                    "Line %d: The number of fields for this row is incorrect. Expected %d but found %d." %
+                    (line_number, len(header), len(row_data))
+                )
 
             field_values = dict(zip(header, row_data))
             log_field_values = field_values.copy()
@@ -1405,7 +1526,10 @@ class Contact(TembaModel):
         if not group_org.is_whitelisted():
             try:
                 # get all of our phone numbers for the imported contacts
-                paths = [int(u.path) for u in ContactURN.objects.filter(scheme=TEL_SCHEME, contact__in=[c.pk for c in contacts])]
+                paths = [
+                    int(u.path)
+                    for u in ContactURN.objects.filter(scheme=TEL_SCHEME, contact__in=[c.pk for c in contacts])
+                ]
                 paths = sorted(paths)
 
                 last_path = None
@@ -1581,8 +1705,9 @@ class Contact(TembaModel):
             setattr(contact, '__urns', list())  # initialize URN list cache (setattr avoids name mangling or __urns)
 
         # cache all field values
-        values = Value.objects.filter(contact_id__in=contact_map.keys(),
-                                      contact_field_id__in=key_map.keys()).select_related('contact_field', 'location_value')
+        values = Value.objects.filter(
+            contact_id__in=contact_map.keys(), contact_field_id__in=key_map.keys()
+        ).select_related('contact_field', 'location_value')
         for value in values:
             contact = contact_map[value.contact_id]
             field_key = key_map[value.contact_field_id]
@@ -1630,7 +1755,9 @@ class Contact(TembaModel):
             context[TWITTER_SCHEME] = context[TWITTERID_SCHEME]
 
         active_ids = ContactField.objects.filter(org_id=self.org_id, is_active=True).values_list('id', flat=True)
-        field_values = Value.objects.filter(contact=self, contact_field_id__in=active_ids).select_related('contact_field')
+        field_values = Value.objects.filter(
+            contact=self, contact_field_id__in=active_ids
+        ).select_related('contact_field')
 
         # get all the values for this contact
         contact_values = {v.contact_field.key: v for v in field_values}
@@ -1719,7 +1846,7 @@ class Contact(TembaModel):
         Gets the highest priority matching URN for this contact. Schemes may be a single scheme or a set/list/tuple
         """
         if isinstance(schemes, six.string_types):
-            schemes = (schemes,)
+            schemes = (schemes, )
 
         urns = self.get_urns()
 
@@ -1872,8 +1999,20 @@ class Contact(TembaModel):
         if tel:
             return tel.path
 
-    def send(self, text, user, trigger_send=True, response_to=None, expressions_context=None, connection=None,
-             attachments=None, msg_type=None, created_on=None, all_urns=False, high_priority=False):
+    def send(
+        self,
+        text,
+        user,
+        trigger_send=True,
+        response_to=None,
+        expressions_context=None,
+        connection=None,
+        attachments=None,
+        msg_type=None,
+        created_on=None,
+        all_urns=False,
+        high_priority=False
+    ):
         from temba.msgs.models import Msg, INBOX, PENDING, SENT, UnreachableException
 
         status = SENT if created_on else PENDING
@@ -1886,10 +2025,20 @@ class Contact(TembaModel):
         msgs = []
         for recipient in recipients:
             try:
-                msg = Msg.create_outgoing(self.org, user, recipient, text,
-                                          response_to=response_to, expressions_context=expressions_context, connection=connection,
-                                          attachments=attachments, msg_type=msg_type or INBOX, status=status,
-                                          created_on=created_on, high_priority=high_priority)
+                msg = Msg.create_outgoing(
+                    self.org,
+                    user,
+                    recipient,
+                    text,
+                    response_to=response_to,
+                    expressions_context=expressions_context,
+                    connection=connection,
+                    attachments=attachments,
+                    msg_type=msg_type or INBOX,
+                    status=status,
+                    created_on=created_on,
+                    high_priority=high_priority
+                )
                 if msg is not None:
                     msgs.append(msg)
             except UnreachableException:
@@ -1915,7 +2064,9 @@ class ContactURN(models.Model):
     CONTEXT_KEYS_TO_LABEL = {c[3]: c[1] for c in URN_SCHEME_CONFIG}
     IMPORT_HEADER_TO_SCHEME = {s[0]: s[1] for s in IMPORT_HEADERS}
 
-    SCHEMES_SUPPORTING_FOLLOW = {TWITTER_SCHEME, TWITTERID_SCHEME, JIOCHAT_SCHEME}  # schemes that support "follow" triggers
+    SCHEMES_SUPPORTING_FOLLOW = {
+        TWITTER_SCHEME, TWITTERID_SCHEME, JIOCHAT_SCHEME
+    }  # schemes that support "follow" triggers
     # schemes that support "new conversation" triggers
     SCHEMES_SUPPORTING_NEW_CONVERSATION = {FACEBOOK_SCHEME, VIBER_SCHEME, TELEGRAM_SCHEME}
     SCHEMES_SUPPORTING_REFERRALS = {FACEBOOK_SCHEME}  # schemes that support "referral" triggers
@@ -1940,42 +2091,45 @@ class ContactURN(models.Model):
     PRIORITY_STANDARD = 50
     PRIORITY_HIGHEST = 99
 
-    PRIORITY_DEFAULTS = {TEL_SCHEME: PRIORITY_STANDARD,
-                         TWITTER_SCHEME: 90, TWITTERID_SCHEME: 90,
-                         FACEBOOK_SCHEME: 90,
-                         TELEGRAM_SCHEME: 90,
-                         VIBER_SCHEME: 90,
-                         FCM_SCHEME: 90}
+    PRIORITY_DEFAULTS = {
+        TEL_SCHEME: PRIORITY_STANDARD,
+        TWITTER_SCHEME: 90,
+        TWITTERID_SCHEME: 90,
+        FACEBOOK_SCHEME: 90,
+        TELEGRAM_SCHEME: 90,
+        VIBER_SCHEME: 90,
+        FCM_SCHEME: 90
+    }
 
-    ANON_MASK = '*' * 8            # Returned instead of URN values for anon orgs
+    ANON_MASK = '*' * 8  # Returned instead of URN values for anon orgs
     ANON_MASK_HTML = '\u2022' * 8  # Pretty HTML version of anon mask
 
-    contact = models.ForeignKey(Contact, null=True, blank=True, related_name='urns',
-                                help_text="The contact that this URN is for, can be null")
+    contact = models.ForeignKey(
+        Contact, null=True, blank=True, related_name='urns', help_text="The contact that this URN is for, can be null"
+    )
 
-    identity = models.CharField(max_length=255,
-                                help_text="The Universal Resource Name as a string, excluding display if present. ex: tel:+250788383383")
+    identity = models.CharField(
+        max_length=255,
+        help_text="The Universal Resource Name as a string, excluding display if present. ex: tel:+250788383383"
+    )
 
-    path = models.CharField(max_length=255,
-                            help_text="The path component of our URN. ex: +250788383383")
+    path = models.CharField(max_length=255, help_text="The path component of our URN. ex: +250788383383")
 
-    display = models.CharField(max_length=255, null=True,
-                               help_text="The display component for this URN, if any")
+    display = models.CharField(max_length=255, null=True, help_text="The display component for this URN, if any")
 
-    scheme = models.CharField(max_length=128,
-                              help_text="The scheme for this URN, broken out for optimization reasons, ex: tel")
+    scheme = models.CharField(
+        max_length=128, help_text="The scheme for this URN, broken out for optimization reasons, ex: tel"
+    )
 
-    org = models.ForeignKey(Org,
-                            help_text="The organization for this URN, can be null")
+    org = models.ForeignKey(Org, help_text="The organization for this URN, can be null")
 
-    priority = models.IntegerField(default=PRIORITY_STANDARD,
-                                   help_text="The priority of this URN for the contact it is associated with")
+    priority = models.IntegerField(
+        default=PRIORITY_STANDARD, help_text="The priority of this URN for the contact it is associated with"
+    )
 
-    channel = models.ForeignKey(Channel, null=True, blank=True,
-                                help_text="The preferred channel for this URN")
+    channel = models.ForeignKey(Channel, null=True, blank=True, help_text="The preferred channel for this URN")
 
-    auth = models.TextField(null=True,
-                            help_text=_("Any authentication information needed by this URN"))
+    auth = models.TextField(null=True, help_text=_("Any authentication information needed by this URN"))
 
     @classmethod
     def get_or_create(cls, org, contact, urn_as_string, channel=None, auth=None):
@@ -1995,8 +2149,17 @@ class ContactURN(models.Model):
         if not priority:
             priority = cls.PRIORITY_DEFAULTS.get(scheme, cls.PRIORITY_STANDARD)
 
-        return cls.objects.create(org=org, contact=contact, priority=priority, channel=channel, auth=auth,
-                                  scheme=scheme, path=path, identity=urn_as_string, display=display)
+        return cls.objects.create(
+            org=org,
+            contact=contact,
+            priority=priority,
+            channel=channel,
+            auth=auth,
+            scheme=scheme,
+            path=path,
+            identity=urn_as_string,
+            display=display
+        )
 
     @classmethod
     def lookup(cls, org, urn_as_string, country_code=None, normalize=True):
@@ -2013,7 +2176,9 @@ class ContactURN(models.Model):
 
         # is this a TWITTER scheme? check TWITTERID scheme by looking up by display
         if scheme == TWITTER_SCHEME:
-            twitterid_urn = cls.objects.filter(org=org, scheme=TWITTERID_SCHEME, display=path).select_related('contact').first()
+            twitterid_urn = cls.objects.filter(
+                org=org, scheme=TWITTERID_SCHEME, display=path
+            ).select_related('contact').first()
             if twitterid_urn:
                 return twitterid_urn
 
@@ -2115,8 +2280,9 @@ class SystemContactGroupManager(models.Manager):
 
 class UserContactGroupManager(models.Manager):
     def get_queryset(self):
-        return super(UserContactGroupManager, self).get_queryset().filter(group_type=ContactGroup.TYPE_USER_DEFINED,
-                                                                          is_active=True)
+        return super(UserContactGroupManager, self).get_queryset().filter(
+            group_type=ContactGroup.TYPE_USER_DEFINED, is_active=True
+        )
 
 
 @six.python_2_unicode_compatible
@@ -2129,21 +2295,25 @@ class ContactGroup(TembaModel):
     TYPE_STOPPED = 'S'
     TYPE_USER_DEFINED = 'U'
 
-    TYPE_CHOICES = ((TYPE_ALL, "All Contacts"),
-                    (TYPE_BLOCKED, "Blocked Contacts"),
-                    (TYPE_STOPPED, "Stopped Contacts"),
+    TYPE_CHOICES = ((TYPE_ALL, "All Contacts"), (TYPE_BLOCKED, "Blocked Contacts"), (TYPE_STOPPED, "Stopped Contacts"),
                     (TYPE_USER_DEFINED, "User Defined Groups"))
 
-    name = models.CharField(verbose_name=_("Name"), max_length=MAX_NAME_LEN,
-                            help_text=_("The name of this contact group"))
+    name = models.CharField(
+        verbose_name=_("Name"), max_length=MAX_NAME_LEN, help_text=_("The name of this contact group")
+    )
 
-    group_type = models.CharField(max_length=1, choices=TYPE_CHOICES, default=TYPE_USER_DEFINED,
-                                  help_text=_("What type of group it is, either user defined or one of our system groups"))
+    group_type = models.CharField(
+        max_length=1,
+        choices=TYPE_CHOICES,
+        default=TYPE_USER_DEFINED,
+        help_text=_("What type of group it is, either user defined or one of our system groups")
+    )
 
     contacts = models.ManyToManyField(Contact, verbose_name=_("Contacts"), related_name='all_groups')
 
-    org = models.ForeignKey(Org, related_name='all_groups',
-                            verbose_name=_("Org"), help_text=_("The organization this group is part of"))
+    org = models.ForeignKey(
+        Org, related_name='all_groups', verbose_name=_("Org"), help_text=_("The organization this group is part of")
+    )
 
     import_task = models.ForeignKey(ImportTask, null=True, blank=True)
 
@@ -2224,8 +2394,9 @@ class ContactGroup(TembaModel):
             existing = cls.get_user_group(org, full_group_name)
             count += 1
 
-        return cls.user_groups.create(org=org, name=full_group_name, query=query,
-                                      import_task=task, created_by=user, modified_by=user)
+        return cls.user_groups.create(
+            org=org, name=full_group_name, query=query, import_task=task, created_by=user, modified_by=user
+        )
 
     @classmethod
     def clean_name(cls, name):
@@ -2328,7 +2499,7 @@ class ContactGroup(TembaModel):
             raise ValueError("Can only update query for a dynamic group")
 
         self.query = query
-        self.save(update_fields=('query',))
+        self.save(update_fields=('query', ))
 
         self.query_fields.clear()
 
@@ -2413,7 +2584,7 @@ class ContactGroupCount(SquashableModel):
     Maintains counts of contact groups. These are calculated via triggers on the database and squashed
     by a recurring task.
     """
-    SQUASH_OVER = ('group_id',)
+    SQUASH_OVER = ('group_id', )
 
     group = models.ForeignKey(ContactGroup, related_name='counts', db_index=True)
     count = models.IntegerField(default=0)
@@ -2426,9 +2597,11 @@ class ContactGroupCount(SquashableModel):
         )
         INSERT INTO %(table)s("group_id", "count", "is_squashed")
         VALUES (%%s, GREATEST(0, (SELECT SUM("count") FROM deleted)), TRUE);
-        """ % {'table': cls._meta.db_table}
+        """ % {
+            'table': cls._meta.db_table
+        }
 
-        return sql, (distinct_set.group_id,) * 2
+        return sql, (distinct_set.group_id, ) * 2
 
     @classmethod
     def get_totals(cls, groups):
@@ -2463,8 +2636,9 @@ class ExportContactsTask(BaseExportTask):
     email_subject = "Your contacts export is ready"
     email_template = 'contacts/email/contacts_export_download'
 
-    group = models.ForeignKey(ContactGroup, null=True, related_name='exports',
-                              help_text=_("The unique group to export"))
+    group = models.ForeignKey(
+        ContactGroup, null=True, related_name='exports', help_text=_("The unique group to export")
+    )
     search = models.TextField(null=True, blank=True, help_text=_("The search query"))
 
     @classmethod
@@ -2473,8 +2647,10 @@ class ExportContactsTask(BaseExportTask):
 
     def get_export_fields_and_schemes(self):
 
-        fields = [dict(label='Contact UUID', key=Contact.UUID, id=0, field=None, urn_scheme=None),
-                  dict(label='Name', key=Contact.NAME, id=0, field=None, urn_scheme=None)]
+        fields = [
+            dict(label='Contact UUID', key=Contact.UUID, id=0, field=None, urn_scheme=None),
+            dict(label='Name', key=Contact.NAME, id=0, field=None, urn_scheme=None)
+        ]
 
         # anon orgs also get an ID column that is just the PK
         if self.org.is_anon:
@@ -2484,7 +2660,13 @@ class ExportContactsTask(BaseExportTask):
         if not self.org.is_anon:
             active_urn_schemes = [c[0] for c in ContactURN.SCHEME_CHOICES]
 
-            scheme_counts = {scheme: ContactURN.objects.filter(org=self.org, scheme=scheme).exclude(contact=None).values('contact').annotate(count=Count('contact')).aggregate(Max('count'))['count__max'] for scheme in active_urn_schemes}
+            scheme_counts = {
+                scheme: ContactURN.objects.filter(
+                    org=self.org, scheme=scheme
+                ).exclude(contact=None).values('contact').annotate(count=Count('contact')).aggregate(Max('count')
+                                                                                                     )['count__max']
+                for scheme in active_urn_schemes
+            }
 
             schemes = scheme_counts.keys()
             schemes.sort()
@@ -2499,11 +2681,15 @@ class ExportContactsTask(BaseExportTask):
 
         contact_fields_list = ContactField.objects.filter(org=self.org, is_active=True).select_related('org')
         for contact_field in contact_fields_list:
-            fields.append(dict(field=contact_field,
-                               label=contact_field.label,
-                               key=contact_field.key,
-                               id=contact_field.id,
-                               urn_scheme=None))
+            fields.append(
+                dict(
+                    field=contact_field,
+                    label=contact_field.label,
+                    key=contact_field.key,
+                    id=contact_field.id,
+                    urn_scheme=None
+                )
+            )
 
         return fields, scheme_counts
 
@@ -2582,10 +2768,12 @@ class ExportContactsTask(BaseExportTask):
                     elapsed = time.time() - start
                     predicted = int(elapsed / (current_contact / (len(contact_ids) * 1.0)))
 
-                    print("Export of %s contacts - %d%% (%s/%s) complete in %0.2fs (predicted %0.0fs)" %
-                          (self.org.name, current_contact * 100 / len(contact_ids),
-                           "{:,}".format(current_contact), "{:,}".format(len(contact_ids)),
-                           time.time() - start, predicted))
+                    print(
+                        "Export of %s contacts - %d%% (%s/%s) complete in %0.2fs (predicted %0.0fs)" % (
+                            self.org.name, current_contact * 100 / len(contact_ids), "{:,}".format(current_contact),
+                            "{:,}".format(len(contact_ids)), time.time() - start, predicted
+                        )
+                    )
 
         return exporter.save_file()
 

--- a/temba/contacts/omnibox.py
+++ b/temba/contacts/omnibox.py
@@ -21,11 +21,11 @@ def omnibox_query(org, **kwargs):
     # determine what type of group/contact/URN lookup is being requested
     contact_uuids = kwargs.get('c', None)  # contacts with ids
     message_ids = kwargs.get('m', None)  # contacts with message ids
-    label_id = kwargs.get('l', None)     # contacts in flow step with UUID
-    group_uuids = kwargs.get('g', None)    # groups with ids
-    urn_ids = kwargs.get('u', None)      # URNs with ids
+    label_id = kwargs.get('l', None)  # contacts in flow step with UUID
+    group_uuids = kwargs.get('g', None)  # groups with ids
+    urn_ids = kwargs.get('u', None)  # URNs with ids
     search = kwargs.get('search', None)  # search of groups, contacts and URNs
-    types = list(kwargs.get('types', ''))    # limit search to types (g | s | c | u)
+    types = list(kwargs.get('types', ''))  # limit search to types (g | s | c | u)
 
     # these lookups return a Contact queryset
     if contact_uuids or message_ids or label_id:
@@ -84,7 +84,7 @@ def omnibox_mixed_search(org, search, types):
             groups = groups.filter(query=None)
 
         if search:
-            groups = term_search(groups, ('name__icontains',), search_terms)
+            groups = term_search(groups, ('name__icontains', ), search_terms)
 
         results += list(groups.order_by(Upper('name'))[:per_type_limit])
 
@@ -99,7 +99,7 @@ def omnibox_mixed_search(org, search, types):
         if org.is_anon and search_id is not None:
             contacts = contacts.filter(id=search_id)
         elif search:
-            contacts = term_search(contacts, ('name__icontains',), search_terms)
+            contacts = term_search(contacts, ('name__icontains', ), search_terms)
 
         results += list(contacts.order_by(Upper('name'))[:per_type_limit])
 
@@ -111,7 +111,7 @@ def omnibox_mixed_search(org, search, types):
         urns = ContactURN.objects.filter(org=org, scheme__in=allowed_schemes).exclude(contact=None)
 
         if search:
-            urns = term_search(urns, ('path__icontains',), search_terms)
+            urns = term_search(urns, ('path__icontains', ), search_terms)
 
         results += list(urns.prefetch_related('contact').order_by(Upper('path'))[:per_type_limit])
 
@@ -129,16 +129,9 @@ def omnibox_results_to_dict(org, results):
 
     for obj in results:
         if isinstance(obj, ContactGroup):
-            result = {
-                'id': 'g-%s' % obj.uuid,
-                'text': obj.name,
-                'extra': group_counts[obj]
-            }
+            result = {'id': 'g-%s' % obj.uuid, 'text': obj.name, 'extra': group_counts[obj]}
         elif isinstance(obj, Contact):
-            result = {
-                'id': 'c-%s' % obj.uuid,
-                'text': obj.get_display(org)
-            }
+            result = {'id': 'c-%s' % obj.uuid, 'text': obj.get_display(org)}
         elif isinstance(obj, ContactURN):
             result = {
                 'id': 'u-%d' % obj.id,

--- a/temba/contacts/search/gen/ContactQLLexer.py
+++ b/temba/contacts/search/gen/ContactQLLexer.py
@@ -161,7 +161,7 @@ class ContactQLLexer(Lexer):
 
     atn = ATNDeserializer().deserialize(serializedATN())
 
-    decisionsToDFA = [ DFA(ds, i) for i, ds in enumerate(atn.decisionToState) ]
+    decisionsToDFA = [DFA(ds, i) for i, ds in enumerate(atn.decisionToState)]
 
     LPAREN = 1
     RPAREN = 2
@@ -173,21 +173,21 @@ class ContactQLLexer(Lexer):
     WS = 8
     ERROR = 9
 
-    channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN" ]
+    channelNames = [u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN"]
 
-    modeNames = [ u"DEFAULT_MODE" ]
+    modeNames = [u"DEFAULT_MODE"]
 
-    literalNames = [ u"<INVALID>",
-            u"'('", u"')'" ]
+    literalNames = [u"<INVALID>", u"'('", u"')'"]
 
-    symbolicNames = [ u"<INVALID>",
-            u"LPAREN", u"RPAREN", u"AND", u"OR", u"COMPARATOR", u"TEXT", 
-            u"STRING", u"WS", u"ERROR" ]
+    symbolicNames = [
+        u"<INVALID>", u"LPAREN", u"RPAREN", u"AND", u"OR", u"COMPARATOR", u"TEXT", u"STRING", u"WS", u"ERROR"
+    ]
 
-    ruleNames = [ u"HAS", u"IS", u"LPAREN", u"RPAREN", u"AND", u"OR", u"COMPARATOR", 
-                  u"TEXT", u"STRING", u"WS", u"ERROR", u"UnicodeLetter", 
-                  u"UnicodeClass_LU", u"UnicodeClass_LL", u"UnicodeClass_LT", 
-                  u"UnicodeClass_LM", u"UnicodeClass_LO", u"UnicodeDigit" ]
+    ruleNames = [
+        u"HAS", u"IS", u"LPAREN", u"RPAREN", u"AND", u"OR", u"COMPARATOR", u"TEXT", u"STRING", u"WS", u"ERROR",
+        u"UnicodeLetter", u"UnicodeClass_LU", u"UnicodeClass_LL", u"UnicodeClass_LT", u"UnicodeClass_LM",
+        u"UnicodeClass_LO", u"UnicodeDigit"
+    ]
 
     grammarFileName = u"ContactQL.g4"
 
@@ -197,5 +197,3 @@ class ContactQLLexer(Lexer):
         self._interp = LexerATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._actions = None
         self._predicates = None
-
-

--- a/temba/contacts/search/gen/ContactQLParser.py
+++ b/temba/contacts/search/gen/ContactQLParser.py
@@ -5,6 +5,7 @@ from antlr4 import *
 from io import StringIO
 import sys
 
+
 def serializedATN():
     with StringIO() as buf:
         buf.write(u"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3")
@@ -25,37 +26,38 @@ def serializedATN():
         return buf.getvalue()
 
 
-class ContactQLParser ( Parser ):
+class ContactQLParser(Parser):
 
     grammarFileName = "ContactQL.g4"
 
     atn = ATNDeserializer().deserialize(serializedATN())
 
-    decisionsToDFA = [ DFA(ds, i) for i, ds in enumerate(atn.decisionToState) ]
+    decisionsToDFA = [DFA(ds, i) for i, ds in enumerate(atn.decisionToState)]
 
     sharedContextCache = PredictionContextCache()
 
-    literalNames = [ u"<INVALID>", u"'('", u"')'" ]
+    literalNames = [u"<INVALID>", u"'('", u"')'"]
 
-    symbolicNames = [ u"<INVALID>", u"LPAREN", u"RPAREN", u"AND", u"OR", 
-                      u"COMPARATOR", u"TEXT", u"STRING", u"WS", u"ERROR" ]
+    symbolicNames = [
+        u"<INVALID>", u"LPAREN", u"RPAREN", u"AND", u"OR", u"COMPARATOR", u"TEXT", u"STRING", u"WS", u"ERROR"
+    ]
 
     RULE_parse = 0
     RULE_expression = 1
     RULE_literal = 2
 
-    ruleNames =  [ u"parse", u"expression", u"literal" ]
+    ruleNames = [u"parse", u"expression", u"literal"]
 
     EOF = Token.EOF
-    LPAREN=1
-    RPAREN=2
-    AND=3
-    OR=4
-    COMPARATOR=5
-    TEXT=6
-    STRING=7
-    WS=8
-    ERROR=9
+    LPAREN = 1
+    RPAREN = 2
+    AND = 3
+    OR = 4
+    COMPARATOR = 5
+    TEXT = 6
+    STRING = 7
+    WS = 8
+    ERROR = 9
 
     def __init__(self, input, output=sys.stdout):
         super(ContactQLParser, self).__init__(input, output=output)
@@ -63,17 +65,13 @@ class ContactQLParser ( Parser ):
         self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, self.sharedContextCache)
         self._predicates = None
 
-
-
     class ParseContext(ParserRuleContext):
-
         def __init__(self, parser, parent=None, invokingState=-1):
             super(ContactQLParser.ParseContext, self).__init__(parent, invokingState)
             self.parser = parser
 
         def expression(self):
-            return self.getTypedRuleContext(ContactQLParser.ExpressionContext,0)
-
+            return self.getTypedRuleContext(ContactQLParser.ExpressionContext, 0)
 
         def EOF(self):
             return self.getToken(ContactQLParser.EOF, 0)
@@ -86,9 +84,6 @@ class ContactQLParser ( Parser ):
                 return visitor.visitParse(self)
             else:
                 return visitor.visitChildren(self)
-
-
-
 
     def parse(self):
 
@@ -109,23 +104,18 @@ class ContactQLParser ( Parser ):
         return localctx
 
     class ExpressionContext(ParserRuleContext):
-
         def __init__(self, parser, parent=None, invokingState=-1):
             super(ContactQLParser.ExpressionContext, self).__init__(parent, invokingState)
             self.parser = parser
 
-
         def getRuleIndex(self):
             return ContactQLParser.RULE_expression
 
-     
         def copyFrom(self, ctx):
             super(ContactQLParser.ExpressionContext, self).copyFrom(ctx)
 
-
     class ImplicitConditionContext(ExpressionContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.ExpressionContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.ExpressionContext)
             super(ContactQLParser.ImplicitConditionContext, self).__init__(parser)
             self.copyFrom(ctx)
 
@@ -138,20 +128,19 @@ class ContactQLParser ( Parser ):
             else:
                 return visitor.visitChildren(self)
 
-
     class ConditionContext(ExpressionContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.ExpressionContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.ExpressionContext)
             super(ContactQLParser.ConditionContext, self).__init__(parser)
             self.copyFrom(ctx)
 
         def TEXT(self):
             return self.getToken(ContactQLParser.TEXT, 0)
+
         def COMPARATOR(self):
             return self.getToken(ContactQLParser.COMPARATOR, 0)
-        def literal(self):
-            return self.getTypedRuleContext(ContactQLParser.LiteralContext,0)
 
+        def literal(self):
+            return self.getTypedRuleContext(ContactQLParser.LiteralContext, 0)
 
         def accept(self, visitor):
             if hasattr(visitor, "visitCondition"):
@@ -159,10 +148,8 @@ class ContactQLParser ( Parser ):
             else:
                 return visitor.visitChildren(self)
 
-
     class CombinationAndContext(ExpressionContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.ExpressionContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.ExpressionContext)
             super(ContactQLParser.CombinationAndContext, self).__init__(parser)
             self.copyFrom(ctx)
 
@@ -170,7 +157,7 @@ class ContactQLParser ( Parser ):
             if i is None:
                 return self.getTypedRuleContexts(ContactQLParser.ExpressionContext)
             else:
-                return self.getTypedRuleContext(ContactQLParser.ExpressionContext,i)
+                return self.getTypedRuleContext(ContactQLParser.ExpressionContext, i)
 
         def AND(self):
             return self.getToken(ContactQLParser.AND, 0)
@@ -181,10 +168,8 @@ class ContactQLParser ( Parser ):
             else:
                 return visitor.visitChildren(self)
 
-
     class CombinationImpicitAndContext(ExpressionContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.ExpressionContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.ExpressionContext)
             super(ContactQLParser.CombinationImpicitAndContext, self).__init__(parser)
             self.copyFrom(ctx)
 
@@ -192,8 +177,7 @@ class ContactQLParser ( Parser ):
             if i is None:
                 return self.getTypedRuleContexts(ContactQLParser.ExpressionContext)
             else:
-                return self.getTypedRuleContext(ContactQLParser.ExpressionContext,i)
-
+                return self.getTypedRuleContext(ContactQLParser.ExpressionContext, i)
 
         def accept(self, visitor):
             if hasattr(visitor, "visitCombinationImpicitAnd"):
@@ -201,10 +185,8 @@ class ContactQLParser ( Parser ):
             else:
                 return visitor.visitChildren(self)
 
-
     class CombinationOrContext(ExpressionContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.ExpressionContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.ExpressionContext)
             super(ContactQLParser.CombinationOrContext, self).__init__(parser)
             self.copyFrom(ctx)
 
@@ -212,7 +194,7 @@ class ContactQLParser ( Parser ):
             if i is None:
                 return self.getTypedRuleContexts(ContactQLParser.ExpressionContext)
             else:
-                return self.getTypedRuleContext(ContactQLParser.ExpressionContext,i)
+                return self.getTypedRuleContext(ContactQLParser.ExpressionContext, i)
 
         def OR(self):
             return self.getToken(ContactQLParser.OR, 0)
@@ -223,17 +205,16 @@ class ContactQLParser ( Parser ):
             else:
                 return visitor.visitChildren(self)
 
-
     class ExpressionGroupingContext(ExpressionContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.ExpressionContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.ExpressionContext)
             super(ContactQLParser.ExpressionGroupingContext, self).__init__(parser)
             self.copyFrom(ctx)
 
         def LPAREN(self):
             return self.getToken(ContactQLParser.LPAREN, 0)
+
         def expression(self):
-            return self.getTypedRuleContext(ContactQLParser.ExpressionContext,0)
+            return self.getTypedRuleContext(ContactQLParser.ExpressionContext, 0)
 
         def RPAREN(self):
             return self.getToken(ContactQLParser.RPAREN, 0)
@@ -243,8 +224,6 @@ class ContactQLParser ( Parser ):
                 return visitor.visitExpressionGrouping(self)
             else:
                 return visitor.visitChildren(self)
-
-
 
     def expression(self, _p=0):
         _parentctx = self._ctx
@@ -257,7 +236,7 @@ class ContactQLParser ( Parser ):
             self.enterOuterAlt(localctx, 1)
             self.state = 18
             self._errHandler.sync(self)
-            la_ = self._interp.adaptivePredict(self._input,0,self._ctx)
+            la_ = self._interp.adaptivePredict(self._input, 0, self._ctx)
             if la_ == 1:
                 localctx = ContactQLParser.ExpressionGroupingContext(self, localctx)
                 self._ctx = localctx
@@ -291,21 +270,22 @@ class ContactQLParser ( Parser ):
                 self.match(ContactQLParser.TEXT)
                 pass
 
-
             self._ctx.stop = self._input.LT(-1)
             self.state = 30
             self._errHandler.sync(self)
-            _alt = self._interp.adaptivePredict(self._input,2,self._ctx)
-            while _alt!=2 and _alt!=ATN.INVALID_ALT_NUMBER:
-                if _alt==1:
+            _alt = self._interp.adaptivePredict(self._input, 2, self._ctx)
+            while _alt != 2 and _alt != ATN.INVALID_ALT_NUMBER:
+                if _alt == 1:
                     if self._parseListeners is not None:
                         self.triggerExitRuleEvent()
                     _prevctx = localctx
                     self.state = 28
                     self._errHandler.sync(self)
-                    la_ = self._interp.adaptivePredict(self._input,1,self._ctx)
+                    la_ = self._interp.adaptivePredict(self._input, 1, self._ctx)
                     if la_ == 1:
-                        localctx = ContactQLParser.CombinationAndContext(self, ContactQLParser.ExpressionContext(self, _parentctx, _parentState))
+                        localctx = ContactQLParser.CombinationAndContext(
+                            self, ContactQLParser.ExpressionContext(self, _parentctx, _parentState)
+                        )
                         self.pushNewRecursionContext(localctx, _startState, self.RULE_expression)
                         self.state = 20
                         if not self.precpred(self._ctx, 6):
@@ -318,7 +298,9 @@ class ContactQLParser ( Parser ):
                         pass
 
                     elif la_ == 2:
-                        localctx = ContactQLParser.CombinationImpicitAndContext(self, ContactQLParser.ExpressionContext(self, _parentctx, _parentState))
+                        localctx = ContactQLParser.CombinationImpicitAndContext(
+                            self, ContactQLParser.ExpressionContext(self, _parentctx, _parentState)
+                        )
                         self.pushNewRecursionContext(localctx, _startState, self.RULE_expression)
                         self.state = 23
                         if not self.precpred(self._ctx, 5):
@@ -329,7 +311,9 @@ class ContactQLParser ( Parser ):
                         pass
 
                     elif la_ == 3:
-                        localctx = ContactQLParser.CombinationOrContext(self, ContactQLParser.ExpressionContext(self, _parentctx, _parentState))
+                        localctx = ContactQLParser.CombinationOrContext(
+                            self, ContactQLParser.ExpressionContext(self, _parentctx, _parentState)
+                        )
                         self.pushNewRecursionContext(localctx, _startState, self.RULE_expression)
                         self.state = 25
                         if not self.precpred(self._ctx, 4):
@@ -341,10 +325,9 @@ class ContactQLParser ( Parser ):
                         self.expression(5)
                         pass
 
-             
                 self.state = 32
                 self._errHandler.sync(self)
-                _alt = self._interp.adaptivePredict(self._input,2,self._ctx)
+                _alt = self._interp.adaptivePredict(self._input, 2, self._ctx)
 
         except RecognitionException as re:
             localctx.exception = re
@@ -355,24 +338,18 @@ class ContactQLParser ( Parser ):
         return localctx
 
     class LiteralContext(ParserRuleContext):
-
         def __init__(self, parser, parent=None, invokingState=-1):
             super(ContactQLParser.LiteralContext, self).__init__(parent, invokingState)
             self.parser = parser
 
-
         def getRuleIndex(self):
             return ContactQLParser.RULE_literal
 
-     
         def copyFrom(self, ctx):
             super(ContactQLParser.LiteralContext, self).copyFrom(ctx)
 
-
-
     class StringLiteralContext(LiteralContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.LiteralContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.LiteralContext)
             super(ContactQLParser.StringLiteralContext, self).__init__(parser)
             self.copyFrom(ctx)
 
@@ -385,10 +362,8 @@ class ContactQLParser ( Parser ):
             else:
                 return visitor.visitChildren(self)
 
-
     class TextLiteralContext(LiteralContext):
-
-        def __init__(self, parser, ctx): # actually a ContactQLParser.LiteralContext)
+        def __init__(self, parser, ctx):  # actually a ContactQLParser.LiteralContext)
             super(ContactQLParser.TextLiteralContext, self).__init__(parser)
             self.copyFrom(ctx)
 
@@ -400,8 +375,6 @@ class ContactQLParser ( Parser ):
                 return visitor.visitTextLiteral(self)
             else:
                 return visitor.visitChildren(self)
-
-
 
     def literal(self):
 
@@ -434,8 +407,6 @@ class ContactQLParser ( Parser ):
             self.exitRule()
         return localctx
 
-
-
     def sempred(self, localctx, ruleIndex, predIndex):
         if self._predicates == None:
             self._predicates = dict()
@@ -447,18 +418,11 @@ class ContactQLParser ( Parser ):
             return pred(localctx, predIndex)
 
     def expression_sempred(self, localctx, predIndex):
-            if predIndex == 0:
-                return self.precpred(self._ctx, 6)
-         
+        if predIndex == 0:
+            return self.precpred(self._ctx, 6)
 
-            if predIndex == 1:
-                return self.precpred(self._ctx, 5)
-         
+        if predIndex == 1:
+            return self.precpred(self._ctx, 5)
 
-            if predIndex == 2:
-                return self.precpred(self._ctx, 4)
-         
-
-
-
-
+        if predIndex == 2:
+            return self.precpred(self._ctx, 4)

--- a/temba/contacts/search/parser.py
+++ b/temba/contacts/search/parser.py
@@ -42,6 +42,7 @@ class SearchException(Exception):
     """
     Exception class for unparseable search queries
     """
+
     def __init__(self, message):
         self.message = message
 
@@ -58,7 +59,7 @@ class ContactQuery(object):
     PROP_SCHEME = 'S'
     PROP_FIELD = 'F'
 
-    SEARCHABLE_ATTRIBUTES = ('name',)
+    SEARCHABLE_ATTRIBUTES = ('name', )
 
     SEARCHABLE_SCHEMES = ('tel', 'twitter')
 
@@ -111,6 +112,7 @@ class QueryNode(object):
     """
     A search query node which is either a condition or a boolean combination of other conditions
     """
+
     def simplify(self):
         return self
 
@@ -129,21 +131,9 @@ class Condition(QueryNode):
 
     TEXT_LOOKUPS = {'=': 'iexact'}
 
-    DECIMAL_LOOKUPS = {
-        '=': 'exact',
-        '>': 'gt',
-        '>=': 'gte',
-        '<': 'lt',
-        '<=': 'lte'
-    }
+    DECIMAL_LOOKUPS = {'=': 'exact', '>': 'gt', '>=': 'gte', '<': 'lt', '<=': 'lte'}
 
-    DATETIME_LOOKUPS = {
-        '=': '<equal>',
-        '>': 'gt',
-        '>=': 'gte',
-        '<': 'lt',
-        '<=': 'lte'
-    }
+    DATETIME_LOOKUPS = {'=': '<equal>', '>': 'gt', '>=': 'gte', '<': 'lt', '<=': 'lte'}
 
     LOCATION_LOOKUPS = {'=': 'iexact', '~': 'icontains'}
 
@@ -297,7 +287,12 @@ class Condition(QueryNode):
     @staticmethod
     def get_base_value_query():
         return Value.objects.annotate(
-            field_and_string_value=Concat('contact_field_id', Val('|'), Upper(Substr('string_value', 1, STRING_VALUE_COMPARISON_LIMIT)), output_field=CharField())
+            field_and_string_value=Concat(
+                'contact_field_id',
+                Val('|'),
+                Upper(Substr('string_value', 1, STRING_VALUE_COMPARISON_LIMIT)),
+                output_field=CharField()
+            )
         ).values('contact_id')
 
     @staticmethod
@@ -308,7 +303,9 @@ class Condition(QueryNode):
             raise SearchException(_("%s isn't a valid number") % val)
 
     def __eq__(self, other):
-        return isinstance(other, Condition) and self.prop == other.prop and self.comparator == other.comparator and self.value == other.value
+        return isinstance(
+            other, Condition
+        ) and self.prop == other.prop and self.comparator == other.comparator and self.value == other.value
 
     def __str__(self):
         return '%s%s%s' % (self.prop, self.comparator, self.value)
@@ -320,7 +317,7 @@ class IsSetCondition(Condition):
       * A condition of the form x != "" is interpreted as "x is set"
       * A condition of the form x = "" is interpreted as "x is not set"
     """
-    IS_SET_LOOKUPS = ('!=',)
+    IS_SET_LOOKUPS = ('!=', )
     IS_NOT_SET_LOOKUPS = ('is', '=')
 
     def __init__(self, prop, comparator):
@@ -442,6 +439,7 @@ class SinglePropCombination(BoolCombination):
     A special case combination where all conditions are on the same property and so may be optimized to query the value
     table only once.
     """
+
     def __init__(self, prop, op, *children):
         assert all([isinstance(c, Condition) and c.prop == prop for c in children])
 
@@ -478,7 +476,8 @@ class SinglePropCombination(BoolCombination):
         return super(SinglePropCombination, self).as_query(org, prop_map, base_set)
 
     def __eq__(self, other):
-        return isinstance(other, SinglePropCombination) and self.prop == other.prop and super(SinglePropCombination, self).__eq__(other)
+        return isinstance(other, SinglePropCombination
+                          ) and self.prop == other.prop and super(SinglePropCombination, self).__eq__(other)
 
     def __str__(self):
         op = 'OR' if self.op == self.OR else 'AND'
@@ -486,7 +485,6 @@ class SinglePropCombination(BoolCombination):
 
 
 class ContactQLVisitor(ParseTreeVisitor):
-
     def visitParse(self, ctx):
         return self.visit(ctx.expression())
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -47,8 +47,13 @@ class ContactCRUDLTest(_CRUDLTest):
 
         self.crudl = ContactCRUDL
         self.user = self.create_user("tito")
-        self.org = Org.objects.create(name="Nyaruka Ltd.", timezone="Africa/Kigali", country=self.country,
-                                      created_by=self.user, modified_by=self.user)
+        self.org = Org.objects.create(
+            name="Nyaruka Ltd.",
+            timezone="Africa/Kigali",
+            country=self.country,
+            created_by=self.user,
+            modified_by=self.user
+        )
         self.org.administrators.add(self.user)
         self.user.set_org(self.org)
         self.org.initialize()
@@ -194,8 +199,9 @@ class ContactGroupTest(TembaTest):
         self.mary.set_field(self.admin, 'age', 21)
         self.mary.set_field(self.admin, 'gender', "female")
 
-        group = ContactGroup.create_dynamic(self.org, self.admin, "Group two",
-                                            '(Age < 18 and gender = "male") or (Age > 18 and gender = "female")')
+        group = ContactGroup.create_dynamic(
+            self.org, self.admin, "Group two", '(Age < 18 and gender = "male") or (Age > 18 and gender = "female")'
+        )
 
         self.assertEqual(group.query, '(Age < 18 and gender = "male") or (Age > 18 and gender = "female")')
         self.assertEqual(set(group.query_fields.all()), {age, gender})
@@ -310,7 +316,13 @@ class ContactGroupTest(TembaTest):
         Contact.objects.all().delete()  # start with none
 
         counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(counts, {ContactGroup.TYPE_ALL: 0, ContactGroup.TYPE_BLOCKED: 0, ContactGroup.TYPE_STOPPED: 0})
+        self.assertEqual(
+            counts, {
+                ContactGroup.TYPE_ALL: 0,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 0
+            }
+        )
 
         self.create_contact("Hannibal", number="0783835001")
         face = self.create_contact("Face", number="0783835002")
@@ -318,7 +330,13 @@ class ContactGroupTest(TembaTest):
         murdock = self.create_contact("Murdock", number="0783835004")
 
         counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(counts, {ContactGroup.TYPE_ALL: 4, ContactGroup.TYPE_BLOCKED: 0, ContactGroup.TYPE_STOPPED: 0})
+        self.assertEqual(
+            counts, {
+                ContactGroup.TYPE_ALL: 4,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 0
+            }
+        )
 
         # call methods twice to check counts don't change twice
         murdock.block(self.user)
@@ -328,7 +346,13 @@ class ContactGroupTest(TembaTest):
         ba.stop(self.user)
 
         counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(counts, {ContactGroup.TYPE_ALL: 1, ContactGroup.TYPE_BLOCKED: 2, ContactGroup.TYPE_STOPPED: 1})
+        self.assertEqual(
+            counts, {
+                ContactGroup.TYPE_ALL: 1,
+                ContactGroup.TYPE_BLOCKED: 2,
+                ContactGroup.TYPE_STOPPED: 1
+            }
+        )
 
         murdock.release(self.user)
         murdock.release(self.user)
@@ -342,7 +366,13 @@ class ContactGroupTest(TembaTest):
         self.assertEqual(ContactGroupCount.objects.all().count(), 3)
 
         counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(counts, {ContactGroup.TYPE_ALL: 3, ContactGroup.TYPE_BLOCKED: 0, ContactGroup.TYPE_STOPPED: 0})
+        self.assertEqual(
+            counts, {
+                ContactGroup.TYPE_ALL: 3,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 0
+            }
+        )
 
         # rebuild just our system contact group
         all_contacts = ContactGroup.all_groups.get(org=self.org, group_type=ContactGroup.TYPE_ALL)
@@ -365,10 +395,14 @@ class ContactGroupTest(TembaTest):
         group = self.create_group("one")
         delete_url = reverse('contacts.contactgroup_delete', args=[group.pk])
 
-        trigger = Trigger.objects.create(org=self.org, flow=flow, keyword="join", created_by=self.admin, modified_by=self.admin)
+        trigger = Trigger.objects.create(
+            org=self.org, flow=flow, keyword="join", created_by=self.admin, modified_by=self.admin
+        )
         trigger.groups.add(group)
 
-        second_trigger = Trigger.objects.create(org=self.org, flow=flow, keyword="register", created_by=self.admin, modified_by=self.admin)
+        second_trigger = Trigger.objects.create(
+            org=self.org, flow=flow, keyword="register", created_by=self.admin, modified_by=self.admin
+        )
         second_trigger.groups.add(group)
 
         response = self.client.get(delete_url, dict(), HTTP_X_PJAX=True)
@@ -496,8 +530,10 @@ class ContactGroupCRUDLTest(TembaTest):
 
         self.assertEqual(ContactGroup.user_groups.all().count(), ContactGroup.MAX_ORG_CONTACTGROUPS)
         response = self.client.post(url, dict(name="People"))
-        self.assertFormError(response, 'form', 'name', 'This org has 10 groups and the limit is 10. '
-                                                       'You must delete existing ones before you can create new ones.')
+        self.assertFormError(
+            response, 'form', 'name', 'This org has 10 groups and the limit is 10. '
+            'You must delete existing ones before you can create new ones.'
+        )
 
     def test_update(self):
         url = reverse('contacts.contactgroup_update', args=[self.joe_and_frank.pk])
@@ -567,7 +603,9 @@ class ContactTest(TembaTest):
         self.voldemort = self.create_contact(number="+250768383383")
 
         # create an orphaned URN
-        ContactURN.objects.create(org=self.org, scheme='tel', path='+250788888888', identity='tel:+250788888888', priority=50)
+        ContactURN.objects.create(
+            org=self.org, scheme='tel', path='+250788888888', identity='tel:+250788888888', priority=50
+        )
 
         # create an deleted contact
         self.jim = self.create_contact(name="Jim")
@@ -581,14 +619,27 @@ class ContactTest(TembaTest):
         self.campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
 
         # create af flow event
-        self.planting_reminder = CampaignEvent.create_flow_event(self.org, self.admin, self.campaign,
-                                                                 relative_to=self.planting_date, offset=0, unit='D',
-                                                                 flow=self.reminder_flow, delivery_hour=17)
+        self.planting_reminder = CampaignEvent.create_flow_event(
+            self.org,
+            self.admin,
+            self.campaign,
+            relative_to=self.planting_date,
+            offset=0,
+            unit='D',
+            flow=self.reminder_flow,
+            delivery_hour=17
+        )
 
         # and a message event
-        self.message_event = CampaignEvent.create_message_event(self.org, self.admin, self.campaign,
-                                                                relative_to=self.planting_date, offset=7, unit='D',
-                                                                message='Sent 7 days after planting date')
+        self.message_event = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            self.campaign,
+            relative_to=self.planting_date,
+            offset=7,
+            unit='D',
+            message='Sent 7 days after planting date'
+        )
 
     def test_get_or_create(self):
 
@@ -673,33 +724,42 @@ class ContactTest(TembaTest):
         self.login(self.admin)
 
         # try creating a contact with a number that belongs to another contact
-        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250781111111"))
+        response = self.client.post(
+            reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250781111111")
+        )
         self.assertFormError(response, 'form', 'urn__tel__0', "Used by another contact")
 
         # now repost with a unique phone number
-        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250 783-835665"))
+        response = self.client.post(
+            reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250 783-835665")
+        )
         self.assertNoFormErrors(response)
 
         # repost with the phone number of an orphaned URN
-        response = self.client.post(reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250788888888"))
+        response = self.client.post(
+            reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="+250788888888")
+        )
         self.assertNoFormErrors(response)
 
         # check that the orphaned URN has been associated with the contact
         self.assertEqual('Ben Haggerty', Contact.from_urn(self.org, 'tel:+250788888888').name)
 
         # check we display error for invalid input
-        response = self.client.post(reverse('contacts.contact_create'),
-                                    data=dict(name='Ben Haggerty', urn__tel__0="="))
+        response = self.client.post(
+            reverse('contacts.contact_create'), data=dict(name='Ben Haggerty', urn__tel__0="=")
+        )
         self.assertFormError(response, 'form', 'urn__tel__0', "Invalid input")
 
     def test_block_contact_clear_triggers(self):
         flow = self.get_flow('favorites')
-        trigger = Trigger.objects.create(org=self.org, flow=flow, keyword="join", created_by=self.admin,
-                                         modified_by=self.admin)
+        trigger = Trigger.objects.create(
+            org=self.org, flow=flow, keyword="join", created_by=self.admin, modified_by=self.admin
+        )
         trigger.contacts.add(self.joe)
 
-        trigger2 = Trigger.objects.create(org=self.org, flow=flow, keyword="register", created_by=self.admin,
-                                          modified_by=self.admin)
+        trigger2 = Trigger.objects.create(
+            org=self.org, flow=flow, keyword="register", created_by=self.admin, modified_by=self.admin
+        )
         trigger2.contacts.add(self.joe)
         trigger2.contacts.add(self.frank)
         self.assertEqual(Trigger.objects.filter(is_archived=False).count(), 2)
@@ -726,12 +786,14 @@ class ContactTest(TembaTest):
 
     def test_stop_contact_clear_triggers(self):
         flow = self.get_flow('favorites')
-        trigger = Trigger.objects.create(org=self.org, flow=flow, keyword="join", created_by=self.admin,
-                                         modified_by=self.admin)
+        trigger = Trigger.objects.create(
+            org=self.org, flow=flow, keyword="join", created_by=self.admin, modified_by=self.admin
+        )
         trigger.contacts.add(self.joe)
 
-        trigger2 = Trigger.objects.create(org=self.org, flow=flow, keyword="register", created_by=self.admin,
-                                          modified_by=self.admin)
+        trigger2 = Trigger.objects.create(
+            org=self.org, flow=flow, keyword="register", created_by=self.admin, modified_by=self.admin
+        )
         trigger2.contacts.add(self.joe)
         trigger2.contacts.add(self.frank)
         self.assertEqual(Trigger.objects.filter(is_archived=False).count(), 2)
@@ -747,7 +809,9 @@ class ContactTest(TembaTest):
     def test_fail_and_block_and_release(self):
         msg1 = self.create_msg(text="Test 1", direction='I', contact=self.joe, msg_type='I', status='H')
         msg2 = self.create_msg(text="Test 2", direction='I', contact=self.joe, msg_type='F', status='H')
-        msg3 = self.create_msg(text="Test 3", direction='I', contact=self.joe, msg_type='I', status='H', visibility='A')
+        msg3 = self.create_msg(
+            text="Test 3", direction='I', contact=self.joe, msg_type='I', status='H', visibility='A'
+        )
         label = Label.get_or_create(self.org, self.user, "Interesting")
         label.toggle_label([msg1, msg2, msg3], add=True)
         static_group = self.create_group("Just Joe", [self.joe])
@@ -766,9 +830,13 @@ class ContactTest(TembaTest):
         self.assertEqual(1, msg_counts[SystemLabel.TYPE_ARCHIVED])
 
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 4,
-                                          ContactGroup.TYPE_BLOCKED: 0,
-                                          ContactGroup.TYPE_STOPPED: 0})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 4,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 0
+            }
+        )
 
         self.assertEqual(set(label.msgs.all()), {msg1, msg2, msg3})
         self.assertEqual(set(static_group.contacts.all()), {self.joe})
@@ -784,9 +852,13 @@ class ContactTest(TembaTest):
 
         # and added to stopped group
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 3,
-                                          ContactGroup.TYPE_BLOCKED: 0,
-                                          ContactGroup.TYPE_STOPPED: 1})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 3,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 1
+            }
+        )
         self.assertEqual(set(static_group.contacts.all()), set())
         self.assertEqual(set(dynamic_group.contacts.all()), set())
 
@@ -800,9 +872,13 @@ class ContactTest(TembaTest):
 
         # and that he's been removed from the all and failed groups, and added to the blocked group
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 3,
-                                          ContactGroup.TYPE_BLOCKED: 1,
-                                          ContactGroup.TYPE_STOPPED: 1})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 3,
+                ContactGroup.TYPE_BLOCKED: 1,
+                ContactGroup.TYPE_STOPPED: 1
+            }
+        )
 
         # and removed from all groups
         self.assertEqual(set(static_group.contacts.all()), set())
@@ -825,9 +901,13 @@ class ContactTest(TembaTest):
 
         # and that he's been removed from the blocked group, and put back in the all and failed groups
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 3,
-                                          ContactGroup.TYPE_BLOCKED: 0,
-                                          ContactGroup.TYPE_STOPPED: 1})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 3,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 1
+            }
+        )
 
         # he should be back in the dynamic group
         self.assertEqual(set(static_group.contacts.all()), set())
@@ -843,9 +923,13 @@ class ContactTest(TembaTest):
 
         # and that he's been removed from the stopped group
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 4,
-                                          ContactGroup.TYPE_BLOCKED: 0,
-                                          ContactGroup.TYPE_STOPPED: 0})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 4,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 0
+            }
+        )
 
         # back in the dynamic group
         self.assertEqual(set(static_group.contacts.all()), set())
@@ -860,9 +944,13 @@ class ContactTest(TembaTest):
         self.assertFalse(self.joe.is_active)
 
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 3,
-                                          ContactGroup.TYPE_BLOCKED: 0,
-                                          ContactGroup.TYPE_STOPPED: 0})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 3,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 0
+            }
+        )
 
         # joe's messages should be inactive, blank and have no labels
         self.assertEqual(0, Msg.objects.filter(contact=self.joe, visibility='V').count())
@@ -886,9 +974,13 @@ class ContactTest(TembaTest):
         self.joe.stop(self.user)
 
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 3,
-                                          ContactGroup.TYPE_BLOCKED: 0,
-                                          ContactGroup.TYPE_STOPPED: 0})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 3,
+                ContactGroup.TYPE_BLOCKED: 0,
+                ContactGroup.TYPE_STOPPED: 0
+            }
+        )
 
         # we don't let users undo releasing a contact... but if we have to do it for some reason
         self.joe.is_active = True
@@ -896,9 +988,13 @@ class ContactTest(TembaTest):
 
         # check joe goes into the appropriate groups
         contact_counts = ContactGroup.get_system_group_counts(self.org)
-        self.assertEqual(contact_counts, {ContactGroup.TYPE_ALL: 3,
-                                          ContactGroup.TYPE_BLOCKED: 1,
-                                          ContactGroup.TYPE_STOPPED: 1})
+        self.assertEqual(
+            contact_counts, {
+                ContactGroup.TYPE_ALL: 3,
+                ContactGroup.TYPE_BLOCKED: 1,
+                ContactGroup.TYPE_STOPPED: 1
+            }
+        )
 
         # don't allow blocking or failing of test contacts
         test_contact = Contact.get_test_contact(self.user)
@@ -989,7 +1085,9 @@ class ContactTest(TembaTest):
         self.assertEqual("blow80", self.joe.get_urn_display(org=self.org, formatted=False))
         self.assertEqual("blow80", self.joe.get_urn_display())
         self.assertEqual("+250768383383", self.voldemort.get_urn_display(org=self.org, formatted=False))
-        self.assertEqual("+250768383383", self.voldemort.get_urn_display(org=self.org, formatted=False, international=True))
+        self.assertEqual(
+            "+250768383383", self.voldemort.get_urn_display(org=self.org, formatted=False, international=True)
+        )
         self.assertEqual("+250 768 383 383", self.voldemort.get_urn_display(org=self.org, international=True))
         self.assertEqual("0768 383 383", self.voldemort.get_urn_display())
         self.assertEqual("8877", mr_long_name.get_urn_display())
@@ -1064,22 +1162,36 @@ class ContactTest(TembaTest):
         self.assertEqual(parse_query('will'), ContactQuery(Condition('*', '=', 'will')))
 
         # boolean combinations of implicit conditions
-        self.assertEqual(parse_query('will felix', optimize=False), ContactQuery(
-            BoolCombination(BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix'))
-        ))
-        self.assertEqual(parse_query('will felix'), ContactQuery(
-            SinglePropCombination('*', BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix'))
-        ))
-        self.assertEqual(parse_query('will and felix', optimize=False), ContactQuery(
-            BoolCombination(BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix'))
-        ))
-        self.assertEqual(parse_query('will or felix or matt', optimize=False), ContactQuery(
-            BoolCombination(BoolCombination.OR,
-                            BoolCombination(BoolCombination.OR,
-                                            Condition('*', '=', 'will'),
-                                            Condition('*', '=', 'felix')),
-                            Condition('*', '=', 'matt'))
-        ))
+        self.assertEqual(
+            parse_query('will felix', optimize=False),
+            ContactQuery(
+                BoolCombination(BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix'))
+            )
+        )
+        self.assertEqual(
+            parse_query('will felix'),
+            ContactQuery(
+                SinglePropCombination(
+                    '*', BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix')
+                )
+            )
+        )
+        self.assertEqual(
+            parse_query('will and felix', optimize=False),
+            ContactQuery(
+                BoolCombination(BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix'))
+            )
+        )
+        self.assertEqual(
+            parse_query('will or felix or matt', optimize=False),
+            ContactQuery(
+                BoolCombination(
+                    BoolCombination.OR,
+                    BoolCombination(BoolCombination.OR, Condition('*', '=', 'will'), Condition('*', '=', 'felix')),
+                    Condition('*', '=', 'matt')
+                )
+            )
+        )
 
         # property conditions
         self.assertEqual(parse_query('name=will'), ContactQuery(Condition('name', '=', 'will')))
@@ -1090,72 +1202,106 @@ class ContactTest(TembaTest):
         self.assertEqual(parse_query('name!=""'), ContactQuery(IsSetCondition('name', '!=')))
 
         # boolean combinations of property conditions
-        self.assertEqual(parse_query('name=will or name ~ "felix"', optimize=False), ContactQuery(
-            BoolCombination(BoolCombination.OR, Condition('name', '=', 'will'), Condition('name', '~', 'felix'))
-        ))
-        self.assertEqual(parse_query('name=will or name ~ "felix"'), ContactQuery(
-            SinglePropCombination('name', BoolCombination.OR, Condition('name', '=', 'will'), Condition('name', '~', 'felix'))
-        ))
+        self.assertEqual(
+            parse_query('name=will or name ~ "felix"', optimize=False),
+            ContactQuery(
+                BoolCombination(BoolCombination.OR, Condition('name', '=', 'will'), Condition('name', '~', 'felix'))
+            )
+        )
+        self.assertEqual(
+            parse_query('name=will or name ~ "felix"'),
+            ContactQuery(
+                SinglePropCombination(
+                    'name', BoolCombination.OR, Condition('name', '=', 'will'), Condition('name', '~', 'felix')
+                )
+            )
+        )
 
         # mixture of simple and property conditions
-        self.assertEqual(parse_query('will or name ~ "felix"'), ContactQuery(
-            BoolCombination(BoolCombination.OR, Condition('*', '=', 'will'), Condition('name', '~', 'felix'))
-        ))
+        self.assertEqual(
+            parse_query('will or name ~ "felix"'),
+            ContactQuery(
+                BoolCombination(BoolCombination.OR, Condition('*', '=', 'will'), Condition('name', '~', 'felix'))
+            )
+        )
 
         # optimization will merge conditions combined with the same op
-        self.assertEqual(parse_query('will or felix or matt'), ContactQuery(
-            SinglePropCombination('*', BoolCombination.OR, Condition('*', '=', 'will'),
-                                  Condition('*', '=', 'felix'), Condition('*', '=', 'matt'))
-        ))
+        self.assertEqual(
+            parse_query('will or felix or matt'),
+            ContactQuery(
+                SinglePropCombination(
+                    '*', BoolCombination.OR,
+                    Condition('*', '=', 'will'), Condition('*', '=', 'felix'), Condition('*', '=', 'matt')
+                )
+            )
+        )
 
         # but not conditions combined with different ops
-        self.assertEqual(parse_query('will or felix and matt'), ContactQuery(
-            BoolCombination(BoolCombination.OR,
-                            Condition('*', '=', 'will'),
-                            SinglePropCombination('*', BoolCombination.AND,
-                                                  Condition('*', '=', 'felix'),
-                                                  Condition('*', '=', 'matt')))
-        ))
+        self.assertEqual(
+            parse_query('will or felix and matt'),
+            ContactQuery(
+                BoolCombination(
+                    BoolCombination.OR,
+                    Condition('*', '=', 'will'),
+                    SinglePropCombination(
+                        '*', BoolCombination.AND, Condition('*', '=', 'felix'), Condition('*', '=', 'matt')
+                    )
+                )
+            )
+        )
 
         # optimization respects explicit precedence defined with parentheses
-        self.assertEqual(parse_query('(will or felix) and matt'), ContactQuery(
-            BoolCombination(BoolCombination.AND,
-                            SinglePropCombination('*', BoolCombination.OR,
-                                                  Condition('*', '=', 'will'),
-                                                  Condition('*', '=', 'felix')),
-                            Condition('*', '=', 'matt'))
-        ))
+        self.assertEqual(
+            parse_query('(will or felix) and matt'),
+            ContactQuery(
+                BoolCombination(
+                    BoolCombination.AND,
+                    SinglePropCombination(
+                        '*', BoolCombination.OR, Condition('*', '=', 'will'), Condition('*', '=', 'felix')
+                    ), Condition('*', '=', 'matt')
+                )
+            )
+        )
 
         # implicit ANDing of conditions
-        self.assertEqual(parse_query('will felix name ~ "matt"', optimize=False), ContactQuery(
-            BoolCombination(BoolCombination.AND,
-                            BoolCombination(BoolCombination.AND,
-                                            Condition('*', '=', 'will'),
-                                            Condition('*', '=', 'felix')),
-                            Condition('name', '~', 'matt'))
-        ))
+        self.assertEqual(
+            parse_query('will felix name ~ "matt"', optimize=False),
+            ContactQuery(
+                BoolCombination(
+                    BoolCombination.AND,
+                    BoolCombination(BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix')),
+                    Condition('name', '~', 'matt')
+                )
+            )
+        )
 
         # boolean operator precedence is AND before OR, even when AND is implicit
-        self.assertEqual(parse_query('will and felix or matt amber', optimize=False), ContactQuery(
-            BoolCombination(BoolCombination.OR,
-                            BoolCombination(BoolCombination.AND,
-                                            Condition('*', '=', 'will'),
-                                            Condition('*', '=', 'felix')),
-                            BoolCombination(BoolCombination.AND,
-                                            Condition('*', '=', 'matt'),
-                                            Condition('*', '=', 'amber')))
-        ))
+        self.assertEqual(
+            parse_query('will and felix or matt amber', optimize=False),
+            ContactQuery(
+                BoolCombination(
+                    BoolCombination.OR,
+                    BoolCombination(BoolCombination.AND, Condition('*', '=', 'will'), Condition('*', '=', 'felix')),
+                    BoolCombination(BoolCombination.AND, Condition('*', '=', 'matt'), Condition('*', '=', 'amber'))
+                )
+            )
+        )
 
         # boolean combinations can themselves be combined
-        self.assertEqual(parse_query('(Age < 18 and Gender = "male") or (Age > 18 and Gender = "female")'), ContactQuery(
-            BoolCombination(BoolCombination.OR,
-                            BoolCombination(BoolCombination.AND,
-                                            Condition('age', '<', '18'),
-                                            Condition('gender', '=', 'male')),
-                            BoolCombination(BoolCombination.AND,
-                                            Condition('age', '>', '18'),
-                                            Condition('gender', '=', 'female')))
-        ))
+        self.assertEqual(
+            parse_query('(Age < 18 and Gender = "male") or (Age > 18 and Gender = "female")'),
+            ContactQuery(
+                BoolCombination(
+                    BoolCombination.OR,
+                    BoolCombination(
+                        BoolCombination.AND, Condition('age', '<', '18'), Condition('gender', '=', 'male')
+                    ),
+                    BoolCombination(
+                        BoolCombination.AND, Condition('age', '>', '18'), Condition('gender', '=', 'female')
+                    )
+                )
+            )
+        )
 
         self.assertEqual(str(parse_query('Age < 18 and Gender = "male"')), "AND(age<18, gender=male)")
         self.assertEqual(str(parse_query('Age > 18 and Age < 30')), "AND[age](>18, <30)")
@@ -1319,7 +1465,9 @@ class ContactTest(TembaTest):
         # Postgres will defer to strcoll for ordering which even for en_US.UTF-8 will return different results on OSX
         # and Ubuntu. To keep ordering consistent for this test, we don't let URNs start with +
         # (see http://postgresql.nabble.com/a-strange-order-by-behavior-td4513038.html)
-        ContactURN.objects.filter(path__startswith="+").update(path=Substr('path', 2), identity=Concat(DbValue('tel:'), Substr('path', 2)))
+        ContactURN.objects.filter(path__startswith="+").update(
+            path=Substr('path', 2), identity=Concat(DbValue('tel:'), Substr('path', 2))
+        )
 
         self.admin.set_org(self.org)
         self.login(self.admin)
@@ -1328,54 +1476,64 @@ class ContactTest(TembaTest):
             response = self.client.get("%s?%s" % (reverse("contacts.contact_omnibox"), query))
             return response.json()['results']
 
-        self.assertEqual(omnibox_request(""), [
-            # all 3 groups A-Z
-            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
-            dict(id='g-%s' % men.uuid, text="Men", extra=0),
-            dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0),
+        self.assertEqual(
+            omnibox_request(""),
+            [
+                # all 3 groups A-Z
+                dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+                dict(id='g-%s' % men.uuid, text="Men", extra=0),
+                dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0),
 
-            # all 4 contacts A-Z
-            dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
-            dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
-            dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
-            dict(id='c-%s' % self.voldemort.uuid, text="250768383383"),
+                # all 4 contacts A-Z
+                dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
+                dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+                dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
+                dict(id='c-%s' % self.voldemort.uuid, text="250768383383"),
 
-            # 3 sendable URNs with names as extra
-            dict(id='u-%d' % voldemort_tel.pk, text="250768383383", extra=None, scheme='tel'),
-            dict(id='u-%d' % joe_tel.pk, text="250781111111", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel'),
-        ])
+                # 3 sendable URNs with names as extra
+                dict(id='u-%d' % voldemort_tel.pk, text="250768383383", extra=None, scheme='tel'),
+                dict(id='u-%d' % joe_tel.pk, text="250781111111", extra="Joe Blow", scheme='tel'),
+                dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel'),
+            ]
+        )
 
         # apply type filters...
 
         # g = just the 3 groups
-        self.assertEqual(omnibox_request("types=g"), [
-            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
-            dict(id='g-%s' % men.uuid, text="Men", extra=0),
-            dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0)
-        ])
+        self.assertEqual(
+            omnibox_request("types=g"), [
+                dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+                dict(id='g-%s' % men.uuid, text="Men", extra=0),
+                dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0)
+            ]
+        )
 
         # s = just the 2 non-dynamic (static) groups
-        self.assertEqual(omnibox_request("types=s"), [
-            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
-            dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0)
-        ])
+        self.assertEqual(
+            omnibox_request("types=s"), [
+                dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+                dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0)
+            ]
+        )
 
         # c,u = contacts and URNs
-        self.assertEqual(omnibox_request("types=c,u"), [
-            dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
-            dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
-            dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
-            dict(id='c-%s' % self.voldemort.uuid, text="250768383383"),
-            dict(id='u-%d' % voldemort_tel.pk, text="250768383383", extra=None, scheme='tel'),
-            dict(id='u-%d' % joe_tel.pk, text="250781111111", extra="Joe Blow", scheme='tel'),
-            dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel')
-        ])
+        self.assertEqual(
+            omnibox_request("types=c,u"), [
+                dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
+                dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+                dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
+                dict(id='c-%s' % self.voldemort.uuid, text="250768383383"),
+                dict(id='u-%d' % voldemort_tel.pk, text="250768383383", extra=None, scheme='tel'),
+                dict(id='u-%d' % joe_tel.pk, text="250781111111", extra="Joe Blow", scheme='tel'),
+                dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel')
+            ]
+        )
 
         # search for Frank by phone
-        self.assertEqual(omnibox_request("search=222"), [
-            dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel')
-        ])
+        self.assertEqual(
+            omnibox_request("search=222"),
+            [dict(id='u-%d' % frank_tel.pk, text="250782222222", extra="Frank Smith", scheme='tel')]
+        )
 
         # search for Joe by twitter - won't return anything because there is no twitter channel
         self.assertEqual(omnibox_request("search=blow80"), [])
@@ -1387,75 +1545,81 @@ class ContactTest(TembaTest):
         Channel.create(self.org, self.user, 'RW', 'EX', schemes=[TEL_SCHEME])
 
         # search for again for Joe by twitter
-        self.assertEqual(omnibox_request("search=blow80"), [
-            dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
-        ])
+        self.assertEqual(
+            omnibox_request("search=blow80"),
+            [dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')]
+        )
 
         # search for Joe again - match on last name and twitter handle
-        self.assertEqual(omnibox_request("search=BLOW"), [
-            dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
-            dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
-        ])
+        self.assertEqual(
+            omnibox_request("search=BLOW"), [
+                dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
+                dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
+            ]
+        )
 
         # make sure our matches are ANDed
-        self.assertEqual(omnibox_request("search=Joe+o&types=c"), [
-            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
-        ])
-        self.assertEqual(omnibox_request("search=Joe+o&types=g"), [
-            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
-        ])
+        self.assertEqual(omnibox_request("search=Joe+o&types=c"), [dict(id='c-%s' % self.joe.uuid, text="Joe Blow")])
+        self.assertEqual(
+            omnibox_request("search=Joe+o&types=g"), [
+                dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+            ]
+        )
 
         # lookup by contact ids
-        self.assertEqual(omnibox_request("c=%s,%s" % (self.joe.uuid, self.frank.uuid)), [
-            dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
-            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
-        ])
+        self.assertEqual(
+            omnibox_request("c=%s,%s" % (self.joe.uuid, self.frank.uuid)),
+            [dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+             dict(id='c-%s' % self.joe.uuid, text="Joe Blow")]
+        )
 
         # lookup by group id
-        self.assertEqual(omnibox_request("g=%s" % joe_and_frank.uuid), [
-            dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2)
-        ])
+        self.assertEqual(
+            omnibox_request("g=%s" % joe_and_frank.uuid),
+            [dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2)]
+        )
 
         # lookup by URN ids
         urn_query = "u=%d,%d" % (self.joe.get_urn(TWITTER_SCHEME).pk, self.frank.get_urn(TEL_SCHEME).pk)
-        self.assertEqual(omnibox_request(urn_query), [
-            dict(id='u-%d' % frank_tel.pk, text="0782 222 222", extra="Frank Smith", scheme='tel'),
-            dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
-        ])
+        self.assertEqual(
+            omnibox_request(urn_query), [
+                dict(id='u-%d' % frank_tel.pk, text="0782 222 222", extra="Frank Smith", scheme='tel'),
+                dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
+            ]
+        )
 
         # lookup by message ids
         msg = self.create_msg(direction='I', contact=self.joe, text="some message")
-        self.assertEqual(omnibox_request("m=%d" % msg.pk), [
-            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
-        ])
+        self.assertEqual(omnibox_request("m=%d" % msg.pk), [dict(id='c-%s' % self.joe.uuid, text="Joe Blow")])
 
         # lookup by label ids
         label = Label.get_or_create(self.org, self.user, "msg label")
         self.assertEqual(omnibox_request("l=%d" % label.pk), [])
 
         msg.labels.add(label)
-        self.assertEqual(omnibox_request("l=%d" % label.pk), [
-            dict(id='c-%s' % self.joe.uuid, text="Joe Blow")
-        ])
+        self.assertEqual(omnibox_request("l=%d" % label.pk), [dict(id='c-%s' % self.joe.uuid, text="Joe Blow")])
 
         with AnonymousOrg(self.org):
-            self.assertEqual(omnibox_request(""), [
-                # all 3 groups...
-                dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
-                dict(id='g-%s' % men.uuid, text="Men", extra=0),
-                dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0),
+            self.assertEqual(
+                omnibox_request(""),
+                [
+                    # all 3 groups...
+                    dict(id='g-%s' % joe_and_frank.uuid, text="Joe and Frank", extra=2),
+                    dict(id='g-%s' % men.uuid, text="Men", extra=0),
+                    dict(id='g-%s' % nobody.uuid, text="Nobody", extra=0),
 
-                # all 4 contacts A-Z
-                dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
-                dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
-                dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
-                dict(id='c-%s' % self.voldemort.uuid, text=self.voldemort.anon_identifier)
-            ])
+                    # all 4 contacts A-Z
+                    dict(id='c-%s' % self.billy.uuid, text="Billy Nophone"),
+                    dict(id='c-%s' % self.frank.uuid, text="Frank Smith"),
+                    dict(id='c-%s' % self.joe.uuid, text="Joe Blow"),
+                    dict(id='c-%s' % self.voldemort.uuid, text=self.voldemort.anon_identifier)
+                ]
+            )
 
             # can search by frank id
-            self.assertEqual(omnibox_request("search=%d" % self.frank.pk), [
-                dict(id='c-%s' % self.frank.uuid, text="Frank Smith")
-            ])
+            self.assertEqual(
+                omnibox_request("search=%d" % self.frank.pk), [dict(id='c-%s' % self.frank.uuid, text="Frank Smith")]
+            )
 
             # but not by frank number
             self.assertEqual(omnibox_request("search=222"), [])
@@ -1469,10 +1633,12 @@ class ContactTest(TembaTest):
 
         # but still lookup by URN ids
         urn_query = "u=%d,%d" % (self.joe.get_urn(TWITTER_SCHEME).pk, self.frank.get_urn(TEL_SCHEME).pk)
-        self.assertEqual(omnibox_request(urn_query), [
-            dict(id='u-%d' % frank_tel.pk, text="0782 222 222", extra="Frank Smith", scheme='tel'),
-            dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
-        ])
+        self.assertEqual(
+            omnibox_request(urn_query), [
+                dict(id='u-%d' % frank_tel.pk, text="0782 222 222", extra="Frank Smith", scheme='tel'),
+                dict(id='u-%d' % joe_twitter.pk, text="blow80", extra="Joe Blow", scheme='twitter')
+            ]
+        )
 
     def test_history(self):
 
@@ -1487,21 +1653,33 @@ class ContactTest(TembaTest):
             self.create_campaign()
 
             # add a message with some attachments
-            self.create_msg(direction='I', contact=self.joe, text="Message caption", created_on=timezone.now(),
-                            attachments=[
-                                "audio/mp3:http://blah/file.mp3",
-                                "video/mp4:http://blah/file.mp4",
-                                "geo:47.5414799,-122.6359908"])
+            self.create_msg(
+                direction='I',
+                contact=self.joe,
+                text="Message caption",
+                created_on=timezone.now(),
+                attachments=[
+                    "audio/mp3:http://blah/file.mp3", "video/mp4:http://blah/file.mp4", "geo:47.5414799,-122.6359908"
+                ]
+            )
 
             # create some messages
             for i in range(99):
-                self.create_msg(direction='I', contact=self.joe, text="Inbound message %d" % i,
-                                created_on=timezone.now() - timedelta(days=(100 - i)))
+                self.create_msg(
+                    direction='I',
+                    contact=self.joe,
+                    text="Inbound message %d" % i,
+                    created_on=timezone.now() - timedelta(days=(100 - i))
+                )
 
             # because messages are stored with timestamps from external systems, possible to have initial message
             # which is little bit older than the contact itself
-            self.create_msg(direction='I', contact=self.joe, text="Very old inbound message",
-                            created_on=self.joe.created_on - timedelta(seconds=10))
+            self.create_msg(
+                direction='I',
+                contact=self.joe,
+                text="Very old inbound message",
+                created_on=self.joe.created_on - timedelta(seconds=10)
+            )
 
             # start a joe flow
             self.reminder_flow.start([], [self.joe, kurt])
@@ -1510,24 +1688,37 @@ class ContactTest(TembaTest):
             failed = Msg.objects.get(direction='O', contact=self.joe)
             failed.status = 'F'
             failed.save()
-            log = ChannelLog.objects.create(channel=failed.channel, msg=failed, is_error=True,
-                                            description="It didn't send!!")
+            log = ChannelLog.objects.create(
+                channel=failed.channel, msg=failed, is_error=True, description="It didn't send!!"
+            )
 
             # pretend that flow run made a webhook request
-            WebHookEvent.trigger_flow_event(FlowRun.objects.get(contact=self.joe), 'https://example.com', '1234', msg=None)
+            WebHookEvent.trigger_flow_event(
+                FlowRun.objects.get(contact=self.joe), 'https://example.com', '1234', msg=None
+            )
 
             # create an event from the past
             scheduled = timezone.now() - timedelta(days=5)
-            EventFire.objects.create(event=self.planting_reminder, contact=self.joe, scheduled=scheduled, fired=scheduled)
+            EventFire.objects.create(
+                event=self.planting_reminder, contact=self.joe, scheduled=scheduled, fired=scheduled
+            )
 
             # create a missed call
-            ChannelEvent.create(self.channel, six.text_type(self.joe.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_OUT_MISSED,
-                                timezone.now(), 5)
+            ChannelEvent.create(
+                self.channel,
+                six.text_type(self.joe.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_OUT_MISSED, timezone.now(), 5
+            )
 
             # try adding some failed calls
-            IVRCall.objects.create(contact=self.joe, status=IVRCall.NO_ANSWER, created_by=self.admin,
-                                   modified_by=self.admin, channel=self.channel, org=self.org,
-                                   contact_urn=self.joe.urns.all().first())
+            IVRCall.objects.create(
+                contact=self.joe,
+                status=IVRCall.NO_ANSWER,
+                created_by=self.admin,
+                modified_by=self.admin,
+                channel=self.channel,
+                org=self.org,
+                contact_urn=self.joe.urns.all().first()
+            )
 
             # fetch our contact history
             with self.assertNumQueries(67):
@@ -1552,7 +1743,10 @@ class ContactTest(TembaTest):
             self.assertContains(response, '<source type="audio/mp3" src="http://blah/file.mp3" />')
             self.assertContains(response, '<video ')
             self.assertContains(response, '<source type="video/mp4" src="http://blah/file.mp4" />')
-            self.assertContains(response, 'http://www.openstreetmap.org/?mlat=47.5414799&amp;mlon=-122.6359908#map=18/47.5414799/-122.6359908')
+            self.assertContains(
+                response,
+                'http://www.openstreetmap.org/?mlat=47.5414799&amp;mlon=-122.6359908#map=18/47.5414799/-122.6359908'
+            )
             self.assertContains(response, '/channels/channellog/read/%d/' % log.id)
 
             # fetch next page
@@ -1587,8 +1781,14 @@ class ContactTest(TembaTest):
             self.assertContains(response, 'icon-bubble-notification')
 
             self.assertEqual(len(activity), 95)
-            self.assertIsInstance(activity[4]['obj'], Broadcast)  # TODO fix order so initial broadcasts come after their run
-            self.assertEqual(activity[4]['obj'].text, {'base': "What is your favorite color?", 'fre': "Quelle est votre couleur préférée?"})
+            self.assertIsInstance(activity[4]['obj'],
+                                  Broadcast)  # TODO fix order so initial broadcasts come after their run
+            self.assertEqual(
+                activity[4]['obj'].text, {
+                    'base': "What is your favorite color?",
+                    'fre': "Quelle est votre couleur préférée?"
+                }
+            )
             self.assertEqual(activity[4]['obj'].translated_text, "What is your favorite color?")
 
             # if a new message comes in
@@ -1662,11 +1862,17 @@ class ContactTest(TembaTest):
             scheduled = timezone.now()
             EventFire.objects.create(event=self.message_event, contact=self.joe, scheduled=scheduled, fired=scheduled)
 
-            response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]) + '?before=%d' % datetime_to_ms(timezone.now()), self.admin)
+            response = self.fetch_protected(
+                reverse('contacts.contact_history', args=[self.joe.uuid]) +
+                '?before=%d' % datetime_to_ms(timezone.now()), self.admin
+            )
             self.assertEqual(self.message_event, response.context['activity'][0]['obj'].event)
 
         # now try the proper max history to test truncation
-        response = self.fetch_protected(reverse('contacts.contact_history', args=[self.joe.uuid]) + '?before=%d' % datetime_to_ms(timezone.now()), self.admin)
+        response = self.fetch_protected(
+            reverse('contacts.contact_history', args=[self.joe.uuid]) + '?before=%d' % datetime_to_ms(timezone.now()),
+            self.admin
+        )
 
         # our before should be the same as the last item
         last_item_date = datetime_to_ms(response.context['activity'][-1]['time'])
@@ -1686,9 +1892,15 @@ class ContactTest(TembaTest):
         from temba.campaigns.models import CampaignEvent
         from temba.contacts.templatetags.contacts import event_time
 
-        event = CampaignEvent.create_message_event(self.org, self.admin, self.campaign,
-                                                   relative_to=self.planting_date, offset=7, unit='D',
-                                                   message='A message to send')
+        event = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            self.campaign,
+            relative_to=self.planting_date,
+            offset=7,
+            unit='D',
+            message='A message to send'
+        )
 
         event.unit = 'D'
         self.assertEqual("7 days after Planting Date", event_time(event))
@@ -1726,8 +1938,7 @@ class ContactTest(TembaTest):
         result.status_code = 404
         self.assertEqual(history_class(item), 'non-msg warning')
 
-        call = IVRCall.create_incoming(self.channel, contact, contact.urns.all().first(),
-                                       self.admin, self.admin)
+        call = IVRCall.create_incoming(self.channel, contact, contact.urns.all().first(), self.admin, self.admin)
 
         item = {'type': 'call', 'obj': call}
         self.assertEqual(history_class(item), 'non-msg')
@@ -1848,7 +2059,9 @@ class ContactTest(TembaTest):
         read_url = reverse('contacts.contact_read', args=[self.joe.uuid])
 
         for i in range(5):
-            self.create_msg(direction='I', contact=self.joe, text="some msg no %d 2 send in sms language if u wish" % i)
+            self.create_msg(
+                direction='I', contact=self.joe, text="some msg no %d 2 send in sms language if u wish" % i
+            )
             i += 1
 
         from temba.campaigns.models import EventFire
@@ -1858,9 +2071,15 @@ class ContactTest(TembaTest):
         from temba.campaigns.models import CampaignEvent
         for i in range(5):
             msg = "Sent %d days after planting date" % (i + 10)
-            self.message_event = CampaignEvent.create_message_event(self.org, self.admin, self.campaign,
-                                                                    relative_to=self.planting_date,
-                                                                    offset=i + 10, unit='D', message=msg)
+            self.message_event = CampaignEvent.create_message_event(
+                self.org,
+                self.admin,
+                self.campaign,
+                relative_to=self.planting_date,
+                offset=i + 10,
+                unit='D',
+                message=msg
+            )
 
         now = timezone.now()
         self.joe.set_field(self.user, 'planting_date', six.text_type(now + timedelta(days=1)))
@@ -2007,11 +2226,15 @@ class ContactTest(TembaTest):
         ContactGroup.user_groups.get(name="First Group")
 
         # try to create another group with the same name, but a dynamic query, should fail
-        response = self.client.post(reverse('contacts.contactgroup_create'), dict(name="First Group", group_query='firsts'))
+        response = self.client.post(
+            reverse('contacts.contactgroup_create'), dict(name="First Group", group_query='firsts')
+        )
         self.assertFormError(response, 'form', 'name', "Name is used by another group")
 
         # try to create another group with same name, not dynamic, same thing
-        response = self.client.post(reverse('contacts.contactgroup_create'), dict(name="First Group", group_query='firsts'))
+        response = self.client.post(
+            reverse('contacts.contactgroup_create'), dict(name="First Group", group_query='firsts')
+        )
         self.assertFormError(response, 'form', 'name', "Name is used by another group")
 
     def test_update_and_list(self):
@@ -2247,16 +2470,22 @@ class ContactTest(TembaTest):
 
         # check that the field appears on the update form
         response = self.client.get(reverse('contacts.contact_update', args=[self.joe.id]))
-        self.assertEqual(response.context['form'].fields.keys(), ['name', 'groups', 'urn__twitter__0', 'urn__tel__1', 'loc'])
+        self.assertEqual(
+            response.context['form'].fields.keys(), ['name', 'groups', 'urn__twitter__0', 'urn__tel__1', 'loc']
+        )
         self.assertEqual(response.context['form'].initial['name'], "Joe Blow")
         self.assertEqual(response.context['form'].fields['urn__tel__1'].initial, "+250781111111")
 
         contact_field = ContactField.objects.filter(key='state').first()
-        response = self.client.get('%s?field=%s' % (reverse('contacts.contact_update_fields', args=[self.joe.id]), contact_field.id))
+        response = self.client.get(
+            '%s?field=%s' % (reverse('contacts.contact_update_fields', args=[self.joe.id]), contact_field.id)
+        )
         self.assertEqual('Home state', response.context['contact_field'].label)
 
         # grab our input field which is loaded async
-        response = self.client.get('%s?field=%s' % (reverse('contacts.contact_update_fields_input', args=[self.joe.id]), contact_field.id))
+        response = self.client.get(
+            '%s?field=%s' % (reverse('contacts.contact_update_fields_input', args=[self.joe.id]), contact_field.id)
+        )
         self.assertContains(response, 'Kigali City')
 
         # update it to something else
@@ -2271,7 +2500,10 @@ class ContactTest(TembaTest):
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), data)
 
         # update the state contact field to something invalid
-        self.client.post(reverse('contacts.contact_update_fields', args=[self.joe.id]), dict(contact_field=contact_field.id, field_value='newyork'))
+        self.client.post(
+            reverse('contacts.contact_update_fields', args=[self.joe.id]),
+            dict(contact_field=contact_field.id, field_value='newyork')
+        )
 
         # check that old URN is detached, new URN is attached, and Joe still exists
         self.joe = Contact.objects.get(pk=self.joe.id)
@@ -2296,8 +2528,12 @@ class ContactTest(TembaTest):
         self.assertEqual(response.context['form'].fields['urn__tel__1'].initial, "+250786666666")
 
         # update joe, add him to "Just Joe" group
-        post_data = dict(name="Joe Gashyantare", groups=[self.just_joe.id],
-                         urn__tel__0="+250781111111", urn__tel__1="+250786666666")
+        post_data = dict(
+            name="Joe Gashyantare",
+            groups=[self.just_joe.id],
+            urn__tel__0="+250781111111",
+            urn__tel__1="+250786666666"
+        )
         response = self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), post_data, follow=True)
         self.assertEqual(response.context['contact'].name, "Joe Gashyantare")
         self.assertEqual(set(self.joe.user_groups.all()), {self.just_joe})
@@ -2331,16 +2567,20 @@ class ContactTest(TembaTest):
         self.joe.unblock(self.user)
 
         # add new urn for joe
-        self.client.post(reverse('contacts.contact_update', args=[self.joe.id]),
-                         dict(name='Joey', urn__tel__0="+250781111111", new_scheme="ext", new_path="EXT123"))
+        self.client.post(
+            reverse('contacts.contact_update', args=[self.joe.id]),
+            dict(name='Joey', urn__tel__0="+250781111111", new_scheme="ext", new_path="EXT123")
+        )
 
         urn = ContactURN.objects.filter(contact=self.joe, scheme='ext').first()
         self.assertIsNotNone(urn)
         self.assertEqual('EXT123', urn.path)
 
         # now try adding one that is invalid
-        self.client.post(reverse('contacts.contact_update', args=[self.joe.id]),
-                         dict(name='Joey', urn__tel__0="+250781111111", new_scheme="mailto", new_path="malformed"))
+        self.client.post(
+            reverse('contacts.contact_update', args=[self.joe.id]),
+            dict(name='Joey', urn__tel__0="+250781111111", new_scheme="mailto", new_path="malformed")
+        )
         self.assertIsNone(ContactURN.objects.filter(contact=self.joe, scheme='mailto').first())
 
         # update our language to something not on the org
@@ -2358,8 +2598,14 @@ class ContactTest(TembaTest):
         state = ContactField.get_or_create(self.org, self.admin, 'state', "Home State", value_type='S')
         district = ContactField.get_or_create(self.org, self.admin, 'home', "Home District", value_type='I')
 
-        self.client.post(reverse('contacts.contact_update_fields', args=[self.joe.id]), dict(contact_field=state.id, field_value='eastern province'))
-        self.client.post(reverse('contacts.contact_update_fields', args=[self.joe.id]), dict(contact_field=district.id, field_value='rwamagana'))
+        self.client.post(
+            reverse('contacts.contact_update_fields', args=[self.joe.id]),
+            dict(contact_field=state.id, field_value='eastern province')
+        )
+        self.client.post(
+            reverse('contacts.contact_update_fields', args=[self.joe.id]),
+            dict(contact_field=district.id, field_value='rwamagana')
+        )
 
         response = self.client.get(reverse('contacts.contact_read', args=[self.joe.uuid]))
 
@@ -2389,13 +2635,18 @@ class ContactTest(TembaTest):
         self.assertContains(response, 'Rwama Value')
 
         # bad field
-        contact_field = ContactField.objects.create(org=self.org, key='language', label='User Language',
-                                                    created_by=self.admin, modified_by=self.admin)
+        contact_field = ContactField.objects.create(
+            org=self.org, key='language', label='User Language', created_by=self.admin, modified_by=self.admin
+        )
 
-        response = self.client.post(reverse('contacts.contact_update_fields', args=[self.joe.id]),
-                                    dict(contact_field=contact_field.id, field_value='Kinyarwanda'))
+        response = self.client.post(
+            reverse('contacts.contact_update_fields', args=[self.joe.id]),
+            dict(contact_field=contact_field.id, field_value='Kinyarwanda')
+        )
 
-        self.assertFormError(response, 'form', None, "Field key language has invalid characters or is a reserved field name")
+        self.assertFormError(
+            response, 'form', None, "Field key language has invalid characters or is a reserved field name"
+        )
 
         # try to push into a dynamic group
         self.login(self.admin)
@@ -2418,7 +2669,8 @@ class ContactTest(TembaTest):
 
         self.joe.refresh_from_db()
         self.assertEqual(self.joe.name, "Joe X")
-        self.assertEqual({six.text_type(u) for u in self.joe.urns.all()}, {"tel:+250781111111", "ext:EXT123"})  # urns unaffected
+        self.assertEqual({six.text_type(u)
+                          for u in self.joe.urns.all()}, {"tel:+250781111111", "ext:EXT123"})  # urns unaffected
 
         # remove all of joe's URNs
         ContactURN.objects.filter(contact=self.joe).update(contact=None)
@@ -2428,8 +2680,10 @@ class ContactTest(TembaTest):
         self.assertNotContains(response, "blow80")
 
         # try delete action
-        event = ChannelEvent.create(self.channel, six.text_type(self.frank.get_urn(TEL_SCHEME)),
-                                    ChannelEvent.TYPE_CALL_OUT_MISSED, timezone.now(), 5)
+        event = ChannelEvent.create(
+            self.channel,
+            six.text_type(self.frank.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_OUT_MISSED, timezone.now(), 5
+        )
         post_data['action'] = 'delete'
         post_data['objects'] = self.frank.pk
 
@@ -2451,7 +2705,10 @@ class ContactTest(TembaTest):
         self.assertEqual("Ryan Lewis", contact.name)
 
         # try the update case
-        self.client.post(reverse('contacts.contact_update', args=[contact.id]), dict(name="Marshal Mathers", urn__tel__0='07531669966'))
+        self.client.post(
+            reverse('contacts.contact_update', args=[contact.id]),
+            dict(name="Marshal Mathers", urn__tel__0='07531669966')
+        )
         contact = Contact.from_urn(self.org, 'tel:+447531669966')
         self.assertEqual("Marshal Mathers", contact.name)
 
@@ -2548,8 +2805,9 @@ class ContactTest(TembaTest):
 
             self.assertFalse('email' in Contact.get_org_import_file_headers(csv_file, self.org))
 
-        with open('%s/test_imports/sample_contacts_with_extra_fields_and_empty_headers.xls' % settings.MEDIA_ROOT,
-                  'rb') as open_file:
+        with open(
+            '%s/test_imports/sample_contacts_with_extra_fields_and_empty_headers.xls' % settings.MEDIA_ROOT, 'rb'
+        ) as open_file:
             csv_file = ContentFile(open_file.read())
             headers = ['country', 'district', 'zip code', 'professional status', 'joined', 'vehicle', 'shoes']
             self.assertEqual(Contact.get_org_import_file_headers(csv_file, self.org), headers)
@@ -2562,8 +2820,10 @@ class ContactTest(TembaTest):
         self.assertRaises(SmartImportRowError, Contact.create_instance, dict(org=self.org, created_by=self.admin))
 
         # or invalid phone number
-        self.assertRaises(SmartImportRowError, Contact.create_instance,
-                          dict(org=self.org, created_by=self.admin, phone="+121535e0884"))
+        self.assertRaises(
+            SmartImportRowError, Contact.create_instance,
+            dict(org=self.org, created_by=self.admin, phone="+121535e0884")
+        )
 
         contact = Contact.create_instance(dict(org=self.org, created_by=self.admin, name="Bob", phone="+250788111111"))
         self.assertEqual(contact.org, self.org)
@@ -2573,13 +2833,19 @@ class ContactTest(TembaTest):
 
     def do_import(self, user, filename):
 
-        import_params = dict(org_id=self.org.id, timezone=six.text_type(self.org.timezone), extra_fields=[],
-                             original_filename=filename)
+        import_params = dict(
+            org_id=self.org.id, timezone=six.text_type(self.org.timezone), extra_fields=[], original_filename=filename
+        )
 
         task = ImportTask.objects.create(
-            created_by=user, modified_by=user,
+            created_by=user,
+            modified_by=user,
             csv_file='test_imports/' + filename,
-            model_class="Contact", import_params=json.dumps(import_params), import_log="", task_id="A")
+            model_class="Contact",
+            import_params=json.dumps(import_params),
+            import_log="",
+            task_id="A"
+        )
 
         return Contact.import_csv(task, log=None)
 
@@ -2591,8 +2857,10 @@ class ContactTest(TembaTest):
         self.assertIsNotNone(response.context['task'])
 
         if task_customize:
-            self.assertEqual(response.request['PATH_INFO'], reverse('contacts.contact_customize',
-                                                                    args=[response.context['task'].pk]))
+            self.assertEqual(
+                response.request['PATH_INFO'],
+                reverse('contacts.contact_customize', args=[response.context['task'].pk])
+            )
             if custom_fields_number:
                 self.assertEqual(len(response.context['form'].fields.keys()), custom_fields_number)
 
@@ -2730,9 +2998,12 @@ class ContactTest(TembaTest):
         self.assertEqual(2, group.contacts.count())
         group = ContactGroup.user_groups.all()[1]
         self.assertEqual(2, group.contacts.count())
-        self.assertEqual(set(["Sample Contacts With Filename Very Long That It Will N",
-                              "Sample Contacts With Filename Very Long That It Will N 2"]),
-                         set(ContactGroup.user_groups.all().values_list('name', flat=True)))
+        self.assertEqual(
+            set([
+                "Sample Contacts With Filename Very Long That It Will N",
+                "Sample Contacts With Filename Very Long That It Will N 2"
+            ]), set(ContactGroup.user_groups.all().values_list('name', flat=True))
+        )
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
@@ -2749,8 +3020,10 @@ class ContactTest(TembaTest):
 
         with patch('temba.orgs.models.Org.lock_on') as mock_lock:
             # import contact with uuid will force update if existing contact for the uuid
-            self.assertContactImport('%s/test_imports/sample_contacts_uuid.xls' % settings.MEDIA_ROOT,
-                                     dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
+            self.assertContactImport(
+                '%s/test_imports/sample_contacts_uuid.xls' % settings.MEDIA_ROOT,
+                dict(records=4, errors=0, error_messages=[], creates=2, updates=2)
+            )
             self.assertEqual(mock_lock.call_count, 3)
 
         self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
@@ -2786,8 +3059,10 @@ class ContactTest(TembaTest):
 
             with patch('temba.orgs.models.Org.lock_on') as mock_lock:
                 # import contact with uuid will force update if existing contact for the uuid
-                self.assertContactImport('%s/test_imports/sample_contacts_uuid.xls' % settings.MEDIA_ROOT,
-                                         dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
+                self.assertContactImport(
+                    '%s/test_imports/sample_contacts_uuid.xls' % settings.MEDIA_ROOT,
+                    dict(records=4, errors=0, error_messages=[], creates=2, updates=2)
+                )
 
                 # we ignore urns so 1 less lock
                 self.assertEqual(mock_lock.call_count, 2)
@@ -2815,51 +3090,77 @@ class ContactTest(TembaTest):
         self.login(self.admin)
 
         with AnonymousOrg(self.org):
-            self.assertContactImport('%s/test_imports/sample_contacts_uuid.xls' % settings.MEDIA_ROOT,
-                                     dict(records=4, errors=0, error_messages=[], creates=1, updates=3))
+            self.assertContactImport(
+                '%s/test_imports/sample_contacts_uuid.xls' % settings.MEDIA_ROOT,
+                dict(records=4, errors=0, error_messages=[], creates=1, updates=3)
+            )
 
             Contact.objects.all().delete()
             ContactGroup.user_groups.all().delete()
 
-            self.assertContactImport('%s/test_imports/sample_contacts.xls' % settings.MEDIA_ROOT,
-                                     dict(records=3, errors=0, error_messages=[], creates=3, updates=0))
+            self.assertContactImport(
+                '%s/test_imports/sample_contacts.xls' % settings.MEDIA_ROOT,
+                dict(records=3, errors=0, error_messages=[], creates=3, updates=0)
+            )
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
 
         # import sample contact spreadsheet with valid headers
-        self.assertContactImport('%s/test_imports/sample_contacts.xls' % settings.MEDIA_ROOT,
-                                 dict(records=3, errors=0, error_messages=[], creates=3, updates=0))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts.xls' % settings.MEDIA_ROOT,
+            dict(records=3, errors=0, error_messages=[], creates=3, updates=0)
+        )
 
         # import again to check contacts are updated
-        self.assertContactImport('%s/test_imports/sample_contacts.xls' % settings.MEDIA_ROOT,
-                                 dict(records=3, errors=0, error_messages=[], creates=0, updates=3))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts.xls' % settings.MEDIA_ROOT,
+            dict(records=3, errors=0, error_messages=[], creates=0, updates=3)
+        )
 
         # import a spreadsheet that includes the test contact
-        self.assertContactImport('%s/test_imports/sample_contacts_inc_test.xls' % settings.MEDIA_ROOT,
-                                 dict(records=2, errors=1, creates=0, updates=2,
-                                      error_messages=[dict(line=4, error="Ignored test contact")]))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts_inc_test.xls' % settings.MEDIA_ROOT,
+            dict(
+                records=2, errors=1, creates=0, updates=2, error_messages=[dict(line=4, error="Ignored test contact")]
+            )
+        )
 
         self.maxDiff = None
 
         # import a spreadsheet where a contact has a missing phone number and another has an invalid number
-        self.assertContactImport('%s/test_imports/sample_contacts_with_missing_and_invalid_phones.xls' % settings.MEDIA_ROOT,
-                                 dict(records=1, errors=2, creates=0, updates=1,
-                                      error_messages=[dict(line=3,
-                                                           error="Missing any valid URNs; at least one among phone, "
-                                                                 "facebook, twitter, twitterid, viber, line, telegram, email, "
-                                                                 "external, jiochat, fcm should be provided or a Contact UUID"),
-                                                      dict(line=4, error="Invalid Phone number 12345")]))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts_with_missing_and_invalid_phones.xls' % settings.MEDIA_ROOT,
+            dict(
+                records=1,
+                errors=2,
+                creates=0,
+                updates=1,
+                error_messages=[
+                    dict(
+                        line=3,
+                        error="Missing any valid URNs; at least one among phone, "
+                        "facebook, twitter, twitterid, viber, line, telegram, email, "
+                        "external, jiochat, fcm should be provided or a Contact UUID"
+                    ),
+                    dict(line=4, error="Invalid Phone number 12345")
+                ]
+            )
+        )
 
         # import a spreadsheet with a name and a twitter columns only
-        self.assertContactImport('%s/test_imports/sample_contacts_twitter.xls' % settings.MEDIA_ROOT,
-                                 dict(records=3, errors=0, error_messages=[], creates=3, updates=0))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts_twitter.xls' % settings.MEDIA_ROOT,
+            dict(records=3, errors=0, error_messages=[], creates=3, updates=0)
+        )
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
 
-        self.assertContactImport('%s/test_imports/sample_contacts_bad_unicode.xls' % settings.MEDIA_ROOT,
-                                 dict(records=2, errors=0, creates=2, updates=0, error_messages=[]))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts_bad_unicode.xls' % settings.MEDIA_ROOT,
+            dict(records=2, errors=0, creates=2, updates=0, error_messages=[])
+        )
 
         self.assertEqual(1, Contact.objects.filter(name='John Doe').count())
         self.assertEqual(1, Contact.objects.filter(name='Mary Smith').count())
@@ -2874,8 +3175,10 @@ class ContactTest(TembaTest):
         ContactGroup.user_groups.all().delete()
 
         # import a spreadsheet with phone, name and twitter columns
-        self.assertContactImport('%s/test_imports/sample_contacts_twitter_and_phone.xls' % settings.MEDIA_ROOT,
-                                 dict(records=3, errors=0, error_messages=[], creates=3, updates=0))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts_twitter_and_phone.xls' % settings.MEDIA_ROOT,
+            dict(records=3, errors=0, error_messages=[], creates=3, updates=0)
+        )
 
         self.assertEqual(3, Contact.objects.all().count())
         self.assertEqual(1, Contact.objects.filter(name='Rapidpro').count())
@@ -2883,8 +3186,10 @@ class ContactTest(TembaTest):
         self.assertEqual(1, Contact.objects.filter(name='Nyaruka').count())
 
         # import file with row different urn on different existing contacts should ignore those lines
-        self.assertContactImport('%s/test_imports/sample_contacts_twitter_and_phone_conflicts.xls' % settings.MEDIA_ROOT,
-                                 dict(records=2, errors=0, creates=0, updates=2, error_messages=[]))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts_twitter_and_phone_conflicts.xls' % settings.MEDIA_ROOT,
+            dict(records=2, errors=0, creates=0, updates=2, error_messages=[])
+        )
 
         self.assertEqual(3, Contact.objects.all().count())
         self.assertEqual(1, Contact.objects.filter(name='Rapidpro').count())
@@ -2897,8 +3202,10 @@ class ContactTest(TembaTest):
         ContactGroup.user_groups.all().delete()
 
         # some columns have either twitter or phone
-        self.assertContactImport('%s/test_imports/sample_contacts_twitter_and_phone_optional.xls' % settings.MEDIA_ROOT,
-                                 dict(records=3, errors=0, error_messages=[], creates=3, updates=0))
+        self.assertContactImport(
+            '%s/test_imports/sample_contacts_twitter_and_phone_optional.xls' % settings.MEDIA_ROOT,
+            dict(records=3, errors=0, error_messages=[], creates=3, updates=0)
+        )
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
@@ -2915,12 +3222,23 @@ class ContactTest(TembaTest):
 
         with patch('temba.orgs.models.Org.lock_on') as mock_lock:
             # import contact with uuid will force update if existing contact for the uuid
-            self.assertContactImport('%s/test_imports/sample_contacts_uuid_no_urns.xls' % settings.MEDIA_ROOT,
-                                     dict(records=3, errors=1, creates=1, updates=2,
-                                          error_messages=[dict(line=3,
-                                                          error="Missing any valid URNs; at least one among phone, "
-                                                                "facebook, twitter, twitterid, viber, line, telegram, email, "
-                                                                "external, jiochat, fcm should be provided or a Contact UUID")]))
+            self.assertContactImport(
+                '%s/test_imports/sample_contacts_uuid_no_urns.xls' % settings.MEDIA_ROOT,
+                dict(
+                    records=3,
+                    errors=1,
+                    creates=1,
+                    updates=2,
+                    error_messages=[
+                        dict(
+                            line=3,
+                            error="Missing any valid URNs; at least one among phone, "
+                            "facebook, twitter, twitterid, viber, line, telegram, email, "
+                            "external, jiochat, fcm should be provided or a Contact UUID"
+                        )
+                    ]
+                )
+            )
 
             # lock for creates only
             self.assertEqual(mock_lock.call_count, 1)
@@ -2943,8 +3261,10 @@ class ContactTest(TembaTest):
         with AnonymousOrg(self.org):
             with patch('temba.orgs.models.Org.lock_on') as mock_lock:
                 # import contact with uuid will force update if existing contact for the uuid for anoa orrg as well
-                self.assertContactImport('%s/test_imports/sample_contacts_uuid_no_urns.xls' % settings.MEDIA_ROOT,
-                                         dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
+                self.assertContactImport(
+                    '%s/test_imports/sample_contacts_uuid_no_urns.xls' % settings.MEDIA_ROOT,
+                    dict(records=4, errors=0, error_messages=[], creates=2, updates=2)
+                )
 
                 # lock for creates only
                 self.assertEqual(mock_lock.call_count, 2)
@@ -2983,12 +3303,23 @@ class ContactTest(TembaTest):
 
         with patch('temba.orgs.models.Org.lock_on') as mock_lock:
             # import contact with uuid will force update if existing contact for the uuid, csv file
-            self.assertContactImport('%s/test_imports/sample_contacts_uuid_no_urns.csv' % settings.MEDIA_ROOT,
-                                     dict(records=3, errors=1, creates=1, updates=2,
-                                          error_messages=[dict(line=3,
-                                                          error="Missing any valid URNs; at least one among phone, "
-                                                                "facebook, twitter, twitterid, viber, line, telegram, email, "
-                                                                "external, jiochat, fcm should be provided or a Contact UUID")]))
+            self.assertContactImport(
+                '%s/test_imports/sample_contacts_uuid_no_urns.csv' % settings.MEDIA_ROOT,
+                dict(
+                    records=3,
+                    errors=1,
+                    creates=1,
+                    updates=2,
+                    error_messages=[
+                        dict(
+                            line=3,
+                            error="Missing any valid URNs; at least one among phone, "
+                            "facebook, twitter, twitterid, viber, line, telegram, email, "
+                            "external, jiochat, fcm should be provided or a Contact UUID"
+                        )
+                    ]
+                )
+            )
 
             # only lock for create
             self.assertEqual(mock_lock.call_count, 1)
@@ -3011,8 +3342,10 @@ class ContactTest(TembaTest):
         with AnonymousOrg(self.org):
             with patch('temba.orgs.models.Org.lock_on') as mock_lock:
                 # import contact with uuid will force update if existing contact for the uuid,csv file for anon org
-                self.assertContactImport('%s/test_imports/sample_contacts_uuid_no_urns.csv' % settings.MEDIA_ROOT,
-                                         dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
+                self.assertContactImport(
+                    '%s/test_imports/sample_contacts_uuid_no_urns.csv' % settings.MEDIA_ROOT,
+                    dict(records=4, errors=0, error_messages=[], creates=2, updates=2)
+                )
 
                 # only lock for creates
                 self.assertEqual(mock_lock.call_count, 2)
@@ -3051,8 +3384,10 @@ class ContactTest(TembaTest):
 
         with patch('temba.orgs.models.Org.lock_on') as mock_lock:
             # import contact with uuid column to group the contacts
-            self.assertContactImport('%s/test_imports/sample_contacts_uuid_only.csv' % settings.MEDIA_ROOT,
-                                     dict(records=3, errors=0, error_messages=[], creates=1, updates=2))
+            self.assertContactImport(
+                '%s/test_imports/sample_contacts_uuid_only.csv' % settings.MEDIA_ROOT,
+                dict(records=3, errors=0, error_messages=[], creates=1, updates=2)
+            )
 
             # one lock for the create
             self.assertEqual(mock_lock.call_count, 1)
@@ -3064,8 +3399,10 @@ class ContactTest(TembaTest):
         with AnonymousOrg(self.org):
             with patch('temba.orgs.models.Org.lock_on') as mock_lock:
                 # import contact with uuid column to group the contacts for anon org
-                self.assertContactImport('%s/test_imports/sample_contacts_uuid_only.csv' % settings.MEDIA_ROOT,
-                                         dict(records=3, errors=0, error_messages=[], creates=1, updates=2))
+                self.assertContactImport(
+                    '%s/test_imports/sample_contacts_uuid_only.csv' % settings.MEDIA_ROOT,
+                    dict(records=3, errors=0, error_messages=[], creates=1, updates=2)
+                )
 
                 # one lock for the create
                 self.assertEqual(mock_lock.call_count, 1)
@@ -3102,40 +3439,52 @@ class ContactTest(TembaTest):
 
             self.assertContactImport(
                 '%s/test_imports/sample_contacts_org_missing_country.csv' % settings.MEDIA_ROOT,
-                dict(records=0, errors=1,
-                     error_messages=[dict(line=2,
-                                          error="Invalid Phone number or no country code specified for 788383385")]))
+                dict(
+                    records=0,
+                    errors=1,
+                    error_messages=[
+                        dict(line=2, error="Invalid Phone number or no country code specified for 788383385")
+                    ]
+                )
+            )
 
         # try importing a file with a unicode in the name
         csv_file = open('%s/test_imports/abc_@@é.xls' % settings.MEDIA_ROOT, 'rb')
         post_data = dict(csv_file=csv_file)
         response = self.client.post(import_url, post_data)
-        self.assertFormError(response, 'form', 'csv_file',
-                             'Please make sure the file name only contains alphanumeric characters [0-9a-zA-Z] and '
-                             'special characters in -, _, ., (, )')
+        self.assertFormError(
+            response, 'form', 'csv_file',
+            'Please make sure the file name only contains alphanumeric characters [0-9a-zA-Z] and '
+            'special characters in -, _, ., (, )'
+        )
 
         # try importing invalid spreadsheets with missing headers
         csv_file = open('%s/test_imports/sample_contacts_missing_name_header.xls' % settings.MEDIA_ROOT, 'rb')
         post_data = dict(csv_file=csv_file)
         response = self.client.post(import_url, post_data)
-        self.assertFormError(response, 'form', 'csv_file',
-                             'The file you provided is missing a required header called "Name".')
+        self.assertFormError(
+            response, 'form', 'csv_file', 'The file you provided is missing a required header called "Name".'
+        )
 
         csv_file = open('%s/test_imports/sample_contacts_missing_phone_header.xls' % settings.MEDIA_ROOT, 'rb')
         post_data = dict(csv_file=csv_file)
         response = self.client.post(import_url, post_data)
-        self.assertFormError(response, 'form', 'csv_file',
-                             'The file you provided is missing a required header. At least one of "Phone", "Facebook", '
-                             '"Twitter", "Twitterid", "Viber", "Line", "Telegram", "Email", "External", '
-                             '"Jiochat", "Fcm" or "Contact UUID" should be included.')
+        self.assertFormError(
+            response, 'form', 'csv_file',
+            'The file you provided is missing a required header. At least one of "Phone", "Facebook", '
+            '"Twitter", "Twitterid", "Viber", "Line", "Telegram", "Email", "External", '
+            '"Jiochat", "Fcm" or "Contact UUID" should be included.'
+        )
 
         csv_file = open('%s/test_imports/sample_contacts_missing_name_phone_headers.xls' % settings.MEDIA_ROOT, 'rb')
         post_data = dict(csv_file=csv_file)
         response = self.client.post(import_url, post_data)
-        self.assertFormError(response, 'form', 'csv_file',
-                             'The file you provided is missing a required header. At least one of "Phone", "Facebook", '
-                             '"Twitter", "Twitterid", "Viber", "Line", "Telegram", "Email", "External", '
-                             '"Jiochat", "Fcm" or "Contact UUID" should be included.')
+        self.assertFormError(
+            response, 'form', 'csv_file',
+            'The file you provided is missing a required header. At least one of "Phone", "Facebook", '
+            '"Twitter", "Twitterid", "Viber", "Line", "Telegram", "Email", "External", '
+            '"Jiochat", "Fcm" or "Contact UUID" should be included.'
+        )
 
         for i in range(ContactGroup.MAX_ORG_CONTACTGROUPS):
             ContactGroup.create_static(self.org, self.admin, 'group%d' % i)
@@ -3143,9 +3492,10 @@ class ContactTest(TembaTest):
         csv_file = open('%s/test_imports/sample_contacts.xls' % settings.MEDIA_ROOT, 'rb')
         post_data = dict(csv_file=csv_file)
         response = self.client.post(import_url, post_data)
-        self.assertFormError(response, 'form', '__all__',
-                             "This org has 10 groups and the limit is 10. "
-                             "You must delete existing ones before you can create new ones.")
+        self.assertFormError(
+            response, 'form', '__all__', "This org has 10 groups and the limit is 10. "
+            "You must delete existing ones before you can create new ones."
+        )
 
         ContactGroup.user_groups.all().delete()
 
@@ -3155,11 +3505,17 @@ class ContactTest(TembaTest):
 
         # existing field
         ContactField.get_or_create(self.org, self.admin, 'ride_or_drive', 'Vehicle')
-        ContactField.get_or_create(self.org, self.admin, 'wears', 'Shoes')  # has trailing spaces on excel files as " Shoes  "
+        ContactField.get_or_create(
+            self.org, self.admin, 'wears', 'Shoes'
+        )  # has trailing spaces on excel files as " Shoes  "
 
         # import spreadsheet with extra columns
-        response = self.assertContactImport('%s/test_imports/sample_contacts_with_extra_fields.xls' % settings.MEDIA_ROOT,
-                                            None, task_customize=True, custom_fields_number=21)
+        response = self.assertContactImport(
+            '%s/test_imports/sample_contacts_with_extra_fields.xls' % settings.MEDIA_ROOT,
+            None,
+            task_customize=True,
+            custom_fields_number=21
+        )
 
         # all checkboxes should default to True
         for key in response.context['form'].fields.keys():
@@ -3192,8 +3548,9 @@ class ContactTest(TembaTest):
         post_data['column_shoes_type'] = 'N'
 
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertEqual(response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3,
-                                                           updates=0))
+        self.assertEqual(
+            response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3, updates=0)
+        )
         self.assertEqual(Contact.objects.all().count(), 3)
         self.assertEqual(ContactGroup.user_groups.all().count(), 1)
         self.assertEqual(ContactGroup.user_groups.all()[0].name, 'Sample Contacts With Extra Fields')
@@ -3235,8 +3592,9 @@ class ContactTest(TembaTest):
 
         # import spreadsheet with extra columns again but check that giving column a reserved name
         # gives validation error
-        response = self.assertContactImport('%s/test_imports/sample_contacts_with_extra_fields.xls' % settings.MEDIA_ROOT,
-                                            None, task_customize=True)
+        response = self.assertContactImport(
+            '%s/test_imports/sample_contacts_with_extra_fields.xls' % settings.MEDIA_ROOT, None, task_customize=True
+        )
         customize_url = reverse('contacts.contact_customize', args=[response.context['task'].pk])
         post_data = dict()
         post_data['column_country_include'] = 'on'
@@ -3257,15 +3615,19 @@ class ContactTest(TembaTest):
         post_data['column_joined_type'] = 'D'
 
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertFormError(response, 'form', None, 'Name is an invalid name or is a reserved name for contact '
-                                                     'fields, field names should start with a letter.')
+        self.assertFormError(
+            response, 'form', None, 'Name is an invalid name or is a reserved name for contact '
+            'fields, field names should start with a letter.'
+        )
 
         # we do not support names not starting by letter
         post_data['column_country_label'] = '12Project'  # reserved when slugified to 'name'
 
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertFormError(response, 'form', None, '12Project is an invalid name or is a reserved name for contact '
-                                                     'fields, field names should start with a letter.')
+        self.assertFormError(
+            response, 'form', None, '12Project is an invalid name or is a reserved name for contact '
+            'fields, field names should start with a letter.'
+        )
 
         # invalid label
         post_data['column_country_label'] = '}{i$t0rY'  # supports only numbers, letters, hyphens
@@ -3284,12 +3646,15 @@ class ContactTest(TembaTest):
         self.assertFormError(response, 'form', None, 'District should be used once')
 
         # wrong field with reserve word key
-        ContactField.objects.create(org=self.org, key='language', label='Lang',
-                                    created_by=self.admin, modified_by=self.admin)
+        ContactField.objects.create(
+            org=self.org, key='language', label='Lang', created_by=self.admin, modified_by=self.admin
+        )
 
         response = self.assertContactImport(
             '%s/test_imports/sample_contacts_with_extra_fields_wrong_lang.xls' % settings.MEDIA_ROOT,
-            None, task_customize=True)
+            None,
+            task_customize=True
+        )
 
         customize_url = reverse('contacts.contact_customize', args=[response.context['task'].pk])
         post_data = dict()
@@ -3298,8 +3663,10 @@ class ContactTest(TembaTest):
         post_data['column_lang_type'] = 'T'
 
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertFormError(response, 'form', None, "'Lang' contact field has 'language' key which is reserved name. "
-                                                     "Column cannot be imported")
+        self.assertFormError(
+            response, 'form', None, "'Lang' contact field has 'language' key which is reserved name. "
+            "Column cannot be imported"
+        )
 
         # we shouldn't be suspended
         self.org.refresh_from_db()
@@ -3308,21 +3675,34 @@ class ContactTest(TembaTest):
         # invalid import params
         with self.assertRaises(Exception):
             task = ImportTask.objects.create(
-                created_by=user, modified_by=user,
+                created_by=user,
+                modified_by=user,
                 csv_file='test_imports/filename',
-                model_class="Contact", import_params='bogus!', import_log="", task_id="A")
+                model_class="Contact",
+                import_params='bogus!',
+                import_log="",
+                task_id="A"
+            )
             Contact.import_csv(task, log=None)
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
 
         # existing datetime field
-        ContactField.objects.create(org=self.org, key='startdate', label='StartDate', value_type=Value.TYPE_DATETIME,
-                                    created_by=self.admin, modified_by=self.admin)
+        ContactField.objects.create(
+            org=self.org,
+            key='startdate',
+            label='StartDate',
+            value_type=Value.TYPE_DATETIME,
+            created_by=self.admin,
+            modified_by=self.admin
+        )
 
         response = self.assertContactImport(
             '%s/test_imports/sample_contacts_with_extra_field_date_joined.xls' % settings.MEDIA_ROOT,
-            None, task_customize=True)
+            None,
+            task_customize=True
+        )
 
         customize_url = reverse('contacts.contact_customize', args=[response.context['task'].pk])
 
@@ -3331,8 +3711,9 @@ class ContactTest(TembaTest):
         post_data['column_joined_type'] = 'D'
         post_data['column_joined_label'] = 'StartDate'
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertEqual(response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3,
-                                                           updates=0))
+        self.assertEqual(
+            response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3, updates=0)
+        )
 
         contact1 = Contact.objects.all().order_by('name')[0]
         self.assertEqual(contact1.get_field_raw('startdate'), '31-12-2014 10:00')
@@ -3351,7 +3732,9 @@ class ContactTest(TembaTest):
 
         response = self.assertContactImport(
             '%s/test_imports/sample_contacts_with_extra_field_date_planting.xls' % settings.MEDIA_ROOT,
-            None, task_customize=True)
+            None,
+            task_customize=True
+        )
 
         customize_url = reverse('contacts.contact_customize', args=[response.context['task'].pk])
 
@@ -3365,15 +3748,17 @@ class ContactTest(TembaTest):
         post_data['column_team_label'] = 'Team'
 
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertEqual(response.context['results'], dict(records=1, errors=0, error_messages=[], creates=0,
-                                                           updates=1))
+        self.assertEqual(
+            response.context['results'], dict(records=1, errors=0, error_messages=[], creates=0, updates=1)
+        )
 
         contact1 = Contact.objects.filter(name='John Blow').first()
         self.assertEqual(contact1.get_field_raw('planting_date'), '31-12-2020 10:00')
         self.assertEqual(contact1.get_field_raw('team'), 'Ballers')
 
-        event_fire = EventFire.objects.filter(event=self.message_event, contact=contact1,
-                                              event__campaign__group__in=[ballers]).first()
+        event_fire = EventFire.objects.filter(
+            event=self.message_event, contact=contact1, event__campaign__group__in=[ballers]
+        ).first()
         contact1_planting_date = contact1.get_field('planting_date').datetime_value.replace(second=0, microsecond=0)
         self.assertEqual(event_fire.scheduled, contact1_planting_date + timedelta(days=7))
 
@@ -3384,7 +3769,7 @@ class ContactTest(TembaTest):
 
         self.assertEqual(Contact.objects.get(urns__path="+250788382382").language, 'eng')  # updated
         self.assertEqual(Contact.objects.get(urns__path="+250788383383").language, 'fre')  # created with language
-        self.assertEqual(Contact.objects.get(urns__path="+250788383385").language, None)   # no language
+        self.assertEqual(Contact.objects.get(urns__path="+250788383385").language, None)  # no language
 
     def test_import_sequential_numbers(self):
 
@@ -3423,9 +3808,11 @@ class ContactTest(TembaTest):
         self.assertEqual(c1.pk, c2.pk)
         self.assertFalse(c2.is_blocked)
 
-        import_params = dict(org_id=self.org.id, timezone=timezone.utc, extra_fields=[
-            dict(key='nick_name', header='nick name', label='Nickname', type='T')
-        ])
+        import_params = dict(
+            org_id=self.org.id,
+            timezone=timezone.utc,
+            extra_fields=[dict(key='nick_name', header='nick name', label='Nickname', type='T')]
+        )
         field_dict = dict(phone='0788123123', created_by=user, modified_by=user, org=self.org, name='LaToya Jackson')
         field_dict['yourmom'] = 'face'
         field_dict['nick name'] = 'bob'
@@ -3441,36 +3828,38 @@ class ContactTest(TembaTest):
 
         # check that trying to save an extra field with a reserved name throws an exception
         with self.assertRaises(Exception):
-            import_params = dict(org_id=self.org.id, timezone=timezone.utc, extra_fields=[
-                dict(key='phone', header='phone', label='Phone')
-            ])
+            import_params = dict(
+                org_id=self.org.id,
+                timezone=timezone.utc,
+                extra_fields=[dict(key='phone', header='phone', label='Phone')]
+            )
             Contact.prepare_fields(field_dict, import_params)
 
         with AnonymousOrg(self.org):
             # should existing urns on anon org
             with self.assertRaises(SmartImportRowError):
-                field_dict = dict(phone='0788123123', created_by=user, modified_by=user,
-                                  org=self.org, name='LaToya Jackson')
+                field_dict = dict(
+                    phone='0788123123', created_by=user, modified_by=user, org=self.org, name='LaToya Jackson'
+                )
                 Contact.create_instance(field_dict)
 
-            field_dict = dict(phone='0788123123', created_by=user, modified_by=user,
-                              org=self.org, name='Janet Jackson')
+            field_dict = dict(
+                phone='0788123123', created_by=user, modified_by=user, org=self.org, name='Janet Jackson'
+            )
             field_dict['contact uuid'] = c1.uuid
 
             c3 = Contact.create_instance(field_dict)
             self.assertEqual(c3.pk, c1.pk)
             self.assertEqual(c3.name, "Janet Jackson")
 
-        field_dict = dict(phone='0788123123', created_by=user, modified_by=user,
-                          org=self.org, name='Josh Childress')
+        field_dict = dict(phone='0788123123', created_by=user, modified_by=user, org=self.org, name='Josh Childress')
         field_dict['contact uuid'] = c1.uuid
 
         c4 = Contact.create_instance(field_dict)
         self.assertEqual(c4.pk, c1.pk)
         self.assertEqual(c4.name, "Josh Childress")
 
-        field_dict = dict(phone='0788123123', created_by=user, modified_by=user,
-                          org=self.org, name='Goran Dragic')
+        field_dict = dict(phone='0788123123', created_by=user, modified_by=user, org=self.org, name='Goran Dragic')
         field_dict['uuid'] = c1.uuid
 
         c5 = Contact.create_instance(field_dict)
@@ -3520,8 +3909,9 @@ class ContactTest(TembaTest):
         self.assertIsNone(self.joe.get_field('birth_date').datetime_value)
 
     def test_serialize_field_value(self):
-        registration_field = ContactField.get_or_create(self.org, self.admin, 'registration_date', "Registration Date",
-                                                        None, Value.TYPE_DATETIME)
+        registration_field = ContactField.get_or_create(
+            self.org, self.admin, 'registration_date', "Registration Date", None, Value.TYPE_DATETIME
+        )
 
         weight_field = ContactField.get_or_create(self.org, self.admin, 'weight', "Weight", None, Value.TYPE_DECIMAL)
         color_field = ContactField.get_or_create(self.org, self.admin, 'color', "Color", None, Value.TYPE_TEXT)
@@ -3546,8 +3936,12 @@ class ContactTest(TembaTest):
         self.assertEqual(Contact.serialize_field_value(color_field, value), 'green')
 
     def test_set_location_fields(self):
-        district_field = ContactField.get_or_create(self.org, self.admin, 'district', 'District', None, Value.TYPE_DISTRICT)
-        not_state_field = ContactField.get_or_create(self.org, self.admin, 'not_state', 'Not State', None, Value.TYPE_TEXT)
+        district_field = ContactField.get_or_create(
+            self.org, self.admin, 'district', 'District', None, Value.TYPE_DISTRICT
+        )
+        not_state_field = ContactField.get_or_create(
+            self.org, self.admin, 'not_state', 'Not State', None, Value.TYPE_TEXT
+        )
 
         # add duplicate district in different states
         east_province = AdminBoundary.objects.create(osm_id='R005', name='East Province', level=1, parent=self.country)
@@ -3740,8 +4134,16 @@ class ContactTest(TembaTest):
 
             joe_flow = self.create_flow()
             joes_campaign = Campaign.create(self.org, self.admin, "Joe Reminders", joes_group)
-            joes_event = CampaignEvent.create_flow_event(self.org, self.admin, joes_campaign, relative_to=joined_field,
-                                                         offset=1, unit='W', flow=joe_flow, delivery_hour=17)
+            joes_event = CampaignEvent.create_flow_event(
+                self.org,
+                self.admin,
+                joes_campaign,
+                relative_to=joined_field,
+                offset=1,
+                unit='W',
+                flow=joe_flow,
+                delivery_hour=17
+            )
             EventFire.update_campaign_events(joes_campaign)
 
             # check initial group members added correctly
@@ -3753,8 +4155,10 @@ class ContactTest(TembaTest):
             # try removing frank from dynamic group (shouldnt happen, ui doesnt allow this)
             with self.assertRaises(ValueError):
                 self.login(self.admin)
-                self.client.post(reverse('contacts.contact_read', args=[self.frank.uuid]),
-                                 dict(contact=self.frank.pk, group=men_group.pk))
+                self.client.post(
+                    reverse('contacts.contact_read', args=[self.frank.uuid]),
+                    dict(contact=self.frank.pk, group=men_group.pk)
+                )
 
             # check event fire initialized correctly
             joe_fires = EventFire.objects.filter(event=joes_event)
@@ -3769,7 +4173,7 @@ class ContactTest(TembaTest):
             # Mary's name changes
             self.mary.name = "Mary Joe"
             self.mary.save()
-            self.mary.handle_update(attrs=('name',))
+            self.mary.handle_update(attrs=('name', ))
             self.assertEqual([self.joe, self.mary], list(joes_group.contacts.order_by('name')))
 
             # Mary should also have an event fire now
@@ -3832,9 +4236,14 @@ class ContactTest(TembaTest):
         self.joe.update_urns(self.admin, ['telegram:12515', 'twitter:macklemore'])
 
         # simulate an incoming message from Mage on Twitter
-        msg = Msg.objects.create(org=self.org, channel=twitter, contact=self.joe,
-                                 contact_urn=ContactURN.get_or_create(self.org, self.joe, 'twitter:macklemore', twitter),
-                                 text="Incoming twitter DM", created_on=timezone.now())
+        msg = Msg.objects.create(
+            org=self.org,
+            channel=twitter,
+            contact=self.joe,
+            contact_urn=ContactURN.get_or_create(self.org, self.joe, 'twitter:macklemore', twitter),
+            text="Incoming twitter DM",
+            created_on=timezone.now()
+        )
 
         process_message_task(dict(id=msg.id, from_mage=True, new_contact=False))
 
@@ -3863,13 +4272,17 @@ class ContactURNTest(TembaTest):
         self.assertEqual(urn, urn2)
 
     def test_get_display(self):
-        urn = ContactURN.objects.create(org=self.org, scheme='tel', path='+250788383383', identity='tel:+250788383383', priority=50)
+        urn = ContactURN.objects.create(
+            org=self.org, scheme='tel', path='+250788383383', identity='tel:+250788383383', priority=50
+        )
         self.assertEqual(urn.get_display(self.org), '0788 383 383')
         self.assertEqual(urn.get_display(self.org, formatted=False), '+250788383383')
         self.assertEqual(urn.get_display(self.org, international=True), '+250 788 383 383')
         self.assertEqual(urn.get_display(self.org, formatted=False, international=True), '+250788383383')
 
-        urn = ContactURN.objects.create(org=self.org, scheme='twitter', path='billy_bob', identity='twitter:billy_bob', priority=50)
+        urn = ContactURN.objects.create(
+            org=self.org, scheme='twitter', path='billy_bob', identity='twitter:billy_bob', priority=50
+        )
         self.assertEqual(urn.get_display(self.org), 'billy_bob')
 
 
@@ -3890,17 +4303,23 @@ class ContactFieldTest(TembaTest):
         self.assertEqual(join_date.label, "Join Date")
         self.assertEqual(join_date.value_type, Value.TYPE_TEXT)
 
-        another = ContactField.get_or_create(self.org, self.admin, "another", "My Label", value_type=Value.TYPE_DECIMAL)
+        another = ContactField.get_or_create(
+            self.org, self.admin, "another", "My Label", value_type=Value.TYPE_DECIMAL
+        )
         self.assertEqual(another.key, "another")
         self.assertEqual(another.label, "My Label")
         self.assertEqual(another.value_type, Value.TYPE_DECIMAL)
 
-        another = ContactField.get_or_create(self.org, self.admin, "another", "Updated Label", value_type=Value.TYPE_DATETIME)
+        another = ContactField.get_or_create(
+            self.org, self.admin, "another", "Updated Label", value_type=Value.TYPE_DATETIME
+        )
         self.assertEqual(another.key, "another")
         self.assertEqual(another.label, "Updated Label")
         self.assertEqual(another.value_type, Value.TYPE_DATETIME)
 
-        another = ContactField.get_or_create(self.org, self.admin, "another", "Updated Label", show_in_table=True, value_type=Value.TYPE_DATETIME)
+        another = ContactField.get_or_create(
+            self.org, self.admin, "another", "Updated Label", show_in_table=True, value_type=Value.TYPE_DATETIME
+        )
         self.assertTrue(another.show_in_table)
 
         for elt in Contact.RESERVED_FIELDS:
@@ -3966,15 +4385,18 @@ class ContactFieldTest(TembaTest):
     def test_make_key(self):
         self.assertEqual("first_name", ContactField.make_key("First Name"))
         self.assertEqual("second_name", ContactField.make_key("Second   Name  "))
-        self.assertEqual("323_ffsn_slfs_ksflskfs_fk_anfaddgas", ContactField.make_key("  ^%$# %$$ $##323 ffsn slfs ksflskfs!!!! fk$%%%$$$anfaDDGAS ))))))))) "))
+        self.assertEqual(
+            "323_ffsn_slfs_ksflskfs_fk_anfaddgas",
+            ContactField.make_key("  ^%$# %$$ $##323 ffsn slfs ksflskfs!!!! fk$%%%$$$anfaDDGAS ))))))))) ")
+        )
 
     def test_is_valid_key(self):
         self.assertTrue(ContactField.is_valid_key("age"))
         self.assertTrue(ContactField.is_valid_key("age_now_2"))
-        self.assertFalse(ContactField.is_valid_key("Age"))   # must be lowercase
+        self.assertFalse(ContactField.is_valid_key("Age"))  # must be lowercase
         self.assertFalse(ContactField.is_valid_key("age!"))  # can't have punctuation
-        self.assertFalse(ContactField.is_valid_key("âge"))   # a-z only
-        self.assertFalse(ContactField.is_valid_key("2up"))   # can't start with a number
+        self.assertFalse(ContactField.is_valid_key("âge"))  # a-z only
+        self.assertFalse(ContactField.is_valid_key("2up"))  # can't start with a number
         self.assertFalse(ContactField.is_valid_key("name"))  # can't be a reserved name
         self.assertFalse(ContactField.is_valid_key("uuid"))
         self.assertFalse(ContactField.is_valid_key("a" * 37))  # too long
@@ -3983,7 +4405,7 @@ class ContactFieldTest(TembaTest):
         self.assertTrue(ContactField.is_valid_label("Age"))
         self.assertTrue(ContactField.is_valid_label("Age Now 2"))
         self.assertFalse(ContactField.is_valid_label("Age_Now"))  # can't have punctuation
-        self.assertFalse(ContactField.is_valid_label("âge"))      # a-z only
+        self.assertFalse(ContactField.is_valid_label("âge"))  # a-z only
 
     def test_contact_export(self):
         self.clear_storage()
@@ -4036,11 +4458,13 @@ class ContactFieldTest(TembaTest):
 
         # no group specified, so will default to 'All Contacts'
         with self.assertNumQueries(40):
-            self.assertExcelSheet(request_export(), [
-                ["Contact UUID", "Name", "Email", "Phone", "Telegram", "Twitter", "First", "Second", "Third"],
-                [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "1234", "adam", "", "", ""],
-                [contact.uuid, "Ben Haggerty", "", "+12067799294", "", "", "One", "", "20-12-2015 08:30"],
-            ])
+            self.assertExcelSheet(
+                request_export(), [
+                    ["Contact UUID", "Name", "Email", "Phone", "Telegram", "Twitter", "First", "Second", "Third"],
+                    [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "1234", "adam", "", "", ""],
+                    [contact.uuid, "Ben Haggerty", "", "+12067799294", "", "", "One", "", "20-12-2015 08:30"],
+                ]
+            )
 
         # more contacts do not increase the queries
         contact3 = self.create_contact('Luol Deng', '+12078776655', twitter='deng')
@@ -4049,46 +4473,77 @@ class ContactFieldTest(TembaTest):
 
         # but should have additional Twitter and phone columns
         with self.assertNumQueries(40):
-            self.assertExcelSheet(request_export(), [
-                ["Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second", "Third"],
-                [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "", "1234", "adam", "", "", ""],
-                [contact.uuid, "Ben Haggerty", "", "+12067799294", "+12062233445", "", "", "One", "", "20-12-2015 08:30"],
-                [contact3.uuid, "Luol Deng", "", "+12078776655", "", "", "deng", "", "", ""],
-                [contact4.uuid, "Stephen", "", "+12078778899", "", "", "stephen", "", "", ""],
-            ])
+            self.assertExcelSheet(
+                request_export(), [
+                    [
+                        "Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second",
+                        "Third"
+                    ],
+                    [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "", "1234", "adam", "", "", ""],
+                    [
+                        contact.uuid, "Ben Haggerty", "", "+12067799294", "+12062233445", "", "", "One", "",
+                        "20-12-2015 08:30"
+                    ],
+                    [contact3.uuid, "Luol Deng", "", "+12078776655", "", "", "deng", "", "", ""],
+                    [contact4.uuid, "Stephen", "", "+12078778899", "", "", "stephen", "", "", ""],
+                ]
+            )
 
         # export a specified group of contacts (only Ben and Adam are in the group)
         with self.assertNumQueries(41):
-            self.assertExcelSheet(request_export('?g=%s' % group.uuid), [
-                ["Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second", "Third"],
-                [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "", "1234", "adam", "", "", ""],
-                [contact.uuid, "Ben Haggerty", "", "+12067799294", "+12062233445", "", "", "One", "", "20-12-2015 08:30"],
-            ])
+            self.assertExcelSheet(
+                request_export('?g=%s' % group.uuid), [
+                    [
+                        "Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second",
+                        "Third"
+                    ],
+                    [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "", "1234", "adam", "", "", ""],
+                    [
+                        contact.uuid, "Ben Haggerty", "", "+12067799294", "+12062233445", "", "", "One", "",
+                        "20-12-2015 08:30"
+                    ],
+                ]
+            )
 
         # export a search
         with self.assertNumQueries(41):
-            self.assertExcelSheet(request_export('?s=name+has+adam+or+name+has+deng'), [
-                ["Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second", "Third"],
-                [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "", "1234", "adam", "", "", ""],
-                [contact3.uuid, "Luol Deng", "", "+12078776655", "", "", "deng", "", "", ""],
-            ])
+            self.assertExcelSheet(
+                request_export('?s=name+has+adam+or+name+has+deng'), [
+                    [
+                        "Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second",
+                        "Third"
+                    ],
+                    [contact2.uuid, "Adam Sumner", "adam@sumner.com", "+12067799191", "", "1234", "adam", "", "", ""],
+                    [contact3.uuid, "Luol Deng", "", "+12078776655", "", "", "deng", "", "", ""],
+                ]
+            )
 
         # export a search within a specified group of contacts
         with self.assertNumQueries(41):
-            self.assertExcelSheet(request_export('?g=%s&s=Hagg' % group.uuid), [
-                ["Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second", "Third"],
-                [contact.uuid, "Ben Haggerty", "", "+12067799294", "+12062233445", "", "", "One", "", "20-12-2015 08:30"],
-            ])
+            self.assertExcelSheet(
+                request_export('?g=%s&s=Hagg' % group.uuid), [
+                    [
+                        "Contact UUID", "Name", "Email", "Phone", "Phone", "Telegram", "Twitter", "First", "Second",
+                        "Third"
+                    ],
+                    [
+                        contact.uuid, "Ben Haggerty", "", "+12067799294", "+12062233445", "", "", "One", "",
+                        "20-12-2015 08:30"
+                    ],
+                ]
+            )
 
         # now try with an anonymous org
         with AnonymousOrg(self.org):
-            self.assertExcelSheet(request_export(), [
-                ["ID", "Contact UUID", "Name", "First", "Second", "Third"],
-                [six.text_type(contact2.id), contact2.uuid, "Adam Sumner", "", "", ""],
-                [six.text_type(contact.id), contact.uuid, "Ben Haggerty", "One", "", "20-12-2015 08:30"],
-                [six.text_type(contact3.id), contact3.uuid, "Luol Deng", "", "", ""],
-                [six.text_type(contact4.id), contact4.uuid, "Stephen", "", "", ""],
-            ])
+            self.assertExcelSheet(
+                request_export(), [
+                    ["ID", "Contact UUID", "Name", "First", "Second", "Third"],
+                    [six.text_type(contact2.id), contact2.uuid, "Adam Sumner", "", "", ""],
+                    [six.text_type(contact.id), contact.uuid, "Ben Haggerty", "One", "", "20-12-2015 08:30"],
+                    [six.text_type(contact3.id), contact3.uuid, "Luol Deng", "", "", ""],
+                    [six.text_type(contact4.id), contact4.uuid, "Stephen", "", "", ""],
+                ]
+            )
 
     def test_contact_field_list(self):
         url = reverse('contacts.contactfield_list')
@@ -4143,7 +4598,10 @@ class ContactFieldTest(TembaTest):
         response = self.client.post(manage_fields_url, post_data, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(before, ContactField.objects.filter(org=self.org, is_active=True).count())
-        self.assertFormError(response, 'form', None, 'The field "Favorite Cat" cannot be removed while it is still used in the flow "Dependencies"')
+        self.assertFormError(
+            response, 'form', None,
+            'The field "Favorite Cat" cannot be removed while it is still used in the flow "Dependencies"'
+        )
 
         # remove it from our list of dependencies
         from temba.flows.models import Flow
@@ -4212,10 +4670,14 @@ class ContactFieldTest(TembaTest):
         self.assertIsNone(ContactField.objects.filter(org=self.org, key="first", is_active=True).first())
 
         # the second should be renamed
-        self.assertEqual("Number 2", ContactField.objects.filter(org=self.org, key="second", is_active=True).first().label)
+        self.assertEqual(
+            "Number 2", ContactField.objects.filter(org=self.org, key="second", is_active=True).first().label
+        )
 
         # the third should have a different type
-        self.assertEqual('N', ContactField.objects.filter(org=self.org, key="third", is_active=True).first().value_type)
+        self.assertEqual(
+            'N', ContactField.objects.filter(org=self.org, key="third", is_active=True).first().value_type
+        )
 
         # we should have a fourth field now
         self.assertTrue(ContactField.objects.filter(org=self.org, key='new_field', label="New Field", value_type='T'))
@@ -4228,16 +4690,16 @@ class ContactFieldTest(TembaTest):
         # check that a field name which contains disallowed characters, gives an error
         post_data['label_2'] = '@name'
         response = self.client.post(manage_fields_url, post_data, follow=True)
-        self.assertFormError(response, 'form', None,
-                             "Field names can only contain letters, numbers and hypens")
+        self.assertFormError(response, 'form', None, "Field names can only contain letters, numbers and hypens")
 
         post_data['label_2'] = 'Name'
         response = self.client.post(manage_fields_url, post_data, follow=True)
         self.assertFormError(response, 'form', None, "Field name 'Name' is a reserved word")
 
         # bad field
-        ContactField.objects.create(org=self.org, key='language', label='User Language',
-                                    created_by=self.admin, modified_by=self.admin)
+        ContactField.objects.create(
+            org=self.org, key='language', label='User Language', created_by=self.admin, modified_by=self.admin
+        )
 
         self.assertEqual(4, ContactField.objects.filter(org=self.org, is_active=True).count())
 
@@ -4252,13 +4714,17 @@ class ContactFieldTest(TembaTest):
                 post_data[id] = field.initial
 
         response = self.client.post(manage_fields_url, post_data, follow=True)
-        self.assertFormError(response, 'form', None, "Field key language has invalid characters "
-                                                     "or is a reserved field name")
+        self.assertFormError(
+            response, 'form', None, "Field key language has invalid characters "
+            "or is a reserved field name"
+        )
 
     def test_json(self):
         contact_field_json_url = reverse('contacts.contactfield_json')
 
-        self.org2 = Org.objects.create(name="kLab", timezone="Africa/Kigali", created_by=self.admin, modified_by=self.admin)
+        self.org2 = Org.objects.create(
+            name="kLab", timezone="Africa/Kigali", created_by=self.admin, modified_by=self.admin
+        )
         for i in range(30):
             key = 'key%d' % i
             label = 'label%d' % i
@@ -4324,7 +4790,6 @@ class ContactFieldTest(TembaTest):
 
 
 class URNTest(TembaTest):
-
     def test_fb_urn(self):
         self.assertEqual('facebook:ref:asdf', URN.from_facebook(URN.path_from_fb_ref('asdf')))
         self.assertEqual('asdf', URN.fb_ref_from_path(URN.path_from_fb_ref('asdf')))

--- a/temba/dashboard/tests.py
+++ b/temba/dashboard/tests.py
@@ -13,8 +13,9 @@ class DashboardTest(TembaTest):
         super(DashboardTest, self).setUp()
 
         self.user = self.create_user("tito")
-        self.flow_label = Label.label_objects.create(name="Color", org=self.org,
-                                                     created_by=self.admin, modified_by=self.admin)
+        self.flow_label = Label.label_objects.create(
+            name="Color", org=self.org, created_by=self.admin, modified_by=self.admin
+        )
 
     def create_activity(self):
 

--- a/temba/dashboard/views.py
+++ b/temba/dashboard/views.py
@@ -36,17 +36,21 @@ class MessageHistory(OrgPermsMixin, SmartTemplateView):
             orgs = Org.objects.filter(Q(id=org.id) | Q(parent=org))
 
         # get all our counts for that period
-        daily_counts = ChannelCount.objects.filter(count_type__in=[ChannelCount.INCOMING_MSG_TYPE,
-                                                                   ChannelCount.OUTGOING_MSG_TYPE,
-                                                                   ChannelCount.INCOMING_IVR_TYPE,
-                                                                   ChannelCount.OUTGOING_IVR_TYPE])
+        daily_counts = ChannelCount.objects.filter(
+            count_type__in=[
+                ChannelCount.INCOMING_MSG_TYPE, ChannelCount.OUTGOING_MSG_TYPE, ChannelCount.INCOMING_IVR_TYPE,
+                ChannelCount.OUTGOING_IVR_TYPE
+            ]
+        )
 
         daily_counts = daily_counts.filter(day__gt='2013-02-01').filter(day__lte=timezone.now())
 
         if orgs or not is_support:
             daily_counts = daily_counts.filter(channel__org__in=orgs)
 
-        daily_counts = list(daily_counts.values('day', 'count_type').order_by('day', 'count_type').annotate(count_sum=Sum('count')))
+        daily_counts = list(
+            daily_counts.values('day', 'count_type').order_by('day', 'count_type').annotate(count_sum=Sum('count'))
+        )
 
         msgs_in = []
         msgs_out = []
@@ -130,18 +134,29 @@ class RangeDetails(OrgPermsMixin, SmartTemplateView):
                 count_types += [ChannelCount.INCOMING_MSG_TYPE, ChannelCount.INCOMING_IVR_TYPE]
 
             # get all our counts for that period
-            daily_counts = ChannelCount.objects.filter(count_type__in=count_types).filter(day__gte=begin).filter(day__lte=end).exclude(channel__org=None)
+            daily_counts = ChannelCount.objects.filter(count_type__in=count_types
+                                                       ).filter(day__gte=begin).filter(day__lte=end
+                                                                                       ).exclude(channel__org=None)
             if orgs:
                 daily_counts = daily_counts.filter(channel__org__in=orgs)
 
-            context['orgs'] = list(daily_counts.values('channel__org', 'channel__org__name').order_by('-count_sum',).annotate(count_sum=Sum('count'))[:12])
+            context['orgs'] = list(
+                daily_counts.values('channel__org', 'channel__org__name').order_by(
+                    '-count_sum',
+                ).annotate(count_sum=Sum('count'))[:12]
+            )
 
-            channel_types = ChannelCount.objects.filter(count_type__in=count_types).filter(day__gte=begin).filter(day__lte=end).exclude(channel__org=None)
+            channel_types = ChannelCount.objects.filter(count_type__in=count_types
+                                                        ).filter(day__gte=begin).filter(day__lte=end
+                                                                                        ).exclude(channel__org=None)
 
             if orgs or not is_support:
                 channel_types = channel_types.filter(channel__org__in=orgs)
 
-            channel_types = list(channel_types.values('channel__channel_type').order_by('-count_sum', ).annotate(count_sum=Sum('count')))
+            channel_types = list(
+                channel_types.values('channel__channel_type').order_by('-count_sum',
+                                                                       ).annotate(count_sum=Sum('count'))
+            )
 
             # populate the channel names
             pie = []

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -48,7 +48,6 @@ from temba.values.models import Value
 from temba_expressions.utils import tokenize
 from uuid import uuid4
 
-
 logger = logging.getLogger(__name__)
 
 FLOW_DEFAULT_EXPIRES_AFTER = 60 * 12
@@ -126,8 +125,12 @@ class FlowSession(models.Model):
 
     contact = models.ForeignKey('contacts.Contact', help_text="The contact that this session is with")
 
-    connection = models.OneToOneField('channels.ChannelSession', null=True, related_name='session',
-                                      help_text=_("The channel connection used for flow sessions over IVR or USSD"))
+    connection = models.OneToOneField(
+        'channels.ChannelSession',
+        null=True,
+        related_name='session',
+        help_text=_("The channel connection used for flow sessions over IVR or USSD")
+    )
 
     @classmethod
     def create(cls, contact, connection):
@@ -183,76 +186,99 @@ class Flow(TembaModel):
     RULES_ENTRY = 'R'
     ACTIONS_ENTRY = 'A'
 
-    FLOW_TYPES = ((FLOW, _("Message flow")),
-                  (MESSAGE, _("Single Message Flow")),
-                  (VOICE, _("Phone call flow")),
-                  (SURVEY, _("Android Survey")),
-                  (USSD, _("USSD flow")))
+    FLOW_TYPES = ((FLOW, _("Message flow")), (MESSAGE, _("Single Message Flow")), (VOICE, _("Phone call flow")),
+                  (SURVEY, _("Android Survey")), (USSD, _("USSD flow")))
 
-    ENTRY_TYPES = ((RULES_ENTRY, "Rules"),
-                   (ACTIONS_ENTRY, "Actions"))
+    ENTRY_TYPES = ((RULES_ENTRY, "Rules"), (ACTIONS_ENTRY, "Actions"))
 
     START_MSG_FLOW_BATCH = 'start_msg_flow_batch'
 
-    VERSIONS = [
-        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "10.1", "10.2", "10.3"
-    ]
+    VERSIONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "10.1", "10.2", "10.3"]
 
-    name = models.CharField(max_length=64,
-                            help_text=_("The name for this flow"))
+    name = models.CharField(max_length=64, help_text=_("The name for this flow"))
 
-    labels = models.ManyToManyField('FlowLabel', related_name='flows', verbose_name=_("Labels"), blank=True,
-                                    help_text=_("Any labels on this flow"))
+    labels = models.ManyToManyField(
+        'FlowLabel',
+        related_name='flows',
+        verbose_name=_("Labels"),
+        blank=True,
+        help_text=_("Any labels on this flow")
+    )
 
     org = models.ForeignKey(Org, related_name='flows')
 
     entry_uuid = models.CharField(null=True, max_length=36, unique=True)
 
-    entry_type = models.CharField(max_length=1, null=True, choices=ENTRY_TYPES,
-                                  help_text=_("The type of node this flow starts with"))
+    entry_type = models.CharField(
+        max_length=1, null=True, choices=ENTRY_TYPES, help_text=_("The type of node this flow starts with")
+    )
 
-    is_archived = models.BooleanField(default=False,
-                                      help_text=_("Whether this flow is archived"))
+    is_archived = models.BooleanField(default=False, help_text=_("Whether this flow is archived"))
 
-    flow_type = models.CharField(max_length=1, choices=FLOW_TYPES, default=FLOW,
-                                 help_text=_("The type of this flow"))
+    flow_type = models.CharField(max_length=1, choices=FLOW_TYPES, default=FLOW, help_text=_("The type of this flow"))
 
-    metadata = models.TextField(null=True, blank=True,
-                                help_text=_("Any extra metadata attached to this flow, strictly used by the user interface."))
+    metadata = models.TextField(
+        null=True,
+        blank=True,
+        help_text=_("Any extra metadata attached to this flow, strictly used by the user interface.")
+    )
 
-    expires_after_minutes = models.IntegerField(default=FLOW_DEFAULT_EXPIRES_AFTER,
-                                                help_text=_("Minutes of inactivity that will cause expiration from flow"))
+    expires_after_minutes = models.IntegerField(
+        default=FLOW_DEFAULT_EXPIRES_AFTER, help_text=_("Minutes of inactivity that will cause expiration from flow")
+    )
 
-    ignore_triggers = models.BooleanField(default=False,
-                                          help_text=_("Ignore keyword triggers while in this flow"))
+    ignore_triggers = models.BooleanField(default=False, help_text=_("Ignore keyword triggers while in this flow"))
 
-    saved_on = models.DateTimeField(auto_now_add=True,
-                                    help_text=_("When this item was saved"))
+    saved_on = models.DateTimeField(auto_now_add=True, help_text=_("When this item was saved"))
 
-    saved_by = models.ForeignKey(User, related_name="flow_saves",
-                                 help_text=_("The user which last saved this flow"))
+    saved_by = models.ForeignKey(User, related_name="flow_saves", help_text=_("The user which last saved this flow"))
 
-    base_language = models.CharField(max_length=4, null=True, blank=True,
-                                     help_text=_('The primary language for editing this flow'),
-                                     default='base')
+    base_language = models.CharField(
+        max_length=4, null=True, blank=True, help_text=_('The primary language for editing this flow'), default='base'
+    )
 
-    version_number = models.CharField(default=get_current_export_version, max_length=8,
-                                      help_text=_("The flow version this definition is in"))
+    version_number = models.CharField(
+        default=get_current_export_version, max_length=8, help_text=_("The flow version this definition is in")
+    )
 
-    flow_dependencies = models.ManyToManyField('Flow', related_name='dependent_flows', verbose_name=("Flow Dependencies"), blank=True,
-                                               help_text=_("Any flows this flow uses"))
+    flow_dependencies = models.ManyToManyField(
+        'Flow',
+        related_name='dependent_flows',
+        verbose_name=("Flow Dependencies"),
+        blank=True,
+        help_text=_("Any flows this flow uses")
+    )
 
-    group_dependencies = models.ManyToManyField(ContactGroup, related_name='dependent_flows', verbose_name=_("Group Dependencies"), blank=True,
-                                                help_text=_("Any groups this flow uses"))
+    group_dependencies = models.ManyToManyField(
+        ContactGroup,
+        related_name='dependent_flows',
+        verbose_name=_("Group Dependencies"),
+        blank=True,
+        help_text=_("Any groups this flow uses")
+    )
 
-    field_dependencies = models.ManyToManyField(ContactField, related_name='dependent_flows', verbose_name=_(''), blank=True,
-                                                help_text=('Any fields this flow depends on'))
+    field_dependencies = models.ManyToManyField(
+        ContactField,
+        related_name='dependent_flows',
+        verbose_name=_(''),
+        blank=True,
+        help_text=('Any fields this flow depends on')
+    )
 
     @classmethod
-    def create(cls, org, user, name, flow_type=FLOW, expires_after_minutes=FLOW_DEFAULT_EXPIRES_AFTER, base_language=None):
-        flow = Flow.objects.create(org=org, name=name, flow_type=flow_type,
-                                   expires_after_minutes=expires_after_minutes, base_language=base_language,
-                                   saved_by=user, created_by=user, modified_by=user)
+    def create(
+        cls, org, user, name, flow_type=FLOW, expires_after_minutes=FLOW_DEFAULT_EXPIRES_AFTER, base_language=None
+    ):
+        flow = Flow.objects.create(
+            org=org,
+            name=name,
+            flow_type=flow_type,
+            expires_after_minutes=expires_after_minutes,
+            base_language=base_language,
+            saved_by=user,
+            created_by=user,
+            modified_by=user
+        )
 
         analytics.track(user.username, 'nyaruka.flow_created', dict(name=name))
         return flow
@@ -282,8 +308,10 @@ class Flow(TembaModel):
         flow = Flow.create(org, user, name, base_language=base_language)
 
         uuid = six.text_type(uuid4())
-        actions = [dict(type='add_group', group=dict(uuid=group.uuid, name=group.name)),
-                   dict(type='save', field='name', label='Contact Name', value='@(PROPER(REMOVE_FIRST_WORD(step.value)))')]
+        actions = [
+            dict(type='add_group', group=dict(uuid=group.uuid, name=group.name)),
+            dict(type='save', field='name', label='Contact Name', value='@(PROPER(REMOVE_FIRST_WORD(step.value)))')
+        ]
 
         if response:
             actions += [dict(type='reply', msg={base_language: response})]
@@ -292,8 +320,7 @@ class Flow(TembaModel):
             actions += [dict(type='flow', flow=dict(uuid=start_flow.uuid, name=start_flow.name))]
 
         action_sets = [dict(x=100, y=0, uuid=uuid, actions=actions)]
-        flow.update(dict(entry=uuid, base_language=base_language,
-                         rule_sets=[], action_sets=action_sets))
+        flow.update(dict(entry=uuid, base_language=base_language, rule_sets=[], action_sets=action_sets))
 
         return flow
 
@@ -351,8 +378,13 @@ class Flow(TembaModel):
                     if flow_type == Flow.VOICE:
                         expires_minutes = min([expires_minutes, 15])
 
-                    flow = Flow.create(org, user, Flow.get_unique_name(org, name), flow_type=flow_type,
-                                       expires_after_minutes=expires_minutes)
+                    flow = Flow.create(
+                        org,
+                        user,
+                        Flow.get_unique_name(org, name),
+                        flow_type=flow_type,
+                        expires_after_minutes=expires_minutes
+                    )
 
                 created_flows.append(dict(flow=flow, flow_spec=flow_spec))
 
@@ -457,10 +489,15 @@ class Flow(TembaModel):
             if saved_media_url and ':' in saved_media_url:
                 text = saved_media_url.partition(':')[2]
 
-            msg = Msg.create_incoming(call.channel, six.text_type(call.contact_urn),
-                                      text, status=PENDING, msg_type=IVR,
-                                      attachments=[saved_media_url] if saved_media_url else None,
-                                      connection=run.connection)
+            msg = Msg.create_incoming(
+                call.channel,
+                six.text_type(call.contact_urn),
+                text,
+                status=PENDING,
+                msg_type=IVR,
+                attachments=[saved_media_url] if saved_media_url else None,
+                connection=run.connection
+            )
         else:
             msg = Msg(org=call.org, contact=call.contact, text='', id=0)
 
@@ -480,7 +517,9 @@ class Flow(TembaModel):
 
         # go and actually handle wherever we are in the flow
         destination = Flow.get_node(run.flow, step.step_uuid, step.step_type)
-        (handled, msgs) = Flow.handle_destination(destination, step, run, msg, user_input=text is not None, resume_parent_run=resume)
+        (handled, msgs) = Flow.handle_destination(
+            destination, step, run, msg, user_input=text is not None, resume_parent_run=resume
+        )
 
         # if we stopped needing user input (likely), then wrap our response accordingly
         voice_response = Flow.wrap_voice_response_with_input(call, run, voice_response)
@@ -600,9 +639,18 @@ class Flow(TembaModel):
                 return True
 
     @classmethod
-    def find_and_handle(cls, msg, started_flows=None, voice_response=None,
-                        triggered_start=False, resume_parent_run=False,
-                        resume_after_timeout=False, user_input=True, trigger_send=True, continue_parent=True):
+    def find_and_handle(
+        cls,
+        msg,
+        started_flows=None,
+        voice_response=None,
+        triggered_start=False,
+        resume_parent_run=False,
+        resume_after_timeout=False,
+        user_input=True,
+        trigger_send=True,
+        continue_parent=True
+    ):
 
         if started_flows is None:
             started_flows = []
@@ -619,11 +667,19 @@ class Flow(TembaModel):
                 Msg.mark_handled(msg)
                 return True, []
 
-            (handled, msgs) = Flow.handle_destination(destination, step, step.run, msg, started_flows,
-                                                      user_input=user_input, triggered_start=triggered_start,
-                                                      resume_parent_run=resume_parent_run,
-                                                      resume_after_timeout=resume_after_timeout, trigger_send=trigger_send,
-                                                      continue_parent=continue_parent)
+            (handled, msgs) = Flow.handle_destination(
+                destination,
+                step,
+                step.run,
+                msg,
+                started_flows,
+                user_input=user_input,
+                triggered_start=triggered_start,
+                resume_parent_run=resume_parent_run,
+                resume_after_timeout=resume_after_timeout,
+                trigger_send=trigger_send,
+                continue_parent=continue_parent
+            )
 
             if handled:
                 # increment our unread count if this isn't the simulator
@@ -635,9 +691,21 @@ class Flow(TembaModel):
         return False, []
 
     @classmethod
-    def handle_destination(cls, destination, step, run, msg,
-                           started_flows=None, is_test_contact=False, user_input=False,
-                           triggered_start=False, trigger_send=True, resume_parent_run=False, resume_after_timeout=False, continue_parent=True):
+    def handle_destination(
+        cls,
+        destination,
+        step,
+        run,
+        msg,
+        started_flows=None,
+        is_test_contact=False,
+        user_input=False,
+        triggered_start=False,
+        trigger_send=True,
+        resume_parent_run=False,
+        resume_after_timeout=False,
+        continue_parent=True
+    ):
 
         if started_flows is None:
             started_flows = []
@@ -666,8 +734,9 @@ class Flow(TembaModel):
                     should_pause = True
 
                 if (user_input or resume_after_timeout) or not should_pause:
-                    result = Flow.handle_ruleset(destination, step, run, msg, started_flows, resume_parent_run,
-                                                 resume_after_timeout)
+                    result = Flow.handle_ruleset(
+                        destination, step, run, msg, started_flows, resume_parent_run, resume_after_timeout
+                    )
                     add_to_path(path, destination.uuid)
 
                     # add any messages generated by this ruleset (ussd and subflow)
@@ -677,9 +746,15 @@ class Flow(TembaModel):
                     if not result.get('interrupted') and \
                             Flow.should_close_connection(run, destination, result.get('destination')):
 
-                        end_message = Msg.create_outgoing(msg.org, get_flow_user(msg.org), msg.contact, '',
-                                                          channel=msg.channel,
-                                                          connection=msg.connection, response_to=msg if msg.id else None)
+                        end_message = Msg.create_outgoing(
+                            msg.org,
+                            get_flow_user(msg.org),
+                            msg.contact,
+                            '',
+                            channel=msg.channel,
+                            connection=msg.connection,
+                            response_to=msg if msg.id else None
+                        )
 
                         end_message.connection.mark_ending()
                         msgs.append(end_message)
@@ -768,7 +843,9 @@ class Flow(TembaModel):
         return dict(handled=True, destination=destination, step=step, msgs=msgs)
 
     @classmethod
-    def handle_ruleset(cls, ruleset, step, run, msg, started_flows, resume_parent_run=False, resume_after_timeout=False):
+    def handle_ruleset(
+        cls, ruleset, step, run, msg, started_flows, resume_parent_run=False, resume_after_timeout=False
+    ):
         msgs = []
 
         if ruleset.is_ussd() and run.connection_interrupted:
@@ -792,9 +869,12 @@ class Flow(TembaModel):
                         run.update_expiration(timezone.now())
 
                     if flow:
-                        child_runs = flow.start([], [run.contact], started_flows=started_flows,
-                                                restart_participants=True, extra=extra,
-                                                parent_run=run, interrupt=False)
+                        child_runs = flow.start([], [run.contact],
+                                                started_flows=started_flows,
+                                                restart_participants=True,
+                                                extra=extra,
+                                                parent_run=run,
+                                                interrupt=False)
                         if child_runs:
                             child_run = child_runs[0]
                             msgs += child_run.start_msgs
@@ -844,8 +924,13 @@ class Flow(TembaModel):
         # Create the step for our destination
         destination = Flow.get_node(flow, rule.destination, rule.destination_type)
         if destination:
-            step = flow.add_step(run, destination, exit_uuid=rule.uuid,
-                                 category=rule.get_category_name(flow.base_language), previous_step=step)
+            step = flow.add_step(
+                run,
+                destination,
+                exit_uuid=rule.uuid,
+                category=rule.get_category_name(flow.base_language),
+                previous_step=step
+            )
 
         return dict(handled=True, destination=destination, step=step, msgs=msgs)
 
@@ -872,7 +957,9 @@ class Flow(TembaModel):
 
             # don't archive flows that belong to campaigns
             from temba.campaigns.models import CampaignEvent
-            if not CampaignEvent.objects.filter(flow=flow, campaign__org=user.get_org(), campaign__is_archived=False).exists():
+            if not CampaignEvent.objects.filter(
+                flow=flow, campaign__org=user.get_org(), campaign__is_archived=False
+            ).exists():
                 flow.archive()
                 changed.append(flow.pk)
 
@@ -914,11 +1001,13 @@ class Flow(TembaModel):
 
         # wrapper around our value dict, lets us do a nice representation of both @flow.foo and @flow.foo.text
         def value_wrapper(val):
-            return dict(__default__=six.text_type(val['rule_value']),
-                        text=val['text'],
-                        time=datetime_to_str(val['time'], format=date_format, tz=self.org.timezone),
-                        category=self.get_localized_text(val['category'], contact),
-                        value=six.text_type(val['rule_value']))
+            return dict(
+                __default__=six.text_type(val['rule_value']),
+                text=val['text'],
+                time=datetime_to_str(val['time'], format=date_format, tz=self.org.timezone),
+                category=self.get_localized_text(val['category'], contact),
+                value=six.text_type(val['rule_value'])
+            )
 
         flow_context = {}
         values = []
@@ -982,7 +1071,9 @@ class Flow(TembaModel):
         # filter by active nodes if we aren't including deleted nodes
         if not deleted_nodes:
             counts = counts.filter(node_uuid__in=uuids)
-        counts = counts.values('result_key', 'category_name').annotate(count=Sum('count'), result_name=Max('result_name'))
+        counts = counts.values('result_key', 'category_name').annotate(
+            count=Sum('count'), result_name=Max('result_name')
+        )
 
         results = {}
         for count in counts:
@@ -1155,10 +1246,15 @@ class Flow(TembaModel):
                     # if its a localized
                     if isinstance(action['recording'], dict):
                         for lang, url in six.iteritems(action['recording']):
-                            path = copy_recording(url, 'recordings/%d/%d/steps/%s.wav' % (self.org.pk, self.pk, action['uuid']))
+                            path = copy_recording(
+                                url, 'recordings/%d/%d/steps/%s.wav' % (self.org.pk, self.pk, action['uuid'])
+                            )
                             action['recording'][lang] = path
                     else:
-                        path = copy_recording(action['recording'], 'recordings/%d/%d/steps/%s.wav' % (self.org.pk, self.pk, action['uuid']))
+                        path = copy_recording(
+                            action['recording'],
+                            'recordings/%d/%d/steps/%s.wav' % (self.org.pk, self.pk, action['uuid'])
+                        )
                         action['recording'] = path
 
         for ruleset in flow_json[Flow.RULE_SETS]:
@@ -1264,7 +1360,9 @@ class Flow(TembaModel):
         rule_categories = dict()
 
         if ruleset_list is None:
-            ruleset_list = RuleSet.objects.filter(flow=self).exclude(label=None).order_by('pk').select_related('flow', 'flow__org')
+            ruleset_list = RuleSet.objects.filter(flow=self).exclude(label=None).order_by('pk').select_related(
+                'flow', 'flow__org'
+            )
 
         for ruleset in ruleset_list:
             rulesets[ruleset.uuid] = ruleset
@@ -1370,14 +1468,16 @@ class Flow(TembaModel):
         steps_cache = {}
         for step in flow_steps:
 
-            step_dict = dict(left_on=step.left_on,
-                             arrived_on=step.arrived_on,
-                             rule_uuid=step.rule_uuid,
-                             rule_category=step.rule_category,
-                             rule_decimal_value=step.rule_decimal_value,
-                             rule_value=step.rule_value,
-                             text=step.get_text(),
-                             step_uuid=step.step_uuid)
+            step_dict = dict(
+                left_on=step.left_on,
+                arrived_on=step.arrived_on,
+                rule_uuid=step.rule_uuid,
+                rule_category=step.rule_category,
+                rule_decimal_value=step.rule_decimal_value,
+                rule_value=step.rule_value,
+                text=step.get_text(),
+                step_uuid=step.step_uuid
+            )
 
             step_run = step.run.id
 
@@ -1413,21 +1513,30 @@ class Flow(TembaModel):
                     if not category:  # pragma: needs cover
                         category = rule_step['rule_category']
 
-                    value = rule_step['rule_decimal_value'] if rule_step['rule_decimal_value'] is not None else rule_step['rule_value']
+                    value = rule_step['rule_decimal_value'
+                                      ] if rule_step['rule_decimal_value'] is not None else rule_step['rule_value']
 
-                    values.append(dict(node=rule_step['step_uuid'],
-                                       label=label,
-                                       category=category,
-                                       text=rule_step['text'],
-                                       value=value,
-                                       rule_value=rule_step['rule_value'],
-                                       time=time))
+                    values.append(
+                        dict(
+                            node=rule_step['step_uuid'],
+                            label=label,
+                            category=category,
+                            text=rule_step['text'],
+                            value=value,
+                            rule_value=rule_step['rule_value'],
+                            time=time
+                        )
+                    )
 
-            results.append(dict(contact=run.contact, values=values, first_seen=first_seen, last_seen=last_seen, run=run.pk))
+            results.append(
+                dict(contact=run.contact, values=values, first_seen=first_seen, last_seen=last_seen, run=run.pk)
+            )
 
         # sort so most recent is first
         now = timezone.now()
-        results = sorted(results, reverse=True, key=lambda result: result['first_seen'] if result['first_seen'] else now)
+        results = sorted(
+            results, reverse=True, key=lambda result: result['first_seen'] if result['first_seen'] else now
+        )
         return results
 
     def async_start(self, user, groups, contacts, restart_participants=False, include_active=True):
@@ -1437,10 +1546,13 @@ class Flow(TembaModel):
         from .tasks import start_flow_task
 
         # create a flow start object
-        flow_start = FlowStart.objects.create(flow=self,
-                                              restart_participants=restart_participants,
-                                              include_active=include_active,
-                                              created_by=user, modified_by=user)
+        flow_start = FlowStart.objects.create(
+            flow=self,
+            restart_participants=restart_participants,
+            include_active=include_active,
+            created_by=user,
+            modified_by=user
+        )
 
         contact_ids = [c.id for c in contacts]
         flow_start.contacts.add(*contact_ids)
@@ -1450,8 +1562,20 @@ class Flow(TembaModel):
 
         on_transaction_commit(lambda: start_flow_task.delay(flow_start.pk))
 
-    def start(self, groups, contacts, restart_participants=False, started_flows=None,
-              start_msg=None, extra=None, flow_start=None, parent_run=None, interrupt=True, connection=None, include_active=True):
+    def start(
+        self,
+        groups,
+        contacts,
+        restart_participants=False,
+        started_flows=None,
+        start_msg=None,
+        extra=None,
+        flow_start=None,
+        parent_run=None,
+        interrupt=True,
+        connection=None,
+        include_active=True
+    ):
         """
         Starts a flow for the passed in groups and contacts.
         """
@@ -1495,7 +1619,9 @@ class Flow(TembaModel):
 
         if not include_active:
             # exclude anybody who has an active flow run
-            already_active = set(FlowRun.objects.filter(is_active=True, org=self.org).values_list('contact_id', flat=True))
+            already_active = set(
+                FlowRun.objects.filter(is_active=True, org=self.org).values_list('contact_id', flat=True)
+            )
             all_contact_ids = [contact_id for contact_id in all_contact_ids if contact_id not in already_active]
 
         # if we have a parent run, find any parents/grandparents that are active, we'll keep these active
@@ -1510,7 +1636,9 @@ class Flow(TembaModel):
 
         # for the contacts that will be started, exit any existing flow runs
         for contact_batch in chunk_list(all_contact_ids, 1000):
-            active_runs = FlowRun.objects.filter(is_active=True, contact__pk__in=contact_batch).exclude(id__in=ancestor_ids)
+            active_runs = FlowRun.objects.filter(
+                is_active=True, contact__pk__in=contact_batch
+            ).exclude(id__in=ancestor_ids)
             FlowRun.bulk_exit(active_runs, FlowRun.EXIT_TYPE_INTERRUPTED)
 
         # if we are interrupting parent flow runs, mark them as completed
@@ -1537,18 +1665,32 @@ class Flow(TembaModel):
                 self.increment_unread_responses()
 
         if self.flow_type == Flow.VOICE:
-            return self.start_call_flow(all_contact_ids, start_msg=start_msg,
-                                        extra=extra, flow_start=flow_start, parent_run=parent_run)
+            return self.start_call_flow(
+                all_contact_ids, start_msg=start_msg, extra=extra, flow_start=flow_start, parent_run=parent_run
+            )
 
         elif self.flow_type == Flow.USSD:
-            return self.start_ussd_flow(all_contact_ids, start_msg=start_msg,
-                                        extra=extra, flow_start=flow_start, parent_run=parent_run, connection=connection)
+            return self.start_ussd_flow(
+                all_contact_ids,
+                start_msg=start_msg,
+                extra=extra,
+                flow_start=flow_start,
+                parent_run=parent_run,
+                connection=connection
+            )
         else:
-            return self.start_msg_flow(all_contact_ids,
-                                       started_flows=started_flows, start_msg=start_msg,
-                                       extra=extra, flow_start=flow_start, parent_run=parent_run)
+            return self.start_msg_flow(
+                all_contact_ids,
+                started_flows=started_flows,
+                start_msg=start_msg,
+                extra=extra,
+                flow_start=flow_start,
+                parent_run=parent_run
+            )
 
-    def start_ussd_flow(self, all_contact_ids, start_msg=None, extra=None, flow_start=None, parent_run=None, connection=None):
+    def start_ussd_flow(
+        self, all_contact_ids, start_msg=None, extra=None, flow_start=None, parent_run=None, connection=None
+    ):
         from temba.ussd.models import USSDSession
 
         runs = []
@@ -1566,7 +1708,10 @@ class Flow(TembaModel):
                 run.update_fields(extra)
 
             if run.contact.is_test:  # pragma: no cover
-                ActionLog.create(run, '%s has entered the "%s" flow' % (run.contact.get_display(self.org, short=True), run.flow.name))
+                ActionLog.create(
+                    run,
+                    '%s has entered the "%s" flow' % (run.contact.get_display(self.org, short=True), run.flow.name)
+                )
 
             # [USSD PUSH] we have to create an outgoing connection for the recipient
             if not connection:
@@ -1574,9 +1719,15 @@ class Flow(TembaModel):
                 contact_urn = contact.get_urn(TEL_SCHEME)
                 channel = self.org.get_ussd_channel(contact_urn=contact_urn)
 
-                connection = USSDSession.objects.create(channel=channel, contact=contact, contact_urn=contact_urn,
-                                                        org=self.org, direction=USSDSession.USSD_PUSH,
-                                                        started_on=timezone.now(), status=USSDSession.INITIATED)
+                connection = USSDSession.objects.create(
+                    channel=channel,
+                    contact=contact,
+                    contact_urn=contact_urn,
+                    org=self.org,
+                    direction=USSDSession.USSD_PUSH,
+                    started_on=timezone.now(),
+                    status=USSDSession.INITIATED
+                )
 
             run.session = connection.get_session()
             run.connection = connection
@@ -1591,7 +1742,9 @@ class Flow(TembaModel):
 
                 step = self.add_step(run, entry_rule, is_start=True, arrived_on=timezone.now())
                 if entry_rule.is_ussd():
-                    handled, step_msgs = Flow.handle_destination(entry_rule, step, run, start_msg, trigger_send=False, continue_parent=False)
+                    handled, step_msgs = Flow.handle_destination(
+                        entry_rule, step, run, start_msg, trigger_send=False, continue_parent=False
+                    )
 
                     # add these messages as ones that are ready to send
                     for msg in step_msgs:
@@ -1666,8 +1819,9 @@ class Flow(TembaModel):
 
         return runs
 
-    def start_msg_flow(self, all_contact_ids, started_flows=None, start_msg=None, extra=None,
-                       flow_start=None, parent_run=None):
+    def start_msg_flow(
+        self, all_contact_ids, started_flows=None, start_msg=None, extra=None, flow_start=None, parent_run=None
+    ):
 
         start_msg_id = start_msg.id if start_msg else None
         flow_start_id = flow_start.id if flow_start else None
@@ -1687,10 +1841,14 @@ class Flow(TembaModel):
                 # check that we either have text or media, available for the base language
                 if (send_action.msg and send_action.msg.get(self.base_language)) or (send_action.media and send_action.media.get(self.base_language)):
 
-                    broadcast = Broadcast.create(self.org, self.created_by, send_action.msg, [],
-                                                 media=send_action.media,
-                                                 base_language=self.base_language,
-                                                 send_all=send_action.send_all)
+                    broadcast = Broadcast.create(
+                        self.org,
+                        self.created_by,
+                        send_action.msg, [],
+                        media=send_action.media,
+                        base_language=self.base_language,
+                        send_all=send_action.send_all
+                    )
                     broadcast.update_contacts(all_contact_ids)
 
                     # manually set our broadcast status to QUEUED, our sub processes will send things off for us
@@ -1702,15 +1860,28 @@ class Flow(TembaModel):
 
         # if there are fewer contacts than our batch size, do it immediately
         if len(all_contact_ids) < START_FLOW_BATCH_SIZE:
-            return self.start_msg_flow_batch(all_contact_ids, broadcasts=broadcasts, started_flows=started_flows,
-                                             start_msg=start_msg, extra=extra, flow_start=flow_start,
-                                             parent_run=parent_run)
+            return self.start_msg_flow_batch(
+                all_contact_ids,
+                broadcasts=broadcasts,
+                started_flows=started_flows,
+                start_msg=start_msg,
+                extra=extra,
+                flow_start=flow_start,
+                parent_run=parent_run
+            )
 
         # otherwise, create batches instead
         else:
             # for all our contacts, build up start sms batches
-            task_context = dict(contacts=[], flow=self.pk, flow_start=flow_start_id,
-                                started_flows=started_flows, broadcasts=[b.id for b in broadcasts], start_msg=start_msg_id, extra=extra)
+            task_context = dict(
+                contacts=[],
+                flow=self.pk,
+                flow_start=flow_start_id,
+                started_flows=started_flows,
+                broadcasts=[b.id for b in broadcasts],
+                start_msg=start_msg_id,
+                extra=extra
+            )
 
             batch_contacts = task_context['contacts']
             for contact_id in all_contact_ids:
@@ -1728,8 +1899,16 @@ class Flow(TembaModel):
 
             return []
 
-    def start_msg_flow_batch(self, batch_contact_ids, broadcasts, started_flows, start_msg=None,
-                             extra=None, flow_start=None, parent_run=None):
+    def start_msg_flow_batch(
+        self,
+        batch_contact_ids,
+        broadcasts,
+        started_flows,
+        start_msg=None,
+        extra=None,
+        flow_start=None,
+        parent_run=None
+    ):
 
         simulation = False
         if len(batch_contact_ids) == 1:
@@ -1748,8 +1927,16 @@ class Flow(TembaModel):
         now = timezone.now()
 
         for contact_id in batch_contact_ids:
-            run = FlowRun.create(self, contact_id, fields=run_fields, start=flow_start, created_on=now,
-                                 parent=parent_run, db_insert=False, responded=start_msg is not None)
+            run = FlowRun.create(
+                self,
+                contact_id,
+                fields=run_fields,
+                start=flow_start,
+                created_on=now,
+                parent=parent_run,
+                db_insert=False,
+                responded=start_msg is not None
+            )
             batch.append(run)
         FlowRun.objects.bulk_create(batch)
 
@@ -1758,12 +1945,18 @@ class Flow(TembaModel):
         for run in FlowRun.objects.filter(contact__in=batch_contact_ids, flow=self, created_on=now):
             run_map[run.contact_id] = run
             if run.contact.is_test:
-                ActionLog.create(run, '%s has entered the "%s" flow' % (run.contact.get_display(self.org, short=True), run.flow.name))
+                ActionLog.create(
+                    run,
+                    '%s has entered the "%s" flow' % (run.contact.get_display(self.org, short=True), run.flow.name)
+                )
 
         # update our expiration date on our runs, we do this by calculating it on one run then updating all others
         run.update_expiration(timezone.now())
-        FlowRun.objects.filter(contact__in=batch_contact_ids, created_on=now).update(expires_on=run.expires_on,
-                                                                                     modified_on=timezone.now())
+        FlowRun.objects.filter(
+            contact__in=batch_contact_ids, created_on=now
+        ).update(
+            expires_on=run.expires_on, modified_on=timezone.now()
+        )
 
         # if we have some broadcasts to optimize for
         message_map = dict()
@@ -1780,9 +1973,16 @@ class Flow(TembaModel):
 
                 # create the sms messages
                 created_on = timezone.now()
-                broadcast.send(expressions_context=expressions_context_base, trigger_send=False,
-                               response_to=start_msg, status=INITIALIZING, msg_type=FLOW,
-                               created_on=created_on, partial_recipients=partial_recipients, run_map=run_map)
+                broadcast.send(
+                    expressions_context=expressions_context_base,
+                    trigger_send=False,
+                    response_to=start_msg,
+                    status=INITIALIZING,
+                    msg_type=FLOW,
+                    created_on=created_on,
+                    partial_recipients=partial_recipients,
+                    run_map=run_map
+                )
 
                 # map all the messages we just created back to our contact
                 for msg in Msg.objects.filter(broadcast=broadcast, created_on=created_on):
@@ -1813,22 +2013,36 @@ class Flow(TembaModel):
 
             try:
                 if entry_actions:
-                    run_msgs += entry_actions.execute_actions(run, start_msg, started_flows_by_contact,
-                                                              skip_leading_reply_actions=not optimize_sending_action)
+                    run_msgs += entry_actions.execute_actions(
+                        run,
+                        start_msg,
+                        started_flows_by_contact,
+                        skip_leading_reply_actions=not optimize_sending_action
+                    )
 
                     step = self.add_step(run, entry_actions, run_msgs, is_start=True, arrived_on=arrived_on)
 
                     # and onto the destination
                     if entry_actions.destination:
-                        destination = Flow.get_node(entry_actions.flow,
-                                                    entry_actions.destination,
-                                                    entry_actions.destination_type)
+                        destination = Flow.get_node(
+                            entry_actions.flow, entry_actions.destination, entry_actions.destination_type
+                        )
 
-                        next_step = self.add_step(run, destination, previous_step=step, exit_uuid=entry_actions.exit_uuid)
+                        next_step = self.add_step(
+                            run, destination, previous_step=step, exit_uuid=entry_actions.exit_uuid
+                        )
 
                         msg = Msg(org=self.org, contact_id=contact_id, text='', id=0)
-                        handled, step_msgs = Flow.handle_destination(destination, next_step, run, msg, started_flows_by_contact,
-                                                                     is_test_contact=simulation, trigger_send=False, continue_parent=False)
+                        handled, step_msgs = Flow.handle_destination(
+                            destination,
+                            next_step,
+                            run,
+                            msg,
+                            started_flows_by_contact,
+                            is_test_contact=simulation,
+                            trigger_send=False,
+                            continue_parent=False
+                        )
                         run_msgs += step_msgs
 
                     else:
@@ -1845,7 +2059,15 @@ class Flow(TembaModel):
                     elif not entry_rules.is_pause():
                         # create an empty placeholder message
                         msg = Msg(org=self.org, contact_id=contact_id, text='', id=0)
-                        handled, step_msgs = Flow.handle_destination(entry_rules, step, run, msg, started_flows_by_contact, trigger_send=False, continue_parent=False)
+                        handled, step_msgs = Flow.handle_destination(
+                            entry_rules,
+                            step,
+                            run,
+                            msg,
+                            started_flows_by_contact,
+                            trigger_send=False,
+                            continue_parent=False
+                        )
                         run_msgs += step_msgs
 
                 if start_msg:
@@ -1860,7 +2082,13 @@ class Flow(TembaModel):
                     msgs.append(msg)
 
             except Exception:
-                logger.error('Failed starting flow %d for contact %d' % (self.id, contact_id), exc_info=1, extra={'stack': True})
+                logger.error(
+                    'Failed starting flow %d for contact %d' % (self.id, contact_id),
+                    exc_info=1,
+                    extra={
+                        'stack': True
+                    }
+                )
 
                 # mark this flow as interrupted
                 run.set_interrupted()
@@ -1886,7 +2114,9 @@ class Flow(TembaModel):
 
         return runs
 
-    def add_step(self, run, node, msgs=None, exit_uuid=None, category=None, is_start=False, previous_step=None, arrived_on=None):
+    def add_step(
+        self, run, node, msgs=None, exit_uuid=None, category=None, is_start=False, previous_step=None, arrived_on=None
+    ):
         if msgs is None:
             msgs = []
 
@@ -1907,12 +2137,16 @@ class Flow(TembaModel):
 
         if not is_start:
             # mark any other states for this contact as evaluated, contacts can only be in one place at time
-            self.get_steps().filter(run=run, left_on=None).update(left_on=arrived_on, next_uuid=node.uuid,
-                                                                  rule_uuid=exit_uuid, rule_category=category)
+            self.get_steps().filter(
+                run=run, left_on=None
+            ).update(
+                left_on=arrived_on, next_uuid=node.uuid, rule_uuid=exit_uuid, rule_category=category
+            )
 
         # then add our new step and associate it with our message
-        step = FlowStep.objects.create(run=run, contact=run.contact, step_type=node.get_step_type(),
-                                       step_uuid=node.uuid, arrived_on=arrived_on)
+        step = FlowStep.objects.create(
+            run=run, contact=run.contact, step_type=node.get_step_type(), step_uuid=node.uuid, arrived_on=arrived_on
+        )
 
         # for each message, associate it with this step and set the label on it
         for msg in msgs:
@@ -1932,7 +2166,7 @@ class Flow(TembaModel):
             path = path[len(path) - FlowRun.PATH_MAX_STEPS:]
 
         run.path = json.dumps(path)
-        run.save(update_fields=('path',))
+        run.save(update_fields=('path', ))
 
         return step
 
@@ -2253,7 +2487,12 @@ class Flow(TembaModel):
 
                         saver = saver.strip()
 
-                        return dict(status="unsaved", description="Flow NOT Saved", saved_on=datetime_to_str(last_save), saved_by=saver)
+                        return dict(
+                            status="unsaved",
+                            description="Flow NOT Saved",
+                            saved_on=datetime_to_str(last_save),
+                            saved_by=saver
+                        )
 
             top_y = 0
             top_uuid = None
@@ -2331,8 +2570,9 @@ class Flow(TembaModel):
                             destinations.add(destination_uuid)
 
                             # determine what kind of destination we are pointing to
-                            rule['destination_type'] = get_step_type(destination_uuid,
-                                                                     current_rulesets, current_actionsets)
+                            rule['destination_type'] = get_step_type(
+                                destination_uuid, current_rulesets, current_actionsets
+                            )
 
                             # print "Setting destination [%s] type to: %s" % (destination_uuid, rule['destination_type'])
 
@@ -2350,15 +2590,18 @@ class Flow(TembaModel):
                     existing.save()
                 else:
 
-                    existing = RuleSet.objects.create(flow=self,
-                                                      uuid=uuid,
-                                                      label=label,
-                                                      rules=json.dumps(rules),
-                                                      finished_key=finished_key,
-                                                      ruleset_type=ruleset_type,
-                                                      operand=operand,
-                                                      config=json.dumps(config),
-                                                      x=x, y=y)
+                    existing = RuleSet.objects.create(
+                        flow=self,
+                        uuid=uuid,
+                        label=label,
+                        rules=json.dumps(rules),
+                        finished_key=finished_key,
+                        ruleset_type=ruleset_type,
+                        operand=operand,
+                        config=json.dumps(config),
+                        x=x,
+                        y=y
+                    )
 
                 existing_rulesets[uuid] = existing
 
@@ -2406,13 +2649,16 @@ class Flow(TembaModel):
                         (existing.x, existing.y) = (x, y)
                         existing.save()
                     else:
-                        existing = ActionSet.objects.create(flow=self,
-                                                            uuid=uuid,
-                                                            destination=destination_uuid,
-                                                            destination_type=destination_type,
-                                                            exit_uuid=exit_uuid,
-                                                            actions=json.dumps(actions),
-                                                            x=x, y=y)
+                        existing = ActionSet.objects.create(
+                            flow=self,
+                            uuid=uuid,
+                            destination=destination_uuid,
+                            destination_type=destination_type,
+                            exit_uuid=exit_uuid,
+                            actions=json.dumps(actions),
+                            x=x,
+                            y=y
+                        )
 
                         existing_actionsets[uuid] = existing
 
@@ -2487,16 +2733,19 @@ class Flow(TembaModel):
                 revision = last_revision.revision + 1
 
             # create a new version
-            self.revisions.create(definition=json.dumps(json_dict),
-                                  created_by=user,
-                                  modified_by=user,
-                                  spec_version=get_current_export_version(),
-                                  revision=revision)
+            self.revisions.create(
+                definition=json.dumps(json_dict),
+                created_by=user,
+                modified_by=user,
+                spec_version=get_current_export_version(),
+                revision=revision
+            )
 
             self.update_dependencies()
 
-            return dict(status="success", description="Flow Saved",
-                        saved_on=datetime_to_str(self.saved_on), revision=revision)
+            return dict(
+                status="success", description="Flow Saved", saved_on=datetime_to_str(self.saved_on), revision=revision
+            )
 
         except Exception as e:
             # note that badness happened
@@ -2614,7 +2863,7 @@ class Flow(TembaModel):
         return self.name
 
     class Meta:
-        ordering = ('-modified_on',)
+        ordering = ('-modified_on', )
 
 
 class FlowRun(models.Model):
@@ -2623,8 +2872,7 @@ class FlowRun(models.Model):
     EXIT_TYPE_COMPLETED = 'C'
     EXIT_TYPE_INTERRUPTED = 'I'
     EXIT_TYPE_EXPIRED = 'E'
-    EXIT_TYPE_CHOICES = ((EXIT_TYPE_COMPLETED, _("Completed")),
-                         (EXIT_TYPE_INTERRUPTED, _("Interrupted")),
+    EXIT_TYPE_CHOICES = ((EXIT_TYPE_COMPLETED, _("Completed")), (EXIT_TYPE_INTERRUPTED, _("Interrupted")),
                          (EXIT_TYPE_EXPIRED, _("Expired")))
 
     INVALID_EXTRA_KEY_CHARS = regex.compile(r'[^a-zA-Z0-9_]')
@@ -2650,58 +2898,89 @@ class FlowRun(models.Model):
 
     contact = models.ForeignKey(Contact, related_name='runs')
 
-    session = models.ForeignKey(FlowSession, related_name='runs', null=True,
-                                help_text=_("The session that handled this flow run, only for voice flows"))
+    session = models.ForeignKey(
+        FlowSession,
+        related_name='runs',
+        null=True,
+        help_text=_("The session that handled this flow run, only for voice flows")
+    )
 
-    connection = models.ForeignKey('channels.ChannelSession', related_name='runs', null=True, blank=True,
-                                   help_text=_("The session that handled this flow run, only for voice flows"))
+    connection = models.ForeignKey(
+        'channels.ChannelSession',
+        related_name='runs',
+        null=True,
+        blank=True,
+        help_text=_("The session that handled this flow run, only for voice flows")
+    )
 
-    is_active = models.BooleanField(default=True,
-                                    help_text=_("Whether this flow run is currently active"))
+    is_active = models.BooleanField(default=True, help_text=_("Whether this flow run is currently active"))
 
-    fields = models.TextField(blank=True, null=True,
-                              help_text=_("A JSON representation of any custom flow values the user has saved away"))
+    fields = models.TextField(
+        blank=True, null=True, help_text=_("A JSON representation of any custom flow values the user has saved away")
+    )
 
-    created_on = models.DateTimeField(default=timezone.now,
-                                      help_text=_("When this flow run was created"))
+    created_on = models.DateTimeField(default=timezone.now, help_text=_("When this flow run was created"))
 
-    modified_on = models.DateTimeField(auto_now=True,
-                                       help_text=_("When this flow run was last updated"))
+    modified_on = models.DateTimeField(auto_now=True, help_text=_("When this flow run was last updated"))
 
-    exited_on = models.DateTimeField(null=True,
-                                     help_text=_("When the contact exited this flow run"))
+    exited_on = models.DateTimeField(null=True, help_text=_("When the contact exited this flow run"))
 
-    exit_type = models.CharField(null=True, max_length=1, choices=EXIT_TYPE_CHOICES,
-                                 help_text=_("Why the contact exited this flow run"))
+    exit_type = models.CharField(
+        null=True, max_length=1, choices=EXIT_TYPE_CHOICES, help_text=_("Why the contact exited this flow run")
+    )
 
-    expires_on = models.DateTimeField(null=True,
-                                      help_text=_("When this flow run will expire"))
+    expires_on = models.DateTimeField(null=True, help_text=_("When this flow run will expire"))
 
-    timeout_on = models.DateTimeField(null=True,
-                                      help_text=_("When this flow will next time out (if any)"))
+    timeout_on = models.DateTimeField(null=True, help_text=_("When this flow will next time out (if any)"))
 
     responded = models.BooleanField(default=False, help_text='Whether contact has responded in this run')
 
-    start = models.ForeignKey('flows.FlowStart', null=True, blank=True, related_name='runs',
-                              help_text=_("The FlowStart objects that started this run"))
+    start = models.ForeignKey(
+        'flows.FlowStart',
+        null=True,
+        blank=True,
+        related_name='runs',
+        help_text=_("The FlowStart objects that started this run")
+    )
 
-    submitted_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True,
-                                     help_text="The user which submitted this flow run")
+    submitted_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, null=True, help_text="The user which submitted this flow run"
+    )
 
     parent = models.ForeignKey('flows.FlowRun', null=True, help_text=_("The parent run that triggered us"))
 
-    results = models.TextField(null=True,
-                               help_text=_("The results collected during this flow run in JSON format"))
+    results = models.TextField(null=True, help_text=_("The results collected during this flow run in JSON format"))
 
-    path = models.TextField(null=True,
-                            help_text=_("The path taken during this flow run in JSON format"))
+    path = models.TextField(null=True, help_text=_("The path taken during this flow run in JSON format"))
 
     @classmethod
-    def create(cls, flow, contact_id, start=None, session=None, connection=None, fields=None,
-               created_on=None, db_insert=True, submitted_by=None, parent=None, responded=False):
+    def create(
+        cls,
+        flow,
+        contact_id,
+        start=None,
+        session=None,
+        connection=None,
+        fields=None,
+        created_on=None,
+        db_insert=True,
+        submitted_by=None,
+        parent=None,
+        responded=False
+    ):
 
-        args = dict(org=flow.org, flow=flow, contact_id=contact_id, start=start,
-                    session=session, connection=connection, fields=fields, submitted_by=submitted_by, parent=parent, responded=responded)
+        args = dict(
+            org=flow.org,
+            flow=flow,
+            contact_id=contact_id,
+            start=start,
+            session=session,
+            connection=connection,
+            fields=fields,
+            submitted_by=submitted_by,
+            parent=parent,
+            responded=responded
+        )
 
         if created_on:
             args['created_on'] = created_on
@@ -2824,8 +3103,9 @@ class FlowRun(models.Model):
                 FlowRun.bulk_exit(FlowRun.objects.filter(id=step.run.id), FlowRun.EXIT_TYPE_INTERRUPTED)
                 return
 
-            ruleset = RuleSet.objects.filter(uuid=step.step_uuid, ruleset_type=RuleSet.TYPE_SUBFLOW,
-                                             flow__org=step.run.org).first()
+            ruleset = RuleSet.objects.filter(
+                uuid=step.step_uuid, ruleset_type=RuleSet.TYPE_SUBFLOW, flow__org=step.run.org
+            ).first()
             if ruleset:
                 # use the last incoming message on this step
                 msg = step.messages.filter(direction=INCOMING).order_by('-created_on').first()
@@ -2838,8 +3118,14 @@ class FlowRun(models.Model):
                     msg.contact = run.contact
 
                 # finally, trigger our parent flow
-                (handled, msgs) = Flow.find_and_handle(msg, user_input=False, started_flows=[run.flow, run.parent.flow],
-                                                       resume_parent_run=True, trigger_send=trigger_send, continue_parent=continue_parent)
+                (handled, msgs) = Flow.find_and_handle(
+                    msg,
+                    user_input=False,
+                    started_flows=[run.flow, run.parent.flow],
+                    resume_parent_run=True,
+                    trigger_send=trigger_send,
+                    continue_parent=continue_parent
+                )
 
         return msgs
 
@@ -2968,7 +3254,9 @@ class FlowRun(models.Model):
         Mark run as interrupted
         """
         if self.contact.is_test:  # pragma: needs cover
-            ActionLog.create(self, _('%s has interrupted this flow') % self.contact.get_display(self.flow.org, short=True))
+            ActionLog.create(
+                self, _('%s has interrupted this flow') % self.contact.get_display(self.flow.org, short=True)
+            )
 
         now = timezone.now()
 
@@ -3053,9 +3341,18 @@ class FlowRun(models.Model):
         if recording_url:
             attachments = ['%s/x-wav:%s' % (Msg.MEDIA_AUDIO, recording_url)]
 
-        msg = Msg.create_outgoing(self.flow.org, self.flow.created_by, self.contact, text, channel=self.connection.channel,
-                                  response_to=response_to, attachments=attachments,
-                                  status=DELIVERED, msg_type=IVR, connection=connection)
+        msg = Msg.create_outgoing(
+            self.flow.org,
+            self.flow.created_by,
+            self.contact,
+            text,
+            channel=self.connection.channel,
+            response_to=response_to,
+            attachments=attachments,
+            status=DELIVERED,
+            msg_type=IVR,
+            connection=connection
+        )
 
         # play a recording or read some text
         if msg:
@@ -3121,8 +3418,7 @@ class FlowStep(models.Model):
     """
     TYPE_RULE_SET = 'R'
     TYPE_ACTION_SET = 'A'
-    STEP_TYPE_CHOICES = ((TYPE_RULE_SET, "RuleSet"),
-                         (TYPE_ACTION_SET, "ActionSet"))
+    STEP_TYPE_CHOICES = ((TYPE_RULE_SET, "RuleSet"), (TYPE_ACTION_SET, "ActionSet"))
 
     run = models.ForeignKey(FlowRun, related_name='steps')
 
@@ -3130,34 +3426,46 @@ class FlowStep(models.Model):
 
     step_type = models.CharField(max_length=1, choices=STEP_TYPE_CHOICES, help_text=_("What type of node was visited"))
 
-    step_uuid = models.CharField(max_length=36, db_index=True,
-                                 help_text=_("The UUID of the ActionSet or RuleSet for this step"))
+    step_uuid = models.CharField(
+        max_length=36, db_index=True, help_text=_("The UUID of the ActionSet or RuleSet for this step")
+    )
 
-    rule_uuid = models.CharField(max_length=36, null=True,
-                                 help_text=_("For uuid of the rule that matched on this ruleset, null on ActionSets"))
+    rule_uuid = models.CharField(
+        max_length=36, null=True, help_text=_("For uuid of the rule that matched on this ruleset, null on ActionSets")
+    )
 
-    rule_category = models.CharField(max_length=36, null=True,
-                                     help_text=_("The category label that matched on this ruleset, null on ActionSets"))
+    rule_category = models.CharField(
+        max_length=36, null=True, help_text=_("The category label that matched on this ruleset, null on ActionSets")
+    )
 
-    rule_value = models.TextField(null=True,
-                                  help_text=_("The value that was matched in our category for this ruleset, null on ActionSets"))
+    rule_value = models.TextField(
+        null=True, help_text=_("The value that was matched in our category for this ruleset, null on ActionSets")
+    )
 
-    rule_decimal_value = models.DecimalField(max_digits=36, decimal_places=8, null=True,
-                                             help_text=_("The decimal value that was matched in our category for this ruleset, null on ActionSets or if a non numeric rule was matched"))
+    rule_decimal_value = models.DecimalField(
+        max_digits=36,
+        decimal_places=8,
+        null=True,
+        help_text=_(
+            "The decimal value that was matched in our category for this ruleset, null on ActionSets or if a non numeric rule was matched"
+        )
+    )
 
-    next_uuid = models.CharField(max_length=36, null=True,
-                                 help_text=_("The uuid of the next step type we took"))
+    next_uuid = models.CharField(max_length=36, null=True, help_text=_("The uuid of the next step type we took"))
 
     arrived_on = models.DateTimeField(help_text=_("When the user arrived at this step in the flow"))
 
-    left_on = models.DateTimeField(null=True, db_index=True,
-                                   help_text=_("When the user left this step in the flow"))
+    left_on = models.DateTimeField(null=True, db_index=True, help_text=_("When the user left this step in the flow"))
 
-    messages = models.ManyToManyField(Msg, related_name='steps',
-                                      help_text=_("Any messages that are associated with this step (either sent or received)"))
+    messages = models.ManyToManyField(
+        Msg,
+        related_name='steps',
+        help_text=_("Any messages that are associated with this step (either sent or received)")
+    )
 
-    broadcasts = models.ManyToManyField(Broadcast, related_name='steps',
-                                        help_text=_("Any broadcasts that are associated with this step (only sent)"))
+    broadcasts = models.ManyToManyField(
+        Broadcast, related_name='steps', help_text=_("Any broadcasts that are associated with this step (only sent)")
+    )
 
     @classmethod
     def from_json(cls, json_obj, flow, run, previous_rule=None):
@@ -3187,10 +3495,17 @@ class FlowStep(models.Model):
                         json_obj['rule']['text'] = url
 
                     # if we received a message
-                    incoming = Msg.create_incoming(org=run.org, contact=run.contact, text=json_obj['rule']['text'],
-                                                   attachments=[media] if media else None,
-                                                   msg_type=FLOW, status=HANDLED, date=arrived_on,
-                                                   channel=None, urn=None)
+                    incoming = Msg.create_incoming(
+                        org=run.org,
+                        contact=run.contact,
+                        text=json_obj['rule']['text'],
+                        attachments=[media] if media else None,
+                        msg_type=FLOW,
+                        status=HANDLED,
+                        date=arrived_on,
+                        channel=None,
+                        urn=None
+                    )
             else:  # pragma: needs cover
                 incoming = Msg.objects.filter(org=run.org, direction=INCOMING, steps__run=run).order_by('-pk').first()
 
@@ -3205,8 +3520,9 @@ class FlowStep(models.Model):
                 context = flow.build_expressions_context(run.contact, last_incoming)
                 msgs += action.execute(run, context, node.uuid, msg=last_incoming, offline_on=arrived_on)
 
-        step = flow.add_step(run, node, msgs=msgs, previous_step=prev_step, arrived_on=arrived_on,
-                             exit_uuid=previous_rule)
+        step = flow.add_step(
+            run, node, msgs=msgs, previous_step=prev_step, arrived_on=arrived_on, exit_uuid=previous_rule
+        )
 
         # if a rule was picked on this ruleset
         if node.is_ruleset() and json_obj['rule']:
@@ -3254,8 +3570,9 @@ class FlowStep(models.Model):
     @classmethod
     def get_active_steps_for_contact(cls, contact, step_type=None):
 
-        steps = FlowStep.objects.filter(run__is_active=True, run__flow__is_active=True, run__contact=contact,
-                                        left_on=None)
+        steps = FlowStep.objects.filter(
+            run__is_active=True, run__flow__is_active=True, run__contact=contact, left_on=None
+        )
 
         # don't consider voice steps, those are interactive
         steps = steps.exclude(run__flow__flow_type=Flow.VOICE)
@@ -3385,57 +3702,68 @@ class RuleSet(models.Model):
 
     TYPE_MEDIA = (TYPE_WAIT_PHOTO, TYPE_WAIT_GPS, TYPE_WAIT_VIDEO, TYPE_WAIT_AUDIO, TYPE_WAIT_RECORDING)
 
-    TYPE_WAIT = (TYPE_WAIT_MESSAGE, TYPE_WAIT_RECORDING, TYPE_WAIT_DIGIT, TYPE_WAIT_DIGITS, TYPE_WAIT_USSD_MENU,
-                 TYPE_WAIT_USSD, TYPE_WAIT_PHOTO, TYPE_WAIT_VIDEO, TYPE_WAIT_AUDIO, TYPE_WAIT_GPS)
+    TYPE_WAIT = (
+        TYPE_WAIT_MESSAGE, TYPE_WAIT_RECORDING, TYPE_WAIT_DIGIT, TYPE_WAIT_DIGITS, TYPE_WAIT_USSD_MENU, TYPE_WAIT_USSD,
+        TYPE_WAIT_PHOTO, TYPE_WAIT_VIDEO, TYPE_WAIT_AUDIO, TYPE_WAIT_GPS
+    )
 
     TYPE_USSD = (TYPE_WAIT_USSD_MENU, TYPE_WAIT_USSD)
 
-    TYPE_CHOICES = ((TYPE_WAIT_MESSAGE, "Wait for message"),
-                    (TYPE_WAIT_USSD_MENU, "Wait for USSD menu"),
-                    (TYPE_WAIT_USSD, "Wait for USSD message"),
-                    (TYPE_WAIT_RECORDING, "Wait for recording"),
-                    (TYPE_WAIT_DIGIT, "Wait for digit"),
-                    (TYPE_WAIT_DIGITS, "Wait for digits"),
-                    (TYPE_SUBFLOW, "Subflow"),
-                    (TYPE_WEBHOOK, "Webhook"),
-                    (TYPE_RESTHOOK, "Resthook"),
-                    (TYPE_AIRTIME, "Transfer Airtime"),
-                    (TYPE_FORM_FIELD, "Split by message form"),
-                    (TYPE_CONTACT_FIELD, "Split on contact field"),
-                    (TYPE_EXPRESSION, "Split by expression"),
-                    (TYPE_RANDOM, "Split Randomly"))
+    TYPE_CHOICES = ((TYPE_WAIT_MESSAGE, "Wait for message"), (TYPE_WAIT_USSD_MENU, "Wait for USSD menu"),
+                    (TYPE_WAIT_USSD, "Wait for USSD message"), (TYPE_WAIT_RECORDING, "Wait for recording"),
+                    (TYPE_WAIT_DIGIT, "Wait for digit"), (TYPE_WAIT_DIGITS,
+                                                          "Wait for digits"), (TYPE_SUBFLOW,
+                                                                               "Subflow"), (TYPE_WEBHOOK, "Webhook"),
+                    (TYPE_RESTHOOK, "Resthook"), (TYPE_AIRTIME,
+                                                  "Transfer Airtime"), (TYPE_FORM_FIELD, "Split by message form"),
+                    (TYPE_CONTACT_FIELD,
+                     "Split on contact field"), (TYPE_EXPRESSION,
+                                                 "Split by expression"), (TYPE_RANDOM, "Split Randomly"))
 
     uuid = models.CharField(max_length=36, unique=True)
 
     flow = models.ForeignKey(Flow, related_name='rule_sets')
 
-    label = models.CharField(max_length=64, null=True, blank=True,
-                             help_text=_("The label for this field"))
+    label = models.CharField(max_length=64, null=True, blank=True, help_text=_("The label for this field"))
 
-    operand = models.CharField(max_length=128, null=True, blank=True,
-                               help_text=_("The value that rules will be run against, if None defaults to @step.value"))
+    operand = models.CharField(
+        max_length=128,
+        null=True,
+        blank=True,
+        help_text=_("The value that rules will be run against, if None defaults to @step.value")
+    )
 
-    webhook_url = models.URLField(null=True, blank=True, max_length=255,
-                                  help_text=_("The URL that will be called with the user's response before we run our rules"))
+    webhook_url = models.URLField(
+        null=True,
+        blank=True,
+        max_length=255,
+        help_text=_("The URL that will be called with the user's response before we run our rules")
+    )
 
-    webhook_action = models.CharField(null=True, blank=True, max_length=8, default='POST',
-                                      help_text=_('How the webhook should be executed'))
+    webhook_action = models.CharField(
+        null=True, blank=True, max_length=8, default='POST', help_text=_('How the webhook should be executed')
+    )
 
     rules = models.TextField(help_text=_("The JSON encoded actions for this action set"))
 
-    finished_key = models.CharField(max_length=1, null=True, blank=True,
-                                    help_text="During IVR, this is the key to indicate we are done waiting")
+    finished_key = models.CharField(
+        max_length=1, null=True, blank=True, help_text="During IVR, this is the key to indicate we are done waiting"
+    )
 
-    value_type = models.CharField(max_length=1, choices=Value.TYPE_CHOICES, default=Value.TYPE_TEXT,
-                                  help_text="The type of value this ruleset saves")
+    value_type = models.CharField(
+        max_length=1,
+        choices=Value.TYPE_CHOICES,
+        default=Value.TYPE_TEXT,
+        help_text="The type of value this ruleset saves"
+    )
 
-    ruleset_type = models.CharField(max_length=16, choices=TYPE_CHOICES, null=True,
-                                    help_text="The type of ruleset")
+    ruleset_type = models.CharField(max_length=16, choices=TYPE_CHOICES, null=True, help_text="The type of ruleset")
 
     response_type = models.CharField(max_length=1, help_text="The type of response that is being saved")
 
-    config = models.TextField(null=True, verbose_name=_("Ruleset Configuration"),
-                              help_text=_("RuleSet type specific configuration"))
+    config = models.TextField(
+        null=True, verbose_name=_("Ruleset Configuration"), help_text=_("RuleSet type specific configuration")
+    )
 
     x = models.IntegerField()
     y = models.IntegerField()
@@ -3453,7 +3781,7 @@ class RuleSet(models.Model):
 
     @property
     def is_messaging(self):
-        return self.ruleset_type in (self.TYPE_USSD + (self.TYPE_WAIT_MESSAGE,))
+        return self.ruleset_type in (self.TYPE_USSD + (self.TYPE_WAIT_MESSAGE, ))
 
     @classmethod
     def contains_step(cls, text):  # pragma: needs cover
@@ -3496,7 +3824,9 @@ class RuleSet(models.Model):
             uuid_to_category[rule.uuid] = label
 
             # this takes care of results that were categorized with different rules that may not exist anymore
-            for value in Value.objects.filter(ruleset=self, category=label).order_by('rule_uuid').distinct('rule_uuid'):
+            for value in Value.objects.filter(
+                ruleset=self, category=label
+            ).order_by('rule_uuid').distinct('rule_uuid'):
                 uuid_to_category[value.rule_uuid] = label
 
         return ordered_categories, uuid_to_category
@@ -3612,8 +3942,9 @@ class RuleSet(models.Model):
 
                 (value, errors) = Msg.evaluate_template(url, context, org=run.flow.org, url_encode=True)
 
-                result = WebHookEvent.trigger_flow_event(run, value, self, msg, action, resthook=resthook,
-                                                         headers=header)
+                result = WebHookEvent.trigger_flow_event(
+                    run, value, self, msg, action, resthook=resthook, headers=header
+                )
 
                 # we haven't recorded any status yet, do so
                 if not status_code:
@@ -3728,17 +4059,28 @@ class RuleSet(models.Model):
         # delete any existing values for this ruleset, run and contact, we only store the latest
         Value.objects.filter(contact=run.contact, run=run, ruleset=self).delete()
 
-        Value.objects.create(contact=run.contact, run=run, ruleset=self, rule_uuid=rule.uuid,
-                             category=rule.get_category_name(run.flow.base_language),
-                             string_value=value, decimal_value=dec_value, datetime_value=dt_value,
-                             location_value=location_value, media_value=media_value, org=run.flow.org)
+        Value.objects.create(
+            contact=run.contact,
+            run=run,
+            ruleset=self,
+            rule_uuid=rule.uuid,
+            category=rule.get_category_name(run.flow.base_language),
+            string_value=value,
+            decimal_value=dec_value,
+            datetime_value=dt_value,
+            location_value=location_value,
+            media_value=media_value,
+            org=run.flow.org
+        )
 
-        run.save_run_result(name=self.label,
-                            node_uuid=self.uuid,
-                            category=rule.get_category_name(run.flow.base_language),
-                            category_localized=rule.get_category_name(run.flow.base_language, run.contact.language),
-                            raw_value=raw_value,
-                            raw_input=raw_input)
+        run.save_run_result(
+            name=self.label,
+            node_uuid=self.uuid,
+            category=rule.get_category_name(run.flow.base_language),
+            category_localized=rule.get_category_name(run.flow.base_language, run.contact.language),
+            raw_value=raw_value,
+            raw_input=raw_input
+        )
 
         # invalidate any cache on this ruleset
         Value.invalidate_cache(ruleset=self)
@@ -3765,15 +4107,24 @@ class RuleSet(models.Model):
         self.set_rules_dict(rules_dict)
 
     def as_json(self):
-        return dict(uuid=self.uuid, x=self.x, y=self.y, label=self.label, rules=self.get_rules_dict(),
-                    finished_key=self.finished_key, ruleset_type=self.ruleset_type, response_type=self.response_type,
-                    operand=self.operand, config=self.config_json())
+        return dict(
+            uuid=self.uuid,
+            x=self.x,
+            y=self.y,
+            label=self.label,
+            rules=self.get_rules_dict(),
+            finished_key=self.finished_key,
+            ruleset_type=self.ruleset_type,
+            response_type=self.response_type,
+            operand=self.operand,
+            config=self.config_json()
+        )
 
     def __str__(self):
         if self.label:
             return "RuleSet: %s - %s" % (self.uuid, self.label)
         else:
-            return "RuleSet: %s" % (self.uuid,)
+            return "RuleSet: %s" % (self.uuid, )
 
 
 @six.python_2_unicode_compatible
@@ -3858,11 +4209,17 @@ class ActionSet(models.Model):
         self.actions = json.dumps(json_dict)
 
     def as_json(self):
-        return dict(uuid=self.uuid, x=self.x, y=self.y, destination=self.destination,
-                    actions=self.get_actions_dict(), exit_uuid=self.exit_uuid)
+        return dict(
+            uuid=self.uuid,
+            x=self.x,
+            y=self.y,
+            destination=self.destination,
+            actions=self.get_actions_dict(),
+            exit_uuid=self.exit_uuid
+        )
 
     def __str__(self):  # pragma: no cover
-        return "ActionSet: %s" % (self.uuid,)
+        return "ActionSet: %s" % (self.uuid, )
 
 
 class FlowRevision(SmartModel):
@@ -3873,8 +4230,9 @@ class FlowRevision(SmartModel):
 
     definition = models.TextField(help_text=_("The JSON flow definition"))
 
-    spec_version = models.CharField(default=get_current_export_version, max_length=8,
-                                    help_text=_("The flow version this definition is in"))
+    spec_version = models.CharField(
+        default=get_current_export_version, max_length=8, help_text=_("The flow version this definition is in")
+    )
 
     revision = models.IntegerField(null=True, help_text=_("Revision number for this definition"))
 
@@ -3963,9 +4321,14 @@ class FlowRevision(SmartModel):
         # if it's previous to version 6, wrap the definition to
         # mirror our exports for those versions
         if Flow.is_before_version(self.spec_version, "6"):
-            definition = dict(definition=definition, flow_type=self.flow.flow_type,
-                              expires=self.flow.expires_after_minutes, id=self.flow.pk,
-                              revision=self.revision, uuid=self.flow.uuid)
+            definition = dict(
+                definition=definition,
+                flow_type=self.flow.flow_type,
+                expires=self.flow.expires_after_minutes,
+                id=self.flow.pk,
+                revision=self.revision,
+                uuid=self.flow.uuid
+            )
 
         # migrate our definition if necessary
         if self.spec_version != get_current_export_version():
@@ -3975,11 +4338,13 @@ class FlowRevision(SmartModel):
     def as_json(self, include_definition=False):
 
         name = self.created_by.get_full_name()
-        return dict(user=dict(email=self.created_by.email, name=name),
-                    created_on=datetime_to_str(self.created_on),
-                    id=self.pk,
-                    version=self.spec_version,
-                    revision=self.revision)
+        return dict(
+            user=dict(email=self.created_by.email, name=name),
+            created_on=datetime_to_str(self.created_on),
+            id=self.pk,
+            version=self.spec_version,
+            revision=self.revision
+        )
 
 
 class FlowCategoryCount(SquashableModel):
@@ -4003,9 +4368,14 @@ class FlowCategoryCount(SquashableModel):
         )
         INSERT INTO %(table)s("flow_id", "node_uuid", "result_key", "result_name", "category_name", "count", "is_squashed")
         VALUES (%%s, %%s, %%s, %%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-        """ % {'table': cls._meta.db_table}
+        """ % {
+            'table': cls._meta.db_table
+        }
 
-        params = (distinct_set.flow_id, distinct_set.node_uuid, distinct_set.result_key, distinct_set.result_name, distinct_set.category_name) * 2
+        params = (
+            distinct_set.flow_id, distinct_set.node_uuid, distinct_set.result_key, distinct_set.result_name,
+            distinct_set.category_name
+        ) * 2
         return sql, params
 
     def __str__(self):
@@ -4034,7 +4404,9 @@ class FlowPathCount(SquashableModel):
             )
             INSERT INTO %(table)s("flow_id", "from_uuid", "to_uuid", "period", "count", "is_squashed")
             VALUES (%%s, %%s, %%s, date_trunc('hour', %%s), GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-            """ % {'table': cls._meta.db_table}
+            """ % {
+                'table': cls._meta.db_table
+            }
 
             params = (distinct_set.flow_id, distinct_set.from_uuid, distinct_set.to_uuid, distinct_set.period) * 2
         else:
@@ -4044,7 +4416,9 @@ class FlowPathCount(SquashableModel):
             )
             INSERT INTO %(table)s("flow_id", "from_uuid", "to_uuid", "period", "count", "is_squashed")
             VALUES (%%s, %%s, NULL, date_trunc('hour', %%s), GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-            """ % {'table': cls._meta.db_table}
+            """ % {
+                'table': cls._meta.db_table
+            }
 
             params = (distinct_set.flow_id, distinct_set.from_uuid, distinct_set.period) * 2
 
@@ -4060,7 +4434,9 @@ class FlowPathCount(SquashableModel):
         return {'%s:%s' % (t[0], t[1]): t[2] for t in totals}
 
     def __str__(self):  # pragma: no cover
-        return "FlowPathCount(%d) %s:%s %s count: %d" % (self.flow_id, self.from_uuid, self.to_uuid, self.period, self.count)
+        return "FlowPathCount(%d) %s:%s %s count: %d" % (
+            self.flow_id, self.from_uuid, self.to_uuid, self.period, self.count
+        )
 
     class Meta:
         index_together = ['flow', 'from_uuid', 'to_uuid', 'period']
@@ -4089,8 +4465,9 @@ class FlowPathRecentMessage(models.Model):
 
         objs = []
         for msg in step.messages.all():
-            objs.append(cls(from_uuid=from_uuid, to_uuid=to_uuid,
-                            run=step.run, text=msg.text, created_on=msg.created_on))
+            objs.append(
+                cls(from_uuid=from_uuid, to_uuid=to_uuid, run=step.run, text=msg.text, created_on=msg.created_on)
+            )
         cls.objects.bulk_create(objs)
 
     @classmethod
@@ -4126,7 +4503,11 @@ class FlowPathRecentMessage(models.Model):
                     SELECT DISTINCT from_uuid, to_uuid FROM %(table)s WHERE id > %(last_id)d
                   )
               ) s WHERE s.pos > %(limit)d
-            )""" % {'table': cls._meta.db_table, 'last_id': last_id, 'limit': cls.PRUNE_TO}
+            )""" % {
+            'table': cls._meta.db_table,
+            'last_id': last_id,
+            'limit': cls.PRUNE_TO
+        }
 
         cursor = db_connection.cursor()
         cursor.execute(sql)
@@ -4136,16 +4517,14 @@ class FlowPathRecentMessage(models.Model):
         return cursor.rowcount  # number of deleted entries
 
     class Meta:
-        indexes = [
-            models.Index(fields=['from_uuid', 'to_uuid', '-created_on'])
-        ]
+        indexes = [models.Index(fields=['from_uuid', 'to_uuid', '-created_on'])]
 
 
 class FlowNodeCount(SquashableModel):
     """
     Maintains counts of unique contacts at each flow node.
     """
-    SQUASH_OVER = ('node_uuid',)
+    SQUASH_OVER = ('node_uuid', )
 
     flow = models.ForeignKey(Flow)
     node_uuid = models.UUIDField(db_index=True)
@@ -4159,7 +4538,9 @@ class FlowNodeCount(SquashableModel):
         )
         INSERT INTO %(table)s("flow_id", "node_uuid", "count", "is_squashed")
         VALUES (%%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-        """ % {'table': cls._meta.db_table}
+        """ % {
+            'table': cls._meta.db_table
+        }
 
         return sql, (distinct_set.node_uuid, distinct_set.flow_id, distinct_set.node_uuid)
 
@@ -4190,7 +4571,9 @@ class FlowRunCount(SquashableModel):
             )
             INSERT INTO %(table)s("flow_id", "exit_type", "count", "is_squashed")
             VALUES (%%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-            """ % {'table': cls._meta.db_table}
+            """ % {
+                'table': cls._meta.db_table
+            }
 
             params = (distinct_set.flow_id, distinct_set.exit_type) * 2
         else:
@@ -4200,9 +4583,11 @@ class FlowRunCount(SquashableModel):
             )
             INSERT INTO %(table)s("flow_id", "exit_type", "count", "is_squashed")
             VALUES (%%s, NULL, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
-            """ % {'table': cls._meta.db_table}
+            """ % {
+                'table': cls._meta.db_table
+            }
 
-            params = (distinct_set.flow_id,) * 2
+            params = (distinct_set.flow_id, ) * 2
 
         return sql, params
 
@@ -4244,16 +4629,17 @@ class ExportFlowResultsTask(BaseExportTask):
 
     flows = models.ManyToManyField(Flow, related_name='exports', help_text=_("The flows to export"))
 
-    config = models.TextField(null=True,
-                              help_text=_("Any configuration options for this flow export"))
+    config = models.TextField(null=True, help_text=_("Any configuration options for this flow export"))
 
     @classmethod
     def create(cls, org, user, flows, contact_fields, responded_only, include_runs, include_msgs, extra_urns):
-        config = {ExportFlowResultsTask.INCLUDE_RUNS: include_runs,
-                  ExportFlowResultsTask.INCLUDE_MSGS: include_msgs,
-                  ExportFlowResultsTask.CONTACT_FIELDS: [c.id for c in contact_fields],
-                  ExportFlowResultsTask.RESPONDED_ONLY: responded_only,
-                  ExportFlowResultsTask.EXTRA_URNS: extra_urns}
+        config = {
+            ExportFlowResultsTask.INCLUDE_RUNS: include_runs,
+            ExportFlowResultsTask.INCLUDE_MSGS: include_msgs,
+            ExportFlowResultsTask.CONTACT_FIELDS: [c.id for c in contact_fields],
+            ExportFlowResultsTask.RESPONDED_ONLY: responded_only,
+            ExportFlowResultsTask.EXTRA_URNS: extra_urns
+        }
 
         export = cls.objects.create(org=org, created_by=user, modified_by=user, config=json.dumps(config))
         for flow in flows:
@@ -4416,7 +4802,9 @@ class ExportFlowResultsTask(BaseExportTask):
             for col in range(len(columns)):
                 ruleset = columns[col]
 
-                sheet_row.append("%s (Category) - %s" % (six.text_type(ruleset.label), six.text_type(ruleset.flow.name)))
+                sheet_row.append(
+                    "%s (Category) - %s" % (six.text_type(ruleset.label), six.text_type(ruleset.flow.name))
+                )
                 col_widths.append(self.WIDTH_SMALL)
                 sheet_row.append("%s (Value) - %s" % (six.text_type(ruleset.label), six.text_type(ruleset.flow.name)))
                 col_widths.append(self.WIDTH_SMALL)
@@ -4476,19 +4864,21 @@ class ExportFlowResultsTask(BaseExportTask):
             urn_display_cache[contact.pk][scheme_key] = urn_display
             return urn_display
 
-        for run_step in ChunkIterator(FlowStep, step_ids,
-                                      order_by=['contact', 'run', 'arrived_on', 'pk'],
-                                      select_related=['run', 'contact'],
-                                      prefetch_related=['messages__contact_urn',
-                                                        'messages__channel',
-                                                        'broadcasts',
-                                                        'contact__all_groups'],
-                                      contact_fields=contact_fields):
+        for run_step in ChunkIterator(
+            FlowStep,
+            step_ids,
+            order_by=['contact', 'run', 'arrived_on', 'pk'],
+            select_related=['run', 'contact'],
+            prefetch_related=['messages__contact_urn', 'messages__channel', 'broadcasts', 'contact__all_groups'],
+            contact_fields=contact_fields
+        ):
 
             processed_steps += 1
             if processed_steps % 10000 == 0:  # pragma: needs cover
-                print("Export of %s - %d%% complete in %0.2fs" %
-                      (flow_names, processed_steps * 100 / total_steps, time.time() - start))
+                print(
+                    "Export of %s - %d%% complete in %0.2fs" %
+                    (flow_names, processed_steps * 100 / total_steps, time.time() - start)
+                )
 
             # skip over test contacts
             if run_step.contact.is_test:  # pragma: needs cover
@@ -4590,7 +4980,9 @@ class ExportFlowResultsTask(BaseExportTask):
 
                     # write our contact fields if any
                     for cf in contact_fields:
-                        field_value = Contact.get_field_display_for_value(cf, run_step.contact.get_field(cf.key.lower()), org)
+                        field_value = Contact.get_field_display_for_value(
+                            cf, run_step.contact.get_field(cf.key.lower()), org
+                        )
                         if field_value is None:
                             field_value = ''
 
@@ -4656,15 +5048,18 @@ class ExportFlowResultsTask(BaseExportTask):
                         if msg_row > self.MAX_EXCEL_ROWS or not msgs:
                             msg_row = 2
 
-                            name = "Messages" if (msg_sheet_index + 1) <= 1 else "Messages (%d)" % (msg_sheet_index + 1)
+                            name = "Messages" if (msg_sheet_index +
+                                                  1) <= 1 else "Messages (%d)" % (msg_sheet_index + 1)
                             msgs = book.create_sheet(name)
                             if org.is_anon:
                                 headers = ["Contact UUID", "ID", "Name", "Date", "Direction", "Message", "Channel"]
                             else:
                                 headers = ["Contact UUID", "URN", "Name", "Date", "Direction", "Message", "Channel"]
 
-                            col_widths = [self.WIDTH_MEDIUM, self.WIDTH_SMALL, self.WIDTH_MEDIUM, self.WIDTH_MEDIUM,
-                                          self.WIDTH_SMALL, self.WIDTH_LARGE, self.WIDTH_MEDIUM]
+                            col_widths = [
+                                self.WIDTH_MEDIUM, self.WIDTH_SMALL, self.WIDTH_MEDIUM, self.WIDTH_MEDIUM,
+                                self.WIDTH_SMALL, self.WIDTH_LARGE, self.WIDTH_MEDIUM
+                            ]
                             msg_sheet_index += 1
 
                             self.set_sheet_column_widths(msgs, col_widths)
@@ -4672,15 +5067,14 @@ class ExportFlowResultsTask(BaseExportTask):
 
                         urn_display = msg.contact_urn.get_display(org=org, formatted=False) if msg.contact_urn else ''
 
-                        self.append_row(msgs, [
-                            run_step.contact.uuid,
-                            run_step.contact.id if org.is_anon else urn_display,
-                            contact_name,
-                            msg.created_on,
-                            "IN" if msg.direction == INCOMING else "OUT",
-                            msg.text,
-                            msg.channel.name if msg.channel else ''
-                        ])
+                        self.append_row(
+                            msgs, [
+                                run_step.contact.uuid, run_step.contact.id
+                                if org.is_anon else urn_display, contact_name, msg.created_on, "IN"
+                                if msg.direction == INCOMING else "OUT", msg.text, msg.channel.name
+                                if msg.channel else ''
+                            ]
+                        )
 
                         seen_msgs.add(msg.pk)
 
@@ -4702,7 +5096,7 @@ class ResultsExportAssetStore(BaseExportAssetStore):
     key = 'results_export'
     directory = 'results_exports'
     permission = 'flows.flow_export_results'
-    extensions = ('xlsx',)
+    extensions = ('xlsx', )
 
 
 @six.python_2_unicode_compatible
@@ -4748,12 +5142,14 @@ class ActionLog(models.Model):
         return cls.create(run, text, cls.LEVEL_ERROR, safe)
 
     def as_json(self):
-        return dict(id=self.id,
-                    direction="O",
-                    level=self.level,
-                    text=self.text,
-                    created_on=self.created_on.strftime('%x %X'),
-                    model="log")
+        return dict(
+            id=self.id,
+            direction="O",
+            level=self.level,
+            text=self.text,
+            created_on=self.created_on.strftime('%x %X'),
+            model="log"
+        )
 
     def simulator_json(self):
         return self.as_json()
@@ -4769,9 +5165,7 @@ class FlowStart(SmartModel):
     STATUS_COMPLETE = 'C'
     STATUS_FAILED = 'F'
 
-    STATUS_CHOICES = ((STATUS_PENDING, "Pending"),
-                      (STATUS_STARTING, "Starting"),
-                      (STATUS_COMPLETE, "Complete"),
+    STATUS_CHOICES = ((STATUS_PENDING, "Pending"), (STATUS_STARTING, "Starting"), (STATUS_COMPLETE, "Complete"),
                       (STATUS_FAILED, "Failed"))
 
     uuid = models.UUIDField(unique=True, default=uuid4)
@@ -4782,34 +5176,38 @@ class FlowStart(SmartModel):
 
     contacts = models.ManyToManyField(Contact, help_text=_("Contacts that will start the flow"))
 
-    restart_participants = models.BooleanField(default=True,
-                                               help_text=_("Whether to restart any participants already in this flow"))
+    restart_participants = models.BooleanField(
+        default=True, help_text=_("Whether to restart any participants already in this flow")
+    )
 
-    include_active = models.BooleanField(default=True,
-                                         help_text=_("Include contacts currently active in flows"))
+    include_active = models.BooleanField(default=True, help_text=_("Include contacts currently active in flows"))
 
-    contact_count = models.IntegerField(default=0,
-                                        help_text=_("How many unique contacts were started down the flow"))
+    contact_count = models.IntegerField(default=0, help_text=_("How many unique contacts were started down the flow"))
 
-    status = models.CharField(max_length=1, default=STATUS_PENDING, choices=STATUS_CHOICES,
-                              help_text=_("The status of this flow start"))
+    status = models.CharField(
+        max_length=1, default=STATUS_PENDING, choices=STATUS_CHOICES, help_text=_("The status of this flow start")
+    )
 
-    extra = models.TextField(null=True,
-                             help_text=_("Any extra parameters to pass to the flow start (json)"))
+    extra = models.TextField(null=True, help_text=_("Any extra parameters to pass to the flow start (json)"))
 
     @classmethod
-    def create(cls, flow, user, groups=None, contacts=None, restart_participants=True, extra=None, include_active=True):
+    def create(
+        cls, flow, user, groups=None, contacts=None, restart_participants=True, extra=None, include_active=True
+    ):
         if contacts is None:  # pragma: needs cover
             contacts = []
 
         if groups is None:  # pragma: needs cover
             groups = []
 
-        start = FlowStart.objects.create(flow=flow,
-                                         restart_participants=restart_participants,
-                                         include_active=include_active,
-                                         extra=json.dumps(extra) if extra else None,
-                                         created_by=user, modified_by=user)
+        start = FlowStart.objects.create(
+            flow=flow,
+            restart_participants=restart_participants,
+            include_active=include_active,
+            extra=json.dumps(extra) if extra else None,
+            created_by=user,
+            modified_by=user
+        )
 
         for contact in contacts:
             start.contacts.add(contact)
@@ -4834,8 +5232,14 @@ class FlowStart(SmartModel):
             # load up our extra if any
             extra = json.loads(self.extra) if self.extra else None
 
-            return self.flow.start(groups, contacts, flow_start=self, extra=extra,
-                                   restart_participants=self.restart_participants, include_active=self.include_active)
+            return self.flow.start(
+                groups,
+                contacts,
+                flow_start=self,
+                extra=extra,
+                restart_participants=self.restart_participants,
+                include_active=self.include_active
+            )
 
         except Exception as e:  # pragma: no cover
             import traceback
@@ -4859,10 +5263,15 @@ class FlowStart(SmartModel):
 class FlowLabel(models.Model):
     org = models.ForeignKey(Org)
 
-    uuid = models.CharField(max_length=36, unique=True, db_index=True, default=generate_uuid,
-                            verbose_name=_("Unique Identifier"), help_text=_("The unique identifier for this label"))
-    name = models.CharField(max_length=64, verbose_name=_("Name"),
-                            help_text=_("The name of this flow label"))
+    uuid = models.CharField(
+        max_length=36,
+        unique=True,
+        db_index=True,
+        default=generate_uuid,
+        verbose_name=_("Unique Identifier"),
+        help_text=_("The unique identifier for this label")
+    )
+    name = models.CharField(max_length=64, verbose_name=_("Name"), help_text=_("The name of this flow label"))
     parent = models.ForeignKey('FlowLabel', verbose_name=_("Parent"), null=True, related_name="children")
 
     def get_flows_count(self):
@@ -4872,7 +5281,9 @@ class FlowLabel(models.Model):
         return self.get_flows().count()
 
     def get_flows(self):
-        return Flow.objects.filter(Q(labels=self) | Q(labels__parent=self)).filter(is_active=True, is_archived=False).distinct()
+        return Flow.objects.filter(Q(labels=self) | Q(labels__parent=self)).filter(
+            is_active=True, is_archived=False
+        ).distinct()
 
     @classmethod
     def create_unique(cls, base, org, parent=None):
@@ -5065,7 +5476,9 @@ class EmailAction(Action):
 
         if not run.contact.is_test:
             if valid_addresses:
-                on_transaction_commit(lambda: send_email_action_task.delay(run.flow.org.id, valid_addresses, subject, message))
+                on_transaction_commit(
+                    lambda: send_email_action_task.delay(run.flow.org.id, valid_addresses, subject, message)
+                )
         else:
             if valid_addresses:
                 valid_addresses = ['"%s"' % elt for elt in valid_addresses]
@@ -5092,14 +5505,20 @@ class WebhookAction(Action):
 
     @classmethod
     def from_json(cls, org, json_obj):
-        return cls(json_obj.get(cls.UUID),
-                   json_obj.get('webhook', org.get_webhook_url()),
-                   json_obj.get('action', 'POST'),
-                   json_obj.get('webhook_headers', []))
+        return cls(
+            json_obj.get(cls.UUID),
+            json_obj.get('webhook', org.get_webhook_url()),
+            json_obj.get('action', 'POST'), json_obj.get('webhook_headers', [])
+        )
 
     def as_json(self):
-        return dict(type=self.TYPE, uuid=self.uuid, webhook=self.webhook, action=self.action,
-                    webhook_headers=self.webhook_headers)
+        return dict(
+            type=self.TYPE,
+            uuid=self.uuid,
+            webhook=self.webhook,
+            action=self.action,
+            webhook_headers=self.webhook_headers
+        )
 
     def execute(self, run, context, actionset_uuid, msg, offline_on=None):
         from temba.api.models import WebHookEvent
@@ -5201,14 +5620,20 @@ class AddToGroupAction(Action):
                     # TODO should become a failure (because it should be impossible) and not just a simulator error
                     if group.is_dynamic:
                         # report to sentry
-                        logger.error("Attempt to add/remove contacts on dynamic group '%s' [%d] "
-                                     "in flow '%s' [%d] for org '%s' [%d]"
-                                     % (group.name, group.pk, run.flow.name, run.flow.pk, run.org.name, run.org.pk))
+                        logger.error(
+                            "Attempt to add/remove contacts on dynamic group '%s' [%d] "
+                            "in flow '%s' [%d] for org '%s' [%d]" %
+                            (group.name, group.pk, run.flow.name, run.flow.pk, run.org.name, run.org.pk)
+                        )
                         if run.contact.is_test:
                             if add:
-                                ActionLog.error(run, _("%s is a dynamic group which we can't add contacts to") % group.name)
+                                ActionLog.error(
+                                    run, _("%s is a dynamic group which we can't add contacts to") % group.name
+                                )
                             else:  # pragma: needs cover
-                                ActionLog.error(run, _("%s is a dynamic group which we can't remove contacts from") % group.name)
+                                ActionLog.error(
+                                    run, _("%s is a dynamic group which we can't remove contacts from") % group.name
+                                )
                         continue
 
                     group.update_contacts(user, [contact], add)
@@ -5249,9 +5674,9 @@ class DeleteFromGroupAction(AddToGroupAction):
             user = get_flow_user(run.org)
             if contact:
                 # remove from all active and inactive user-defined, static groups
-                for group in ContactGroup.user_groups.filter(org=contact.org,
-                                                             group_type=ContactGroup.TYPE_USER_DEFINED,
-                                                             query__isnull=True):
+                for group in ContactGroup.user_groups.filter(
+                    org=contact.org, group_type=ContactGroup.TYPE_USER_DEFINED, query__isnull=True
+                ):
                     group.update_contacts(user, [contact], False)
                     if run.contact.is_test:  # pragma: needs cover
                         ActionLog.info(run, _("Removed %s from %s") % (run.contact.name, group.name))
@@ -5452,8 +5877,12 @@ class ReplyAction(Action):
         elif not msg:
             raise FlowException("Invalid reply action, no message")
 
-        return cls(json_obj.get(cls.UUID), msg=json_obj.get(cls.MESSAGE), media=json_obj.get(cls.MEDIA, None),
-                   send_all=json_obj.get(cls.SEND_ALL, False))
+        return cls(
+            json_obj.get(cls.UUID),
+            msg=json_obj.get(cls.MESSAGE),
+            media=json_obj.get(cls.MEDIA, None),
+            send_all=json_obj.get(cls.SEND_ALL, False)
+        )
 
     def as_json(self):
         return dict(type=self.TYPE, uuid=self.uuid, msg=self.msg, media=self.media, send_all=self.send_all)
@@ -5486,16 +5915,33 @@ class ReplyAction(Action):
                 created_on = None
 
             if msg and msg.id:
-                replies = msg.reply(text, user, trigger_send=False, expressions_context=context,
-                                    connection=run.connection, msg_type=self.MSG_TYPE, attachments=attachments,
-                                    send_all=self.send_all, created_on=created_on)
+                replies = msg.reply(
+                    text,
+                    user,
+                    trigger_send=False,
+                    expressions_context=context,
+                    connection=run.connection,
+                    msg_type=self.MSG_TYPE,
+                    attachments=attachments,
+                    send_all=self.send_all,
+                    created_on=created_on
+                )
             else:
                 # if our run has been responded to or any of our parent runs have
                 # been responded to consider us interactive with high priority
                 high_priority = run.get_session_responded()
-                replies = run.contact.send(text, user, trigger_send=False, expressions_context=context,
-                                           connection=run.connection, msg_type=self.MSG_TYPE, attachments=attachments,
-                                           created_on=created_on, all_urns=self.send_all, high_priority=high_priority)
+                replies = run.contact.send(
+                    text,
+                    user,
+                    trigger_send=False,
+                    expressions_context=context,
+                    connection=run.connection,
+                    msg_type=self.MSG_TYPE,
+                    attachments=attachments,
+                    created_on=created_on,
+                    all_urns=self.send_all,
+                    high_priority=high_priority
+                )
         return replies
 
 
@@ -5546,8 +5992,13 @@ class UssdAction(ReplyAction):
             primary_language = getattr(getattr(org, 'primary_language', None), 'iso_code', None)
 
             # initialize UssdAction
-            ussd_action = cls(uuid=uuid, msg=msg, base_language=base_language, languages=org_languages,
-                              primary_language=primary_language)
+            ussd_action = cls(
+                uuid=uuid,
+                msg=msg,
+                base_language=base_language,
+                languages=org_languages,
+                primary_language=primary_language
+            )
 
             ussd_action.substitute_missing_languages()
 
@@ -5577,8 +6028,13 @@ class UssdAction(ReplyAction):
         # add menu to the msg
         for rule in rules:
             if rule.get('label'):  # filter "other" and "interrupted"
-                self.msg = {language: localised_msg + ": ".join(
-                    (str(rule['test']['test']), self.get_menu_label(rule['label'], language),)) + '\n' for language, localised_msg in six.iteritems(self.msg)}
+                self.msg = {
+                    language: localised_msg + ": ".join((
+                        str(rule['test']['test']),
+                        self.get_menu_label(rule['label'], language),
+                    )) + '\n'
+                    for language, localised_msg in six.iteritems(self.msg)
+                }
 
 
 class VariableContactAction(Action):
@@ -5718,8 +6174,14 @@ class TriggerFlowAction(VariableContactAction):
         group_ids = [dict(uuid=_.uuid, name=_.name) for _ in self.groups]
         variables = [dict(id=_) for _ in self.variables]
 
-        return dict(type=self.TYPE, uuid=self.uuid, flow=dict(uuid=self.flow.uuid, name=self.flow.name),
-                    contacts=contact_ids, groups=group_ids, variables=variables)
+        return dict(
+            type=self.TYPE,
+            uuid=self.uuid,
+            flow=dict(uuid=self.flow.uuid, name=self.flow.name),
+            contacts=contact_ids,
+            groups=group_ids,
+            variables=variables
+        )
 
     def execute(self, run, context, actionset_uuid, msg, offline_on=None):
         if self.flow:
@@ -5728,8 +6190,14 @@ class TriggerFlowAction(VariableContactAction):
             if not run.contact.is_test:
                 # our extra will be our flow variables in our message context
                 extra = context.get('extra', dict())
-                child_runs = self.flow.start(groups, contacts, restart_participants=True, started_flows=[run.flow.pk],
-                                             extra=extra, parent_run=run)
+                child_runs = self.flow.start(
+                    groups,
+                    contacts,
+                    restart_participants=True,
+                    started_flows=[run.flow.pk],
+                    extra=extra,
+                    parent_run=run
+                )
 
                 # build up all the msgs that where sent by our flow
                 msgs = []
@@ -5837,13 +6305,19 @@ class StartFlowAction(Action):
 
         # if they are both flow runs, just redirect the call
         if run.flow.flow_type == Flow.VOICE and self.flow.flow_type == Flow.VOICE:
-            new_run = self.flow.start([], [run.contact], started_flows=started_flows,
-                                      restart_participants=True, extra=extra, parent_run=run)[0]
+            new_run = self.flow.start([], [run.contact],
+                                      started_flows=started_flows,
+                                      restart_participants=True,
+                                      extra=extra,
+                                      parent_run=run)[0]
             url = "https://%s%s" % (settings.HOSTNAME, reverse('ivr.ivrcall_handle', args=[new_run.connection.pk]))
             run.voice_response.redirect(url)
         else:
-            child_runs = self.flow.start([], [run.contact], started_flows=started_flows, restart_participants=True,
-                                         extra=extra, parent_run=run)
+            child_runs = self.flow.start([], [run.contact],
+                                         started_flows=started_flows,
+                                         restart_participants=True,
+                                         extra=extra,
+                                         parent_run=run)
             for run in child_runs:
                 msgs += run.start_msgs
 
@@ -5965,7 +6439,10 @@ class SaveToContactAction(Action):
                 if not URN.validate(new_urn, contact.org.get_country_code()):
                     new_urn = False
                     if contact.is_test:
-                        ActionLog.warn(run, _('Contact not updated, invalid connection for contact (%s:%s)' % (scheme, new_value)))
+                        ActionLog.warn(
+                            run,
+                            _('Contact not updated, invalid connection for contact (%s:%s)' % (scheme, new_value))
+                        )
             else:
                 if contact.is_test:
                     ActionLog.warn(run, _('Contact not updated, missing connection for contact'))
@@ -6026,7 +6503,8 @@ class SetChannelAction(Action):
 
     def as_json(self):
         channel_uuid = self.channel.uuid if self.channel else None
-        channel_name = "%s: %s" % (self.channel.get_channel_type_display(), self.channel.get_address_display()) if self.channel else None
+        channel_name = "%s: %s" % (self.channel.get_channel_type_display(),
+                                   self.channel.get_address_display()) if self.channel else None
         return dict(type=self.TYPE, uuid=self.uuid, channel=channel_uuid, name=channel_name)
 
     def execute(self, run, context, actionset_uuid, msg, offline_on=None):
@@ -6068,16 +6546,24 @@ class SendAction(VariableContactAction):
         contacts = VariableContactAction.parse_contacts(org, json_obj)
         variables = VariableContactAction.parse_variables(org, json_obj)
 
-        return cls(json_obj.get(cls.UUID), json_obj.get(cls.MESSAGE), groups, contacts, variables,
-                   json_obj.get(cls.MEDIA, None))
+        return cls(
+            json_obj.get(cls.UUID),
+            json_obj.get(cls.MESSAGE), groups, contacts, variables, json_obj.get(cls.MEDIA, None)
+        )
 
     def as_json(self):
         contact_ids = [dict(uuid=_.uuid) for _ in self.contacts]
         group_ids = [dict(uuid=_.uuid, name=_.name) for _ in self.groups]
         variables = [dict(id=_) for _ in self.variables]
-        return dict(type=self.TYPE, uuid=self.uuid, msg=self.msg,
-                    contacts=contact_ids, groups=group_ids, variables=variables,
-                    media=self.media)
+        return dict(
+            type=self.TYPE,
+            uuid=self.uuid,
+            msg=self.msg,
+            contacts=contact_ids,
+            groups=group_ids,
+            variables=variables,
+            media=self.media
+        )
 
     def execute(self, run, context, actionset_uuid, msg, offline_on=None):
         if self.msg or self.media:
@@ -6092,8 +6578,14 @@ class SendAction(VariableContactAction):
 
                 recipients = groups + contacts
 
-                broadcast = Broadcast.create(flow.org, flow.modified_by, self.msg, recipients,
-                                             media=self.media, base_language=flow.base_language)
+                broadcast = Broadcast.create(
+                    flow.org,
+                    flow.modified_by,
+                    self.msg,
+                    recipients,
+                    media=self.media,
+                    base_language=flow.base_language
+                )
                 broadcast.send(trigger_send=False, expressions_context=context)
                 return list(broadcast.get_messages())
 
@@ -6116,15 +6608,16 @@ class SendAction(VariableContactAction):
             return []
 
     def logger(self, run, text, contact_count):
-        log_txt = _n("Sending '%(msg)s' to %(count)d contact",
-                     "Sending '%(msg)s' to %(count)d contacts",
-                     contact_count) % dict(msg=text, count=contact_count)
+        log_txt = _n(
+            "Sending '%(msg)s' to %(count)d contact", "Sending '%(msg)s' to %(count)d contacts", contact_count
+        ) % dict(
+            msg=text, count=contact_count
+        )
         log = ActionLog.create(run, log_txt)
         return log
 
 
 class Rule(object):
-
     def __init__(self, uuid, category, destination, destination_type, test, label=None):
         self.uuid = uuid
         self.category = category
@@ -6158,12 +6651,14 @@ class Rule(object):
         return self.test.evaluate(run, sms, context, text)
 
     def as_json(self):
-        return dict(uuid=self.uuid,
-                    category=self.category,
-                    destination=self.destination,
-                    destination_type=self.destination_type,
-                    test=self.test.as_json(),
-                    label=self.label)
+        return dict(
+            uuid=self.uuid,
+            category=self.category,
+            destination=self.destination,
+            destination_type=self.destination_type,
+            test=self.test.as_json(),
+            label=self.label
+        )
 
     @classmethod
     def from_json_array(cls, org, json):
@@ -6186,12 +6681,12 @@ class Rule(object):
             if destination:
                 destination_type = rule.get('destination_type', FlowStep.TYPE_ACTION_SET)
 
-            rules.append(Rule(rule.get('uuid'),
-                              category,
-                              destination,
-                              destination_type,
-                              Test.from_json(org, rule['test']),
-                              rule.get('label')))
+            rules.append(
+                Rule(
+                    rule.get('uuid'), category, destination, destination_type,
+                    Test.from_json(org, rule['test']), rule.get('label')
+                )
+            )
 
         return rules
 
@@ -6262,7 +6757,9 @@ class Test(object):
         according to their definition given the passed in message. Tests do not have
         side effects.
         """
-        raise FlowException("Subclasses must implement evaluate, returning a tuple containing 1 or 0 and the value tested")
+        raise FlowException(
+            "Subclasses must implement evaluate, returning a tuple containing 1 or 0 and the value tested"
+        )
 
 
 class WebhookStatusTest(Test):
@@ -6307,8 +6804,7 @@ class AirtimeStatusTest(Test):
     STATUS_SUCCESS = 'success'
     STATUS_FAILED = 'failed'
 
-    STATUS_MAP = {STATUS_SUCCESS: AirtimeTransfer.SUCCESS,
-                  STATUS_FAILED: AirtimeTransfer.FAILED}
+    STATUS_MAP = {STATUS_SUCCESS: AirtimeTransfer.SUCCESS, STATUS_FAILED: AirtimeTransfer.FAILED}
 
     def __init__(self, exit_status):
         self.exit_status = exit_status
@@ -6366,8 +6862,7 @@ class SubflowTest(Test):
     TYPE_COMPLETED = 'completed'
     TYPE_EXPIRED = 'expired'
 
-    EXIT_MAP = {TYPE_COMPLETED: FlowRun.EXIT_TYPE_COMPLETED,
-                TYPE_EXPIRED: FlowRun.EXIT_TYPE_EXPIRED}
+    EXIT_MAP = {TYPE_COMPLETED: FlowRun.EXIT_TYPE_COMPLETED, TYPE_EXPIRED: FlowRun.EXIT_TYPE_EXPIRED}
 
     def __init__(self, exit_type):
         self.exit_type = exit_type
@@ -7215,4 +7710,5 @@ class InterruptTest(Test):
         return dict(type=self.TYPE)
 
     def evaluate(self, run, msg, context, text):
-        return (True, self.TYPE) if run.connection and run.connection.status == ChannelSession.INTERRUPTED else (False, None)
+        return (True, self.TYPE
+                ) if run.connection and run.connection.status == ChannelSession.INTERRUPTED else (False, None)

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -29,7 +29,9 @@ def update_run_expirations_task(flow_id):
     """
     Update all of our current run expirations according to our new expiration period
     """
-    for step in FlowStep.objects.filter(run__flow__id=flow_id, run__is_active=True, left_on=None).distinct('run'):  # pragma: needs cover
+    for step in FlowStep.objects.filter(
+        run__flow__id=flow_id, run__is_active=True, left_on=None
+    ).distinct('run'):  # pragma: needs cover
         step.run.update_expiration(step.arrived_on)
 
     # force an expiration update
@@ -45,7 +47,9 @@ def check_flows_task():
     FlowRun.bulk_exit(runs, FlowRun.EXIT_TYPE_EXPIRED)
 
 
-@nonoverlapping_task(track_started=True, name='check_flow_timeouts_task', lock_key='check_flow_timeouts', lock_timeout=3600)  # pragma: no cover
+@nonoverlapping_task(
+    track_started=True, name='check_flow_timeouts_task', lock_key='check_flow_timeouts', lock_timeout=3600
+)  # pragma: no cover
 def check_flow_timeouts_task():
     """
     See if any flow runs have timed out
@@ -117,18 +121,26 @@ def start_msg_flow_batch_task():
         started_flows = [] if not task_obj['started_flows'] else task_obj['started_flows']
         start_msg = None if not task_obj['start_msg'] else Msg.objects.filter(pk=task_obj['start_msg']).first()
         extra = task_obj['extra']
-        flow_start = None if not task_obj['flow_start'] else FlowStart.objects.filter(pk=task_obj['flow_start']).first()
+        flow_start = None if not task_obj['flow_start'] else FlowStart.objects.filter(pk=task_obj['flow_start']
+                                                                                      ).first()
         contacts = task_obj['contacts']
 
         # and go do our work
-        flow.start_msg_flow_batch(contacts, broadcasts=broadcasts,
-                                  started_flows=started_flows, start_msg=start_msg,
-                                  extra=extra, flow_start=flow_start)
+        flow.start_msg_flow_batch(
+            contacts,
+            broadcasts=broadcasts,
+            started_flows=started_flows,
+            start_msg=start_msg,
+            extra=extra,
+            flow_start=flow_start
+        )
     finally:
         complete_task(Flow.START_MSG_FLOW_BATCH, org_id)
 
-    print("Started batch of %d contacts in flow %d [%d] in %0.3fs"
-          % (len(contacts), flow.id, flow.org_id, time.time() - start))
+    print(
+        "Started batch of %d contacts in flow %d [%d] in %0.3fs" %
+        (len(contacts), flow.id, flow.org_id, time.time() - start)
+    )
 
 
 @nonoverlapping_task(track_started=True, name="squash_flowpathcounts", lock_key='squash_flowpathcounts')

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -47,34 +47,15 @@ from .models import FlowStep, RuleSet, ActionLog, ExportFlowResultsTask, FlowLab
 
 logger = logging.getLogger(__name__)
 
+EXPIRES_CHOICES = ((0, _('Never')), (5, _('After 5 minutes')), (10, _('After 10 minutes')),
+                   (15, _('After 15 minutes')), (30, _('After 30 minutes')), (60, _('After 1 hour')),
+                   (60 * 3, _('After 3 hours')), (60 * 6, _('After 6 hours')), (60 * 12, _('After 12 hours')),
+                   (60 * 24, _('After 1 day')), (60 * 24 * 3, _('After 3 days')), (60 * 24 * 7, _('After 1 week')),
+                   (60 * 24 * 14, _('After 2 weeks')), (60 * 24 * 30, _('After 30 days')))
 
-EXPIRES_CHOICES = (
-    (0, _('Never')),
-    (5, _('After 5 minutes')),
-    (10, _('After 10 minutes')),
-    (15, _('After 15 minutes')),
-    (30, _('After 30 minutes')),
-    (60, _('After 1 hour')),
-    (60 * 3, _('After 3 hours')),
-    (60 * 6, _('After 6 hours')),
-    (60 * 12, _('After 12 hours')),
-    (60 * 24, _('After 1 day')),
-    (60 * 24 * 3, _('After 3 days')),
-    (60 * 24 * 7, _('After 1 week')),
-    (60 * 24 * 14, _('After 2 weeks')),
-    (60 * 24 * 30, _('After 30 days'))
-)
-
-
-IVR_EXPIRES_CHOICES = (
-    (1, _('After 1 minute')),
-    (2, _('After 2 minutes')),
-    (3, _('After 3 minutes')),
-    (4, _('After 4 minutes')),
-    (5, _('After 5 minutes')),
-    (10, _('After 10 minutes')),
-    (15, _('After 15 minutes'))
-)
+IVR_EXPIRES_CHOICES = ((1, _('After 1 minute')), (2, _('After 2 minutes')), (3, _('After 3 minutes')),
+                       (4, _('After 4 minutes')), (5, _('After 5 minutes')), (10, _('After 10 minutes')),
+                       (15, _('After 15 minutes')))
 
 
 class BaseFlowForm(forms.ModelForm):
@@ -91,7 +72,9 @@ class BaseFlowForm(forms.ModelForm):
             if not keyword:
                 continue
 
-            if not regex.match('^\w+$', keyword, flags=regex.UNICODE | regex.V0) or len(keyword) > Trigger.KEYWORD_MAX_LEN:
+            if not regex.match(
+                '^\w+$', keyword, flags=regex.UNICODE | regex.V0
+            ) or len(keyword) > Trigger.KEYWORD_MAX_LEN:
                 wrong_format.append(keyword)
 
             # make sure it is unique on this org
@@ -105,8 +88,10 @@ class BaseFlowForm(forms.ModelForm):
                 cleaned_keywords.append(keyword)
 
         if wrong_format:
-            raise forms.ValidationError(_('"%s" must be a single word, less than %d characters, containing only letter '
-                                          'and numbers') % (', '.join(wrong_format), Trigger.KEYWORD_MAX_LEN))
+            raise forms.ValidationError(
+                _('"%s" must be a single word, less than %d characters, containing only letter '
+                  'and numbers') % (', '.join(wrong_format), Trigger.KEYWORD_MAX_LEN)
+            )
 
         if duplicates:
             if len(duplicates) > 1:
@@ -123,8 +108,7 @@ class BaseFlowForm(forms.ModelForm):
 
 
 class FlowActionForm(BaseActionForm):
-    allowed_actions = (('archive', _("Archive Flows")),
-                       ('label', _("Label Messages")),
+    allowed_actions = (('archive', _("Archive Flows")), ('label', _("Label Messages")),
                        ('restore', _("Restore Flows")))
 
     model = Flow
@@ -136,7 +120,6 @@ class FlowActionForm(BaseActionForm):
 
 
 class FlowActionMixin(SmartListView):
-
     @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super(FlowActionMixin, self).dispatch(*args, **kwargs)
@@ -157,9 +140,15 @@ class FlowActionMixin(SmartListView):
 
             if form.cleaned_data['action'] == 'archive' and ignored:
                 if len(ignored) > 1:
-                    toast = _('%s are used inside a campaign. To archive them, first remove them from your campaigns.' % ' and '.join(ignored))
+                    toast = _(
+                        '%s are used inside a campaign. To archive them, first remove them from your campaigns.' %
+                        ' and '.join(ignored)
+                    )
                 else:
-                    toast = _('%s is used inside a campaign. To archive it, first remove it from your campaigns.' % ignored[0])
+                    toast = _(
+                        '%s is used inside a campaign. To archive it, first remove it from your campaigns.' %
+                        ignored[0]
+                    )
 
         response = self.get(request, *args, **kwargs)
 
@@ -174,7 +163,6 @@ class RuleCRUDL(SmartCRUDL):
     model = RuleSet
 
     class Results(OrgPermsMixin, SmartReadView):
-
         def get_context_data(self, **kwargs):
             filters = json.loads(self.request.GET.get('filters', '[]'))
             segment = json.loads(self.request.GET.get('segment', 'null'))
@@ -188,7 +176,6 @@ class RuleCRUDL(SmartCRUDL):
             return response
 
     class Choropleth(OrgPermsMixin, SmartReadView):
-
         def get_context_data(self, **kwargs):
             filters = json.loads(self.request.GET.get('filters', '[]'))
 
@@ -245,9 +232,7 @@ class RuleCRUDL(SmartCRUDL):
             prime_category['percentage'] = percentage(prime_category['count'], total)
             other_category['percentage'] = percentage(other_category['count'], total)
 
-            totals = dict(name=parent.name,
-                          count=total,
-                          results=[prime_category, other_category])
+            totals = dict(name=parent.name, count=total, results=[prime_category, other_category])
             categories = [prime_category['label'], other_category['label']]
 
             # calculate our percentages per segment
@@ -263,16 +248,11 @@ class RuleCRUDL(SmartCRUDL):
 
                 total = prime_count + other_count
                 score = 1.0 * prime_count / total if total else 0
-                results = [dict(count=prime_count,
-                                percentage=percentage(prime_count, total),
-                                label=prime_category['label']),
-                           dict(count=other_count,
-                                percentage=percentage(other_count, total),
-                                label=other_category['label'])]
-                scores[result['boundary']] = dict(count=total,
-                                                  score=score,
-                                                  results=results,
-                                                  name=result['label'])
+                results = [
+                    dict(count=prime_count, percentage=percentage(prime_count, total), label=prime_category['label']),
+                    dict(count=other_count, percentage=percentage(other_count, total), label=other_category['label'])
+                ]
+                scores[result['boundary']] = dict(count=total, score=score, results=results, name=result['label'])
 
             breaks = [.2, .3, .35, .40, .45, .55, .60, .65, .7, .8, 1]
             return dict(breaks=breaks, totals=totals, scores=scores, categories=categories)
@@ -285,7 +265,9 @@ class RuleCRUDL(SmartCRUDL):
                 return obj.isoformat() if isinstance(obj, datetime) else obj
 
             org = self.request.user.get_org()
-            rules = RuleSet.objects.filter(flow__is_active=True, flow__org=org).exclude(label=None).order_by('flow__created_on', 'y').select_related('flow')
+            rules = RuleSet.objects.filter(
+                flow__is_active=True, flow__org=org
+            ).exclude(label=None).order_by('flow__created_on', 'y').select_related('flow')
             current_flow = None
             flow_json = []
 
@@ -296,14 +278,16 @@ class RuleCRUDL(SmartCRUDL):
                         flow_json.append(current_flow)
 
                     flow = rule.flow
-                    current_flow = dict(id=flow.id,
-                                        text=flow.name,
-                                        rules=[],
-                                        stats=dict(runs=flow.get_run_stats()['total'],
-                                                   created_on=flow.created_on))
+                    current_flow = dict(
+                        id=flow.id,
+                        text=flow.name,
+                        rules=[],
+                        stats=dict(runs=flow.get_run_stats()['total'], created_on=flow.created_on)
+                    )
 
-                current_flow['rules'].append(dict(text=rule.label, id=rule.pk, flow=current_flow['id'],
-                                                  stats=dict(created_on=rule.created_on)))
+                current_flow['rules'].append(
+                    dict(text=rule.label, id=rule.pk, flow=current_flow['id'], stats=dict(created_on=rule.created_on))
+                )
 
             # append our last flow if appropriate
             if current_flow and len(current_flow['rules']) > 0:
@@ -331,8 +315,13 @@ class RuleCRUDL(SmartCRUDL):
             district_fields = org.contactfields.filter(value_type=Value.TYPE_DISTRICT)
             org_supports_map = org.country and state_fields.first() and district_fields.first()
 
-            return dict(flows=json.dumps(flow_json, default=dthandler), org_supports_map=org_supports_map,
-                        groups=json.dumps(groups_json), reports=json.dumps(reports_json), current_report=current_report)
+            return dict(
+                flows=json.dumps(flow_json, default=dthandler),
+                org_supports_map=org_supports_map,
+                groups=json.dumps(groups_json),
+                reports=json.dumps(reports_json),
+                current_report=current_report
+            )
 
 
 def msg_log_cmp(a, b):
@@ -348,7 +337,6 @@ def msg_log_cmp(a, b):
 
 
 class PartialTemplate(SmartTemplateView):  # pragma: no cover
-
     def pre_process(self, request, *args, **kwargs):
         self.template = kwargs['template']
         return
@@ -358,11 +346,11 @@ class PartialTemplate(SmartTemplateView):  # pragma: no cover
 
 
 class FlowRunCRUDL(SmartCRUDL):
-    actions = ('delete',)
+    actions = ('delete', )
     model = FlowRun
 
     class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
-        fields = ('pk',)
+        fields = ('pk', )
         success_message = None
 
         def post(self, request, *args, **kwargs):
@@ -371,10 +359,11 @@ class FlowRunCRUDL(SmartCRUDL):
 
 
 class FlowCRUDL(SmartCRUDL):
-    actions = ('list', 'archived', 'copy', 'create', 'delete', 'update', 'simulate', 'export_results',
-               'upload_action_recording', 'read', 'editor', 'results', 'run_table', 'json', 'broadcast', 'activity',
-               'activity_chart', 'filter', 'campaign', 'completion', 'revisions', 'recent_messages',
-               'upload_media_action')
+    actions = (
+        'list', 'archived', 'copy', 'create', 'delete', 'update', 'simulate', 'export_results',
+        'upload_action_recording', 'read', 'editor', 'results', 'run_table', 'json', 'broadcast', 'activity',
+        'activity_chart', 'filter', 'campaign', 'completion', 'revisions', 'recent_messages', 'upload_media_action'
+    )
 
     model = Flow
 
@@ -400,7 +389,6 @@ class FlowCRUDL(SmartCRUDL):
             return JsonResponse(recent_messages, safe=False)
 
     class Revisions(OrgObjPermsMixin, SmartReadView):
-
         def get(self, request, *args, **kwargs):
             flow = self.get_object()
 
@@ -438,15 +426,18 @@ class FlowCRUDL(SmartCRUDL):
 
     class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
         class FlowCreateForm(BaseFlowForm):
-            keyword_triggers = forms.CharField(required=False, label=_("Global keyword triggers"),
-                                               help_text=_("When a user sends any of these keywords they will begin this flow"))
+            keyword_triggers = forms.CharField(
+                required=False,
+                label=_("Global keyword triggers"),
+                help_text=_("When a user sends any of these keywords they will begin this flow")
+            )
 
-            flow_type = forms.ChoiceField(label=_('Run flow over'),
-                                          help_text=_('Send messages, place phone calls, or submit Surveyor runs'),
-                                          choices=((Flow.FLOW, 'Messaging'),
-                                                   (Flow.USSD, 'USSD Messaging'),
-                                                   (Flow.VOICE, 'Phone Call'),
-                                                   (Flow.SURVEY, 'Surveyor')))
+            flow_type = forms.ChoiceField(
+                label=_('Run flow over'),
+                help_text=_('Send messages, place phone calls, or submit Surveyor runs'),
+                choices=((Flow.FLOW, 'Messaging'), (Flow.USSD, 'USSD Messaging'), (Flow.VOICE, 'Phone Call'),
+                         (Flow.SURVEY, 'Surveyor'))
+            )
 
             def __init__(self, user, *args, **kwargs):
                 super(FlowCRUDL.Create.FlowCreateForm, self).__init__(*args, **kwargs)
@@ -454,9 +445,9 @@ class FlowCRUDL(SmartCRUDL):
 
                 org_languages = self.user.get_org().languages.all().order_by('orgs', 'name')
                 language_choices = ((lang.iso_code, lang.name) for lang in org_languages)
-                self.fields['base_language'] = forms.ChoiceField(label=_('Language'),
-                                                                 initial=self.user.get_org().primary_language,
-                                                                 choices=language_choices)
+                self.fields['base_language'] = forms.ChoiceField(
+                    label=_('Language'), initial=self.user.get_org().primary_language, choices=language_choices
+                )
 
             class Meta:
                 model = Flow
@@ -503,9 +494,14 @@ class FlowCRUDL(SmartCRUDL):
                 # ivr expires after 5 minutes of inactivity
                 expires_after_minutes = 5
 
-            self.object = Flow.create(org, self.request.user, obj.name,
-                                      flow_type=obj.flow_type, expires_after_minutes=expires_after_minutes,
-                                      base_language=obj.base_language)
+            self.object = Flow.create(
+                org,
+                self.request.user,
+                obj.name,
+                flow_type=obj.flow_type,
+                expires_after_minutes=expires_after_minutes,
+                base_language=obj.base_language
+            )
 
         def post_save(self, obj):
             user = self.request.user
@@ -520,7 +516,7 @@ class FlowCRUDL(SmartCRUDL):
             return obj
 
     class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
-        fields = ('id',)
+        fields = ('id', )
         cancel_url = 'uuid@flows.flow_editor'
         success_message = ''
 
@@ -539,8 +535,11 @@ class FlowCRUDL(SmartCRUDL):
             flow.release()
 
             # we can't just redirect so as to make our modal do the right thing
-            response = self.render_to_response(self.get_context_data(success_url=self.get_success_url(),
-                                                                     success_script=getattr(self, 'success_script', None)))
+            response = self.render_to_response(
+                self.get_context_data(
+                    success_url=self.get_success_url(), success_script=getattr(self, 'success_script', None)
+                )
+            )
             response['Temba-Success'] = self.get_success_url()
 
             return response
@@ -559,11 +558,12 @@ class FlowCRUDL(SmartCRUDL):
     class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
         class FlowUpdateForm(BaseFlowForm):
 
-            expires_after_minutes = forms.ChoiceField(label=_('Expire inactive contacts'),
-                                                      help_text=_(
-                                                          "When inactive contacts should be removed from the flow"),
-                                                      initial=str(60 * 24 * 7),
-                                                      choices=EXPIRES_CHOICES)
+            expires_after_minutes = forms.ChoiceField(
+                label=_('Expire inactive contacts'),
+                help_text=_("When inactive contacts should be removed from the flow"),
+                initial=str(60 * 24 * 7),
+                choices=EXPIRES_CHOICES
+            )
 
             def __init__(self, user, *args, **kwargs):
                 super(FlowCRUDL.Update.FlowUpdateForm, self).__init__(*args, **kwargs)
@@ -571,7 +571,10 @@ class FlowCRUDL(SmartCRUDL):
 
                 metadata = self.instance.get_metadata_json()
                 flow_triggers = Trigger.objects.filter(
-                    org=self.instance.org, flow=self.instance, is_archived=False, groups=None,
+                    org=self.instance.org,
+                    flow=self.instance,
+                    is_archived=False,
+                    groups=None,
                     trigger_type=Trigger.TYPE_KEYWORD
                 ).order_by('created_on')
 
@@ -583,7 +586,8 @@ class FlowCRUDL(SmartCRUDL):
                 # if we don't have a base language let them pick one (this is immutable)
                 if not self.instance.base_language:
                     choices = [('', 'No Preference')]
-                    choices += [(lang.iso_code, lang.name) for lang in self.instance.org.languages.all().order_by('orgs', 'name')]
+                    choices += [(lang.iso_code, lang.name)
+                                for lang in self.instance.org.languages.all().order_by('orgs', 'name')]
                     self.fields['base_language'] = forms.ChoiceField(label=_('Language'), choices=choices)
 
                 if self.instance.flow_type == Flow.SURVEY:
@@ -591,18 +595,18 @@ class FlowCRUDL(SmartCRUDL):
                         label=_('Create a contact '),
                         initial=metadata.get(Flow.CONTACT_CREATION, Flow.CONTACT_PER_RUN),
                         help_text=_("Whether surveyor logins should be used as the contact for each run"),
-                        choices=(
-                            (Flow.CONTACT_PER_RUN, _('For each run')),
-                            (Flow.CONTACT_PER_LOGIN, _('For each login'))
-                        )
+                        choices=((Flow.CONTACT_PER_RUN, _('For each run')),
+                                 (Flow.CONTACT_PER_LOGIN, _('For each login')))
                     )
 
                     self.fields[Flow.CONTACT_CREATION] = contact_creation
                 else:
-                    self.fields['keyword_triggers'] = forms.CharField(required=False,
-                                                                      label=_("Global keyword triggers"),
-                                                                      help_text=_("When a user sends any of these keywords they will begin this flow"),
-                                                                      initial=','.join([t.keyword for t in flow_triggers]))
+                    self.fields['keyword_triggers'] = forms.CharField(
+                        required=False,
+                        label=_("Global keyword triggers"),
+                        help_text=_("When a user sends any of these keywords they will begin this flow"),
+                        initial=','.join([t.keyword for t in flow_triggers])
+                    )
 
             class Meta:
                 model = Flow
@@ -648,28 +652,40 @@ class FlowCRUDL(SmartCRUDL):
 
             if 'keyword_triggers' in self.form.cleaned_data:
 
-                existing_keywords = set(t.keyword for t in obj.triggers.filter(org=org, flow=obj,
-                                                                               trigger_type=Trigger.TYPE_KEYWORD,
-                                                                               is_archived=False, groups=None))
+                existing_keywords = set(
+                    t.keyword
+                    for t in obj.triggers.
+                    filter(org=org, flow=obj, trigger_type=Trigger.TYPE_KEYWORD, is_archived=False, groups=None)
+                )
 
                 if len(self.form.cleaned_data['keyword_triggers']) > 0:
                     keywords = set(self.form.cleaned_data['keyword_triggers'].split(','))
 
                 removed_keywords = existing_keywords.difference(keywords)
                 for keyword in removed_keywords:
-                    obj.triggers.filter(org=org, flow=obj, keyword=keyword,
-                                        groups=None, is_archived=False).update(is_archived=True)
+                    obj.triggers.filter(
+                        org=org, flow=obj, keyword=keyword, groups=None, is_archived=False
+                    ).update(is_archived=True)
 
                 added_keywords = keywords.difference(existing_keywords)
-                archived_keywords = [t.keyword for t in obj.triggers.filter(org=org, flow=obj, trigger_type=Trigger.TYPE_KEYWORD,
-                                                                            is_archived=True, groups=None)]
+                archived_keywords = [
+                    t.keyword
+                    for t in obj.triggers.
+                    filter(org=org, flow=obj, trigger_type=Trigger.TYPE_KEYWORD, is_archived=True, groups=None)
+                ]
                 for keyword in added_keywords:
                     # first check if the added keyword is not amongst archived
                     if keyword in archived_keywords:  # pragma: needs cover
                         obj.triggers.filter(org=org, flow=obj, keyword=keyword, groups=None).update(is_archived=False)
                     else:
-                        Trigger.objects.create(org=org, keyword=keyword, trigger_type=Trigger.TYPE_KEYWORD,
-                                               flow=obj, created_by=user, modified_by=user)
+                        Trigger.objects.create(
+                            org=org,
+                            keyword=keyword,
+                            trigger_type=Trigger.TYPE_KEYWORD,
+                            flow=obj,
+                            created_by=user,
+                            modified_by=user
+                        )
 
             # run async task to update all runs
             from .tasks import update_run_expirations_task
@@ -679,7 +695,9 @@ class FlowCRUDL(SmartCRUDL):
 
     class UploadActionRecording(OrgPermsMixin, SmartUpdateView):
         def post(self, request, *args, **kwargs):  # pragma: needs cover
-            path = self.save_recording_upload(self.request.FILES['file'], self.request.POST.get('actionset'), self.request.POST.get('action'))
+            path = self.save_recording_upload(
+                self.request.FILES['file'], self.request.POST.get('actionset'), self.request.POST.get('action')
+            )
             return JsonResponse(dict(path=path))
 
         def save_recording_upload(self, file, actionset_id, action_uuid):  # pragma: needs cover
@@ -689,23 +707,25 @@ class FlowCRUDL(SmartCRUDL):
     class UploadMediaAction(OrgPermsMixin, SmartUpdateView):
         def post(self, request, *args, **kwargs):
             generated_uuid = six.text_type(uuid4())
-            path = self.save_media_upload(self.request.FILES['file'], self.request.POST.get('actionset'),
-                                          generated_uuid)
+            path = self.save_media_upload(
+                self.request.FILES['file'], self.request.POST.get('actionset'), generated_uuid
+            )
             return JsonResponse(dict(path=path))
 
         def save_media_upload(self, file, actionset_id, name_uuid):
             flow = self.get_object()
             extension = file.name.split('.')[-1]
-            return default_storage.save('attachments/%d/%d/steps/%s.%s' % (flow.org.pk, flow.id, name_uuid, extension),
-                                        file)
+            return default_storage.save(
+                'attachments/%d/%d/steps/%s.%s' % (flow.org.pk, flow.id, name_uuid, extension), file
+            )
 
     class BaseList(FlowActionMixin, OrgQuerysetMixin, OrgPermsMixin, SmartListView):
         title = _("Flows")
         refresh = 10000
         fields = ('name', 'modified_on')
         default_template = 'flows/flow_list.html'
-        default_order = ('-saved_on',)
-        search_fields = ('name__icontains',)
+        default_order = ('-saved_on', )
+        search_fields = ('name__icontains', )
 
         def get_context_data(self, **kwargs):
             context = super(FlowCRUDL.BaseList, self).get_context_data(**kwargs)
@@ -729,36 +749,53 @@ class FlowCRUDL(SmartCRUDL):
         def get_campaigns(self):
             from temba.campaigns.models import CampaignEvent
             org = self.request.user.get_org()
-            events = CampaignEvent.objects.filter(campaign__org=org, is_active=True, campaign__is_active=True,
-                                                  flow__is_archived=False, flow__is_active=True, flow__flow_type=Flow.FLOW)
-            return events.values('campaign__name', 'campaign__id').annotate(count=Count('id')).order_by('campaign__name')
+            events = CampaignEvent.objects.filter(
+                campaign__org=org,
+                is_active=True,
+                campaign__is_active=True,
+                flow__is_archived=False,
+                flow__is_active=True,
+                flow__flow_type=Flow.FLOW
+            )
+            return events.values('campaign__name',
+                                 'campaign__id').annotate(count=Count('id')).order_by('campaign__name')
 
         def get_flow_labels(self):
             labels = []
             for label in FlowLabel.objects.filter(org=self.request.user.get_org(), parent=None):
-                labels.append(dict(pk=label.pk, label=label.name, count=label.get_flows_count(), children=label.children.all()))
+                labels.append(
+                    dict(pk=label.pk, label=label.name, count=label.get_flows_count(), children=label.children.all())
+                )
             return labels
 
         def get_folders(self):
             org = self.request.user.get_org()
 
             return [
-                dict(label="Active", url=reverse('flows.flow_list'),
-                     count=Flow.objects.exclude(flow_type=Flow.MESSAGE).filter(is_active=True,
-                                                                               is_archived=False,
-                                                                               org=org).count()),
-                dict(label="Archived", url=reverse('flows.flow_archived'),
-                     count=Flow.objects.exclude(flow_type=Flow.MESSAGE).filter(is_active=True,
-                                                                               is_archived=True,
-                                                                               org=org).count())
+                dict(
+                    label="Active",
+                    url=reverse('flows.flow_list'),
+                    count=Flow.objects.exclude(flow_type=Flow.MESSAGE).filter(
+                        is_active=True, is_archived=False, org=org
+                    ).count()
+                ),
+                dict(
+                    label="Archived",
+                    url=reverse('flows.flow_archived'),
+                    count=Flow.objects.exclude(flow_type=Flow.MESSAGE).filter(
+                        is_active=True, is_archived=True, org=org
+                    ).count()
+                )
             ]
 
     class Archived(BaseList):
-        actions = ('restore',)
-        default_order = ('-created_on',)
+        actions = ('restore', )
+        default_order = ('-created_on', )
 
         def derive_queryset(self, *args, **kwargs):
-            return super(FlowCRUDL.Archived, self).derive_queryset(*args, **kwargs).filter(is_active=True, is_archived=True)
+            return super(FlowCRUDL.Archived, self).derive_queryset(*args, **kwargs).filter(
+                is_active=True, is_archived=True
+            )
 
     class List(BaseList):
         title = _("Flows")
@@ -792,9 +829,9 @@ class FlowCRUDL(SmartCRUDL):
 
         def get_queryset(self, **kwargs):
             from temba.campaigns.models import CampaignEvent
-            flow_ids = CampaignEvent.objects.filter(campaign=self.get_campaign(),
-                                                    flow__is_archived=False,
-                                                    flow__flow_type=Flow.FLOW).values('flow__id')
+            flow_ids = CampaignEvent.objects.filter(
+                campaign=self.get_campaign(), flow__is_archived=False, flow__flow_type=Flow.FLOW
+            ).values('flow__id')
 
             flows = Flow.objects.filter(id__in=flow_ids).order_by('-modified_on')
             return flows
@@ -812,9 +849,7 @@ class FlowCRUDL(SmartCRUDL):
             links = []
 
             if self.has_org_perm('flows.flow_update'):
-                links.append(dict(title=_('Edit'),
-                                  href='#',
-                                  js_class="label-update-btn"))
+                links.append(dict(title=_('Edit'), href='#', js_class="label-update-btn"))
 
             if self.has_org_perm('flows.flow_delete'):
                 links.append(dict(title=_('Remove'), href="#", js_class='remove-label'))
@@ -869,12 +904,16 @@ class FlowCRUDL(SmartCRUDL):
                 dict(name='new_contact', display=six.text_type(_('New Contact')))
             ]
 
-            contact_variables += [dict(name="contact.%s" % scheme, display=six.text_type(_("Contact %s" % label)))
-                                  for scheme, label in ContactURN.SCHEME_CHOICES if scheme != TEL_SCHEME and scheme in
-                                  org.get_schemes(Channel.ROLE_SEND)]
+            contact_variables += [
+                dict(name="contact.%s" % scheme, display=six.text_type(_("Contact %s" % label)))
+                for scheme, label in ContactURN.SCHEME_CHOICES
+                if scheme != TEL_SCHEME and scheme in org.get_schemes(Channel.ROLE_SEND)
+            ]
 
-            contact_variables += [dict(name="contact.%s" % field.key, display=field.label) for field in
-                                  ContactField.objects.filter(org=org, is_active=True)]
+            contact_variables += [
+                dict(name="contact.%s" % field.key, display=field.label)
+                for field in ContactField.objects.filter(org=org, is_active=True)
+            ]
 
             date_variables = [
                 dict(name='date', display=six.text_type(_('Current Date and Time'))),
@@ -916,8 +955,9 @@ class FlowCRUDL(SmartCRUDL):
             function_completions = get_function_listing()
             messages_completions = contact_variables + date_variables + flow_variables
             messages_completions += parent_variables + child_variables
-            return JsonResponse(dict(message_completions=messages_completions,
-                                     function_completions=function_completions))
+            return JsonResponse(
+                dict(message_completions=messages_completions, function_completions=function_completions)
+            )
 
     class Read(OrgObjPermsMixin, SmartReadView):
         slug_url_kwarg = 'uuid'
@@ -941,7 +981,9 @@ class FlowCRUDL(SmartCRUDL):
             initial = flow.as_json(expand_contacts=True)
             initial['archived'] = self.object.is_archived
             context['initial'] = json.dumps(initial)
-            context['flows'] = Flow.objects.filter(org=org, is_active=True, flow_type__in=[Flow.FLOW, Flow.VOICE], is_archived=False)
+            context['flows'] = Flow.objects.filter(
+                org=org, is_active=True, flow_type__in=[Flow.FLOW, Flow.VOICE], is_archived=False
+            )
 
             if org:
                 languages = org.languages.all().order_by('orgs')
@@ -965,7 +1007,9 @@ class FlowCRUDL(SmartCRUDL):
             # are there pending starts?
             starting = False
             start = self.object.starts.all().order_by('-created_on')
-            if start.exists() and start[0].status in [FlowStart.STATUS_STARTING, FlowStart.STATUS_PENDING]:  # pragma: needs cover
+            if start.exists() and start[0].status in [
+                FlowStart.STATUS_STARTING, FlowStart.STATUS_PENDING
+            ]:  # pragma: needs cover
                 starting = True
             context['starting'] = starting
             context['has_ussd_channel'] = True if org and org.get_ussd_channel() else False
@@ -980,42 +1024,32 @@ class FlowCRUDL(SmartCRUDL):
                     and self.has_org_perm('flows.flow_broadcast') \
                     and not flow.is_archived:
 
-                links.append(dict(title=_("Start Flow"),
-                                  style='btn-primary',
-                                  js_class='broadcast-rulesflow',
-                                  href='#'))
+                links.append(
+                    dict(title=_("Start Flow"), style='btn-primary', js_class='broadcast-rulesflow', href='#')
+                )
 
             if self.has_org_perm('flows.flow_results'):
-                links.append(dict(title=_("Results"),
-                                  style='btn-primary',
-                                  href=reverse('flows.flow_results', args=[flow.id])))
+                links.append(
+                    dict(title=_("Results"), style='btn-primary', href=reverse('flows.flow_results', args=[flow.id]))
+                )
             if len(links) > 1:
                 links.append(dict(divider=True)),
 
             if self.has_org_perm('flows.flow_update'):
-                links.append(dict(title=_("Edit"),
-                                  js_class='update-rulesflow',
-                                  href='#'))
+                links.append(dict(title=_("Edit"), js_class='update-rulesflow', href='#'))
 
             if self.has_org_perm('flows.flow_copy'):
-                links.append(dict(title=_("Copy"),
-                                  posterize=True,
-                                  href=reverse('flows.flow_copy', args=[flow.id])))
+                links.append(dict(title=_("Copy"), posterize=True, href=reverse('flows.flow_copy', args=[flow.id])))
 
             if self.has_org_perm('orgs.org_export'):
-                links.append(dict(title=_("Export"),
-                                  href='%s?flow=%s' % (reverse('orgs.org_export'), flow.id)))
+                links.append(dict(title=_("Export"), href='%s?flow=%s' % (reverse('orgs.org_export'), flow.id)))
 
             if self.has_org_perm('flows.flow_revisions'):
                 links.append(dict(divider=True)),
-                links.append(dict(title=_("Revision History"),
-                                  ngClick='showRevisionHistory()',
-                                  href='#'))
+                links.append(dict(title=_("Revision History"), ngClick='showRevisionHistory()', href='#'))
 
             if self.has_org_perm('flows.flow_delete'):
-                links.append(dict(title=_('Delete'),
-                                  js_class='delete-flow',
-                                  href="#"))
+                links.append(dict(title=_('Delete'), js_class='delete-flow', href="#"))
 
             return links
 
@@ -1028,7 +1062,9 @@ class FlowCRUDL(SmartCRUDL):
             # are there pending starts?
             starting = False
             start = self.object.starts.all().order_by('-created_on')
-            if start.exists() and start[0].status in [FlowStart.STATUS_STARTING, FlowStart.STATUS_PENDING]:  # pragma: needs cover
+            if start.exists() and start[0].status in [
+                FlowStart.STATUS_STARTING, FlowStart.STATUS_PENDING
+            ]:  # pragma: needs cover
                 starting = True
             context['starting'] = starting
             context['mutable'] = False
@@ -1049,36 +1085,55 @@ class FlowCRUDL(SmartCRUDL):
 
     class ExportResults(ModalMixin, OrgPermsMixin, SmartFormView):
         class ExportForm(forms.Form):
-            flows = forms.ModelMultipleChoiceField(Flow.objects.filter(id__lt=0), required=True,
-                                                   widget=forms.MultipleHiddenInput())
-            contact_fields = forms.ModelMultipleChoiceField(ContactField.objects.filter(id__lt=0), required=False,
-                                                            help_text=_("Which contact fields, if any, to include "
-                                                                        "in the export"))
+            flows = forms.ModelMultipleChoiceField(
+                Flow.objects.filter(id__lt=0), required=True, widget=forms.MultipleHiddenInput()
+            )
+            contact_fields = forms.ModelMultipleChoiceField(
+                ContactField.objects.filter(id__lt=0),
+                required=False,
+                help_text=_("Which contact fields, if any, to include "
+                            "in the export")
+            )
 
-            extra_urns = forms.MultipleChoiceField(required=False, label=_("Extra URNs"),
-                                                   choices=ContactURN.EXPORT_SCHEME_HEADERS,
-                                                   help_text=_("Extra URNs to include in the export in addition to "
-                                                               "the URN used in the flow"))
+            extra_urns = forms.MultipleChoiceField(
+                required=False,
+                label=_("Extra URNs"),
+                choices=ContactURN.EXPORT_SCHEME_HEADERS,
+                help_text=_("Extra URNs to include in the export in addition to "
+                            "the URN used in the flow")
+            )
 
-            responded_only = forms.BooleanField(required=False, label=_("Responded Only"), initial=True,
-                                                help_text=_("Only export results for contacts which responded"))
-            include_messages = forms.BooleanField(required=False, label=_("Include Messages"),
-                                                  help_text=_("Export all messages sent and received in this flow"))
-            include_runs = forms.BooleanField(required=False, label=_("Include Runs"),
-                                              help_text=_("Include all runs for each contact. Leave unchecked for "
-                                                          "only their most recent runs"))
+            responded_only = forms.BooleanField(
+                required=False,
+                label=_("Responded Only"),
+                initial=True,
+                help_text=_("Only export results for contacts which responded")
+            )
+            include_messages = forms.BooleanField(
+                required=False,
+                label=_("Include Messages"),
+                help_text=_("Export all messages sent and received in this flow")
+            )
+            include_runs = forms.BooleanField(
+                required=False,
+                label=_("Include Runs"),
+                help_text=_("Include all runs for each contact. Leave unchecked for "
+                            "only their most recent runs")
+            )
 
             def __init__(self, user, *args, **kwargs):
                 super(FlowCRUDL.ExportResults.ExportForm, self).__init__(*args, **kwargs)
                 self.user = user
-                self.fields['contact_fields'].queryset = ContactField.objects.filter(org=self.user.get_org(),
-                                                                                     is_active=True)
+                self.fields['contact_fields'].queryset = ContactField.objects.filter(
+                    org=self.user.get_org(), is_active=True
+                )
                 self.fields['flows'].queryset = Flow.objects.filter(org=self.user.get_org(), is_active=True)
 
             def clean(self):
                 cleaned_data = super(FlowCRUDL.ExportResults.ExportForm, self).clean()
 
-                if 'contact_fields' in cleaned_data and len(cleaned_data['contact_fields']) > 10:  # pragma: needs cover
+                if 'contact_fields' in cleaned_data and len(cleaned_data['contact_fields']
+                                                            ) > 10:  # pragma: needs cover
                     raise forms.ValidationError(_("You can only include up to 10 contact fields in your export"))
 
                 return cleaned_data
@@ -1095,8 +1150,10 @@ class FlowCRUDL(SmartCRUDL):
         def derive_initial(self):
             flow_ids = self.request.GET.get('ids', None)
             if flow_ids:  # pragma: needs cover
-                return dict(flows=Flow.objects.filter(org=self.request.user.get_org(), is_active=True,
-                                                      id__in=flow_ids.split(',')))
+                return dict(
+                    flows=Flow.objects.
+                    filter(org=self.request.user.get_org(), is_active=True, id__in=flow_ids.split(','))
+                )
             else:
                 return dict()
 
@@ -1109,37 +1166,51 @@ class FlowCRUDL(SmartCRUDL):
             # is there already an export taking place?
             existing = ExportFlowResultsTask.get_recent_unfinished(org)
             if existing:
-                messages.info(self.request,
-                              _("There is already an export in progress, started by %s. You must wait "
-                                "for that export to complete before starting another." % existing.created_by.username))
+                messages.info(
+                    self.request,
+                    _(
+                        "There is already an export in progress, started by %s. You must wait "
+                        "for that export to complete before starting another." % existing.created_by.username
+                    )
+                )
             else:
-                export = ExportFlowResultsTask.create(org, user, form.cleaned_data['flows'],
-                                                      contact_fields=form.cleaned_data['contact_fields'],
-                                                      include_runs=form.cleaned_data['include_runs'],
-                                                      include_msgs=form.cleaned_data['include_messages'],
-                                                      responded_only=form.cleaned_data['responded_only'],
-                                                      extra_urns=form.cleaned_data['extra_urns'])
+                export = ExportFlowResultsTask.create(
+                    org,
+                    user,
+                    form.cleaned_data['flows'],
+                    contact_fields=form.cleaned_data['contact_fields'],
+                    include_runs=form.cleaned_data['include_runs'],
+                    include_msgs=form.cleaned_data['include_messages'],
+                    responded_only=form.cleaned_data['responded_only'],
+                    extra_urns=form.cleaned_data['extra_urns']
+                )
                 on_transaction_commit(lambda: export_flow_results_task.delay(export.pk))
 
                 if not getattr(settings, 'CELERY_ALWAYS_EAGER', False):  # pragma: needs cover
-                    messages.info(self.request,
-                                  _("We are preparing your export. We will e-mail you at %s when it is ready.")
-                                  % self.request.user.username)
+                    messages.info(
+                        self.request,
+                        _("We are preparing your export. We will e-mail you at %s when it is ready.") %
+                        self.request.user.username
+                    )
 
                 else:
                     export = ExportFlowResultsTask.objects.get(id=export.pk)
                     dl_url = reverse('assets.download', kwargs=dict(type='results_export', pk=export.pk))
-                    messages.info(self.request,
-                                  _("Export complete, you can find it here: %s (production users will get an email)")
-                                  % dl_url)
+                    messages.info(
+                        self.request,
+                        _("Export complete, you can find it here: %s (production users will get an email)") % dl_url
+                    )
 
             if 'HTTP_X_PJAX' not in self.request.META:
                 return HttpResponseRedirect(self.get_success_url())
             else:  # pragma: no cover
                 response = self.render_to_response(
-                    self.get_context_data(form=form,
-                                          success_url=self.get_success_url(),
-                                          success_script=getattr(self, 'success_script', None)))
+                    self.get_context_data(
+                        form=form,
+                        success_url=self.get_success_url(),
+                        success_script=getattr(self, 'success_script', None)
+                    )
+                )
                 response['Temba-Success'] = self.get_success_url()
                 response['REDIRECT'] = self.get_success_url()
                 return response
@@ -1175,12 +1246,18 @@ class FlowCRUDL(SmartCRUDL):
             for ruleset in rulesets:
                 from_uuids += [rule.uuid for rule in ruleset.get_rules()]
 
-            dates = FlowPathCount.objects.filter(flow=flow, from_uuid__in=from_uuids).aggregate(Max('period'), Min('period'))
+            dates = FlowPathCount.objects.filter(
+                flow=flow, from_uuid__in=from_uuids
+            ).aggregate(Max('period'), Min('period'))
             start_date = dates.get('period__min')
             end_date = dates.get('period__max')
 
             # by hour of the day
-            hod = FlowPathCount.objects.filter(flow=flow, from_uuid__in=from_uuids).extra({"hour": "extract(hour from period::timestamp)"})
+            hod = FlowPathCount.objects.filter(
+                flow=flow, from_uuid__in=from_uuids
+            ).extra({
+                "hour": "extract(hour from period::timestamp)"
+            })
             hod = hod.values('hour').annotate(count=Sum('count')).order_by('hour')
             hod_dict = {int(h.get('hour')): h.get('count') for h in hod}
 
@@ -1189,7 +1266,11 @@ class FlowCRUDL(SmartCRUDL):
                 hours.append({'bucket': datetime(1970, 1, 1, hour=x), 'count': hod_dict.get(x, 0)})
 
             # by day of the week
-            dow = FlowPathCount.objects.filter(flow=flow, from_uuid__in=from_uuids).extra({"day": "extract(dow from period::timestamp)"})
+            dow = FlowPathCount.objects.filter(
+                flow=flow, from_uuid__in=from_uuids
+            ).extra({
+                "day": "extract(dow from period::timestamp)"
+            })
             dow = dow.values('day').annotate(count=Sum('count'))
             dow_dict = {int(d.get('day')): d.get('count') for d in dow}
 
@@ -1201,9 +1282,14 @@ class FlowCRUDL(SmartCRUDL):
 
             if total_responses > self.PERIOD_MIN:
                 dow = sorted(dow, key=lambda k: k['day'])
-                days = (_('Sunday'), _('Monday'), _('Tuesday'), _('Wednesday'), _('Thursday'), _('Friday'), _('Saturday'))
-                dow = [{'day': days[d['day']], 'count': d['count'],
-                        'pct': 100 * float(d['count']) / float(total_responses)} for d in dow]
+                days = (
+                    _('Sunday'), _('Monday'), _('Tuesday'), _('Wednesday'), _('Thursday'), _('Friday'), _('Saturday')
+                )
+                dow = [{
+                    'day': days[d['day']],
+                    'count': d['count'],
+                    'pct': 100 * float(d['count']) / float(total_responses)
+                } for d in dow]
                 context['dow'] = dow
                 context['hod'] = hours
 
@@ -1269,9 +1355,18 @@ class FlowCRUDL(SmartCRUDL):
             contact_ids = []
             if query:
                 query = query.strip()
-                contact_ids = list(Contact.objects.filter(org=flow.org, name__icontains=query).exclude(id__in=test_contacts).values_list('id', flat=True))
+                contact_ids = list(
+                    Contact.objects.filter(org=flow.org, name__icontains=query).exclude(id__in=test_contacts
+                                                                                        ).values_list('id', flat=True)
+                )
                 query = query.replace("-", "")
-                contact_ids += list(ContactURN.objects.filter(org=flow.org, path__icontains=query).exclude(contact__in=test_contacts).order_by('contact__id').distinct('contact__id').values_list('contact__id', flat=True))
+                contact_ids += list(
+                    ContactURN.objects.filter(
+                        org=flow.org, path__icontains=query
+                    ).exclude(contact__in=test_contacts).order_by('contact__id').distinct('contact__id').values_list(
+                        'contact__id', flat=True
+                    )
+                )
                 runs = runs.filter(contact__in=contact_ids)
 
             # paginate
@@ -1290,8 +1385,10 @@ class FlowCRUDL(SmartCRUDL):
 
             # populate ruleset values
             for run in runs:
-                values = {v.ruleset.uuid: v for v in
-                          Value.objects.filter(run=run, ruleset__in=context['rulesets']).select_related('ruleset')}
+                values = {
+                    v.ruleset.uuid: v
+                    for v in Value.objects.filter(run=run, ruleset__in=context['rulesets']).select_related('ruleset')
+                }
                 run.value_list = []
                 for ruleset in context['rulesets']:
                     value = values.get(ruleset.uuid)
@@ -1303,7 +1400,6 @@ class FlowCRUDL(SmartCRUDL):
             return context
 
     class Results(OrgObjPermsMixin, SmartReadView):
-
         def get_context_data(self, *args, **kwargs):
             context = super(FlowCRUDL.Results, self).get_context_data(*args, **kwargs)
             flow = self.get_object()
@@ -1314,7 +1410,6 @@ class FlowCRUDL(SmartCRUDL):
             return context
 
     class Activity(OrgObjPermsMixin, SmartReadView):
-
         def get(self, request, *args, **kwargs):
             flow = self.get_object(self.get_queryset())
 
@@ -1335,8 +1430,11 @@ class FlowCRUDL(SmartCRUDL):
             messages = []
             call = IVRCall.objects.filter(contact__is_test=True).first()
             if call:
-                messages = Msg.objects.filter(contact=Contact.get_test_contact(self.request.user)).order_by('created_on')
-                action_logs = list(ActionLog.objects.filter(run__flow=flow, run__contact__is_test=True).order_by('created_on'))
+                messages = Msg.objects.filter(contact=Contact.get_test_contact(self.request.user)
+                                              ).order_by('created_on')
+                action_logs = list(
+                    ActionLog.objects.filter(run__flow=flow, run__contact__is_test=True).order_by('created_on')
+                )
 
                 messages_and_logs = chain(messages, action_logs)
                 messages_and_logs = sorted(messages_and_logs, key=cmp_to_key(msg_log_cmp))
@@ -1349,11 +1447,11 @@ class FlowCRUDL(SmartCRUDL):
 
             (active, visited) = flow.get_activity()
 
-            return JsonResponse(dict(messages=messages, activity=active, visited=visited,
-                                     flow=flow_json, pending=pending))
+            return JsonResponse(
+                dict(messages=messages, activity=active, visited=visited, flow=flow_json, pending=pending)
+            )
 
     class Simulate(OrgObjPermsMixin, SmartReadView):
-
         def get(self, request, *args, **kwargs):
             return HttpResponseRedirect(reverse('flows.flow_editor', args=[self.get_object().uuid]))
 
@@ -1440,27 +1538,32 @@ class FlowCRUDL(SmartCRUDL):
                             status = USSDSession.INTERRUPTED
                         else:
                             status = None
-                        USSDSession.handle_incoming(test_contact.org.get_ussd_channel(contact_urn=test_contact.get_urn(TEL_SCHEME)),
-                                                    test_contact.get_urn(TEL_SCHEME).path,
-                                                    content=new_message,
-                                                    contact=test_contact,
-                                                    date=timezone.now(),
-                                                    message_id=str(randint(0, 1000)),
-                                                    external_id='test',
-                                                    org=user.get_org(),
-                                                    status=status)
+                        USSDSession.handle_incoming(
+                            test_contact.org.get_ussd_channel(contact_urn=test_contact.get_urn(TEL_SCHEME)),
+                            test_contact.get_urn(TEL_SCHEME).path,
+                            content=new_message,
+                            contact=test_contact,
+                            date=timezone.now(),
+                            message_id=str(randint(0, 1000)),
+                            external_id='test',
+                            org=user.get_org(),
+                            status=status
+                        )
                     else:
-                        Msg.create_incoming(None,
-                                            six.text_type(test_contact.get_urn(TEL_SCHEME)),
-                                            new_message,
-                                            attachments=[media] if media else None,
-                                            org=user.get_org(),
-                                            status=PENDING)
+                        Msg.create_incoming(
+                            None,
+                            six.text_type(test_contact.get_urn(TEL_SCHEME)),
+                            new_message,
+                            attachments=[media] if media else None,
+                            org=user.get_org(),
+                            status=PENDING
+                        )
                 except Exception as e:  # pragma: needs cover
 
                     traceback.print_exc(e)
-                    return JsonResponse(dict(status="error", description="Error creating message: %s" % str(e)),
-                                        status=400)
+                    return JsonResponse(
+                        dict(status="error", description="Error creating message: %s" % str(e)), status=400
+                    )
 
             messages = Msg.objects.filter(contact=test_contact).order_by('pk', 'created_on')
 
@@ -1513,9 +1616,18 @@ class FlowCRUDL(SmartCRUDL):
                 channel_countries = []
 
             # all the channels available for our org
-            channels = [dict(uuid=chan.uuid, name=u"%s: %s" % (chan.get_channel_type_display(), chan.get_address_display())) for chan in flow.org.channels.filter(is_active=True)]
-            return JsonResponse(dict(flow=flow.as_json(expand_contacts=True), languages=languages,
-                                     channel_countries=channel_countries, channels=channels))
+            channels = [
+                dict(uuid=chan.uuid, name=u"%s: %s" % (chan.get_channel_type_display(), chan.get_address_display()))
+                for chan in flow.org.channels.filter(is_active=True)
+            ]
+            return JsonResponse(
+                dict(
+                    flow=flow.as_json(expand_contacts=True),
+                    languages=languages,
+                    channel_countries=channel_countries,
+                    channels=channels
+                )
+            )
 
         def post(self, request, *args, **kwargs):
 
@@ -1550,14 +1662,24 @@ class FlowCRUDL(SmartCRUDL):
                 super(FlowCRUDL.Broadcast.BroadcastForm, self).__init__(*args, **kwargs)
                 self.fields['omnibox'].set_user(self.user)
 
-            omnibox = OmniboxField(label=_("Contacts & Groups"),
-                                   help_text=_("These contacts will be added to the flow, sending the first message if appropriate."))
+            omnibox = OmniboxField(
+                label=_("Contacts & Groups"),
+                help_text=_("These contacts will be added to the flow, sending the first message if appropriate.")
+            )
 
-            restart_participants = forms.BooleanField(label=_("Restart Participants"), required=False, initial=False,
-                                                      help_text=_("Restart any contacts already participating in this flow"))
+            restart_participants = forms.BooleanField(
+                label=_("Restart Participants"),
+                required=False,
+                initial=False,
+                help_text=_("Restart any contacts already participating in this flow")
+            )
 
-            include_active = forms.BooleanField(label=_("Include Active Contacts"), required=False, initial=False,
-                                                help_text=_("Include contacts currently active in a flow"))
+            include_active = forms.BooleanField(
+                label=_("Include Active Contacts"),
+                required=False,
+                initial=False,
+                help_text=_("Include contacts currently active in a flow")
+            )
 
             def clean_omnibox(self):
                 starting = self.cleaned_data['omnibox']
@@ -1570,11 +1692,20 @@ class FlowCRUDL(SmartCRUDL):
                 cleaned = super(FlowCRUDL.Broadcast.BroadcastForm, self).clean()
 
                 # check whether there are any flow starts that are incomplete
-                if FlowStart.objects.filter(flow=self.flow).exclude(status__in=[FlowStart.STATUS_COMPLETE, FlowStart.STATUS_FAILED]):
-                    raise ValidationError(_("This flow is already being started, please wait until that process is complete before starting more contacts."))
+                if FlowStart.objects.filter(flow=self.flow
+                                            ).exclude(status__in=[FlowStart.STATUS_COMPLETE, FlowStart.STATUS_FAILED]):
+                    raise ValidationError(
+                        _(
+                            "This flow is already being started, please wait until that process is complete before starting more contacts."
+                        )
+                    )
 
                 if self.flow.org.is_suspended():
-                    raise ValidationError(_("Sorry, your account is currently suspended. To enable sending messages, please contact support."))
+                    raise ValidationError(
+                        _(
+                            "Sorry, your account is currently suspended. To enable sending messages, please contact support."
+                        )
+                    )
 
                 return cleaned
 
@@ -1609,27 +1740,33 @@ class FlowCRUDL(SmartCRUDL):
             # save off our broadcast info
             omnibox = form.cleaned_data['omnibox']
 
-            analytics.track(self.request.user.username, 'temba.flow_broadcast',
-                            dict(contacts=len(omnibox['contacts']), groups=len(omnibox['groups'])))
+            analytics.track(
+                self.request.user.username, 'temba.flow_broadcast',
+                dict(contacts=len(omnibox['contacts']), groups=len(omnibox['groups']))
+            )
 
             # activate all our contacts
-            flow.async_start(self.request.user,
-                             list(omnibox['groups']), list(omnibox['contacts']),
-                             restart_participants=form.cleaned_data['restart_participants'],
-                             include_active=form.cleaned_data['include_active'])
+            flow.async_start(
+                self.request.user,
+                list(omnibox['groups']),
+                list(omnibox['contacts']),
+                restart_participants=form.cleaned_data['restart_participants'],
+                include_active=form.cleaned_data['include_active']
+            )
             return flow
 
 
 # this is just for adhoc testing of the preprocess url
 class PreprocessTest(FormView):  # pragma: no cover
-
     @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super(PreprocessTest, self).dispatch(*args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        return HttpResponse(json.dumps(dict(text='Norbert', extra=dict(occupation='hoopster', skillz=7.9))),
-                            content_type='application/json')
+        return HttpResponse(
+            json.dumps(dict(text='Norbert', extra=dict(occupation='hoopster', skillz=7.9))),
+            content_type='application/json'
+        )
 
 
 class FlowLabelForm(forms.ModelForm):

--- a/temba/formax.py
+++ b/temba/formax.py
@@ -9,7 +9,6 @@ from orgs.context_processors import user_group_perms_processor
 
 
 class FormaxMixin(object):
-
     def derive_formax_sections(self, formax, context):  # pragma: needs cover
         return None
 
@@ -24,7 +23,6 @@ class FormaxMixin(object):
 
 
 class Formax(object):
-
     def __init__(self, request):
         self.sections = []
         self.request = request
@@ -47,8 +45,18 @@ class Formax(object):
         # redirects don't do us any good
         if not isinstance(response, HttpResponseRedirect):
             response.render()
-            self.sections.append(dict(name=name, url=url, response=response.content,
-                                      icon=icon, action=action, button=button, nobutton=nobutton, dependents=dependents))
+            self.sections.append(
+                dict(
+                    name=name,
+                    url=url,
+                    response=response.content,
+                    icon=icon,
+                    action=action,
+                    button=button,
+                    nobutton=nobutton,
+                    dependents=dependents
+                )
+            )
 
         if settings.DEBUG:
             print("%s took: %f" % (url, time.time() - start))

--- a/temba/ivr/clients.py
+++ b/temba/ivr/clients.py
@@ -26,7 +26,6 @@ class IVRException(Exception):
 
 
 class NexmoClient(NexmoCli):
-
     def __init__(self, api_key, api_secret, app_id, app_private_key, org=None):
         self.org = org
         NexmoCli.__init__(self, api_key, api_secret, app_id, app_private_key)
@@ -75,7 +74,9 @@ class NexmoClient(NexmoCli):
                 ChannelLog.log_ivr_interaction(call, 'Started call', event)
 
         except Exception as e:
-            event = HttpEvent('POST', 'https://api.nexmo.com/v1/calls', json.dumps(params), response_body=six.text_type(e))
+            event = HttpEvent(
+                'POST', 'https://api.nexmo.com/v1/calls', json.dumps(params), response_body=six.text_type(e)
+            )
             ChannelLog.log_ivr_interaction(call, 'Call start failed', event, is_error=True)
 
             call.status = IVRCall.FAILED
@@ -120,7 +121,6 @@ class NexmoClient(NexmoCli):
 
 
 class TwilioClient(TembaTwilioRestClient):
-
     def __init__(self, account, token, org=None, **kwargs):
         self.org = org
         super(TwilioClient, self).__init__(account=account, token=token, **kwargs)
@@ -130,10 +130,9 @@ class TwilioClient(TembaTwilioRestClient):
             raise IVRException("SEND_CALLS set to False, skipping call start")
 
         try:
-            twilio_call = self.calls.create(to=to,
-                                            from_=call.channel.address,
-                                            url=status_callback,
-                                            status_callback=status_callback)
+            twilio_call = self.calls.create(
+                to=to, from_=call.channel.address, url=status_callback, status_callback=status_callback
+            )
             call.external_id = six.text_type(twilio_call.sid)
             call.save()
 
@@ -187,7 +186,6 @@ class TwilioClient(TembaTwilioRestClient):
 
 
 class VerboiceClient:  # pragma: needs cover
-
     def __init__(self, channel):
         self.endpoint = 'https://verboice.instedd.org/api/call'
 

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -27,15 +27,28 @@ class IVRCall(ChannelSession):
 
     @classmethod
     def create_outgoing(cls, channel, contact, contact_urn, user):
-        return IVRCall.objects.create(channel=channel, contact=contact, contact_urn=contact_urn,
-                                      direction=IVRCall.OUTGOING, org=channel.org,
-                                      created_by=user, modified_by=user)
+        return IVRCall.objects.create(
+            channel=channel,
+            contact=contact,
+            contact_urn=contact_urn,
+            direction=IVRCall.OUTGOING,
+            org=channel.org,
+            created_by=user,
+            modified_by=user
+        )
 
     @classmethod
     def create_incoming(cls, channel, contact, contact_urn, user, external_id):
-        return IVRCall.objects.create(channel=channel, contact=contact, contact_urn=contact_urn,
-                                      direction=IVRCall.INCOMING, org=channel.org, created_by=user,
-                                      modified_by=user, external_id=external_id)
+        return IVRCall.objects.create(
+            channel=channel,
+            contact=contact,
+            contact_urn=contact_urn,
+            direction=IVRCall.INCOMING,
+            org=channel.org,
+            created_by=user,
+            modified_by=user,
+            external_id=external_id
+        )
 
     @classmethod
     def hangup_test_call(cls, flow):

--- a/temba/ivr/views.py
+++ b/temba/ivr/views.py
@@ -15,7 +15,6 @@ from temba.flows.models import Flow, FlowRun, FlowStep
 
 
 class CallHandler(View):
-
     @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super(CallHandler, self).dispatch(*args, **kwargs)
@@ -31,7 +30,7 @@ class CallHandler(View):
 
         channel = call.channel
 
-        if not(channel.is_active and channel.org):
+        if not (channel.is_active and channel.org):
             return HttpResponse("No channel found", status=400)
 
         channel_type = channel.channel_type
@@ -128,7 +127,9 @@ class CallHandler(View):
 
             if not has_event and call.status not in IVRCall.DONE or hangup:
                 if call.is_ivr():
-                    response = Flow.handle_call(call, text=text, saved_media_url=saved_media_url, hangup=hangup, resume=resume)
+                    response = Flow.handle_call(
+                        call, text=text, saved_media_url=saved_media_url, hangup=hangup, resume=resume
+                    )
                     event = HttpEvent(request_method, request_path, request_body, 200, six.text_type(response))
                     if ivr_protocol == ChannelType.IVRProtocol.IVR_PROTOCOL_NCCO:
                         ChannelLog.log_ivr_interaction(call, "Incoming request for call", event)
@@ -148,8 +149,10 @@ class CallHandler(View):
                             final_step = FlowStep.objects.filter(run=run).order_by('-arrived_on').first()
                             run.set_completed(final_step=final_step)
 
-                response = dict(description="Updated call status",
-                                call=dict(status=call.get_status_display(), duration=call.duration))
+                response = dict(
+                    description="Updated call status",
+                    call=dict(status=call.get_status_display(), duration=call.duration)
+                )
 
                 event = HttpEvent(request_method, request_path, request_body, 200, json.dumps(response))
                 ChannelLog.log_ivr_interaction(call, "Updated call status", event)

--- a/temba/locations/management/commands/download_geojson.py
+++ b/temba/locations/management/commands/download_geojson.py
@@ -12,13 +12,25 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('relation_ids', nargs='+')
-        parser.add_argument('--oauth-token', dest='oauth_token', default=None,
-                            help='The OAuth token to use when authenticating to GitHub. Unauthenticated requests are '
-                                 'rate limited to 60 per hour. Defaults to None')
-        parser.add_argument('--repo', dest='repo', default='nyaruka/posm-extracts',
-                            help="The GitHub posm-extracts repo to use. Defaults to nyaruka/posm-extracts")
-        parser.add_argument('--dir', dest='dir', default='geojson',
-                            help='The directory to write the geojson files to. Defaults to `geojson`')
+        parser.add_argument(
+            '--oauth-token',
+            dest='oauth_token',
+            default=None,
+            help='The OAuth token to use when authenticating to GitHub. Unauthenticated requests are '
+            'rate limited to 60 per hour. Defaults to None'
+        )
+        parser.add_argument(
+            '--repo',
+            dest='repo',
+            default='nyaruka/posm-extracts',
+            help="The GitHub posm-extracts repo to use. Defaults to nyaruka/posm-extracts"
+        )
+        parser.add_argument(
+            '--dir',
+            dest='dir',
+            default='geojson',
+            help='The directory to write the geojson files to. Defaults to `geojson`'
+        )
 
     def handle(self, *args, **options):
 
@@ -28,29 +40,33 @@ class Command(BaseCommand):
         oauth_token = options['oauth_token']
 
         if oauth_token:
-            headers = {
-                'Authorization': 'token %s' % (oauth_token,)
-            }
+            headers = {'Authorization': 'token %s' % (oauth_token, )}
         else:
             headers = {}
 
-        data = requests.get(
-            "https://api.github.com/repos/%s/git/trees/master" % (repo,), headers=headers).json()
+        data = requests.get("https://api.github.com/repos/%s/git/trees/master" % (repo, ), headers=headers).json()
         [geojson] = filter(lambda obj: obj['path'] == "geojson", data['tree'])
         geojson_sha = geojson['sha']
 
-        files = requests.get('https://api.github.com/repos/%s/git/trees/%s' % (repo, geojson_sha,),
-                             headers=headers).json()
+        files = requests.get(
+            'https://api.github.com/repos/%s/git/trees/%s' % (
+                repo,
+                geojson_sha,
+            ), headers=headers
+        ).json()
 
         if not os.path.exists(destination_dir):
             os.makedirs(destination_dir)
 
         for relation_id in relation_ids:
             relation_files = filter(
-                lambda obj: regex.match(r'R%s.*_simplified.json' % (relation_id,), obj['path']), files['tree'])
+                lambda obj: regex.match(r'R%s.*_simplified.json' % (relation_id, ), obj['path']), files['tree']
+            )
             for relation_file in relation_files:
                 destination = os.path.join(destination_dir, relation_file['path'])
                 with open(destination, 'w') as fp:
-                    response = requests.get('https://raw.githubusercontent.com/%s/master/geojson/%s' % (
-                                            repo, relation_file['path']), headers=headers)
+                    response = requests.get(
+                        'https://raw.githubusercontent.com/%s/master/geojson/%s' % (repo, relation_file['path']),
+                        headers=headers
+                    )
                     fp.write(response.content)

--- a/temba/locations/management/commands/import_geojson.py
+++ b/temba/locations/management/commands/import_geojson.py
@@ -15,10 +15,9 @@ class Command(BaseCommand):  # pragma: no cover
 
     def add_arguments(self, parser):
         parser.add_argument('files', nargs='+')
-        parser.add_argument('--country',
-                            dest='country',
-                            default=None,
-                            help="Only process the boundary files for this country osm id")
+        parser.add_argument(
+            '--country', dest='country', default=None, help="Only process the boundary files for this country osm id"
+        )
 
     def import_file(self, filename, file):
         admin_json = geojson.loads(file.read())
@@ -30,8 +29,7 @@ class Command(BaseCommand):  # pragma: no cover
 
         # parse our filename.. they are in the format:
         # 192787admin2_simplified.json
-        match = regex.match(
-            r'(\w\d+)admin(\d)(_simplified)?\.json$', filename, regex.V0)
+        match = regex.match(r'(\w\d+)admin(\d)(_simplified)?\.json$', filename, regex.V0)
         level = None
         is_simplified = None
         if match:
@@ -40,8 +38,7 @@ class Command(BaseCommand):  # pragma: no cover
         else:
             # else parse other filenames that are in
             # admin_level_0_simplified.json format.
-            match = regex.match(
-                r'admin_level_(\d)(_simplified)?\.json$', filename, regex.V0)
+            match = regex.match(r'admin_level_(\d)(_simplified)?\.json$', filename, regex.V0)
             if match:
                 level = int(match.group(1))
                 is_simplified = True if match.group(2) else False
@@ -74,8 +71,7 @@ class Command(BaseCommand):  # pragma: no cover
             if parent_osm_id and parent_osm_id != 'None':
                 parent = AdminBoundary.objects.filter(osm_id=parent_osm_id).first()
                 if not parent:
-                    print("Skipping %s (%s) as parent %s not found." %
-                          (name, osm_id, parent_osm_id))
+                    print("Skipping %s (%s) as parent %s not found." % (name, osm_id, parent_osm_id))
                     continue
 
             # try to find existing admin level by osm_id
@@ -96,8 +92,7 @@ class Command(BaseCommand):  # pragma: no cover
                 for polygon in feature['geometry']['coordinates']:
                     polygons.append(Polygon(*polygon))
             else:
-                raise Exception("Error importing %s, unknown geometry type '%s'" % (
-                    name, feature['geometry']['type']))
+                raise Exception("Error importing %s, unknown geometry type '%s'" % (name, feature['geometry']['type']))
 
             geometry = MultiPolygon(polygons)
 

--- a/temba/locations/models.py
+++ b/temba/locations/models.py
@@ -26,22 +26,30 @@ class AdminBoundary(MPTTModel, models.Model):
     # being very unlikely to show up in an admin boundary name.
     PATH_SEPARATOR = '>'
 
-    osm_id = models.CharField(max_length=15, unique=True,
-                              help_text="This is the OSM id for this administrative boundary")
+    osm_id = models.CharField(
+        max_length=15, unique=True, help_text="This is the OSM id for this administrative boundary"
+    )
 
-    name = models.CharField(max_length=128,
-                            help_text="The name of our administrative boundary")
+    name = models.CharField(max_length=128, help_text="The name of our administrative boundary")
 
-    level = models.IntegerField(help_text="The level of the boundary, 0 for country, 1 for state, 2 for district, 3 for ward")
+    level = models.IntegerField(
+        help_text="The level of the boundary, 0 for country, 1 for state, 2 for district, 3 for ward"
+    )
 
-    parent = TreeForeignKey('self', null=True, blank=True, related_name='children', db_index=True,
-                            help_text="The parent to this political boundary if any")
+    parent = TreeForeignKey(
+        'self',
+        null=True,
+        blank=True,
+        related_name='children',
+        db_index=True,
+        help_text="The parent to this political boundary if any"
+    )
 
-    geometry = models.MultiPolygonField(null=True,
-                                        help_text="The full geometry of this administrative boundary")
+    geometry = models.MultiPolygonField(null=True, help_text="The full geometry of this administrative boundary")
 
-    simplified_geometry = models.MultiPolygonField(null=True,
-                                                   help_text="The simplified geometry of this administrative boundary")
+    simplified_geometry = models.MultiPolygonField(
+        null=True, help_text="The simplified geometry of this administrative boundary"
+    )
 
     objects = models.GeoManager()
 
@@ -52,8 +60,7 @@ class AdminBoundary(MPTTModel, models.Model):
         return geojson.dumps(feature_collection)
 
     def as_json(self):
-        result = dict(osm_id=self.osm_id, name=self.name,
-                      level=self.level, aliases='')
+        result = dict(osm_id=self.osm_id, name=self.name, level=self.level, aliases='')
 
         if self.parent:
             result['parent_osm_id'] = self.parent.osm_id
@@ -63,9 +70,11 @@ class AdminBoundary(MPTTModel, models.Model):
         return result
 
     def get_geojson_feature(self):
-        return geojson.Feature(properties=dict(name=self.name, osm_id=self.osm_id, id=self.pk, level=self.level),
-                               zoomable=True if self.children.all() else False,
-                               geometry=None if not self.simplified_geometry else geojson.loads(self.simplified_geometry.geojson))
+        return geojson.Feature(
+            properties=dict(name=self.name, osm_id=self.osm_id, id=self.pk, level=self.level),
+            zoomable=True if self.children.all() else False,
+            geometry=None if not self.simplified_geometry else geojson.loads(self.simplified_geometry.geojson)
+        )
 
     def get_geojson(self):
         return AdminBoundary.get_geojson_dump([self.get_geojson_feature()])
@@ -82,7 +91,10 @@ class AdminBoundary(MPTTModel, models.Model):
         each level.
         """
         if self.parent:
-            return "%s %s %s" % (self.parent.as_path(), AdminBoundary.PATH_SEPARATOR, self.name.replace(AdminBoundary.PATH_SEPARATOR, " "))
+            return "%s %s %s" % (
+                self.parent.as_path(), AdminBoundary.PATH_SEPARATOR,
+                self.name.replace(AdminBoundary.PATH_SEPARATOR, " ")
+            )
         else:
             return self.name.replace(AdminBoundary.PATH_SEPARATOR, " ")
 
@@ -109,7 +121,9 @@ class BoundaryAlias(SmartModel):
     """
     name = models.CharField(max_length=128, help_text="The name for our alias")
 
-    boundary = models.ForeignKey(AdminBoundary, help_text='The admin boundary this alias applies to', related_name='aliases')
+    boundary = models.ForeignKey(
+        AdminBoundary, help_text='The admin boundary this alias applies to', related_name='aliases'
+    )
 
     org = models.ForeignKey('orgs.Org', help_text="The org that owns this alias")
 

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -12,7 +12,6 @@ from temba.contacts.models import Contact
 
 
 class ExceptionMiddleware(object):
-
     def process_exception(self, request, exception):
         if settings.DEBUG:
             traceback.print_exc(exception)
@@ -24,6 +23,7 @@ class OrgHeaderMiddleware(object):
     """
     Simple middleware to add a response header with the current org id, which can then be included in logs
     """
+
     def process_response(self, request, response):
         # if we have a user, log our org id
         if hasattr(request, 'user') and request.user.is_authenticated():
@@ -34,7 +34,6 @@ class OrgHeaderMiddleware(object):
 
 
 class BrandingMiddleware(object):
-
     @classmethod
     def get_branding_for_host(cls, host):
 
@@ -73,7 +72,6 @@ class BrandingMiddleware(object):
 
 
 class ActivateLanguageMiddleware(object):
-
     def process_request(self, request):
         user = request.user
         language = request.branding.get('language', settings.DEFAULT_LANGUAGE)
@@ -86,7 +84,6 @@ class ActivateLanguageMiddleware(object):
 
 
 class OrgTimezoneMiddleware(object):
-
     def process_request(self, request):
         user = request.user
         org = None
@@ -103,7 +100,8 @@ class OrgTimezoneMiddleware(object):
 
             # otherwise, show them what orgs are available
             else:
-                user_orgs = user.org_admins.all() | user.org_editors.all() | user.org_viewers.all() | user.org_surveyors.all()
+                user_orgs = user.org_admins.all() | user.org_editors.all() | user.org_viewers.all(
+                ) | user.org_surveyors.all()
                 user_orgs = user_orgs.distinct('pk')
 
                 if user_orgs.count() == 1:
@@ -123,6 +121,7 @@ class FlowSimulationMiddleware(object):
     """
     Resets Contact.set_simulation(False) for every request
     """
+
     def process_request(self, request):
         Contact.set_simulation(False)
         return None
@@ -146,13 +145,14 @@ class ProfilerMiddleware(object):  # pragma: no cover
     This is adapted from an example found here:
     http://www.slideshare.net/zeeg/django-con-high-performance-django-presentation.
     """
+
     def can(self, request):
         return settings.DEBUG and 'prof' in request.GET
 
     def process_view(self, request, callback, callback_args, callback_kwargs):
         if self.can(request):
             self.profiler = cProfile.Profile()
-            args = (request,) + callback_args
+            args = (request, ) + callback_args
             return self.profiler.runcall(callback, *args, **callback_kwargs)
 
     def process_response(self, request, response):

--- a/temba/msgs/handler.py
+++ b/temba/msgs/handler.py
@@ -10,6 +10,7 @@ class MessageHandler(object):  # pragma: no cover
     """
     Base class for message handlers.
     """
+
     def __init__(self, name):
         self.name = name
 

--- a/temba/msgs/management/commands/msg_console.py
+++ b/temba/msgs/management/commands/msg_console.py
@@ -10,7 +10,6 @@ from temba.orgs.models import Org
 from temba.msgs.models import Msg, OUTGOING
 import six
 
-
 DEFAULT_ORG = '1'
 DEFAULT_URN = "tel:+250788123123"
 
@@ -37,6 +36,7 @@ class MessageConsole(cmd.Cmd):
     Useful REPL'like utility to simulate sending messages into RapidPro. Mostly useful for testing things
     with real contacts across multiple flows and contacts where the simulator isn't enough.
     """
+
     def __init__(self, org, urn, *args, **kwargs):
         cmd.Cmd.__init__(self, *args, **kwargs)
 
@@ -110,15 +110,18 @@ class MessageConsole(cmd.Cmd):
         """
         urn = self.contact.get_urn()
 
-        incoming = Msg.create_incoming(None, URN.from_parts(urn.scheme, urn.path),
-                                       line, date=timezone.now(), org=self.org)
+        incoming = Msg.create_incoming(
+            None, URN.from_parts(urn.scheme, urn.path), line, date=timezone.now(), org=self.org
+        )
 
-        self.echo((Fore.GREEN + "[%s] " + Fore.YELLOW + ">>" + Fore.MAGENTA + " %s" + Fore.WHITE) % (six.text_type(urn), incoming.text))
+        self.echo((Fore.GREEN + "[%s] " + Fore.YELLOW + ">>" + Fore.MAGENTA + " %s" + Fore.WHITE) %
+                  (six.text_type(urn), incoming.text))
 
         # look up any message responses
         outgoing = Msg.objects.filter(org=self.org, pk__gt=incoming.pk, direction=OUTGOING).order_by('sent_on')
         for response in outgoing:
-            self.echo((Fore.GREEN + "[%s] " + Fore.YELLOW + "<<" + Fore.MAGENTA + " %s" + Fore.WHITE) % (six.text_type(urn), response.text))
+            self.echo((Fore.GREEN + "[%s] " + Fore.YELLOW + "<<" + Fore.MAGENTA + " %s" + Fore.WHITE) %
+                      (six.text_type(urn), response.text))
 
     def do_EOF(self, line):
         """
@@ -134,13 +137,24 @@ class MessageConsole(cmd.Cmd):
 
 
 class Command(BaseCommand):  # pragma: no cover
-
     def add_arguments(self, parser):
-        parser.add_argument('--org', type=str, action='store', dest='org', default=DEFAULT_ORG,
-                            help="The id or name of the organization to send messages for")
+        parser.add_argument(
+            '--org',
+            type=str,
+            action='store',
+            dest='org',
+            default=DEFAULT_ORG,
+            help="The id or name of the organization to send messages for"
+        )
 
-        parser.add_argument('--urn', type=str, action='store', dest='urn', default=DEFAULT_URN,
-                            help="The URN of the contact to send messages for")
+        parser.add_argument(
+            '--urn',
+            type=str,
+            action='store',
+            dest='urn',
+            default=DEFAULT_URN,
+            help="The URN of the contact to send messages for"
+        )
 
     def handle(self, *args, **options):
         colorama_init()
@@ -154,6 +168,7 @@ class Command(BaseCommand):  # pragma: no cover
         intro += "Change contact with the contact command, ex: " + Fore.YELLOW + "contact tel:+250788124124" + Fore.WHITE + "\n"
         intro += "Exit with the " + Fore.YELLOW + "exit" + Fore.WHITE + " command\n\n"
 
-        intro += ("Currently sending messages for %s [%d] as " + Fore.CYAN + "%s" + Fore.WHITE) % (org.name, org.id, urn)
+        intro += ("Currently sending messages for %s [%d] as " + Fore.CYAN + "%s" + Fore.WHITE
+                  ) % (org.name, org.id, urn)
 
         MessageConsole(org, urn).cmdloop(intro=intro)

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -79,21 +79,19 @@ MSG_SENT_KEY = 'msgs_sent_%y_%m_%d'
 STATUS_CONFIG = (
     # special state for flows used to hold off sending the message until the flow is ready to receive a response
     (INITIALIZING, _("Initializing"), 'initializing'),
-
-    (PENDING, _("Pending"), 'pending'),        # initial state for all messages
+    (PENDING, _("Pending"), 'pending'),  # initial state for all messages
 
     # valid only for outgoing messages
     (QUEUED, _("Queued"), 'queued'),
-    (WIRED, _("Wired"), 'wired'),              # message was handed off to the provider and credits were deducted for it
-    (SENT, _("Sent"), 'sent'),                 # we have confirmation that a message was sent
+    (WIRED, _("Wired"), 'wired'),  # message was handed off to the provider and credits were deducted for it
+    (SENT, _("Sent"), 'sent'),  # we have confirmation that a message was sent
     (DELIVERED, _("Delivered"), 'delivered'),
 
     # valid only for incoming messages
     (HANDLED, _("Handled"), 'handled'),
-
     (ERRORED, _("Error Sending"), 'errored'),  # there was an error during delivery
-    (FAILED, _("Failed Sending"), 'failed'),   # we gave up on sending this message
-    (RESENT, _("Resent message"), 'resent'),   # we retried this message
+    (FAILED, _("Failed Sending"), 'failed'),  # we gave up on sending this message
+    (RESENT, _("Resent message"), 'resent'),  # we retried this message
 )
 
 
@@ -155,8 +153,9 @@ class BroadcastRecipient(models.Model):
 
     contact = models.ForeignKey(Contact)
 
-    purged_status = models.CharField(null=True, max_length=1,
-                                     help_text=_("Used when broadcast is purged to record contact's message's state"))
+    purged_status = models.CharField(
+        null=True, max_length=1, help_text=_("Used when broadcast is purged to record contact's message's state")
+    )
 
     class Meta:
         db_table = 'msgs_broadcast_recipients'
@@ -173,67 +172,109 @@ class Broadcast(models.Model):
 
     MAX_TEXT_LEN = settings.MSG_FIELD_SIZE
 
-    org = models.ForeignKey(Org, verbose_name=_("Org"),
-                            help_text=_("The org this broadcast is connected to"))
+    org = models.ForeignKey(Org, verbose_name=_("Org"), help_text=_("The org this broadcast is connected to"))
 
-    groups = models.ManyToManyField(ContactGroup, verbose_name=_("Groups"), related_name='addressed_broadcasts',
-                                    help_text=_("The groups to send the message to"))
+    groups = models.ManyToManyField(
+        ContactGroup,
+        verbose_name=_("Groups"),
+        related_name='addressed_broadcasts',
+        help_text=_("The groups to send the message to")
+    )
 
-    contacts = models.ManyToManyField(Contact, verbose_name=_("Contacts"), related_name='addressed_broadcasts',
-                                      help_text=_("Individual contacts included in this message"))
+    contacts = models.ManyToManyField(
+        Contact,
+        verbose_name=_("Contacts"),
+        related_name='addressed_broadcasts',
+        help_text=_("Individual contacts included in this message")
+    )
 
-    urns = models.ManyToManyField(ContactURN, verbose_name=_("URNs"), related_name='addressed_broadcasts',
-                                  help_text=_("Individual URNs included in this message"))
+    urns = models.ManyToManyField(
+        ContactURN,
+        verbose_name=_("URNs"),
+        related_name='addressed_broadcasts',
+        help_text=_("Individual URNs included in this message")
+    )
 
-    recipients = models.ManyToManyField(Contact, through=BroadcastRecipient, verbose_name=_("Recipients"),
-                                        related_name='broadcasts',
-                                        help_text=_("The contacts which received this message"))
+    recipients = models.ManyToManyField(
+        Contact,
+        through=BroadcastRecipient,
+        verbose_name=_("Recipients"),
+        related_name='broadcasts',
+        help_text=_("The contacts which received this message")
+    )
 
-    recipient_count = models.IntegerField(verbose_name=_("Number of recipients"), null=True,
-                                          help_text=_("Number of urns which received this broadcast"))
+    recipient_count = models.IntegerField(
+        verbose_name=_("Number of recipients"), null=True, help_text=_("Number of urns which received this broadcast")
+    )
 
-    channel = models.ForeignKey(Channel, null=True, verbose_name=_("Channel"),
-                                help_text=_("Channel to use for message sending"))
+    channel = models.ForeignKey(
+        Channel, null=True, verbose_name=_("Channel"), help_text=_("Channel to use for message sending")
+    )
 
-    status = models.CharField(max_length=1, verbose_name=_("Status"), choices=STATUS_CHOICES, default=INITIALIZING,
-                              help_text=_("The current status for this broadcast"))
+    status = models.CharField(
+        max_length=1,
+        verbose_name=_("Status"),
+        choices=STATUS_CHOICES,
+        default=INITIALIZING,
+        help_text=_("The current status for this broadcast")
+    )
 
-    schedule = models.OneToOneField(Schedule, verbose_name=_("Schedule"), null=True,
-                                    help_text=_("Our recurring schedule if we have one"), related_name="broadcast")
+    schedule = models.OneToOneField(
+        Schedule,
+        verbose_name=_("Schedule"),
+        null=True,
+        help_text=_("Our recurring schedule if we have one"),
+        related_name="broadcast"
+    )
 
     parent = models.ForeignKey('Broadcast', verbose_name=_("Parent"), null=True, related_name='children')
 
-    text = TranslatableField(verbose_name=_("Translations"), max_length=MAX_TEXT_LEN,
-                             help_text=_("The localized versions of the message text"))
+    text = TranslatableField(
+        verbose_name=_("Translations"),
+        max_length=MAX_TEXT_LEN,
+        help_text=_("The localized versions of the message text")
+    )
 
-    base_language = models.CharField(max_length=4,
-                                     help_text=_('The language used to send this to contacts without a language'))
+    base_language = models.CharField(
+        max_length=4, help_text=_('The language used to send this to contacts without a language')
+    )
 
     is_active = models.BooleanField(default=True, help_text="Whether this broadcast is active")
 
-    created_by = models.ForeignKey(User, related_name="%(app_label)s_%(class)s_creations",
-                                   help_text="The user which originally created this item")
+    created_by = models.ForeignKey(
+        User,
+        related_name="%(app_label)s_%(class)s_creations",
+        help_text="The user which originally created this item"
+    )
 
-    created_on = models.DateTimeField(default=timezone.now, blank=True, editable=False, db_index=True,
-                                      help_text=_("When this broadcast was created"))
+    created_on = models.DateTimeField(
+        default=timezone.now,
+        blank=True,
+        editable=False,
+        db_index=True,
+        help_text=_("When this broadcast was created")
+    )
 
-    modified_by = models.ForeignKey(User, related_name="%(app_label)s_%(class)s_modifications",
-                                    help_text="The user which last modified this item")
+    modified_by = models.ForeignKey(
+        User, related_name="%(app_label)s_%(class)s_modifications", help_text="The user which last modified this item"
+    )
 
-    modified_on = models.DateTimeField(auto_now=True,
-                                       help_text="When this item was last modified")
+    modified_on = models.DateTimeField(auto_now=True, help_text="When this item was last modified")
 
-    purged = models.BooleanField(default=False,
-                                 help_text="If the messages for this broadcast have been purged")
+    purged = models.BooleanField(default=False, help_text="If the messages for this broadcast have been purged")
 
-    media = TranslatableField(verbose_name=_("Media"), max_length=255,
-                              help_text=_("The localized versions of the media"), null=True)
+    media = TranslatableField(
+        verbose_name=_("Media"), max_length=255, help_text=_("The localized versions of the media"), null=True
+    )
 
-    send_all = models.BooleanField(default=False,
-                                   help_text="Whether this broadcast should send to all URNs for each contact")
+    send_all = models.BooleanField(
+        default=False, help_text="Whether this broadcast should send to all URNs for each contact"
+    )
 
     @classmethod
-    def create(cls, org, user, text, recipients, base_language=None, channel=None, media=None, send_all=False, **kwargs):
+    def create(
+        cls, org, user, text, recipients, base_language=None, channel=None, media=None, send_all=False, **kwargs
+    ):
         # for convenience broadcasts can still be created with single translation and no base_language
         if isinstance(text, six.string_types):
             base_language = org.primary_language.iso_code if org.primary_language else 'base'
@@ -244,9 +285,17 @@ class Broadcast(models.Model):
         if media and base_language not in media:  # pragma: no cover
             raise ValueError("Base language %s doesn't exist in the provided translations dict")
 
-        broadcast = cls.objects.create(org=org, channel=channel, send_all=send_all,
-                                       base_language=base_language, text=text, media=media,
-                                       created_by=user, modified_by=user, **kwargs)
+        broadcast = cls.objects.create(
+            org=org,
+            channel=channel,
+            send_all=send_all,
+            base_language=base_language,
+            text=text,
+            media=media,
+            created_by=user,
+            modified_by=user,
+            **kwargs
+        )
         broadcast.update_recipients(recipients)
         return broadcast
 
@@ -268,7 +317,7 @@ class Broadcast(models.Model):
             RelatedModel.objects.bulk_create(bulk_contacts)
 
         self.recipient_count = len(contact_ids)
-        self.save(update_fields=('recipient_count',))
+        self.save(update_fields=('recipient_count', ))
 
         # cache on object for use in subsequent send(..) calls
         delattr(self, '_recipient_cache')
@@ -304,7 +353,7 @@ class Broadcast(models.Model):
 
         # update the recipient count - the number of messages we intend to send
         self.recipient_count = len(urns) + len(contacts)
-        self.save(update_fields=('recipient_count',))
+        self.save(update_fields=('recipient_count', ))
 
         # cache on object for use in subsequent send(..) calls
         setattr(self, '_recipient_cache', (urns, contacts))
@@ -316,9 +365,15 @@ class Broadcast(models.Model):
 
     def fire(self):
         recipients = list(self.urns.all()) + list(self.contacts.all()) + list(self.groups.all())
-        broadcast = Broadcast.create(self.org, self.created_by, self.text, recipients,
-                                     media=self.media, base_language=self.base_language,
-                                     parent=self)
+        broadcast = Broadcast.create(
+            self.org,
+            self.created_by,
+            self.text,
+            recipients,
+            media=self.media,
+            base_language=self.base_language,
+            parent=self
+        )
 
         broadcast.send(trigger_send=True, expressions_context={})
 
@@ -385,8 +440,18 @@ class Broadcast(models.Model):
         preferred_languages = self.get_preferred_languages(contact, org)
         return Language.get_localized_text(self.media, preferred_languages)
 
-    def send(self, trigger_send=True, expressions_context=None, response_to=None, status=PENDING, msg_type=INBOX,
-             created_on=None, partial_recipients=None, run_map=None, high_priority=False):
+    def send(
+        self,
+        trigger_send=True,
+        expressions_context=None,
+        response_to=None,
+        status=PENDING,
+        msg_type=INBOX,
+        created_on=None,
+        partial_recipients=None,
+        run_map=None,
+        high_priority=False
+    ):
         """
         Sends this broadcast by creating outgoing messages for each recipient.
         """
@@ -426,7 +491,9 @@ class Broadcast(models.Model):
         # we batch up our SQL calls to speed up the creation of our SMS objects
         batch = []
         batch_recipients = []
-        existing_recipients = set(BroadcastRecipient.objects.filter(broadcast_id=self.id).values_list('contact_id', flat=True))
+        existing_recipients = set(
+            BroadcastRecipient.objects.filter(broadcast_id=self.id).values_list('contact_id', flat=True)
+        )
 
         # if they didn't pass in a created on, create one ourselves
         if not created_on:
@@ -467,23 +534,27 @@ class Broadcast(models.Model):
                     if 'parent' in text:
                         if run.parent:
                             from temba.flows.models import Flow
-                            message_context.update(dict(parent=Flow.build_flow_context(run.parent.flow, run.parent.contact)))
+                            message_context.update(
+                                dict(parent=Flow.build_flow_context(run.parent.flow, run.parent.contact))
+                            )
 
             try:
-                msg = Msg.create_outgoing(org,
-                                          self.created_by,
-                                          recipient,
-                                          text,
-                                          broadcast=self,
-                                          channel=self.channel,
-                                          response_to=response_to,
-                                          expressions_context=message_context,
-                                          status=status,
-                                          msg_type=msg_type,
-                                          high_priority=high_priority,
-                                          insert_object=False,
-                                          attachments=[media] if media else None,
-                                          created_on=created_on)
+                msg = Msg.create_outgoing(
+                    org,
+                    self.created_by,
+                    recipient,
+                    text,
+                    broadcast=self,
+                    channel=self.channel,
+                    response_to=response_to,
+                    expressions_context=message_context,
+                    status=status,
+                    msg_type=msg_type,
+                    high_priority=high_priority,
+                    insert_object=False,
+                    attachments=[media] if media else None,
+                    created_on=created_on
+                )
 
             except UnreachableException:
                 # there was no way to reach this contact, do not create a message
@@ -505,7 +576,10 @@ class Broadcast(models.Model):
 
                 # send any messages
                 if trigger_send:
-                    self.org.trigger_send(Msg.objects.filter(broadcast=self, created_on=created_on).select_related('contact', 'contact_urn', 'channel'))
+                    self.org.trigger_send(
+                        Msg.objects.filter(broadcast=self,
+                                           created_on=created_on).select_related('contact', 'contact_urn', 'channel')
+                    )
 
                     # increment our created on so we can load our next batch
                     created_on = created_on + timedelta(seconds=1)
@@ -519,14 +593,17 @@ class Broadcast(models.Model):
             RelatedRecipient.objects.bulk_create(batch_recipients)
 
             if trigger_send:
-                self.org.trigger_send(Msg.objects.filter(broadcast=self, created_on=created_on).select_related('contact', 'contact_urn', 'channel'))
+                self.org.trigger_send(
+                    Msg.objects.filter(broadcast=self,
+                                       created_on=created_on).select_related('contact', 'contact_urn', 'channel')
+                )
 
         # for large batches, status is handled externally
         # we do this as with the high concurrency of sending we can run into postgresl deadlocks
         # (this could be our fault, or could be: http://www.postgresql.org/message-id/20140731233051.GN17765@andrew-ThinkPad-X230)
         if not partial_recipients:
             self.status = QUEUED if len(recipients) > 0 else SENT
-            self.save(update_fields=('status',))
+            self.save(update_fields=('status', ))
 
     def update(self):
         """
@@ -572,6 +649,7 @@ class Attachment(object):
     """
     Represents a message attachment stored as type:url
     """
+
     def __init__(self, content_type, url):
         self.content_type = content_type
         self.url = url
@@ -615,18 +693,15 @@ class Msg(models.Model):
     VISIBILITY_DELETED = 'D'
 
     # single char flag, human readable name, API readable name
-    VISIBILITY_CONFIG = ((VISIBILITY_VISIBLE, _("Visible"), 'visible'),
-                         (VISIBILITY_ARCHIVED, _("Archived"), 'archived'),
+    VISIBILITY_CONFIG = ((VISIBILITY_VISIBLE, _("Visible"),
+                          'visible'), (VISIBILITY_ARCHIVED, _("Archived"), 'archived'),
                          (VISIBILITY_DELETED, _("Deleted"), 'deleted'))
 
     VISIBILITY_CHOICES = [(s[0], s[1]) for s in VISIBILITY_CONFIG]
 
-    DIRECTION_CHOICES = ((INCOMING, _("Incoming")),
-                         (OUTGOING, _("Outgoing")))
+    DIRECTION_CHOICES = ((INCOMING, _("Incoming")), (OUTGOING, _("Outgoing")))
 
-    MSG_TYPES = ((INBOX, _("Inbox Message")),
-                 (FLOW, _("Flow Message")),
-                 (IVR, _("IVR Message")),
+    MSG_TYPES = ((INBOX, _("Inbox Message")), (FLOW, _("Flow Message")), (IVR, _("IVR Message")),
                  (USSD, _("USSD Message")))
 
     MEDIA_GPS = 'geo'
@@ -640,86 +715,159 @@ class Msg(models.Model):
 
     MAX_TEXT_LEN = settings.MSG_FIELD_SIZE
 
-    uuid = models.UUIDField(null=True, default=uuid.uuid4,
-                            help_text=_("The UUID for this message"))
+    uuid = models.UUIDField(null=True, default=uuid.uuid4, help_text=_("The UUID for this message"))
 
-    org = models.ForeignKey(Org, related_name='msgs', verbose_name=_("Org"),
-                            help_text=_("The org this message is connected to"))
+    org = models.ForeignKey(
+        Org, related_name='msgs', verbose_name=_("Org"), help_text=_("The org this message is connected to")
+    )
 
-    channel = models.ForeignKey(Channel, null=True,
-                                related_name='msgs', verbose_name=_("Channel"),
-                                help_text=_("The channel object that this message is associated with"))
+    channel = models.ForeignKey(
+        Channel,
+        null=True,
+        related_name='msgs',
+        verbose_name=_("Channel"),
+        help_text=_("The channel object that this message is associated with")
+    )
 
-    contact = models.ForeignKey(Contact,
-                                related_name='msgs', verbose_name=_("Contact"),
-                                help_text=_("The contact this message is communicating with"),
-                                db_index=False)
+    contact = models.ForeignKey(
+        Contact,
+        related_name='msgs',
+        verbose_name=_("Contact"),
+        help_text=_("The contact this message is communicating with"),
+        db_index=False
+    )
 
-    contact_urn = models.ForeignKey(ContactURN, null=True,
-                                    related_name='msgs', verbose_name=_("Contact URN"),
-                                    help_text=_("The URN this message is communicating with"))
+    contact_urn = models.ForeignKey(
+        ContactURN,
+        null=True,
+        related_name='msgs',
+        verbose_name=_("Contact URN"),
+        help_text=_("The URN this message is communicating with")
+    )
 
-    broadcast = models.ForeignKey(Broadcast, null=True, blank=True,
-                                  related_name='msgs', verbose_name=_("Broadcast"),
-                                  help_text=_("If this message was sent to more than one recipient"))
+    broadcast = models.ForeignKey(
+        Broadcast,
+        null=True,
+        blank=True,
+        related_name='msgs',
+        verbose_name=_("Broadcast"),
+        help_text=_("If this message was sent to more than one recipient")
+    )
 
-    text = models.TextField(verbose_name=_("Text"),
-                            help_text=_("The actual message content that was sent"))
+    text = models.TextField(verbose_name=_("Text"), help_text=_("The actual message content that was sent"))
 
     high_priority = models.NullBooleanField(help_text=_("Give this message higher priority than other messages"))
 
-    created_on = models.DateTimeField(verbose_name=_("Created On"), db_index=True,
-                                      help_text=_("When this message was created"))
+    created_on = models.DateTimeField(
+        verbose_name=_("Created On"), db_index=True, help_text=_("When this message was created")
+    )
 
-    modified_on = models.DateTimeField(null=True, blank=True, verbose_name=_("Modified On"), auto_now=True,
-                                       help_text=_("When this message was last modified"))
+    modified_on = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Modified On"),
+        auto_now=True,
+        help_text=_("When this message was last modified")
+    )
 
-    sent_on = models.DateTimeField(null=True, blank=True, verbose_name=_("Sent On"),
-                                   help_text=_("When this message was sent to the endpoint"))
+    sent_on = models.DateTimeField(
+        null=True, blank=True, verbose_name=_("Sent On"), help_text=_("When this message was sent to the endpoint")
+    )
 
-    queued_on = models.DateTimeField(null=True, blank=True, verbose_name=_("Queued On"),
-                                     help_text=_("When this message was queued to be sent or handled."))
+    queued_on = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Queued On"),
+        help_text=_("When this message was queued to be sent or handled.")
+    )
 
-    direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES, verbose_name=_("Direction"),
-                                 help_text=_("The direction for this message, either incoming or outgoing"))
+    direction = models.CharField(
+        max_length=1,
+        choices=DIRECTION_CHOICES,
+        verbose_name=_("Direction"),
+        help_text=_("The direction for this message, either incoming or outgoing")
+    )
 
-    status = models.CharField(max_length=1, choices=STATUS_CHOICES, default='P', verbose_name=_("Status"), db_index=True,
-                              help_text=_("The current status for this message"))
+    status = models.CharField(
+        max_length=1,
+        choices=STATUS_CHOICES,
+        default='P',
+        verbose_name=_("Status"),
+        db_index=True,
+        help_text=_("The current status for this message")
+    )
 
-    response_to = models.ForeignKey('Msg', null=True, blank=True, related_name='responses',
-                                    verbose_name=_("Response To"), db_index=False,
-                                    help_text=_("The message that this message is in reply to"))
+    response_to = models.ForeignKey(
+        'Msg',
+        null=True,
+        blank=True,
+        related_name='responses',
+        verbose_name=_("Response To"),
+        db_index=False,
+        help_text=_("The message that this message is in reply to")
+    )
 
-    labels = models.ManyToManyField('Label', related_name='msgs', verbose_name=_("Labels"),
-                                    help_text=_("Any labels on this message"))
+    labels = models.ManyToManyField(
+        'Label', related_name='msgs', verbose_name=_("Labels"), help_text=_("Any labels on this message")
+    )
 
-    visibility = models.CharField(max_length=1, choices=VISIBILITY_CHOICES, default=VISIBILITY_VISIBLE, db_index=True,
-                                  verbose_name=_("Visibility"),
-                                  help_text=_("The current visibility of this message, either visible, archived or deleted"))
+    visibility = models.CharField(
+        max_length=1,
+        choices=VISIBILITY_CHOICES,
+        default=VISIBILITY_VISIBLE,
+        db_index=True,
+        verbose_name=_("Visibility"),
+        help_text=_("The current visibility of this message, either visible, archived or deleted")
+    )
 
-    msg_type = models.CharField(max_length=1, choices=MSG_TYPES, null=True, verbose_name=_("Message Type"),
-                                help_text=_('The type of this message'))
+    msg_type = models.CharField(
+        max_length=1,
+        choices=MSG_TYPES,
+        null=True,
+        verbose_name=_("Message Type"),
+        help_text=_('The type of this message')
+    )
 
-    msg_count = models.IntegerField(default=1, verbose_name=_("Message Count"),
-                                    help_text=_("The number of messages that were used to send this message, calculated on Twilio channels"))
+    msg_count = models.IntegerField(
+        default=1,
+        verbose_name=_("Message Count"),
+        help_text=_("The number of messages that were used to send this message, calculated on Twilio channels")
+    )
 
-    error_count = models.IntegerField(default=0, verbose_name=_("Error Count"),
-                                      help_text=_("The number of times this message has errored"))
+    error_count = models.IntegerField(
+        default=0, verbose_name=_("Error Count"), help_text=_("The number of times this message has errored")
+    )
 
-    next_attempt = models.DateTimeField(auto_now_add=True, verbose_name=_("Next Attempt"),
-                                        help_text=_("When we should next attempt to deliver this message"))
+    next_attempt = models.DateTimeField(
+        auto_now_add=True,
+        verbose_name=_("Next Attempt"),
+        help_text=_("When we should next attempt to deliver this message")
+    )
 
-    external_id = models.CharField(max_length=255, null=True, blank=True, verbose_name=_("External ID"),
-                                   help_text=_("External id used for integrating with callbacks from other APIs"))
+    external_id = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        verbose_name=_("External ID"),
+        help_text=_("External id used for integrating with callbacks from other APIs")
+    )
 
-    topup = models.ForeignKey(TopUp, null=True, blank=True, related_name='msgs', on_delete=models.SET_NULL,
-                              help_text="The topup that this message was deducted from")
+    topup = models.ForeignKey(
+        TopUp,
+        null=True,
+        blank=True,
+        related_name='msgs',
+        on_delete=models.SET_NULL,
+        help_text="The topup that this message was deducted from"
+    )
 
-    attachments = ArrayField(models.URLField(max_length=255), null=True,
-                             help_text=_("The media attachments on this message if any"))
+    attachments = ArrayField(
+        models.URLField(max_length=255), null=True, help_text=_("The media attachments on this message if any")
+    )
 
-    connection = models.ForeignKey('channels.ChannelSession', null=True,
-                                   help_text=_("The session this message was a part of if any"))
+    connection = models.ForeignKey(
+        'channels.ChannelSession', null=True, help_text=_("The session this message was a part of if any")
+    )
 
     @classmethod
     def send_messages(cls, all_msgs):
@@ -755,7 +903,9 @@ class Msg(models.Model):
 
                 # now push each onto our queue
                 for msg in msgs:
-                    if (msg.msg_type != IVR and msg.channel and msg.channel.channel_type != Channel.TYPE_ANDROID) and msg.topup and not msg.contact.is_test:
+                    if (
+                        msg.msg_type != IVR and msg.channel and msg.channel.channel_type != Channel.TYPE_ANDROID
+                    ) and msg.topup and not msg.contact.is_test:
                         if msg.channel.channel_type in settings.COURIER_CHANNELS and msg.uuid:
                             courier_msgs.append(msg)
                             continue
@@ -789,8 +939,11 @@ class Msg(models.Model):
                 last_channel = None
                 for msg in courier_msgs:
                     if task_msgs and (last_contact != msg.contact_id or last_channel != msg.channel_id):
-                        courier_batches.append(dict(channel=task_msgs[0].channel, msgs=task_msgs,
-                                                    high_priority=task_msgs[0].high_priority))
+                        courier_batches.append(
+                            dict(
+                                channel=task_msgs[0].channel, msgs=task_msgs, high_priority=task_msgs[0].high_priority
+                            )
+                        )
                         task_msgs = []
 
                     last_contact = msg.contact_id
@@ -799,8 +952,9 @@ class Msg(models.Model):
 
                 # push any remaining courier msgs
                 if task_msgs:
-                    courier_batches.append(dict(channel=task_msgs[0].channel, msgs=task_msgs,
-                                                high_priority=task_msgs[0].high_priority))
+                    courier_batches.append(
+                        dict(channel=task_msgs[0].channel, msgs=task_msgs, high_priority=task_msgs[0].high_priority)
+                    )
 
         # send our batches
         on_transaction_commit(lambda: cls._send_rapid_msg_batches(rapid_batches))
@@ -862,8 +1016,10 @@ class Msg(models.Model):
         if not msg.contact.is_test:
             (chatbase_api_key, chatbase_version) = msg.org.get_chatbase_credentials()
             if chatbase_api_key:
-                cls.send_chatbase_log(chatbase_api_key, chatbase_version, msg.channel.name, msg.text, msg.contact.id,
-                                      CHATBASE_TYPE_USER, chatbase_not_handled)
+                cls.send_chatbase_log(
+                    chatbase_api_key, chatbase_version, msg.channel.name, msg.text, msg.contact.id, CHATBASE_TYPE_USER,
+                    chatbase_not_handled
+                )
 
         # record our handling latency for this object
         if msg.queued_on:
@@ -874,8 +1030,9 @@ class Msg(models.Model):
         analytics.gauge('temba.channel_handling_latency', (msg.modified_on - msg.created_on).total_seconds())
 
     @classmethod
-    def send_chatbase_log(cls, chatbase_api_key, chatbase_version, channel_name, text, contact_id, log_type,
-                          not_handled=True):
+    def send_chatbase_log(
+        cls, chatbase_api_key, chatbase_version, channel_name, text, contact_id, log_type, not_handled=True
+    ):
         """
         Send messages logs in batch to Chatbase
         """
@@ -925,8 +1082,9 @@ class Msg(models.Model):
         probably be confusing to go out.
         """
         one_week_ago = timezone.now() - timedelta(days=7)
-        failed_messages = Msg.objects.filter(created_on__lte=one_week_ago, direction=OUTGOING,
-                                             status__in=[QUEUED, PENDING, ERRORED])
+        failed_messages = Msg.objects.filter(
+            created_on__lte=one_week_ago, direction=OUTGOING, status__in=[QUEUED, PENDING, ERRORED]
+        )
 
         failed_broadcasts = list(failed_messages.order_by('broadcast').values('broadcast').distinct())
 
@@ -945,9 +1103,15 @@ class Msg(models.Model):
         unread_count = cache.get(key, None)
 
         if unread_count is None:
-            unread_count = Msg.objects.filter(org=org, visibility=Msg.VISIBILITY_VISIBLE, direction=INCOMING,
-                                              msg_type=INBOX, contact__is_test=False,
-                                              created_on__gt=org.msg_last_viewed, labels=None).count()
+            unread_count = Msg.objects.filter(
+                org=org,
+                visibility=Msg.VISIBILITY_VISIBLE,
+                direction=INCOMING,
+                msg_type=INBOX,
+                contact__is_test=False,
+                created_on__gt=org.msg_last_viewed,
+                labels=None
+            ).count()
             cache.set(key, unread_count, 900)
 
         return unread_count
@@ -991,8 +1155,12 @@ class Msg(models.Model):
             if isinstance(msg, Msg):
                 msg.save(update_fields=('status', 'modified_on', 'next_attempt', 'error_count'))
             else:
-                Msg.objects.filter(id=msg.id).update(status=msg.status, next_attempt=msg.next_attempt,
-                                                     error_count=msg.error_count, modified_on=msg.modified_on)
+                Msg.objects.filter(id=msg.id).update(
+                    status=msg.status,
+                    next_attempt=msg.next_attempt,
+                    error_count=msg.error_count,
+                    modified_on=msg.modified_on
+                )
 
             # clear that we tried to send this message (otherwise we'll ignore it when we retry)
             pipe = r.pipeline()
@@ -1027,12 +1195,14 @@ class Msg(models.Model):
             Msg.objects.filter(id=msg.id).update(status=status, sent_on=msg.sent_on)
 
     def as_json(self):
-        return dict(direction=self.direction,
-                    text=self.text,
-                    id=self.id,
-                    attachments=self.attachments,
-                    created_on=self.created_on.strftime('%x %X'),
-                    model="msg")
+        return dict(
+            direction=self.direction,
+            text=self.text,
+            id=self.id,
+            attachments=self.attachments,
+            created_on=self.created_on.strftime('%x %X'),
+            model="msg"
+        )
 
     def simulator_json(self):
         msg_json = self.as_json()
@@ -1048,6 +1218,7 @@ class Msg(models.Model):
             return [text]
 
         else:
+
             def next_part(text):
                 if len(text) <= max_length:
                     return text, None
@@ -1113,12 +1284,32 @@ class Msg(models.Model):
             sorted_logs = sorted(self.channel_logs.all(), key=lambda l: l.created_on, reverse=True)
         return sorted_logs[0] if sorted_logs else None
 
-    def reply(self, text, user, trigger_send=False, expressions_context=None, connection=None, attachments=None, msg_type=None,
-              send_all=False, created_on=None):
+    def reply(
+        self,
+        text,
+        user,
+        trigger_send=False,
+        expressions_context=None,
+        connection=None,
+        attachments=None,
+        msg_type=None,
+        send_all=False,
+        created_on=None
+    ):
 
-        return self.contact.send(text, user, trigger_send=trigger_send, expressions_context=expressions_context,
-                                 response_to=self if self.id else None, connection=connection, attachments=attachments,
-                                 msg_type=msg_type or self.msg_type, created_on=created_on, all_urns=send_all, high_priority=True)
+        return self.contact.send(
+            text,
+            user,
+            trigger_send=trigger_send,
+            expressions_context=expressions_context,
+            response_to=self if self.id else None,
+            connection=connection,
+            attachments=attachments,
+            msg_type=msg_type or self.msg_type,
+            created_on=created_on,
+            all_urns=send_all,
+            high_priority=True
+        )
 
     def update(self, cmd):
         """
@@ -1165,7 +1356,9 @@ class Msg(models.Model):
         new_message - should be true for messages which were created outside rapidpro
         new_contact - should be true for contacts which were created outside rapidpro
         """
-        payload = dict(type=MSG_EVENT, contact_id=self.contact.id, id=self.id, new_message=new_message, new_contact=new_contact)
+        payload = dict(
+            type=MSG_EVENT, contact_id=self.contact.id, id=self.id, new_message=new_message, new_contact=new_contact
+        )
 
         # first push our msg on our contact's queue using our created date
         r = get_redis_connection('default')
@@ -1210,18 +1403,20 @@ class Msg(models.Model):
         # see if we should use a new channel
         channel = self.org.get_send_channel(contact_urn=self.contact_urn)
 
-        cloned = Msg.objects.create(org=self.org,
-                                    channel=channel,
-                                    contact=self.contact,
-                                    contact_urn=self.contact_urn,
-                                    created_on=now,
-                                    modified_on=now,
-                                    text=self.text,
-                                    response_to=self.response_to,
-                                    direction=self.direction,
-                                    topup_id=topup_id,
-                                    status=PENDING,
-                                    broadcast=self.broadcast)
+        cloned = Msg.objects.create(
+            org=self.org,
+            channel=channel,
+            contact=self.contact,
+            contact_urn=self.contact_urn,
+            created_on=now,
+            modified_on=now,
+            text=self.text,
+            response_to=self.response_to,
+            direction=self.direction,
+            topup_id=topup_id,
+            status=PENDING,
+            broadcast=self.broadcast
+        )
 
         # mark ourselves as resent
         self.status = RESENT
@@ -1239,24 +1434,43 @@ class Msg(models.Model):
         """
         Used internally to serialize to JSON when queueing messages in Redis
         """
-        data = dict(id=self.id, org=self.org_id, channel=self.channel_id, broadcast=self.broadcast_id,
-                    text=self.text, urn_path=self.contact_urn.path, urn=six.text_type(self.contact_urn),
-                    contact=self.contact_id, contact_urn=self.contact_urn_id,
-                    error_count=self.error_count, next_attempt=self.next_attempt,
-                    status=self.status, direction=self.direction, attachments=self.attachments,
-                    external_id=self.external_id, response_to_id=self.response_to_id,
-                    sent_on=self.sent_on, queued_on=self.queued_on,
-                    created_on=self.created_on, modified_on=self.modified_on,
-                    high_priority=self.high_priority,
-                    connection_id=self.connection_id)
+        data = dict(
+            id=self.id,
+            org=self.org_id,
+            channel=self.channel_id,
+            broadcast=self.broadcast_id,
+            text=self.text,
+            urn_path=self.contact_urn.path,
+            urn=six.text_type(self.contact_urn),
+            contact=self.contact_id,
+            contact_urn=self.contact_urn_id,
+            error_count=self.error_count,
+            next_attempt=self.next_attempt,
+            status=self.status,
+            direction=self.direction,
+            attachments=self.attachments,
+            external_id=self.external_id,
+            response_to_id=self.response_to_id,
+            sent_on=self.sent_on,
+            queued_on=self.queued_on,
+            created_on=self.created_on,
+            modified_on=self.modified_on,
+            high_priority=self.high_priority,
+            connection_id=self.connection_id
+        )
 
         if self.contact_urn.auth:
             data.update(dict(auth=self.contact_urn.auth))
 
         (chatbase_api_key, chatbase_version) = self.org.get_chatbase_credentials()
         if chatbase_api_key:
-            data.update(dict(chatbase_api_key=chatbase_api_key, chatbase_version=chatbase_version,
-                             is_org_connected_to_chatbase=True))
+            data.update(
+                dict(
+                    chatbase_api_key=chatbase_api_key,
+                    chatbase_version=chatbase_version,
+                    is_org_connected_to_chatbase=True
+                )
+            )
 
         return data
 
@@ -1268,8 +1482,22 @@ class Msg(models.Model):
             return self.text
 
     @classmethod
-    def create_incoming(cls, channel, urn, text, user=None, date=None, org=None, contact=None,
-                        status=PENDING, attachments=None, msg_type=None, topup=None, external_id=None, connection=None):
+    def create_incoming(
+        cls,
+        channel,
+        urn,
+        text,
+        user=None,
+        date=None,
+        org=None,
+        contact=None,
+        status=PENDING,
+        attachments=None,
+        msg_type=None,
+        topup=None,
+        external_id=None,
+        connection=None
+    ):
 
         from temba.api.models import WebHookEvent
         if not org and channel:
@@ -1315,21 +1543,23 @@ class Msg(models.Model):
 
         now = timezone.now()
 
-        msg_args = dict(contact=contact,
-                        contact_urn=contact_urn,
-                        org=org,
-                        channel=channel,
-                        text=text,
-                        sent_on=date,
-                        created_on=now,
-                        modified_on=now,
-                        queued_on=now,
-                        direction=INCOMING,
-                        msg_type=msg_type,
-                        attachments=attachments,
-                        status=status,
-                        external_id=external_id,
-                        connection=connection)
+        msg_args = dict(
+            contact=contact,
+            contact_urn=contact_urn,
+            org=org,
+            channel=channel,
+            text=text,
+            sent_on=date,
+            created_on=now,
+            modified_on=now,
+            queued_on=now,
+            direction=INCOMING,
+            msg_type=msg_type,
+            attachments=attachments,
+            status=status,
+            external_id=external_id,
+            connection=connection
+        )
 
         if topup_id is not None:
             msg_args['topup_id'] = topup_id
@@ -1397,9 +1627,25 @@ class Msg(models.Model):
         return evaluate_template(text, context, url_encode, partial_vars)
 
     @classmethod
-    def create_outgoing(cls, org, user, recipient, text, broadcast=None, channel=None, high_priority=False,
-                        created_on=None, response_to=None, expressions_context=None, status=PENDING, insert_object=True,
-                        attachments=None, topup_id=None, msg_type=INBOX, connection=None):
+    def create_outgoing(
+        cls,
+        org,
+        user,
+        recipient,
+        text,
+        broadcast=None,
+        channel=None,
+        high_priority=False,
+        created_on=None,
+        response_to=None,
+        expressions_context=None,
+        status=PENDING,
+        insert_object=True,
+        attachments=None,
+        topup_id=None,
+        msg_type=INBOX,
+        connection=None
+    ):
 
         if not org or not user:  # pragma: no cover
             raise ValueError("Trying to create outgoing message with no org or user")
@@ -1464,13 +1710,15 @@ class Msg(models.Model):
         if insert_object:
             # prevent the loop of message while the sending phone is the channel
             # get all messages with same text going to same number
-            same_msgs = Msg.objects.filter(contact_urn=contact_urn,
-                                           contact__is_test=False,
-                                           channel=channel,
-                                           attachments=evaluated_attachments,
-                                           text=text,
-                                           direction=OUTGOING,
-                                           created_on__gte=created_on - timedelta(minutes=10))
+            same_msgs = Msg.objects.filter(
+                contact_urn=contact_urn,
+                contact__is_test=False,
+                channel=channel,
+                attachments=evaluated_attachments,
+                text=text,
+                direction=OUTGOING,
+                created_on__gte=created_on - timedelta(minutes=10)
+            )
 
             # we aren't considered with robo detection on calls
             same_msg_count = same_msgs.exclude(msg_type=IVR).count()
@@ -1483,12 +1731,14 @@ class Msg(models.Model):
             # we don't want machines talking to each other
             tel = contact.raw_tel()
             if tel and len(tel) < 6:
-                same_msg_count = Msg.objects.filter(contact_urn=contact_urn,
-                                                    contact__is_test=False,
-                                                    channel=channel,
-                                                    text=text,
-                                                    direction=OUTGOING,
-                                                    created_on__gte=created_on - timedelta(hours=24)).count()
+                same_msg_count = Msg.objects.filter(
+                    contact_urn=contact_urn,
+                    contact__is_test=False,
+                    channel=channel,
+                    text=text,
+                    direction=OUTGOING,
+                    created_on__gte=created_on - timedelta(hours=24)
+                ).count()
                 if same_msg_count >= 10:  # pragma: needs cover
                     analytics.gauge('temba.msg_shortcode_loop_caught')
                     return None
@@ -1506,21 +1756,23 @@ class Msg(models.Model):
         if channel:
             analytics.gauge('temba.msg_outgoing_%s' % channel.channel_type.lower())
 
-        msg_args = dict(contact=contact,
-                        contact_urn=contact_urn,
-                        org=org,
-                        channel=channel,
-                        text=text,
-                        created_on=created_on,
-                        modified_on=created_on,
-                        direction=OUTGOING,
-                        status=status,
-                        broadcast=broadcast,
-                        response_to=response_to,
-                        msg_type=msg_type,
-                        high_priority=high_priority,
-                        attachments=evaluated_attachments,
-                        connection=connection)
+        msg_args = dict(
+            contact=contact,
+            contact_urn=contact_urn,
+            org=org,
+            channel=channel,
+            text=text,
+            created_on=created_on,
+            modified_on=created_on,
+            direction=OUTGOING,
+            status=status,
+            broadcast=broadcast,
+            response_to=response_to,
+            msg_type=msg_type,
+            high_priority=high_priority,
+            attachments=evaluated_attachments,
+            connection=connection
+        )
 
         if topup_id is not None:
             msg_args['topup_id'] = topup_id
@@ -1699,14 +1951,8 @@ class SystemLabel(object):
     TYPE_SCHEDULED = 'E'
     TYPE_CALLS = 'C'
 
-    TYPE_CHOICES = ((TYPE_INBOX, "Inbox"),
-                    (TYPE_FLOWS, "Flows"),
-                    (TYPE_ARCHIVED, "Archived"),
-                    (TYPE_OUTBOX, "Outbox"),
-                    (TYPE_SENT, "Sent"),
-                    (TYPE_FAILED, "Failed"),
-                    (TYPE_SCHEDULED, "Scheduled"),
-                    (TYPE_CALLS, "Calls"))
+    TYPE_CHOICES = ((TYPE_INBOX, "Inbox"), (TYPE_FLOWS, "Flows"), (TYPE_ARCHIVED, "Archived"), (TYPE_OUTBOX, "Outbox"),
+                    (TYPE_SENT, "Sent"), (TYPE_FAILED, "Failed"), (TYPE_SCHEDULED, "Scheduled"), (TYPE_CALLS, "Calls"))
 
     @classmethod
     def get_counts(cls, org):
@@ -1726,10 +1972,13 @@ class SystemLabel(object):
         elif label_type == cls.TYPE_ARCHIVED:
             qs = Msg.objects.filter(direction=INCOMING, visibility=Msg.VISIBILITY_ARCHIVED)
         elif label_type == cls.TYPE_OUTBOX:
-            qs = Msg.objects.filter(direction=OUTGOING, visibility=Msg.VISIBILITY_VISIBLE, status__in=(PENDING, QUEUED))
+            qs = Msg.objects.filter(
+                direction=OUTGOING, visibility=Msg.VISIBILITY_VISIBLE, status__in=(PENDING, QUEUED)
+            )
         elif label_type == cls.TYPE_SENT:
-            qs = Msg.objects.filter(direction=OUTGOING, visibility=Msg.VISIBILITY_VISIBLE,
-                                    status__in=(WIRED, SENT, DELIVERED))
+            qs = Msg.objects.filter(
+                direction=OUTGOING, visibility=Msg.VISIBILITY_VISIBLE, status__in=(WIRED, SENT, DELIVERED)
+            )
         elif label_type == cls.TYPE_FAILED:
             qs = Msg.objects.filter(direction=OUTGOING, visibility=Msg.VISIBILITY_VISIBLE, status=FAILED)
         elif label_type == cls.TYPE_SCHEDULED:
@@ -1770,7 +2019,9 @@ class SystemLabelCount(SquashableModel):
         )
         INSERT INTO %(table)s("org_id", "label_type", "count", "is_squashed")
         VALUES (%%s, %%s, GREATEST(0, (SELECT SUM("count") FROM deleted)), TRUE);
-        """ % {'table': cls._meta.db_table}
+        """ % {
+            'table': cls._meta.db_table
+        }
 
         return sql, (distinct_set.org_id, distinct_set.label_type) * 2
 
@@ -1813,8 +2064,7 @@ class Label(TembaModel):
     TYPE_FOLDER = 'F'
     TYPE_LABEL = 'L'
 
-    TYPE_CHOICES = ((TYPE_FOLDER, "Folder of labels"),
-                    (TYPE_LABEL, "Regular label"))
+    TYPE_CHOICES = ((TYPE_FOLDER, "Folder of labels"), (TYPE_LABEL, "Regular label"))
 
     org = models.ForeignKey(Org)
 
@@ -1856,8 +2106,9 @@ class Label(TembaModel):
         if folder:  # pragma: needs cover
             return folder
 
-        return cls.folder_objects.create(org=org, name=name, label_type=Label.TYPE_FOLDER,
-                                         created_by=user, modified_by=user)
+        return cls.folder_objects.create(
+            org=org, name=name, label_type=Label.TYPE_FOLDER, created_by=user, modified_by=user
+        )
 
     @classmethod
     def get_hierarchy(cls, org):
@@ -1968,7 +2219,7 @@ class LabelCount(SquashableModel):
     """
     Counts of user labels maintained by database level triggers
     """
-    SQUASH_OVER = ('label_id',)
+    SQUASH_OVER = ('label_id', )
 
     label = models.ForeignKey(Label, related_name='counts')
 
@@ -1982,7 +2233,9 @@ class LabelCount(SquashableModel):
             )
             INSERT INTO %(table)s("label_id", "count", "is_squashed")
             VALUES (%%s, GREATEST(0, (SELECT SUM("count") FROM deleted)), TRUE);
-            """ % {'table': cls._meta.db_table}
+            """ % {
+            'table': cls._meta.db_table
+        }
 
         return sql, (distinct_set.label_id, distinct_set.label_id)
 
@@ -2000,6 +2253,7 @@ class MsgIterator(object):
     """
     Queryset wrapper to chunk queries and reduce in-memory footprint
     """
+
     def __init__(self, ids, order_by=None, select_related=None, prefetch_related=None, max_obj_num=1000):
         self._ids = ids
         self._order_by = order_by
@@ -2059,9 +2313,15 @@ class ExportMessagesTask(BaseExportTask):
         if label and system_label:  # pragma: no cover
             raise ValueError("Can't specify both label and system label")
 
-        export = cls.objects.create(org=org, system_label=system_label, label=label,
-                                    start_date=start_date, end_date=end_date,
-                                    created_by=user, modified_by=user)
+        export = cls.objects.create(
+            org=org,
+            system_label=system_label,
+            label=label,
+            start_date=start_date,
+            end_date=end_date,
+            created_by=user,
+            modified_by=user
+        )
         export.groups.add(*groups)
         return export
 
@@ -2071,15 +2331,17 @@ class ExportMessagesTask(BaseExportTask):
         book = Workbook(write_only=True)
 
         fields = ['Date', 'Contact', 'Contact Type', 'Name', 'Contact UUID', 'Direction', 'Text', 'Labels', "Status"]
-        fields_col_width = [self.WIDTH_MEDIUM,  # Date
-                            self.WIDTH_MEDIUM,  # Contact
-                            self.WIDTH_SMALL,   # Contact Type
-                            self.WIDTH_MEDIUM,  # Name
-                            self.WIDTH_MEDIUM,  # Contact UUID
-                            self.WIDTH_SMALL,   # Direction
-                            self.WIDTH_LARGE,   # Text
-                            self.WIDTH_MEDIUM,  # Labels
-                            self.WIDTH_SMALL]   # Status
+        fields_col_width = [
+            self.WIDTH_MEDIUM,  # Date
+            self.WIDTH_MEDIUM,  # Contact
+            self.WIDTH_SMALL,  # Contact Type
+            self.WIDTH_MEDIUM,  # Name
+            self.WIDTH_MEDIUM,  # Contact UUID
+            self.WIDTH_SMALL,  # Direction
+            self.WIDTH_LARGE,  # Text
+            self.WIDTH_MEDIUM,  # Labels
+            self.WIDTH_SMALL
+        ]  # Status
 
         if self.system_label:
             messages = SystemLabel.get_queryset(self.org, self.system_label)
@@ -2115,11 +2377,13 @@ class ExportMessagesTask(BaseExportTask):
         start = time.time()
 
         prefetch = Prefetch('labels', queryset=Label.label_objects.order_by('name'))
-        for msg in MsgIterator(all_message_ids,
-                               order_by=[''
-                                         '-created_on'],
-                               select_related=['contact', 'contact_urn'],
-                               prefetch_related=[prefetch]):
+        for msg in MsgIterator(
+            all_message_ids,
+            order_by=[''
+                      '-created_on'],
+            select_related=['contact', 'contact_urn'],
+            prefetch_related=[prefetch]
+        ):
 
             if row >= self.MAX_EXCEL_ROWS:  # pragma: needs cover
                 messages_sheet_number += 1
@@ -2139,24 +2403,22 @@ class ExportMessagesTask(BaseExportTask):
 
             urn_scheme = msg.contact_urn.scheme if msg.contact_urn else ''
 
-            self.append_row(current_messages_sheet, [
-                msg.created_on,
-                urn_path,
-                urn_scheme,
-                msg.contact.name,
-                msg.contact.uuid,
-                msg.get_direction_display(),
-                msg.text,
-                ", ".join(msg_label.name for msg_label in msg.labels.all()),
-                msg.get_status_display()
-            ])
+            self.append_row(
+                current_messages_sheet, [
+                    msg.created_on, urn_path, urn_scheme, msg.contact.name, msg.contact.uuid,
+                    msg.get_direction_display(), msg.text, ", ".join(msg_label.name for msg_label in msg.labels.all()),
+                    msg.get_status_display()
+                ]
+            )
 
             row += 1
             processed += 1
 
             if processed % 10000 == 0:  # pragma: needs cover
-                print("Export of %d msgs for %s - %d%% complete in %0.2fs" %
-                      (len(all_message_ids), self.org.name, processed * 100 / len(all_message_ids), time.time() - start))
+                print(
+                    "Export of %d msgs for %s - %d%% complete in %0.2fs" %
+                    (len(all_message_ids), self.org.name, processed * 100 / len(all_message_ids), time.time() - start)
+                )
 
         temp = NamedTemporaryFile(delete=True)
         book.save(temp)
@@ -2170,4 +2432,4 @@ class MessageExportAssetStore(BaseExportAssetStore):
     key = 'message_export'
     directory = 'message_exports'
     permission = 'msgs.msg_export'
-    extensions = ('xlsx',)
+    extensions = ('xlsx', )

--- a/temba/msgs/templatetags/sms.py
+++ b/temba/msgs/templatetags/sms.py
@@ -7,14 +7,7 @@ from temba.channels.models import ChannelEvent
 register = template.Library()
 
 PLAYABLE_CONTENT_TYPES = {
-    'audio/wav',
-    'audio/x-wav',
-    'audio/vnd.wav',
-    'audio/ogg',
-    'audio/mp3',
-    'audio/m4a',
-    'video/mp4',
-    'video/webm'
+    'audio/wav', 'audio/x-wav', 'audio/vnd.wav', 'audio/ogg', 'audio/mp3', 'audio/m4a', 'video/mp4', 'video/webm'
 }
 
 
@@ -97,7 +90,7 @@ def render(parser, token):
         raise ValueError("render tag should be followed by keyword as and the name of a context variable")
     as_var = bits[2]
 
-    nodes = parser.parse(('endrender',))
+    nodes = parser.parse(('endrender', ))
     parser.delete_first_token()
     return RenderNode(nodes, as_var)
 
@@ -107,7 +100,7 @@ def attachment_button(attachment):
     content_type, delim, url = attachment.partition(":")
 
     # some OGG/OGA attachments may have wrong content type
-    if content_type == 'application/octet-stream' and (url.endswith('.ogg') or url.endswith('.oga')):  # pragma: no cover
+    if (content_type == 'application/octet-stream' and (url.endswith('.ogg') or url.endswith('.oga'))):  # pragma: no cover
         content_type = 'audio/ogg'
 
     category = content_type.split('/')[0] if '/' in content_type else content_type
@@ -116,7 +109,10 @@ def attachment_button(attachment):
         preview = url
 
         (lat, lng) = url.split(',')
-        url = 'http://www.openstreetmap.org/?mlat=%(lat)s&mlon=%(lng)s#map=18/%(lat)s/%(lng)s' % {"lat": lat, "lng": lng}
+        url = 'http://www.openstreetmap.org/?mlat=%(lat)s&mlon=%(lng)s#map=18/%(lat)s/%(lng)s' % {
+            "lat": lat,
+            "lng": lng
+        }
     else:
         preview = url.rpartition('.')[2].upper()  # preview is the file extension in uppercase
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -37,7 +37,6 @@ from temba.utils.queues import DEFAULT_PRIORITY
 
 
 class MsgTest(TembaTest):
-
     def setUp(self):
         super(MsgTest, self).setUp()
 
@@ -55,34 +54,76 @@ class MsgTest(TembaTest):
 
         commands = Msg.get_sync_commands(Msg.objects.filter(id__in=(msg1.id, msg2.id, msg3.id)))
 
-        self.assertEqual(commands, [
-            {'cmd': 'mt_bcast', 'to': [
-                {'phone': "123", 'id': msg1.id},
-                {'phone': "321", 'id': msg2.id},
-                {'phone': "987", 'id': msg3.id}
-            ], 'msg': "Hello, we heard from you."}
-        ])
+        self.assertEqual(
+            commands, [{
+                'cmd': 'mt_bcast',
+                'to': [{
+                    'phone': "123",
+                    'id': msg1.id
+                }, {
+                    'phone': "321",
+                    'id': msg2.id
+                }, {
+                    'phone': "987",
+                    'id': msg3.id
+                }],
+                'msg': "Hello, we heard from you."
+            }]
+        )
 
         msg4 = Msg.create_outgoing(self.org, self.admin, self.kevin, "Hello, there")
 
         commands = Msg.get_sync_commands(Msg.objects.filter(id__in=(msg1.id, msg2.id, msg4.id)))
 
-        self.assertEqual(commands, [
-            {'cmd': 'mt_bcast', 'to': [
-                {'phone': "123", 'id': msg1.id}, {'phone': "321", 'id': msg2.id}
-            ], 'msg': "Hello, we heard from you."},
-            {'cmd': 'mt_bcast', 'to': [{'phone': "987", 'id': msg4.id}], 'msg': "Hello, there"}
-        ])
+        self.assertEqual(
+            commands, [{
+                'cmd': 'mt_bcast',
+                'to': [{
+                    'phone': "123",
+                    'id': msg1.id
+                }, {
+                    'phone': "321",
+                    'id': msg2.id
+                }],
+                'msg': "Hello, we heard from you."
+            }, {
+                'cmd': 'mt_bcast',
+                'to': [{
+                    'phone': "987",
+                    'id': msg4.id
+                }],
+                'msg': "Hello, there"
+            }]
+        )
 
         msg5 = Msg.create_outgoing(self.org, self.admin, self.frank, "Hello, we heard from you.")
 
         commands = Msg.get_sync_commands(Msg.objects.filter(id__in=(msg1.id, msg4.id, msg5.id)))
 
-        self.assertEqual(commands, [
-            {'cmd': 'mt_bcast', 'to': [{'phone': "123", 'id': msg1.id}], 'msg': "Hello, we heard from you."},
-            {'cmd': 'mt_bcast', 'to': [{'phone': "987", 'id': msg4.id}], 'msg': "Hello, there"},
-            {'cmd': 'mt_bcast', 'to': [{'phone': "321", 'id': msg5.id}], 'msg': "Hello, we heard from you."}
-        ])
+        self.assertEqual(
+            commands, [{
+                'cmd': 'mt_bcast',
+                'to': [{
+                    'phone': "123",
+                    'id': msg1.id
+                }],
+                'msg': "Hello, we heard from you."
+            }, {
+                'cmd': 'mt_bcast',
+                'to': [{
+                    'phone': "987",
+                    'id': msg4.id
+                }],
+                'msg': "Hello, there"
+            }, {
+                'cmd': 'mt_bcast',
+                'to': [{
+                    'phone': "321",
+                    'id': msg5.id
+                }],
+                'msg': "Hello, we heard from you."
+            }]
+        )
 
     def test_archive_and_release(self):
         msg1 = Msg.create_incoming(self.channel, 'tel:123', "Incoming")
@@ -117,8 +158,9 @@ class MsgTest(TembaTest):
         else:
             msg = Msg.create_incoming(self.channel, "tel:+250788123123", "Hey hey")
 
-        Msg.objects.filter(id=msg.id).update(status=status, direction=direction,
-                                             visibility=visibility, msg_type=msg_type)
+        Msg.objects.filter(id=msg.id).update(
+            status=status, direction=direction, visibility=visibility, msg_type=msg_type
+        )
 
         # assert our folder count is right
         counts = SystemLabel.get_counts(self.org)
@@ -185,19 +227,21 @@ class MsgTest(TembaTest):
 
         # login in as manager, with contacts but without extra contactfields yet
         self.login(self.admin)
-        completions = [dict(name='contact', display="Contact Name"),
-                       dict(name='contact.first_name', display="Contact First Name"),
-                       dict(name='contact.groups', display="Contact Groups"),
-                       dict(name='contact.language', display="Contact Language"),
-                       dict(name='contact.name', display="Contact Name"),
-                       dict(name='contact.tel', display="Contact Phone"),
-                       dict(name='contact.tel_e164', display="Contact Phone - E164"),
-                       dict(name='contact.uuid', display="Contact UUID"),
-                       dict(name="date", display="Current Date and Time"),
-                       dict(name="date.now", display="Current Date and Time"),
-                       dict(name="date.today", display="Current Date"),
-                       dict(name="date.tomorrow", display="Tomorrow's Date"),
-                       dict(name="date.yesterday", display="Yesterday's Date")]
+        completions = [
+            dict(name='contact', display="Contact Name"),
+            dict(name='contact.first_name', display="Contact First Name"),
+            dict(name='contact.groups', display="Contact Groups"),
+            dict(name='contact.language', display="Contact Language"),
+            dict(name='contact.name', display="Contact Name"),
+            dict(name='contact.tel', display="Contact Phone"),
+            dict(name='contact.tel_e164', display="Contact Phone - E164"),
+            dict(name='contact.uuid', display="Contact UUID"),
+            dict(name="date", display="Current Date and Time"),
+            dict(name="date.now", display="Current Date and Time"),
+            dict(name="date.today", display="Current Date"),
+            dict(name="date.tomorrow", display="Tomorrow's Date"),
+            dict(name="date.yesterday", display="Yesterday's Date")
+        ]
 
         response = self.client.get(outbox_url)
 
@@ -342,7 +386,9 @@ class MsgTest(TembaTest):
         self.assertEqual(msg5.text, "Don't be null!")
 
     def test_empty(self):
-        broadcast = Broadcast.create(self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", [])
+        broadcast = Broadcast.create(
+            self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", []
+        )
         broadcast.send(True)
 
         # should have no messages but marked as sent
@@ -352,7 +398,12 @@ class MsgTest(TembaTest):
     def test_send_all(self):
         contact = self.create_contact('Stephen', '+12078778899')
         ContactURN.get_or_create(self.org, contact, 'tel:+12078778800')
-        broadcast = Broadcast.create(self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", [contact], send_all=True)
+        broadcast = Broadcast.create(
+            self.org,
+            self.admin,
+            "If a broadcast is sent and nobody receives it, does it still send?", [contact],
+            send_all=True
+        )
         partial_recipients = list(), Contact.objects.filter(pk=contact.pk)
         broadcast.send(True, partial_recipients=partial_recipients)
 
@@ -362,7 +413,12 @@ class MsgTest(TembaTest):
         self.assertEqual(1, broadcast.msgs.all().filter(contact_urn__path='+12078778800').count())
 
         # should not create a broadcast recipient if a similar one exists
-        broadcast = Broadcast.create(self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", [contact], send_all=True)
+        broadcast = Broadcast.create(
+            self.org,
+            self.admin,
+            "If a broadcast is sent and nobody receives it, does it still send?", [contact],
+            send_all=True
+        )
         BroadcastRecipient.objects.create(broadcast_id=broadcast.id, contact_id=contact.id)
 
         partial_recipients = list(), Contact.objects.filter(pk=contact.pk)
@@ -374,7 +430,9 @@ class MsgTest(TembaTest):
         self.assertEqual(1, broadcast.msgs.all().filter(contact_urn__path='+12078778800').count())
 
     def test_update_contacts(self):
-        broadcast = Broadcast.create(self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", [])
+        broadcast = Broadcast.create(
+            self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", []
+        )
 
         # update the contacts using contact ids
         broadcast.update_contacts([self.joe.id])
@@ -396,14 +454,16 @@ class MsgTest(TembaTest):
 
         # now send the broadcast so we have messages
         broadcast1.send(trigger_send=False)
-        (msg1,) = tuple(Msg.objects.filter(broadcast=broadcast1))
+        (msg1, ) = tuple(Msg.objects.filter(broadcast=broadcast1))
 
         response = self.client.get(reverse('msgs.msg_outbox'))
         self.assertContains(response, "Outbox (1)")
         self.assertEqual(set(response.context_data['object_list']), {msg1})
 
-        broadcast2 = Broadcast.create(self.channel.org, self.admin, 'kLab is an awesome place for @contact.name',
-                                      [self.kevin, self.joe_and_frank])
+        broadcast2 = Broadcast.create(
+            self.channel.org, self.admin, 'kLab is an awesome place for @contact.name',
+            [self.kevin, self.joe_and_frank]
+        )
 
         # now send the broadcast so we have messages
         broadcast2.send(trigger_send=False)
@@ -692,31 +752,83 @@ class MsgTest(TembaTest):
         self.joe.name = "Jo\02e Blow"
         self.joe.save()
 
-        msg1 = self.create_msg(contact=self.joe, text="hello 1", direction='I', status=HANDLED,
-                               msg_type='I', created_on=datetime(2017, 1, 1, 10, tzinfo=pytz.UTC))
-        msg2 = self.create_msg(contact=self.joe, text="hello 2", direction='I', status=HANDLED,
-                               msg_type='I', created_on=datetime(2017, 1, 2, 10, tzinfo=pytz.UTC))
-        msg3 = self.create_msg(contact=self.joe, text="hello 3", direction='I', status=HANDLED,
-                               msg_type='I', created_on=datetime(2017, 1, 3, 10, tzinfo=pytz.UTC))
+        msg1 = self.create_msg(
+            contact=self.joe,
+            text="hello 1",
+            direction='I',
+            status=HANDLED,
+            msg_type='I',
+            created_on=datetime(2017, 1, 1, 10, tzinfo=pytz.UTC)
+        )
+        msg2 = self.create_msg(
+            contact=self.joe,
+            text="hello 2",
+            direction='I',
+            status=HANDLED,
+            msg_type='I',
+            created_on=datetime(2017, 1, 2, 10, tzinfo=pytz.UTC)
+        )
+        msg3 = self.create_msg(
+            contact=self.joe,
+            text="hello 3",
+            direction='I',
+            status=HANDLED,
+            msg_type='I',
+            created_on=datetime(2017, 1, 3, 10, tzinfo=pytz.UTC)
+        )
 
         # inbound message that looks like a surveyor message
-        msg4 = self.create_msg(contact=self.joe, contact_urn=None, text="hello 4", direction='I', status=HANDLED,
-                               channel=None, msg_type='I', created_on=datetime(2017, 1, 4, 10, tzinfo=pytz.UTC))
+        msg4 = self.create_msg(
+            contact=self.joe,
+            contact_urn=None,
+            text="hello 4",
+            direction='I',
+            status=HANDLED,
+            channel=None,
+            msg_type='I',
+            created_on=datetime(2017, 1, 4, 10, tzinfo=pytz.UTC)
+        )
 
         # inbound message with media attached, such as an ivr recording
-        msg5 = self.create_msg(contact=self.joe, text="Media message", direction='I', status=HANDLED,
-                               msg_type='I', attachments=['audio:http://rapidpro.io/audio/sound.mp3'],
-                               created_on=datetime(2017, 1, 5, 10, tzinfo=pytz.UTC))
+        msg5 = self.create_msg(
+            contact=self.joe,
+            text="Media message",
+            direction='I',
+            status=HANDLED,
+            msg_type='I',
+            attachments=['audio:http://rapidpro.io/audio/sound.mp3'],
+            created_on=datetime(2017, 1, 5, 10, tzinfo=pytz.UTC)
+        )
 
         # create some outbound messages with different statuses
-        msg6 = self.create_msg(contact=self.joe, text="Hey out 6", direction='O', status=SENT,
-                               created_on=datetime(2017, 1, 6, 10, tzinfo=pytz.UTC))
-        msg7 = self.create_msg(contact=self.joe, text="Hey out 7", direction='O', status=DELIVERED,
-                               created_on=datetime(2017, 1, 7, 10, tzinfo=pytz.UTC))
-        msg8 = self.create_msg(contact=self.joe, text="Hey out 8", direction='O', status=ERRORED,
-                               created_on=datetime(2017, 1, 8, 10, tzinfo=pytz.UTC))
-        msg9 = self.create_msg(contact=self.joe, text="Hey out 9", direction='O', status=FAILED,
-                               created_on=datetime(2017, 1, 9, 10, tzinfo=pytz.UTC))
+        msg6 = self.create_msg(
+            contact=self.joe,
+            text="Hey out 6",
+            direction='O',
+            status=SENT,
+            created_on=datetime(2017, 1, 6, 10, tzinfo=pytz.UTC)
+        )
+        msg7 = self.create_msg(
+            contact=self.joe,
+            text="Hey out 7",
+            direction='O',
+            status=DELIVERED,
+            created_on=datetime(2017, 1, 7, 10, tzinfo=pytz.UTC)
+        )
+        msg8 = self.create_msg(
+            contact=self.joe,
+            text="Hey out 8",
+            direction='O',
+            status=ERRORED,
+            created_on=datetime(2017, 1, 8, 10, tzinfo=pytz.UTC)
+        )
+        msg9 = self.create_msg(
+            contact=self.joe,
+            text="Hey out 9",
+            direction='O',
+            status=FAILED,
+            created_on=datetime(2017, 1, 9, 10, tzinfo=pytz.UTC)
+        )
 
         self.assertEqual(msg5.get_attachments(), [Attachment('audio', 'http://rapidpro.io/audio/sound.mp3')])
 
@@ -746,18 +858,21 @@ class MsgTest(TembaTest):
             return workbook.worksheets[0]
 
         # export all visible messages (i.e. not msg3) using export_all param
+        # yapf: disable
         with self.assertNumQueries(25):
-            self.assertExcelSheet(request_export('?l=I', {'export_all': 1}), [
-                ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
-                [msg9.created_on, "123", "tel", "Joe Blow", msg9.contact.uuid, "Outgoing", "Hey out 9", "", "Failed Sending"],
-                [msg8.created_on, "123", "tel", "Joe Blow", msg8.contact.uuid, "Outgoing", "Hey out 8", "", "Error Sending"],
-                [msg7.created_on, "123", "tel", "Joe Blow", msg7.contact.uuid, "Outgoing", "Hey out 7", "", "Delivered"],
-                [msg6.created_on, "123", "tel", "Joe Blow", msg6.contact.uuid, "Outgoing", "Hey out 6", "", "Sent"],
-                [msg5.created_on, "123", "tel", "Joe Blow", msg5.contact.uuid, "Incoming", "Media message", "", "Handled"],
-                [msg4.created_on, "", "", "Joe Blow", msg4.contact.uuid, "Incoming", "hello 4", "", "Handled"],
-                [msg2.created_on, "123", "tel", "Joe Blow", msg2.contact.uuid, "Incoming", "hello 2", "", "Handled"],
-                [msg1.created_on, "123", "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"]
-            ], self.org.timezone)
+            self.assertExcelSheet(
+                request_export('?l=I', {'export_all': 1}), [
+                    ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
+                    [msg9.created_on, "123", "tel", "Joe Blow", msg9.contact.uuid, "Outgoing", "Hey out 9", "", "Failed Sending"],
+                    [msg8.created_on, "123", "tel", "Joe Blow", msg8.contact.uuid, "Outgoing", "Hey out 8", "", "Error Sending"],
+                    [msg7.created_on, "123", "tel", "Joe Blow", msg7.contact.uuid, "Outgoing", "Hey out 7", "", "Delivered"],
+                    [msg6.created_on, "123", "tel", "Joe Blow", msg6.contact.uuid, "Outgoing", "Hey out 6", "", "Sent"],
+                    [msg5.created_on, "123", "tel", "Joe Blow", msg5.contact.uuid, "Incoming", "Media message", "", "Handled"],
+                    [msg4.created_on, "", "", "Joe Blow", msg4.contact.uuid, "Incoming", "hello 4", "", "Handled"],
+                    [msg2.created_on, "123", "tel", "Joe Blow", msg2.contact.uuid, "Incoming", "hello 2", "", "Handled"],
+                    [msg1.created_on, "123", "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"],
+                ], self.org.timezone
+            )
 
         # check email was sent correctly
         email_args = mock_send_temba_email.call_args[0]  # all positional args
@@ -769,26 +884,32 @@ class MsgTest(TembaTest):
         self.assertNotIn('{{', email_args[2])
 
         # export just archived messages
-        self.assertExcelSheet(request_export('?l=A', {'export_all': 0}), [
-            ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
-            [msg3.created_on, "123", "tel", "Joe Blow", msg3.contact.uuid, "Incoming", "hello 3", "", "Handled"],
-        ], self.org.timezone)
+        self.assertExcelSheet(
+            request_export('?l=A', {'export_all': 0}), [
+                ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
+                [msg3.created_on, "123", "tel", "Joe Blow", msg3.contact.uuid, "Incoming", "hello 3", "", "Handled"],
+            ], self.org.timezone
+        )
 
         # filter page should have an export option
         response = self.client.get(reverse('msgs.msg_filter', args=[label.id]))
         self.assertContains(response, "Export")
 
         # try export with user label
-        self.assertExcelSheet(request_export('?l=%s' % label.uuid, {'export_all': 0}), [
-            ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
-            [msg1.created_on, "123", "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"]
-        ], self.org.timezone)
+        self.assertExcelSheet(
+            request_export('?l=%s' % label.uuid, {'export_all': 0}), [
+                ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
+                [msg1.created_on, "123", "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"],
+            ], self.org.timezone
+        )
 
         # try export with user label folder
-        self.assertExcelSheet(request_export('?l=%s' % folder.uuid, {'export_all': 0}), [
-            ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
-            [msg1.created_on, "123", "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"]
-        ], self.org.timezone)
+        self.assertExcelSheet(
+            request_export('?l=%s' % folder.uuid, {'export_all': 0}), [
+                ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
+                [msg1.created_on, "123", "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"]
+            ], self.org.timezone
+        )
 
         # try export with groups and date range
         export_data = {
@@ -798,12 +919,14 @@ class MsgTest(TembaTest):
             'end_date': msg7.created_on.strftime('%B %d, %Y'),
         }
 
-        self.assertExcelSheet(request_export('?l=I', export_data), [
-            ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
-            [msg7.created_on, "123", "tel", "Joe Blow", msg7.contact.uuid, "Outgoing", "Hey out 7", "", "Delivered"],
-            [msg6.created_on, "123", "tel", "Joe Blow", msg6.contact.uuid, "Outgoing", "Hey out 6", "", "Sent"],
-            [msg5.created_on, "123", "tel", "Joe Blow", msg5.contact.uuid, "Incoming", "Media message", "", "Handled"],
-        ], self.org.timezone)
+        self.assertExcelSheet(
+            request_export('?l=I', export_data), [
+                ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
+                [msg7.created_on, "123", "tel", "Joe Blow", msg7.contact.uuid, "Outgoing", "Hey out 7", "", "Delivered"],
+                [msg6.created_on, "123", "tel", "Joe Blow", msg6.contact.uuid, "Outgoing", "Hey out 6", "", "Sent"],
+                [msg5.created_on, "123", "tel", "Joe Blow", msg5.contact.uuid, "Incoming", "Media message", "", "Handled"],
+            ], self.org.timezone
+        )
 
         # check sending an invalid date
         response = self.client.post(reverse('msgs.msg_export') + '?l=I', {'export_all': 1, 'start_date': 'xyz'})
@@ -814,17 +937,21 @@ class MsgTest(TembaTest):
         with AnonymousOrg(self.org):
             joe_anon_id = "%010d" % self.joe.id
 
-            self.assertExcelSheet(request_export('?l=I', {'export_all': 1}), [
-                ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
-                [msg9.created_on, joe_anon_id, "tel", "Joe Blow", msg9.contact.uuid, "Outgoing", "Hey out 9", "", "Failed Sending"],
-                [msg8.created_on, joe_anon_id, "tel", "Joe Blow", msg8.contact.uuid, "Outgoing", "Hey out 8", "", "Error Sending"],
-                [msg7.created_on, joe_anon_id, "tel", "Joe Blow", msg7.contact.uuid, "Outgoing", "Hey out 7", "", "Delivered"],
-                [msg6.created_on, joe_anon_id, "tel", "Joe Blow", msg6.contact.uuid, "Outgoing", "Hey out 6", "", "Sent"],
-                [msg5.created_on, joe_anon_id, "tel", "Joe Blow", msg5.contact.uuid, "Incoming", "Media message", "", "Handled"],
-                [msg4.created_on, joe_anon_id, "", "Joe Blow", msg4.contact.uuid, "Incoming", "hello 4", "", "Handled"],
-                [msg2.created_on, joe_anon_id, "tel", "Joe Blow", msg2.contact.uuid, "Incoming", "hello 2", "", "Handled"],
-                [msg1.created_on, joe_anon_id, "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"]
-            ], self.org.timezone)
+            self.assertExcelSheet(
+                request_export('?l=I', {'export_all': 1}), [
+                    ["Date", "Contact", "Contact Type", "Name", "Contact UUID", "Direction", "Text", "Labels", "Status"],
+                    [msg9.created_on, joe_anon_id, "tel", "Joe Blow", msg9.contact.uuid, "Outgoing", "Hey out 9", "", "Failed Sending"],
+                    [msg8.created_on, joe_anon_id, "tel", "Joe Blow", msg8.contact.uuid, "Outgoing", "Hey out 8", "", "Error Sending"],
+                    [msg7.created_on, joe_anon_id, "tel", "Joe Blow", msg7.contact.uuid, "Outgoing", "Hey out 7", "", "Delivered"],
+                    [msg6.created_on, joe_anon_id, "tel", "Joe Blow", msg6.contact.uuid, "Outgoing", "Hey out 6", "", "Sent"],
+                    [msg5.created_on, joe_anon_id, "tel", "Joe Blow", msg5.contact.uuid, "Incoming", "Media message", "", "Handled"],
+                    [msg4.created_on, joe_anon_id, "", "Joe Blow", msg4.contact.uuid, "Incoming", "hello 4", "", "Handled"],
+                    [msg2.created_on, joe_anon_id, "tel", "Joe Blow", msg2.contact.uuid, "Incoming", "hello 2", "", "Handled"],
+                    [msg1.created_on, joe_anon_id, "tel", "Joe Blow", msg1.contact.uuid, "Incoming", "hello 1", "label1", "Handled"]
+                ], self.org.timezone
+            )
+
+        # yapf: enable
 
 
 class MsgCRUDLTest(TembaTest):
@@ -846,8 +973,12 @@ class MsgCRUDLTest(TembaTest):
         msg1 = self.create_msg(direction='I', msg_type='I', contact=self.joe, text="test1")
         msg2 = self.create_msg(direction='I', msg_type='I', contact=self.frank, text="test2")
         msg3 = self.create_msg(direction='I', msg_type='I', contact=self.billy, text="test3")
-        msg4 = self.create_msg(direction='I', msg_type='I', contact=self.joe, text="test4", visibility=Msg.VISIBILITY_ARCHIVED)
-        msg5 = self.create_msg(direction='I', msg_type='I', contact=self.joe, text="test5", visibility=Msg.VISIBILITY_DELETED)
+        msg4 = self.create_msg(
+            direction='I', msg_type='I', contact=self.joe, text="test4", visibility=Msg.VISIBILITY_ARCHIVED
+        )
+        msg5 = self.create_msg(
+            direction='I', msg_type='I', contact=self.joe, text="test5", visibility=Msg.VISIBILITY_DELETED
+        )
         msg6 = self.create_msg(direction='I', msg_type='F', contact=self.joe, text="flow test")
 
         # apply the labels
@@ -936,7 +1067,6 @@ class BroadcastTest(TembaTest):
             msgs_models.BATCH_SIZE = orig_batch_size
 
     def test_broadcast_model(self):
-
         def assertBroadcastStatus(sms, new_sms_status, broadcast_status):
             sms.status = new_sms_status
             sms.save()
@@ -1007,7 +1137,10 @@ class BroadcastTest(TembaTest):
 
         test_contact = Contact.get_test_contact(self.admin)
 
-        post_data = dict(text="you simulator display this", omnibox="c-%s,c-%s,c-%s" % (self.joe.uuid, self.frank.uuid, test_contact.uuid))
+        post_data = dict(
+            text="you simulator display this",
+            omnibox="c-%s,c-%s,c-%s" % (self.joe.uuid, self.frank.uuid, test_contact.uuid)
+        )
         self.client.post(send_url + "?simulation=true", post_data)
         self.assertEqual(Broadcast.objects.all().count(), 1)
         self.assertEqual(Broadcast.objects.all()[0].groups.all().count(), 0)
@@ -1025,7 +1158,9 @@ class BroadcastTest(TembaTest):
         response = self.client.get(send_url)
         self.assertEqual(['omnibox', 'text', 'schedule', 'step_node'], response.context['fields'])
 
-        post_data = dict(text="message #1", omnibox="g-%s,c-%s,c-%s" % (self.joe_and_frank.uuid, self.joe.uuid, self.lucy.uuid))
+        post_data = dict(
+            text="message #1", omnibox="g-%s,c-%s,c-%s" % (self.joe_and_frank.uuid, self.joe.uuid, self.lucy.uuid)
+        )
         self.client.post(send_url, post_data, follow=True)
         broadcast = Broadcast.objects.get()
         self.assertEqual(broadcast.text, {'base': "message #1"})
@@ -1080,7 +1215,11 @@ class BroadcastTest(TembaTest):
         self.assertIn("success", response.content)
 
         # send using our omnibox
-        post_data = dict(text="this is a test message", omnibox="c-%s,g-%s,n-911" % (self.kevin.pk, self.joe_and_frank.pk), _format="json")
+        post_data = dict(
+            text="this is a test message",
+            omnibox="c-%s,g-%s,n-911" % (self.kevin.pk, self.joe_and_frank.pk),
+            _format="json"
+        )
         response = self.client.post(send_url, post_data, follow=True)
         self.assertIn("success", response.content)
 
@@ -1134,7 +1273,9 @@ class BroadcastTest(TembaTest):
         self.assertEqual(sorted([m.contact.name for m in msgs]), ["Lucy", "Ryan Lewis"])
 
         # send another broadcast to all and force use of the twitter channel
-        broadcast = Broadcast.create(self.org, self.admin, "Want to go thrift shopping?", recipients, channel=self.twitter)
+        broadcast = Broadcast.create(
+            self.org, self.admin, "Want to go thrift shopping?", recipients, channel=self.twitter
+        )
         broadcast.send(True)
 
         # should have only one message created to Lucy
@@ -1203,8 +1344,12 @@ class BroadcastTest(TembaTest):
         self.assertEqual(("Hello World", []), substitute("Hello World", dict()))
         self.assertEqual(("Hello World Joe", []), substitute("Hello World @contact.first_name", dict()))
         self.assertEqual(("Hello World Joe Blow", []), substitute("Hello World @contact", dict()))
-        self.assertEqual(("Hello World: Well", []), substitute("Hello World: @flow.water_source", dict(flow=dict(water_source="Well"))))
-        self.assertEqual(("Hello World: Well  Boil: @flow.boil", ["Undefined variable: flow.boil"]), substitute("Hello World: @flow.water_source  Boil: @flow.boil", dict(flow=dict(water_source="Well"))))
+        self.assertEqual(("Hello World: Well", []),
+                         substitute("Hello World: @flow.water_source", dict(flow=dict(water_source="Well"))))
+        self.assertEqual(
+            ("Hello World: Well  Boil: @flow.boil", ["Undefined variable: flow.boil"]),
+            substitute("Hello World: @flow.water_source  Boil: @flow.boil", dict(flow=dict(water_source="Well")))
+        )
 
         self.assertEqual(("Hello joe", []), substitute("Hello @(LOWER(contact.first_name))", dict()))
         self.assertEqual(("Hello Joe", []), substitute("Hello @(PROPER(LOWER(contact.first_name)))", dict()))
@@ -1214,10 +1359,14 @@ class BroadcastTest(TembaTest):
         self.assertEqual(("Hello JOE", []), substitute("Hello @(UPPER(contact.first_name))", dict()))
         self.assertEqual(("Hello 3", []), substitute("Hello @(contact.goats)", dict()))
 
-        self.assertEqual(("Email is: foo@bar.com", []),
-                         substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@bar.com"))))
-        self.assertEqual(("Email is: foo@@bar.com", []),
-                         substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@@bar.com"))))
+        self.assertEqual(
+            ("Email is: foo@bar.com", []),
+            substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@bar.com")))
+        )
+        self.assertEqual(
+            ("Email is: foo@@bar.com", []),
+            substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@@bar.com")))
+        )
 
         # check date variables
         text, errors = substitute("Today is @date.today", dict())
@@ -1293,7 +1442,9 @@ class BroadcastTest(TembaTest):
         msg.save()
         context = msg.build_expressions_context()
 
-        self.assertEqual(context['__default__'], "keyword remainder-remainder\nhttp://e.com/test.jpg\nhttp://e.com/test.mp3")
+        self.assertEqual(
+            context['__default__'], "keyword remainder-remainder\nhttp://e.com/test.jpg\nhttp://e.com/test.mp3"
+        )
         self.assertEqual(context['value'], "keyword remainder-remainder\nhttp://e.com/test.jpg\nhttp://e.com/test.mp3")
         self.assertEqual(context['text'], "keyword remainder-remainder")
         self.assertEqual(context['attachments'], {"0": "http://e.com/test.jpg", "1": "http://e.com/test.mp3"})
@@ -1319,20 +1470,30 @@ class BroadcastTest(TembaTest):
         self.joe.set_field(self.user, "team", "Amavubi")
         self.kevin.set_field(self.user, "team", "Junior")
 
-        broadcast1 = Broadcast.create(self.org, self.user,
-                                      "Hi @contact.name, You live in @contact.sector and your team is @contact.team.",
-                                      [self.joe_and_frank, self.kevin])
+        broadcast1 = Broadcast.create(
+            self.org, self.user, "Hi @contact.name, You live in @contact.sector and your team is @contact.team.",
+            [self.joe_and_frank, self.kevin]
+        )
         broadcast1.send(trigger_send=False, expressions_context={})
 
         # no message created for Frank because he misses some fields for variables substitution
         self.assertEqual(Msg.objects.all().count(), 3)
 
-        self.assertEqual(self.joe.msgs.get(broadcast=broadcast1).text, 'Hi Joe Blow, You live in Kacyiru and your team is Amavubi.')
-        self.assertEqual(self.frank.msgs.get(broadcast=broadcast1).text, 'Hi Frank Blow, You live in Remera and your team is .')
-        self.assertEqual(self.kevin.msgs.get(broadcast=broadcast1).text, 'Hi Kevin Durant, You live in Kanombe and your team is Junior.')
+        self.assertEqual(
+            self.joe.msgs.get(broadcast=broadcast1).text, 'Hi Joe Blow, You live in Kacyiru and your team is Amavubi.'
+        )
+        self.assertEqual(
+            self.frank.msgs.get(broadcast=broadcast1).text, 'Hi Frank Blow, You live in Remera and your team is .'
+        )
+        self.assertEqual(
+            self.kevin.msgs.get(broadcast=broadcast1).text,
+            'Hi Kevin Durant, You live in Kanombe and your team is Junior.'
+        )
 
         # if we don't provide a context then substitution isn't performed
-        broadcast2 = Broadcast.create(self.org, self.user, "Hi @contact.name on @channel", [self.joe_and_frank, self.kevin])
+        broadcast2 = Broadcast.create(
+            self.org, self.user, "Hi @contact.name on @channel", [self.joe_and_frank, self.kevin]
+        )
         broadcast2.send(trigger_send=False)
 
         self.assertEqual(self.joe.msgs.get(broadcast=broadcast2).text, "Hi @contact.name on @channel")
@@ -1348,8 +1509,9 @@ class BroadcastTest(TembaTest):
 
         # and one non-purgeable
         admin3 = self.create_user("Administrator3")
-        org3 = Org.objects.create(name="Hoarders", timezone="Africa/Kampala", brand='rapidpro.io',
-                                  created_by=admin3, modified_by=admin3)
+        org3 = Org.objects.create(
+            name="Hoarders", timezone="Africa/Kampala", brand='rapidpro.io', created_by=admin3, modified_by=admin3
+        )
 
         # create an old broadcast which is a response to an incoming message
         incoming = self.create_msg(contact=self.joe, direction='I', text="Hello")
@@ -1357,15 +1519,20 @@ class BroadcastTest(TembaTest):
         broadcast1.send(trigger_send=False, response_to=incoming)
 
         # create an old broadcast which is to several contacts
-        broadcast2 = Broadcast.create(self.org, self.user, "Very old broadcast",
-                                      [self.joe_and_frank, self.kevin, self.lucy], created_on=long_ago)
+        broadcast2 = Broadcast.create(
+            self.org,
+            self.user,
+            "Very old broadcast", [self.joe_and_frank, self.kevin, self.lucy],
+            created_on=long_ago
+        )
         broadcast2.send(trigger_send=False)
 
         # print(repr([{'name': m.contact.name, 'status': m.status} for m in broadcast2.msgs.all()]))
 
         # create a recent broadcast to same contacts
-        broadcast3 = Broadcast.create(self.org, self.user, "New broadcast",
-                                      [self.joe_and_frank, self.kevin, self.lucy])
+        broadcast3 = Broadcast.create(
+            self.org, self.user, "New broadcast", [self.joe_and_frank, self.kevin, self.lucy]
+        )
         broadcast3.send(trigger_send=False)
 
         # create an old broadcast for the other purgeable org
@@ -1432,9 +1599,12 @@ class BroadcastTest(TembaTest):
         self.assertEqual(Broadcast.objects.filter(org=org3, purged=True).count(), 0)
 
         # create another old broadcast
-        broadcast5 = Broadcast.create(self.org, self.admin, "Another old broadcast",
-                                      [self.joe_and_frank, self.kevin, self.lucy],
-                                      created_on=timezone.now() - timedelta(days=100))
+        broadcast5 = Broadcast.create(
+            self.org,
+            self.admin,
+            "Another old broadcast", [self.joe_and_frank, self.kevin, self.lucy],
+            created_on=timezone.now() - timedelta(days=100)
+        )
         broadcast5.send(trigger_send=False)
 
         self.assertEqual(SystemLabel.get_counts(self.org)[SystemLabel.TYPE_OUTBOX], 4)
@@ -1453,10 +1623,12 @@ class BroadcastTest(TembaTest):
 
     def test_clear_old_msg_external_ids(self):
         last_month = timezone.now() - timedelta(days=31)
-        msg1 = self.create_msg(contact=self.joe, text="What's your name?", direction='O', external_id='ex101',
-                               created_on=last_month)
-        msg2 = self.create_msg(contact=self.joe, text="It's Joe", direction='I', external_id='ex102',
-                               created_on=last_month)
+        msg1 = self.create_msg(
+            contact=self.joe, text="What's your name?", direction='O', external_id='ex101', created_on=last_month
+        )
+        msg2 = self.create_msg(
+            contact=self.joe, text="It's Joe", direction='I', external_id='ex102', created_on=last_month
+        )
         msg3 = self.create_msg(contact=self.joe, text="Good name", direction='O', external_id='ex103')
 
         clear_old_msg_external_ids()
@@ -1494,8 +1666,10 @@ class BroadcastCRUDLTest(TembaTest):
 
         just_joe = self.create_group("Just Joe")
         just_joe.contacts.add(self.joe)
-        post_data = dict(omnibox="g-%s,c-%s,n-0780000001" % (just_joe.uuid, self.frank.uuid),
-                         text="Hey Joe, where you goin' with that gun in your hand?")
+        post_data = dict(
+            omnibox="g-%s,c-%s,n-0780000001" % (just_joe.uuid, self.frank.uuid),
+            text="Hey Joe, where you goin' with that gun in your hand?"
+        )
         response = self.client.post(url + '?_format=json', post_data)
 
         self.assertEqual(response.status_code, 200)
@@ -1513,8 +1687,9 @@ class BroadcastCRUDLTest(TembaTest):
 
     def test_update(self):
         self.login(self.editor)
-        self.client.post(reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid,
-                                                              text="Lunch reminder", schedule=True))
+        self.client.post(
+            reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid, text="Lunch reminder", schedule=True)
+        )
         broadcast = Broadcast.objects.get()
         url = reverse('msgs.broadcast_update', args=[broadcast.pk])
 
@@ -1539,10 +1714,10 @@ class BroadcastCRUDLTest(TembaTest):
         self.login(self.editor)
 
         # send some messages - one immediately, one scheduled
-        self.client.post(reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid,
-                                                              text="See you later"))
-        self.client.post(reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid,
-                                                              text="Lunch reminder", schedule=True))
+        self.client.post(reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid, text="See you later"))
+        self.client.post(
+            reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid, text="Lunch reminder", schedule=True)
+        )
 
         scheduled = Broadcast.objects.exclude(schedule=None).first()
 
@@ -1551,8 +1726,9 @@ class BroadcastCRUDLTest(TembaTest):
 
     def test_schedule_read(self):
         self.login(self.editor)
-        self.client.post(reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid,
-                                                              text="Lunch reminder", schedule=True))
+        self.client.post(
+            reverse('msgs.broadcast_send'), dict(omnibox="c-%s" % self.joe.uuid, text="Lunch reminder", schedule=True)
+        )
         broadcast = Broadcast.objects.get()
 
         # view with empty Send History
@@ -1570,7 +1746,6 @@ class BroadcastCRUDLTest(TembaTest):
 
 
 class LabelTest(TembaTest):
-
     def setUp(self):
         super(LabelTest, self).setUp()
 
@@ -1691,14 +1866,32 @@ class LabelTest(TembaTest):
 
         with self.assertNumQueries(2):
             hierarchy = Label.get_hierarchy(self.org)
-            self.assertEqual(hierarchy, [
-                {'obj': label3, 'count': 1, 'children': []},
-                {'obj': folder1, 'count': None, 'children': [
-                    {'obj': label2, 'count': 2, 'children': []},
-                    {'obj': label1, 'count': 2, 'children': []},
-                ]},
-                {'obj': folder2, 'count': None, 'children': []}
-            ])
+            self.assertEqual(
+                hierarchy, [{
+                    'obj': label3,
+                    'count': 1,
+                    'children': []
+                }, {
+                    'obj': folder1,
+                    'count': None,
+                    'children': [
+                        {
+                            'obj': label2,
+                            'count': 2,
+                            'children': []
+                        },
+                        {
+                            'obj': label1,
+                            'count': 2,
+                            'children': []
+                        },
+                    ]
+                }, {
+                    'obj': folder2,
+                    'count': None,
+                    'children': []
+                }]
+            )
 
     def test_delete_folder(self):
         folder1 = Label.get_or_create_folder(self.org, self.user, "Folder")
@@ -1731,7 +1924,6 @@ class LabelTest(TembaTest):
 
 
 class LabelCRUDLTest(TembaTest):
-
     @patch.object(Label, "MAX_ORG_LABELS", new=10)
     def test_create_and_update(self):
         create_label_url = reverse('msgs.label_create')
@@ -1780,9 +1972,10 @@ class LabelCRUDLTest(TembaTest):
             Label.get_or_create(self.org, self.user, "label%d" % i)
 
         response = self.client.post(create_label_url, dict(name="Label"))
-        self.assertFormError(response, 'form', 'name',
-                             "This org has 10 labels and the limit is 10. "
-                             "You must delete existing ones before you can create new ones.")
+        self.assertFormError(
+            response, 'form', 'name', "This org has 10 labels and the limit is 10. "
+            "You must delete existing ones before you can create new ones."
+        )
 
     def test_label_delete(self):
         label_one = Label.get_or_create(self.org, self.user, "label1")
@@ -1824,7 +2017,6 @@ class LabelCRUDLTest(TembaTest):
 
 
 class ScheduleTest(TembaTest):
-
     def tearDown(self):
         from temba.channels import models as channel_models
         channel_models.SEND_QUEUE_DEPTH = 500
@@ -1866,7 +2058,6 @@ class ScheduleTest(TembaTest):
 
 
 class ConsoleTest(TembaTest):
-
     def setUp(self):
         from temba.triggers.models import Trigger
 
@@ -1881,7 +2072,9 @@ class ConsoleTest(TembaTest):
 
         # create a flow and set "color" as its trigger
         self.flow = self.create_flow(definition=self.COLOR_FLOW_DEFINITION)
-        Trigger.objects.create(flow=self.flow, keyword="color", created_by=self.admin, modified_by=self.admin, org=self.org)
+        Trigger.objects.create(
+            flow=self.flow, keyword="color", created_by=self.admin, modified_by=self.admin, org=self.org
+        )
 
     def assertEchoed(self, needle, clear=True):
         found = False
@@ -1942,7 +2135,6 @@ class ConsoleTest(TembaTest):
 
 
 class BroadcastLanguageTest(TembaTest):
-
     def setUp(self):
         super(BroadcastLanguageTest, self).setUp()
 
@@ -1967,8 +2159,12 @@ class BroadcastLanguageTest(TembaTest):
         fre_msg = "Ceci est mon message"
 
         # now create a broadcast with a couple contacts, one with an explicit language, the other not
-        bcast = Broadcast.create(self.org, self.admin, dict(eng=eng_msg, fre=fre_msg),
-                                 [self.francois, self.greg, self.wilbert], base_language='eng')
+        bcast = Broadcast.create(
+            self.org,
+            self.admin,
+            dict(eng=eng_msg, fre=fre_msg), [self.francois, self.greg, self.wilbert],
+            base_language='eng'
+        )
 
         bcast.send()
 
@@ -1984,9 +2180,13 @@ class BroadcastLanguageTest(TembaTest):
         fre_attachment = 'image/jpeg:attachments/fre_picture.jpg'
 
         # now create a broadcast with a couple contacts, one with an explicit language, the other not
-        bcast = Broadcast.create(self.org, self.admin, dict(eng=eng_msg, fre=fre_msg),
-                                 [self.francois, self.greg, self.wilbert], base_language='eng',
-                                 media=dict(eng=eng_attachment, fre=fre_attachment))
+        bcast = Broadcast.create(
+            self.org,
+            self.admin,
+            dict(eng=eng_msg, fre=fre_msg), [self.francois, self.greg, self.wilbert],
+            base_language='eng',
+            media=dict(eng=eng_attachment, fre=fre_attachment)
+        )
 
         bcast.send()
 
@@ -2011,10 +2211,18 @@ class BroadcastLanguageTest(TembaTest):
 
 class SystemLabelTest(TembaTest):
     def test_get_counts(self):
-        self.assertEqual(SystemLabel.get_counts(self.org), {SystemLabel.TYPE_INBOX: 0, SystemLabel.TYPE_FLOWS: 0,
-                                                            SystemLabel.TYPE_ARCHIVED: 0, SystemLabel.TYPE_OUTBOX: 0,
-                                                            SystemLabel.TYPE_SENT: 0, SystemLabel.TYPE_FAILED: 0,
-                                                            SystemLabel.TYPE_SCHEDULED: 0, SystemLabel.TYPE_CALLS: 0})
+        self.assertEqual(
+            SystemLabel.get_counts(self.org), {
+                SystemLabel.TYPE_INBOX: 0,
+                SystemLabel.TYPE_FLOWS: 0,
+                SystemLabel.TYPE_ARCHIVED: 0,
+                SystemLabel.TYPE_OUTBOX: 0,
+                SystemLabel.TYPE_SENT: 0,
+                SystemLabel.TYPE_FAILED: 0,
+                SystemLabel.TYPE_SCHEDULED: 0,
+                SystemLabel.TYPE_CALLS: 0
+            }
+        )
 
         contact1 = self.create_contact("Bob", number="0783835001")
         contact2 = self.create_contact("Jim", number="0783835002")
@@ -2024,8 +2232,12 @@ class SystemLabelTest(TembaTest):
         msg4 = Msg.create_incoming(self.channel, "tel:0783835001", text="Message 4")
         call1 = ChannelEvent.create(self.channel, "tel:0783835001", ChannelEvent.TYPE_CALL_IN, timezone.now(), 10)
         bcast1 = Broadcast.create(self.org, self.user, "Broadcast 1", [contact1, contact2])
-        Broadcast.create(self.org, self.user, "Broadcast 2", [contact1, contact2],
-                         schedule=Schedule.create_schedule(timezone.now(), 'D', self.user))
+        Broadcast.create(
+            self.org,
+            self.user,
+            "Broadcast 2", [contact1, contact2],
+            schedule=Schedule.create_schedule(timezone.now(), 'D', self.user)
+        )
 
         # create a broadcast with a test contact to make sure they aren't included
         test_bcast = Broadcast.create(self.org, self.user, "Test Broadcast", [Contact.get_test_contact(self.admin)])
@@ -2033,22 +2245,42 @@ class SystemLabelTest(TembaTest):
         # this will create some test outgoing messages as well
         test_bcast.send()
 
-        self.assertEqual(SystemLabel.get_counts(self.org), {SystemLabel.TYPE_INBOX: 4, SystemLabel.TYPE_FLOWS: 0,
-                                                            SystemLabel.TYPE_ARCHIVED: 0, SystemLabel.TYPE_OUTBOX: 0,
-                                                            SystemLabel.TYPE_SENT: 0, SystemLabel.TYPE_FAILED: 0,
-                                                            SystemLabel.TYPE_SCHEDULED: 1, SystemLabel.TYPE_CALLS: 1})
+        self.assertEqual(
+            SystemLabel.get_counts(self.org), {
+                SystemLabel.TYPE_INBOX: 4,
+                SystemLabel.TYPE_FLOWS: 0,
+                SystemLabel.TYPE_ARCHIVED: 0,
+                SystemLabel.TYPE_OUTBOX: 0,
+                SystemLabel.TYPE_SENT: 0,
+                SystemLabel.TYPE_FAILED: 0,
+                SystemLabel.TYPE_SCHEDULED: 1,
+                SystemLabel.TYPE_CALLS: 1
+            }
+        )
 
         msg3.archive()
         bcast1.send(status=QUEUED)
         msg5, msg6 = tuple(Msg.objects.filter(broadcast=bcast1))
         ChannelEvent.create(self.channel, "tel:0783835002", ChannelEvent.TYPE_CALL_IN, timezone.now(), 10)
-        Broadcast.create(self.org, self.user, "Broadcast 3", [contact1],
-                         schedule=Schedule.create_schedule(timezone.now(), 'W', self.user))
+        Broadcast.create(
+            self.org,
+            self.user,
+            "Broadcast 3", [contact1],
+            schedule=Schedule.create_schedule(timezone.now(), 'W', self.user)
+        )
 
-        self.assertEqual(SystemLabel.get_counts(self.org), {SystemLabel.TYPE_INBOX: 3, SystemLabel.TYPE_FLOWS: 0,
-                                                            SystemLabel.TYPE_ARCHIVED: 1, SystemLabel.TYPE_OUTBOX: 2,
-                                                            SystemLabel.TYPE_SENT: 0, SystemLabel.TYPE_FAILED: 0,
-                                                            SystemLabel.TYPE_SCHEDULED: 2, SystemLabel.TYPE_CALLS: 2})
+        self.assertEqual(
+            SystemLabel.get_counts(self.org), {
+                SystemLabel.TYPE_INBOX: 3,
+                SystemLabel.TYPE_FLOWS: 0,
+                SystemLabel.TYPE_ARCHIVED: 1,
+                SystemLabel.TYPE_OUTBOX: 2,
+                SystemLabel.TYPE_SENT: 0,
+                SystemLabel.TYPE_FAILED: 0,
+                SystemLabel.TYPE_SCHEDULED: 2,
+                SystemLabel.TYPE_CALLS: 2
+            }
+        )
 
         msg1.archive()
         msg3.release()  # deleting an archived msg
@@ -2057,20 +2289,36 @@ class SystemLabelTest(TembaTest):
         msg6.status_sent()
         call1.release()
 
-        self.assertEqual(SystemLabel.get_counts(self.org), {SystemLabel.TYPE_INBOX: 1, SystemLabel.TYPE_FLOWS: 0,
-                                                            SystemLabel.TYPE_ARCHIVED: 1, SystemLabel.TYPE_OUTBOX: 0,
-                                                            SystemLabel.TYPE_SENT: 1, SystemLabel.TYPE_FAILED: 1,
-                                                            SystemLabel.TYPE_SCHEDULED: 2, SystemLabel.TYPE_CALLS: 1})
+        self.assertEqual(
+            SystemLabel.get_counts(self.org), {
+                SystemLabel.TYPE_INBOX: 1,
+                SystemLabel.TYPE_FLOWS: 0,
+                SystemLabel.TYPE_ARCHIVED: 1,
+                SystemLabel.TYPE_OUTBOX: 0,
+                SystemLabel.TYPE_SENT: 1,
+                SystemLabel.TYPE_FAILED: 1,
+                SystemLabel.TYPE_SCHEDULED: 2,
+                SystemLabel.TYPE_CALLS: 1
+            }
+        )
 
         msg1.restore()
         msg3.release()  # already released
         msg5.status_fail()  # already failed
         msg6.status_delivered()
 
-        self.assertEqual(SystemLabel.get_counts(self.org), {SystemLabel.TYPE_INBOX: 2, SystemLabel.TYPE_FLOWS: 0,
-                                                            SystemLabel.TYPE_ARCHIVED: 0, SystemLabel.TYPE_OUTBOX: 0,
-                                                            SystemLabel.TYPE_SENT: 1, SystemLabel.TYPE_FAILED: 1,
-                                                            SystemLabel.TYPE_SCHEDULED: 2, SystemLabel.TYPE_CALLS: 1})
+        self.assertEqual(
+            SystemLabel.get_counts(self.org), {
+                SystemLabel.TYPE_INBOX: 2,
+                SystemLabel.TYPE_FLOWS: 0,
+                SystemLabel.TYPE_ARCHIVED: 0,
+                SystemLabel.TYPE_OUTBOX: 0,
+                SystemLabel.TYPE_SENT: 1,
+                SystemLabel.TYPE_FAILED: 1,
+                SystemLabel.TYPE_SCHEDULED: 2,
+                SystemLabel.TYPE_CALLS: 1
+            }
+        )
 
         msg5.resend()
 
@@ -2079,10 +2327,18 @@ class SystemLabelTest(TembaTest):
         # squash our counts
         squash_labelcounts()
 
-        self.assertEqual(SystemLabel.get_counts(self.org), {SystemLabel.TYPE_INBOX: 2, SystemLabel.TYPE_FLOWS: 0,
-                                                            SystemLabel.TYPE_ARCHIVED: 0, SystemLabel.TYPE_OUTBOX: 1,
-                                                            SystemLabel.TYPE_SENT: 1, SystemLabel.TYPE_FAILED: 0,
-                                                            SystemLabel.TYPE_SCHEDULED: 2, SystemLabel.TYPE_CALLS: 1})
+        self.assertEqual(
+            SystemLabel.get_counts(self.org), {
+                SystemLabel.TYPE_INBOX: 2,
+                SystemLabel.TYPE_FLOWS: 0,
+                SystemLabel.TYPE_ARCHIVED: 0,
+                SystemLabel.TYPE_OUTBOX: 1,
+                SystemLabel.TYPE_SENT: 1,
+                SystemLabel.TYPE_FAILED: 0,
+                SystemLabel.TYPE_SCHEDULED: 2,
+                SystemLabel.TYPE_CALLS: 1
+            }
+        )
 
         # we should only have one system label per type
         self.assertEqual(SystemLabelCount.objects.all().count(), 7)
@@ -2125,26 +2381,31 @@ class TagsTest(TembaTest):
         # default cause is pending sent
         self.assertHasClass(as_icon(None), 'icon-bubble-dots-2 green')
 
-        in_call = ChannelEvent.create(self.channel, six.text_type(self.joe.get_urn(TEL_SCHEME)),
-                                      ChannelEvent.TYPE_CALL_IN, timezone.now(), 5)
+        in_call = ChannelEvent.create(
+            self.channel, six.text_type(self.joe.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_IN, timezone.now(), 5
+        )
         self.assertHasClass(as_icon(in_call), 'icon-call-incoming green')
 
-        in_miss = ChannelEvent.create(self.channel, six.text_type(self.joe.get_urn(TEL_SCHEME)),
-                                      ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now(), 5)
+        in_miss = ChannelEvent.create(
+            self.channel,
+            six.text_type(self.joe.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now(), 5
+        )
         self.assertHasClass(as_icon(in_miss), 'icon-call-incoming red')
 
-        out_call = ChannelEvent.create(self.channel, six.text_type(self.joe.get_urn(TEL_SCHEME)),
-                                       ChannelEvent.TYPE_CALL_OUT, timezone.now(), 5)
+        out_call = ChannelEvent.create(
+            self.channel, six.text_type(self.joe.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_OUT, timezone.now(), 5
+        )
         self.assertHasClass(as_icon(out_call), 'icon-call-outgoing green')
 
-        out_miss = ChannelEvent.create(self.channel, six.text_type(self.joe.get_urn(TEL_SCHEME)),
-                                       ChannelEvent.TYPE_CALL_OUT_MISSED, timezone.now(), 5)
+        out_miss = ChannelEvent.create(
+            self.channel,
+            six.text_type(self.joe.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_OUT_MISSED, timezone.now(), 5
+        )
         self.assertHasClass(as_icon(out_miss), 'icon-call-outgoing red')
 
     def test_render(self):
         template_src = '{% load sms %}{% render as foo %}123<a>{{ bar }}{% endrender %}-{{ foo }}-'
-        self.assertEqual(self.render_template(template_src, {'bar': 'abc'}),
-                         '-123<a>abc-')
+        self.assertEqual(self.render_template(template_src, {'bar': 'abc'}), '-123<a>abc-')
 
         # exception if tag not used correctly
         self.assertRaises(ValueError, self.render_template, '{% load sms %}{% render with bob %}{% endrender %}')
@@ -2152,7 +2413,6 @@ class TagsTest(TembaTest):
 
 
 class CeleryTaskTest(TembaTest):
-
     def setUp(self):
         super(CeleryTaskTest, self).setUp()
 
@@ -2161,9 +2421,16 @@ class CeleryTaskTest(TembaTest):
         self.joe = self.create_contact("Joe", "+250788383444")
 
         self.channel2 = Channel.create(
-            self.org, self.user, 'RW', 'JNU', None, '1234',
+            self.org,
+            self.user,
+            'RW',
+            'JNU',
+            None,
+            '1234',
             config=dict(username='junebug-user', password='junebug-pass', send_url='http://example.org/'),
-            uuid='00000000-0000-0000-0000-000000001234', role=Channel.ROLE_USSD)
+            uuid='00000000-0000-0000-0000-000000001234',
+            role=Channel.ROLE_USSD
+        )
 
     def _fixture_teardown(self):
         Msg.objects.all().delete()
@@ -2210,14 +2477,16 @@ class CeleryTaskTest(TembaTest):
             self.assertInDB(msg1)
             self.assert_task_sent('send_msg_task')
 
-        with patch('celery.current_app.send_task', new_send_task), patch('temba.msgs.models.push_task', new_push_task), transaction.atomic():
-            msg1 = Msg.create_outgoing(self.org, self.user, self.joe, "Hello, we heard from you.", channel=self.channel2)
+        with patch('celery.current_app.send_task', new_send_task), patch('temba.msgs.models.push_task',
+                                                                         new_push_task), transaction.atomic():
+            msg1 = Msg.create_outgoing(
+                self.org, self.user, self.joe, "Hello, we heard from you.", channel=self.channel2
+            )
 
             Msg.send_messages([msg1])
 
 
 class HandleEventTest(TembaTest):
-
     def test_stop_contact_task(self):
         self.joe = self.create_contact("Joe", "+12065551212")
         push_task(self.org, HANDLER_QUEUE, HANDLE_EVENT_TASK, dict(type=STOP_CONTACT_EVENT, contact_id=self.joe.id))

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -47,7 +47,6 @@ from timezone_field import TimeZoneField
 from urlparse import urlparse
 from uuid import uuid4
 
-
 UNREAD_INBOX_MSGS = 'unread_inbox_msgs'
 UNREAD_FLOW_MSGS = 'unread_flow_msgs'
 
@@ -81,17 +80,11 @@ TIER_449_PLAN = 'TIER_449'
 DAYFIRST = 'D'
 MONTHFIRST = 'M'
 
-PLANS = ((FREE_PLAN, _("Free Plan")),
-         (TRIAL_PLAN, _("Trial")),
-         (TIER_39_PLAN, _("Bronze")),
-         (TIER1_PLAN, _("Silver")),
-         (TIER2_PLAN, _("Gold (Legacy)")),
-         (TIER3_PLAN, _("Platinum (Legacy)")),
-         (TIER_249_PLAN, _("Gold")),
+PLANS = ((FREE_PLAN, _("Free Plan")), (TRIAL_PLAN, _("Trial")), (TIER_39_PLAN, _("Bronze")), (TIER1_PLAN, _("Silver")),
+         (TIER2_PLAN, _("Gold (Legacy)")), (TIER3_PLAN, _("Platinum (Legacy)")), (TIER_249_PLAN, _("Gold")),
          (TIER_449_PLAN, _("Platinum")))
 
-DATE_PARSING = ((DAYFIRST, "DD-MM-YYYY"),
-                (MONTHFIRST, "MM-DD-YYYY"))
+DATE_PARSING = ((DAYFIRST, "DD-MM-YYYY"), (MONTHFIRST, "MM-DD-YYYY"))
 
 APPLICATION_SID = 'APPLICATION_SID'
 ACCOUNT_SID = 'ACCOUNT_SID'
@@ -183,68 +176,124 @@ class Org(SmartModel):
     each country where they are deploying messaging applications.
     """
     name = models.CharField(verbose_name=_("Name"), max_length=128)
-    plan = models.CharField(verbose_name=_("Plan"), max_length=16, choices=PLANS, default=FREE_PLAN,
-                            help_text=_("What plan your organization is on"))
-    plan_start = models.DateTimeField(verbose_name=_("Plan Start"), auto_now_add=True,
-                                      help_text=_("When the user switched to this plan"))
+    plan = models.CharField(
+        verbose_name=_("Plan"),
+        max_length=16,
+        choices=PLANS,
+        default=FREE_PLAN,
+        help_text=_("What plan your organization is on")
+    )
+    plan_start = models.DateTimeField(
+        verbose_name=_("Plan Start"), auto_now_add=True, help_text=_("When the user switched to this plan")
+    )
 
-    stripe_customer = models.CharField(verbose_name=_("Stripe Customer"), max_length=32, null=True, blank=True,
-                                       help_text=_("Our Stripe customer id for your organization"))
+    stripe_customer = models.CharField(
+        verbose_name=_("Stripe Customer"),
+        max_length=32,
+        null=True,
+        blank=True,
+        help_text=_("Our Stripe customer id for your organization")
+    )
 
-    administrators = models.ManyToManyField(User, verbose_name=_("Administrators"), related_name="org_admins",
-                                            help_text=_("The administrators in your organization"))
+    administrators = models.ManyToManyField(
+        User,
+        verbose_name=_("Administrators"),
+        related_name="org_admins",
+        help_text=_("The administrators in your organization")
+    )
 
-    viewers = models.ManyToManyField(User, verbose_name=_("Viewers"), related_name="org_viewers",
-                                     help_text=_("The viewers in your organization"))
+    viewers = models.ManyToManyField(
+        User, verbose_name=_("Viewers"), related_name="org_viewers", help_text=_("The viewers in your organization")
+    )
 
-    editors = models.ManyToManyField(User, verbose_name=_("Editors"), related_name="org_editors",
-                                     help_text=_("The editors in your organization"))
+    editors = models.ManyToManyField(
+        User, verbose_name=_("Editors"), related_name="org_editors", help_text=_("The editors in your organization")
+    )
 
-    surveyors = models.ManyToManyField(User, verbose_name=_("Surveyors"), related_name="org_surveyors",
-                                       help_text=_("The users can login via Android for your organization"))
+    surveyors = models.ManyToManyField(
+        User,
+        verbose_name=_("Surveyors"),
+        related_name="org_surveyors",
+        help_text=_("The users can login via Android for your organization")
+    )
 
-    language = models.CharField(verbose_name=_("Language"), max_length=64, null=True, blank=True,
-                                choices=settings.LANGUAGES, help_text=_("The main language used by this organization"))
+    language = models.CharField(
+        verbose_name=_("Language"),
+        max_length=64,
+        null=True,
+        blank=True,
+        choices=settings.LANGUAGES,
+        help_text=_("The main language used by this organization")
+    )
 
     timezone = TimeZoneField(verbose_name=_("Timezone"))
 
-    date_format = models.CharField(verbose_name=_("Date Format"), max_length=1, choices=DATE_PARSING, default=DAYFIRST,
-                                   help_text=_("Whether day comes first or month comes first in dates"))
+    date_format = models.CharField(
+        verbose_name=_("Date Format"),
+        max_length=1,
+        choices=DATE_PARSING,
+        default=DAYFIRST,
+        help_text=_("Whether day comes first or month comes first in dates")
+    )
 
-    webhook = models.TextField(null=True, verbose_name=_("Webhook"),
-                               help_text=_("Webhook endpoint and configuration"))
+    webhook = models.TextField(null=True, verbose_name=_("Webhook"), help_text=_("Webhook endpoint and configuration"))
 
-    webhook_events = models.IntegerField(default=0, verbose_name=_("Webhook Events"),
-                                         help_text=_("Which type of actions will trigger webhook events."))
+    webhook_events = models.IntegerField(
+        default=0, verbose_name=_("Webhook Events"), help_text=_("Which type of actions will trigger webhook events.")
+    )
 
-    country = models.ForeignKey('locations.AdminBoundary', null=True, blank=True, on_delete=models.SET_NULL,
-                                help_text="The country this organization should map results for.")
+    country = models.ForeignKey(
+        'locations.AdminBoundary',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        help_text="The country this organization should map results for."
+    )
 
     msg_last_viewed = models.DateTimeField(verbose_name=_("Message Last Viewed"), auto_now_add=True)
 
     flows_last_viewed = models.DateTimeField(verbose_name=_("Flows Last Viewed"), auto_now_add=True)
 
-    config = models.TextField(null=True, verbose_name=_("Configuration"),
-                              help_text=_("More Organization specific configuration"))
+    config = models.TextField(
+        null=True, verbose_name=_("Configuration"), help_text=_("More Organization specific configuration")
+    )
 
-    slug = models.SlugField(verbose_name=_("Slug"), max_length=255, null=True, blank=True, unique=True,
-                            error_messages=dict(unique=_("This slug is not available")))
+    slug = models.SlugField(
+        verbose_name=_("Slug"),
+        max_length=255,
+        null=True,
+        blank=True,
+        unique=True,
+        error_messages=dict(unique=_("This slug is not available"))
+    )
 
-    is_anon = models.BooleanField(default=False,
-                                  help_text=_("Whether this organization anonymizes the phone numbers of contacts within it"))
+    is_anon = models.BooleanField(
+        default=False, help_text=_("Whether this organization anonymizes the phone numbers of contacts within it")
+    )
 
-    is_purgeable = models.BooleanField(default=False,
-                                       help_text=_("Whether this org's outgoing messages should be purged"))
+    is_purgeable = models.BooleanField(
+        default=False, help_text=_("Whether this org's outgoing messages should be purged")
+    )
 
-    primary_language = models.ForeignKey('orgs.Language', null=True, blank=True, related_name='orgs',
-                                         help_text=_('The primary language will be used for contacts with no language preference.'),
-                                         on_delete=models.SET_NULL)
+    primary_language = models.ForeignKey(
+        'orgs.Language',
+        null=True,
+        blank=True,
+        related_name='orgs',
+        help_text=_('The primary language will be used for contacts with no language preference.'),
+        on_delete=models.SET_NULL
+    )
 
-    brand = models.CharField(max_length=128, default=settings.DEFAULT_BRAND, verbose_name=_("Brand"),
-                             help_text=_("The brand used in emails"))
+    brand = models.CharField(
+        max_length=128,
+        default=settings.DEFAULT_BRAND,
+        verbose_name=_("Brand"),
+        help_text=_("The brand used in emails")
+    )
 
-    surveyor_password = models.CharField(null=True, max_length=128, default=None,
-                                         help_text=_('A password that allows users to register as surveyors'))
+    surveyor_password = models.CharField(
+        null=True, max_length=128, default=None, help_text=_('A password that allows users to register as surveyors')
+    )
 
     parent = models.ForeignKey('orgs.Org', null=True, blank=True, help_text=_('The parent org that manages this org'))
 
@@ -276,8 +325,15 @@ class Org(SmartModel):
             # generate a unique slug
             slug = Org.get_unique_slug(name)
 
-            org = Org.objects.create(name=name, timezone=timezone, brand=self.brand, parent=self, slug=slug,
-                                     created_by=created_by, modified_by=created_by)
+            org = Org.objects.create(
+                name=name,
+                timezone=timezone,
+                brand=self.brand,
+                parent=self,
+                slug=slug,
+                created_by=created_by,
+                modified_by=created_by
+            )
 
             org.administrators.add(created_by)
 
@@ -334,11 +390,10 @@ class Org(SmartModel):
             r = get_redis_connection()
 
             active_topup_keys = [ORG_ACTIVE_TOPUP_REMAINING % (self.pk, topup.pk) for topup in self.topups.all()]
-            return r.delete(ORG_CREDITS_TOTAL_CACHE_KEY % self.pk,
-                            ORG_CREDITS_USED_CACHE_KEY % self.pk,
-                            ORG_CREDITS_PURCHASED_CACHE_KEY % self.pk,
-                            ORG_ACTIVE_TOPUP_KEY % self.pk,
-                            **active_topup_keys)
+            return r.delete(
+                ORG_CREDITS_TOTAL_CACHE_KEY % self.pk, ORG_CREDITS_USED_CACHE_KEY % self.pk,
+                ORG_CREDITS_PURCHASED_CACHE_KEY % self.pk, ORG_ACTIVE_TOPUP_KEY % self.pk, **active_topup_keys
+            )
         else:
             return 0  # pragma: needs cover
 
@@ -411,11 +466,13 @@ class Org(SmartModel):
             elif isinstance(component, Trigger):
                 exported_triggers.append(component.as_json())
 
-        return dict(version=get_current_export_version(),
-                    site=site_link,
-                    flows=exported_flows,
-                    campaigns=exported_campaigns,
-                    triggers=exported_triggers)
+        return dict(
+            version=get_current_export_version(),
+            site=site_link,
+            flows=exported_flows,
+            campaigns=exported_campaigns,
+            triggers=exported_triggers
+        )
 
     def config_json(self):
         if self.config:
@@ -537,26 +594,36 @@ class Org(SmartModel):
 
     def get_send_channel(self, scheme=None, contact_urn=None, country_code=None):
         from temba.channels.models import Channel
-        return self.get_channel_for_role(Channel.ROLE_SEND, scheme=scheme, contact_urn=contact_urn, country_code=country_code)
+        return self.get_channel_for_role(
+            Channel.ROLE_SEND, scheme=scheme, contact_urn=contact_urn, country_code=country_code
+        )
 
     def get_ussd_channel(self, contact_urn=None, country_code=None):
         from temba.contacts.models import TEL_SCHEME
         from temba.channels.models import Channel
-        return self.get_channel_for_role(Channel.ROLE_USSD, scheme=TEL_SCHEME, contact_urn=contact_urn, country_code=country_code)
+        return self.get_channel_for_role(
+            Channel.ROLE_USSD, scheme=TEL_SCHEME, contact_urn=contact_urn, country_code=country_code
+        )
 
     def get_receive_channel(self, scheme, contact_urn=None, country_code=None):
         from temba.channels.models import Channel
-        return self.get_channel_for_role(Channel.ROLE_RECEIVE, scheme=scheme, contact_urn=contact_urn, country_code=country_code)
+        return self.get_channel_for_role(
+            Channel.ROLE_RECEIVE, scheme=scheme, contact_urn=contact_urn, country_code=country_code
+        )
 
     def get_call_channel(self, contact_urn=None, country_code=None):
         from temba.contacts.models import TEL_SCHEME
         from temba.channels.models import Channel
-        return self.get_channel_for_role(Channel.ROLE_CALL, scheme=TEL_SCHEME, contact_urn=contact_urn, country_code=country_code)
+        return self.get_channel_for_role(
+            Channel.ROLE_CALL, scheme=TEL_SCHEME, contact_urn=contact_urn, country_code=country_code
+        )
 
     def get_answer_channel(self, contact_urn=None, country_code=None):
         from temba.contacts.models import TEL_SCHEME
         from temba.channels.models import Channel
-        return self.get_channel_for_role(Channel.ROLE_ANSWER, scheme=TEL_SCHEME, contact_urn=contact_urn, country_code=country_code)
+        return self.get_channel_for_role(
+            Channel.ROLE_ANSWER, scheme=TEL_SCHEME, contact_urn=contact_urn, country_code=country_code
+        )
 
     def get_ussd_channels(self):
         from temba.channels.models import ChannelType, Channel
@@ -636,8 +703,11 @@ class Org(SmartModel):
             country_obj = pycountry.countries.get(alpha_2=country_code)
             country_name = country_obj.name
             currency = currency_for_country(country_code)
-            channel_countries.append(dict(code=country_code, name=country_name, currency_code=currency.alpha_3,
-                                          currency_name=currency.name))
+            channel_countries.append(
+                dict(
+                    code=country_code, name=country_name, currency_code=currency.alpha_3, currency_name=currency.name
+                )
+            )
 
         return sorted(channel_countries, key=lambda k: k['name'])
 
@@ -666,7 +736,9 @@ class Org(SmartModel):
 
         # otherwise, sync all pending messages and channels
         else:
-            for channel in self.channels.filter(is_active=True, channel_type=Channel.TYPE_ANDROID):  # pragma: needs cover
+            for channel in self.channels.filter(
+                is_active=True, channel_type=Channel.TYPE_ANDROID
+            ):  # pragma: needs cover
                 channel.trigger_sync()
 
             # otherwise, send any pending messages on our channels
@@ -681,9 +753,14 @@ class Org(SmartModel):
                     Msg.send_messages(pending)
 
     def add_smtp_config(self, from_email, host, username, password, port, encryption, user):
-        smtp_config = {SMTP_FROM_EMAIL: from_email.strip(),
-                       SMTP_HOST: host, SMTP_USERNAME: username, SMTP_PASSWORD: password,
-                       SMTP_PORT: port, SMTP_ENCRYPTION: encryption}
+        smtp_config = {
+            SMTP_FROM_EMAIL: from_email.strip(),
+            SMTP_HOST: host,
+            SMTP_USERNAME: username,
+            SMTP_PASSWORD: password,
+            SMTP_PORT: port,
+            SMTP_ENCRYPTION: encryption
+        }
 
         config = self.config_json()
         config.update(smtp_config)
@@ -727,9 +804,9 @@ class Org(SmartModel):
             smtp_password = config.get(SMTP_PASSWORD, None)
             use_tls = config.get(SMTP_ENCRYPTION, None) == 'T' or None
 
-            send_custom_smtp_email(recipients, subject, body, smtp_from_email,
-                                   smtp_host, smtp_port, smtp_username, smtp_password,
-                                   use_tls)
+            send_custom_smtp_email(
+                recipients, subject, body, smtp_from_email, smtp_host, smtp_port, smtp_username, smtp_password, use_tls
+            )
         else:
             send_simple_email(recipients, subject, body, from_email=settings.FLOW_FROM_EMAIL)
 
@@ -738,8 +815,10 @@ class Org(SmartModel):
         return AirtimeTransfer.objects.filter(org=self).exists()
 
     def connect_transferto(self, account_login, airtime_api_token, user):
-        transferto_config = {TRANSFERTO_ACCOUNT_LOGIN: account_login.strip(),
-                             TRANSFERTO_AIRTIME_API_TOKEN: airtime_api_token.strip()}
+        transferto_config = {
+            TRANSFERTO_ACCOUNT_LOGIN: account_login.strip(),
+            TRANSFERTO_AIRTIME_API_TOKEN: airtime_api_token.strip()
+        }
 
         config = self.config_json()
         config.update(transferto_config)
@@ -753,8 +832,9 @@ class Org(SmartModel):
         airtime_api_token = config.get(TRANSFERTO_AIRTIME_API_TOKEN, None)
 
         from temba.airtime.models import AirtimeTransfer
-        response = AirtimeTransfer.post_transferto_api_response(account_login, airtime_api_token,
-                                                                action='check_wallet')
+        response = AirtimeTransfer.post_transferto_api_response(
+            account_login, airtime_api_token, action='check_wallet'
+        )
         parsed_response = AirtimeTransfer.parse_transferto_response(response.content)
         account_currency = parsed_response.get('currency', '')
         config.update({TRANSFERTO_ACCOUNT_CURRENCY: account_currency})
@@ -795,8 +875,14 @@ class Org(SmartModel):
 
         event_url = "https://%s%s" % (hostname, reverse('handlers.nexmo_call_handler', args=['event', nexmo_uuid]))
 
-        params = dict(name=app_name, type='voice', answer_url=answer_url, answer_method='POST',
-                      event_url=event_url, event_method='POST')
+        params = dict(
+            name=app_name,
+            type='voice',
+            answer_url=answer_url,
+            answer_method='POST',
+            event_url=event_url,
+            event_method='POST'
+        )
 
         response = client.create_application(params=params)
         app_id = response.get('id', None)
@@ -884,11 +970,7 @@ class Org(SmartModel):
             self.clear_channel_caches()
 
     def connect_chatbase(self, agent_name, api_key, version, user):
-        chatbase_config = {
-            CHATBASE_AGENT_NAME: agent_name,
-            CHATBASE_API_KEY: api_key,
-            CHATBASE_VERSION: version
-        }
+        chatbase_config = {CHATBASE_AGENT_NAME: agent_name, CHATBASE_API_KEY: api_key, CHATBASE_VERSION: version}
 
         config = self.config_json()
         config.update(chatbase_config)
@@ -1004,12 +1086,12 @@ class Org(SmartModel):
 
             if iso_code == primary:
                 self.primary_language = language
-                self.save(update_fields=('primary_language',))
+                self.save(update_fields=('primary_language', ))
 
         # unset the primary language if not in the new list of codes
         if self.primary_language and self.primary_language.iso_code not in iso_codes:
             self.primary_language = None
-            self.save(update_fields=('primary_language',))
+            self.save(update_fields=('primary_language', ))
 
         # remove any languages that are not in the new list
         self.languages.exclude(iso_code__in=iso_codes).delete()
@@ -1072,8 +1154,9 @@ class Org(SmartModel):
         # not found by name, try looking up by alias
         if not boundary:
             if parent:
-                alias = BoundaryAlias.objects.filter(name__iexact=name, boundary__level=level,
-                                                     boundary__parent=parent).first()
+                alias = BoundaryAlias.objects.filter(
+                    name__iexact=name, boundary__level=level, boundary__parent=parent
+                ).first()
             else:
                 query = self.generate_location_query(name, level, True)
                 alias = BoundaryAlias.objects.filter(**query).first()
@@ -1160,7 +1243,8 @@ class Org(SmartModel):
         return self.get_purchased_credits() >= self.get_branding().get('tiers', {}).get('multi_user', 0)
 
     def is_multi_org_tier(self):
-        return not self.parent and self.get_purchased_credits() >= self.get_branding().get('tiers', {}).get('multi_org', 0)
+        return not self.parent and self.get_purchased_credits() >= self.get_branding().get('tiers', {}
+                                                                                           ).get('multi_org', 0)
 
     def get_user_org_group(self, user):
         if user in self.get_org_admins():
@@ -1195,12 +1279,24 @@ class Org(SmartModel):
         """
         from temba.contacts.models import ContactGroup
 
-        self.all_groups.create(name='All Contacts', group_type=ContactGroup.TYPE_ALL,
-                               created_by=self.created_by, modified_by=self.modified_by)
-        self.all_groups.create(name='Blocked Contacts', group_type=ContactGroup.TYPE_BLOCKED,
-                               created_by=self.created_by, modified_by=self.modified_by)
-        self.all_groups.create(name='Stopped Contacts', group_type=ContactGroup.TYPE_STOPPED,
-                               created_by=self.created_by, modified_by=self.modified_by)
+        self.all_groups.create(
+            name='All Contacts',
+            group_type=ContactGroup.TYPE_ALL,
+            created_by=self.created_by,
+            modified_by=self.modified_by
+        )
+        self.all_groups.create(
+            name='Blocked Contacts',
+            group_type=ContactGroup.TYPE_BLOCKED,
+            created_by=self.created_by,
+            modified_by=self.modified_by
+        )
+        self.all_groups.create(
+            name='Stopped Contacts',
+            group_type=ContactGroup.TYPE_STOPPED,
+            created_by=self.created_by,
+            modified_by=self.modified_by
+        )
 
     def create_sample_flows(self, api_url):
         import json
@@ -1249,16 +1345,19 @@ class Org(SmartModel):
         """
         Get the number of credits expiring in less than a month.
         """
-        return get_cacheable_result(ORG_CREDIT_EXPIRING_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL,
-                                    self._calculate_credits_expiring_soon)
+        return get_cacheable_result(
+            ORG_CREDIT_EXPIRING_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL, self._calculate_credits_expiring_soon
+        )
 
     def _calculate_credits_expiring_soon(self):
         now = timezone.now()
         one_month_period = now + timedelta(days=30)
-        expiring_topups_qs = self.topups.filter(is_active=True,
-                                                expires_on__lte=one_month_period).exclude(expires_on__lte=now)
+        expiring_topups_qs = self.topups.filter(
+            is_active=True, expires_on__lte=one_month_period
+        ).exclude(expires_on__lte=now)
 
-        used_credits = TopUpCredits.objects.filter(topup__in=expiring_topups_qs).aggregate(Sum('used')).get('used__sum')
+        used_credits = TopUpCredits.objects.filter(topup__in=expiring_topups_qs).aggregate(Sum('used')
+                                                                                           ).get('used__sum')
 
         expiring_topups_credits = expiring_topups_qs.aggregate(Sum('credits')).get('credits__sum')
 
@@ -1277,35 +1376,47 @@ class Org(SmartModel):
         """
         Get the credits number to consider as low threshold to this org
         """
-        return get_cacheable_result(ORG_LOW_CREDIT_THRESHOLD_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL,
-                                    self._calculate_low_credits_threshold)
+        return get_cacheable_result(
+            ORG_LOW_CREDIT_THRESHOLD_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL, self._calculate_low_credits_threshold
+        )
 
     def _calculate_low_credits_threshold(self):
         now = timezone.now()
-        last_topup_credits = self.topups.filter(is_active=True, expires_on__gte=now).aggregate(Sum('credits')).get('credits__sum')
+        last_topup_credits = self.topups.filter(
+            is_active=True, expires_on__gte=now
+        ).aggregate(Sum('credits')).get('credits__sum')
         return int(last_topup_credits * 0.15) if last_topup_credits else 0
 
     def get_credits_total(self, force_dirty=False):
         """
         Gets the total number of credits purchased or assigned to this org
         """
-        return get_cacheable_result(ORG_CREDITS_TOTAL_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL,
-                                    self._calculate_credits_total, force_dirty=force_dirty)
+        return get_cacheable_result(
+            ORG_CREDITS_TOTAL_CACHE_KEY % self.pk,
+            ORG_CREDITS_CACHE_TTL,
+            self._calculate_credits_total,
+            force_dirty=force_dirty
+        )
 
     def get_purchased_credits(self):
         """
         Returns the total number of credits purchased
         :return:
         """
-        return get_cacheable_result(ORG_CREDITS_PURCHASED_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL,
-                                    self._calculate_purchased_credits)
+        return get_cacheable_result(
+            ORG_CREDITS_PURCHASED_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL, self._calculate_purchased_credits
+        )
 
     def _calculate_purchased_credits(self):
-        purchased_credits = self.topups.filter(is_active=True, price__gt=0).aggregate(Sum('credits')).get('credits__sum')
+        purchased_credits = self.topups.filter(
+            is_active=True, price__gt=0
+        ).aggregate(Sum('credits')).get('credits__sum')
         return purchased_credits if purchased_credits else 0
 
     def _calculate_credits_total(self):
-        active_credits = self.topups.filter(is_active=True, expires_on__gte=timezone.now()).aggregate(Sum('credits')).get('credits__sum')
+        active_credits = self.topups.filter(
+            is_active=True, expires_on__gte=timezone.now()
+        ).aggregate(Sum('credits')).get('credits__sum')
         active_credits = active_credits if active_credits else 0
 
         # these are the credits that have been used in expired topups
@@ -1321,8 +1432,9 @@ class Org(SmartModel):
         """
         Gets the number of credits used by this org
         """
-        return get_cacheable_result(ORG_CREDITS_USED_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL,
-                                    self._calculate_credits_used)
+        return get_cacheable_result(
+            ORG_CREDITS_USED_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL, self._calculate_credits_used
+        )
 
     def _calculate_credits_used(self):
         used_credits_sum = TopUpCredits.objects.filter(topup__org=self, topup__is_active=True)
@@ -1337,10 +1449,18 @@ class Org(SmartModel):
         """
         Calculates both our total as well as our active topup
         """
-        get_cacheable_result(ORG_CREDITS_TOTAL_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL,
-                             self._calculate_credits_total, force_dirty=True)
-        get_cacheable_result(ORG_CREDITS_USED_CACHE_KEY % self.pk, ORG_CREDITS_CACHE_TTL,
-                             self._calculate_credits_used, force_dirty=True)
+        get_cacheable_result(
+            ORG_CREDITS_TOTAL_CACHE_KEY % self.pk,
+            ORG_CREDITS_CACHE_TTL,
+            self._calculate_credits_total,
+            force_dirty=True
+        )
+        get_cacheable_result(
+            ORG_CREDITS_USED_CACHE_KEY % self.pk,
+            ORG_CREDITS_CACHE_TTL,
+            self._calculate_credits_used,
+            force_dirty=True
+        )
 
     def get_credits_remaining(self):
         """
@@ -1369,11 +1489,18 @@ class Org(SmartModel):
                             topup = TopUp.objects.get(id=topup_id)
 
                             # create the topup for our child, expiring on the same date
-                            new_topup = TopUp.create(user, credits=debited, org=org, expires_on=topup.expires_on, price=None)
+                            new_topup = TopUp.create(
+                                user, credits=debited, org=org, expires_on=topup.expires_on, price=None
+                            )
 
                             # create a debit for transaction history
-                            Debit.objects.create(topup_id=topup_id, amount=debited, beneficiary=new_topup,
-                                                 debit_type=Debit.TYPE_ALLOCATION, created_by=user)
+                            Debit.objects.create(
+                                topup_id=topup_id,
+                                amount=debited,
+                                beneficiary=new_topup,
+                                debit_type=Debit.TYPE_ALLOCATION,
+                                created_by=user
+                            )
 
                             # decrease the amount of credits we need
                             amount -= debited
@@ -1436,7 +1563,9 @@ class Org(SmartModel):
         """
         Calculates the oldest non-expired topup that still has credits
         """
-        non_expired_topups = self.topups.filter(is_active=True, expires_on__gte=timezone.now()).order_by('expires_on', 'id')
+        non_expired_topups = self.topups.filter(
+            is_active=True, expires_on__gte=timezone.now()
+        ).order_by('expires_on', 'id')
         active_topups = non_expired_topups.annotate(used_credits=Sum('topupcredits__used'))\
                                           .filter(credits__gt=0)\
                                           .filter(Q(used_credits__lt=F('credits')) | Q(used_credits=None))
@@ -1456,7 +1585,9 @@ class Org(SmartModel):
             all_uncredited = list(msg_uncredited)
 
             # get all topups that haven't expired
-            unexpired_topups = list(self.topups.filter(is_active=True, expires_on__gte=timezone.now()).order_by('-expires_on'))
+            unexpired_topups = list(
+                self.topups.filter(is_active=True, expires_on__gte=timezone.now()).order_by('-expires_on')
+            )
 
             # dict of topups to lists of their newly assigned items
             new_topup_items = {topup: [] for topup in unexpired_topups}
@@ -1544,8 +1675,7 @@ class Org(SmartModel):
         try:
             if not customer or customer.email != user.email:
                 # then go create a customer object for this user
-                customer = stripe.Customer.create(card=token, email=user.email,
-                                                  description="{ org: %d }" % self.pk)
+                customer = stripe.Customer.create(card=token, email=user.email, description="{ org: %d }" % self.pk)
 
                 stripe_customer = customer.id
                 self.stripe_customer = stripe_customer
@@ -1563,31 +1693,35 @@ class Org(SmartModel):
                 try:
                     card = customer.cards.create(card=token)
                 except stripe.CardError:
-                    raise ValidationError(_("Sorry, your card was declined, please contact your provider or try another card."))
+                    raise ValidationError(
+                        _("Sorry, your card was declined, please contact your provider or try another card.")
+                    )
 
                 customer.default_card = card.id
                 customer.save()
 
                 stripe_customer = customer.id
 
-            charge = stripe.Charge.create(amount=bundle['cents'],
-                                          currency='usd',
-                                          customer=stripe_customer,
-                                          description=bundle['description'])
+            charge = stripe.Charge.create(
+                amount=bundle['cents'], currency='usd', customer=stripe_customer, description=bundle['description']
+            )
 
             remaining = self.get_credits_remaining()
 
             # create our top up
-            topup = TopUp.create(user, price=bundle['cents'], credits=bundle['credits'],
-                                 stripe_charge=charge.id, org=self)
+            topup = TopUp.create(
+                user, price=bundle['cents'], credits=bundle['credits'], stripe_charge=charge.id, org=self
+            )
 
-            context = dict(description=bundle['description'],
-                           charge_id=charge.id,
-                           charge_date=timezone.now().strftime("%b %e, %Y"),
-                           amount=bundle['dollars'],
-                           credits=bundle['credits'],
-                           remaining=remaining,
-                           org=self.name)
+            context = dict(
+                description=bundle['description'],
+                charge_id=charge.id,
+                charge_date=timezone.now().strftime("%b %e, %Y"),
+                amount=bundle['dollars'],
+                credits=bundle['credits'],
+                remaining=remaining,
+                org=self.name
+            )
 
             # card
             if getattr(charge, 'card', None):
@@ -1623,7 +1757,9 @@ class Org(SmartModel):
         except Exception as e:
             logger = logging.getLogger(__name__)
             logger.error("Error adding credits to org", exc_info=True)
-            raise ValidationError(_("Sorry, we were unable to process your payment, please try again later or contact us."))
+            raise ValidationError(
+                _("Sorry, we were unable to process your payment, please try again later or contact us.")
+            )
 
     def account_value(self):
         """
@@ -1659,7 +1795,9 @@ class Org(SmartModel):
                     subscription = customer.cancel_subscription(at_period_end=True)
                 except Exception as e:
                     traceback.print_exc(e)
-                    raise ValidationError(_("Sorry, we are unable to cancel your plan at this time.  Please contact us."))
+                    raise ValidationError(
+                        _("Sorry, we are unable to cancel your plan at this time.  Please contact us.")
+                    )
             else:
                 raise ValidationError(_("Sorry, we are unable to cancel your plan at this time.  Please contact us."))
 
@@ -1680,8 +1818,9 @@ class Org(SmartModel):
             if not customer:
                 try:
                     # then go create a customer object for this user
-                    customer = stripe.Customer.create(card=token, plan=new_plan, email=user,
-                                                      description="{ org: %d }" % self.pk)
+                    customer = stripe.Customer.create(
+                        card=token, plan=new_plan, email=user, description="{ org: %d }" % self.pk
+                    )
 
                     stripe_customer = customer.id
                     subscription = customer['subscription']
@@ -1690,7 +1829,9 @@ class Org(SmartModel):
 
                 except Exception as e:
                     traceback.print_exc(e)
-                    raise ValidationError(_("Sorry, we were unable to charge your card, please try again later or contact us."))
+                    raise ValidationError(
+                        _("Sorry, we were unable to charge your card, please try again later or contact us.")
+                    )
 
         # update our org
         self.stripe_customer = stripe_customer
@@ -1715,15 +1856,22 @@ class Org(SmartModel):
 
         flow_prefetches = ('action_sets', 'rule_sets')
         campaign_prefetches = (
-            Prefetch('events', queryset=CampaignEvent.objects.filter(is_active=True).exclude(flow__flow_type=Flow.MESSAGE), to_attr='flow_events'),
-            'flow_events__flow'
+            Prefetch(
+                'events',
+                queryset=CampaignEvent.objects.filter(is_active=True).exclude(flow__flow_type=Flow.MESSAGE),
+                to_attr='flow_events'
+            ), 'flow_events__flow'
         )
 
-        all_flows = self.flows.filter(is_active=True).exclude(flow_type=Flow.MESSAGE).prefetch_related(*flow_prefetches)
+        all_flows = self.flows.filter(is_active=True).exclude(flow_type=Flow.MESSAGE).prefetch_related(
+            *flow_prefetches
+        )
         all_flow_map = {f.uuid: f for f in all_flows}
 
         if include_campaigns:
-            all_campaigns = self.campaign_set.filter(is_active=True).select_related('group').prefetch_related(*campaign_prefetches)
+            all_campaigns = self.campaign_set.filter(is_active=True).select_related('group').prefetch_related(
+                *campaign_prefetches
+            )
         else:
             all_campaigns = Campaign.objects.none()
 
@@ -1764,13 +1912,15 @@ class Org(SmartModel):
 
         return dependencies
 
-    def resolve_dependencies(self, flows, campaigns, include_campaigns=True, include_triggers=False, include_archived=False):
+    def resolve_dependencies(
+        self, flows, campaigns, include_campaigns=True, include_triggers=False, include_archived=False
+    ):
         """
         Given a set of flows and and a set of campaigns, returns a new set including all dependencies
         """
-        dependencies = self.generate_dependency_graph(include_campaigns=include_campaigns,
-                                                      include_triggers=include_triggers,
-                                                      include_archived=include_archived)
+        dependencies = self.generate_dependency_graph(
+            include_campaigns=include_campaigns, include_triggers=include_triggers, include_archived=include_archived
+        )
 
         primary_components = set(itertools.chain(flows, campaigns))
         all_components = set()
@@ -1854,7 +2004,9 @@ class Org(SmartModel):
                         extension = path_pieces[-1]
 
         else:
-            raise Exception("Received non-200 response (%s) for request: %s" % (response.status_code, response.content))
+            raise Exception(
+                "Received non-200 response (%s) for request: %s" % (response.status_code, response.content)
+            )
 
         return self.save_media(File(temp), extension)
 
@@ -1927,6 +2079,7 @@ class Org(SmartModel):
 
 
 # ===================== monkey patch User class with a few extra functions ========================
+
 
 def get_user_orgs(user, brand=None):
     if not brand:
@@ -2009,16 +2162,16 @@ User.get_user_orgs = get_user_orgs
 User.get_org_group = get_org_group
 User.has_org_perm = _user_has_org_perm
 
-
-USER_GROUPS = (('A', _("Administrator")),
-               ('E', _("Editor")),
-               ('V', _("Viewer")),
-               ('S', _("Surveyor")))
+USER_GROUPS = (('A', _("Administrator")), ('E', _("Editor")), ('V', _("Viewer")), ('S', _("Surveyor")))
 
 
 def get_stripe_credentials():
-    public_key = os.environ.get('STRIPE_PUBLIC_KEY', getattr(settings, 'STRIPE_PUBLIC_KEY', 'MISSING_STRIPE_PUBLIC_KEY'))
-    private_key = os.environ.get('STRIPE_PRIVATE_KEY', getattr(settings, 'STRIPE_PRIVATE_KEY', 'MISSING_STRIPE_PRIVATE_KEY'))
+    public_key = os.environ.get(
+        'STRIPE_PUBLIC_KEY', getattr(settings, 'STRIPE_PUBLIC_KEY', 'MISSING_STRIPE_PUBLIC_KEY')
+    )
+    private_key = os.environ.get(
+        'STRIPE_PRIVATE_KEY', getattr(settings, 'STRIPE_PRIVATE_KEY', 'MISSING_STRIPE_PRIVATE_KEY')
+    )
     return (public_key, private_key)
 
 
@@ -2074,20 +2227,29 @@ class Invitation(SmartModel):
     """
     An Invitation to an e-mail address to join an Org with specific roles.
     """
-    org = models.ForeignKey(Org, verbose_name=_("Org"), related_name="invitations",
-                            help_text=_("The organization to which the account is invited to view"))
+    org = models.ForeignKey(
+        Org,
+        verbose_name=_("Org"),
+        related_name="invitations",
+        help_text=_("The organization to which the account is invited to view")
+    )
 
-    email = models.EmailField(verbose_name=_("Email"), help_text=_("The email to which we send the invitation of the viewer"))
+    email = models.EmailField(
+        verbose_name=_("Email"), help_text=_("The email to which we send the invitation of the viewer")
+    )
 
-    secret = models.CharField(verbose_name=_("Secret"), max_length=64, unique=True,
-                              help_text=_("a unique code associated with this invitation"))
+    secret = models.CharField(
+        verbose_name=_("Secret"),
+        max_length=64,
+        unique=True,
+        help_text=_("a unique code associated with this invitation")
+    )
 
     user_group = models.CharField(max_length=1, choices=USER_GROUPS, default='V', verbose_name=_("User Role"))
 
     @classmethod
     def create(cls, org, user, email, user_group):
-        return cls.objects.create(org=org, email=email, user_group=user_group,
-                                  created_by=user, modified_by=user)
+        return cls.objects.create(org=org, email=email, user_group=user_group, created_by=user, modified_by=user)
 
     def save(self, *args, **kwargs):
         if not self.secret:
@@ -2133,10 +2295,16 @@ class UserSettings(models.Model):
     User specific configuration
     """
     user = models.ForeignKey(User, related_name='settings')
-    language = models.CharField(max_length=8, choices=settings.LANGUAGES, default="en-us",
-                                help_text=_('Your preferred language'))
-    tel = models.CharField(verbose_name=_("Phone Number"), max_length=16, null=True, blank=True,
-                           help_text=_("Phone number for testing and recording voice flows"))
+    language = models.CharField(
+        max_length=8, choices=settings.LANGUAGES, default="en-us", help_text=_('Your preferred language')
+    )
+    tel = models.CharField(
+        verbose_name=_("Phone Number"),
+        max_length=16,
+        null=True,
+        blank=True,
+        help_text=_("Phone number for testing and recording voice flows")
+    )
 
     def get_tel_formatted(self):
         if self.tel:
@@ -2151,18 +2319,32 @@ class TopUp(SmartModel):
     TopUps are used to track usage across the platform. Each TopUp represents a certain number of
     credits that can be consumed by messages.
     """
-    org = models.ForeignKey(Org, related_name='topups',
-                            help_text="The organization that was toppped up")
-    price = models.IntegerField(null=True, blank=True, verbose_name=_("Price Paid"),
-                                help_text=_("The price paid for the messages in this top up (in cents)"))
-    credits = models.IntegerField(verbose_name=_("Number of Credits"),
-                                  help_text=_("The number of credits bought in this top up"))
-    expires_on = models.DateTimeField(verbose_name=_("Expiration Date"),
-                                      help_text=_("The date that this top up will expire"))
-    stripe_charge = models.CharField(verbose_name=_("Stripe Charge Id"), max_length=32, null=True, blank=True,
-                                     help_text=_("The Stripe charge id for this charge"))
-    comment = models.CharField(max_length=255, null=True, blank=True,
-                               help_text="Any comment associated with this topup, used when we credit accounts")
+    org = models.ForeignKey(Org, related_name='topups', help_text="The organization that was toppped up")
+    price = models.IntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Price Paid"),
+        help_text=_("The price paid for the messages in this top up (in cents)")
+    )
+    credits = models.IntegerField(
+        verbose_name=_("Number of Credits"), help_text=_("The number of credits bought in this top up")
+    )
+    expires_on = models.DateTimeField(
+        verbose_name=_("Expiration Date"), help_text=_("The date that this top up will expire")
+    )
+    stripe_charge = models.CharField(
+        verbose_name=_("Stripe Charge Id"),
+        max_length=32,
+        null=True,
+        blank=True,
+        help_text=_("The Stripe charge id for this charge")
+    )
+    comment = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="Any comment associated with this topup, used when we credit accounts"
+    )
 
     @classmethod
     def create(cls, user, price, credits, stripe_charge=None, org=None, expires_on=None):
@@ -2175,8 +2357,15 @@ class TopUp(SmartModel):
         if not expires_on:
             expires_on = timezone.now() + timedelta(days=365)  # credits last 1 year
 
-        topup = TopUp.objects.create(org=org, price=price, credits=credits, expires_on=expires_on,
-                                     stripe_charge=stripe_charge, created_by=user, modified_by=user)
+        topup = TopUp.objects.create(
+            org=org,
+            price=price,
+            credits=credits,
+            expires_on=expires_on,
+            stripe_charge=stripe_charge,
+            created_by=user,
+            modified_by=user
+        )
 
         org.update_caches(OrgEvent.topup_new, topup)
         return topup
@@ -2201,34 +2390,38 @@ class TopUp(SmartModel):
                 else:
                     comment = _('Credits')
 
-            ledger.append(dict(date=self.created_on,
-                               comment=comment,
-                               amount=self.credits,
-                               balance=self.credits))
+            ledger.append(dict(date=self.created_on, comment=comment, amount=self.credits, balance=self.credits))
 
         for debit in debits:  # pragma: needs cover
             balance -= debit.amount
-            ledger.append(dict(date=debit.created_on,
-                          comment=_('Transfer to %(org)s') % dict(org=debit.beneficiary.org.name),
-                          amount=-debit.amount,
-                          balance=balance))
+            ledger.append(
+                dict(
+                    date=debit.created_on,
+                    comment=_('Transfer to %(org)s') % dict(org=debit.beneficiary.org.name),
+                    amount=-debit.amount,
+                    balance=balance
+                )
+            )
 
         now = timezone.now()
         expired = self.expires_on < now
 
         # add a line for used message credits
         if active:
-            ledger.append(dict(date=self.expires_on if expired else now,
-                               comment=_('Messaging credits used'),
-                               amount=self.get_remaining() - balance,
-                               balance=self.get_remaining()))
+            ledger.append(
+                dict(
+                    date=self.expires_on if expired else now,
+                    comment=_('Messaging credits used'),
+                    amount=self.get_remaining() - balance,
+                    balance=self.get_remaining()
+                )
+            )
 
         # add a line for expired credits
         if expired and self.get_remaining() > 0:
-            ledger.append(dict(date=self.expires_on,
-                               comment=_('Expired credits'),
-                               amount=-self.get_remaining(),
-                               balance=0))
+            ledger.append(
+                dict(date=self.expires_on, comment=_('Expired credits'), amount=-self.get_remaining(), balance=0)
+            )
         return ledger
 
     def get_price_display(self):
@@ -2282,29 +2475,33 @@ class Debit(SquashableModel):
     """
     Transactional history of credits allocated to other topups or chunks of archived messages
     """
-    SQUASH_OVER = ('topup_id',)
+    SQUASH_OVER = ('topup_id', )
 
     TYPE_ALLOCATION = 'A'
     TYPE_PURGE = 'P'
 
-    DEBIT_TYPES = ((TYPE_ALLOCATION, 'Allocation'),
-                   (TYPE_PURGE, 'Purge'))
+    DEBIT_TYPES = ((TYPE_ALLOCATION, 'Allocation'), (TYPE_PURGE, 'Purge'))
 
     topup = models.ForeignKey(TopUp, related_name="debits", help_text=_("The topup these credits are applied against"))
 
     amount = models.IntegerField(help_text=_('How many credits were debited'))
 
-    beneficiary = models.ForeignKey(TopUp, null=True,
-                                    related_name="allocations",
-                                    help_text=_('Optional topup that was allocated with these credits'))
+    beneficiary = models.ForeignKey(
+        TopUp,
+        null=True,
+        related_name="allocations",
+        help_text=_('Optional topup that was allocated with these credits')
+    )
 
     debit_type = models.CharField(max_length=1, choices=DEBIT_TYPES, null=False, help_text=_('What caused this debit'))
 
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True,
-                                   related_name="debits_created",
-                                   help_text="The user which originally created this item")
-    created_on = models.DateTimeField(default=timezone.now,
-                                      help_text="When this item was originally created")
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        related_name="debits_created",
+        help_text="The user which originally created this item"
+    )
+    created_on = models.DateTimeField(default=timezone.now, help_text="When this item was originally created")
 
     @classmethod
     def get_unsquashed(cls):
@@ -2318,7 +2515,9 @@ class Debit(SquashableModel):
             )
             INSERT INTO %(table)s("topup_id", "amount", "debit_type", "created_on", "is_squashed")
             VALUES (%%s, GREATEST(0, (SELECT SUM("amount") FROM removed)), 'P', %%s, TRUE);
-        """ % {'table': cls._meta.db_table}
+        """ % {
+            'table': cls._meta.db_table
+        }
 
         return sql, (distinct_set.topup_id, distinct_set.topup_id, timezone.now())
 
@@ -2327,10 +2526,9 @@ class TopUpCredits(SquashableModel):
     """
     Used to track number of credits used on a topup, mostly maintained by triggers on Msg insertion.
     """
-    SQUASH_OVER = ('topup_id',)
+    SQUASH_OVER = ('topup_id', )
 
-    topup = models.ForeignKey(TopUp,
-                              help_text=_("The topup these credits are being used against"))
+    topup = models.ForeignKey(TopUp, help_text=_("The topup these credits are being used against"))
     used = models.IntegerField(help_text=_("How many credits were used, can be negative"))
 
     @classmethod
@@ -2341,9 +2539,11 @@ class TopUpCredits(SquashableModel):
         )
         INSERT INTO %(table)s("topup_id", "used", "is_squashed")
         VALUES (%%s, GREATEST(0, (SELECT SUM("used") FROM deleted)), TRUE);
-        """ % {'table': cls._meta.db_table}
+        """ % {
+            'table': cls._meta.db_table
+        }
 
-        return sql, (distinct_set.topup_id,) * 2
+        return sql, (distinct_set.topup_id, ) * 2
 
 
 class CreditAlert(SmartModel):
@@ -2351,13 +2551,11 @@ class CreditAlert(SmartModel):
     Tracks when we have sent alerts to organization admins about low credits.
     """
 
-    ALERT_TYPES_CHOICES = ((ORG_CREDIT_OVER, _("Credits Over")),
-                           (ORG_CREDIT_LOW, _("Low Credits")),
+    ALERT_TYPES_CHOICES = ((ORG_CREDIT_OVER, _("Credits Over")), (ORG_CREDIT_LOW, _("Low Credits")),
                            (ORG_CREDIT_EXPIRING, _("Credits expiring soon")))
 
     org = models.ForeignKey(Org, help_text="The organization this alert was triggered for")
-    alert_type = models.CharField(max_length=1, choices=ALERT_TYPES_CHOICES,
-                                  help_text="The type of this alert")
+    alert_type = models.CharField(max_length=1, choices=ALERT_TYPES_CHOICES, help_text="The type of this alert")
 
     @classmethod
     def trigger_credit_alert(cls, org, alert_type):
@@ -2371,8 +2569,7 @@ class CreditAlert(SmartModel):
 
         if admin:
             # Otherwise, create our alert objects and trigger our event
-            alert = CreditAlert.objects.create(org=org, alert_type=alert_type,
-                                               created_by=admin, modified_by=admin)
+            alert = CreditAlert.objects.create(org=org, alert_type=alert_type, created_by=admin, modified_by=admin)
 
             alert.send_alert()
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -71,6 +71,7 @@ class OrgPermsMixin(object):
     Get the organisation and the user within the inheriting view so that it be come easy to decide
     whether this user has a certain permission for that particular organization to perform the view's actions
     """
+
     def get_user(self):
         return self.request.user
 
@@ -125,6 +126,7 @@ class AnonMixin(OrgPermsMixin):
     """
     Mixin that makes sure that anonymous orgs cannot add channels (have no permission if anon)
     """
+
     def has_permission(self, request, *args, **kwargs):
         org = self.derive_org()
 
@@ -140,7 +142,6 @@ class AnonMixin(OrgPermsMixin):
 
 
 class OrgObjPermsMixin(OrgPermsMixin):
-
     def get_object_org(self):
         return self.get_object().org
 
@@ -169,7 +170,6 @@ class OrgObjPermsMixin(OrgPermsMixin):
 
 
 class ModalMixin(SmartFormView):
-
     def get_context_data(self, **kwargs):
         context = super(ModalMixin, self).get_context_data(**kwargs)
 
@@ -201,9 +201,13 @@ class ModalMixin(SmartFormView):
             if 'HTTP_X_PJAX' not in self.request.META:
                 return HttpResponseRedirect(self.get_success_url())
             else:  # pragma: no cover
-                response = self.render_to_response(self.get_context_data(form=form,
-                                                                         success_url=self.get_success_url(),
-                                                                         success_script=getattr(self, 'success_script', None)))
+                response = self.render_to_response(
+                    self.get_context_data(
+                        form=form,
+                        success_url=self.get_success_url(),
+                        success_script=getattr(self, 'success_script', None)
+                    )
+                )
                 response['Temba-Success'] = self.get_success_url()
                 return response
 
@@ -221,10 +225,8 @@ class OrgSignupForm(forms.ModelForm):
     last_name = forms.CharField(help_text=_("Your last name"))
     email = forms.EmailField(help_text=_("Your email address"))
     timezone = TimeZoneFormField(help_text=_("The timezone your organization is in"))
-    password = forms.CharField(widget=forms.PasswordInput,
-                               help_text=_("Your password, at least eight letters please"))
-    name = forms.CharField(label=_("Organization"),
-                           help_text=_("The name of your organization"))
+    password = forms.CharField(widget=forms.PasswordInput, help_text=_("Your password, at least eight letters please"))
+    name = forms.CharField(label=_("Organization"), help_text=_("The name of your organization"))
 
     def __init__(self, *args, **kwargs):
         if 'branding' in kwargs:
@@ -257,10 +259,12 @@ class OrgGrantForm(forms.ModelForm):
     last_name = forms.CharField(help_text=_("Your last name of the organization administrator"))
     email = forms.EmailField(help_text=_("Their email address"))
     timezone = TimeZoneFormField(help_text=_("The timezone the organization is in"))
-    password = forms.CharField(widget=forms.PasswordInput, required=False,
-                               help_text=_("Their password, at least eight letters please. (leave blank for existing users)"))
-    name = forms.CharField(label=_("Organization"),
-                           help_text=_("The name of the new organization"))
+    password = forms.CharField(
+        widget=forms.PasswordInput,
+        required=False,
+        help_text=_("Their password, at least eight letters please. (leave blank for existing users)")
+    )
+    name = forms.CharField(label=_("Organization"), help_text=_("The name of the new organization"))
     credits = forms.ChoiceField([], help_text=_("The initial number of credits granted to this organization."))
 
     def __init__(self, *args, **kwargs):
@@ -303,7 +307,7 @@ class OrgGrantForm(forms.ModelForm):
 
 class UserCRUDL(SmartCRUDL):
     model = User
-    actions = ('edit',)
+    actions = ('edit', )
 
     class Edit(SmartUpdateView):
         class EditForm(forms.ModelForm):
@@ -311,7 +315,9 @@ class UserCRUDL(SmartCRUDL):
             last_name = forms.CharField(label=_("Your Last Name (required)"))
             email = forms.EmailField(required=True, label=_("Email"))
             current_password = forms.CharField(label=_("Current Password (required)"), widget=forms.PasswordInput)
-            new_password = forms.CharField(required=False, label=_("New Password (optional)"), widget=forms.PasswordInput)
+            new_password = forms.CharField(
+                required=False, label=_("New Password (optional)"), widget=forms.PasswordInput
+            )
             language = forms.ChoiceField(choices=settings.LANGUAGES, required=True, label=_("Website Language"))
 
             def clean_new_password(self):
@@ -427,7 +433,7 @@ class PhoneRequiredForm(forms.ModelForm):
 
     class Meta:
         model = UserSettings
-        fields = ('tel',)
+        fields = ('tel', )
 
 
 class UserSettingsCRUDL(SmartCRUDL):
@@ -435,7 +441,6 @@ class UserSettingsCRUDL(SmartCRUDL):
     model = UserSettings
 
     class Phone(ModalMixin, OrgPermsMixin, SmartUpdateView):
-
         @classmethod
         def derive_url_pattern(cls, path, action):
             return r'^%s/%s/$' % (path, action)
@@ -443,23 +448,24 @@ class UserSettingsCRUDL(SmartCRUDL):
         def get_object(self, *args, **kwargs):
             return self.request.user.get_settings()
 
-        fields = ('tel',)
+        fields = ('tel', )
         form_class = PhoneRequiredForm
         submit_button_name = _("Start Call")
         success_url = '@orgs.usersettings_phone'
 
 
 class OrgCRUDL(SmartCRUDL):
-    actions = ('signup', 'home', 'webhook', 'edit', 'edit_sub_org', 'join', 'grant', 'accounts', 'create_login',
-               'chatbase', 'choose', 'manage_accounts', 'manage_accounts_sub_org', 'manage', 'update', 'country',
-               'languages', 'clear_cache', 'twilio_connect', 'twilio_account', 'nexmo_configuration', 'nexmo_account',
-               'nexmo_connect', 'sub_orgs', 'create_sub_org', 'export', 'import', 'plivo_connect', 'resthooks',
-               'service', 'surveyor', 'transfer_credits', 'transfer_to_account', 'smtp_server')
+    actions = (
+        'signup', 'home', 'webhook', 'edit', 'edit_sub_org', 'join', 'grant', 'accounts', 'create_login', 'chatbase',
+        'choose', 'manage_accounts', 'manage_accounts_sub_org', 'manage', 'update', 'country', 'languages',
+        'clear_cache', 'twilio_connect', 'twilio_account', 'nexmo_configuration', 'nexmo_account', 'nexmo_connect',
+        'sub_orgs', 'create_sub_org', 'export', 'import', 'plivo_connect', 'resthooks', 'service', 'surveyor',
+        'transfer_credits', 'transfer_to_account', 'smtp_server'
+    )
 
     model = Org
 
     class Import(InferOrgMixin, OrgPermsMixin, SmartFormView):
-
         class FlowImportForm(Form):
             import_file = forms.FileField(help_text=_('The import file'))
             update = forms.BooleanField(help_text=_('Update all flows and campaigns'), required=False)
@@ -510,7 +516,6 @@ class OrgCRUDL(SmartCRUDL):
             return super(OrgCRUDL.Import, self).form_valid(form)  # pragma: needs cover
 
     class Export(InferOrgMixin, OrgPermsMixin, SmartTemplateView):
-
         def post(self, request, *args, **kwargs):
             org = self.get_object()
 
@@ -596,7 +601,6 @@ class OrgCRUDL(SmartCRUDL):
             return non_single_buckets, singles
 
     class TwilioConnect(ModalMixin, InferOrgMixin, OrgPermsMixin, SmartFormView):
-
         class TwilioConnectForm(forms.Form):
             account_sid = forms.CharField(help_text=_("Your Twilio Account SID"))
             account_token = forms.CharField(help_text=_("Your Twilio Account Token"))
@@ -619,7 +623,9 @@ class OrgCRUDL(SmartCRUDL):
                     self.cleaned_data['account_sid'] = account.sid
                     self.cleaned_data['account_token'] = account.auth_token
                 except Exception:
-                    raise ValidationError(_("The Twilio account SID and Token seem invalid. Please check them again and retry."))
+                    raise ValidationError(
+                        _("The Twilio account SID and Token seem invalid. Please check them again and retry.")
+                    )
 
                 return self.cleaned_data
 
@@ -640,7 +646,6 @@ class OrgCRUDL(SmartCRUDL):
             return HttpResponseRedirect(self.get_success_url())
 
     class NexmoConfiguration(InferOrgMixin, OrgPermsMixin, SmartReadView):
-
         def get(self, request, *args, **kwargs):
             org = self.get_object()
 
@@ -653,8 +658,7 @@ class OrgCRUDL(SmartCRUDL):
             dl_path = reverse('courier.nx', args=[nexmo_uuid, 'status'])
             try:
                 from temba.settings import HOSTNAME
-                nexmo_client.update_account('http://%s%s' % (HOSTNAME, mo_path),
-                                            'http://%s%s' % (HOSTNAME, dl_path))
+                nexmo_client.update_account('http://%s%s' % (HOSTNAME, mo_path), 'http://%s%s' % (HOSTNAME, dl_path))
 
                 return HttpResponseRedirect(reverse("channels.claim_nexmo"))
 
@@ -703,7 +707,9 @@ class OrgCRUDL(SmartCRUDL):
                         client = NexmoClient(key=api_key, secret=api_secret)
                         client.get_balance()
                     except Exception:  # pragma: needs cover
-                        raise ValidationError(_("Your Nexmo API key and secret seem invalid. Please check them again and retry."))
+                        raise ValidationError(
+                            _("Your Nexmo API key and secret seem invalid. Please check them again and retry.")
+                        )
 
                 return self.cleaned_data
 
@@ -749,7 +755,6 @@ class OrgCRUDL(SmartCRUDL):
             return context
 
     class NexmoConnect(ModalMixin, InferOrgMixin, OrgPermsMixin, SmartFormView):
-
         class NexmoConnectForm(forms.Form):
             api_key = forms.CharField(help_text=_("Your Nexmo API key"))
             api_secret = forms.CharField(help_text=_("Your Nexmo API secret"))
@@ -766,7 +771,9 @@ class OrgCRUDL(SmartCRUDL):
                     client = NexmoClient(key=api_key, secret=api_secret)
                     client.get_balance()
                 except Exception:
-                    raise ValidationError(_("Your Nexmo API key and secret seem invalid. Please check them again and retry."))
+                    raise ValidationError(
+                        _("Your Nexmo API key and secret seem invalid. Please check them again and retry.")
+                    )
 
                 return self.cleaned_data
 
@@ -789,7 +796,6 @@ class OrgCRUDL(SmartCRUDL):
             return HttpResponseRedirect(self.get_success_url())
 
     class PlivoConnect(ModalMixin, InferOrgMixin, OrgPermsMixin, SmartFormView):
-
         class PlivoConnectForm(forms.Form):
             auth_id = forms.CharField(help_text=_("Your Plivo AUTH ID"))
             auth_token = forms.CharField(help_text=_("Your Plivo AUTH TOKEN"))
@@ -804,10 +810,14 @@ class OrgCRUDL(SmartCRUDL):
                     client = plivo.RestAPI(auth_id, auth_token)
                     validation_response = client.get_account()
                 except Exception:  # pragma: needs cover
-                    raise ValidationError(_("Your Plivo AUTH ID and AUTH TOKEN seem invalid. Please check them again and retry."))
+                    raise ValidationError(
+                        _("Your Plivo AUTH ID and AUTH TOKEN seem invalid. Please check them again and retry.")
+                    )
 
                 if validation_response[0] != 200:
-                    raise ValidationError(_("Your Plivo AUTH ID and AUTH TOKEN seem invalid. Please check them again and retry."))
+                    raise ValidationError(
+                        _("Your Plivo AUTH ID and AUTH TOKEN seem invalid. Please check them again and retry.")
+                    )
 
                 return self.cleaned_data
 
@@ -826,9 +836,13 @@ class OrgCRUDL(SmartCRUDL):
             self.request.session[Channel.CONFIG_PLIVO_AUTH_ID] = auth_id
             self.request.session[Channel.CONFIG_PLIVO_AUTH_TOKEN] = auth_token
 
-            response = self.render_to_response(self.get_context_data(form=form,
-                                               success_url=self.get_success_url(),
-                                               success_script=getattr(self, 'success_script', None)))
+            response = self.render_to_response(
+                self.get_context_data(
+                    form=form,
+                    success_url=self.get_success_url(),
+                    success_script=getattr(self, 'success_script', None)
+                )
+            )
 
             response['Temba-Success'] = self.get_success_url()
             return response
@@ -837,17 +851,25 @@ class OrgCRUDL(SmartCRUDL):
         success_message = ""
 
         class SmtpConfig(forms.ModelForm):
-            smtp_from_email = forms.CharField(max_length=128, label=_("Email Address"), required=False,
-                                              help_text=_("The from email address, can contain a name: ex: Jane Doe <jane@example.org>"))
+            smtp_from_email = forms.CharField(
+                max_length=128,
+                label=_("Email Address"),
+                required=False,
+                help_text=_("The from email address, can contain a name: ex: Jane Doe <jane@example.org>")
+            )
             smtp_host = forms.CharField(max_length=128, label=_("SMTP Host"), required=False)
             smtp_username = forms.CharField(max_length=128, label=_("Username"), required=False)
-            smtp_password = forms.CharField(max_length=128, label=_("Password"), required=False,
-                                            help_text=_("Leave blank to keep the existing set password if one exists"),
-                                            widget=forms.PasswordInput)
+            smtp_password = forms.CharField(
+                max_length=128,
+                label=_("Password"),
+                required=False,
+                help_text=_("Leave blank to keep the existing set password if one exists"),
+                widget=forms.PasswordInput
+            )
             smtp_port = forms.CharField(max_length=128, label=_("Port"), required=False)
-            smtp_encryption = forms.ChoiceField(choices=(('', _("No encryption")),
-                                                         ('T', _("Use TLS"))),
-                                                required=False, label=_("Encryption"))
+            smtp_encryption = forms.ChoiceField(
+                choices=(('', _("No encryption")), ('T', _("Use TLS"))), required=False, label=_("Encryption")
+            )
             disconnect = forms.CharField(widget=forms.HiddenInput, max_length=6, required=True)
 
             def clean(self):
@@ -888,7 +910,10 @@ class OrgCRUDL(SmartCRUDL):
 
             class Meta:
                 model = Org
-                fields = ('smtp_from_email', 'smtp_host', 'smtp_username', 'smtp_password', 'smtp_port', 'smtp_encryption', 'disconnect')
+                fields = (
+                    'smtp_from_email', 'smtp_host', 'smtp_username', 'smtp_password', 'smtp_port', 'smtp_encryption',
+                    'disconnect'
+                )
 
         form_class = SmtpConfig
 
@@ -922,7 +947,9 @@ class OrgCRUDL(SmartCRUDL):
                 smtp_port = form.cleaned_data['smtp_port']
                 smtp_encryption = form.cleaned_data['smtp_encryption']
 
-                org.add_smtp_config(smtp_from_email, smtp_host, smtp_username, smtp_password, smtp_port, smtp_encryption, user)
+                org.add_smtp_config(
+                    smtp_from_email, smtp_host, smtp_username, smtp_password, smtp_port, smtp_encryption, user
+                )
 
             return super(OrgCRUDL.SmtpServer, self).form_valid(form)
 
@@ -944,7 +971,10 @@ class OrgCRUDL(SmartCRUDL):
     class Manage(SmartListView):
         fields = ('credits', 'used', 'name', 'owner', 'service', 'created_on')
         field_config = {'service': {'label': ''}}
-        default_order = ('-credits', '-created_on',)
+        default_order = (
+            '-credits',
+            '-created_on',
+        )
         search_fields = ('name__icontains', 'created_by__email__iexact', 'config__icontains')
         link_fields = ('name', 'owner')
         title = "Organizations"
@@ -965,29 +995,36 @@ class OrgCRUDL(SmartCRUDL):
         def get_credits(self, obj):
             if not obj.credits:  # pragma: needs cover
                 obj.credits = 0
-            return mark_safe("<div class='num-credits'><a href='%s'>%s</a></div>"
-                             % (reverse('orgs.topup_manage') + "?org=%d" % obj.id, format(obj.credits, ",d")))
+            return mark_safe(
+                "<div class='num-credits'><a href='%s'>%s</a></div>" %
+                (reverse('orgs.topup_manage') + "?org=%d" % obj.id, format(obj.credits, ",d"))
+            )
 
         def get_owner(self, obj):
             # default to the created by if there are no admins
             owner = obj.latest_admin() or obj.created_by
 
-            return mark_safe("<div class='owner-name'>%s %s</div><div class='owner-email'>%s</div>"
-                             % (owner.first_name, owner.last_name, owner))
+            return mark_safe(
+                "<div class='owner-name'>%s %s</div><div class='owner-email'>%s</div>" %
+                (owner.first_name, owner.last_name, owner)
+            )
 
         def get_service(self, obj):
             url = reverse('orgs.org_service')
 
-            return mark_safe("<a href='%s?organization=%d' class='service posterize btn btn-tiny'>Service</a>"
-                             % (url, obj.id))
+            return mark_safe(
+                "<a href='%s?organization=%d' class='service posterize btn btn-tiny'>Service</a>" % (url, obj.id)
+            )
 
         def get_name(self, obj):
             suspended = ''
             if obj.is_suspended():
                 suspended = '<span class="suspended">(Suspended)</span>'
 
-            return mark_safe("<div class='org-name'>%s %s</div><div class='org-timezone'>%s</div>"
-                             % (suspended, obj.name, obj.timezone))
+            return mark_safe(
+                "<div class='org-name'>%s %s</div><div class='org-timezone'>%s</div>" %
+                (suspended, obj.name, obj.timezone)
+            )
 
         def derive_queryset(self, **kwargs):
             queryset = super(OrgCRUDL.Manage, self).derive_queryset(**kwargs)
@@ -1004,7 +1041,9 @@ class OrgCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super(OrgCRUDL.Manage, self).get_context_data(**kwargs)
-            context['searches'] = ['Nyaruka', ]
+            context['searches'] = [
+                'Nyaruka',
+            ]
             return context
 
         def lookup_field_link(self, context, field, obj):
@@ -1037,26 +1076,40 @@ class OrgCRUDL(SmartCRUDL):
 
             org = self.get_object()
 
-            links.append(dict(title=_('Topups'),
-                              style='btn-primary',
-                              href='%s?org=%d' % (reverse("orgs.topup_manage"), org.pk)))
+            links.append(
+                dict(
+                    title=_('Topups'), style='btn-primary', href='%s?org=%d' % (reverse("orgs.topup_manage"), org.pk)
+                )
+            )
 
             if org.is_suspended():
-                links.append(dict(title=_('Restore'),
-                                  style='btn-secondary',
-                                  posterize=True,
-                                  href='%s?status=restored' % reverse("orgs.org_update", args=[org.pk])))
+                links.append(
+                    dict(
+                        title=_('Restore'),
+                        style='btn-secondary',
+                        posterize=True,
+                        href='%s?status=restored' % reverse("orgs.org_update", args=[org.pk])
+                    )
+                )
             else:  # pragma: needs cover
-                links.append(dict(title=_('Suspend'),
-                                  style='btn-secondary',
-                                  posterize=True,
-                                  href='%s?status=suspended' % reverse("orgs.org_update", args=[org.pk])))
+                links.append(
+                    dict(
+                        title=_('Suspend'),
+                        style='btn-secondary',
+                        posterize=True,
+                        href='%s?status=suspended' % reverse("orgs.org_update", args=[org.pk])
+                    )
+                )
 
             if not org.is_whitelisted():
-                links.append(dict(title=_('Whitelist'),
-                                  style='btn-secondary',
-                                  posterize=True,
-                                  href='%s?status=whitelisted' % reverse("orgs.org_update", args=[org.pk])))
+                links.append(
+                    dict(
+                        title=_('Whitelist'),
+                        style='btn-secondary',
+                        posterize=True,
+                        href='%s?status=whitelisted' % reverse("orgs.org_update", args=[org.pk])
+                    )
+                )
 
             return links
 
@@ -1072,7 +1125,6 @@ class OrgCRUDL(SmartCRUDL):
             return super(OrgCRUDL.Update, self).post(request, *args, **kwargs)
 
     class Accounts(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-
         class PasswordForm(forms.ModelForm):
             surveyor_password = forms.CharField(max_length=128)
 
@@ -1085,24 +1137,24 @@ class OrgCRUDL(SmartCRUDL):
 
             class Meta:
                 model = Org
-                fields = ('surveyor_password',)
+                fields = ('surveyor_password', )
 
         form_class = PasswordForm
         success_url = "@orgs.org_home"
         success_message = ""
         submit_button_name = _("Save Changes")
         title = 'User Accounts'
-        fields = ('surveyor_password',)
+        fields = ('surveyor_password', )
 
     class ManageAccounts(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-
         class AccountsForm(forms.ModelForm):
             invite_emails = forms.CharField(label=_("Invite people to your organization"), required=False)
-            invite_group = forms.ChoiceField(choices=(('A', _("Administrators")),
-                                                      ('E', _("Editors")),
-                                                      ('V', _("Viewers")),
-                                                      ('S', _("Surveyors"))),
-                                             required=True, initial='V', label=_("User group"))
+            invite_group = forms.ChoiceField(
+                choices=(('A', _("Administrators")), ('E', _("Editors")), ('V', _("Viewers")), ('S', _("Surveyors"))),
+                required=True,
+                initial='V',
+                label=_("User group")
+            )
 
             def add_user_group_fields(self, groups, users):
                 fields_by_user = {}
@@ -1268,7 +1320,6 @@ class OrgCRUDL(SmartCRUDL):
             return response
 
     class ManageAccountsSubOrg(MultiOrgMixin, ManageAccounts):
-
         def get_context_data(self, **kwargs):
             context = super(OrgCRUDL.ManageAccountsSubOrg, self).get_context_data(**kwargs)
             org_id = self.request.GET.get('org')
@@ -1289,7 +1340,7 @@ class OrgCRUDL(SmartCRUDL):
 
         form_class = ServiceForm
         success_url = '@msgs.msg_inbox'
-        fields = ('organization',)
+        fields = ('organization', )
 
         # valid form means we set our org and redirect to their inbox
         def form_valid(self, form):
@@ -1312,43 +1363,43 @@ class OrgCRUDL(SmartCRUDL):
             links = []
 
             if self.has_org_perm("orgs.org_dashboard"):
-                links.append(dict(title='Dashboard',
-                                  href=reverse('dashboard.dashboard_home')))
+                links.append(dict(title='Dashboard', href=reverse('dashboard.dashboard_home')))
 
             if self.has_org_perm("orgs.org_create_sub_org"):
-                links.append(dict(title='New',
-                                  js_class='add-sub-org',
-                                  href='#'))
+                links.append(dict(title='New', js_class='add-sub-org', href='#'))
 
             if self.has_org_perm("orgs.org_transfer_credits"):
-                links.append(dict(title='Transfer Credits',
-                                  js_class='transfer-credits',
-                                  href='#'))
+                links.append(dict(title='Transfer Credits', js_class='transfer-credits', href='#'))
 
             if self.has_org_perm("orgs.org_home"):
-                links.append(dict(title='Manage Account',
-                                  href=reverse('orgs.org_home')))
+                links.append(dict(title='Manage Account', href=reverse('orgs.org_home')))
 
             return links
 
         def get_manage(self, obj):
             if obj.parent:  # pragma: needs cover
-                return mark_safe('<a href="%s?org=%s"><div class="btn btn-tiny">Manage Accounts</div></a>'
-                                 % (reverse('orgs.org_manage_accounts_sub_org'), obj.id))
+                return mark_safe(
+                    '<a href="%s?org=%s"><div class="btn btn-tiny">Manage Accounts</div></a>' %
+                    (reverse('orgs.org_manage_accounts_sub_org'), obj.id)
+                )
             return ''
 
         def get_credits(self, obj):
             credits = obj.get_credits_remaining()
-            return mark_safe('<div class="edit-org" data-url="%s?org=%d"><div class="num-credits">%s</div></div>'
-                             % (reverse('orgs.org_edit_sub_org'), obj.id, format(credits, ",d")))
+            return mark_safe(
+                '<div class="edit-org" data-url="%s?org=%d"><div class="num-credits">%s</div></div>' %
+                (reverse('orgs.org_edit_sub_org'), obj.id, format(credits, ",d"))
+            )
 
         def get_name(self, obj):
             org_type = 'child'
             if not obj.parent:
                 org_type = 'parent'
 
-            return mark_safe("<div class='%s-org-name'>%s</div><div class='org-timezone'>%s</div>"
-                             % (org_type, obj.name, obj.timezone))
+            return mark_safe(
+                "<div class='%s-org-name'>%s</div><div class='org-timezone'>%s</div>" %
+                (org_type, obj.name, obj.timezone)
+            )
 
         def derive_queryset(self, **kwargs):
             queryset = super(OrgCRUDL.SubOrgs, self).derive_queryset(**kwargs)
@@ -1366,17 +1417,17 @@ class OrgCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super(OrgCRUDL.SubOrgs, self).get_context_data(**kwargs)
-            context['searches'] = ['Nyaruka', ]
+            context['searches'] = [
+                'Nyaruka',
+            ]
             return context
 
         def get_created_by(self, obj):  # pragma: needs cover
             return "%s %s - %s" % (obj.created_by.first_name, obj.created_by.last_name, obj.created_by.email)
 
     class CreateSubOrg(MultiOrgMixin, ModalMixin, InferOrgMixin, SmartCreateView):
-
         class CreateOrgForm(forms.ModelForm):
-            name = forms.CharField(label=_("Organization"),
-                                   help_text=_("The name of your organization"))
+            name = forms.CharField(label=_("Organization"), help_text=_("The name of your organization"))
 
             timezone = TimeZoneFormField(help_text=_("The timezone your organization is in"))
 
@@ -1403,9 +1454,13 @@ class OrgCRUDL(SmartCRUDL):
             if 'HTTP_X_PJAX' not in self.request.META:
                 return HttpResponseRedirect(self.get_success_url())
             else:  # pragma: no cover
-                response = self.render_to_response(self.get_context_data(form=form,
-                                                                         success_url=self.get_success_url(),
-                                                                         success_script=getattr(self, 'success_script', None)))
+                response = self.render_to_response(
+                    self.get_context_data(
+                        form=form,
+                        success_url=self.get_success_url(),
+                        success_script=getattr(self, 'success_script', None)
+                    )
+                )
                 response['Temba-Success'] = self.get_success_url()
                 return response
 
@@ -1415,7 +1470,7 @@ class OrgCRUDL(SmartCRUDL):
 
         form_class = ChooseForm
         success_url = '@msgs.msg_inbox'
-        fields = ('organization',)
+        fields = ('organization', )
         title = _("Select your Organization")
 
         def get_user_orgs(self):
@@ -1486,15 +1541,16 @@ class OrgCRUDL(SmartCRUDL):
         def pre_process(self, request, *args, **kwargs):
             org = self.get_object()
             if not org:  # pragma: needs cover
-                messages.info(request, _("Your invitation link is invalid. Please contact your organization administrator."))
+                messages.info(
+                    request, _("Your invitation link is invalid. Please contact your organization administrator.")
+                )
                 return HttpResponseRedirect(reverse('public.public_index'))
             return None
 
         def pre_save(self, obj):
             obj = super(OrgCRUDL.CreateLogin, self).pre_save(obj)
 
-            user = Org.create_user(self.form.cleaned_data['email'],
-                                   self.form.cleaned_data['password'])
+            user = Org.create_user(self.form.cleaned_data['email'], self.form.cleaned_data['password'])
 
             user.first_name = self.form.cleaned_data['first_name']
             user.last_name = self.form.cleaned_data['last_name']
@@ -1557,7 +1613,6 @@ class OrgCRUDL(SmartCRUDL):
 
     class Join(SmartUpdateView):
         class JoinForm(forms.ModelForm):
-
             class Meta:
                 model = Org
                 fields = ()
@@ -1573,7 +1628,9 @@ class OrgCRUDL(SmartCRUDL):
 
             org = self.get_object()
             if not org:
-                messages.info(request, _("Your invitation link has expired. Please contact your organization administrator."))
+                messages.info(
+                    request, _("Your invitation link has expired. Please contact your organization administrator.")
+                )
                 return HttpResponseRedirect(reverse('public.public_index'))
 
             if not request.user.is_authenticated():
@@ -1635,7 +1692,6 @@ class OrgCRUDL(SmartCRUDL):
             return context
 
     class Surveyor(SmartFormView):
-
         class PasswordForm(forms.Form):
             surveyor_password = forms.CharField(widget=forms.PasswordInput(attrs={'placeholder': 'Password'}))
 
@@ -1643,17 +1699,35 @@ class OrgCRUDL(SmartCRUDL):
                 password = self.cleaned_data['surveyor_password']
                 org = Org.objects.filter(surveyor_password=password).first()
                 if not org:
-                    raise forms.ValidationError(_("Invalid surveyor password, please check with your project leader and try again."))
+                    raise forms.ValidationError(
+                        _("Invalid surveyor password, please check with your project leader and try again.")
+                    )
                 self.cleaned_data['org'] = org
                 return password
 
         class RegisterForm(PasswordForm):
             surveyor_password = forms.CharField(widget=forms.HiddenInput())
-            first_name = forms.CharField(help_text=_("Your first name"), widget=forms.TextInput(attrs={'placeholder': 'First Name'}))
-            last_name = forms.CharField(help_text=_("Your last name"), widget=forms.TextInput(attrs={'placeholder': 'Last Name'}))
-            email = forms.EmailField(help_text=_("Your email address"), widget=forms.TextInput(attrs={'placeholder': 'Email'}))
-            password = forms.CharField(widget=forms.PasswordInput(attrs={'placeholder': 'Password'}),
-                                       help_text=_("Your password, at least eight letters please"))
+            first_name = forms.CharField(
+                help_text=_("Your first name"), widget=forms.TextInput(attrs={
+                    'placeholder': 'First Name'
+                })
+            )
+            last_name = forms.CharField(
+                help_text=_("Your last name"), widget=forms.TextInput(attrs={
+                    'placeholder': 'Last Name'
+                })
+            )
+            email = forms.EmailField(
+                help_text=_("Your email address"), widget=forms.TextInput(attrs={
+                    'placeholder': 'Email'
+                })
+            )
+            password = forms.CharField(
+                widget=forms.PasswordInput(attrs={
+                    'placeholder': 'Password'
+                }),
+                help_text=_("Your password, at least eight letters please")
+            )
 
             def __init__(self, *args, **kwargs):
                 super(OrgCRUDL.Surveyor.RegisterForm, self).__init__(*args, **kwargs)
@@ -1720,8 +1794,7 @@ class OrgCRUDL(SmartCRUDL):
 
                 # create our user
                 username = self.form.cleaned_data['email']
-                user = Org.create_user(username,
-                                       self.form.cleaned_data['password'])
+                user = Org.create_user(username, self.form.cleaned_data['password'])
 
                 user.first_name = self.form.cleaned_data['first_name']
                 user.last_name = self.form.cleaned_data['last_name']
@@ -1765,8 +1838,7 @@ class OrgCRUDL(SmartCRUDL):
         def create_user(self):
             user = User.objects.filter(username__iexact=self.form.cleaned_data['email']).first()
             if not user:
-                user = Org.create_user(self.form.cleaned_data['email'],
-                                       self.form.cleaned_data['password'])
+                user = Org.create_user(self.form.cleaned_data['email'], self.form.cleaned_data['password'])
 
             user.first_name = self.form.cleaned_data['first_name']
             user.last_name = self.form.cleaned_data['last_name']
@@ -1805,7 +1877,8 @@ class OrgCRUDL(SmartCRUDL):
             obj = super(OrgCRUDL.Grant, self).post_save(obj)
             obj.administrators.add(self.user)
 
-            if not self.request.user.is_anonymous() and self.request.user.has_perm('orgs.org_grant'):  # pragma: needs cover
+            if not self.request.user.is_anonymous(
+            ) and self.request.user.has_perm('orgs.org_grant'):  # pragma: needs cover
                 obj.administrators.add(self.request.user.pk)
 
             obj.initialize(branding=obj.get_branding(), topup_size=self.get_welcome_size())
@@ -1851,8 +1924,9 @@ class OrgCRUDL(SmartCRUDL):
 
     class Resthooks(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class ResthookForm(forms.ModelForm):
-            resthook = forms.SlugField(required=False, label=_("New Event"),
-                                       help_text="Enter a name for your event. ex: new-registration")
+            resthook = forms.SlugField(
+                required=False, label=_("New Event"), help_text="Enter a name for your event. ex: new-registration"
+            )
 
             def add_resthook_fields(self):
                 resthooks = []
@@ -1909,7 +1983,6 @@ class OrgCRUDL(SmartCRUDL):
             return super(OrgCRUDL.Resthooks, self).pre_save(obj)
 
     class Webhook(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-
         class WebhookForm(forms.ModelForm):
             webhook = forms.URLField(required=False, label=_("Webhook URL"), help_text="")
             headers = forms.CharField(required=False)
@@ -1984,14 +2057,20 @@ class OrgCRUDL(SmartCRUDL):
             return context
 
     class Chatbase(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-
         class ChatbaseForm(forms.ModelForm):
-            agent_name = forms.CharField(max_length=255, label=_("Agent Name"), required=False,
-                                         help_text="Enter your Chatbase Agent's name")
-            api_key = forms.CharField(max_length=255, label=_("API Key"), required=False,
-                                      help_text="You can find your Agent's API Key "
-                                                "<a href='https://chatbase.com/agents/main-page' target='_new'>here</a>")
-            version = forms.CharField(max_length=10, label=_("Version"), required=False, help_text="Any will do, e.g. 1.0, 1.2.1")
+            agent_name = forms.CharField(
+                max_length=255, label=_("Agent Name"), required=False, help_text="Enter your Chatbase Agent's name"
+            )
+            api_key = forms.CharField(
+                max_length=255,
+                label=_("API Key"),
+                required=False,
+                help_text="You can find your Agent's API Key "
+                "<a href='https://chatbase.com/agents/main-page' target='_new'>here</a>"
+            )
+            version = forms.CharField(
+                max_length=10, label=_("Version"), required=False, help_text="Any will do, e.g. 1.0, 1.2.1"
+            )
             disconnect = forms.CharField(widget=forms.HiddenInput, max_length=6, required=True)
 
             def clean(self):
@@ -2001,8 +2080,10 @@ class OrgCRUDL(SmartCRUDL):
                     api_key = self.cleaned_data.get('api_key')
 
                     if not agent_name or not api_key:
-                        raise ValidationError(_("Missing data: Agent Name or API Key."
-                                                "Please check them again and retry."))
+                        raise ValidationError(
+                            _("Missing data: Agent Name or API Key."
+                              "Please check them again and retry.")
+                        )
 
                 return self.cleaned_data
 
@@ -2057,13 +2138,10 @@ class OrgCRUDL(SmartCRUDL):
         def get_gear_links(self):
             links = []
 
-            links.append(dict(title=_('Logout'),
-                              style='btn-primary',
-                              href=reverse("users.user_logout")))
+            links.append(dict(title=_('Logout'), style='btn-primary', href=reverse("users.user_logout")))
 
             if self.has_org_perm("channels.channel_claim"):
-                links.append(dict(title=_('Add Channel'),
-                                  href=reverse('channels.channel_claim')))
+                links.append(dict(title=_('Add Channel'), href=reverse('channels.channel_claim')))
 
             if self.has_org_perm("orgs.org_export"):
                 links.append(dict(title=_('Export'), href=reverse('orgs.org_export')))
@@ -2077,7 +2155,9 @@ class OrgCRUDL(SmartCRUDL):
 
             if self.has_org_perm('channels.channel_read'):
                 from temba.channels.views import get_channel_read_url
-                formax.add_section('channel', get_channel_read_url(channel), icon=channel.get_type().icon, action='link')
+                formax.add_section(
+                    'channel', get_channel_read_url(channel), icon=channel.get_type().icon, action='link'
+                )
 
         def derive_formax_sections(self, formax, context):
 
@@ -2119,26 +2199,48 @@ class OrgCRUDL(SmartCRUDL):
 
             if self.has_org_perm('orgs.org_transfer_to_account'):
                 if not self.object.is_connected_to_transferto():
-                    formax.add_section('transferto', reverse('orgs.org_transfer_to_account'), icon='icon-transferto',
-                                       action='redirect', button=_("Connect"))
+                    formax.add_section(
+                        'transferto',
+                        reverse('orgs.org_transfer_to_account'),
+                        icon='icon-transferto',
+                        action='redirect',
+                        button=_("Connect")
+                    )
                 else:  # pragma: needs cover
-                    formax.add_section('transferto', reverse('orgs.org_transfer_to_account'), icon='icon-transferto',
-                                       action='redirect', nobutton=True)
+                    formax.add_section(
+                        'transferto',
+                        reverse('orgs.org_transfer_to_account'),
+                        icon='icon-transferto',
+                        action='redirect',
+                        nobutton=True
+                    )
 
             if self.has_org_perm('orgs.org_chatbase'):
                 (chatbase_api_key, chatbase_version) = self.object.get_chatbase_credentials()
                 if not chatbase_api_key:
-                    formax.add_section('chatbase', reverse('orgs.org_chatbase'), icon='icon-chatbase',
-                                       action='redirect', button=_("Connect"))
+                    formax.add_section(
+                        'chatbase',
+                        reverse('orgs.org_chatbase'),
+                        icon='icon-chatbase',
+                        action='redirect',
+                        button=_("Connect")
+                    )
                 else:  # pragma: needs cover
-                    formax.add_section('chatbase', reverse('orgs.org_chatbase'), icon='icon-chatbase',
-                                       action='redirect', nobutton=True)
+                    formax.add_section(
+                        'chatbase',
+                        reverse('orgs.org_chatbase'),
+                        icon='icon-chatbase',
+                        action='redirect',
+                        nobutton=True
+                    )
 
             if self.has_org_perm('orgs.org_webhook'):
                 formax.add_section('webhook', reverse('orgs.org_webhook'), icon='icon-cloud-upload')
 
             if self.has_org_perm('orgs.org_resthooks'):
-                formax.add_section('resthooks', reverse('orgs.org_resthooks'), icon='icon-cloud-lightning', dependents="resthooks")
+                formax.add_section(
+                    'resthooks', reverse('orgs.org_resthooks'), icon='icon-cloud-lightning', dependents="resthooks"
+                )
 
             # only pro orgs get multiple users
             if self.has_org_perm("orgs.org_manage_accounts") and org.is_multi_user_tier():
@@ -2161,7 +2263,9 @@ class OrgCRUDL(SmartCRUDL):
 
                     try:
                         from temba.airtime.models import AirtimeTransfer
-                        response = AirtimeTransfer.post_transferto_api_response(account_login, airtime_api_token, action='ping')
+                        response = AirtimeTransfer.post_transferto_api_response(
+                            account_login, airtime_api_token, action='ping'
+                        )
                         parsed_response = AirtimeTransfer.parse_transferto_response(response.content)
 
                         error_code = int(parsed_response.get('error_code', None))
@@ -2169,12 +2273,18 @@ class OrgCRUDL(SmartCRUDL):
                         error_txt = parsed_response.get('error_txt', None)
 
                     except Exception:
-                        raise ValidationError(_("Your TransferTo API key and secret seem invalid. "
-                                                "Please check them again and retry."))
+                        raise ValidationError(
+                            _(
+                                "Your TransferTo API key and secret seem invalid. "
+                                "Please check them again and retry."
+                            )
+                        )
 
                     if error_code != 0 and info_txt != 'pong':
-                        raise ValidationError(_("Connecting to your TransferTo account "
-                                                "failed with error text: %s") % error_txt)
+                        raise ValidationError(
+                            _("Connecting to your TransferTo account "
+                              "failed with error text: %s") % error_txt
+                        )
 
                 return self.cleaned_data
 
@@ -2247,7 +2357,9 @@ class OrgCRUDL(SmartCRUDL):
                         self.cleaned_data['account_sid'] = account.sid
                         self.cleaned_data['account_token'] = account.auth_token
                     except Exception:  # pragma: needs cover
-                        raise ValidationError(_("The Twilio account SID and Token seem invalid. Please check them again and retry."))
+                        raise ValidationError(
+                            _("The Twilio account SID and Token seem invalid. Please check them again and retry.")
+                        )
 
                 return self.cleaned_data
 
@@ -2290,11 +2402,12 @@ class OrgCRUDL(SmartCRUDL):
                 return super(OrgCRUDL.TwilioAccount, self).form_valid(form)
 
     class Edit(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-
         class OrgForm(forms.ModelForm):
             name = forms.CharField(max_length=128, label=_("The name of your organization"), help_text="")
             timezone = TimeZoneFormField(label=_("Your organization's timezone"), help_text="")
-            slug = forms.SlugField(max_length=255, label=_("The slug, or short name for your organization"), help_text="")
+            slug = forms.SlugField(
+                max_length=255, label=_("The slug, or short name for your organization"), help_text=""
+            )
 
             class Meta:
                 model = Org
@@ -2323,21 +2436,26 @@ class OrgCRUDL(SmartCRUDL):
             return Org.objects.filter(id=org_id, parent=self.request.user.get_org()).first()
 
     class TransferCredits(MultiOrgMixin, ModalMixin, InferOrgMixin, SmartFormView):
-
         class TransferForm(forms.Form):
-
             class OrgChoiceField(forms.ModelChoiceField):
                 def label_from_instance(self, org):
                     return '%s (%s)' % (org.name, "{:,}".format(org.get_credits_remaining()))
 
-            from_org = OrgChoiceField(None, required=True, label=_("From Organization"),
-                                      help_text=_("Select which organization to take credits from"))
+            from_org = OrgChoiceField(
+                None,
+                required=True,
+                label=_("From Organization"),
+                help_text=_("Select which organization to take credits from")
+            )
 
-            to_org = OrgChoiceField(None, required=True, label=_("To Organization"),
-                                    help_text=_("Select which organization to receive the credits"))
+            to_org = OrgChoiceField(
+                None,
+                required=True,
+                label=_("To Organization"),
+                help_text=_("Select which organization to receive the credits")
+            )
 
-            amount = forms.IntegerField(required=True, label=_('Credits'),
-                                        help_text=_("How many credits to transfer"))
+            amount = forms.IntegerField(required=True, label=_('Credits'), help_text=_("How many credits to transfer"))
 
             def __init__(self, *args, **kwargs):
                 org = kwargs['org']
@@ -2345,8 +2463,12 @@ class OrgCRUDL(SmartCRUDL):
 
                 super(OrgCRUDL.TransferCredits.TransferForm, self).__init__(*args, **kwargs)
 
-                self.fields['from_org'].queryset = Org.objects.filter(Q(parent=org) | Q(id=org.id)).order_by('-parent', 'id')
-                self.fields['to_org'].queryset = Org.objects.filter(Q(parent=org) | Q(id=org.id)).order_by('-parent', 'id')
+                self.fields['from_org'].queryset = Org.objects.filter(Q(parent=org) | Q(id=org.id)).order_by(
+                    '-parent', 'id'
+                )
+                self.fields['to_org'].queryset = Org.objects.filter(Q(parent=org) | Q(id=org.id)).order_by(
+                    '-parent', 'id'
+                )
 
             def clean(self):
                 cleaned_data = super(OrgCRUDL.TransferCredits.TransferForm, self).clean()
@@ -2355,7 +2477,11 @@ class OrgCRUDL(SmartCRUDL):
                     from_org = cleaned_data['from_org']
 
                     if cleaned_data['amount'] > from_org.get_credits_remaining():
-                        raise ValidationError(_("Sorry, %(org_name)s doesn't have enough credits for this transfer. Pick a different organization to transfer from or reduce the transfer amount.") % dict(org_name=from_org.name))
+                        raise ValidationError(
+                            _(
+                                "Sorry, %(org_name)s doesn't have enough credits for this transfer. Pick a different organization to transfer from or reduce the transfer amount."
+                            ) % dict(org_name=from_org.name)
+                        )
 
         success_url = '@orgs.org_sub_orgs'
         form_class = TransferForm
@@ -2378,25 +2504,29 @@ class OrgCRUDL(SmartCRUDL):
 
             from_org.allocate_credits(from_org.created_by, to_org, amount)
 
-            response = self.render_to_response(self.get_context_data(form=form,
-                                               success_url=self.get_success_url(),
-                                               success_script=getattr(self, 'success_script', None)))
+            response = self.render_to_response(
+                self.get_context_data(
+                    form=form,
+                    success_url=self.get_success_url(),
+                    success_script=getattr(self, 'success_script', None)
+                )
+            )
 
             response['Temba-Success'] = self.get_success_url()
             return response
 
     class Country(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-
         class CountryForm(forms.ModelForm):
             country = forms.ModelChoiceField(
-                Org.get_possible_countries(), required=False,
+                Org.get_possible_countries(),
+                required=False,
                 label=_("The country used for location values. (optional)"),
                 help_text="State and district names will be searched against this country."
             )
 
             class Meta:
                 model = Org
-                fields = ('country',)
+                fields = ('country', )
 
         success_message = ''
         form_class = CountryForm
@@ -2406,14 +2536,15 @@ class OrgCRUDL(SmartCRUDL):
             return self.request.user.has_perm('orgs.org_country') or self.has_org_perm('orgs.org_country')
 
     class Languages(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
-
         class LanguagesForm(forms.ModelForm):
             primary_lang = forms.CharField(
-                required=False, label=_('Primary Language'),
+                required=False,
+                label=_('Primary Language'),
                 help_text=_('The primary language will be used for contacts with no language preference.')
             )
             languages = forms.CharField(
-                required=False, label=_('Additional Languages'),
+                required=False,
+                label=_('Additional Languages'),
                 help_text=_('Add any other languages you would like to provide translations for.')
             )
 
@@ -2437,7 +2568,9 @@ class OrgCRUDL(SmartCRUDL):
         def derive_initial(self):
 
             initial = super(OrgCRUDL.Languages, self).derive_initial()
-            langs = ','.join([lang.iso_code for lang in self.get_object().languages.filter(orgs=None).order_by('name')])
+            langs = ','.join([
+                lang.iso_code for lang in self.get_object().languages.filter(orgs=None).order_by('name')
+            ])
             initial['languages'] = langs
 
             if self.object.primary_language:
@@ -2447,7 +2580,9 @@ class OrgCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super(OrgCRUDL.Languages, self).get_context_data(**kwargs)
-            languages = [lang.name for lang in self.request.user.get_org().languages.filter(orgs=None).order_by('name')]
+            languages = [
+                lang.name for lang in self.request.user.get_org().languages.filter(orgs=None).order_by('name')
+            ]
             lang_count = len(languages)
 
             if lang_count == 2:
@@ -2496,7 +2631,7 @@ class OrgCRUDL(SmartCRUDL):
             return self.request.user.has_perm('orgs.org_country') or self.has_org_perm('orgs.org_country')
 
     class ClearCache(SmartUpdateView):  # pragma: no cover
-        fields = ('id',)
+        fields = ('id', )
         success_message = None
         success_url = 'id@orgs.org_update'
 
@@ -2517,7 +2652,9 @@ class TopUpCRUDL(SmartCRUDL):
     class List(OrgPermsMixin, SmartListView):
         def derive_queryset(self, **kwargs):
             queryset = TopUp.objects.filter(is_active=True, org=self.request.user.get_org())
-            return queryset.annotate(credits_remaining=ExpressionWrapper(F('credits') - Sum(F('topupcredits__used')), IntegerField()))
+            return queryset.annotate(
+                credits_remaining=ExpressionWrapper(F('credits') - Sum(F('topupcredits__used')), IntegerField())
+            )
 
         def get_context_data(self, **kwargs):
             context = super(TopUpCRUDL.List, self).get_context_data(**kwargs)
@@ -2635,6 +2772,7 @@ class StripeHandler(View):  # pragma: no cover
     Handles WebHook events from Stripe.  We are interested as to when invoices are
     charged by Stripe so we can send the user an invoice email.
     """
+
     @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super(StripeHandler, self).dispatch(*args, **kwargs)
@@ -2687,11 +2825,13 @@ class StripeHandler(View):  # pragma: no cover
                 else:
                     track = "temba.charge_failed"
 
-                context = dict(description=description,
-                               invoice_id=charge.id,
-                               invoice_date=charge_date.strftime("%b %e, %Y"),
-                               amount=amount,
-                               org=org.name)
+                context = dict(
+                    description=description,
+                    invoice_id=charge.id,
+                    invoice_date=charge_date.strftime("%b %e, %Y"),
+                    amount=amount,
+                    org=org.name
+                )
 
                 if getattr(charge, 'card', None):
                     context['cc_last4'] = charge.card.last4

--- a/temba/public/models.py
+++ b/temba/public/models.py
@@ -6,17 +6,18 @@ from smartmin.models import SmartModel
 
 
 class Lead(SmartModel):
-    email = models.EmailField(unique=False,
-                              error_messages={'unique': '{% trans "This email has already been registered." %}'})
+    email = models.EmailField(
+        unique=False, error_messages={
+            'unique': '{% trans "This email has already been registered." %}'
+        }
+    )
 
 
 class Video(SmartModel):
-    name = models.CharField(verbose_name=_("Name"),
-                            help_text=_("The name of the video"), max_length=255)
-    summary = models.TextField(verbose_name=_("Summary"),
-                               help_text=_("A short blurb about the video"))
-    description = models.TextField(verbose_name=_("Description"),
-                                   help_text="The full description for the video")
-    vimeo_id = models.CharField(verbose_name=_("Vimeo ID"), max_length=255,
-                                help_text=_("The id vimeo uses for this video"))
+    name = models.CharField(verbose_name=_("Name"), help_text=_("The name of the video"), max_length=255)
+    summary = models.TextField(verbose_name=_("Summary"), help_text=_("A short blurb about the video"))
+    description = models.TextField(verbose_name=_("Description"), help_text="The full description for the video")
+    vimeo_id = models.CharField(
+        verbose_name=_("Vimeo ID"), max_length=255, help_text=_("The id vimeo uses for this video")
+    )
     order = models.IntegerField(default=0)

--- a/temba/public/templatetags/public.py
+++ b/temba/public/templatetags/public.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from django import template
 from django.utils.safestring import mark_safe
 
-
 register = template.Library()
 
 

--- a/temba/public/tests.py
+++ b/temba/public/tests.py
@@ -8,7 +8,6 @@ from .views import VideoCRUDL
 
 
 class PublicTest(SmartminTest):
-
     def setUp(self):
         self.superuser = User.objects.create_superuser(username="super", email="super@user.com", password="super")
         self.user = self.create_user("tito")
@@ -118,24 +117,34 @@ class PublicTest(SmartminTest):
         response = self.client.get(sitemap_url)
 
         # but first item is always home page
-        self.assertEqual(response.context['urlset'][0], {'priority': '0.5',
-                                                         'item': 'public.public_index',
-                                                         'lastmod': None,
-                                                         'changefreq': 'daily',
-                                                         'location': u'http://example.com/'})
+        self.assertEqual(
+            response.context['urlset'][0], {
+                'priority': '0.5',
+                'item': 'public.public_index',
+                'lastmod': None,
+                'changefreq': 'daily',
+                'location': u'http://example.com/'
+            }
+        )
 
         num_fixed_items = len(response.context['urlset'])
 
         # adding a video will dynamically add a new item
-        Video.objects.create(name="Item14", summary="Unicorn", description="Video of unicorns", vimeo_id="1234",
-                             order=0, created_by=self.superuser, modified_by=self.superuser)
+        Video.objects.create(
+            name="Item14",
+            summary="Unicorn",
+            description="Video of unicorns",
+            vimeo_id="1234",
+            order=0,
+            created_by=self.superuser,
+            modified_by=self.superuser
+        )
 
         response = self.client.get(sitemap_url)
         self.assertEqual(len(response.context['urlset']), num_fixed_items + 1)
 
 
 class VideoCRUDLTest(_CRUDLTest):
-
     def setUp(self):
         super(VideoCRUDLTest, self).setUp()
         self.crudl = VideoCRUDL

--- a/temba/public/urls.py
+++ b/temba/public/urls.py
@@ -8,21 +8,15 @@ from .sitemaps import PublicViewSitemap, VideoSitemap
 from .views import LeadCRUDL, LeadViewer, VideoCRUDL
 from .views import IndexView, Blog, Welcome, Deploy, Privacy, WelcomeRedirect, OrderStatus, GenerateCoupon
 
-
-sitemaps = {
-    'public': PublicViewSitemap,
-    'video': VideoSitemap
-}
+sitemaps = {'public': PublicViewSitemap, 'video': VideoSitemap}
 
 urlpatterns = [
     url(r'^$', IndexView.as_view(), {}, 'public.public_index'),
     url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps}, name='public.sitemaps'),
     url(r'^blog/$', Blog.as_view(), {}, 'public.public_blog'),
-
     url(r'^welcome/$', Welcome.as_view(), {}, 'public.public_welcome'),
     url(r'^deploy/$', Deploy.as_view(), {}, 'public.public_deploy'),
     url(r'^privacy/$', Privacy.as_view(), {}, 'public.public_privacy'),
-
     url(r'^public/welcome/$', WelcomeRedirect.as_view(), {}, 'public.public_welcome_redirect'),
     url(r'^demo/status/$', csrf_exempt(OrderStatus.as_view()), {}, 'demo.order_status'),
     url(r'^demo/coupon/$', csrf_exempt(GenerateCoupon.as_view()), {}, 'demo.generate_coupon'),

--- a/temba/public/views.py
+++ b/temba/public/views.py
@@ -48,8 +48,12 @@ class Welcome(SmartTemplateView):
         org = user.get_org()
 
         if org:
-            user_dict = dict(email=user.email, first_name=user.first_name,
-                             last_name=user.last_name, brand=self.request.branding['slug'])
+            user_dict = dict(
+                email=user.email,
+                first_name=user.first_name,
+                last_name=user.last_name,
+                brand=self.request.branding['slug']
+            )
             if org:
                 user_dict['org'] = org.name
                 user_dict['paid'] = org.account_value()
@@ -67,12 +71,12 @@ class Privacy(SmartTemplateView):
 
 
 class LeadViewer(SmartCRUDL):
-    actions = ('list',)
+    actions = ('list', )
     model = Lead
     permissions = True
 
     class List(SmartListView):
-        default_order = ('-created_on',)
+        default_order = ('-created_on', )
         fields = ('created_on', 'email')
 
 
@@ -99,12 +103,12 @@ class VideoCRUDL(SmartCRUDL):
 
 
 class LeadCRUDL(SmartCRUDL):
-    actions = ('create',)
+    actions = ('create', )
     model = Lead
     permissions = False
 
     class Create(SmartFormView, SmartCreateView):
-        fields = ('email',)
+        fields = ('email', )
         title = _("Register for public beta")
         success_message = ''
 
@@ -131,8 +135,10 @@ class LeadCRUDL(SmartCRUDL):
             obj.modified_by = anon
 
             if self.request.user.is_anonymous():
-                analytics.identify(obj.email, dict(email=obj.email, plan='None', segment=randint(1, 10),
-                                                   brand=self.request.branding['slug']))
+                analytics.identify(
+                    obj.email,
+                    dict(email=obj.email, plan='None', segment=randint(1, 10), brand=self.request.branding['slug'])
+                )
                 analytics.track(obj.email, 'temba.org_lead')
 
             return obj
@@ -143,7 +149,6 @@ class Blog(RedirectView):
 
 
 class GenerateCoupon(View):
-
     def post(self, *args, **kwargs):
         # return a generated coupon
         return HttpResponse(json.dumps(dict(coupon=random_string(6))))
@@ -153,36 +158,41 @@ class GenerateCoupon(View):
 
 
 class OrderStatus(View):
-
     def post(self, request, *args, **kwargs):
         text = request.GET.get('text', '')
 
         if text.lower() == 'cu001':
-            response = dict(status="Shipped",
-                            order='CU001',
-                            name="Ben Haggerty",
-                            order_number="PLAT2012",
-                            ship_date="October 9th",
-                            delivery_date="April 3rd",
-                            description="Vogue White Wall x 4")
+            response = dict(
+                status="Shipped",
+                order='CU001',
+                name="Ben Haggerty",
+                order_number="PLAT2012",
+                ship_date="October 9th",
+                delivery_date="April 3rd",
+                description="Vogue White Wall x 4"
+            )
 
         elif text.lower() == 'cu002':
-            response = dict(status="Pending",
-                            order='CU002',
-                            name="Ryan Lewis",
-                            username="rlewis",
-                            ship_date="August 14th",
-                            order_number="FLAG13",
-                            description="American Flag x 1")
+            response = dict(
+                status="Pending",
+                order='CU002',
+                name="Ryan Lewis",
+                username="rlewis",
+                ship_date="August 14th",
+                order_number="FLAG13",
+                description="American Flag x 1"
+            )
 
         elif text.lower() == 'cu003':
-            response = dict(status="Cancelled",
-                            order='CU003',
-                            name="R Kelly",
-                            username="rkelly",
-                            cancel_date="December 2nd",
-                            order_number="SHET51",
-                            description="Bed Sheets, Queen x 1")
+            response = dict(
+                status="Cancelled",
+                order='CU003',
+                name="R Kelly",
+                username="rkelly",
+                cancel_date="December 2nd",
+                order_number="SHET51",
+                description="Bed Sheets, Queen x 1"
+            )
         else:
             response = dict(status="Invalid")
 

--- a/temba/reports/models.py
+++ b/temba/reports/models.py
@@ -16,20 +16,17 @@ class Report(SmartModel):
     CONFIG = 'config'
     ID = 'id'
 
-    title = models.CharField(verbose_name=_("Title"),
-                             max_length=64,
-                             help_text=_("The name title or this report"))
+    title = models.CharField(verbose_name=_("Title"), max_length=64, help_text=_("The name title or this report"))
 
-    description = models.TextField(verbose_name=_("Description"),
-                                   help_text=_("The full description for the report"))
+    description = models.TextField(verbose_name=_("Description"), help_text=_("The full description for the report"))
 
     org = models.ForeignKey(Org)
 
-    config = models.TextField(null=True, verbose_name=_("Configuration"),
-                              help_text=_("The JSON encoded configurations for this report"))
+    config = models.TextField(
+        null=True, verbose_name=_("Configuration"), help_text=_("The JSON encoded configurations for this report")
+    )
 
-    is_published = models.BooleanField(default=False,
-                                       help_text=_("Whether this report is currently published"))
+    is_published = models.BooleanField(default=False, help_text=_("Whether this report is currently published"))
 
     @classmethod
     def create_report(cls, org, user, json_dict):
@@ -40,24 +37,26 @@ class Report(SmartModel):
 
         existing = cls.objects.filter(pk=id, org=org)
         if existing:
-            existing.update(title=title,
-                            description=description,
-                            config=json.dumps(config))
+            existing.update(title=title, description=description, config=json.dumps(config))
 
             return cls.objects.get(pk=id)
 
-        return cls.objects.create(title=title,
-                                  description=description,
-                                  config=json.dumps(config),
-                                  org=org,
-                                  created_by=user,
-                                  modified_by=user)
+        return cls.objects.create(
+            title=title,
+            description=description,
+            config=json.dumps(config),
+            org=org,
+            created_by=user,
+            modified_by=user
+        )
 
     def as_json(self):
-        return dict(text=self.title, id=self.pk, description=self.description, config=self.config, public=self.is_published)
+        return dict(
+            text=self.title, id=self.pk, description=self.description, config=self.config, public=self.is_published
+        )
 
     def __str__(self):  # pragma: needs cover
         return "%s - %s" % (self.pk, self.title)
 
     class Meta:
-        unique_together = (('org', 'title'),)
+        unique_together = (('org', 'title'), )

--- a/temba/reports/tests.py
+++ b/temba/reports/tests.py
@@ -6,7 +6,6 @@ from temba.tests import TembaTest
 
 
 class ReportTest(TembaTest):
-
     def test_create(self):
         self.login(self.admin)
 
@@ -19,11 +18,21 @@ class ReportTest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.request['PATH_INFO'], reverse('flows.ruleset_analytics'))
 
-        response = self.client.post(create_url, {"title": "first report", "description": "some description", "config": "{}"})
+        response = self.client.post(
+            create_url, {
+                "title": "first report",
+                "description": "some description",
+                "config": "{}"
+            }
+        )
         self.assertEqual(response.json()['status'], "error")
         self.assertFalse('report' in response.json())
 
-        response = self.client.post(create_url, data='{"title":"first report", "description":"some description", "config":""}', content_type='application/json')
+        response = self.client.post(
+            create_url,
+            data='{"title":"first report", "description":"some description", "config":""}',
+            content_type='application/json'
+        )
         self.assertEqual(response.json()['status'], "success")
         self.assertTrue('report' in response.json())
         self.assertTrue('id' in response.json()['report'])
@@ -31,18 +40,23 @@ class ReportTest(TembaTest):
         self.assertEqual(report.pk, response.json()['report']['id'])
 
     def test_report_model(self):
-        Report.create_report(self.org, self.admin, dict(title="first", description="blah blah text",
-                                                        config=dict(fields=[1, 2, 3])))
+        Report.create_report(
+            self.org, self.admin, dict(title="first", description="blah blah text", config=dict(fields=[1, 2, 3]))
+        )
         self.assertEqual(Report.objects.all().count(), 1)
 
-        Report.create_report(self.org, self.admin, dict(title="second", description="yeah yeah yeah",
-                                                        config=dict(fields=[4, 5, 6])))
+        Report.create_report(
+            self.org, self.admin, dict(title="second", description="yeah yeah yeah", config=dict(fields=[4, 5, 6]))
+        )
         self.assertEqual(Report.objects.all().count(), 2)
 
         report_id = Report.objects.filter(title="first")[0].pk
-        Report.create_report(self.org, self.admin, dict(title="updated",
-                                                        description="yeah yeah yeahnew description",
-                                                        config=dict(fields=[8, 4]), id=report_id))
+        Report.create_report(
+            self.org, self.admin,
+            dict(
+                title="updated", description="yeah yeah yeahnew description", config=dict(fields=[8, 4]), id=report_id
+            )
+        )
         self.assertEqual(Report.objects.all().count(), 2)
         self.assertFalse(Report.objects.filter(title="first"))
         self.assertEqual(Report.objects.get(title="updated").pk, report_id)

--- a/temba/reports/views.py
+++ b/temba/reports/views.py
@@ -11,7 +11,7 @@ from .models import Report
 
 
 class ReportCRUDL(SmartCRUDL):
-    actions = ('create',)
+    actions = ('create', )
     model = Report
 
     class Create(OrgPermsMixin, SmartCreateView):

--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -16,29 +16,39 @@ class Schedule(SmartModel):
     Describes a point in the future to execute some action. These are used to schedule Broadcasts
     as a single event or with a specified interval for recurrence.
     """
-    REPEAT_CHOICES = (('O', 'Never'),
-                      ('D', 'Daily'),
-                      ('W', 'Weekly'),
-                      ('M', 'Monthly'),)
+    REPEAT_CHOICES = (
+        ('O', 'Never'),
+        ('D', 'Daily'),
+        ('W', 'Weekly'),
+        ('M', 'Monthly'),
+    )
 
-    STATUS_CHOICES = (('U', 'Unscheduled'),
-                      ('S', 'Scheduled'))
+    STATUS_CHOICES = (('U', 'Unscheduled'), ('S', 'Scheduled'))
 
     status = models.CharField(default='U', choices=STATUS_CHOICES, max_length=1)
     repeat_hour_of_day = models.IntegerField(help_text="The hour of the day", null=True)
     repeat_minute_of_hour = models.IntegerField(help_text="The minute of the hour", null=True)
     repeat_day_of_month = models.IntegerField(null=True, help_text="The day of the month to repeat on")
-    repeat_period = models.CharField(max_length=1, null=True, help_text="When this schedule repeats", choices=REPEAT_CHOICES)
+    repeat_period = models.CharField(
+        max_length=1, null=True, help_text="When this schedule repeats", choices=REPEAT_CHOICES
+    )
     repeat_days = models.IntegerField(default=0, null=True, blank=True, help_text="bit mask of days of the week")
     last_fire = models.DateTimeField(null=True, blank=True, default=None, help_text="When this schedule last fired")
     next_fire = models.DateTimeField(null=True, blank=True, default=None, help_text="When this schedule fires next")
 
     @classmethod
     def create_schedule(cls, start_date, repeat_period, user, repeat_days=None, status='S'):
-        return Schedule.objects.create(repeat_period=repeat_period, repeat_days=repeat_days,
-                                       created_by=user, modified_by=user, repeat_day_of_month=start_date.day,
-                                       repeat_hour_of_day=start_date.hour, repeat_minute_of_hour=start_date.minute,
-                                       next_fire=start_date, status=status)
+        return Schedule.objects.create(
+            repeat_period=repeat_period,
+            repeat_days=repeat_days,
+            created_by=user,
+            modified_by=user,
+            repeat_day_of_month=start_date.day,
+            repeat_hour_of_day=start_date.hour,
+            repeat_minute_of_hour=start_date.minute,
+            next_fire=start_date,
+            status=status
+        )
 
     def reset(self):
         self.next_fire = None
@@ -81,8 +91,15 @@ class Schedule(SmartModel):
         if self.repeat_period == "M":
             (weekday, days) = calendar.monthrange(trigger_date.year, trigger_date.month)
             day_of_month = min(days, self.repeat_day_of_month)
-            next_date = datetime(trigger_date.year, trigger_date.month, day=day_of_month,
-                                 hour=hour, minute=minute, second=0, microsecond=0)
+            next_date = datetime(
+                trigger_date.year,
+                trigger_date.month,
+                day=day_of_month,
+                hour=hour,
+                minute=minute,
+                second=0,
+                microsecond=0
+            )
             next_date = self.get_org_timezone().localize(next_date)
             if trigger_date.day >= self.repeat_day_of_month:
                 next_date += relativedelta(months=1)
@@ -165,5 +182,7 @@ class Schedule(SmartModel):
         return days
 
     def __str__(self):  # pragma: no cover
-        return "[%s] %s %s %s:%s" % (str(self.next_fire), self.repeat_period, self.repeat_day_of_month,
-                                     self.repeat_hour_of_day, self.repeat_minute_of_hour)
+        return "[%s] %s %s %s:%s" % (
+            str(self.next_fire), self.repeat_period, self.repeat_day_of_month, self.repeat_hour_of_day,
+            self.repeat_minute_of_hour
+        )

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -12,17 +12,16 @@ from temba.msgs.models import Broadcast
 from temba.tests import TembaTest
 from .models import Schedule
 
-MONDAY = 0     # 2
-TUESDAY = 1    # 4
+MONDAY = 0  # 2
+TUESDAY = 1  # 4
 WEDNESDAY = 2  # 8
-THURSDAY = 3   # 16
-FRIDAY = 4     # 32
-SATURDAY = 5   # 64
-SUNDAY = 6     # 128
+THURSDAY = 3  # 16
+FRIDAY = 4  # 32
+SATURDAY = 5  # 64
+SUNDAY = 6  # 128
 
 
 class ScheduleTest(TembaTest):
-
     def create_schedule(self, repeat_period, repeat_days=[], start_date=None):
 
         if not start_date:
@@ -60,15 +59,21 @@ class ScheduleTest(TembaTest):
         sched = self.create_schedule('W', [THURSDAY, SATURDAY])
 
         self.assertEqual(sched.repeat_days, 80)
-        self.assertEqual(datetime(2013, 1, 5, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(
+            datetime(2013, 1, 5, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire)
+        )
 
         # updates six days later on Wednesday
         sched = self.create_schedule('W', [WEDNESDAY, THURSDAY])
-        self.assertEqual(datetime(2013, 1, 9, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(
+            datetime(2013, 1, 9, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire)
+        )
 
         # since we are starting thursday, a thursday should be 7 days out
         sched = self.create_schedule('W', [THURSDAY])
-        self.assertEqual(datetime(2013, 1, 10, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(
+            datetime(2013, 1, 10, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire)
+        )
 
         # now update, should advance to next thursday (present time)
         now = timezone.now()
@@ -107,7 +112,10 @@ class ScheduleTest(TembaTest):
         self.assertEqual(str(datetime(2014, 4, 30, hour=10).replace(tzinfo=pytz.utc)), str(sched.next_fire))
 
         sched = self.create_schedule('M', start_date=datetime(2014, 1, 31, hour=10).replace(tzinfo=pytz.utc))
-        self.assertEqual(datetime(2014, 2, 28, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(datetime(2014, 2, 27, hour=10).replace(tzinfo=pytz.utc)))
+        self.assertEqual(
+            datetime(2014, 2, 28, hour=10).replace(tzinfo=pytz.utc),
+            sched.get_next_fire(datetime(2014, 2, 27, hour=10).replace(tzinfo=pytz.utc))
+        )
 
     def test_schedule_ui(self):
 
@@ -126,8 +134,12 @@ class ScheduleTest(TembaTest):
         self.assertIn("This field is required", response.content)
 
         # finally create our message
-        post_data = dict(text="A scheduled message to Joe", omnibox="c-%s" % joe.uuid, sender=self.channel.pk, schedule=True)
-        response = json.loads(self.client.post(reverse('msgs.broadcast_send') + '?_format=json', post_data, follow=True).content)
+        post_data = dict(
+            text="A scheduled message to Joe", omnibox="c-%s" % joe.uuid, sender=self.channel.pk, schedule=True
+        )
+        response = json.loads(
+            self.client.post(reverse('msgs.broadcast_send') + '?_format=json', post_data, follow=True).content
+        )
         self.assertIn("/broadcast/schedule_read", response['redirect'])
 
         # fetch our formax page

--- a/temba/schedules/views.py
+++ b/temba/schedules/views.py
@@ -14,7 +14,6 @@ from .models import Schedule
 
 
 class BaseScheduleForm(object):
-
     def starts_never(self):
         return self.cleaned_data['start'] == "never"
 
@@ -61,7 +60,7 @@ class ScheduleForm(BaseScheduleForm, forms.ModelForm):
 
 class ScheduleCRUDL(SmartCRUDL):
     model = Schedule
-    actions = ('update',)
+    actions = ('update', )
 
     class Update(OrgPermsMixin, SmartUpdateView):
         form_class = ScheduleForm

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -19,12 +19,10 @@ DEBUG = True
 TESTING = sys.argv[1:2] == ['test']
 
 if TESTING:
-    PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+    PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher', )
     DEBUG = False
 
-ADMINS = (
-    ('RapidPro', 'code@yourdomain.io'),
-)
+ADMINS = (('RapidPro', 'code@yourdomain.io'), )
 MANAGERS = ADMINS
 
 # hardcode the postgis version so we can do reset db's from a blank database
@@ -72,11 +70,7 @@ LANGUAGE_CODE = 'en-us'
 # -----------------------------------------------------------------------------------
 # Available languages for translation
 # -----------------------------------------------------------------------------------
-LANGUAGES = (
-    ('en-us', _("English")),
-    ('pt-br', _("Portuguese")),
-    ('fr', _("French")),
-    ('es', _("Spanish")))
+LANGUAGES = (('en-us', _("English")), ('pt-br', _("Portuguese")), ('fr', _("French")), ('es', _("Spanish")))
 
 DEFAULT_LANGUAGE = "en-us"
 DEFAULT_SMS_LANGUAGE = "en-us"
@@ -107,24 +101,25 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'your own secret key'
 
-EMAIL_CONTEXT_PROCESSORS = ('temba.utils.email.link_components',)
-
+EMAIL_CONTEXT_PROCESSORS = ('temba.utils.email.link_components', )
 
 # -----------------------------------------------------------------------------------
 # Directory Configuration
 # -----------------------------------------------------------------------------------
 PROJECT_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)))
-LOCALE_PATHS = (os.path.join(PROJECT_DIR, '../locale'),)
+LOCALE_PATHS = (os.path.join(PROJECT_DIR, '../locale'), )
 RESOURCES_DIR = os.path.join(PROJECT_DIR, '../resources')
-FIXTURE_DIRS = (os.path.join(PROJECT_DIR, '../fixtures'),)
+FIXTURE_DIRS = (os.path.join(PROJECT_DIR, '../fixtures'), )
 TESTFILES_DIR = os.path.join(PROJECT_DIR, '../testfiles')
-STATICFILES_DIRS = (os.path.join(PROJECT_DIR, '../static'), os.path.join(PROJECT_DIR, '../media'), )
+STATICFILES_DIRS = (
+    os.path.join(PROJECT_DIR, '../static'),
+    os.path.join(PROJECT_DIR, '../media'),
+)
 STATIC_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
 STATIC_URL = '/sitestatic/'
 COMPRESS_ROOT = os.path.join(PROJECT_DIR, '../sitestatic')
 MEDIA_ROOT = os.path.join(PROJECT_DIR, '../media')
 MEDIA_URL = "/media/"
-
 
 # -----------------------------------------------------------------------------------
 # Templates Configuration
@@ -150,10 +145,8 @@ TEMPLATES = [
                 'temba.orgs.context_processors.settings_includer',
             ],
             'loaders': [
-                'temba.utils.haml.HamlFilesystemLoader',
-                'temba.utils.haml.HamlAppDirectoriesLoader',
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
+                'temba.utils.haml.HamlFilesystemLoader', 'temba.utils.haml.HamlAppDirectoriesLoader',
+                'django.template.loaders.filesystem.Loader', 'django.template.loaders.app_directories.Loader',
                 'django.template.loaders.eggs.Loader'
             ],
             'debug': False if TESTING else DEBUG
@@ -182,10 +175,7 @@ ROOT_URLCONF = 'temba.urls'
 # other urls to add
 APP_URLS = []
 
-SITEMAP = ('public.public_index',
-           'public.public_blog',
-           'public.video_list',
-           'api')
+SITEMAP = ('public.public_index', 'public.public_blog', 'public.video_list', 'api')
 
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -309,7 +299,8 @@ BRANDING = {
         'allow_signups': True,
         'tiers': dict(import_flows=0, multi_user=0, multi_org=0),
         'bundles': [],
-        'welcome_packs': [dict(size=5000, name="Demo Account"), dict(size=100000, name="UNICEF Account")],
+        'welcome_packs': [dict(size=5000, name="Demo Account"),
+                          dict(size=100000, name="UNICEF Account")],
         'description': _("Visually build nationally scalable mobile applications from anywhere in the world."),
         'credits': _("Copyright &copy; 2012-2017 UNICEF, Nyaruka. All Rights Reserved.")
     }
@@ -322,187 +313,154 @@ DEFAULT_BRAND = 'rapidpro.io'
 
 # this lets us easily create new permissions across our objects
 PERMISSIONS = {
-    '*': ('create',  # can create an object
-          'read',    # can read an object, viewing it's details
-          'update',  # can update an object
-          'delete',  # can delete an object,
-          'list'),   # can view a list of the objects
-
-    'api.apitoken': ('refresh',),
-
+    '*': (
+        'create',  # can create an object
+        'read',  # can read an object, viewing it's details
+        'update',  # can update an object
+        'delete',  # can delete an object,
+        'list'
+    ),  # can view a list of the objects
+    'api.apitoken': ('refresh', ),
     'api.resthook': ('api', 'list'),
-
-    'api.webhookevent': ('api',),
-
-    'api.resthooksubscriber': ('api',),
-
-    'campaigns.campaign': ('api',
-                           'archived',
-                           ),
-
-    'campaigns.campaignevent': ('api',),
-
-
-    'contacts.contact': ('api',
-                         'block',
-                         'blocked',
-                         'break_anon',
-                         'customize',
-                         'export',
-                         'stopped',
-                         'filter',
-                         'history',
-                         'import',
-                         'omnibox',
-                         'unblock',
-                         'unstop',
-                         'update_fields',
-                         'update_fields_input'
-                         ),
-
-    'contacts.contactfield': ('api',
-                              'json',
-                              'managefields'),
-
-    'contacts.contactgroup': ('api',),
-
-    'ivr.ivrcall': ('start',),
-
-    'locations.adminboundary': ('alias',
-                                'api',
-                                'boundaries',
-                                'geometry'),
-
-    'orgs.org': ('accounts',
-                 'smtp_server',
-                 'api',
-                 'country',
-                 'chatbase',
-                 'clear_cache',
-                 'create_login',
-                 'create_sub_org',
-                 'dashboard',
-                 'download',
-                 'edit',
-                 'edit_sub_org',
-                 'export',
-                 'grant',
-                 'home',
-                 'import',
-                 'join',
-                 'languages',
-                 'manage',
-                 'manage_accounts',
-                 'manage_accounts_sub_org',
-                 'nexmo_configuration',
-                 'nexmo_account',
-                 'nexmo_connect',
-                 'plivo_connect',
-                 'profile',
-                 'resthooks',
-                 'service',
-                 'signup',
-                 'sub_orgs',
-                 'surveyor',
-                 'transfer_credits',
-                 'transfer_to_account',
-                 'trial',
-                 'twilio_account',
-                 'twilio_connect',
-                 'webhook',
-                 ),
-
-    'orgs.usersettings': ('phone',),
-
-    'channels.channel': ('api',
-                         'bulk_sender_options',
-                         'claim',
-                         'configuration',
-                         'create_bulk_sender',
-                         'create_caller',
-                         'errors',
-                         'facebook_whitelist',
-                         'search_nexmo',
-                         'search_numbers',
-                         ),
-
-    'channels.channellog': ('session',),
-
-    'channels.channelevent': ('api',
-                              'calls'),
-
-    'flows.flowstart': ('api',),
-
-    'flows.flow': ('activity',
-                   'activity_chart',
-                   'activity_list',
-                   'analytics',
-                   'api',
-                   'archived',
-                   'broadcast',
-                   'campaign',
-                   'completion',
-                   'copy',
-                   'editor',
-                   'export',
-                   'export_results',
-                   'filter',
-                   'json',
-                   'read',
-                   'recent_messages',
-                   'results',
-                   'revisions',
-                   'run_table',
-                   'simulate',
-                   'upload_action_recording',
-                   'upload_media_action',
-                   ),
-
-    'flows.ruleset': ('analytics',
-                      'choropleth',
-                      'map',
-                      'results',
-                      ),
-
-    'msgs.msg': ('api',
-                 'archive',
-                 'archived',
-                 'export',
-                 'failed',
-                 'filter',
-                 'flow',
-                 'inbox',
-                 'label',
-                 'outbox',
-                 'sent',
-                 'test',
-                 'update',
-                 ),
-
-    'msgs.broadcast': ('api',
-                       'detail',
-                       'schedule',
-                       'schedule_list',
-                       'schedule_read',
-                       'send',
-                       ),
-
+    'api.webhookevent': ('api', ),
+    'api.resthooksubscriber': ('api', ),
+    'campaigns.campaign': (
+        'api',
+        'archived',
+    ),
+    'campaigns.campaignevent': ('api', ),
+    'contacts.contact': (
+        'api', 'block', 'blocked', 'break_anon', 'customize', 'export', 'stopped', 'filter', 'history', 'import',
+        'omnibox', 'unblock', 'unstop', 'update_fields', 'update_fields_input'
+    ),
+    'contacts.contactfield': ('api', 'json', 'managefields'),
+    'contacts.contactgroup': ('api', ),
+    'ivr.ivrcall': ('start', ),
+    'locations.adminboundary': ('alias', 'api', 'boundaries', 'geometry'),
+    'orgs.org': (
+        'accounts',
+        'smtp_server',
+        'api',
+        'country',
+        'chatbase',
+        'clear_cache',
+        'create_login',
+        'create_sub_org',
+        'dashboard',
+        'download',
+        'edit',
+        'edit_sub_org',
+        'export',
+        'grant',
+        'home',
+        'import',
+        'join',
+        'languages',
+        'manage',
+        'manage_accounts',
+        'manage_accounts_sub_org',
+        'nexmo_configuration',
+        'nexmo_account',
+        'nexmo_connect',
+        'plivo_connect',
+        'profile',
+        'resthooks',
+        'service',
+        'signup',
+        'sub_orgs',
+        'surveyor',
+        'transfer_credits',
+        'transfer_to_account',
+        'trial',
+        'twilio_account',
+        'twilio_connect',
+        'webhook',
+    ),
+    'orgs.usersettings': ('phone', ),
+    'channels.channel': (
+        'api',
+        'bulk_sender_options',
+        'claim',
+        'configuration',
+        'create_bulk_sender',
+        'create_caller',
+        'errors',
+        'facebook_whitelist',
+        'search_nexmo',
+        'search_numbers',
+    ),
+    'channels.channellog': ('session', ),
+    'channels.channelevent': ('api', 'calls'),
+    'flows.flowstart': ('api', ),
+    'flows.flow': (
+        'activity',
+        'activity_chart',
+        'activity_list',
+        'analytics',
+        'api',
+        'archived',
+        'broadcast',
+        'campaign',
+        'completion',
+        'copy',
+        'editor',
+        'export',
+        'export_results',
+        'filter',
+        'json',
+        'read',
+        'recent_messages',
+        'results',
+        'revisions',
+        'run_table',
+        'simulate',
+        'upload_action_recording',
+        'upload_media_action',
+    ),
+    'flows.ruleset': (
+        'analytics',
+        'choropleth',
+        'map',
+        'results',
+    ),
+    'msgs.msg': (
+        'api',
+        'archive',
+        'archived',
+        'export',
+        'failed',
+        'filter',
+        'flow',
+        'inbox',
+        'label',
+        'outbox',
+        'sent',
+        'test',
+        'update',
+    ),
+    'msgs.broadcast': (
+        'api',
+        'detail',
+        'schedule',
+        'schedule_list',
+        'schedule_read',
+        'send',
+    ),
     'msgs.label': ('api', 'create', 'create_folder'),
-
-    'orgs.topup': ('manage',),
-
-    'triggers.trigger': ('archived',
-                         'catchall',
-                         'follow',
-                         'inbound_call',
-                         'keyword',
-                         'missed_call',
-                         'new_conversation',
-                         'referral',
-                         'register',
-                         'schedule',
-                         'ussd',
-                         ),
+    'orgs.topup': ('manage', ),
+    'triggers.trigger': (
+        'archived',
+        'catchall',
+        'follow',
+        'inbound_call',
+        'keyword',
+        'missed_call',
+        'new_conversation',
+        'referral',
+        'register',
+        'schedule',
+        'ussd',
+    ),
 }
 
 # assigns the permissions that each group should have
@@ -510,10 +468,8 @@ GROUP_PERMISSIONS = {
     "Service Users": (  # internal Temba services have limited permissions
         'msgs.msg_create',
     ),
-    "Alpha": (
-    ),
-    "Beta": (
-    ),
+    "Alpha": (),
+    "Beta": (),
     "Surveyors": (
         'contacts.contact_api',
         'contacts.contactfield_api',
@@ -523,9 +479,7 @@ GROUP_PERMISSIONS = {
         'orgs.org_surveyor',
         'msgs.msg_api',
     ),
-    "Granters": (
-        'orgs.org_grant',
-    ),
+    "Granters": ('orgs.org_grant', ),
     "Customer Support": (
         'auth.user_list',
         'auth.user_update',
@@ -547,7 +501,6 @@ GROUP_PERMISSIONS = {
     "Administrators": (
         'airtime.airtimetransfer_list',
         'airtime.airtimetransfer_read',
-
         'api.apitoken_refresh',
         'api.resthook_api',
         'api.resthook_list',
@@ -555,10 +508,8 @@ GROUP_PERMISSIONS = {
         'api.webhookevent_api',
         'api.webhookevent_list',
         'api.webhookevent_read',
-
         'campaigns.campaign.*',
         'campaigns.campaignevent.*',
-
         'contacts.contact_api',
         'contacts.contact_block',
         'contacts.contact_blocked',
@@ -580,17 +531,13 @@ GROUP_PERMISSIONS = {
         'contacts.contact_update_fields_input',
         'contacts.contactfield.*',
         'contacts.contactgroup.*',
-
         'csv_imports.importtask.*',
-
         'ivr.ivrcall.*',
         'ussd.ussdsession.*',
-
         'locations.adminboundary_alias',
         'locations.adminboundary_api',
         'locations.adminboundary_boundaries',
         'locations.adminboundary_geometry',
-
         'orgs.org_accounts',
         'orgs.org_smtp_server',
         'orgs.org_api',
@@ -623,7 +570,6 @@ GROUP_PERMISSIONS = {
         'orgs.topup_read',
         'orgs.usersettings_phone',
         'orgs.usersettings_update',
-
         'channels.channel_api',
         'channels.channel_bulk_sender_options',
         'channels.channel_claim',
@@ -642,17 +588,13 @@ GROUP_PERMISSIONS = {
         'channels.channellog_list',
         'channels.channellog_read',
         'channels.channellog_session',
-
         'reports.report.*',
-
         'flows.flow.*',
         'flows.flowstart_api',
         'flows.flowlabel.*',
         'flows.ruleset.*',
         'flows.flowrun_delete',
-
         'schedules.schedule.*',
-
         'msgs.broadcast.*',
         'msgs.broadcastschedule.*',
         'msgs.label.*',
@@ -669,9 +611,7 @@ GROUP_PERMISSIONS = {
         'msgs.msg_outbox',
         'msgs.msg_sent',
         'msgs.msg_update',
-
         'triggers.trigger.*',
-
     ),
     "Editors": (
         'api.apitoken_refresh',
@@ -681,13 +621,10 @@ GROUP_PERMISSIONS = {
         'api.webhookevent_api',
         'api.webhookevent_list',
         'api.webhookevent_read',
-
         'airtime.airtimetransfer_list',
         'airtime.airtimetransfer_read',
-
         'campaigns.campaign.*',
         'campaigns.campaignevent.*',
-
         'contacts.contact_api',
         'contacts.contact_block',
         'contacts.contact_blocked',
@@ -709,17 +646,13 @@ GROUP_PERMISSIONS = {
         'contacts.contact_update_fields_input',
         'contacts.contactfield.*',
         'contacts.contactgroup.*',
-
         'csv_imports.importtask.*',
-
         'ivr.ivrcall.*',
         'ussd.ussdsession.*',
-
         'locations.adminboundary_alias',
         'locations.adminboundary_api',
         'locations.adminboundary_boundaries',
         'locations.adminboundary_geometry',
-
         'orgs.org_api',
         'orgs.org_download',
         'orgs.org_export',
@@ -732,7 +665,6 @@ GROUP_PERMISSIONS = {
         'orgs.topup_read',
         'orgs.usersettings_phone',
         'orgs.usersettings_update',
-
         'channels.channel_api',
         'channels.channel_bulk_sender_options',
         'channels.channel_claim',
@@ -746,16 +678,12 @@ GROUP_PERMISSIONS = {
         'channels.channel_search_numbers',
         'channels.channel_update',
         'channels.channelevent.*',
-
         'reports.report.*',
-
         'flows.flow.*',
         'flows.flowstart_api',
         'flows.flowlabel.*',
         'flows.ruleset.*',
-
         'schedules.schedule.*',
-
         'msgs.broadcast.*',
         'msgs.broadcastschedule.*',
         'msgs.label.*',
@@ -772,18 +700,14 @@ GROUP_PERMISSIONS = {
         'msgs.msg_outbox',
         'msgs.msg_sent',
         'msgs.msg_update',
-
         'triggers.trigger.*',
-
     ),
     "Viewers": (
         'api.resthook_list',
-
         'campaigns.campaign_archived',
         'campaigns.campaign_list',
         'campaigns.campaign_read',
         'campaigns.campaignevent_read',
-
         'contacts.contact_blocked',
         'contacts.contact_export',
         'contacts.contact_filter',
@@ -791,22 +715,18 @@ GROUP_PERMISSIONS = {
         'contacts.contact_list',
         'contacts.contact_read',
         'contacts.contact_stopped',
-
         'locations.adminboundary_boundaries',
         'locations.adminboundary_geometry',
         'locations.adminboundary_alias',
-
         'orgs.org_download',
         'orgs.org_export',
         'orgs.org_home',
         'orgs.org_profile',
         'orgs.topup_list',
         'orgs.topup_read',
-
         'channels.channel_list',
         'channels.channel_read',
         'channels.channelevent_calls',
-
         'flows.flow_activity',
         'flows.flow_activity_chart',
         'flows.flow_archived',
@@ -826,7 +746,6 @@ GROUP_PERMISSIONS = {
         'flows.ruleset_analytics',
         'flows.ruleset_results',
         'flows.ruleset_choropleth',
-
         'msgs.broadcast_schedule_list',
         'msgs.broadcast_schedule_read',
         'msgs.msg_archived',
@@ -837,7 +756,6 @@ GROUP_PERMISSIONS = {
         'msgs.msg_inbox',
         'msgs.msg_outbox',
         'msgs.msg_sent',
-
         'triggers.trigger_archived',
         'triggers.trigger_list',
     )
@@ -851,9 +769,7 @@ LOGOUT_URL = "/users/logout/"
 LOGIN_REDIRECT_URL = "/org/choose/"
 LOGOUT_REDIRECT_URL = "/"
 
-AUTHENTICATION_BACKENDS = (
-    'smartmin.backends.CaseInsensitiveBackend',
-)
+AUTHENTICATION_BACKENDS = ('smartmin.backends.CaseInsensitiveBackend', )
 
 ANONYMOUS_USER_NAME = 'AnonymousUser'
 
@@ -861,7 +777,7 @@ ANONYMOUS_USER_NAME = 'AnonymousUser'
 # Our test runner includes a mocked HTTP server and the ability to exclude apps
 # -----------------------------------------------------------------------------------
 TEST_RUNNER = 'temba.tests.TembaTestRunner'
-TEST_EXCLUDE = ('smartmin',)
+TEST_EXCLUDE = ('smartmin', )
 
 # -----------------------------------------------------------------------------------
 # Debug Toolbar
@@ -969,7 +885,6 @@ CELERYBEAT_SCHEDULE = {
         'task': 'refresh_jiochat_access_tokens',
         'schedule': timedelta(seconds=3600),
     },
-
 }
 
 # Mapping of task name to task function path, used when CELERY_ALWAYS_EAGER is set to True
@@ -1020,16 +935,12 @@ CACHES = {
 # Django-rest-framework configuration
 # -----------------------------------------------------------------------------------
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
-    ),
+    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated', ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'temba.api.support.APITokenAuthentication',
     ),
-    'DEFAULT_THROTTLE_CLASSES': (
-        'temba.api.support.OrgRateThrottle',
-    ),
+    'DEFAULT_THROTTLE_CLASSES': ('temba.api.support.OrgRateThrottle', ),
     'DEFAULT_THROTTLE_RATES': {
         'v2': '2500/hour',
         'v2.contacts': '2500/hour',
@@ -1038,10 +949,7 @@ REST_FRAMEWORK = {
         'v2.api': '2500/hour',
     },
     'PAGE_SIZE': 250,
-    'DEFAULT_RENDERER_CLASSES': (
-        'temba.api.support.DocumentationRenderer',
-        'rest_framework.renderers.JSONRenderer'
-    ),
+    'DEFAULT_RENDERER_CLASSES': ('temba.api.support.DocumentationRenderer', 'rest_framework.renderers.JSONRenderer'),
     'EXCEPTION_HANDLER': 'temba.api.support.temba_exception_handler',
     'UNICODE_JSON': False
 }
@@ -1055,10 +963,9 @@ if TESTING:
     # if only testing, disable coffeescript and less compilation
     COMPRESS_PRECOMPILERS = ()
 else:
-    COMPRESS_PRECOMPILERS = (
-        ('text/less', 'lessc --include-path="%s" {infile} {outfile}' % os.path.join(PROJECT_DIR, '../static', 'less')),
-        ('text/coffeescript', 'coffee --compile --stdio')
-    )
+    COMPRESS_PRECOMPILERS = ((
+        'text/less', 'lessc --include-path="%s" {infile} {outfile}' % os.path.join(PROJECT_DIR, '../static', 'less')
+    ), ('text/coffeescript', 'coffee --compile --stdio'))
 
 COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = False
@@ -1108,8 +1015,7 @@ SEND_CHATBASE = False
 SEND_CALLS = False
 
 MESSAGE_HANDLERS = [
-    'temba.triggers.handlers.TriggerHandler',
-    'temba.flows.handlers.FlowHandler',
+    'temba.triggers.handlers.TriggerHandler', 'temba.flows.handlers.FlowHandler',
     'temba.triggers.handlers.CatchAllHandler'
 ]
 
@@ -1205,7 +1111,6 @@ COURIER_CHANNELS = set(['DK'])
 # Chatbase integration
 # -----------------------------------------------------------------------------------
 CHATBASE_API_URL = 'https://chatbase.com/api/message'
-
 
 # To allow manage fields to support up to 1000 fields
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 4000

--- a/temba/settings_travis.py
+++ b/temba/settings_travis.py
@@ -6,8 +6,6 @@ from .settings import *  # noqa
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_CSS_HASHING_METHOD = 'content'
-COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL,
-                                base_template='frame.html',
-                                brand=BRANDING[DEFAULT_BRAND],
-                                debug=False,
-                                testing=False)
+COMPRESS_OFFLINE_CONTEXT = dict(
+    STATIC_URL=STATIC_URL, base_template='frame.html', brand=BRANDING[DEFAULT_BRAND], debug=False, testing=False
+)

--- a/temba/sql/__init__.py
+++ b/temba/sql/__init__.py
@@ -9,6 +9,7 @@ class InstallSQL(RunSQL):
     """
     Migration that reads the SQL from the named file and runs it as a RunSQL migration
     """
+
     def __init__(self, filename):
         # build the full path to our filename
         sql_path = os.path.join(os.path.dirname(__file__), '%s.sql' % filename)

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -44,6 +44,7 @@ class MockServerRequestHandler(BaseHTTPRequestHandler):
     """
     A simple HTTP handler which responds to a request with a matching mocked request
     """
+
     def _handle_request(self, method, data=None):
         if not self.server.mocked_requests:
             raise ValueError("unexpected request %s %s with no mock configured" % (method, self.path))
@@ -86,6 +87,7 @@ class MockServer(HTTPServer):
     Webhook calls may call out to external HTTP servers so a instance of this server runs alongside the test suite
     and provides a mechanism for mocking requests to particular URLs
     """
+
     @six.python_2_unicode_compatible
     class Request(object):
         def __init__(self, method, path, content, content_type, status):
@@ -129,6 +131,7 @@ class TembaTestRunner(DiscoverRunner):
     """
     Adds the ability to exclude tests in given packages to the default test runner, and starts the mock server instance
     """
+
     def __init__(self, *args, **kwargs):
         settings.TESTING = True
 
@@ -185,7 +188,9 @@ class TembaTest(SmartminTest):
         # setup admin boundaries for Rwanda
         self.country = AdminBoundary.objects.create(osm_id='171496', name='Rwanda', level=0)
         self.state1 = AdminBoundary.objects.create(osm_id='1708283', name='Kigali City', level=1, parent=self.country)
-        self.state2 = AdminBoundary.objects.create(osm_id='171591', name='Eastern Province', level=1, parent=self.country)
+        self.state2 = AdminBoundary.objects.create(
+            osm_id='171591', name='Eastern Province', level=1, parent=self.country
+        )
         self.district1 = AdminBoundary.objects.create(osm_id='1711131', name='Gatsibo', level=2, parent=self.state2)
         self.district2 = AdminBoundary.objects.create(osm_id='1711163', name='Kayônza', level=2, parent=self.state2)
         self.district3 = AdminBoundary.objects.create(osm_id='3963734', name='Nyarugenge', level=2, parent=self.state1)
@@ -194,8 +199,14 @@ class TembaTest(SmartminTest):
         self.ward2 = AdminBoundary.objects.create(osm_id='171116381', name='Kabare', level=3, parent=self.district2)
         self.ward3 = AdminBoundary.objects.create(osm_id='171114281', name='Bukure', level=3, parent=self.district4)
 
-        self.org = Org.objects.create(name="Temba", timezone=pytz.timezone("Africa/Kigali"), country=self.country,
-                                      brand=settings.DEFAULT_BRAND, created_by=self.user, modified_by=self.user)
+        self.org = Org.objects.create(
+            name="Temba",
+            timezone=pytz.timezone("Africa/Kigali"),
+            country=self.country,
+            brand=settings.DEFAULT_BRAND,
+            created_by=self.user,
+            modified_by=self.user
+        )
 
         self.org.initialize(topup_size=1000)
 
@@ -218,8 +229,17 @@ class TembaTest(SmartminTest):
         self.welcome_topup = self.org.topups.all()[0]
 
         # a single Android channel
-        self.channel = Channel.create(self.org, self.user, 'RW', 'A', name="Test Channel", address="+250785551212",
-                                      device="Nexus 5X", secret="12345", gcm_id="123")
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            'RW',
+            'A',
+            name="Test Channel",
+            address="+250785551212",
+            device="Nexus 5X",
+            secret="12345",
+            gcm_id="123"
+        )
 
         # reset our simulation to False
         Contact.set_simulation(False)
@@ -315,8 +335,13 @@ class TembaTest(SmartminTest):
 
     def create_secondary_org(self, topup_size=None):
         self.admin2 = self.create_user("Administrator2")
-        self.org2 = Org.objects.create(name="Trileet Inc.", timezone="Africa/Kigali", brand='rapidpro.io',
-                                       created_by=self.admin2, modified_by=self.admin2)
+        self.org2 = Org.objects.create(
+            name="Trileet Inc.",
+            timezone="Africa/Kigali",
+            brand='rapidpro.io',
+            created_by=self.admin2,
+            modified_by=self.admin2
+        )
         self.org2.administrators.add(self.admin2)
         self.admin2.set_org(self.org)
 
@@ -363,8 +388,9 @@ class TembaTest(SmartminTest):
             return group
 
     def create_field(self, key, label, value_type=Value.TYPE_TEXT):
-        return ContactField.objects.create(org=self.org, key=key, label=label, value_type=value_type,
-                                           created_by=self.admin, modified_by=self.admin)
+        return ContactField.objects.create(
+            org=self.org, key=key, label=label, value_type=value_type, created_by=self.admin, modified_by=self.admin
+        )
 
     def create_msg(self, **kwargs):
         if 'org' not in kwargs:
@@ -398,22 +424,20 @@ class TembaTest(SmartminTest):
                 "flow_type": "F",
                 "base_language": "eng",
                 "entry": node_uuid,
-                "action_sets": [
-                    {
-                        "uuid": node_uuid,
-                        "x": 0,
-                        "y": 0,
-                        "actions": [
-                            {
-                                "msg": {"eng": "Hey everybody!"},
-                                "media": {},
-                                "send_all": False,
-                                "type": "reply"
-                            }
-                        ],
-                        "destination": None
-                    }
-                ],
+                "action_sets": [{
+                    "uuid": node_uuid,
+                    "x": 0,
+                    "y": 0,
+                    "actions": [{
+                        "msg": {
+                            "eng": "Hey everybody!"
+                        },
+                        "media": {},
+                        "send_all": False,
+                        "type": "reply"
+                    }],
+                    "destination": None
+                }],
                 "rule_sets": [],
             }
         flow.update(definition)
@@ -478,7 +502,10 @@ class TembaTest(SmartminTest):
 
     def assertAllRequestsMade(self):
         if self.mock_server.mocked_requests:
-            self.fail("test has %d unused mock requests: %s" % (len(mock_server.mocked_requests), mock_server.mocked_requests))
+            self.fail(
+                "test has %d unused mock requests: %s" %
+                (len(mock_server.mocked_requests), mock_server.mocked_requests)
+            )
 
     def assertExcelRow(self, sheet, row_num, values, tz=None):
         """
@@ -526,7 +553,6 @@ class TembaTest(SmartminTest):
 
 
 class FlowFileTest(TembaTest):
-
     def setUp(self):
         super(FlowFileTest, self).setUp()
         self.contact = self.create_contact('Ben Haggerty', '+12065552020')
@@ -550,8 +576,16 @@ class FlowFileTest(TembaTest):
             Flow.find_and_handle(incoming)
         return Msg.objects.filter(response_to=incoming).order_by('pk').first()
 
-    def send_message(self, flow, message, restart_participants=False, contact=None, initiate_flow=False,
-                     assert_reply=True, assert_handle=True):
+    def send_message(
+        self,
+        flow,
+        message,
+        restart_participants=False,
+        contact=None,
+        initiate_flow=False,
+        assert_reply=True,
+        assert_handle=True
+    ):
         """
         Starts the flow, sends the message, returns the reply
         """
@@ -565,7 +599,9 @@ class FlowFileTest(TembaTest):
 
             # start the flow
             if initiate_flow:
-                flow.start(groups=[], contacts=[contact], restart_participants=restart_participants, start_msg=incoming)
+                flow.start(
+                    groups=[], contacts=[contact], restart_participants=restart_participants, start_msg=incoming
+                )
             else:
                 flow.start(groups=[], contacts=[contact], restart_participants=restart_participants)
                 (handled, msgs) = Flow.find_and_handle(incoming)
@@ -613,7 +649,6 @@ class MLStripper(HTMLParser):  # pragma: no cover
 
 
 class BrowserTest(LiveServerTestCase):  # pragma: no cover
-
     @classmethod
     def setUpClass(cls):
         cls.driver = WebDriver()
@@ -715,8 +750,17 @@ class BrowserTest(LiveServerTestCase):  # pragma: no cover
 
         # set up our channel for claiming
         anon = get_anonymous_user()
-        channel = Channel.create(None, anon, 'RW', 'A', name="Test Channel", address="0785551212",
-                                 claim_code='AAABBBCCC', secret="12345", gcm_id="123")
+        channel = Channel.create(
+            None,
+            anon,
+            'RW',
+            'A',
+            name="Test Channel",
+            address="0785551212",
+            claim_code='AAABBBCCC',
+            secret="12345",
+            gcm_id="123"
+        )
 
         # and claim it
         self.fetch_page(reverse('channels.channel_claim_android'))
@@ -744,7 +788,6 @@ class BrowserTest(LiveServerTestCase):  # pragma: no cover
 
 
 class MockResponse(object):
-
     def __init__(self, status_code, text, method='GET', url='http://foo.com/', headers=None):
         self.text = text
         self.content = text
@@ -773,6 +816,7 @@ class AnonymousOrg(object):
     """
     Makes the given org temporarily anonymous
     """
+
     def __init__(self, org):
         self.org = org
 
@@ -786,7 +830,6 @@ class AnonymousOrg(object):
 
 
 class MockRequestValidator(RequestValidator):
-
     def __init__(self, token):
         pass
 
@@ -795,7 +838,6 @@ class MockRequestValidator(RequestValidator):
 
 
 class MockTwilioClient(TwilioClient):
-
     def __init__(self, sid, token, org=None, base=None):
         self.org = org
         self.base = base

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -34,15 +34,13 @@ class Trigger(SmartModel):
     TYPE_USSD_PULL = 'U'
     TYPE_INBOUND_CALL = 'V'
 
-    TRIGGER_TYPES = ((TYPE_KEYWORD, _("Keyword Trigger")),
-                     (TYPE_SCHEDULE, _("Schedule Trigger")),
-                     (TYPE_INBOUND_CALL, _("Inbound Call Trigger")),
-                     (TYPE_MISSED_CALL, _("Missed Call Trigger")),
-                     (TYPE_CATCH_ALL, _("Catch All Trigger")),
-                     (TYPE_FOLLOW, _("Follow Account Trigger")),
-                     (TYPE_NEW_CONVERSATION, _("New Conversation Trigger")),
-                     (TYPE_USSD_PULL, _("USSD Pull Session Trigger")),
-                     (TYPE_REFERRAL, _("Referral Trigger")))
+    TRIGGER_TYPES = ((TYPE_KEYWORD, _("Keyword Trigger")), (TYPE_SCHEDULE, _("Schedule Trigger")),
+                     (TYPE_INBOUND_CALL,
+                      _("Inbound Call Trigger")), (TYPE_MISSED_CALL,
+                                                   _("Missed Call Trigger")), (TYPE_CATCH_ALL, _("Catch All Trigger")),
+                     (TYPE_FOLLOW,
+                      _("Follow Account Trigger")), (TYPE_NEW_CONVERSATION, _("New Conversation Trigger")),
+                     (TYPE_USSD_PULL, _("USSD Pull Session Trigger")), (TYPE_REFERRAL, _("Referral Trigger")))
 
     KEYWORD_MAX_LEN = 16
 
@@ -54,47 +52,87 @@ class Trigger(SmartModel):
 
     org = models.ForeignKey(Org, verbose_name=_("Org"), help_text=_("The organization this trigger belongs to"))
 
-    keyword = models.CharField(verbose_name=_("Keyword"), max_length=KEYWORD_MAX_LEN, null=True, blank=True,
-                               help_text=_("Word to match in the message text"))
+    keyword = models.CharField(
+        verbose_name=_("Keyword"),
+        max_length=KEYWORD_MAX_LEN,
+        null=True,
+        blank=True,
+        help_text=_("Word to match in the message text")
+    )
 
-    referrer_id = models.CharField(verbose_name=_("Referrer Id"), max_length=255, null=True, blank=True,
-                                   help_text=_("The referrer id that triggers us"))
+    referrer_id = models.CharField(
+        verbose_name=_("Referrer Id"),
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text=_("The referrer id that triggers us")
+    )
 
-    flow = models.ForeignKey(Flow, verbose_name=_("Flow"),
-                             help_text=_("Which flow will be started"), related_name="triggers")
+    flow = models.ForeignKey(
+        Flow, verbose_name=_("Flow"), help_text=_("Which flow will be started"), related_name="triggers"
+    )
 
-    last_triggered = models.DateTimeField(verbose_name=_("Last Triggered"), default=None, null=True,
-                                          help_text=_("The last time this trigger was fired"))
+    last_triggered = models.DateTimeField(
+        verbose_name=_("Last Triggered"), default=None, null=True, help_text=_("The last time this trigger was fired")
+    )
 
-    trigger_count = models.IntegerField(verbose_name=_("Trigger Count"), default=0,
-                                        help_text=_("How many times this trigger has fired"))
+    trigger_count = models.IntegerField(
+        verbose_name=_("Trigger Count"), default=0, help_text=_("How many times this trigger has fired")
+    )
 
-    is_archived = models.BooleanField(verbose_name=_("Is Archived"), default=False,
-                                      help_text=_("Whether this trigger is archived"))
+    is_archived = models.BooleanField(
+        verbose_name=_("Is Archived"), default=False, help_text=_("Whether this trigger is archived")
+    )
 
-    groups = models.ManyToManyField(ContactGroup, verbose_name=_("Groups"),
-                                    help_text=_("The groups to broadcast the flow to"))
+    groups = models.ManyToManyField(
+        ContactGroup, verbose_name=_("Groups"), help_text=_("The groups to broadcast the flow to")
+    )
 
-    contacts = models.ManyToManyField(Contact, verbose_name=_("Contacts"),
-                                      help_text=_("Individual contacts to broadcast the flow to"))
+    contacts = models.ManyToManyField(
+        Contact, verbose_name=_("Contacts"), help_text=_("Individual contacts to broadcast the flow to")
+    )
 
-    schedule = models.OneToOneField('schedules.Schedule', verbose_name=_("Schedule"),
-                                    null=True, blank=True, related_name='trigger',
-                                    help_text=_('Our recurring schedule'))
+    schedule = models.OneToOneField(
+        'schedules.Schedule',
+        verbose_name=_("Schedule"),
+        null=True,
+        blank=True,
+        related_name='trigger',
+        help_text=_('Our recurring schedule')
+    )
 
-    trigger_type = models.CharField(max_length=1, choices=TRIGGER_TYPES, default=TYPE_KEYWORD,
-                                    verbose_name=_("Trigger Type"), help_text=_('The type of this trigger'))
+    trigger_type = models.CharField(
+        max_length=1,
+        choices=TRIGGER_TYPES,
+        default=TYPE_KEYWORD,
+        verbose_name=_("Trigger Type"),
+        help_text=_('The type of this trigger')
+    )
 
-    match_type = models.CharField(max_length=1, choices=MATCH_TYPES, default=MATCH_FIRST_WORD, null=True,
-                                  verbose_name=_("Trigger When"), help_text=_('How to match a message with a keyword'))
+    match_type = models.CharField(
+        max_length=1,
+        choices=MATCH_TYPES,
+        default=MATCH_FIRST_WORD,
+        null=True,
+        verbose_name=_("Trigger When"),
+        help_text=_('How to match a message with a keyword')
+    )
 
-    channel = models.ForeignKey(Channel, verbose_name=_("Channel"), null=True, related_name='triggers',
-                                help_text=_("The associated channel"))
+    channel = models.ForeignKey(
+        Channel, verbose_name=_("Channel"), null=True, related_name='triggers', help_text=_("The associated channel")
+    )
 
     @classmethod
     def create(cls, org, user, trigger_type, flow, channel=None, **kwargs):
-        trigger = cls.objects.create(org=org, trigger_type=trigger_type, flow=flow, channel=channel,
-                                     created_by=user, modified_by=user, **kwargs)
+        trigger = cls.objects.create(
+            org=org,
+            trigger_type=trigger_type,
+            flow=flow,
+            channel=channel,
+            created_by=user,
+            modified_by=user,
+            **kwargs
+        )
 
         # archive any conflicts
         trigger.archive_conflicts(user)
@@ -114,18 +152,22 @@ class Trigger(SmartModel):
         """
         An exportable dict representing our trigger
         """
-        return dict(trigger_type=self.trigger_type,
-                    keyword=self.keyword,
-                    flow=dict(uuid=self.flow.uuid, name=self.flow.name),
-                    groups=[dict(uuid=group.uuid, name=group.name) for group in self.groups.all()],
-                    channel=self.channel.uuid if self.channel else None)
+        return dict(
+            trigger_type=self.trigger_type,
+            keyword=self.keyword,
+            flow=dict(uuid=self.flow.uuid, name=self.flow.name),
+            groups=[dict(uuid=group.uuid, name=group.name) for group in self.groups.all()],
+            channel=self.channel.uuid if self.channel else None
+        )
 
     def trigger_scopes(self):
         """
         Returns keys that represents the scopes that this trigger can operate against (and might conflict with other triggers with)
         """
         groups = ['**'] if not self.groups else [str(g.id) for g in self.groups.all().order_by('id')]
-        return ['%s_%s_%s_%s' % (self.trigger_type, str(self.channel_id), group, str(self.keyword)) for group in groups]
+        return [
+            '%s_%s_%s_%s' % (self.trigger_type, str(self.channel_id), group, str(self.keyword)) for group in groups
+        ]
 
     def archive(self, user):
         self.modified_by = user
@@ -153,7 +195,9 @@ class Trigger(SmartModel):
         now = timezone.now()
 
         if not self.trigger_type == Trigger.TYPE_SCHEDULE:
-            matches = Trigger.objects.filter(org=self.org, is_active=True, is_archived=False, trigger_type=self.trigger_type)
+            matches = Trigger.objects.filter(
+                org=self.org, is_active=True, is_archived=False, trigger_type=self.trigger_type
+            )
 
             # if this trigger has a keyword, only archive others with the same keyword
             if self.keyword:
@@ -243,10 +287,15 @@ class Trigger(SmartModel):
                     if channel:
                         channel = Channel.objects.filter(uuid=channel, org=org).first()
 
-                    trigger = Trigger.objects.create(org=org, trigger_type=trigger_spec['trigger_type'],
-                                                     keyword=trigger_spec['keyword'], flow=flow,
-                                                     created_by=user, modified_by=user,
-                                                     channel=channel)
+                    trigger = Trigger.objects.create(
+                        org=org,
+                        trigger_type=trigger_spec['trigger_type'],
+                        keyword=trigger_spec['keyword'],
+                        flow=flow,
+                        created_by=user,
+                        modified_by=user,
+                        channel=channel
+                    )
 
                     for group in groups:
                         trigger.groups.add(group)
@@ -309,19 +358,26 @@ class Trigger(SmartModel):
             return False
 
         # skip if message contact is currently active in a flow
-        active_run_qs = FlowRun.objects.filter(is_active=True, contact=msg.contact,
-                                               flow__is_active=True, flow__is_archived=False)
+        active_run_qs = FlowRun.objects.filter(
+            is_active=True, contact=msg.contact, flow__is_active=True, flow__is_archived=False
+        )
         active_run = active_run_qs.prefetch_related('steps').order_by("-created_on", "-pk").first()
 
         if active_run and active_run.flow.ignore_triggers and not active_run.is_completed():
             return False
 
         # find a matching keyword trigger with an active flow
-        trigger = Trigger.objects.filter(org=msg.org, is_archived=False, is_active=True, trigger_type=cls.TYPE_KEYWORD,
-                                         flow__is_archived=False, flow__is_active=True)
+        trigger = Trigger.objects.filter(
+            org=msg.org,
+            is_archived=False,
+            is_active=True,
+            trigger_type=cls.TYPE_KEYWORD,
+            flow__is_archived=False,
+            flow__is_active=True
+        )
 
         # if message text is only one word, then we can match 'only-word' triggers too
-        match_types = (cls.MATCH_FIRST_WORD, cls.MATCH_ONLY_WORD) if len(words) == 1 else (cls.MATCH_FIRST_WORD,)
+        match_types = (cls.MATCH_FIRST_WORD, cls.MATCH_ONLY_WORD) if len(words) == 1 else (cls.MATCH_FIRST_WORD, )
         trigger = trigger.filter(keyword__iexact=words[0], match_type__in=match_types)
 
         # trigger needs to match the contact's groups or be non-group specific
@@ -384,9 +440,16 @@ class Trigger(SmartModel):
         else:
             return None
 
-        matching = Trigger.objects.filter(is_archived=False, is_active=True, org=contact.org, keyword__iexact=keyword,
-                                          trigger_type=Trigger.TYPE_USSD_PULL, flow__is_archived=False,
-                                          flow__is_active=True, groups=None)
+        matching = Trigger.objects.filter(
+            is_archived=False,
+            is_active=True,
+            org=contact.org,
+            keyword__iexact=keyword,
+            trigger_type=Trigger.TYPE_USSD_PULL,
+            flow__is_archived=False,
+            flow__is_active=True,
+            groups=None
+        )
 
         if not matching:
             return None

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -23,7 +23,6 @@ from .views import DefaultTriggerForm, RegisterTriggerForm
 
 
 class TriggerTest(TembaTest):
-
     def test_no_trigger_redirects_to_create_page(self):
         self.login(self.admin)
 
@@ -226,9 +225,16 @@ class TriggerTest(TembaTest):
         self.login(self.admin)
         flow = self.create_flow()
 
-        self.fb_channel = Channel.create(self.org, self.user, None, 'FB', None, '1234',
-                                         config={Channel.CONFIG_AUTH_TOKEN: 'auth'},
-                                         uuid='00000000-0000-0000-0000-000000001234')
+        self.fb_channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'FB',
+            None,
+            '1234',
+            config={Channel.CONFIG_AUTH_TOKEN: 'auth'},
+            uuid='00000000-0000-0000-0000-000000001234'
+        )
 
         create_url = reverse('triggers.trigger_referral')
 
@@ -601,7 +607,10 @@ class TriggerTest(TembaTest):
 
         self.assertFalse(missed_call_trigger)
 
-        ChannelEvent.create(self.channel, six.text_type(contact.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now(), 0)
+        ChannelEvent.create(
+            self.channel,
+            six.text_type(contact.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now(), 0
+        )
         self.assertEqual(ChannelEvent.objects.all().count(), 1)
         self.assertEqual(flow.runs.all().count(), 0)
 
@@ -622,7 +631,10 @@ class TriggerTest(TembaTest):
 
         self.assertEqual(missed_call_trigger.pk, trigger.pk)
 
-        ChannelEvent.create(self.channel, six.text_type(contact.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now(), 0)
+        ChannelEvent.create(
+            self.channel,
+            six.text_type(contact.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now(), 0
+        )
         self.assertEqual(ChannelEvent.objects.all().count(), 2)
         self.assertEqual(flow.runs.all().count(), 1)
         self.assertEqual(flow.runs.all()[0].contact.pk, contact.pk)
@@ -643,7 +655,9 @@ class TriggerTest(TembaTest):
 
             response = self.client.post(trigger_url, post_data)
             self.assertEqual(i + 2, Trigger.objects.all().count())
-            self.assertEqual(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL).count())
+            self.assertEqual(
+                1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL).count()
+            )
 
         # even unarchiving we only have one acive trigger at a time
         triggers = Trigger.objects.filter(trigger_type=Trigger.TYPE_MISSED_CALL, is_archived=True)
@@ -655,7 +669,9 @@ class TriggerTest(TembaTest):
 
         response = self.client.post(reverse("triggers.trigger_archived"), post_data)
         self.assertEqual(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL).count())
-        self.assertFalse(active_trigger.pk == Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL)[0].pk)
+        self.assertFalse(
+            active_trigger.pk == Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL)[0].pk
+        )
 
     def test_new_conversation_trigger_viber(self):
         self.login(self.admin)
@@ -668,9 +684,18 @@ class TriggerTest(TembaTest):
         self.assertNotContains(response, "conversation is started")
 
         # add a viber public channel
-        viber_channel = Channel.create(self.org, self.user, None, 'VP', None, '1001',
-                                       uuid='00000000-0000-0000-0000-000000001234',
-                                       config={Channel.CONFIG_AUTH_TOKEN: "auth_token"})
+        viber_channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            'VP',
+            None,
+            '1001',
+            uuid='00000000-0000-0000-0000-000000001234',
+            config={
+                Channel.CONFIG_AUTH_TOKEN: "auth_token"
+            }
+        )
 
         # should now be able to create one
         response = self.client.get(create_trigger_url)
@@ -681,16 +706,21 @@ class TriggerTest(TembaTest):
         self.assertTrue(viber_channel in response.context['form'].fields['channel'].queryset.all())
 
         # create a facebook channel
-        fb_channel = Channel.create(self.org, self.user, None, 'FB', address='1001',
-                                    config={'page_name': "Temba", 'auth_token': 'fb_token'})
+        fb_channel = Channel.create(
+            self.org, self.user, None, 'FB', address='1001', config={
+                'page_name': "Temba",
+                'auth_token': 'fb_token'
+            }
+        )
 
         response = self.client.get(reverse('triggers.trigger_new_conversation', args=[]))
         self.assertEqual(response.context['form'].fields['channel'].queryset.count(), 2)
         self.assertTrue(viber_channel in response.context['form'].fields['channel'].queryset.all())
         self.assertTrue(fb_channel in response.context['form'].fields['channel'].queryset.all())
 
-        response = self.client.post(reverse('triggers.trigger_new_conversation', args=[]),
-                                    data=dict(channel=viber_channel.id, flow=flow.id))
+        response = self.client.post(
+            reverse('triggers.trigger_new_conversation', args=[]), data=dict(channel=viber_channel.id, flow=flow.id)
+        )
         self.assertEqual(response.status_code, 200)
 
         trigger = Trigger.objects.get(trigger_type=Trigger.TYPE_NEW_CONVERSATION, is_active=True, is_archived=False)
@@ -698,15 +728,18 @@ class TriggerTest(TembaTest):
         self.assertEqual(trigger.flow, flow)
 
         # try to create another one, fails as we already have a trigger for that channel
-        response = self.client.post(reverse('triggers.trigger_new_conversation', args=[]),
-                                    data=dict(channel=viber_channel.id, flow=flow2.id))
+        response = self.client.post(
+            reverse('triggers.trigger_new_conversation', args=[]), data=dict(channel=viber_channel.id, flow=flow2.id)
+        )
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', 'channel', 'Trigger with this Channel already exists.')
 
         # try to change the existing trigger
-        response = self.client.post(reverse('triggers.trigger_update', args=[trigger.id]),
-                                    data=dict(id=trigger.id, flow=flow2.id, channel=viber_channel.id),
-                                    follow=True)
+        response = self.client.post(
+            reverse('triggers.trigger_update', args=[trigger.id]),
+            data=dict(id=trigger.id, flow=flow2.id, channel=viber_channel.id),
+            follow=True
+        )
         self.assertEqual(response.status_code, 200)
 
         trigger.refresh_from_db()
@@ -726,8 +759,12 @@ class TriggerTest(TembaTest):
         self.assertNotContains(response, "conversation is started")
 
         # create a facebook channel
-        fb_channel = Channel.create(self.org, self.user, None, 'FB', address='1001',
-                                    config={'page_name': "Temba", 'auth_token': 'fb_token'})
+        fb_channel = Channel.create(
+            self.org, self.user, None, 'FB', address='1001', config={
+                'page_name': "Temba",
+                'auth_token': 'fb_token'
+            }
+        )
 
         # should now be able to create one
         response = self.client.get(create_trigger_url)
@@ -736,8 +773,9 @@ class TriggerTest(TembaTest):
         # go create it
         mock_post.return_value = MockResponse(200, '{"message": "Success"}')
 
-        response = self.client.post(reverse('triggers.trigger_new_conversation', args=[]),
-                                    data=dict(channel=fb_channel.id, flow=flow.id))
+        response = self.client.post(
+            reverse('triggers.trigger_new_conversation', args=[]), data=dict(channel=fb_channel.id, flow=flow.id)
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_post.call_count, 1)
 
@@ -747,12 +785,15 @@ class TriggerTest(TembaTest):
         self.assertEqual(trigger.flow, flow)
 
         # try to create another one, fails as we already have a trigger for that channel
-        response = self.client.post(reverse('triggers.trigger_new_conversation', args=[]), data=dict(channel=fb_channel.id, flow=flow2.id))
+        response = self.client.post(
+            reverse('triggers.trigger_new_conversation', args=[]), data=dict(channel=fb_channel.id, flow=flow2.id)
+        )
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', 'channel', 'Trigger with this Channel already exists.')
 
         # ok, trigger a facebook event
-        data = json.loads("""{
+        data = json.loads(
+            """{
         "object": "page",
           "entry": [
             {
@@ -775,7 +816,8 @@ class TriggerTest(TembaTest):
             }
           ]
         }
-        """ % fb_channel.address)
+        """ % fb_channel.address
+        )
 
         with patch('requests.get') as mock_get:
             mock_get.return_value = MockResponse(200, '{"first_name": "Ben","last_name": "Haggerty"}')
@@ -789,8 +831,11 @@ class TriggerTest(TembaTest):
             self.assertTrue(contact.name, "Ben Haggerty")
 
             # and a new channel event for the conversation
-            self.assertTrue(ChannelEvent.objects.filter(channel=fb_channel, contact=contact,
-                                                        event_type=ChannelEvent.TYPE_NEW_CONVERSATION))
+            self.assertTrue(
+                ChannelEvent.objects.filter(
+                    channel=fb_channel, contact=contact, event_type=ChannelEvent.TYPE_NEW_CONVERSATION
+                )
+            )
 
             run = FlowRun.objects.get(contact=contact)
             self.assertEqual(run.flow, flow)
@@ -999,8 +1044,9 @@ class TriggerTest(TembaTest):
 
         # setup a flow and keyword trigger
         flow = self.create_flow()
-        trigger = Trigger.objects.create(org=self.org, keyword='when', flow=flow,
-                                         created_by=self.admin, modified_by=self.admin)
+        trigger = Trigger.objects.create(
+            org=self.org, keyword='when', flow=flow, created_by=self.admin, modified_by=self.admin
+        )
 
         incoming = self.create_msg(direction=INCOMING, contact=self.contact, text="when is it?")
 
@@ -1044,8 +1090,9 @@ class TriggerTest(TembaTest):
 
         # create trigger for specific contact group
         group = self.create_group("first", [self.contact2])
-        trigger = Trigger.objects.create(org=self.org, keyword='where', flow=flow,
-                                         created_by=self.admin, modified_by=self.admin)
+        trigger = Trigger.objects.create(
+            org=self.org, keyword='where', flow=flow, created_by=self.admin, modified_by=self.admin
+        )
         trigger.groups.add(group)
 
         incoming = self.create_msg(direction=INCOMING, contact=self.contact, text="where do you go?")
@@ -1075,18 +1122,21 @@ class TriggerTest(TembaTest):
         keyword = 'unique'
 
         # no group trigger
-        Trigger.objects.create(org=self.org, keyword=keyword, flow=flow1,
-                               created_by=self.admin, modified_by=self.admin)
+        Trigger.objects.create(
+            org=self.org, keyword=keyword, flow=flow1, created_by=self.admin, modified_by=self.admin
+        )
 
         # group1 trigger
-        trigger2 = Trigger.objects.create(org=self.org, keyword=keyword, flow=flow2,
-                                          created_by=self.admin, modified_by=self.admin)
+        trigger2 = Trigger.objects.create(
+            org=self.org, keyword=keyword, flow=flow2, created_by=self.admin, modified_by=self.admin
+        )
 
         trigger2.groups.add(group1)
 
         # group2 trigger
-        trigger3 = Trigger.objects.create(org=self.org, keyword=keyword, flow=flow3,
-                                          created_by=self.admin, modified_by=self.admin)
+        trigger3 = Trigger.objects.create(
+            org=self.org, keyword=keyword, flow=flow3, created_by=self.admin, modified_by=self.admin
+        )
 
         trigger3.groups.add(group2)
 
@@ -1121,8 +1171,14 @@ class TriggerTest(TembaTest):
         group = self.create_group("Trigger Group", [])
 
         # create a trigger on this flow for the follow actions but only on some groups
-        trigger = Trigger.objects.create(org=self.org, flow=flow, trigger_type=Trigger.TYPE_FOLLOW, channel=self.channel,
-                                         created_by=self.admin, modified_by=self.admin)
+        trigger = Trigger.objects.create(
+            org=self.org,
+            flow=flow,
+            trigger_type=Trigger.TYPE_FOLLOW,
+            channel=self.channel,
+            created_by=self.admin,
+            modified_by=self.admin
+        )
         trigger.groups.add(group)
 
         components = self.org.resolve_dependencies([flow], [], include_triggers=True)
@@ -1155,13 +1211,20 @@ class TriggerTest(TembaTest):
         self.assertTrue(get_ussd_channels.called)
         self.assertContains(response, 'USSD mobile initiated flow')
 
-        channel = Channel.add_config_external_channel(self.org, self.user,
-                                                      "HU", 1234, 'VMU',
-                                                      dict(account_key="11111",
-                                                           access_token=str(uuid4()),
-                                                           transport_name="ussd_transport",
-                                                           conversation_key="22222"),
-                                                      role=Channel.ROLE_USSD)
+        channel = Channel.add_config_external_channel(
+            self.org,
+            self.user,
+            "HU",
+            1234,
+            'VMU',
+            dict(
+                account_key="11111",
+                access_token=str(uuid4()),
+                transport_name="ussd_transport",
+                conversation_key="22222"
+            ),
+            role=Channel.ROLE_USSD
+        )
 
         # flow options should show ussd flow example
         response = self.client.get(reverse("triggers.trigger_ussd"))
@@ -1185,8 +1248,10 @@ class TriggerTest(TembaTest):
         post_data = dict(channel=channel.pk, keyword='*111#', flow=flow.pk)
         response = self.client.post(reverse("triggers.trigger_ussd"), data=post_data)
         self.assertEqual(1, len(response.context['form'].errors))
-        self.assertEqual(response.context['form'].errors['__all__'],
-                         [u'An active trigger already exists, triggers must be unique for each group'])
+        self.assertEqual(
+            response.context['form'].errors['__all__'],
+            [u'An active trigger already exists, triggers must be unique for each group']
+        )
 
         # different code on same channel should work
         post_data = dict(channel=channel.pk, keyword='*112#', flow=flow.pk)

--- a/temba/urls.py
+++ b/temba/urls.py
@@ -45,7 +45,6 @@ if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += [url(r'^__debug__/', include(debug_toolbar.urls))]
 
-
 # import any additional urls
 for app in settings.APP_URLS:  # pragma: needs cover
     importlib.import_module(app)

--- a/temba/ussd/models.py
+++ b/temba/ussd/models.py
@@ -62,25 +62,52 @@ class USSDSession(ChannelSession):
     def start_async(self, flow, date, message_id):
         from temba.msgs.models import Msg, USSD
         message = Msg.objects.create(
-            channel=self.channel, contact=self.contact, contact_urn=self.contact_urn,
-            sent_on=date, connection=self, msg_type=USSD, external_id=message_id,
-            created_on=timezone.now(), modified_on=timezone.now(), org=self.channel.org,
-            direction=self.INCOMING)
+            channel=self.channel,
+            contact=self.contact,
+            contact_urn=self.contact_urn,
+            sent_on=date,
+            connection=self,
+            msg_type=USSD,
+            external_id=message_id,
+            created_on=timezone.now(),
+            modified_on=timezone.now(),
+            org=self.channel.org,
+            direction=self.INCOMING
+        )
         flow.start([], [self.contact], start_msg=message, restart_participants=True, connection=self)
 
     def handle_async(self, urn, content, date, message_id):
         from temba.msgs.models import Msg, USSD
         Msg.create_incoming(
-            channel=self.channel, org=self.org, urn=urn, text=content or '', date=date, connection=self,
-            msg_type=USSD, external_id=message_id)
+            channel=self.channel,
+            org=self.org,
+            urn=urn,
+            text=content or '',
+            date=date,
+            connection=self,
+            msg_type=USSD,
+            external_id=message_id
+        )
 
     def handle_sync(self):  # pragma: needs cover
         # TODO: implement for InfoBip and other sync APIs
         pass
 
     @classmethod
-    def handle_incoming(cls, channel, urn, date, external_id, contact=None, message_id=None, status=None,
-                        content=None, starcode=None, org=None, async=True):
+    def handle_incoming(
+        cls,
+        channel,
+        urn,
+        date,
+        external_id,
+        contact=None,
+        message_id=None,
+        status=None,
+        content=None,
+        starcode=None,
+        org=None,
+        async=True
+    ):
 
         trigger = None
         contact_urn = None
@@ -100,8 +127,9 @@ class USSDSession(ChannelSession):
             contact_urn.update_affinity(channel)
 
         # setup session
-        defaults = dict(channel=channel, contact=contact, contact_urn=contact_urn,
-                        org=channel.org if channel else contact.org)
+        defaults = dict(
+            channel=channel, contact=contact, contact_urn=contact_urn, org=channel.org if channel else contact.org
+        )
 
         if status == cls.TRIGGERED:
             trigger = Trigger.find_trigger_for_ussd_session(contact, starcode)

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -21,7 +21,6 @@ from itertools import islice
 DEFAULT_DATE = datetime.datetime(1, 1, 1, 0, 0, 0, 0, None)
 MAX_UTC_OFFSET = 14 * 60 * 60  # max offset postgres supports for a timezone
 
-
 TRANSFERTO_COUNTRY_NAMES = {
     'Democratic Republic of the Congo': 'CD',
     'Ivory Coast': 'CI',
@@ -48,7 +47,10 @@ def datetime_to_str(date_obj, format=None, ms=True, tz=None):
         date_obj = tz.localize(datetime.datetime.combine(date_obj, datetime.time(0, 0, 0)))
 
     if date_obj.year < 1900:
-        return "%d-%d-%dT%d:%d:%d.%dZ" % (date_obj.year, date_obj.month, date_obj.day, date_obj.hour, date_obj.minute, date_obj.second, date_obj.microsecond)
+        return "%d-%d-%dT%d:%d:%d.%dZ" % (
+            date_obj.year, date_obj.month, date_obj.day, date_obj.hour, date_obj.minute, date_obj.second,
+            date_obj.microsecond
+        )
 
     if isinstance(date_obj, datetime.datetime):
         date_obj = timezone.localtime(date_obj, tz)
@@ -236,10 +238,7 @@ def get_dict_from_cursor(cursor):
     Returns all rows from a cursor as a dict
     """
     desc = cursor.description
-    return [
-        dict(zip([col[0] for col in desc], row))
-        for row in cursor.fetchall()
-    ]
+    return [dict(zip([col[0] for col in desc], row)) for row in cursor.fetchall()]
 
 
 @six.python_2_unicode_compatible
@@ -248,6 +247,7 @@ class DictStruct(object):
     Wraps a dictionary turning it into a structure looking object. This is useful to 'mock' dictionaries
     coming from Redis to look like normal objects
     """
+
     def __init__(self, classname, entries, datetime_fields=()):
         self._classname = classname
         self._values = entries
@@ -305,6 +305,7 @@ class DateTimeJsonEncoder(json.JSONEncoder):
     """
     Our own encoder for datetimes.. we always convert to UTC and always include milliseconds
     """
+
     def default(self, o):
         # See "Date Time String Format" in the ECMA-262 specification.
         if isinstance(o, datetime.datetime):

--- a/temba/utils/cache.py
+++ b/temba/utils/cache.py
@@ -73,6 +73,7 @@ class QueueRecord(object):
     objects as queued, which is more efficient than having separate keys for each item. By having these expire after
     24 hours we ensure that our Redis sets can't grow indefinitely even if things fail.
     """
+
     def __init__(self, key_prefix, item_val=None):
         self.item_val = item_val or str
 

--- a/temba/utils/currencies.py
+++ b/temba/utils/currencies.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import pycountry
-
 """
 These are exceptions according to ISO 4217 because they are super-national
 currencies, not belonging to any single country.
@@ -134,7 +133,8 @@ CURRENCY_EXCEPTIONS = {
     'YE': 'YER',
     'YT': 'EUR',
     'ZM': 'ZMW',
-    'ZW': 'ZWL'}
+    'ZW': 'ZWL'
+}
 
 
 def currency_for_country(alpha2):

--- a/temba/utils/email.py
+++ b/temba/utils/email.py
@@ -14,11 +14,13 @@ class TembaEmailValidator(EmailValidator):
     user_regex = re.compile(
         r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z"  # dot-atom
         r'|^"([\001-\010\013\014\016-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',  # quoted-string
-        re.IGNORECASE)
+        re.IGNORECASE
+    )
     domain_regex = re.compile(
         # max length for domain name labels is 63 characters per RFC 1034
         r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,63}|[A-Z0-9-]{2,}(?<!-))\Z',
-        re.IGNORECASE)
+        re.IGNORECASE
+    )
 
 
 temba_validate_email = TembaEmailValidator()
@@ -64,7 +66,9 @@ def send_simple_email(recipients, subject, body, from_email=None):
     send_temba_email(subject, body, None, from_email, recipient_list)
 
 
-def send_custom_smtp_email(recipients, subject, body, from_email, smtp_host, smtp_port, smtp_username, smtp_password, use_tls):
+def send_custom_smtp_email(
+    recipients, subject, body, from_email, smtp_host, smtp_port, smtp_username, smtp_password, use_tls
+):
     """
     Sends a text email to the given recipients using the SMTP configuration
 
@@ -83,8 +87,15 @@ def send_custom_smtp_email(recipients, subject, body, from_email, smtp_host, smt
     if smtp_port is not None:
         smtp_port = int(smtp_port)
 
-    connection = get_smtp_connection(None, fail_silently=False, host=smtp_host, port=smtp_port, username=smtp_username,
-                                     password=smtp_password, use_tls=use_tls)
+    connection = get_smtp_connection(
+        None,
+        fail_silently=False,
+        host=smtp_host,
+        port=smtp_port,
+        username=smtp_username,
+        password=smtp_password,
+        use_tls=use_tls
+    )
 
     send_temba_email(subject, body, None, from_email, recipient_list, connection=connection)
 

--- a/temba/utils/export.py
+++ b/temba/utils/export.py
@@ -44,10 +44,8 @@ class BaseExportTask(TembaModel):
     STATUS_PROCESSING = 'O'
     STATUS_COMPLETE = 'C'
     STATUS_FAILED = 'F'
-    STATUS_CHOICES = ((STATUS_PENDING, _("Pending")),
-                      (STATUS_PROCESSING, _("Processing")),
-                      (STATUS_COMPLETE, _("Complete")),
-                      (STATUS_FAILED, _("Failed")))
+    STATUS_CHOICES = ((STATUS_PENDING, _("Pending")), (STATUS_PROCESSING, _("Processing")),
+                      (STATUS_COMPLETE, _("Complete")), (STATUS_FAILED, _("Failed")))
 
     org = models.ForeignKey('orgs.Org', related_name='%(class)ss', help_text=_("The organization of the user."))
 
@@ -70,8 +68,10 @@ class BaseExportTask(TembaModel):
             branding = self.org.get_branding()
 
             # notify user who requested this export
-            send_template_email(self.created_by.username, self.email_subject, self.email_template,
-                                self.get_email_context(branding), branding)
+            send_template_email(
+                self.created_by.username, self.email_subject, self.email_template,
+                self.get_email_context(branding), branding
+            )
         except Exception:
             import traceback
             traceback.print_exc()
@@ -81,7 +81,9 @@ class BaseExportTask(TembaModel):
         finally:
             elapsed = time.time() - start
             print("Completed %s in %.1f seconds" % (self.analytics_key, elapsed))
-            analytics.track(self.created_by.username, 'temba.%s_latency' % self.analytics_key, properties=dict(value=elapsed))
+            analytics.track(
+                self.created_by.username, 'temba.%s_latency' % self.analytics_key, properties=dict(value=elapsed)
+            )
 
             gc.collect()  # force garbage collection
 
@@ -93,7 +95,7 @@ class BaseExportTask(TembaModel):
 
     def update_status(self, status):
         self.status = status
-        self.save(update_fields=('status',))
+        self.save(update_fields=('status', ))
 
     @classmethod
     def get_recent_unfinished(cls, org):
@@ -101,7 +103,8 @@ class BaseExportTask(TembaModel):
         Checks for unfinished exports created in the last 24 hours for this org, and returns the most recent
         """
         return cls.objects.filter(
-            org=org, created_on__gt=timezone.now() - timedelta(hours=24),
+            org=org,
+            created_on__gt=timezone.now() - timedelta(hours=24),
             status__in=(cls.STATUS_PENDING, cls.STATUS_PROCESSING)
         ).order_by('-created_on').first()
 
@@ -146,6 +149,7 @@ class TableExporter(object):
     When writing to an Excel sheet, this also takes care of creating different sheets every 1048576
     rows, as again, Excel file only support that many per sheet.
     """
+
     def __init__(self, task, sheet_name, columns):
         self.task = task
         self.columns = columns

--- a/temba/utils/expressions.py
+++ b/temba/utils/expressions.py
@@ -31,7 +31,11 @@ def get_function_listing():
     global listing
 
     if listing is None:
-        listing = [{'name': f['name'], 'display': f['description'], 'signature': _build_function_signature(f)} for f in DEFAULT_FUNCTION_MANAGER.build_listing()]
+        listing = [{
+            'name': f['name'],
+            'display': f['description'],
+            'signature': _build_function_signature(f)
+        } for f in DEFAULT_FUNCTION_MANAGER.build_listing()]
     return listing
 
 
@@ -65,14 +69,16 @@ def _build_function_signature(f):
 # Old style expression migration
 # ======================================================================================================================
 
-FILTER_REPLACEMENTS = {'lower_case': 'LOWER({0})',
-                       'upper_case': 'UPPER({0})',
-                       'capitalize': 'PROPER({0})',
-                       'title_case': 'PROPER({0})',
-                       'first_word': 'FIRST_WORD({0})',
-                       'remove_first_word': 'REMOVE_FIRST_WORD({0})',
-                       'read_digits': 'READ_DIGITS({0})',
-                       'time_delta': '{0} + {1}'}
+FILTER_REPLACEMENTS = {
+    'lower_case': 'LOWER({0})',
+    'upper_case': 'UPPER({0})',
+    'capitalize': 'PROPER({0})',
+    'title_case': 'PROPER({0})',
+    'first_word': 'FIRST_WORD({0})',
+    'remove_first_word': 'REMOVE_FIRST_WORD({0})',
+    'read_digits': 'READ_DIGITS({0})',
+    'time_delta': '{0} + {1}'
+}
 
 
 def migrate_template(text):
@@ -94,6 +100,7 @@ def replace_filter_style(text):
     Migrates text which may contain filter style expressions, e.g. "Hi @contact.name|upper_case", converting them to
     new style expressions, e.g. "Hi @(UPPER(contact))"
     """
+
     def replace_expression(match):
         expression = match.group(1)
         new_style = convert_filter_style(expression)
@@ -142,10 +149,10 @@ def replace_equals_style(text):
     Migrates text which may contain equals style expressions, e.g. "Hi =UPPER(contact)", converting them to new style
     expressions, e.g. "Hi @(UPPER(contact))"
     """
-    STATE_BODY = 0            # not in a expression
-    STATE_PREFIX = 1          # '=' prefix that denotes the start of an expression
-    STATE_IDENTIFIER = 2      # the identifier part, e.g. 'SUM' in '=SUM(1, 2)' or 'contact.age' in '=contact.age'
-    STATE_BALANCED = 3        # the balanced parentheses delimited part, e.g. '(1, 2)' in 'SUM(1, 2)'
+    STATE_BODY = 0  # not in a expression
+    STATE_PREFIX = 1  # '=' prefix that denotes the start of an expression
+    STATE_IDENTIFIER = 2  # the identifier part, e.g. 'SUM' in '=SUM(1, 2)' or 'contact.age' in '=contact.age'
+    STATE_BALANCED = 3  # the balanced parentheses delimited part, e.g. '(1, 2)' in 'SUM(1, 2)'
     STATE_STRING_LITERAL = 4  # a string literal
     input_chars = list(text)
     output_chars = []

--- a/temba/utils/gsm7.py
+++ b/temba/utils/gsm7.py
@@ -9,7 +9,6 @@ GSM7_BASIC = u"@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !
 
 GSM7_EXTENDED = u"^{}\\[~]|€"
 
-
 # All valid GSM7 characters, table format
 VALID_GSM7 = GSM7_BASIC + GSM7_EXTENDED
 
@@ -19,45 +18,45 @@ GSM7_BASIC_CHARS = {c for c in GSM7_BASIC}
 GSM7_EXTENDED_CHARS = {c for c in GSM7_EXTENDED}
 
 # Characters we replace in GSM7 with versions that can actually be encoded
-GSM7_REPLACEMENTS = {u'á': 'a',
-                     u'ê': 'e',
-                     u'ã': 'a',
-                     u'â': 'a',
-                     u'ç': 'c',
-                     u'í': 'i',
-                     u'î': 'i',
-                     u'ú': 'u',
-                     u'û': 'u',
-                     u'õ': 'o',
-                     u'ô': 'o',
-                     u'ó': 'o',
+GSM7_REPLACEMENTS = {
+    u'á': 'a',
+    u'ê': 'e',
+    u'ã': 'a',
+    u'â': 'a',
+    u'ç': 'c',
+    u'í': 'i',
+    u'î': 'i',
+    u'ú': 'u',
+    u'û': 'u',
+    u'õ': 'o',
+    u'ô': 'o',
+    u'ó': 'o',
+    u'Á': 'A',
+    u'Â': 'A',
+    u'Ã': 'A',
+    u'À': 'A',
+    u'Ç': 'C',
+    u'È': 'E',
+    u'Ê': 'E',
+    u'Í': 'I',
+    u'Î': 'I',
+    u'Ì': 'I',
+    u'Ó': 'O',
+    u'Ô': 'O',
+    u'Ò': 'O',
+    u'Õ': 'O',
+    u'Ú': 'U',
+    u'Ù': 'U',
+    u'Û': 'U',
 
-                     u'Á': 'A',
-                     u'Â': 'A',
-                     u'Ã': 'A',
-                     u'À': 'A',
-                     u'Ç': 'C',
-                     u'È': 'E',
-                     u'Ê': 'E',
-                     u'Í': 'I',
-                     u'Î': 'I',
-                     u'Ì': 'I',
-                     u'Ó': 'O',
-                     u'Ô': 'O',
-                     u'Ò': 'O',
-                     u'Õ': 'O',
-                     u'Ú': 'U',
-                     u'Ù': 'U',
-                     u'Û': 'U',
-
-                     # shit Word likes replacing automatically
-                     u'’': '\'',
-                     u'‘': '\'',
-                     u'“': '"',
-                     u'”': '"',
-                     u'–': '-',
-                     u'\xa0': ' ',
-                     }
+    # shit Word likes replacing automatically
+    u'’': '\'',
+    u'‘': '\'',
+    u'“': '"',
+    u'”': '"',
+    u'–': '-',
+    u'\xa0': ' ',
+}
 
 
 def is_gsm7(text):
@@ -94,10 +93,9 @@ def_regular_decode_dict = {
     '\x07': u'\u00EC',  # LATIN SMALL LETTER I WITH GRAVE
     '\x08': u'\u00F2',  # LATIN SMALL LETTER O WITH GRAVE
     '\x09': u'\u00C7',  # LATIN CAPITAL LETTER C WITH CEDILLA
-                        # The Unicode page suggests this is a mistake: but
-                        # it's still in the latest version of the spec and
-                        # our implementation has to be exact.
-
+    # The Unicode page suggests this is a mistake: but
+    # it's still in the latest version of the spec and
+    # our implementation has to be exact.
     '\x0A': u'\u000A',  # LINE FEED
     '\x0B': u'\u00D8',  # LATIN CAPITAL LETTER O WITH STROKE
     '\x0C': u'\u00F8',  # LATIN SMALL LETTER O WITH STROKE
@@ -237,7 +235,6 @@ def_escape_decode_dict = {
 # important to ensure the conversion is exact.
 def_replace_encode_dict = {
     u'\u00E7': '\x09',  # LATIN SMALL LETTER C WITH CEDILLA
-
     u'\u0391': '\x41',  # GREEK CAPITAL LETTER ALPHA
     u'\u0392': '\x42',  # GREEK CAPITAL LETTER BETA
     u'\u0395': '\x45',  # GREEK CAPITAL LETTER EPSILON

--- a/temba/utils/haml.py
+++ b/temba/utils/haml.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-
 """
 We need our own custom template loaders because we allow templates to be overridden even when the extension doesn't
 match, i.e. a template called index.haml can override index.html in Smartmin
@@ -48,7 +47,6 @@ def get_haml_loader(loader):
 
 
 haml_loaders = dict((name, get_haml_loader(loader)) for (name, loader) in get_django_template_loaders())
-
 
 HamlFilesystemLoader = get_haml_loader(filesystem)
 HamlAppDirectoriesLoader = get_haml_loader(app_directories)

--- a/temba/utils/http.py
+++ b/temba/utils/http.py
@@ -17,7 +17,6 @@ def http_headers(extra=None):
 
 @six.python_2_unicode_compatible
 class HttpEvent(object):
-
     def __init__(self, method, url, request_body=None, status_code=None, response_body=None):
         self.method = method
         self.url = url

--- a/temba/utils/jiochat.py
+++ b/temba/utils/jiochat.py
@@ -62,7 +62,9 @@ class JiochatClient:
 
                 response_json = response.json()
                 event.response_body = json.dumps(response_json)
-                ChannelLog.log_channel_request(channel_id, "Successfully fetched access token from Jiochat", event, start)
+                ChannelLog.log_channel_request(
+                    channel_id, "Successfully fetched access token from Jiochat", event, start
+                )
 
                 access_token = response_json['access_token']
                 cache.set(key, access_token, timeout=7200)
@@ -155,8 +157,9 @@ class JiochatClient:
             raise SendException(six.text_type(e), event=event, start=start)
 
         if response.status_code != 200 and response.status_code != 201 and response.status_code != 202:
-            raise SendException("Got non-200 response [%d] from JioChat" % response.status_code,
-                                event=event, start=start)
+            raise SendException(
+                "Got non-200 response [%d] from JioChat" % response.status_code, event=event, start=start
+            )
 
         return response, event
 

--- a/temba/utils/mage.py
+++ b/temba/utils/mage.py
@@ -21,6 +21,7 @@ class MageClient(object):  # pragma: needs cover
     """
     Simple client for API calls to a Message Mage instance
     """
+
     def __init__(self, base_url, auth_token):
         self.base_url = base_url
         self.auth_token = auth_token
@@ -48,9 +49,7 @@ class MageClient(object):  # pragma: needs cover
         func = getattr(self.client, method)
         params = params or {}
 
-        requests_args = {
-            'headers': {'Authorization': 'Token %s' % self.auth_token}
-        }
+        requests_args = {'headers': {'Authorization': 'Token %s' % self.auth_token}}
 
         if method == 'get':
             requests_args['params'] = params
@@ -78,7 +77,7 @@ def handle_new_message(org, msg):
     # Mage no longer assigns topups
     if not msg.topup_id:
         (msg.topup_id, amount) = org.decrement_credit()
-        msg.save(update_fields=('topup_id',))
+        msg.save(update_fields=('topup_id', ))
 
     # set the preferred channel for this contact
     msg.contact.set_preferred_channel(msg.channel)
@@ -95,6 +94,6 @@ def handle_new_contact(org, contact):
     Contacts created by mage or courier are only saved to the database. Here we take care of the other stuff
     """
     # possible to have dynamic groups based on name
-    contact.handle_update(attrs=('name',))
+    contact.handle_update(attrs=('name', ))
 
     analytics.gauge('temba.contact_created')

--- a/temba/utils/management/commands/collect_sql.py
+++ b/temba/utils/management/commands/collect_sql.py
@@ -51,7 +51,7 @@ class SqlObjectOperation(object):
 
         if tokens[0].value.upper() in ('CREATE', 'CREATE OR REPLACE'):
             is_create = True
-        elif tokens[0].value.upper() in ('DROP',):
+        elif tokens[0].value.upper() in ('DROP', ):
             is_create = False
         else:
             return None
@@ -85,11 +85,17 @@ class Command(BaseCommand):  # pragma: no cover
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--preserve-order', action='store_true', dest='preserve_order', default=False,
+            '--preserve-order',
+            action='store_true',
+            dest='preserve_order',
+            default=False,
             help='Whether to preserve order of operations rather than sorting by object name.',
         )
         parser.add_argument(
-            '--output-dir', action='store', dest='output_dir', default='temba/sql',
+            '--output-dir',
+            action='store',
+            dest='output_dir',
+            default='temba/sql',
             help='The output directory for generated SQL files.',
         )
 

--- a/temba/utils/management/commands/migrate_manual.py
+++ b/temba/utils/management/commands/migrate_manual.py
@@ -16,12 +16,11 @@ class Command(BaseCommand):  # pragma: no cover
     help = "Applies a migration manually which may have been previously applied or faked"
 
     def add_arguments(self, parser):
-        parser.add_argument('app_label',
-                            help='App label of an application to synchronize the state.')
-        parser.add_argument('migration_name',
-                            help='Database state will be brought to the state after that migration.')
-        parser.add_argument('--record', action='store_true', dest='record', default=False,
-                            help='Record migration as applied.')
+        parser.add_argument('app_label', help='App label of an application to synchronize the state.')
+        parser.add_argument('migration_name', help='Database state will be brought to the state after that migration.')
+        parser.add_argument(
+            '--record', action='store_true', dest='record', default=False, help='Record migration as applied.'
+        )
 
     def handle(self, app_label, migration_name, *args, **options):
         self.verbosity = options.get('verbosity')

--- a/temba/utils/management/commands/perf_test.py
+++ b/temba/utils/management/commands/perf_test.py
@@ -59,8 +59,10 @@ TEST_URLS = (
     '/contact/?search=' + urlquote_plus('gender=F'),
     '/contact/?search=' + urlquote_plus('joined=""'),
     '/contact/?search=' + urlquote_plus('joined!=""'),
-    '/contact/?search=' + urlquote_plus('district=Wudil or district=Anka or district=Zuru or district=Kaura or '
-                                        'district=Giwa or district=Kalgo or district=Shanga or district=Bunza'),
+    '/contact/?search=' + urlquote_plus(
+        'district=Wudil or district=Anka or district=Zuru or district=Kaura or '
+        'district=Giwa or district=Kalgo or district=Shanga or district=Bunza'
+    ),
     '/contact/?search=' + urlquote_plus('gender=M and state=Katsina and age<40 and joined>') + '{1-year-ago}',
     '/contact/?search=' + urlquote_plus('(gender=M and district=Faskari) or (gender=F and district=Zuru)'),
     '/contact/blocked/',
@@ -112,18 +114,54 @@ class Command(BaseCommand):  # pragma: no cover
     help = "Runs performance tests on a database generated with make_test_db"
 
     def add_arguments(self, parser):
-        parser.add_argument('--include', type=str, action='store', dest='include_pattern', default=None,
-                            help="Only test URLs matching this pattern.")
-        parser.add_argument('--orgs', type=str, action='store', dest='org_ids', default=None,
-                            help="Comma separated database ids of orgs to test. Defaults to first and last org.")
-        parser.add_argument('--org-limits', type=str, action='store', dest='org_limits', default=None,
-                            help="Comma separated hard time limits for each org in milliseconds.")
-        parser.add_argument('--num-requests', type=int, action='store', dest='num_requests', default=DEFAULT_NUM_REQUESTS,
-                            help="Number of requests to make for each URL. Default is %d." % DEFAULT_NUM_REQUESTS)
-        parser.add_argument('--results-file', type=str, action='store', dest='results_file', default=DEFAULT_RESULTS_FILE,
-                            help="Path of file to write results to. Default is '%s'." % DEFAULT_RESULTS_FILE)
-        parser.add_argument('--results-html', type=str, action='store', dest='results_html', default=None,
-                            help="Path of file to write HTML results to. Default is none.")
+        parser.add_argument(
+            '--include',
+            type=str,
+            action='store',
+            dest='include_pattern',
+            default=None,
+            help="Only test URLs matching this pattern."
+        )
+        parser.add_argument(
+            '--orgs',
+            type=str,
+            action='store',
+            dest='org_ids',
+            default=None,
+            help="Comma separated database ids of orgs to test. Defaults to first and last org."
+        )
+        parser.add_argument(
+            '--org-limits',
+            type=str,
+            action='store',
+            dest='org_limits',
+            default=None,
+            help="Comma separated hard time limits for each org in milliseconds."
+        )
+        parser.add_argument(
+            '--num-requests',
+            type=int,
+            action='store',
+            dest='num_requests',
+            default=DEFAULT_NUM_REQUESTS,
+            help="Number of requests to make for each URL. Default is %d." % DEFAULT_NUM_REQUESTS
+        )
+        parser.add_argument(
+            '--results-file',
+            type=str,
+            action='store',
+            dest='results_file',
+            default=DEFAULT_RESULTS_FILE,
+            help="Path of file to write results to. Default is '%s'." % DEFAULT_RESULTS_FILE
+        )
+        parser.add_argument(
+            '--results-html',
+            type=str,
+            action='store',
+            dest='results_html',
+            default=None,
+            help="Path of file to write HTML results to. Default is none."
+        )
 
     def handle(self, include_pattern, org_ids, org_limits, num_requests, results_file, results_html, *args, **options):
         self.client = Client()
@@ -175,8 +213,11 @@ class Command(BaseCommand):  # pragma: no cover
         """
         Tests the given URLs for the given org
         """
-        self.stdout.write(self.style.MIGRATE_HEADING("Org #%d (%d contacts, %dms max allowed)"
-                                                     % (org.id, org.org_contacts.count(), org.allowed_max)))
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(
+                "Org #%d (%d contacts, %dms max allowed)" % (org.id, org.org_contacts.count(), org.allowed_max)
+            )
+        )
 
         # build a URL context for this org
         url_context = {}
@@ -258,9 +299,10 @@ class Command(BaseCommand):  # pragma: no cover
         with open(path, 'w') as f:
             json.dump({
                 'started': started.isoformat(),
-                'results': [
-                    {'org': r['org'].id, 'tests': [t.as_json() for t in r['tests']]} for r in results
-                ]
+                'results': [{
+                    'org': r['org'].id,
+                    'tests': [t.as_json() for t in r['tests']]
+                } for r in results]
             }, f, indent=4)
 
     def save_html_results(self, path, results):
@@ -274,7 +316,8 @@ class Command(BaseCommand):  # pragma: no cover
             f.write(footer)
 
     def write_org_html(self, f, org, tests):
-        f.write("""
+        f.write(
+            """
         <tr style="background-color: #2f4970; color: white">
             <th style="padding: 5px" colspan="5">Org #%d (%d contacts, %dms max allowed)</th>
         </tr>
@@ -285,7 +328,8 @@ class Command(BaseCommand):  # pragma: no cover
             <th style="padding: 5px">Change (ms)</th>
             <th style="padding: 5px">Change (%%)</th>
         </tr>
-        """ % (org.id, org.org_contacts.count(), org.allowed_max))
+        """ % (org.id, org.org_contacts.count(), org.allowed_max)
+        )
 
         for test in tests:
             if test.change:

--- a/temba/utils/management/commands/test_db.py
+++ b/temba/utils/management/commands/test_db.py
@@ -33,7 +33,6 @@ from temba.orgs.tasks import squash_topupcredits
 from temba.utils import chunk_list, ms_to_datetime, datetime_to_str, datetime_to_ms
 from temba.values.models import Value
 
-
 # maximum age in days of database content
 CONTENT_AGE = 3 * 365
 
@@ -44,53 +43,153 @@ USER_PASSWORD = "Qwerty123"
 LOCATIONS_DUMP = 'test-data/nigeria.bin'
 
 # organization names are generated from these components
-ORG_NAMES = (
-    ("UNICEF", "WHO", "WFP", "UNESCO", "UNHCR", "UNITAR", "FAO", "UNEP", "UNAIDS", "UNDAF"),
-    ("Nigeria", "Chile", "Indonesia", "Rwanda", "Mexico", "Zambia", "India", "Brazil", "Sudan", "Mozambique")
-)
+ORG_NAMES = (("UNICEF", "WHO", "WFP", "UNESCO", "UNHCR", "UNITAR", "FAO", "UNEP", "UNAIDS", "UNDAF"),
+             ("Nigeria", "Chile", "Indonesia", "Rwanda", "Mexico", "Zambia", "India", "Brazil", "Sudan", "Mozambique"))
 
 # the users, channels, groups, labels and fields to create for each organization
 USERS = (
-    {'username': "admin%d", 'email': "org%d_admin@example.com", 'role': 'administrators'},
-    {'username': "editor%d", 'email': "org%d_editor@example.com", 'role': 'editors'},
-    {'username': "viewer%d", 'email': "org%d_viewer@example.com", 'role': 'viewers'},
-    {'username': "surveyor%d", 'email': "org%d_surveyor@example.com", 'role': 'surveyors'},
+    {
+        'username': "admin%d",
+        'email': "org%d_admin@example.com",
+        'role': 'administrators'
+    },
+    {
+        'username': "editor%d",
+        'email': "org%d_editor@example.com",
+        'role': 'editors'
+    },
+    {
+        'username': "viewer%d",
+        'email': "org%d_viewer@example.com",
+        'role': 'viewers'
+    },
+    {
+        'username': "surveyor%d",
+        'email': "org%d_surveyor@example.com",
+        'role': 'surveyors'
+    },
 )
 CHANNELS = (
-    {'name': "Android", 'channel_type': Channel.TYPE_ANDROID, 'scheme': 'tel', 'address': "1234"},
-    {'name': "Nexmo", 'channel_type': 'NX', 'scheme': 'tel', 'address': "2345"},
-    {'name': "Twitter", 'channel_type': 'TT', 'scheme': 'twitter', 'address': "my_handle"},
+    {
+        'name': "Android",
+        'channel_type': Channel.TYPE_ANDROID,
+        'scheme': 'tel',
+        'address': "1234"
+    },
+    {
+        'name': "Nexmo",
+        'channel_type': 'NX',
+        'scheme': 'tel',
+        'address': "2345"
+    },
+    {
+        'name': "Twitter",
+        'channel_type': 'TT',
+        'scheme': 'twitter',
+        'address': "my_handle"
+    },
 )
 FIELDS = (
-    {'key': 'gender', 'label': "Gender", 'value_type': Value.TYPE_TEXT},
-    {'key': 'age', 'label': "Age", 'value_type': Value.TYPE_DECIMAL},
-    {'key': 'joined', 'label': "Joined On", 'value_type': Value.TYPE_DATETIME},
-    {'key': 'ward', 'label': "Ward", 'value_type': Value.TYPE_WARD},
-    {'key': 'district', 'label': "District", 'value_type': Value.TYPE_DISTRICT},
-    {'key': 'state', 'label': "State", 'value_type': Value.TYPE_STATE},
+    {
+        'key': 'gender',
+        'label': "Gender",
+        'value_type': Value.TYPE_TEXT
+    },
+    {
+        'key': 'age',
+        'label': "Age",
+        'value_type': Value.TYPE_DECIMAL
+    },
+    {
+        'key': 'joined',
+        'label': "Joined On",
+        'value_type': Value.TYPE_DATETIME
+    },
+    {
+        'key': 'ward',
+        'label': "Ward",
+        'value_type': Value.TYPE_WARD
+    },
+    {
+        'key': 'district',
+        'label': "District",
+        'value_type': Value.TYPE_DISTRICT
+    },
+    {
+        'key': 'state',
+        'label': "State",
+        'value_type': Value.TYPE_STATE
+    },
 )
 GROUPS = (
-    {'name': "Reporters", 'query': None, 'member': 0.95},  # member is either a probability or callable
-    {'name': "Farmers", 'query': None, 'member': 0.5},
-    {'name': "Doctors", 'query': None, 'member': 0.4},
-    {'name': "Teachers", 'query': None, 'member': 0.3},
-    {'name': "Drivers", 'query': None, 'member': 0.2},
-    {'name': "Testers", 'query': None, 'member': 0.1},
-    {'name': "Empty", 'query': None, 'member': 0.0},
-    {'name': "Youth (Dynamic)", 'query': 'age <= 18', 'member': lambda c: c['age'] and c['age'] <= 18},
-    {'name': "Unregistered (Dynamic)", 'query': 'joined = ""', 'member': lambda c: not c['joined']},
-    {'name': "Districts (Dynamic)", 'query': 'district=Faskari or district=Zuru or district=Anka',
-     'member': lambda c: c['district'] and c['district'].name in ("Faskari", "Zuru", "Anka")},
+    {
+        'name': "Reporters",
+        'query': None,
+        'member': 0.95
+    },  # member is either a probability or callable
+    {
+        'name': "Farmers",
+        'query': None,
+        'member': 0.5
+    },
+    {
+        'name': "Doctors",
+        'query': None,
+        'member': 0.4
+    },
+    {
+        'name': "Teachers",
+        'query': None,
+        'member': 0.3
+    },
+    {
+        'name': "Drivers",
+        'query': None,
+        'member': 0.2
+    },
+    {
+        'name': "Testers",
+        'query': None,
+        'member': 0.1
+    },
+    {
+        'name': "Empty",
+        'query': None,
+        'member': 0.0
+    },
+    {
+        'name': "Youth (Dynamic)",
+        'query': 'age <= 18',
+        'member': lambda c: c['age'] and c['age'] <= 18
+    },
+    {
+        'name': "Unregistered (Dynamic)",
+        'query': 'joined = ""',
+        'member': lambda c: not c['joined']
+    },
+    {
+        'name': "Districts (Dynamic)",
+        'query': 'district=Faskari or district=Zuru or district=Anka',
+        'member': lambda c: c['district'] and c['district'].name in ("Faskari", "Zuru", "Anka")
+    },
 )
 LABELS = ("Reporting", "Testing", "Youth", "Farming", "Health", "Education", "Trade", "Driving", "Building", "Spam")
-FLOWS = (
-    {'name': "Favorites", 'file': "favorites.json", 'templates': (
+FLOWS = ({
+    'name': "Favorites",
+    'file': "favorites.json",
+    'templates': (
         ["blue", "mutzig", "bob"],
         ["orange", "green", "primus", "jeb"],
-    )},
-    {'name': "SMS Form", 'file': "sms_form.json", 'templates': (["22 F Seattle"], ["35 M MIAMI"])},
-    {'name': "Pick a Number", 'file': "pick_a_number.json", 'templates': (["1"], ["4"], ["5"], ["7"], ["8"])}
-)
+    )
+}, {
+    'name': "SMS Form",
+    'file': "sms_form.json",
+    'templates': (["22 F Seattle"], ["35 M MIAMI"])
+}, {
+    'name': "Pick a Number",
+    'file': "pick_a_number.json",
+    'templates': (["1"], ["4"], ["5"], ["7"], ["8"])
+})
 
 # contact names are generated from these components
 CONTACT_NAMES = (
@@ -117,8 +216,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         cmd = self
-        subparsers = parser.add_subparsers(dest='command', help='Command to perform',
-                                           parser_class=lambda **kw: CommandParser(cmd, **kw))
+        subparsers = parser.add_subparsers(
+            dest='command', help='Command to perform', parser_class=lambda **kw: CommandParser(cmd, **kw)
+        )
 
         gen_parser = subparsers.add_parser('generate', help='Generates a clean testing database')
         gen_parser.add_argument('--orgs', type=int, action='store', dest='num_orgs', default=10)
@@ -241,8 +341,11 @@ class Command(BaseCommand):
         # load dump into current db with pg_restore
         db_config = settings.DATABASES['default']
         try:
-            check_call('export PGPASSWORD=%s && pg_restore -U%s -w -d %s %s' %
-                       (db_config['PASSWORD'], db_config['USER'], db_config['NAME'], path), shell=True)
+            check_call(
+                'export PGPASSWORD=%s && pg_restore -U%s -w -d %s %s' %
+                (db_config['PASSWORD'], db_config['USER'], db_config['NAME'], path),
+                shell=True
+            )
         except CalledProcessError:  # pragma: no cover
             raise CommandError("Error occurred whilst calling pg_restore to load locations dump")
 
@@ -266,9 +369,17 @@ class Command(BaseCommand):
 
         orgs = []
         for o in range(num_total):
-            orgs.append(Org(name=org_names[o % len(org_names)], timezone=self.random.choice(pytz.all_timezones),
-                            brand='rapidpro.io', country=country,
-                            created_on=self.db_begins_on, created_by=superuser, modified_by=superuser))
+            orgs.append(
+                Org(
+                    name=org_names[o % len(org_names)],
+                    timezone=self.random.choice(pytz.all_timezones),
+                    brand='rapidpro.io',
+                    country=country,
+                    created_on=self.db_begins_on,
+                    created_by=superuser,
+                    modified_by=superuser
+                )
+            )
         Org.objects.bulk_create(orgs)
         orgs = list(Org.objects.order_by('id'))
 
@@ -282,7 +393,8 @@ class Command(BaseCommand):
                 'users': [],
                 'fields': {},
                 'groups': [],
-                'system_groups': {g.group_type: g for g in ContactGroup.system_groups.filter(org=org)},
+                'system_groups': {g.group_type: g
+                                  for g in ContactGroup.system_groups.filter(org=org)},
             }
 
         self._log(self.style.SUCCESS("OK") + '\n')
@@ -313,9 +425,15 @@ class Command(BaseCommand):
         for org in orgs:
             user = org.cache['users'][0]
             for c in CHANNELS:
-                Channel.objects.create(org=org, name=c['name'], channel_type=c['channel_type'],
-                                       address=c['address'], schemes=[c['scheme']],
-                                       created_by=user, modified_by=user)
+                Channel.objects.create(
+                    org=org,
+                    name=c['name'],
+                    channel_type=c['channel_type'],
+                    address=c['address'],
+                    schemes=[c['scheme']],
+                    created_by=user,
+                    modified_by=user
+                )
 
         self._log(self.style.SUCCESS("OK") + '\n')
 
@@ -328,9 +446,15 @@ class Command(BaseCommand):
         for org in orgs:
             user = org.cache['users'][0]
             for f in FIELDS:
-                field = ContactField.objects.create(org=org, key=f['key'], label=f['label'],
-                                                    value_type=f['value_type'], show_in_table=True,
-                                                    created_by=user, modified_by=user)
+                field = ContactField.objects.create(
+                    org=org,
+                    key=f['key'],
+                    label=f['label'],
+                    value_type=f['value_type'],
+                    show_in_table=True,
+                    created_by=user,
+                    modified_by=user
+                )
                 org.cache['fields'][f['key']] = field
 
         self._log(self.style.SUCCESS("OK") + '\n')
@@ -422,7 +546,8 @@ class Command(BaseCommand):
                         'name': name,
                         'groups': [],
                         'tel': '+2507%08d' % c_index if self.probability(CONTACT_HAS_TEL_PROB) else None,
-                        'twitter': '%s%d' % (name.replace(' ', '_').lower() if name else 'tweep', c_index) if self.probability(CONTACT_HAS_TWITTER_PROB) else None,
+                        'twitter': '%s%d' % (name.replace(' ', '_').lower() if name else 'tweep', c_index)
+                        if self.probability(CONTACT_HAS_TWITTER_PROB) else None,
                         'gender': self.random_choice(('M', 'F')) if self.probability(CONTACT_HAS_FIELD_PROB) else None,
                         'age': self.random.randint(16, 80) if self.probability(CONTACT_HAS_FIELD_PROB) else None,
                         'joined': self.random_date() if self.probability(CONTACT_HAS_FIELD_PROB) else None,
@@ -473,11 +598,18 @@ class Command(BaseCommand):
         Bulk creates a batch of contacts from flat representations
         """
         for c in batch:
-            c['object'] = Contact(org=c['org'], name=c['name'], language=c['language'],
-                                  is_stopped=c['is_stopped'], is_blocked=c['is_blocked'],
-                                  is_active=c['is_active'],
-                                  created_by=c['user'], created_on=c['created_on'],
-                                  modified_by=c['user'], modified_on=c['modified_on'])
+            c['object'] = Contact(
+                org=c['org'],
+                name=c['name'],
+                language=c['language'],
+                is_stopped=c['is_stopped'],
+                is_blocked=c['is_blocked'],
+                is_active=c['is_active'],
+                created_by=c['user'],
+                created_on=c['created_on'],
+                modified_by=c['user'],
+                modified_on=c['modified_on']
+            )
         Contact.objects.bulk_create([c['object'] for c in batch])
 
         # now that contacts have pks, bulk create the actual URN, value and group membership objects
@@ -490,29 +622,86 @@ class Command(BaseCommand):
             c['urns'] = []
 
             if c['tel']:
-                c['urns'].append(ContactURN(org=org, contact=c['object'], priority=50, scheme=TEL_SCHEME,
-                                            path=c['tel'], identity=URN.from_tel(c['tel'])))
+                c['urns'].append(
+                    ContactURN(
+                        org=org,
+                        contact=c['object'],
+                        priority=50,
+                        scheme=TEL_SCHEME,
+                        path=c['tel'],
+                        identity=URN.from_tel(c['tel'])
+                    )
+                )
             if c['twitter']:
-                c['urns'].append(ContactURN(org=org, contact=c['object'], priority=50, scheme=TWITTER_SCHEME,
-                                            path=c['twitter'], identity=URN.from_twitter(c['twitter'])))
+                c['urns'].append(
+                    ContactURN(
+                        org=org,
+                        contact=c['object'],
+                        priority=50,
+                        scheme=TWITTER_SCHEME,
+                        path=c['twitter'],
+                        identity=URN.from_twitter(c['twitter'])
+                    )
+                )
             if c['gender']:
-                batch_values.append(Value(org=org, contact=c['object'], contact_field=org.cache['fields']['gender'],
-                                          string_value=c['gender']))
+                batch_values.append(
+                    Value(
+                        org=org,
+                        contact=c['object'],
+                        contact_field=org.cache['fields']['gender'],
+                        string_value=c['gender']
+                    )
+                )
             if c['age']:
-                batch_values.append(Value(org=org, contact=c['object'], contact_field=org.cache['fields']['age'],
-                                          string_value=str(c['age']), decimal_value=c['age']))
+                batch_values.append(
+                    Value(
+                        org=org,
+                        contact=c['object'],
+                        contact_field=org.cache['fields']['age'],
+                        string_value=str(c['age']),
+                        decimal_value=c['age']
+                    )
+                )
             if c['joined']:
-                batch_values.append(Value(org=org, contact=c['object'], contact_field=org.cache['fields']['joined'],
-                                          string_value=datetime_to_str(c['joined']), datetime_value=c['joined']))
+                batch_values.append(
+                    Value(
+                        org=org,
+                        contact=c['object'],
+                        contact_field=org.cache['fields']['joined'],
+                        string_value=datetime_to_str(c['joined']),
+                        datetime_value=c['joined']
+                    )
+                )
             if c['ward']:
-                batch_values.append(Value(org=org, contact=c['object'], contact_field=org.cache['fields']['ward'],
-                                          string_value=c['ward'].name, location_value=c['ward']))
+                batch_values.append(
+                    Value(
+                        org=org,
+                        contact=c['object'],
+                        contact_field=org.cache['fields']['ward'],
+                        string_value=c['ward'].name,
+                        location_value=c['ward']
+                    )
+                )
             if c['district']:
-                batch_values.append(Value(org=org, contact=c['object'], contact_field=org.cache['fields']['district'],
-                                          string_value=c['district'].name, location_value=c['district']))
+                batch_values.append(
+                    Value(
+                        org=org,
+                        contact=c['object'],
+                        contact_field=org.cache['fields']['district'],
+                        string_value=c['district'].name,
+                        location_value=c['district']
+                    )
+                )
             if c['state']:
-                batch_values.append(Value(org=org, contact=c['object'], contact_field=org.cache['fields']['state'],
-                                          string_value=c['state'].name, location_value=c['state']))
+                batch_values.append(
+                    Value(
+                        org=org,
+                        contact=c['object'],
+                        contact_field=org.cache['fields']['state'],
+                        string_value=c['state'].name,
+                        location_value=c['state']
+                    )
+                )
             for g in c['groups']:
                 batch_memberships.append(ContactGroup.contacts.through(contact=c['object'], contactgroup=g))
 
@@ -565,8 +754,10 @@ class Command(BaseCommand):
             group = self.random_choice(org.cache['groups'])
             contacts_started = list(group.contacts.values_list('id', flat=True))
 
-            self._log(" > Starting flow %s for group %s (%d) in org %s\n"
-                      % (flow.name, group.name, len(contacts_started), org.name))
+            self._log(
+                " > Starting flow %s for group %s (%d) in org %s\n" %
+                (flow.name, group.name, len(contacts_started), org.name)
+            )
 
             start = FlowStart.create(flow, user, groups=[group], restart_participants=True)
             start.start()
@@ -691,6 +882,7 @@ class DisableTriggersOn(object):
     """
     Helper context manager for temporarily disabling database triggers for a given model
     """
+
     def __init__(self, *models):
         self.tables = [m._meta.db_table for m in models]
 

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -21,6 +21,7 @@ class TranslatableField(HStoreField):
     """
     Model field which is a set of language code and translation pairs stored as HSTORE
     """
+
     class Validator(object):
         def __init__(self, max_length):
             self.max_length = max_length
@@ -30,7 +31,9 @@ class TranslatableField(HStoreField):
                 if lang != 'base' and len(lang) != 3:
                     raise ValidationError("'%s' is not a valid language code." % lang)
                 if len(translation) > self.max_length:
-                    raise ValidationError("Translation for '%s' exceeds the %d character limit." % (lang, self.max_length))
+                    raise ValidationError(
+                        "Translation for '%s' exceeds the %d character limit." % (lang, self.max_length)
+                    )
 
     def __init__(self, max_length, **kwargs):
         super(TranslatableField, self).__init__(**kwargs)
@@ -44,8 +47,14 @@ class TranslatableField(HStoreField):
 
 class TembaModel(SmartModel):
 
-    uuid = models.CharField(max_length=36, unique=True, db_index=True, default=generate_uuid,
-                            verbose_name=_("Unique Identifier"), help_text=_("The unique identifier for this object"))
+    uuid = models.CharField(
+        max_length=36,
+        unique=True,
+        db_index=True,
+        default=generate_uuid,
+        verbose_name=_("Unique Identifier"),
+        help_text=_("The unique identifier for this object")
+    )
 
     class Meta:
         abstract = True
@@ -89,8 +98,17 @@ class ChunkIterator(object):
     """
     Queryset wrapper to chunk queries and reduce in-memory footprint
     """
-    def __init__(self, model, ids, order_by=None, select_related=None, prefetch_related=None,
-                 contact_fields=None, max_obj_num=1000):
+
+    def __init__(
+        self,
+        model,
+        ids,
+        order_by=None,
+        select_related=None,
+        prefetch_related=None,
+        contact_fields=None,
+        max_obj_num=1000
+    ):
         self._model = model
         self._ids = ids
         self._order_by = order_by

--- a/temba/utils/nexmo.py
+++ b/temba/utils/nexmo.py
@@ -86,21 +86,24 @@ class NexmoClient(nx.Client):
             raise SendException(u"Failed sending message: %s" % response.text, event=event)
 
         if not messages or int(messages[0]['status']) != 0:
-            raise SendException(u"Failed sending message, received error status [%s]" % messages[0]['status'],
-                                event=event)
+            raise SendException(
+                u"Failed sending message, received error status [%s]" % messages[0]['status'], event=event
+            )
 
         else:
             return messages[0]['message-id'], event
 
     def search_numbers(self, country, pattern):
-        response = nx.Client.get_available_numbers(self, country_code=country, pattern=pattern, search_pattern=1,
-                                                   features='SMS', country=country)
+        response = nx.Client.get_available_numbers(
+            self, country_code=country, pattern=pattern, search_pattern=1, features='SMS', country=country
+        )
         numbers = []
         if int(response.get('count', 0)):
             numbers += response['numbers']
 
-        response = nx.Client.get_available_numbers(self, country_code=country, pattern=pattern, search_pattern=1,
-                                                   features='VOICE', country=country)
+        response = nx.Client.get_available_numbers(
+            self, country_code=country, pattern=pattern, search_pattern=1, features='VOICE', country=country
+        )
         if int(response.get('count', 0)):
             numbers += response['numbers']
 
@@ -120,8 +123,9 @@ class NexmoClient(nx.Client):
 
     def update_nexmo_number(self, country, number, moURL, app_id):
         number = number.lstrip('+')
-        params = dict(moHttpUrl=moURL, msisdn=number, country=country, voiceCallbackType='app',
-                      voiceCallbackValue=app_id)
+        params = dict(
+            moHttpUrl=moURL, msisdn=number, country=country, voiceCallbackType='app', voiceCallbackValue=app_id
+        )
         try:
             nx.Client.update_number(self, params=params)
         except nx.ClientError as e:
@@ -173,8 +177,10 @@ def __main__():  # pragma: no cover
     # print "Buying %s: %s" % (seattle_numbers[0]['msisdn'], n.buy_number('US', seattle_numbers[0]['msisdn']))
 
     # update the MO for one of our numbers
-    print("Updating Number %s: %s" % (numbers[0]['msisdn'],
-                                      n.update_nexmo_number('US', numbers[0]['msisdn'], 'http://rapidpro.io')))
+    print(
+        "Updating Number %s: %s" %
+        (numbers[0]['msisdn'], n.update_nexmo_number('US', numbers[0]['msisdn'], 'http://rapidpro.io'))
+    )
 
     # update the MO for our account
     print("Updating Account: %s" % n.update_account("http://rapidpro.io", "http://rapidpro.io"))
@@ -188,7 +194,6 @@ class NCCOException(Exception):
 
 
 class NCCOResponse(object):
-
     def __init__(self, **kwargs):
         self.document = []
 
@@ -243,8 +248,12 @@ class NCCOResponse(object):
         return self
 
     def redirect(self, url=None, **kwargs):
-        result = dict(action='input', maxDigits=1, timeOut=1,
-                      eventUrl=["%s%sinput_redirect=1" % (url, "?" if '?' not in url else "&")])
+        result = dict(
+            action='input',
+            maxDigits=1,
+            timeOut=1,
+            eventUrl=["%s%sinput_redirect=1" % (url, "?" if '?' not in url else "&")]
+        )
 
         self.document.append(result)
         return self
@@ -288,9 +297,15 @@ class NCCOResponse(object):
             result['eventUrl'] = [kwargs.get('action')]
 
         self.document.append(result)
-        result = dict(action='input', maxDigits=1, timeOut=1,
-                      eventUrl=["%s%ssave_media=1" % (kwargs.get('action'),
-                                                      "?" if '?' not in six.text_type(kwargs.get('action')) else "&")])
+        result = dict(
+            action='input',
+            maxDigits=1,
+            timeOut=1,
+            eventUrl=[
+                "%s%ssave_media=1" %
+                (kwargs.get('action'), "?" if '?' not in six.text_type(kwargs.get('action')) else "&")
+            ]
+        )
 
         self.document.append(result)
 

--- a/temba/utils/profiler.py
+++ b/temba/utils/profiler.py
@@ -19,6 +19,7 @@ class SegmentProfiler(object):  # pragma: no cover
     """
     Used in a with block to profile a segment of code
     """
+
     def __init__(self, name, test=None, db_profile=True, assert_queries=None, assert_tx=None, force_profile=False):
         self.name = name
 
@@ -95,6 +96,7 @@ def time_monitor(threshold):
     """
     Method decorator to time a method call and log an error if time exceeds the given threshold in milliseconds.
     """
+
     def _time_monitor(func):
         def wrapper(*args, **kwargs):
             start = time.time()
@@ -106,5 +108,7 @@ def time_monitor(threshold):
                 logger.error('Call to %s took %d milliseconds.' % (func.__name__, time_taken), extra={'stack': True})
 
             return result
+
         return wrapper
+
     return _time_monitor

--- a/temba/utils/queues.py
+++ b/temba/utils/queues.py
@@ -9,8 +9,7 @@ from django.conf import settings
 from django_redis import get_redis_connection
 from temba.utils import dict_to_json
 
-
-LOW_PRIORITY = +10000000   # +10M ~ 110 days
+LOW_PRIORITY = +10000000  # +10M ~ 110 days
 DEFAULT_PRIORITY = 0
 HIGH_PRIORITY = -10000000  # -10M ~ 110 days
 HIGHER_PRIORITY = -20000000  # -20M ~ 220 days
@@ -75,7 +74,9 @@ def start_task(task_name):
               "if not next(val) then redis.call('zrem', ARGV[1], ARGV[3]) return nil \n"\
               "else redis.call('zincrby', ARGV[1], 1, ARGV[3]); redis.call('zremrangebyrank', ARGV[2], 0, 0) return val[1] end\n"
 
-        task = r.eval(lua, 3, 'active_set', 'queue', 'org', active_set, '%s:%d' % (task_name, int(org_queue[0])), org_queue[0])
+        task = r.eval(
+            lua, 3, 'active_set', 'queue', 'org', active_set, '%s:%d' % (task_name, int(org_queue[0])), org_queue[0]
+        )
 
         # found a task? then break out
         if task is not None:
@@ -125,6 +126,7 @@ def nonoverlapping_task(*task_args, **task_kwargs):
     """
     Decorator to create an task whose executions are prevented from overlapping by a redis lock
     """
+
     def _nonoverlapping_task(task_func):
         def wrapper(*exec_args, **exec_kwargs):
             r = get_redis_connection()
@@ -146,4 +148,5 @@ def nonoverlapping_task(*task_args, **task_kwargs):
                     task_func(*exec_args, **exec_kwargs)
 
         return shared_task(*task_args, **task_kwargs)(wrapper)
+
     return _nonoverlapping_task

--- a/temba/utils/templatetags/temba.py
+++ b/temba/utils/templatetags/temba.py
@@ -9,15 +9,13 @@ from ...campaigns.models import Campaign
 from ...flows.models import Flow
 from ...triggers.models import Trigger
 
-TIME_SINCE_CHUNKS = (
-    (60 * 60 * 24 * 365, ungettext_lazy('%d year', '%d years')),
-    (60 * 60 * 24 * 30, ungettext_lazy('%d month', '%d months')),
-    (60 * 60 * 24 * 7, ungettext_lazy('%d week', '%d weeks')),
-    (60 * 60 * 24, ungettext_lazy('%d day', '%d days')),
-    (60 * 60, ungettext_lazy('%d hour', '%d hours')),
-    (60, ungettext_lazy('%d minute', '%d minutes')),
-    (1, ungettext_lazy('%d second', '%d seconds'))
-)
+TIME_SINCE_CHUNKS = ((60 * 60 * 24 * 365,
+                      ungettext_lazy('%d year',
+                                     '%d years')), (60 * 60 * 24 * 30, ungettext_lazy('%d month', '%d months')),
+                     (60 * 60 * 24 * 7,
+                      ungettext_lazy('%d week', '%d weeks')), (60 * 60 * 24, ungettext_lazy('%d day', '%d days')),
+                     (60 * 60, ungettext_lazy('%d hour', '%d hours')), (60, ungettext_lazy('%d minute', '%d minutes')),
+                     (1, ungettext_lazy('%d second', '%d seconds')))
 
 
 @register.filter
@@ -130,7 +128,7 @@ def lessblock(parser, token):
     if len(args) != 1:  # pragma: no cover
         raise TemplateSyntaxError("lessblock tag takes no arguments, got: [%s]" % ",".join(args))
 
-    nodelist = parser.parse(('endlessblock',))
+    nodelist = parser.parse(('endlessblock', ))
     parser.delete_first_token()
     return LessBlockNode(nodelist)
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -49,40 +49,65 @@ from .voicexml import VoiceXMLException
 
 
 class InitTest(TembaTest):
-
     def test_decode_base64(self):
 
         self.assertEqual('This test\nhas a newline', decode_base64('This test\nhas a newline'))
 
-        self.assertEqual('Please vote NO on the confirmation of Gorsuch.',
-                         decode_base64('Please vote NO on the confirmation of Gorsuch.'))
+        self.assertEqual(
+            'Please vote NO on the confirmation of Gorsuch.',
+            decode_base64('Please vote NO on the confirmation of Gorsuch.')
+        )
 
         # length not multiple of 4
-        self.assertEqual('The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play)',
-                         decode_base64('The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play)'))
+        self.assertEqual(
+            'The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play)',
+            decode_base64(
+                'The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play)'
+            )
+        )
 
         # end not match base64 characteres
-        self.assertEqual('The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play) by a player discarding all of their cards!!???',
-                         decode_base64('The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play) by a player discarding all of their cards!!???'))
+        self.assertEqual(
+            'The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play) by a player discarding all of their cards!!???',
+            decode_base64(
+                'The aim of the game is to be the first player to score 500 points, achieved (usually over several rounds of play) by a player discarding all of their cards!!???'
+            )
+        )
 
-        self.assertEqual('Bannon Explains The World ...\n\u201cThe Camp of the Saints',
-                         decode_base64('QmFubm9uIEV4cGxhaW5zIFRoZSBXb3JsZCAuLi4K4oCcVGhlIENhbXAgb2YgdGhlIFNhaW50c+KA\r'))
+        self.assertEqual(
+            'Bannon Explains The World ...\n\u201cThe Camp of the Saints',
+            decode_base64('QmFubm9uIEV4cGxhaW5zIFRoZSBXb3JsZCAuLi4K4oCcVGhlIENhbXAgb2YgdGhlIFNhaW50c+KA\r')
+        )
 
-        self.assertEqual('the sweat, the tears and the sacrifice of working America',
-                         decode_base64('dGhlIHN3ZWF0LCB0aGUgdGVhcnMgYW5kIHRoZSBzYWNyaWZpY2Ugb2Ygd29ya2luZyBBbWVyaWNh\r'))
+        self.assertEqual(
+            'the sweat, the tears and the sacrifice of working America',
+            decode_base64('dGhlIHN3ZWF0LCB0aGUgdGVhcnMgYW5kIHRoZSBzYWNyaWZpY2Ugb2Ygd29ya2luZyBBbWVyaWNh\r')
+        )
 
-        self.assertIn('I find them to be friendly',
-                      decode_base64('Tm93IGlzDQp0aGUgdGltZQ0KZm9yIGFsbCBnb29kDQpwZW9wbGUgdG8NCnJlc2lzdC4NCg0KSG93IGFib3V0IGhhaWt1cz8NCkkgZmluZCB0aGVtIHRvIGJlIGZyaWVuZGx5Lg0KcmVmcmlnZXJhdG9yDQoNCjAxMjM0NTY3ODkNCiFAIyQlXiYqKCkgW117fS09Xys7JzoiLC4vPD4/fFx+YA0KQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg=='))
+        self.assertIn(
+            'I find them to be friendly',
+            decode_base64(
+                'Tm93IGlzDQp0aGUgdGltZQ0KZm9yIGFsbCBnb29kDQpwZW9wbGUgdG8NCnJlc2lzdC4NCg0KSG93IGFib3V0IGhhaWt1cz8NCkkgZmluZCB0aGVtIHRvIGJlIGZyaWVuZGx5Lg0KcmVmcmlnZXJhdG9yDQoNCjAxMjM0NTY3ODkNCiFAIyQlXiYqKCkgW117fS09Xys7JzoiLC4vPD4/fFx+YA0KQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg=='
+            )
+        )
 
         # not 50% ascii letters
-        self.assertEqual('8J+YgvCfmITwn5iA8J+YhvCfkY3wn5ii8J+Yn/CfmK3wn5it4pi677iP8J+YjPCfmInwn5iK8J+YivCfmIrwn5iK8J+YivCfmIrwn5iK8J+ko/CfpKPwn6Sj8J+ko/CfpKNvaw==',
-                         decode_base64('8J+YgvCfmITwn5iA8J+YhvCfkY3wn5ii8J+Yn/CfmK3wn5it4pi677iP8J+YjPCfmInwn5iK8J+YivCfmIrwn5iK8J+YivCfmIrwn5iK8J+ko/CfpKPwn6Sj8J+ko/CfpKNvaw=='))
+        self.assertEqual(
+            '8J+YgvCfmITwn5iA8J+YhvCfkY3wn5ii8J+Yn/CfmK3wn5it4pi677iP8J+YjPCfmInwn5iK8J+YivCfmIrwn5iK8J+YivCfmIrwn5iK8J+ko/CfpKPwn6Sj8J+ko/CfpKNvaw==',
+            decode_base64(
+                '8J+YgvCfmITwn5iA8J+YhvCfkY3wn5ii8J+Yn/CfmK3wn5it4pi677iP8J+YjPCfmInwn5iK8J+YivCfmIrwn5iK8J+YivCfmIrwn5iK8J+ko/CfpKPwn6Sj8J+ko/CfpKNvaw=='
+            )
+        )
 
         with patch('temba.utils.text.Counter') as mock_decode:
             mock_decode.side_effect = Exception('blah')
 
-            self.assertEqual('Tm93IGlzDQp0aGUgdGltZQ0KZm9yIGFsbCBnb29kDQpwZW9wbGUgdG8NCnJlc2lzdC4NCg0KSG93IGFib3V0IGhhaWt1cz8NCkkgZmluZCB0aGVtIHRvIGJlIGZyaWVuZGx5Lg0KcmVmcmlnZXJhdG9yDQoNCjAxMjM0NTY3ODkNCiFAIyQlXiYqKCkgW117fS09Xys7JzoiLC4vPD4/fFx+YA0KQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg==',
-                             decode_base64('Tm93IGlzDQp0aGUgdGltZQ0KZm9yIGFsbCBnb29kDQpwZW9wbGUgdG8NCnJlc2lzdC4NCg0KSG93IGFib3V0IGhhaWt1cz8NCkkgZmluZCB0aGVtIHRvIGJlIGZyaWVuZGx5Lg0KcmVmcmlnZXJhdG9yDQoNCjAxMjM0NTY3ODkNCiFAIyQlXiYqKCkgW117fS09Xys7JzoiLC4vPD4/fFx+YA0KQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg=='))
+            self.assertEqual(
+                'Tm93IGlzDQp0aGUgdGltZQ0KZm9yIGFsbCBnb29kDQpwZW9wbGUgdG8NCnJlc2lzdC4NCg0KSG93IGFib3V0IGhhaWt1cz8NCkkgZmluZCB0aGVtIHRvIGJlIGZyaWVuZGx5Lg0KcmVmcmlnZXJhdG9yDQoNCjAxMjM0NTY3ODkNCiFAIyQlXiYqKCkgW117fS09Xys7JzoiLC4vPD4/fFx+YA0KQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg==',
+                decode_base64(
+                    'Tm93IGlzDQp0aGUgdGltZQ0KZm9yIGFsbCBnb29kDQpwZW9wbGUgdG8NCnJlc2lzdC4NCg0KSG93IGFib3V0IGhhaWt1cz8NCkkgZmluZCB0aGVtIHRvIGJlIGZyaWVuZGx5Lg0KcmVmcmlnZXJhdG9yDQoNCjAxMjM0NTY3ODkNCiFAIyQlXiYqKCkgW117fS09Xys7JzoiLC4vPD4/fFx+YA0KQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg=='
+                )
+            )
 
     def test_datetime_to_ms(self):
         d1 = datetime.datetime(2014, 1, 2, 3, 4, 5, tzinfo=pytz.utc)
@@ -127,42 +152,57 @@ class InitTest(TembaTest):
             self.assertIsNone(str_to_datetime('', tz))  # empty string
             self.assertIsNone(str_to_datetime('xxx', tz))  # unparseable string
             self.assertIsNone(str_to_datetime('xxx', tz, fill_time=False))  # unparseable string
-            self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 3, 4, 5, 6)),
-                             str_to_datetime('01-02-2013', tz, dayfirst=True))  # day first
-            self.assertEqual(tz.localize(datetime.datetime(2013, 1, 2, 3, 4, 5, 6)),
-                             str_to_datetime('01-02-2013', tz, dayfirst=False))  # month first
-            self.assertEqual(tz.localize(datetime.datetime(2013, 1, 31, 3, 4, 5, 6)),
-                             str_to_datetime('01-31-2013', tz, dayfirst=True))  # impossible as day first
-            self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 7, 8, 5, 6)),
-                             str_to_datetime('01-02-2013 07:08', tz, dayfirst=True))  # hour and minute provided
-            self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 7, 8, 9, 100000)),
-                             str_to_datetime('01-02-2013 07:08:09.100000', tz, dayfirst=True))  # complete time provided
-            self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 0, 0, 0, 0)),
-                             str_to_datetime('01-02-2013', tz, dayfirst=True, fill_time=False))  # no time filling
+            self.assertEqual(
+                tz.localize(datetime.datetime(2013, 2, 1, 3, 4, 5, 6)),
+                str_to_datetime('01-02-2013', tz, dayfirst=True)
+            )  # day first
+            self.assertEqual(
+                tz.localize(datetime.datetime(2013, 1, 2, 3, 4, 5, 6)),
+                str_to_datetime('01-02-2013', tz, dayfirst=False)
+            )  # month first
+            self.assertEqual(
+                tz.localize(datetime.datetime(2013, 1, 31, 3, 4, 5, 6)),
+                str_to_datetime('01-31-2013', tz, dayfirst=True)
+            )  # impossible as day first
+            self.assertEqual(
+                tz.localize(datetime.datetime(2013, 2, 1, 7, 8, 5, 6)),
+                str_to_datetime('01-02-2013 07:08', tz, dayfirst=True)
+            )  # hour and minute provided
+            self.assertEqual(
+                tz.localize(datetime.datetime(2013, 2, 1, 7, 8, 9, 100000)),
+                str_to_datetime('01-02-2013 07:08:09.100000', tz, dayfirst=True)
+            )  # complete time provided
+            self.assertEqual(
+                tz.localize(datetime.datetime(2013, 2, 1, 0, 0, 0, 0)),
+                str_to_datetime('01-02-2013', tz, dayfirst=True, fill_time=False)
+            )  # no time filling
 
             # just year
-            self.assertEqual(datetime.datetime(123, 1, 2, 3, 4, 5, 6, tz),
-                             str_to_datetime('123', tz))
+            self.assertEqual(datetime.datetime(123, 1, 2, 3, 4, 5, 6, tz), str_to_datetime('123', tz))
 
         # localizing while in DST to something outside DST
         tz = pytz.timezone('US/Eastern')
         with patch.object(timezone, 'now', return_value=tz.localize(datetime.datetime(2029, 11, 1, 12, 30, 0, 0))):
             parsed = str_to_datetime('06-11-2029', tz, dayfirst=True)
-            self.assertEqual(tz.localize(datetime.datetime(2029, 11, 6, 12, 30, 0, 0)),
-                             parsed)
+            self.assertEqual(tz.localize(datetime.datetime(2029, 11, 6, 12, 30, 0, 0)), parsed)
 
             # assert there is no DST offset
             self.assertFalse(parsed.tzinfo.dst(parsed))
 
-            self.assertEqual(tz.localize(datetime.datetime(2029, 11, 6, 13, 45, 0, 0)),
-                             str_to_datetime('06-11-2029 13:45', tz, dayfirst=True))
+            self.assertEqual(
+                tz.localize(datetime.datetime(2029, 11, 6, 13, 45, 0, 0)),
+                str_to_datetime('06-11-2029 13:45', tz, dayfirst=True)
+            )
 
         # deal with datetimes that have timezone info
-        self.assertEqual(pytz.utc.localize(datetime.datetime(2016, 11, 21, 20, 36, 51, 215681)).astimezone(tz),
-                         str_to_datetime('2016-11-21T20:36:51.215681Z', tz))
+        self.assertEqual(
+            pytz.utc.localize(datetime.datetime(2016, 11, 21, 20, 36, 51, 215681)).astimezone(tz),
+            str_to_datetime('2016-11-21T20:36:51.215681Z', tz)
+        )
 
-        self.assertEqual(datetime.datetime(123, 1, 2, 5, 4, 5, 6, pytz.utc),
-                         str_to_datetime('123-1-2T5:4:5.000006Z', tz))
+        self.assertEqual(
+            datetime.datetime(123, 1, 2, 5, 4, 5, 6, pytz.utc), str_to_datetime('123-1-2T5:4:5.000006Z', tz)
+        )
 
     def test_str_to_time(self):
         tz = pytz.timezone('Asia/Kabul')
@@ -173,10 +213,12 @@ class InitTest(TembaTest):
             self.assertEqual(datetime.time(15, 4), str_to_time('3:04 PM'))  # as PM
 
     def test_date_to_utc_range(self):
-        self.assertEqual(date_to_utc_range(datetime.date(2017, 2, 20), self.org), (
-            datetime.datetime(2017, 2, 19, 22, 0, 0, 0, tzinfo=pytz.UTC),
-            datetime.datetime(2017, 2, 20, 22, 0, 0, 0, tzinfo=pytz.UTC)
-        ))
+        self.assertEqual(
+            date_to_utc_range(datetime.date(2017, 2, 20), self.org), (
+                datetime.datetime(2017, 2, 19, 22, 0, 0, 0, tzinfo=pytz.UTC),
+                datetime.datetime(2017, 2, 20, 22, 0, 0, 0, tzinfo=pytz.UTC)
+            )
+        )
 
     def test_str_to_bool(self):
         self.assertFalse(str_to_bool(None))
@@ -261,7 +303,6 @@ class TimezonesTest(TembaTest):
 
 
 class TemplateTagTest(TembaTest):
-
     def test_icon(self):
         from temba.campaigns.models import Campaign
         from temba.triggers.models import Trigger
@@ -270,7 +311,9 @@ class TemplateTagTest(TembaTest):
 
         campaign = Campaign.create(self.org, self.admin, 'Test Campaign', self.create_group('Test group', []))
         flow = Flow.create(self.org, self.admin, 'Test Flow')
-        trigger = Trigger.objects.create(org=self.org, keyword='trigger', flow=flow, created_by=self.admin, modified_by=self.admin)
+        trigger = Trigger.objects.create(
+            org=self.org, keyword='trigger', flow=flow, created_by=self.admin, modified_by=self.admin
+        )
 
         self.assertEqual('icon-instant', icon(campaign))
         self.assertEqual('icon-feed', icon(trigger))
@@ -334,7 +377,6 @@ class TemplateTagTest(TembaTest):
 
 
 class CacheTest(TembaTest):
-
     def test_get_cacheable_result(self):
         self.create_contact("Bob", number="1234")
 
@@ -414,7 +456,6 @@ class CacheTest(TembaTest):
 
 
 class EmailTest(TembaTest):
-
     @override_settings(SEND_EMAILS=True)
     def test_send_simple_email(self):
         send_simple_email(['recipient@bar.com'], "Test Subject", "Test Body")
@@ -450,7 +491,6 @@ class EmailTest(TembaTest):
             '" "@example.org',
             'example@localhost',
             'example@s.solutions',
-
 
             # Cases from Django tests
             'email@here.com',
@@ -533,7 +573,6 @@ class EmailTest(TembaTest):
 
 
 class JsonTest(TembaTest):
-
     def test_encode_decode(self):
         # create a time that has a set millisecond
         now = timezone.now().replace(microsecond=1000)
@@ -572,7 +611,6 @@ class JsonTest(TembaTest):
 
 
 class QueueTest(TembaTest):
-
     def test_queueing(self):
         r = get_redis_connection()
 
@@ -734,7 +772,6 @@ class QueueTest(TembaTest):
 
 
 class ExpressionsTest(TembaTest):
-
     def setUp(self):
         super(ExpressionsTest, self).setUp()
 
@@ -744,16 +781,18 @@ class ExpressionsTest(TembaTest):
 
         variables = dict()
         variables['contact'] = contact.build_expressions_context()
-        variables['flow'] = dict(water_source="Well",     # key with underscore
-                                 blank="",                # blank string
-                                 arabic="اثنين ثلاثة",    # RTL chars
-                                 english="two three",     # LTR chars
-                                 urlstuff=' =&\u0628',    # stuff that needs URL encoding
-                                 users=5,                 # numeric as int
-                                 count="5",               # numeric as string
-                                 average=2.5,             # numeric as float
-                                 joined=datetime.datetime(2014, 12, 1, 9, 0, 0, 0, timezone.utc),  # date as datetime
-                                 started="1/12/14 9:00")  # date as string
+        variables['flow'] = dict(
+            water_source="Well",  # key with underscore
+            blank="",  # blank string
+            arabic="اثنين ثلاثة",  # RTL chars
+            english="two three",  # LTR chars
+            urlstuff=' =&\u0628',  # stuff that needs URL encoding
+            users=5,  # numeric as int
+            count="5",  # numeric as string
+            average=2.5,  # numeric as float
+            joined=datetime.datetime(2014, 12, 1, 9, 0, 0, 0, timezone.utc),  # date as datetime
+            started="1/12/14 9:00"
+        )  # date as string
 
         self.context = EvaluationContext(variables, timezone.utc, DateStyle.DAY_FIRST)
 
@@ -761,18 +800,19 @@ class ExpressionsTest(TembaTest):
         self.assertEqual(("Hello World", []), evaluate_template('Hello World', self.context))  # no expressions
         self.assertEqual(("Hello = Well 5", []),
                          evaluate_template("Hello = @(flow.water_source) @flow.users", self.context))
-        self.assertEqual(("xxJoexx", []),
-                         evaluate_template("xx@(contact.first_name)xx", self.context))  # no whitespace
-        self.assertEqual(('Hello "World"', []),
-                         evaluate_template('@( "Hello ""World""" )', self.context))  # string with escaping
-        self.assertEqual(("Hello World", []),
-                         evaluate_template('@( "Hello" & " " & "World" )', self.context))  # string concatenation
-        self.assertEqual(('("', []),
-                         evaluate_template('@("(" & """")', self.context))  # string literals containing delimiters
-        self.assertEqual(('Joe Blow and Joe Blow', []),
-                         evaluate_template('@contact and @(contact)', self.context))  # old and new style
+        self.assertEqual(("xxJoexx", []), evaluate_template("xx@(contact.first_name)xx",
+                                                            self.context))  # no whitespace
+        self.assertEqual(('Hello "World"', []), evaluate_template('@( "Hello ""World""" )',
+                                                                  self.context))  # string with escaping
+        self.assertEqual(("Hello World", []), evaluate_template('@( "Hello" & " " & "World" )',
+                                                                self.context))  # string concatenation
+        self.assertEqual(('("', []), evaluate_template('@("(" & """")',
+                                                       self.context))  # string literals containing delimiters
+        self.assertEqual(('Joe Blow and Joe Blow', []), evaluate_template('@contact and @(contact)',
+                                                                          self.context))  # old and new style
         self.assertEqual(("Joe Blow language is set to 'eng'", []),
-                         evaluate_template("@contact language is set to '@contact.language'", self.context))  # language
+                         evaluate_template("@contact language is set to '@contact.language'",
+                                           self.context))  # language
 
         # test LTR and RTL mixing
         self.assertEqual(("one two three four", []),
@@ -785,28 +825,21 @@ class ExpressionsTest(TembaTest):
                          evaluate_template("واحد @flow.english أربعة", self.context))  # LTR var, LTR value, RTL text
 
         # test decimal arithmetic
-        self.assertEqual(("Result: 7", []),
-                         evaluate_template("Result: @(flow.users + 2)",
-                                           self.context))  # var is int
-        self.assertEqual(("Result: 0", []),
-                         evaluate_template("Result: @(flow.count - 5)",
-                                           self.context))  # var is string
-        self.assertEqual(("Result: 0.5", []),
-                         evaluate_template("Result: @(5 / (flow.users * 2))",
-                                           self.context))  # result is decimal
-        self.assertEqual(("Result: -10", []),
-                         evaluate_template("Result: @(-5 - flow.users)", self.context))  # negatives
+        self.assertEqual(("Result: 7", []), evaluate_template("Result: @(flow.users + 2)", self.context))  # var is int
+        self.assertEqual(("Result: 0", []), evaluate_template("Result: @(flow.count - 5)",
+                                                              self.context))  # var is string
+        self.assertEqual(("Result: 0.5", []), evaluate_template("Result: @(5 / (flow.users * 2))",
+                                                                self.context))  # result is decimal
+        self.assertEqual(("Result: -10", []), evaluate_template("Result: @(-5 - flow.users)",
+                                                                self.context))  # negatives
 
         # test date arithmetic
-        self.assertEqual(("Date: 02-12-2014 09:00", []),
-                         evaluate_template("Date: @(flow.joined + 1)",
-                                           self.context))  # var is datetime
-        self.assertEqual(("Date: 28-11-2014 09:00", []),
-                         evaluate_template("Date: @(flow.started - 3)",
-                                           self.context))  # var is string
-        self.assertEqual(("Date: 04-07-2014", []),
-                         evaluate_template("Date: @(DATE(2014, 7, 1) + 3)",
-                                           self.context))  # date constructor
+        self.assertEqual(("Date: 02-12-2014 09:00", []), evaluate_template("Date: @(flow.joined + 1)",
+                                                                           self.context))  # var is datetime
+        self.assertEqual(("Date: 28-11-2014 09:00", []), evaluate_template("Date: @(flow.started - 3)",
+                                                                           self.context))  # var is string
+        self.assertEqual(("Date: 04-07-2014", []), evaluate_template("Date: @(DATE(2014, 7, 1) + 3)",
+                                                                     self.context))  # date constructor
         self.assertEqual(("Date: 01-12-2014 11:30", []),
                          evaluate_template("Date: @(flow.joined + TIME(2, 30, 0))",
                                            self.context))  # time addition to datetime var
@@ -815,26 +848,21 @@ class ExpressionsTest(TembaTest):
                                            self.context))  # time subtraction from string var
 
         # test function calls
-        self.assertEqual(("Hello joe", []),
-                         evaluate_template("Hello @(lower(contact.first_name))",
-                                           self.context))  # use lowercase for function name
-        self.assertEqual(("Hello JOE", []),
-                         evaluate_template("Hello @(UPPER(contact.first_name))",
-                                           self.context))  # use uppercase for function name
+        self.assertEqual(("Hello joe", []), evaluate_template("Hello @(lower(contact.first_name))",
+                                                              self.context))  # use lowercase for function name
+        self.assertEqual(("Hello JOE", []), evaluate_template("Hello @(UPPER(contact.first_name))",
+                                                              self.context))  # use uppercase for function name
         self.assertEqual(("Bonjour world", []),
                          evaluate_template('@(SUBSTITUTE("Hello world", "Hello", "Bonjour"))',
                                            self.context))  # string arguments
         self.assertRegex(evaluate_template('Today is @(TODAY())', self.context)[0],
                          'Today is \d\d-\d\d-\d\d\d\d')  # function with no args
-        self.assertEqual(('3', []),
-                         evaluate_template('@(LEN( 1.2 ))',
-                                           self.context))  # auto decimal -> string conversion
-        self.assertEqual(('16', []),
-                         evaluate_template('@(LEN(flow.joined))',
-                                           self.context))  # auto datetime -> string conversion
-        self.assertEqual(('2', []),
-                         evaluate_template('@(WORD_COUNT("abc-def", FALSE))',
-                                           self.context))  # built-in variable
+        self.assertEqual(('3', []), evaluate_template('@(LEN( 1.2 ))',
+                                                      self.context))  # auto decimal -> string conversion
+        self.assertEqual(('16', []), evaluate_template('@(LEN(flow.joined))',
+                                                       self.context))  # auto datetime -> string conversion
+        self.assertEqual(('2', []), evaluate_template('@(WORD_COUNT("abc-def", FALSE))',
+                                                      self.context))  # built-in variable
         self.assertEqual(('TRUE', []),
                          evaluate_template('@(OR(AND(True, flow.count = flow.users, 1), 0))',
                                            self.context))  # booleans / varargs
@@ -844,70 +872,61 @@ class ExpressionsTest(TembaTest):
 
         # evaluation errors
         self.assertEqual(("Error: @()", ["Expression error at: )"]),
-                         evaluate_template("Error: @()",
-                                           self.context))  # syntax error due to empty expression
+                         evaluate_template("Error: @()", self.context))  # syntax error due to empty expression
         self.assertEqual(("Error: @('2')", ["Expression error at: '"]),
                          evaluate_template("Error: @('2')",
                                            self.context))  # don't support single quote string literals
         self.assertEqual(("Error: @(2 / 0)", ["Division by zero"]),
-                         evaluate_template("Error: @(2 / 0)",
-                                           self.context))  # division by zero
-        self.assertEqual(("Error: @(1 + flow.blank)", ["Expression could not be evaluated as decimal or date arithmetic"]),
-                         evaluate_template("Error: @(1 + flow.blank)",
-                                           self.context))  # string that isn't numeric
+                         evaluate_template("Error: @(2 / 0)", self.context))  # division by zero
+        self.assertEqual(
+            ("Error: @(1 + flow.blank)", ["Expression could not be evaluated as decimal or date arithmetic"]),
+            evaluate_template("Error: @(1 + flow.blank)", self.context)
+        )  # string that isn't numeric
         self.assertEqual(("Well @flow.boil", ["Undefined variable: flow.boil"]),
-                         evaluate_template("@flow.water_source @flow.boil",
-                                           self.context))  # undefined variables
+                         evaluate_template("@flow.water_source @flow.boil", self.context))  # undefined variables
         self.assertEqual(("Hello @(XXX(1, 2))", ["Undefined function: XXX"]),
-                         evaluate_template("Hello @(XXX(1, 2))",
-                                           self.context))  # undefined function
+                         evaluate_template("Hello @(XXX(1, 2))", self.context))  # undefined function
         self.assertEqual(('Hello @(ABS(1, "x", TRUE))', ["Too many arguments provided for function ABS"]),
-                         evaluate_template('Hello @(ABS(1, "x", TRUE))',
-                                           self.context))  # wrong number of args
+                         evaluate_template('Hello @(ABS(1, "x", TRUE))', self.context))  # wrong number of args
         self.assertEqual(('Hello @(REPT(flow.blank, -2))', ['Error calling function REPT with arguments "", -2']),
-                         evaluate_template('Hello @(REPT(flow.blank, -2))',
-                                           self.context))  # internal function error
+                         evaluate_template('Hello @(REPT(flow.blank, -2))', self.context))  # internal function error
 
     def test_evaluate_template_compat(self):
         # test old style expressions, i.e. @ and with filters
         self.assertEqual(("Hello World Joe Joe", []),
                          evaluate_template_compat("Hello World @contact.first_name @contact.first_name", self.context))
-        self.assertEqual(("Hello World Joe Blow", []),
-                         evaluate_template_compat("Hello World @contact", self.context))
+        self.assertEqual(("Hello World Joe Blow", []), evaluate_template_compat("Hello World @contact", self.context))
         self.assertEqual(("Hello World: Well", []),
                          evaluate_template_compat("Hello World: @flow.water_source", self.context))
-        self.assertEqual(("Hello World: ", []),
-                         evaluate_template_compat("Hello World: @flow.blank", self.context))
+        self.assertEqual(("Hello World: ", []), evaluate_template_compat("Hello World: @flow.blank", self.context))
         self.assertEqual(("Hello اثنين ثلاثة thanks", []),
                          evaluate_template_compat("Hello @flow.arabic thanks", self.context))
-        self.assertEqual((' %20%3D%26%D8%A8 ', []),
-                         evaluate_template_compat(' @flow.urlstuff ', self.context, True))  # url encoding enabled
+        self.assertEqual((' %20%3D%26%D8%A8 ', []), evaluate_template_compat(' @flow.urlstuff ', self.context,
+                                                                             True))  # url encoding enabled
         self.assertEqual(("Hello Joe", []),
                          evaluate_template_compat("Hello @contact.first_name|notthere", self.context))
         self.assertEqual(("Hello joe", []),
                          evaluate_template_compat("Hello @contact.first_name|lower_case", self.context))
         self.assertEqual(("Hello Joe", []),
                          evaluate_template_compat("Hello @contact.first_name|lower_case|capitalize", self.context))
-        self.assertEqual(("Hello Joe", []),
-                         evaluate_template_compat("Hello @contact|first_word", self.context))
+        self.assertEqual(("Hello Joe", []), evaluate_template_compat("Hello @contact|first_word", self.context))
         self.assertEqual(("Hello Blow", []),
                          evaluate_template_compat("Hello @contact|remove_first_word|title_case", self.context))
-        self.assertEqual(("Hello Joe Blow", []),
-                         evaluate_template_compat("Hello @contact|title_case", self.context))
+        self.assertEqual(("Hello Joe Blow", []), evaluate_template_compat("Hello @contact|title_case", self.context))
         self.assertEqual(("Hello JOE", []),
                          evaluate_template_compat("Hello @contact.first_name|upper_case", self.context))
         self.assertEqual(("Hello Joe from info@example.com", []),
                          evaluate_template_compat("Hello @contact.first_name from info@example.com", self.context))
-        self.assertEqual(("Joe", []),
-                         evaluate_template_compat("@contact.first_name", self.context))
-        self.assertEqual(("foo@nicpottier.com", []),
-                         evaluate_template_compat("foo@nicpottier.com", self.context))
+        self.assertEqual(("Joe", []), evaluate_template_compat("@contact.first_name", self.context))
+        self.assertEqual(("foo@nicpottier.com", []), evaluate_template_compat("foo@nicpottier.com", self.context))
         self.assertEqual(("@nicpottier is on twitter", []),
                          evaluate_template_compat("@nicpottier is on twitter", self.context))
 
     def test_migrate_template(self):
-        self.assertEqual(migrate_template("Hi @contact.name|upper_case|capitalize from @flow.chw|lower_case"),
-                         "Hi @(PROPER(UPPER(contact.name))) from @(LOWER(flow.chw))")
+        self.assertEqual(
+            migrate_template("Hi @contact.name|upper_case|capitalize from @flow.chw|lower_case"),
+            "Hi @(PROPER(UPPER(contact.name))) from @(LOWER(flow.chw))"
+        )
         self.assertEqual(migrate_template('Hi @date.now|time_delta:"1"'), "Hi @(date.now + 1)")
         self.assertEqual(migrate_template('Hi @date.now|time_delta:"-3"'), "Hi @(date.now - 3)")
 
@@ -917,7 +936,10 @@ class ExpressionsTest(TembaTest):
         self.assertEqual(migrate_template('Hi =LEN("@=")'), 'Hi @(LEN("@="))')
 
         # handle @ expressions embedded inside = expressions, with optional surrounding quotes
-        self.assertEqual(migrate_template('=AND("Malkapur"= "@flow.stuff.category", 13 = @extra.Depar_city|upper_case)'), '@(AND("Malkapur"= flow.stuff.category, 13 = UPPER(extra.Depar_city)))')
+        self.assertEqual(
+            migrate_template('=AND("Malkapur"= "@flow.stuff.category", 13 = @extra.Depar_city|upper_case)'),
+            '@(AND("Malkapur"= flow.stuff.category, 13 = UPPER(extra.Depar_city)))'
+        )
 
         # don't convert unnecessarily
         self.assertEqual(migrate_template("Hi @contact.name from @flow.chw"), "Hi @contact.name from @flow.chw")
@@ -927,58 +949,62 @@ class ExpressionsTest(TembaTest):
 
     def test_get_function_listing(self):
         listing = get_function_listing()
-        self.assertEqual(listing[0], {
-            'signature': 'ABS(number)',
-            'name': 'ABS',
-            'display': "Returns the absolute value of a number"
-        })
+        self.assertEqual(
+            listing[0], {
+                'signature': 'ABS(number)',
+                'name': 'ABS',
+                'display': "Returns the absolute value of a number"
+            }
+        )
 
     def test_build_function_signature(self):
-        self.assertEqual('ABS()',
-                         _build_function_signature(dict(name='ABS',
-                                                        params=[])))
+        self.assertEqual('ABS()', _build_function_signature(dict(name='ABS', params=[])))
 
-        self.assertEqual('ABS(number)',
-                         _build_function_signature(dict(name='ABS',
-                                                        params=[dict(optional=False,
-                                                                     name='number',
-                                                                     vararg=False)])))
+        self.assertEqual(
+            'ABS(number)',
+            _build_function_signature(dict(name='ABS', params=[dict(optional=False, name='number', vararg=False)]))
+        )
 
-        self.assertEqual('ABS(number, ...)',
-                         _build_function_signature(dict(name='ABS',
-                                                        params=[dict(optional=False,
-                                                                     name='number',
-                                                                     vararg=True)])))
+        self.assertEqual(
+            'ABS(number, ...)',
+            _build_function_signature(dict(name='ABS', params=[dict(optional=False, name='number', vararg=True)]))
+        )
 
-        self.assertEqual('ABS([number])',
-                         _build_function_signature(dict(name='ABS',
-                                                        params=[dict(optional=True,
-                                                                     name='number',
-                                                                     vararg=False)])))
+        self.assertEqual(
+            'ABS([number])',
+            _build_function_signature(dict(name='ABS', params=[dict(optional=True, name='number', vararg=False)]))
+        )
 
-        self.assertEqual('ABS([number], ...)',
-                         _build_function_signature(dict(name='ABS',
-                                                        params=[dict(optional=True,
-                                                                     name='number',
-                                                                     vararg=True)])))
+        self.assertEqual(
+            'ABS([number], ...)',
+            _build_function_signature(dict(name='ABS', params=[dict(optional=True, name='number', vararg=True)]))
+        )
 
-        self.assertEqual('MOD(number, divisor)',
-                         _build_function_signature(dict(name='MOD',
-                                                        params=[dict(optional=False,
-                                                                     name='number',
-                                                                     vararg=False),
-                                                                dict(optional=False,
-                                                                     name='divisor',
-                                                                     vararg=False)])))
+        self.assertEqual(
+            'MOD(number, divisor)',
+            _build_function_signature(
+                dict(
+                    name='MOD',
+                    params=[
+                        dict(optional=False, name='number', vararg=False),
+                        dict(optional=False, name='divisor', vararg=False)
+                    ]
+                )
+            )
+        )
 
-        self.assertEqual('MOD(number, ..., divisor)',
-                         _build_function_signature(dict(name='MOD',
-                                                        params=[dict(optional=False,
-                                                                     name='number',
-                                                                     vararg=True),
-                                                                dict(optional=False,
-                                                                     name='divisor',
-                                                                     vararg=False)])))
+        self.assertEqual(
+            'MOD(number, ..., divisor)',
+            _build_function_signature(
+                dict(
+                    name='MOD',
+                    params=[
+                        dict(optional=False, name='number', vararg=True),
+                        dict(optional=False, name='divisor', vararg=False)
+                    ]
+                )
+            )
+        )
 
     def test_percentage(self):
         self.assertEqual(0, percentage(0, 100))
@@ -989,7 +1015,6 @@ class ExpressionsTest(TembaTest):
 
 
 class GSM7Test(TembaTest):
-
     def test_is_gsm7(self):
         self.assertTrue(is_gsm7("Hello World! {} <>"))
         self.assertFalse(is_gsm7("No capital accented È!"))
@@ -1034,7 +1059,6 @@ class GSM7Test(TembaTest):
 
 
 class ChunkTest(TembaTest):
-
     def test_chunking(self):
         curr = 0
         for chunk in chunk_list(six.moves.xrange(100), 7):
@@ -1057,8 +1081,9 @@ class ExportTest(TembaTest):
         super(ExportTest, self).setUp()
 
         self.group = self.create_group("New contacts", [])
-        self.task = ExportContactsTask.objects.create(org=self.org, group=self.group,
-                                                      created_by=self.admin, modified_by=self.admin)
+        self.task = ExportContactsTask.objects.create(
+            org=self.org, group=self.group, created_by=self.admin, modified_by=self.admin
+        )
 
     def test_prepare_value(self):
         self.assertEqual(self.task.prepare_value(None), '')
@@ -1075,8 +1100,9 @@ class ExportTest(TembaTest):
 
         self.assertEqual(self.task.status, ExportContactsTask.STATUS_COMPLETE)
 
-        task2 = ExportContactsTask.objects.create(org=self.org, group=self.group,
-                                                  created_by=self.admin, modified_by=self.admin)
+        task2 = ExportContactsTask.objects.create(
+            org=self.org, group=self.group, created_by=self.admin, modified_by=self.admin
+        )
 
         # if task throws exception, will be marked as failed
         with patch.object(task2, 'write_export') as mock_write_export:
@@ -1174,7 +1200,6 @@ class ExportTest(TembaTest):
 
 
 class CurrencyTest(TembaTest):
-
     def test_currencies(self):
 
         self.assertEqual(currency_for_country('US').alpha_3, 'USD')
@@ -1192,7 +1217,6 @@ class CurrencyTest(TembaTest):
 
 
 class VoiceXMLTest(TembaTest):
-
     def test_context_managers(self):
         response = voicexml.VXMLResponse()
         self.assertEqual(response, response.__enter__())
@@ -1201,12 +1225,14 @@ class VoiceXMLTest(TembaTest):
     def test_response(self):
         response = voicexml.VXMLResponse()
         self.assertEqual(response.document, '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>')
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form></form></vxml>'
+        )
 
         response.document += '</form></vxml>'
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form></form></vxml>'
+        )
 
     def test_join(self):
         response1 = voicexml.VXMLResponse()
@@ -1216,16 +1242,19 @@ class VoiceXMLTest(TembaTest):
         response2.document += 'Hey '
 
         # the content of response2 should be prepended before the content of response1
-        self.assertEqual(six.text_type(response1.join(response2)),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>Hey Allo </form></vxml>')
+        self.assertEqual(
+            six.text_type(response1.join(response2)),
+            '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>Hey Allo </form></vxml>'
+        )
 
     def test_say(self):
         response = voicexml.VXMLResponse()
         response.say('Hello')
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<block><prompt>Hello</prompt></block></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<block><prompt>Hello</prompt></block></form></vxml>'
+        )
 
     def test_play(self):
         response = voicexml.VXMLResponse()
@@ -1234,104 +1263,117 @@ class VoiceXMLTest(TembaTest):
             response.play()
 
         response.play(digits='123')
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<block><prompt>123</prompt></block></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<block><prompt>123</prompt></block></form></vxml>'
+        )
 
         response = voicexml.VXMLResponse()
         response.play(url='http://example.com/audio.wav')
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<block><prompt><audio src="http://example.com/audio.wav" /></prompt></block></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<block><prompt><audio src="http://example.com/audio.wav" /></prompt></block></form></vxml>'
+        )
 
     def test_pause(self):
         response = voicexml.VXMLResponse()
 
         response.pause()
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<block><prompt><break /></prompt></block></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<block><prompt><break /></prompt></block></form></vxml>'
+        )
 
         response = voicexml.VXMLResponse()
 
         response.pause(length=40)
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<block><prompt><break time="40s"/></prompt></block></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<block><prompt><break time="40s"/></prompt></block></form></vxml>'
+        )
 
     def test_redirect(self):
         response = voicexml.VXMLResponse()
         response.redirect('http://example.com/')
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<subdialog src="http://example.com/" ></subdialog></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<subdialog src="http://example.com/" ></subdialog></form></vxml>'
+        )
 
     def test_hangup(self):
         response = voicexml.VXMLResponse()
         response.hangup()
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form><exit /></form></vxml>')
+        self.assertEqual(
+            six.text_type(response),
+            '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form><exit /></form></vxml>'
+        )
 
     def test_reject(self):
         response = voicexml.VXMLResponse()
         response.reject(reason='some')
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form><exit /></form></vxml>')
+        self.assertEqual(
+            six.text_type(response),
+            '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form><exit /></form></vxml>'
+        )
 
     def test_gather(self):
         response = voicexml.VXMLResponse()
         response.gather()
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<field name="Digits"><grammar termchar="#" src="builtin:dtmf/digits" />'
-                         '</field></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<field name="Digits"><grammar termchar="#" src="builtin:dtmf/digits" />'
+            '</field></form></vxml>'
+        )
 
         response = voicexml.VXMLResponse()
         response.gather(action='http://example.com')
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<field name="Digits"><grammar termchar="#" src="builtin:dtmf/digits" />'
-                         '<nomatch><submit next="http://example.com?empty=1" method="post" /></nomatch></field>'
-                         '<filled><submit next="http://example.com" method="post" /></filled></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<field name="Digits"><grammar termchar="#" src="builtin:dtmf/digits" />'
+            '<nomatch><submit next="http://example.com?empty=1" method="post" /></nomatch></field>'
+            '<filled><submit next="http://example.com" method="post" /></filled></form></vxml>'
+        )
 
         response = voicexml.VXMLResponse()
         response.gather(action='http://example.com', numDigits=1, timeout=45, finishOnKey='*')
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<field name="Digits"><grammar termtimeout="45s" timeout="45s" termchar="*" '
-                         'src="builtin:dtmf/digits?minlength=1;maxlength=1" />'
-                         '<nomatch><submit next="http://example.com?empty=1" method="post" /></nomatch></field>'
-                         '<filled><submit next="http://example.com" method="post" /></filled></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<field name="Digits"><grammar termtimeout="45s" timeout="45s" termchar="*" '
+            'src="builtin:dtmf/digits?minlength=1;maxlength=1" />'
+            '<nomatch><submit next="http://example.com?empty=1" method="post" /></nomatch></field>'
+            '<filled><submit next="http://example.com" method="post" /></filled></form></vxml>'
+        )
 
     def test_record(self):
         response = voicexml.VXMLResponse()
         response.record()
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<record name="UserRecording" beep="true" finalsilence="4000ms" '
-                         'dtmfterm="true" type="audio/x-wav"></record></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<record name="UserRecording" beep="true" finalsilence="4000ms" '
+            'dtmfterm="true" type="audio/x-wav"></record></form></vxml>'
+        )
 
         response = voicexml.VXMLResponse()
         response.record(action="http://example.com", method="post", maxLength=60)
 
-        self.assertEqual(six.text_type(response),
-                         '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
-                         '<record name="UserRecording" beep="true" maxtime="60s" finalsilence="4000ms" '
-                         'dtmfterm="true" type="audio/x-wav">'
-                         '<filled><submit next="http://example.com" method="post" '
-                         'enctype="multipart/form-data" /></filled></record></form></vxml>')
+        self.assertEqual(
+            six.text_type(response), '<?xml version="1.0" encoding="UTF-8"?><vxml version = "2.1"><form>'
+            '<record name="UserRecording" beep="true" maxtime="60s" finalsilence="4000ms" '
+            'dtmfterm="true" type="audio/x-wav">'
+            '<filled><submit next="http://example.com" method="post" '
+            'enctype="multipart/form-data" /></filled></record></form></vxml>'
+        )
 
 
 class NCCOTest(TembaTest):
-
     def test_context_managers(self):
         response = NCCOResponse()
         self.assertEqual(response, response.__enter__())
@@ -1350,7 +1392,10 @@ class NCCOTest(TembaTest):
         response2.document.append(dict(action='bar'))
 
         # the content of response2 should be prepended before the content of response1
-        self.assertEqual(json.loads(six.text_type(response1.join(response2))), [dict(action='bar'), dict(action='foo')])
+        self.assertEqual(
+            json.loads(six.text_type(response1.join(response2))),
+            [dict(action='bar'), dict(action='foo')]
+        )
 
     def test_say(self):
         response = NCCOResponse()
@@ -1370,36 +1415,43 @@ class NCCOTest(TembaTest):
         response = NCCOResponse()
         response.play(url='http://example.com/audio.wav')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='stream', bargeIn=False,
-                                                                    streamUrl=['http://example.com/audio.wav'])])
+        self.assertEqual(
+            json.loads(six.text_type(response)),
+            [dict(action='stream', bargeIn=False, streamUrl=['http://example.com/audio.wav'])]
+        )
 
         response = NCCOResponse()
         response.play(url='http://example.com/audio.wav', digits='123')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='stream', bargeIn=False,
-                                                                    streamUrl=['http://example.com/audio.wav'])])
+        self.assertEqual(
+            json.loads(six.text_type(response)),
+            [dict(action='stream', bargeIn=False, streamUrl=['http://example.com/audio.wav'])]
+        )
 
     def test_bargeIn(self):
         response = NCCOResponse()
         response.say('Hello')
         response.redirect('http://example.com/')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='talk', text='Hello', bargeIn=True),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        "%s?input_redirect=1" % 'http://example.com/'
-                                                                    ])])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(action='talk', text='Hello', bargeIn=True),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?input_redirect=1" % 'http://example.com/'])
+            ]
+        )
 
         response = NCCOResponse()
         response.say('Hello')
         response.redirect('http://example.com/')
         response.say('Goodbye')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='talk', text='Hello', bargeIn=True),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        "%s?input_redirect=1" % 'http://example.com/']),
-                                                               dict(action='talk', text='Goodbye', bargeIn=False)])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(action='talk', text='Hello', bargeIn=True),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?input_redirect=1" % 'http://example.com/']),
+                dict(action='talk', text='Goodbye', bargeIn=False)
+            ]
+        )
 
         response = NCCOResponse()
         response.say('Hello')
@@ -1412,38 +1464,42 @@ class NCCOTest(TembaTest):
         response.redirect('http://example.com/')
         response.say('Bye')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='talk', text='Hello', bargeIn=True),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        "%s?input_redirect=1" % 'http://example.com/']),
-                                                               dict(action='talk', text='Please make a recording',
-                                                                    bargeIn=False),
-                                                               dict(format='wav', eventMethod='post',
-                                                                    eventUrl=['http://example.com'],
-                                                                    endOnSilence=4, timeOut=60, endOnKey='#',
-                                                                    action='record', beepStart=True),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        "%s?save_media=1" % "http://example.com"]),
-                                                               dict(action='talk', text='Thanks', bargeIn=False),
-                                                               dict(action='talk', text='Allo', bargeIn=False),
-                                                               dict(action='talk', text='Cool', bargeIn=True),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        "%s?input_redirect=1" % 'http://example.com/']),
-                                                               dict(action='talk', text='Bye', bargeIn=False)])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(action='talk', text='Hello', bargeIn=True),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?input_redirect=1" % 'http://example.com/']),
+                dict(action='talk', text='Please make a recording', bargeIn=False),
+                dict(
+                    format='wav',
+                    eventMethod='post',
+                    eventUrl=['http://example.com'],
+                    endOnSilence=4,
+                    timeOut=60,
+                    endOnKey='#',
+                    action='record',
+                    beepStart=True
+                ),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?save_media=1" % "http://example.com"]),
+                dict(action='talk', text='Thanks', bargeIn=False),
+                dict(action='talk', text='Allo', bargeIn=False),
+                dict(action='talk', text='Cool', bargeIn=True),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?input_redirect=1" % 'http://example.com/']),
+                dict(action='talk', text='Bye', bargeIn=False)
+            ]
+        )
 
         response = NCCOResponse()
         response.play(url='http://example.com/audio.wav')
         response.redirect('http://example.com/')
         response.say('Goodbye')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='stream', bargeIn=True,
-                                                                    streamUrl=['http://example.com/audio.wav']),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        "%s?input_redirect=1" % 'http://example.com/']),
-                                                               dict(action='talk', text='Goodbye', bargeIn=False)])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(action='stream', bargeIn=True, streamUrl=['http://example.com/audio.wav']),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?input_redirect=1" % 'http://example.com/']),
+                dict(action='talk', text='Goodbye', bargeIn=False)
+            ]
+        )
 
     def test_pause(self):
         response = NCCOResponse()
@@ -1453,18 +1509,18 @@ class NCCOTest(TembaTest):
         response = NCCOResponse()
         response.redirect('http://example.com/')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        "%s?input_redirect=1" % 'http://example.com/'
-                                                                    ])])
+        self.assertEqual(
+            json.loads(six.text_type(response)),
+            [dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?input_redirect=1" % 'http://example.com/'])]
+        )
 
         response = NCCOResponse()
         response.redirect('http://example.com/?param=12')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=[
-                                                                        'http://example.com/?param=12&input_redirect=1'
-                                                                    ])])
+        self.assertEqual(
+            json.loads(six.text_type(response)),
+            [dict(action='input', maxDigits=1, timeOut=1, eventUrl=['http://example.com/?param=12&input_redirect=1'])]
+        )
 
     def test_hangup(self):
         response = NCCOResponse()
@@ -1483,52 +1539,77 @@ class NCCOTest(TembaTest):
         response = NCCOResponse()
         response.gather(action='http://example.com')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(eventMethod='post', action='input',
-                                                                    submitOnHash=True,
-                                                                    eventUrl=['http://example.com'])])
+        self.assertEqual(
+            json.loads(six.text_type(response)),
+            [dict(eventMethod='post', action='input', submitOnHash=True, eventUrl=['http://example.com'])]
+        )
 
         response = NCCOResponse()
         response.gather(action='http://example.com', numDigits=1, timeout=45, finishOnKey='*')
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(maxDigits=1, eventMethod='post', action='input',
-                                                                    submitOnHash=False,
-                                                                    eventUrl=['http://example.com'],
-                                                                    timeOut=45)])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(
+                    maxDigits=1,
+                    eventMethod='post',
+                    action='input',
+                    submitOnHash=False,
+                    eventUrl=['http://example.com'],
+                    timeOut=45
+                )
+            ]
+        )
 
     def test_record(self):
         response = NCCOResponse()
         response.record()
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(format='wav', endOnSilence=4, beepStart=True,
-                                                                    action='record', endOnKey='#'),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=["None?save_media=1"])
-                                                               ])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(format='wav', endOnSilence=4, beepStart=True, action='record', endOnKey='#'),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["None?save_media=1"])
+            ]
+        )
 
         response = NCCOResponse()
         response.record(action="http://example.com", method="post", maxLength=60)
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(format='wav', eventMethod='post',
-                                                                    eventUrl=['http://example.com'],
-                                                                    endOnSilence=4, timeOut=60, endOnKey='#',
-                                                                    action='record', beepStart=True),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=["%s?save_media=1" % "http://example.com"])
-                                                               ])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(
+                    format='wav',
+                    eventMethod='post',
+                    eventUrl=['http://example.com'],
+                    endOnSilence=4,
+                    timeOut=60,
+                    endOnKey='#',
+                    action='record',
+                    beepStart=True
+                ),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["%s?save_media=1" % "http://example.com"])
+            ]
+        )
         response = NCCOResponse()
         response.record(action="http://example.com?param=12", method="post", maxLength=60)
 
-        self.assertEqual(json.loads(six.text_type(response)), [dict(format='wav', eventMethod='post',
-                                                                    eventUrl=['http://example.com?param=12'],
-                                                                    endOnSilence=4, timeOut=60, endOnKey='#',
-                                                                    action='record', beepStart=True),
-                                                               dict(action='input', maxDigits=1, timeOut=1,
-                                                                    eventUrl=["http://example.com?param=12&save_media=1"])
-                                                               ])
+        self.assertEqual(
+            json.loads(six.text_type(response)), [
+                dict(
+                    format='wav',
+                    eventMethod='post',
+                    eventUrl=['http://example.com?param=12'],
+                    endOnSilence=4,
+                    timeOut=60,
+                    endOnKey='#',
+                    action='record',
+                    beepStart=True
+                ),
+                dict(action='input', maxDigits=1, timeOut=1, eventUrl=["http://example.com?param=12&save_media=1"])
+            ]
+        )
 
 
 class MiddlewareTest(TembaTest):
-
     def test_org_header(self):
         response = self.client.get(reverse('public.public_index'))
         self.assertFalse(response.has_header('X-Temba-Org'))
@@ -1605,7 +1686,9 @@ class MakeTestDBTest(SimpleTestCase):
             self.assertEqual([qs.filter(org=o).count() for o in (org1, org2, org3)], counts)
 
         print(User.objects.all())
-        self.assertEqual(User.objects.exclude(username__in=["AnonymousUser", "root", "rapidpro_flow", "temba_flow"]).count(), 12)
+        self.assertEqual(
+            User.objects.exclude(username__in=["AnonymousUser", "root", "rapidpro_flow", "temba_flow"]).count(), 12
+        )
         assertOrgCounts(ContactField.objects.all(), [6, 6, 6])
         assertOrgCounts(ContactGroup.user_groups.all(), [10, 10, 10])
         assertOrgCounts(Contact.objects.filter(is_test=True), [4, 4, 4])  # 1 for each user
@@ -1614,7 +1697,9 @@ class MakeTestDBTest(SimpleTestCase):
         org_1_all_contacts = ContactGroup.system_groups.get(org=org1, name="All Contacts")
 
         self.assertEqual(org_1_all_contacts.contacts.count(), 17)
-        self.assertEqual(list(ContactGroupCount.objects.filter(group=org_1_all_contacts).values_list('count')), [(17,)])
+        self.assertEqual(
+            list(ContactGroupCount.objects.filter(group=org_1_all_contacts).values_list('count')), [(17, )]
+        )
 
         # same seed should generate objects with same UUIDs
         self.assertEqual(ContactGroup.user_groups.order_by('id').first().uuid, 'ea60312b-25f5-47a0-8ac7-4fe0c2064f3e')

--- a/temba/utils/timezones.py
+++ b/temba/utils/timezones.py
@@ -6,7 +6,6 @@ import six
 from datetime import datetime
 from timezone_field import TimeZoneFormField as BaseTimeZoneFormField
 
-
 # these are not mapped by pytz.country_timezones
 INITIAL_TIMEZONE_COUNTRY = {
     'US/Hawaii': 'US',

--- a/temba/utils/twilio.py
+++ b/temba/utils/twilio.py
@@ -20,12 +20,10 @@ def encode_atom(atom):  # pragma: no cover
     elif isinstance(atom, six.string_types):
         return atom.encode('utf-8')
     else:
-        raise ValueError('list elements should be an integer, '
-                         'binary, or string')
+        raise ValueError('list elements should be an integer, ' 'binary, or string')
 
 
 class LoggingResource(Resource):  # pragma: no cover
-
     def __init__(self, *args, **kwargs):
         super(LoggingResource, self).__init__(*args, **kwargs)
         self.events = []
@@ -49,8 +47,7 @@ class LoggingResource(Resource):  # pragma: no cover
                 elif isinstance(v, (six.integer_types, six.binary_type, six.string_types)):
                     udata[key] = encode_atom(v)
                 else:
-                    raise ValueError('data should be an integer, '
-                                     'binary, or string, or sequence ')
+                    raise ValueError('data should be an integer, ' 'binary, or string, or sequence ')
             data = urlencode(udata, doseq=True)
 
         event = HttpEvent(method, uri, data)
@@ -68,19 +65,16 @@ class LoggingResource(Resource):  # pragma: no cover
 
 
 class LoggingCalls(LoggingResource, Calls):  # pragma: no cover
-
     def __init__(self, *args, **kwargs):
         super(LoggingCalls, self).__init__(*args, **kwargs)
 
 
 class LoggingMessages(LoggingResource, Messages):  # pragma: nocover
-
     def __init__(self, *args, **kwargs):
         super(LoggingMessages, self).__init__(*args, **kwargs)
 
 
 class TembaTwilioRestClient(TwilioRestClient):  # pragma: no cover
-
     def __init__(self, *args, **kwargs):
         super(TembaTwilioRestClient, self).__init__(*args, **kwargs)
 

--- a/temba/utils/twitter.py
+++ b/temba/utils/twitter.py
@@ -19,7 +19,6 @@ from temba.utils.http import HttpEvent
 
 
 class TembaTwython(Twython):  # pragma: no cover
-
     def __init__(self, *args, **kwargs):
         super(TembaTwython, self).__init__(*args, **kwargs)
         self.events = []
@@ -103,8 +102,7 @@ class TembaTwython(Twython):  # pragma: no cover
 
         if response.status_code > 304:
             # If there is no error message, use a default.
-            errors = content.get('errors',
-                                 [{'message': 'An error occurred processing your request.'}])
+            errors = content.get('errors', [{'message': 'An error occurred processing your request.'}])
             if errors and isinstance(errors, list):
                 error_message = errors[0]['message']
             else:
@@ -120,9 +118,9 @@ class TembaTwython(Twython):  # pragma: no cover
                 # a 400 "Bad Authentication data" for invalid/expired app keys/user tokens
                 ExceptionType = TwythonAuthError
 
-            raise ExceptionType(error_message,
-                                error_code=response.status_code,
-                                retry_after=response.headers.get('retry-after'))
+            raise ExceptionType(
+                error_message, error_code=response.status_code, retry_after=response.headers.get('retry-after')
+            )
 
         # if we have a json error here, then it's not an official Twitter API error
         if json_error and response.status_code not in (200, 201, 202):  # pragma: no cover

--- a/temba/utils/voicexml.py
+++ b/temba/utils/voicexml.py
@@ -33,7 +33,7 @@ class VXMLResponse(object):
 
     def play(self, url=None, digits=None, **kwargs):
         if url is None and digits is None:
-            raise VoiceXMLException("Please specify either a url or digits to play.",)
+            raise VoiceXMLException("Please specify either a url or digits to play.", )
 
         result = ''
         if digits:
@@ -88,7 +88,9 @@ class VXMLResponse(object):
 
         if kwargs.get('action', False):
             method = kwargs.get('method', 'post')
-            result += '<nomatch><submit next="' + kwargs.get('action') + '?empty=1" method="' + method + '" /></nomatch>'
+            result += '<nomatch><submit next="' + kwargs.get(
+                'action'
+            ) + '?empty=1" method="' + method + '" /></nomatch>'
 
         result += '</field>'
         if kwargs.get('action', False):

--- a/temba/values/tests.py
+++ b/temba/values/tests.py
@@ -14,7 +14,6 @@ from .models import Value
 
 
 class ResultTest(FlowFileTest):
-
     def assertResult(self, result, index, category, count):
         self.assertEqual(count, result['categories'][index]['count'])
         self.assertEqual(category, result['categories'][index]['label'])
@@ -65,7 +64,9 @@ class ResultTest(FlowFileTest):
         self.assertEqual(3, result['unset'])
         self.assertResult(result, 0, "1708283", 2)
 
-        reg_date = ContactField.get_or_create(self.org, self.admin, 'reg_date', label="Registration Date", value_type=Value.TYPE_DATETIME)
+        reg_date = ContactField.get_or_create(
+            self.org, self.admin, 'reg_date', label="Registration Date", value_type=Value.TYPE_DATETIME
+        )
         now = timezone.now()
 
         c1.set_field(self.user, 'reg_date', now.replace(hour=9))
@@ -96,17 +97,19 @@ class ResultTest(FlowFileTest):
         self.assertNotEqual(new_value.string_value, original_value.string_value)
 
     def run_color_gender_flow(self, contact, color, gender, age):
-        self.assertEqual(self.send_message(self.flow, color, contact=contact, restart_participants=True), "What is your gender?")
+        self.assertEqual(
+            self.send_message(self.flow, color, contact=contact, restart_participants=True), "What is your gender?"
+        )
         self.assertEqual(self.send_message(self.flow, gender, contact=contact), "What is your age?")
         self.assertEqual(self.send_message(self.flow, age, contact=contact), "Thanks.")
 
     def setup_color_gender_flow(self):
         self.flow = self.get_flow('color_gender_age')
 
-        (self.c1, self.c2, self.c3, self.c4) = (self.create_contact("Contact1", '0788111111'),
-                                                self.create_contact("Contact2", '0788222222'),
-                                                self.create_contact("Contact3", '0788333333'),
-                                                self.create_contact("Contact4", '0788444444'))
+        (self.c1, self.c2, self.c3, self.c4) = (
+            self.create_contact("Contact1", '0788111111'), self.create_contact("Contact2", '0788222222'),
+            self.create_contact("Contact3", '0788333333'), self.create_contact("Contact4", '0788444444')
+        )
 
     def test_category_results(self):
         self.setup_color_gender_flow()
@@ -178,22 +181,33 @@ class ResultTest(FlowFileTest):
         self.assertResult(result, 2, "Green", 1)
 
         # what about men that are adults?
-        result = Value.get_value_summary(ruleset=color, filters=[dict(ruleset=gender.pk, categories=["Male"]),
-                                         dict(ruleset=age.pk, categories=["Adult"])])[0]
+        result = Value.get_value_summary(
+            ruleset=color,
+            filters=[dict(ruleset=gender.pk, categories=["Male"]),
+                     dict(ruleset=age.pk, categories=["Adult"])]
+        )[0]
         self.assertResult(result, 0, "Red", 0)
         self.assertResult(result, 1, "Blue", 0)
         self.assertResult(result, 2, "Green", 0)
 
         # union of all genders
-        result = Value.get_value_summary(ruleset=color, filters=[dict(ruleset=gender.pk, categories=["Male", "Female"]),
-                                         dict(ruleset=age.pk, categories=["Adult"])])[0]
+        result = Value.get_value_summary(
+            ruleset=color,
+            filters=[
+                dict(ruleset=gender.pk, categories=["Male", "Female"]),
+                dict(ruleset=age.pk, categories=["Adult"])
+            ]
+        )[0]
 
         self.assertResult(result, 0, "Red", 1)
         self.assertResult(result, 1, "Blue", 1)
         self.assertResult(result, 2, "Green", 0)
 
         # just women adults by group
-        result = Value.get_value_summary(ruleset=color, filters=[dict(groups=[ladies.pk]), dict(ruleset=age.pk, categories="Adult")])[0]
+        result = Value.get_value_summary(
+            ruleset=color, filters=[dict(groups=[ladies.pk]),
+                                    dict(ruleset=age.pk, categories="Adult")]
+        )[0]
 
         self.assertResult(result, 0, "Red", 1)
         self.assertResult(result, 1, "Blue", 1)
@@ -203,7 +217,10 @@ class ResultTest(FlowFileTest):
         ladies.update_contacts(self.user, [self.c2], False)
 
         # get a new summary
-        result = Value.get_value_summary(ruleset=color, filters=[dict(groups=[ladies.pk]), dict(ruleset=age.pk, categories="Adult")])[0]
+        result = Value.get_value_summary(
+            ruleset=color, filters=[dict(groups=[ladies.pk]),
+                                    dict(ruleset=age.pk, categories="Adult")]
+        )[0]
 
         self.assertResult(result, 0, "Red", 1)
         self.assertResult(result, 1, "Blue", 0)
@@ -234,7 +251,9 @@ class ResultTest(FlowFileTest):
         self.run_color_gender_flow(self.c1, "blue", "male", "16")
 
         # ok, now segment by gender
-        result = Value.get_value_summary(ruleset=color, filters=[], segment=dict(ruleset=gender.pk, categories=["Male", "Female"]))
+        result = Value.get_value_summary(
+            ruleset=color, filters=[], segment=dict(ruleset=gender.pk, categories=["Male", "Female"])
+        )
         male_result = result[0]
         self.assertResult(male_result, 0, "Red", 0)
         self.assertResult(male_result, 1, "Blue", 1)
@@ -246,7 +265,9 @@ class ResultTest(FlowFileTest):
         self.assertResult(female_result, 2, "Green", 0)
 
         # segment by gender again, but use the contact field to do so
-        result = Value.get_value_summary(ruleset=color, filters=[], segment=dict(contact_field="Gender", values=["MALE", "Female"]))
+        result = Value.get_value_summary(
+            ruleset=color, filters=[], segment=dict(contact_field="Gender", values=["MALE", "Female"])
+        )
         male_result = result[0]
         self.assertResult(male_result, 0, "Red", 0)
         self.assertResult(male_result, 1, "Blue", 1)
@@ -258,8 +279,11 @@ class ResultTest(FlowFileTest):
         self.assertResult(female_result, 2, "Green", 0)
 
         # add in a filter at the same time
-        result = Value.get_value_summary(ruleset=color, filters=[dict(ruleset=color.pk, categories=["Blue"])],
-                                         segment=dict(ruleset=gender.pk, categories=["Male", "Female"]))
+        result = Value.get_value_summary(
+            ruleset=color,
+            filters=[dict(ruleset=color.pk, categories=["Blue"])],
+            segment=dict(ruleset=gender.pk, categories=["Male", "Female"])
+        )
 
         male_result = result[0]
         self.assertResult(male_result, 0, "Red", 0)
@@ -320,8 +344,9 @@ class ResultTest(FlowFileTest):
 
         # do a sanity check on our choropleth view
         self.login(self.admin)
-        response = self.client.get(reverse('flows.ruleset_choropleth', args=[color.pk]) +
-                                   "?_format=json&boundary=" + self.org.country.osm_id)
+        response = self.client.get(
+            reverse('flows.ruleset_choropleth', args=[color.pk]) + "?_format=json&boundary=" + self.org.country.osm_id
+        )
 
         # response should be valid json
         response = response.json()
@@ -350,8 +375,10 @@ class ResultTest(FlowFileTest):
         with patch('temba.values.models.Value.get_value_summary') as mock:
             mock.return_value = []
 
-            response = self.client.get(reverse('flows.ruleset_choropleth', args=[color.pk]) +
-                                       "?_format=json&boundary=" + self.org.country.osm_id)
+            response = self.client.get(
+                reverse('flows.ruleset_choropleth', args=[color.pk]) + "?_format=json&boundary=" +
+                self.org.country.osm_id
+            )
 
             # response should be valid json
             response = response.json()
@@ -386,12 +413,11 @@ class ResultTest(FlowFileTest):
         def run_flow(contact, word):
             self.assertEqual("Thank you", self.send_message(flow, word, contact=contact, restart_participants=True))
 
-        (c1, c2, c3, c4, c5, c6) = (self.create_contact("Contact1", '0788111111'),
-                                    self.create_contact("Contact2", '0788222222'),
-                                    self.create_contact("Contact3", '0788333333'),
-                                    self.create_contact("Contact4", '0788444444'),
-                                    self.create_contact("Contact5", '0788555555'),
-                                    self.create_contact("Contact6", '0788666666', is_test=True))
+        (c1, c2, c3, c4, c5, c6) = (
+            self.create_contact("Contact1", '0788111111'), self.create_contact("Contact2", '0788222222'),
+            self.create_contact("Contact3", '0788333333'), self.create_contact("Contact4", '0788444444'),
+            self.create_contact("Contact5", '0788555555'), self.create_contact("Contact6", '0788666666', is_test=True)
+        )
 
         run_flow(c1, "1 better place")
         run_flow(c2, "the great coffee")


### PR DESCRIPTION
For discussion.. run as:

```
% find . -name "*.py" | grep -v migrations | xargs yapf -i --style='{column_limit=119, indent_width: 4, coalesce_brackets: true, allow_split_before_dict_value: false, split_before_first_argument: false, dedent_closing_brackets: true }'
```

Some manual tweaks made to make flake8 pass