### PR TITLE
Msg view tweaks

### DIFF
--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -457,7 +457,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit inbox page as a manager of the organization
-        with self.assertNumQueries(70):
+        with self.assertNumQueries(60):
             response = self.fetch_protected(inbox_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 5)
@@ -534,7 +534,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit archived page as a manager of the organization
-        with self.assertNumQueries(56):
+        with self.assertNumQueries(54):
             response = self.fetch_protected(archive_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 1)
@@ -620,7 +620,7 @@ class MsgTest(TembaTest):
         # org viewer can
         self.login(self.admin)
 
-        with self.assertNumQueries(47):
+        with self.assertNumQueries(41):
             response = self.client.get(url)
 
         self.assertEqual(set(response.context['object_list']), {msg3, msg2, msg1})

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -389,7 +389,9 @@ class MsgTest(TembaTest):
         broadcast1.send(trigger_send=False)
         (msg1,) = tuple(Msg.objects.filter(broadcast=broadcast1))
 
-        response = self.client.get(reverse('msgs.msg_outbox'))
+        with self.assertNumQueries(43):
+            response = self.client.get(reverse('msgs.msg_outbox'))
+
         self.assertContains(response, "Outbox (1)")
         self.assertEqual(set(response.context_data['object_list']), {msg1})
 
@@ -400,7 +402,8 @@ class MsgTest(TembaTest):
         broadcast2.send(trigger_send=False)
         msg4, msg3, msg2 = tuple(Msg.objects.filter(broadcast=broadcast2))
 
-        response = self.client.get(reverse('msgs.msg_outbox'))
+        with self.assertNumQueries(38):
+            response = self.client.get(reverse('msgs.msg_outbox'))
 
         self.assertContains(response, "Outbox (4)")
         self.assertEqual(set(response.context_data['object_list']), {msg4, msg3, msg2, msg1})
@@ -454,7 +457,8 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit inbox page as a manager of the organization
-        response = self.fetch_protected(inbox_url, self.admin)
+        with self.assertNumQueries(70):
+            response = self.fetch_protected(inbox_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 5)
         self.assertEqual(response.context['folders'][0]['url'], '/msg/inbox/')
@@ -530,7 +534,8 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit archived page as a manager of the organization
-        response = self.fetch_protected(archive_url, self.admin)
+        with self.assertNumQueries(56):
+            response = self.fetch_protected(archive_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 1)
         self.assertEqual(response.context['actions'], ['restore', 'label', 'delete'])
@@ -605,6 +610,8 @@ class MsgTest(TembaTest):
         url = reverse('msgs.msg_flow')
 
         msg1 = Msg.create_incoming(self.channel, six.text_type(self.joe.get_urn()), "test 1", msg_type='F')
+        msg2 = Msg.create_incoming(self.channel, six.text_type(self.joe.get_urn()), "test 2", msg_type='F')
+        msg3 = Msg.create_incoming(self.channel, six.text_type(self.joe.get_urn()), "test 3", msg_type='F')
 
         # user not in org can't access
         self.login(self.non_org_user)
@@ -612,9 +619,11 @@ class MsgTest(TembaTest):
 
         # org viewer can
         self.login(self.admin)
-        response = self.client.get(url)
 
-        self.assertEqual(set(response.context['object_list']), {msg1})
+        with self.assertNumQueries(47):
+            response = self.client.get(url)
+
+        self.assertEqual(set(response.context['object_list']), {msg3, msg2, msg1})
         self.assertEqual(response.context['actions'], ['label'])
 
     def test_failed(self):
@@ -646,8 +655,9 @@ class MsgTest(TembaTest):
         response = self.client.get(failed_url)
         self.assertEqual(302, response.status_code)
 
-        # visit inbox page as an administrator
-        response = self.fetch_protected(failed_url, self.admin)
+        # visit failed page as an administrator
+        with self.assertNumQueries(61):
+            response = self.fetch_protected(failed_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 3)
         self.assertEqual(response.context['actions'], ['resend'])

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -105,6 +105,7 @@ class InboxView(OrgPermsMixin, SmartListView):
     paginate_by = 100
     actions = ()
     allow_export = False
+    show_channel_logs = False
 
     def derive_label(self):
         return self.system_label
@@ -165,6 +166,7 @@ class InboxView(OrgPermsMixin, SmartListView):
         context['actions'] = self.actions
         context['current_label'] = label
         context['export_url'] = self.derive_export_url()
+        context['show_channel_logs'] = self.show_channel_logs
         return context
 
     def get_gear_links(self):
@@ -622,6 +624,7 @@ class MsgCRUDL(SmartCRUDL):
         system_label = SystemLabel.TYPE_OUTBOX
         actions = ()
         allow_export = True
+        show_channel_logs = True
 
         def get_queryset(self, **kwargs):
             qs = super(MsgCRUDL.Outbox, self).get_queryset(**kwargs)
@@ -633,6 +636,7 @@ class MsgCRUDL(SmartCRUDL):
         system_label = SystemLabel.TYPE_SENT
         actions = ()
         allow_export = True
+        show_channel_logs = True
 
         def get_queryset(self, **kwargs):  # pragma: needs cover
             qs = super(MsgCRUDL.Sent, self).get_queryset(**kwargs)
@@ -645,6 +649,7 @@ class MsgCRUDL(SmartCRUDL):
         system_label = SystemLabel.TYPE_FAILED
         actions = ['resend']
         allow_export = True
+        show_channel_logs = True
 
         def get_queryset(self, **kwargs):
             qs = super(MsgCRUDL.Failed, self).get_queryset(**kwargs)

--- a/templates/msgs/message_box.haml
+++ b/templates/msgs/message_box.haml
@@ -200,7 +200,7 @@
                           {{object.created_on|gmail_time}}
 
                         .log-icon
-                          -if not user_org.is_anon or perms.contacts.contact_break_anon
+                          -if show_channel_logs and not user_org.is_anon or perms.contacts.contact_break_anon
                             {% channel_log_link object %}
 
                     -empty


### PR DESCRIPTION
Currently we prefetch channel_logs for the views that have them (sent/failed/outbox) but we try to look up channel_logs in all views (inbox etc) - leading to a lot of extra pointless db hits.

Have also added some num-query checks to the tests for good measure.