### PR TITLE
Brand redirect

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -712,7 +712,7 @@ class ChannelTest(TembaTest):
         # non-org users can't view our channels
         self.login(self.non_org_user)
         response = self.client.get(reverse('channels.channel_read', args=[self.tel_channel.uuid]))
-        self.assertLoginRedirect(response)
+        self.assertRedirect(response, reverse('orgs.org_choose'))
 
         # org users can
         response = self.fetch_protected(reverse('channels.channel_read', args=[self.tel_channel.uuid]), self.user)

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -671,7 +671,7 @@ class MsgTest(TembaTest):
 
         # user not in org can't access
         self.login(self.non_org_user)
-        self.assertLoginRedirect(self.client.get(url))
+        self.assertRedirect(self.client.get(url), reverse('orgs.org_choose'))
 
         # org viewer can
         self.login(self.admin)
@@ -917,7 +917,7 @@ class MsgCRUDLTest(TembaTest):
         # can't visit a filter page as a non-org user
         self.login(self.non_org_user)
         response = self.client.get(reverse('msgs.msg_filter', args=[label3.pk]))
-        self.assertLoginRedirect(response)
+        self.assertRedirect(response, reverse('orgs.org_choose'))
 
         # can as org viewer user
         self.login(self.user)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -489,7 +489,7 @@ class OrgTest(TembaTest):
         # or just not an org user
         self.login(self.non_org_user)
         response = self.client.post(reverse('api.apitoken_refresh'))
-        self.assertLoginRedirect(response)
+        self.assertRedirect(response, reverse('orgs.org_choose'))
 
     @override_settings(SEND_EMAILS=True)
     def test_manage_accounts(self):

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -107,9 +107,11 @@ class OrgPermsMixin(object):
 
     def dispatch(self, request, *args, **kwargs):
 
-        # authenticated but without orgs get the org chooser
-        if self.get_user().is_authenticated() and not self.derive_org():
-            return HttpResponseRedirect(reverse('orgs.org_choose'))
+        # non admin authenticated users without orgs get the org chooser
+        user = self.get_user()
+        if user.is_authenticated() and not (user.is_superuser or user.is_staff):
+            if not self.derive_org():
+                return HttpResponseRedirect(reverse('orgs.org_choose'))
 
         return super(OrgPermsMixin, self).dispatch(request, *args, **kwargs)
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -80,21 +80,6 @@ class OrgPermsMixin(object):
             org = self.get_user().get_org()
         return org
 
-    def pre_process(self, request, *args, **kwargs):
-        user = self.get_user()
-        org = self.derive_org()
-
-        if not org:  # pragma: needs cover
-            if user.is_authenticated():
-                if user.is_superuser or user.is_staff:
-                    return None
-
-                return HttpResponseRedirect(reverse('orgs.org_choose'))
-            else:
-                return HttpResponseRedirect(settings.LOGIN_URL)
-
-        return None
-
     def has_org_perm(self, permission):
         if self.org:
             return self.get_user().has_org_perm(self.org, permission)
@@ -119,6 +104,14 @@ class OrgPermsMixin(object):
             return True
 
         return self.has_org_perm(self.permission)
+
+    def dispatch(self, request, *args, **kwargs):
+
+        # authenticated but without orgs get the org chooser
+        if self.get_user().is_authenticated() and not self.derive_org():
+            return HttpResponseRedirect(reverse('orgs.org_choose'))
+
+        return super(OrgPermsMixin, self).dispatch(request, *args, **kwargs)
 
 
 class AnonMixin(OrgPermsMixin):


### PR DESCRIPTION
Fixes: rapidpro/rapidpro/issues/727

Change prevents repeat redirect badness with /org/choose when a redirect is configured.