### PR TITLE
Block saving migrated flows

### DIFF
--- a/media/test_flows/flow_loop.json
+++ b/media/test_flows/flow_loop.json
@@ -1,0 +1,74 @@
+{
+  "campaigns": [], 
+  "version": "10.4", 
+  "site": "https://textit.in", 
+  "flows": [
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "uuid": "73de0931-2af4-46b0-9f45-aa0446e0a696", 
+          "exit_uuid": "1a9f4c90-c1da-442d-8c22-085a88541365", 
+          "y": 0, 
+          "x": 100, 
+          "destination": null, 
+          "actions": [
+            {
+              "type": "flow", 
+              "flow": {
+                "name": "Second Flow", 
+                "uuid": "668db0e9-5a21-4ea6-8ccf-113e08e71d4c"
+              }, 
+              "uuid": "6d457e64-042a-4e65-8a84-29893b20ac11"
+            }
+          ]
+        }
+      ], 
+      "version": "10.4", 
+      "flow_type": "F", 
+      "entry": "73de0931-2af4-46b0-9f45-aa0446e0a696", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 1, 
+        "uuid": "dd2c376d-4d33-43e9-8cc2-84995b2281d7", 
+        "name": "First Flow", 
+        "saved_on": "2017-11-21T15:58:04.190439Z"
+      }
+    }, 
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "uuid": "bc47a4a7-6411-404d-9547-8865c63b0b1a", 
+          "exit_uuid": "11452f8b-c6a3-4bf1-a69d-9ed3994c6cfd", 
+          "y": 0, 
+          "x": 100, 
+          "destination": null, 
+          "actions": [
+            {
+              "type": "flow", 
+              "flow": {
+                "name": "First Flow", 
+                "uuid": "dd2c376d-4d33-43e9-8cc2-84995b2281d7"
+              }, 
+              "uuid": "2962f638-6971-4f8f-af81-96e242be591b"
+            }
+          ]
+        }
+      ], 
+      "version": "10.4", 
+      "flow_type": "F", 
+      "entry": "bc47a4a7-6411-404d-9547-8865c63b0b1a", 
+      "rule_sets": [], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 1, 
+        "uuid": "668db0e9-5a21-4ea6-8ccf-113e08e71d4c", 
+        "name": "Second Flow", 
+        "saved_on": "2017-11-21T15:58:13.387818Z"
+      }
+    }
+  ], 
+  "triggers": []
+}

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -670,13 +670,28 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
           .success (data, statusCode) ->
             $rootScope.error = null
             $rootScope.errorDelay = quietPeriod
+
+            if data.status == 'flow_migrated'
+              resolveObj =
+                type: -> "info"
+                title: -> "Flow Upgraded"
+                body: -> "Your flow has been upgraded to the latest version. In order to continue editing, please refresh your browser."
+                ok: -> 'Reload'
+                hideCancel: -> true
+                details: -> ''
+              modalInstance = utils.openModal("/partials/modal?v=" + version, ModalController, resolveObj)
+
+              modalInstance.result.then (reload) ->
+                if reload
+                  document.location.reload()
+
             if data.status == 'unsaved'
               resolveObj =
                 type: -> "error"
                 title: -> "Editing Conflict"
                 body: -> data.saved_by + " is currently editing this Flow. Your changes will not be saved until the Flow is reloaded."
                 ok: -> 'Reload'
-                hideCancel: -> false
+                hideCancel: -> true
                 details: -> ''
               modalInstance = utils.openModal("/partials/modal?v=" + version, ModalController, resolveObj)
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2540,9 +2540,6 @@ class Flow(TembaModel):
             elif entry in existing_rulesets:
                 self.entry_uuid = entry
                 self.entry_type = Flow.RULES_ENTRY
-            else:
-                self.entry_uuid = None
-                self.entry_type = None
 
             # if we have a base language, set that
             self.base_language = json_dict.get('base_language', None)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -285,6 +285,7 @@ class Flow(TembaModel):
 
         entry_uuid = six.text_type(uuid4())
         definition = {
+            'version': flow.version_number,
             'entry': entry_uuid,
             'base_language': base_language,
             'rule_sets': [],
@@ -1274,6 +1275,7 @@ class Flow(TembaModel):
 
         entry_uuid = str(uuid4())
         definition = {
+            'version': self.version_number,
             'entry': entry_uuid,
             'base_language': base_language,
             'rule_sets': [],

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2309,7 +2309,8 @@ class Flow(TembaModel):
         try:
 
             # make sure the flow version hasn't changed out from under us
-            if json_dict.get(Flow.VERSION) != get_current_export_version():
+            current_version = get_current_export_version()
+            if json_dict.get(Flow.VERSION, current_version) != current_version:
                 return dict(status="flow_migrated")
 
             flow_user = get_flow_user(self.org)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2309,8 +2309,7 @@ class Flow(TembaModel):
         try:
 
             # make sure the flow version hasn't changed out from under us
-            current_version = get_current_export_version()
-            if json_dict.get(Flow.VERSION, current_version) != current_version:
+            if json_dict.get(Flow.VERSION) != get_current_export_version():
                 return dict(status="flow_migrated")
 
             flow_user = get_flow_user(self.org)
@@ -4017,6 +4016,7 @@ class FlowRevision(SmartModel):
 
                     if migrate_fn:
                         json_flow = migrate_fn(json_flow, None)
+                        json_flow[Flow.VERSION] = version
                     flows.append(json_flow)
                 exported_json['flows'] = flows
 
@@ -4038,6 +4038,7 @@ class FlowRevision(SmartModel):
 
             if migrate_fn:
                 json_flow = migrate_fn(json_flow, flow)
+                json_flow[Flow.VERSION] = version
 
             if version == to_version:
                 break

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2307,6 +2307,11 @@ class Flow(TembaModel):
             raise FlowException("Found invalid cycle: %s" % cycle)
 
         try:
+
+            # make sure the flow version hasn't changed out from under us
+            if json_dict.get(Flow.VERSION) != get_current_export_version():
+                return dict(status="flow_migrated")
+
             flow_user = get_flow_user(self.org)
             # check whether the flow has changed since this flow was last saved
             if user and not force:

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -6049,15 +6049,10 @@ class FlowsTest(FlowFileTest):
         self.assertEqual('http://preprocessor.com/endpoint.php', flow.rule_sets.all().order_by('y')[0].config_json()[RuleSet.CONFIG_WEBHOOK])
 
     def test_flow_loops(self):
+        self.get_flow('flow_loop')
         # this tests two flows that start each other
-        flow1 = self.create_flow()
-        flow2 = self.create_flow()
-
-        # create an action on flow1 to start flow2
-        flow1.update(dict(action_sets=[dict(uuid=str(uuid4()), x=1, y=1,
-                                            actions=[dict(type='flow', flow=dict(uuid=flow2.uuid))])]))
-        flow2.update(dict(action_sets=[dict(uuid=str(uuid4()), x=1, y=1,
-                                            actions=[dict(type='flow', flow=dict(uuid=flow1.uuid))])]))
+        flow1 = Flow.objects.get(name='First Flow')
+        flow2 = Flow.objects.get(name='Second Flow')
 
         # start the flow, shouldn't get into a loop, but both should get started
         flow1.start([], [self.contact])

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4531,6 +4531,15 @@ class FlowsTest(FlowFileTest):
         response = flow.update(flow_json, self.admin)
         self.assertEqual(response.get('status'), 'unsaved')
 
+        # we should also fail if we try saving an old spec version from the editor
+        flow.refresh_from_db()
+        flow_json = flow.as_json()
+
+        with patch('temba.flows.models.get_current_export_version') as mock_version:
+            mock_version.return_value = '1.234'
+            response = flow.update(flow_json, self.admin)
+            self.assertEqual(response.get('status'), 'flow_migrated')
+
     def test_flow_category_counts(self):
 
         def assertCount(counts, result_key, category_name, truth):

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -31,7 +31,7 @@ from temba.contacts.models import Contact, ContactGroup, ContactField, URN
 from temba.orgs.models import Org
 from temba.channels.models import Channel
 from temba.locations.models import AdminBoundary
-from temba.flows.models import Flow, ActionSet, RuleSet, FlowStep
+from temba.flows.models import Flow, ActionSet, RuleSet, FlowStep, FlowRevision
 from temba.ivr.clients import TwilioClient
 from temba.msgs.models import Msg, INCOMING
 from temba.utils import dict_to_struct, get_anonymous_user
@@ -410,7 +410,13 @@ class TembaTest(SmartminTest):
                 ],
                 "rule_sets": [],
             }
-        flow.update(definition)
+
+        flow.version_number = definition['version']
+        flow.save()
+
+        json_flow = FlowRevision.migrate_definition(definition, flow)
+        flow.update(json_flow)
+
         return flow
 
     def update_destination(self, flow, source, destination):


### PR DESCRIPTION
Handles case where the flow version is migrated while an editor is currently open.