### PR TITLE
limit scope of squashing so we can recover from giant unsquashed numbers

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4081,7 +4081,11 @@ class FlowCategoryCount(SquashableModel):
     def get_squash_query(cls, distinct_set):
         sql = """
         WITH removed as (
-            DELETE FROM %(table)s WHERE "flow_id" = %%s AND "node_uuid" = %%s AND "result_key" = %%s AND "result_name" = %%s AND "category_name" = %%s RETURNING "count"
+          DELETE FROM %(table)s WHERE "id" IN (
+            SELECT "id" FROM %(table)s
+              WHERE "flow_id" = %%s AND "node_uuid" = %%s AND "result_key" = %%s AND "result_name" = %%s AND "category_name" = %%s
+              LIMIT 10000
+          ) RETURNING "count"
         )
         INSERT INTO %(table)s("flow_id", "node_uuid", "result_key", "result_name", "category_name", "count", "is_squashed")
         VALUES (%%s, %%s, %%s, %%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -11,7 +11,7 @@ from temba.utils import datetime_to_epoch
 from temba.utils.cache import QueueRecord
 from temba.utils.queues import start_task, complete_task, push_task, nonoverlapping_task
 from .models import ExportFlowResultsTask, Flow, FlowStart, FlowRun, FlowStep
-from .models import FlowRunCount, FlowNodeCount, FlowPathCount, FlowPathRecentMessage
+from .models import FlowRunCount, FlowNodeCount, FlowPathCount, FlowPathRecentMessage, FlowCategoryCount
 
 FLOW_TIMEOUT_KEY = 'flow_timeouts_%y_%m_%d'
 logger = logging.getLogger(__name__)
@@ -145,6 +145,7 @@ def prune_recentmessages():
 def squash_flowruncounts():
     FlowNodeCount.squash()
     FlowRunCount.squash()
+    FlowCategoryCount.squash()
 
 
 @task(track_started=True, name="delete_flow_results_task")

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4611,7 +4611,9 @@ class FlowsTest(FlowFileTest):
         assertCount(counts, 'beer', 'Turbo King', 3)
 
         # make sure it still works after ze squashings
+        self.assertEqual(76, FlowCategoryCount.objects.all().count())
         FlowCategoryCount.squash()
+        self.assertEqual(9, FlowCategoryCount.objects.all().count())
         counts = favorites.get_category_counts()
         assertCount(counts, 'beer', 'Turbo King', 3)
 

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -69,7 +69,7 @@ class SquashableModel(models.Model):
     def squash(cls):
         start = time.time()
         num_sets = 0
-        for distinct_set in cls.get_unsquashed().order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER)[:1000]:
+        for distinct_set in cls.get_unsquashed().order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER)[:5000]:
             with connection.cursor() as cursor:
                 sql, params = cls.get_squash_query(distinct_set)
 

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -69,7 +69,7 @@ class SquashableModel(models.Model):
     def squash(cls):
         start = time.time()
         num_sets = 0
-        for distinct_set in cls.get_unsquashed().order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER)[:10000]:
+        for distinct_set in cls.get_unsquashed().order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER)[:1000]:
             with connection.cursor() as cursor:
                 sql, params = cls.get_squash_query(distinct_set)
 

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -69,7 +69,7 @@ class SquashableModel(models.Model):
     def squash(cls):
         start = time.time()
         num_sets = 0
-        for distinct_set in cls.get_unsquashed().order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER):
+        for distinct_set in cls.get_unsquashed().order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER)[:10000]:
             with connection.cursor() as cursor:
                 sql, params = cls.get_squash_query(distinct_set)
 


### PR DESCRIPTION
1) Adds squashing of the category flow counts to the same task that squashes other counts
2) Only squash up to 1,000 unique unsquashed combinations
3) For FlowCategoryCount, only squash 10,000 things at a time

I think with those three we should get decent performance and start squashing the hundreds of millions of these we have around.