### PR TITLE
Credit cache changes

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1495,7 +1495,7 @@ class Msg(models.Model):
 
         # costs 1 credit to send a message
         if not topup_id and not contact.is_test:
-            (topup_id, amount) = org.decrement_credit()
+            (topup_id, _) = org.decrement_credit()
 
         if response_to:
             msg_type = response_to.msg_type

--- a/temba/orgs/tasks.py
+++ b/temba/orgs/tasks.py
@@ -1,12 +1,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-import time
-
 from celery.task import task
-from datetime import timedelta
-from django.utils import timezone
 from temba.utils.queues import nonoverlapping_task
-from .models import CreditAlert, Invitation, Org, TopUpCredits
+from .models import CreditAlert, Invitation, TopUpCredits
 
 
 @task(track_started=True, name='send_invitation_email_task')
@@ -24,22 +20,6 @@ def send_alert_email_task(alert_id):
 @task(track_started=True, name='check_credits_task')
 def check_credits_task():  # pragma: needs cover
     CreditAlert.check_org_credits()
-
-
-@task(track_started=True, name='calculate_credit_caches')
-def calculate_credit_caches():  # pragma: needs cover
-    """
-    Repopulates the active topup and total credits for each organization
-    that received messages in the past week.
-    """
-    # get all orgs that have sent a message in the past week
-    last_week = timezone.now() - timedelta(days=7)
-
-    # for every org that has sent a message in the past week
-    for org in Org.objects.filter(msgs__created_on__gte=last_week).distinct('pk'):
-        start = time.time()
-        org._calculate_credit_caches()
-        print(" -- recalculated credits for %s in %0.2f seconds" % (org.name, time.time() - start))
 
 
 @nonoverlapping_task(track_started=True, name="squash_topupcredits", lock_key='squash_topupcredits')

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -31,8 +31,8 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from email.utils import parseaddr
 from functools import cmp_to_key
-from smartmin.views import SmartCRUDL, SmartCreateView, SmartFormView, SmartReadView, SmartUpdateView, SmartListView, SmartTemplateView
-from smartmin.views import SmartModelFormView, SmartModelActionView
+from smartmin.views import SmartCRUDL, SmartCreateView, SmartFormView, SmartReadView, SmartUpdateView, SmartListView
+from smartmin.views import SmartTemplateView, SmartModelFormView, SmartModelActionView
 from datetime import timedelta
 from temba.api.models import APIToken
 from temba.campaigns.models import Campaign
@@ -43,8 +43,7 @@ from temba.utils import analytics, languages
 from temba.utils.timezones import TimeZoneFormField
 from temba.utils.email import is_valid_address
 from twilio.rest import TwilioRestClient
-from .models import Org, OrgCache, OrgEvent, TopUp, Invitation, UserSettings, get_stripe_credentials, ACCOUNT_SID, \
-    ACCOUNT_TOKEN
+from .models import Org, OrgCache, TopUp, Invitation, UserSettings, get_stripe_credentials, ACCOUNT_SID, ACCOUNT_TOKEN
 from .models import MT_SMS_EVENTS, MO_SMS_EVENTS, MT_CALL_EVENTS, MO_CALL_EVENTS, ALARM_EVENTS
 from .models import SUSPENDED, WHITELISTED, RESTORED, NEXMO_UUID, NEXMO_SECRET, NEXMO_KEY
 from .models import TRANSFERTO_AIRTIME_API_TOKEN, TRANSFERTO_ACCOUNT_LOGIN, SMTP_FROM_EMAIL
@@ -2596,7 +2595,6 @@ class TopUpCRUDL(SmartCRUDL):
 
         def post_save(self, obj):
             obj = super(TopUpCRUDL.Update, self).post_save(obj)
-            obj.org.update_caches(OrgEvent.topup_updated, obj)
             obj.org.apply_topups()
             return obj
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -933,10 +933,6 @@ CELERYBEAT_SCHEDULE = {
         'task': 'trim_webhook_event_task',
         'schedule': crontab(hour=3, minute=0),
     },
-    "calculate-credit-caches": {
-        'task': 'calculate_credit_caches',
-        'schedule': timedelta(days=3),
-    },
     "squash-flowruncounts": {
         'task': 'squash_flowruncounts',
         'schedule': timedelta(seconds=300),

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -217,6 +217,10 @@ class TembaTest(SmartminTest):
         # reset our simulation to False
         Contact.set_simulation(False)
 
+    def create_inbound_msgs(self, recipient, count):
+        for m in range(count):
+            self.create_msg(contact=recipient, direction='I', text="Test %d" % m)
+
     def get_verbosity(self):
         for s in reversed(inspect.stack()):
             options = s[0].f_locals.get('options')

--- a/temba/utils/cache.py
+++ b/temba/utils/cache.py
@@ -8,7 +8,7 @@ from django_redis import get_redis_connection
 from . import chunk_list
 
 
-def get_cacheable(cache_key, cache_ttl, callable, r=None, force_dirty=False):
+def get_cacheable(cache_key, callable, r=None, force_dirty=False):
     """
     Gets the result of a method call, using the given key and TTL as a cache
     """
@@ -20,17 +20,17 @@ def get_cacheable(cache_key, cache_ttl, callable, r=None, force_dirty=False):
         if cached is not None:
             return json.loads(cached)
 
-    calculated = callable()
+    (calculated, cache_ttl) = callable()
     r.set(cache_key, json.dumps(calculated), cache_ttl)
 
     return calculated
 
 
-def get_cacheable_result(cache_key, cache_ttl, callable, r=None, force_dirty=False):
+def get_cacheable_result(cache_key, callable, r=None, force_dirty=False):
     """
     Gets a cache-able integer calculation result
     """
-    return int(get_cacheable(cache_key, cache_ttl, callable, r=r, force_dirty=force_dirty))
+    return int(get_cacheable(cache_key, callable, r=r, force_dirty=force_dirty))
 
 
 def get_cacheable_attr(obj, attr_name, calculate):

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -340,24 +340,24 @@ class CacheTest(TembaTest):
         self.create_contact("Bob", number="1234")
 
         def calculate():
-            return Contact.objects.all().count()
+            return Contact.objects.all().count(), 60
 
         with self.assertNumQueries(1):
-            self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 1)  # from db
+            self.assertEqual(get_cacheable_result('test_contact_count', calculate), 1)  # from db
         with self.assertNumQueries(0):
-            self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 1)  # from cache
+            self.assertEqual(get_cacheable_result('test_contact_count', calculate), 1)  # from cache
 
         self.create_contact("Jim", number="2345")
 
         with self.assertNumQueries(0):
-            self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 1)  # not updated
+            self.assertEqual(get_cacheable_result('test_contact_count', calculate), 1)  # not updated
 
         get_redis_connection().delete('test_contact_count')  # delete from cache for force re-fetch from db
 
         with self.assertNumQueries(1):
-            self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 2)  # from db
+            self.assertEqual(get_cacheable_result('test_contact_count', calculate), 2)  # from db
         with self.assertNumQueries(0):
-            self.assertEqual(get_cacheable_result('test_contact_count', 60, calculate), 2)  # from cache
+            self.assertEqual(get_cacheable_result('test_contact_count', calculate), 2)  # from cache
 
     def test_get_cacheable_attr(self):
         def calculate():

--- a/templates/orgs/email/alert_email.html
+++ b/templates/orgs/email/alert_email.html
@@ -35,9 +35,9 @@ Your {{ brand }} account for {{ org }} is out of credit. You will no longer be a
 
 {% elif alert.alert_type == 'E' %}
 
-{% blocktrans with org=alert.org.name brand=branding.name expiring=org.get_credits_expiring_soon %}
+{% blocktrans with org=alert.org.name brand=branding.name %}
 
-Your {{ brand }} account for {{ org }} has {{ expiring }} expiring credits in less than one month.
+Your {{ brand }} account for {{ org }} has expiring credits in less than one month.
 {% endblocktrans %}
 
   <br/>

--- a/templates/orgs/email/alert_email.txt
+++ b/templates/orgs/email/alert_email.txt
@@ -14,9 +14,9 @@ To resume your service please visit your account page to purchase a top up.
 
 {% endblocktrans %}
 {% elif alert.alert_type == 'E' %}
-{% blocktrans with org=alert.org.name brand=branding.name expiring=org.get_credits_expiring_soon %}
+{% blocktrans with org=alert.org.name brand=branding.name%}
 
-Your {{ brand }} account for {{ org }} has {{ expiring }} expiring credits in less than one month.
+Your {{ brand }} account for {{ org }} has expiring credits in less than one month.
 
 Messages will no longer be sent when your credits expire, to prevent an interruption in your service visit your account page to purchase a top up.
 


### PR DESCRIPTION
* Changes our get_cacheable_result to defer to the evaluation method for the ttl
* Remove OrgEvent and superfluous cache clearing methods in favor of a singular comprehensive org.clear_credit_cache method
* Optimizations for calculating total credits used