### PR TITLE
Date parsing fixes

### DIFF
--- a/temba/utils/dates.py
+++ b/temba/utils/dates.py
@@ -16,10 +16,10 @@ MAX_UTC_OFFSET = 14 * 60 * 60
 FULL_ISO8601_REGEX = regex.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{6})?([\+\-]\d{2}:\d{2}|Z)$')
 
 # patterns for date and time formats supported for human-entered data
-DD_MM_YYYY = regex.compile(r'([0-9]{1,2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]([0-9]{4}|[0-9]{2})')
-MM_DD_YYYY = regex.compile(r'([0-9]{1,2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]([0-9]{4}|[0-9]{2})')
-YYYY_MM_DD = regex.compile(r'([0-9]{4}|[0-9]{2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]([0-9]{1,2})')
-HH_MM_SS = regex.compile(r'([0-9]{1,2}):([0-9]{2})(:([0-9]{2})(\.(\d+))?)?\W*([aApP][mM])?')
+DD_MM_YYYY = regex.compile(r'\b([0-9]{1,2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]([0-9]{4}|[0-9]{2})\b')
+MM_DD_YYYY = regex.compile(r'\b([0-9]{1,2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]([0-9]{4}|[0-9]{2})\b')
+YYYY_MM_DD = regex.compile(r'\b([0-9]{4}|[0-9]{2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]([0-9]{1,2})\b')
+HH_MM_SS = regex.compile(r'\b([0-9]{1,2}):([0-9]{2})(:([0-9]{2})(\.(\d+))?)?\W*([aApP][mM])?\b')
 
 
 def datetime_to_str(date_obj, format=None, ms=True, tz=None):
@@ -114,25 +114,22 @@ def _date_from_formats(date_str, current_year, pattern, d, m, y):
     Parses a human-entered date which should be in the org display format
     """
     for match in pattern.finditer(date_str):
-        # does our day look believable?
         day = _atoi(match[d])
-        if day == 0 or day > 31:
-            continue
-
         month = _atoi(match[m])
-        if month == 0 or month > 12:
-            continue
+        year = _atoi(match[y])
 
         # convert to four digit year
-        year = _atoi(match[y])
         if len(match[y]) == 2:
             if year > current_year % 1000:
                 year += 1900
             else:
                 year += 2000
 
-        # looks believable, let's return it
-        return datetime.date(year, month, day)
+        try:
+            return datetime.date(year, month, day)
+        except ValueError:
+            # if our numbers don't form a valid date keep trying
+            pass
 
     return None
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -194,10 +194,9 @@ class DatesTest(TembaTest):
             self.assertIsNone(str_to_datetime('', tz))  # empty string
             self.assertIsNone(str_to_datetime('xxx', tz))  # unparseable string
             self.assertIsNone(str_to_datetime('xxx', tz, fill_time=False))  # unparseable string
-            self.assertIsNone(str_to_datetime('41-12-2017', tz))
-            self.assertIsNone(str_to_datetime('03-13-2017', tz))
-            self.assertIsNone(str_to_datetime('41-12-17', tz))
-            self.assertIsNone(str_to_datetime('03-13-17', tz))
+            self.assertIsNone(str_to_datetime('31-02-2017', tz))   # day out of range
+            self.assertIsNone(str_to_datetime('03-13-2017', tz))   # month out of range
+            self.assertIsNone(str_to_datetime('03-12-99999', tz))  # year out of range
 
             self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 3, 4, 5, 6)),
                              str_to_datetime('01-02-2013', tz, dayfirst=True))  # day first


### PR DESCRIPTION
 * Don't blow up with logically invalid dates (e.g. 31-02-2017)
 * Ensure regex matches begin and end with word boundaries, e.g. otherwise "231231-12-1234567" can match as "31-12-1234"