### PR TITLE
Superautoscaler updates

### DIFF
--- a/temba/celery_autoscaler.py
+++ b/temba/celery_autoscaler.py
@@ -103,18 +103,16 @@ class SuperAutoscaler(Autoscaler):
         self.cpu_stats = cur_stats
 
         if self.processes > 0:
-            cpu_usage_per_proc = cpu_usage / self.processes
-            max_cpu_bound_workers = int(
-                ((settings.AUTOSCALE_MAX_CPU_USAGE - cpu_usage) / cpu_usage_per_proc) + self.processes
-            )
-            target_cpu_bound_workers = min(max_cpu_bound_workers or 1, self.max_concurrency)
+            if cpu_usage < settings.AUTOSCALE_MAX_CPU_USAGE:
+                target_cpu_bound_workers = self.max_concurrency
+            else:
+                target_cpu_bound_workers = 1
         else:
             target_cpu_bound_workers = 1
-            cpu_usage_per_proc = -1
 
         self._debug(
-            '_cpu => %s %s %s %s' % (
-                settings.AUTOSCALE_MAX_CPU_USAGE, cpu_usage, cpu_usage_per_proc, target_cpu_bound_workers
+            '_cpu => %s %s %s' % (
+                settings.AUTOSCALE_MAX_CPU_USAGE, cpu_usage, target_cpu_bound_workers
             )
         )
 
@@ -124,18 +122,16 @@ class SuperAutoscaler(Autoscaler):
         used_memory = self._get_used_memory()
 
         if self.processes > 0:
-            mem_usage_per_proc = (used_memory - self.initial_memory_usage) / self.processes
-            max_mem_bound_workers = int(
-                ((settings.AUTOSCALE_MAX_USED_MEMORY - used_memory) / mem_usage_per_proc) + self.processes
-            )
-            target_mem_bound_workers = min(max_mem_bound_workers or 1, self.max_concurrency)
+            if used_memory < settings.AUTOSCALE_MAX_USED_MEMORY:
+                target_mem_bound_workers = self.max_concurrency
+            else:
+                target_mem_bound_workers = 1
         else:
             target_mem_bound_workers = 1
-            mem_usage_per_proc = -1
 
         self._debug(
-            '_mem => %s %s %s %s' % (
-                settings.AUTOSCALE_MAX_CPU_USAGE, used_memory, mem_usage_per_proc, target_mem_bound_workers
+            '_mem => %s %s %s' % (
+                settings.AUTOSCALE_MAX_USED_MEMORY, used_memory, target_mem_bound_workers
             )
         )
 


### PR DESCRIPTION
* log current stats in `_maybe_scale` as celery.INFO
  * we need to add `-l INFO` when starting celery on the CLI
* simplify calculation of mem/cpu bound workers
  * if there are available resources, set limit to `max_concurrency`