### PR TITLE
Define METRICS_HOSTNAME

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import iptools
 import os
 import sys
+import socket
 
 from celery.schedules import crontab
 from datetime import timedelta
@@ -1220,3 +1221,7 @@ CHATBASE_API_URL = 'https://chatbase.com/api/message'
 
 # To allow manage fields to support up to 1000 fields
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 4000
+
+# When reporting metrics we use the hostname of the physical machine, not the hostname of the service
+system_hostname = socket.gethostname().split('.')[0]
+MACHINE_HOSTNAME = '%s.%s' % (system_hostname, HOSTNAME)

--- a/temba/utils/analytics.py
+++ b/temba/utils/analytics.py
@@ -22,7 +22,7 @@ def gauge(event, value=None):
         value = 1
 
     if _librato:
-        _librato.gauge(event, value, settings.HOSTNAME)  # pragma: needs cover
+        _librato.gauge(event, value, settings.MACHINE_HOSTNAME)  # pragma: needs cover
 
 
 def identify(username, attributes):
@@ -45,7 +45,7 @@ def track(user, event, properties=None, context=None):  # pragma: needs cover
     if context is None:
         context = dict()
 
-    # set our source according to our hostname
+    # set our source according to our hostname (name of the platform instance, and not machine hostname)
     context['source'] = settings.HOSTNAME
 
     # create properties if none were passed in


### PR DESCRIPTION
METRICS_HOSTNAME is used by Librato when reporting metrics per host