### PR TITLE
Stepless tests part 1

### DIFF
--- a/media/test_flows/webhook.json
+++ b/media/test_flows/webhook.json
@@ -1,0 +1,147 @@
+{
+  "campaigns": [], 
+  "version": "11.2", 
+  "site": "https://app.rapidpro.io", 
+  "flows": [
+    {
+      "base_language": "eng", 
+      "action_sets": [
+        {
+          "uuid": "5d8b8512-e76e-4cb6-a74c-17f6d584bef5", 
+          "exit_uuid": "0c032f7f-b951-4814-8a18-62454cd8da2c", 
+          "y": 0, 
+          "x": 100, 
+          "destination": "2144f113-1b8e-438e-908f-8b2018865d97", 
+          "actions": [
+            {
+              "quick_replies": [], 
+              "media": {}, 
+              "msg": {
+                "eng": "Let's call a webhook!"
+              }, 
+              "send_all": false, 
+              "type": "reply", 
+              "uuid": "0f5f7871-8f8c-425d-9f26-da3e625a8dc6"
+            }
+          ]
+        }
+      ], 
+      "version": "11.2", 
+      "flow_type": "F", 
+      "entry": "5d8b8512-e76e-4cb6-a74c-17f6d584bef5", 
+      "rule_sets": [
+        {
+          "uuid": "2144f113-1b8e-438e-908f-8b2018865d97", 
+          "rules": [
+            {
+              "category": {
+                "eng": "Success"
+              }, 
+              "uuid": "68921cf2-589a-492c-9608-77b86c03e1eb", 
+              "destination": "52612a0f-4112-43b3-b6dd-0694a80682c6", 
+              "label": null, 
+              "destination_type": "R", 
+              "test": {
+                "status": "success", 
+                "type": "webhook_status"
+              }
+            }, 
+            {
+              "category": {
+                "eng": "Failure"
+              }, 
+              "uuid": "bb3fadc1-5e12-49ff-bca4-cf3577b4dbcb", 
+              "destination": null, 
+              "label": null, 
+              "destination_type": null, 
+              "test": {
+                "status": "failure", 
+                "type": "webhook_status"
+              }
+            }
+          ], 
+          "ruleset_type": "webhook", 
+          "label": "Response 1", 
+          "operand": "@step.value", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 91, 
+          "x": 234, 
+          "config": {
+            "webhook": "http://localhost:49999/check_order.php?phone=@step.contact.tel_e164", 
+            "webhook_action": "GET", 
+            "webhook_headers": [
+              {
+                "name": "Authorization", 
+                "value": "Token 12345"
+              }
+            ]
+          }
+        }, 
+        {
+          "uuid": "52612a0f-4112-43b3-b6dd-0694a80682c6", 
+          "rules": [
+            {
+              "category": {
+                "eng": "Valid"
+              }, 
+              "uuid": "453458d6-6dc7-4ec5-88ff-d98bb113a7ba", 
+              "destination": null, 
+              "label": null, 
+              "destination_type": null, 
+              "test": {
+                "test": {
+                  "eng": "valid"
+                }, 
+                "type": "contains_any"
+              }
+            }, 
+            {
+              "category": {
+                "eng": "Invalid"
+              }, 
+              "uuid": "1ad18838-44e8-48e0-8526-76dee0537468", 
+              "destination": null, 
+              "label": null, 
+              "destination_type": null, 
+              "test": {
+                "test": {
+                  "eng": "invalid"
+                }, 
+                "type": "contains_any"
+              }
+            }, 
+            {
+              "category": {
+                "eng": "Other"
+              }, 
+              "uuid": "926437aa-a9d8-4113-aa39-b42b6a494050", 
+              "destination": null, 
+              "label": null, 
+              "destination_type": null, 
+              "test": {
+                "type": "true"
+              }
+            }
+          ], 
+          "ruleset_type": "expression", 
+          "label": "Order Status",
+          "operand": "@extra.text @extra.blank", 
+          "finished_key": null, 
+          "response_type": "", 
+          "y": 226, 
+          "x": 158, 
+          "config": {}
+        }
+      ], 
+      "metadata": {
+        "expires": 10080, 
+        "revision": 15, 
+        "uuid": "4b2459a5-c9b2-4217-9aa4-cc4663457c47", 
+        "name": "Webhook", 
+        "saved_on": "2017-12-14T14:32:08.641540Z"
+      }
+    }
+  ], 
+  "triggers": []
+}

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -606,11 +606,13 @@ class APITest(TembaTest):
                     submitted_by=self.surveyor.username,
                     started='2015-08-25T11:09:29.088Z',
                     steps=[
-                        dict(node=color_prompt.uuid,
-                             arrived_on='2015-08-25T11:09:30.088Z',
-                             actions=[
-                                 dict(type="reply", msg="What is your favorite color?")
-                             ])
+                        dict(
+                            node=color_prompt.uuid,
+                            arrived_on='2015-08-25T11:09:30.088Z',
+                            actions=[
+                                dict(type="reply", msg="What is your favorite color?")
+                            ]
+                        )
                     ],
                     completed=False)
 
@@ -649,31 +651,41 @@ class APITest(TembaTest):
         # check flow activity
         self.assertEqual(flow.get_activity(), ({color_prompt.uuid: 1}, {}))
 
-        data = dict(flow=flow.uuid,
-                    revision=2,
-                    contact=self.joe.uuid,
-                    started='2015-08-25T11:09:29.088Z',
-                    submitted_by=self.surveyor.username,
-                    steps=[
-                        dict(node=color_ruleset.uuid,
-                             arrived_on='2015-08-25T11:11:30.088Z',
-                             rule=dict(uuid=orange_rule.uuid,
-                                       value="orange",
-                                       category="Orange",
-                                       text="I like orange")),
-                        dict(node=color_reply.uuid,
-                             arrived_on='2015-08-25T11:13:30.088Z',
-                             actions=[
-                                 dict(type="reply", msg="I love orange too!")
-                             ]),
-                        dict(node=new_node['uuid'],
-                             arrived_on='2015-08-25T11:15:30.088Z',
-                             actions=[
-                                 dict(type="save", field="tel_e164", value="+12065551212"),
-                                 dict(type="del_group", group=dict(name="Remove Me"))
-                             ]),
-                    ],
-                    completed=True)
+        data = dict(
+            flow=flow.uuid,
+            revision=2,
+            contact=self.joe.uuid,
+            started='2015-08-25T11:09:29.088Z',
+            submitted_by=self.surveyor.username,
+            steps=[
+                dict(
+                    node=color_ruleset.uuid,
+                    arrived_on='2015-08-25T11:11:30.088Z',
+                    rule=dict(
+                        uuid=orange_rule.uuid,
+                        value="orange",
+                        category="Orange",
+                        text="I like orange"
+                    )
+                ),
+                dict(
+                    node=color_reply.uuid,
+                    arrived_on='2015-08-25T11:13:30.088Z',
+                    actions=[
+                        dict(type="reply", msg="I love orange too!")
+                    ]
+                ),
+                dict(
+                    node=new_node['uuid'],
+                    arrived_on='2015-08-25T11:15:30.088Z',
+                    actions=[
+                        dict(type="save", field="tel_e164", value="+12065551212"),
+                        dict(type="del_group", group=dict(name="Remove Me"))
+                    ]
+                ),
+            ],
+            completed=True
+        )
 
         with patch.object(timezone, 'now', return_value=datetime(2015, 9, 16, 0, 0, 0, 0, pytz.UTC)):
             self.postJSON(url, data)
@@ -736,18 +748,22 @@ class APITest(TembaTest):
         flow.update(definition)
 
         # update a value for our missing node
-        data = dict(flow=flow.uuid,
-                    revision=2,
-                    contact=self.joe.uuid,
-                    started='2015-08-26T11:09:29.088Z',
-                    steps=[
-                        dict(node=new_node['uuid'],
-                             arrived_on='2015-08-26T11:15:30.088Z',
-                             actions=[
-                                 dict(type="save", field="tel_e164", value="+13605551212")
-                             ]),
-                    ],
-                    completed=True)
+        data = dict(
+            flow=flow.uuid,
+            revision=2,
+            contact=self.joe.uuid,
+            started='2015-08-26T11:09:29.088Z',
+            steps=[
+                dict(
+                    node=new_node['uuid'],
+                    arrived_on='2015-08-26T11:15:30.088Z',
+                    actions=[
+                        dict(type="save", field="tel_e164", value="+13605551212")
+                    ]
+                ),
+            ],
+            completed=True
+        )
 
         with patch.object(timezone, 'now', return_value=datetime(2015, 9, 16, 0, 0, 0, 0, pytz.UTC)):
 
@@ -780,31 +796,41 @@ class APITest(TembaTest):
             self.assertIsNotNone(self.joe.urns.filter(path='+13605551212').first())
 
             # rule uuid not existing we should find the actual matching rule
-            data = dict(flow=flow.uuid,
-                        revision=2,
-                        contact=self.joe.uuid,
-                        started='2015-08-25T11:09:29.088Z',
-                        submitted_by=self.admin.username,
-                        steps=[
-                            dict(node=color_ruleset.uuid,
-                                 arrived_on='2015-08-25T11:11:30.088Z',
-                                 rule=dict(uuid='abc5fd71-027b-40e8-a819-151a0f8140e6',
-                                           value="orange",
-                                           category="Orange",
-                                           text="I like orange")),
-                            dict(node=color_reply.uuid,
-                                 arrived_on='2015-08-25T11:13:30.088Z',
-                                 actions=[
-                                     dict(type="reply", msg="I love orange too!")
-                                 ]),
-                            dict(node=new_node['uuid'],
-                                 arrived_on='2015-08-25T11:15:30.088Z',
-                                 actions=[
-                                     dict(type="save", field="tel_e164", value="+12065551212"),
-                                     dict(type="del_group", group=dict(name="Remove Me"))
-                                 ]),
-                        ],
-                        completed=True)
+            data = dict(
+                flow=flow.uuid,
+                revision=2,
+                contact=self.joe.uuid,
+                started='2015-08-25T11:09:29.088Z',
+                submitted_by=self.admin.username,
+                steps=[
+                    dict(
+                        node=color_ruleset.uuid,
+                        arrived_on='2015-08-25T11:11:30.088Z',
+                        rule=dict(
+                            uuid='abc5fd71-027b-40e8-a819-151a0f8140e6',
+                            value="orange",
+                            category="Orange",
+                            text="I like orange"
+                        )
+                    ),
+                    dict(
+                        node=color_reply.uuid,
+                        arrived_on='2015-08-25T11:13:30.088Z',
+                        actions=[
+                            dict(type="reply", msg="I love orange too!")
+                        ]
+                    ),
+                    dict(
+                        node=new_node['uuid'],
+                        arrived_on='2015-08-25T11:15:30.088Z',
+                        actions=[
+                            dict(type="save", field="tel_e164", value="+12065551212"),
+                            dict(type="del_group", group=dict(name="Remove Me"))
+                        ]
+                    ),
+                ],
+                completed=True
+            )
 
             response = self.postJSON(url, data)
             self.assertEqual(201, response.status_code)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3258,7 +3258,7 @@ class FlowStep(models.Model):
         else:
             self.rule_value = six.text_type(value)[:Msg.MAX_TEXT_LEN]
 
-        self.save(update_fields=('rule_uuid',))
+        self.save(update_fields=('rule_uuid', 'rule_value'))
 
     def get_text(self, run=None):
         """

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3624,7 +3624,7 @@ class RuleSet(models.Model):
                 if msg:
                     msg.text = orig_text
 
-        return None, None
+        return None, None  # pragma: no cover
 
     def find_interrupt_rule(self, step, run, msg):
         rules = self.get_rules()
@@ -3674,7 +3674,7 @@ class RuleSet(models.Model):
     def __str__(self):
         if self.label:
             return "RuleSet: %s - %s" % (self.uuid, self.label)
-        else:
+        else:  # pragma: no cover
             return "RuleSet: %s" % (self.uuid,)
 
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4032,14 +4032,21 @@ class WebhookTest(TembaTest):
         run4.refresh_from_db()
         self.assertEqual(run4.field_dict(), {str(n): 'x' for n in range(256)})
 
-        # check we handle a non-JSON response
-        self.mockRequest('POST', '/check_order.php?phone=%2B250788383383', "asdfasdfasdf")
+        # check we handle a non-dict or list response
+        self.mockRequest('POST', '/check_order.php?phone=%2B250788383383', "12345")
 
         run5, = flow.start([], [contact], restart_participants=True)
         run5.refresh_from_db()
         self.assertEqual(run5.field_dict(), {})
 
-        results = run5.get_results()
+        # check we handle a non-JSON response
+        self.mockRequest('POST', '/check_order.php?phone=%2B250788383383', "asdfasdfasdf")
+
+        run6, = flow.start([], [contact], restart_participants=True)
+        run6.refresh_from_db()
+        self.assertEqual(run6.field_dict(), {})
+
+        results = run6.get_results()
         self.assertEqual(len(results), 2)
         self.assertEqual(results['response_1']['name'], 'Response 1')
         self.assertEqual(results['response_1']['value'], 'asdfasdfasdf')
@@ -4048,11 +4055,11 @@ class WebhookTest(TembaTest):
         # check a webhook that responds with a 500 error
         self.mockRequest('POST', '/check_order.php?phone=%2B250788383383', "Server Error", status=500)
 
-        run6, = flow.start([], [contact], restart_participants=True)
-        run6.refresh_from_db()
-        self.assertEqual(run6.field_dict(), {})
+        run7, = flow.start([], [contact], restart_participants=True)
+        run7.refresh_from_db()
+        self.assertEqual(run7.field_dict(), {})
 
-        results = run6.get_results()
+        results = run7.get_results()
         self.assertEqual(len(results), 1)
         self.assertEqual(results['response_1']['name'], 'Response 1')
         self.assertEqual(results['response_1']['value'], 'Server Error')
@@ -4061,11 +4068,11 @@ class WebhookTest(TembaTest):
         # check a webhook that responds with a 400 error
         self.mockRequest('POST', '/check_order.php?phone=%2B250788383383', '{ "text": "Valid", "error": "400", "message": "Missing field in request" }', status=400)
 
-        run7, = flow.start([], [contact], restart_participants=True)
-        run7.refresh_from_db()
-        self.assertEqual(run7.field_dict(), {'text': "Valid", 'error': "400", 'message': "Missing field in request"})
+        run8, = flow.start([], [contact], restart_participants=True)
+        run8.refresh_from_db()
+        self.assertEqual(run8.field_dict(), {'text': "Valid", 'error': "400", 'message': "Missing field in request"})
 
-        results = run7.get_results()
+        results = run8.get_results()
         self.assertEqual(len(results), 1)
         self.assertEqual(results['response_1']['name'], 'Response 1')
         self.assertEqual(results['response_1']['value'], '{ "text": "Valid", "error": "400", "message": "Missing field in request" }')


### PR DESCRIPTION
Also stops setting `rule_category` and `rule_value_decimal` on steps as these aren't used anywhere. The only properties of steps that we currently rely on are step_uuid/rule_uuid/rule_uuid and its messages m2m.