### PR TITLE
Test tweaks

### DIFF
--- a/temba/airtime/tests.py
+++ b/temba/airtime/tests.py
@@ -48,13 +48,13 @@ class AirtimeEventTest(TembaTest):
             self.assertEqual(mock_post.call_count, 1)
             self.assertEqual('https://airtime.transferto.com/cgi-bin/shop/topup', mock_post.call_args_list[0][0][0])
             mock_args = mock_post.call_args_list[0][0][1]
-            self.assertTrue('action' in mock_args.keys())
-            self.assertTrue('login' in mock_args.keys())
-            self.assertTrue('key' in mock_args.keys())
-            self.assertTrue('md5' in mock_args.keys())
+            self.assertIn('action', mock_args.keys())
+            self.assertIn('login', mock_args.keys())
+            self.assertIn('key', mock_args.keys())
+            self.assertIn('md5', mock_args.keys())
 
-            self.assertTrue('ping' in mock_args.values())
-            self.assertTrue('login_acc' in mock_args.values())
+            self.assertIn('ping', mock_args.values())
+            self.assertIn('login_acc', mock_args.values())
 
             self.airtime.refresh_from_db()
             # model not changed since not passed in args
@@ -69,13 +69,13 @@ class AirtimeEventTest(TembaTest):
             self.assertEqual(mock_post.call_count, 1)
             self.assertEqual('https://airtime.transferto.com/cgi-bin/shop/topup', mock_post.call_args_list[0][0][0])
             mock_args = mock_post.call_args_list[0][0][1]
-            self.assertTrue('action' in mock_args.keys())
-            self.assertTrue('login' in mock_args.keys())
-            self.assertTrue('key' in mock_args.keys())
-            self.assertTrue('md5' in mock_args.keys())
+            self.assertIn('action', mock_args.keys())
+            self.assertIn('login', mock_args.keys())
+            self.assertIn('key', mock_args.keys())
+            self.assertIn('md5', mock_args.keys())
 
-            self.assertTrue('ping' in mock_args.values())
-            self.assertTrue('login_acc' in mock_args.values())
+            self.assertIn('ping', mock_args.values())
+            self.assertIn('login_acc', mock_args.values())
 
             self.airtime.refresh_from_db()
             # model changed since it is passed in args

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -163,7 +163,7 @@ class WebHookTest(TembaTest):
             self.assertEqual(self.joe.name, data['contact_name'][0])
             self.assertEqual(call.pk, int(data['call'][0]))
             self.assertEqual(call.event_type, data['event'][0])
-            self.assertTrue('occurred_on' in data)
+            self.assertIn('occurred_on', data)
             self.assertEqual(self.channel.pk, int(data['channel'][0]))
 
     def test_alarm_deliveries(self):
@@ -547,7 +547,7 @@ class WebHookTest(TembaTest):
             self.assertEqual(self.channel.pk, int(data['channel'][0]))
             self.assertEqual(WebHookEvent.TYPE_SMS_RECEIVED, data['event'][0])
             self.assertEqual("I'm gonna pop some tags", data['text'][0])
-            self.assertTrue('time' in data)
+            self.assertIn('time', data)
 
             WebHookEvent.objects.all().delete()
             WebHookResult.objects.all().delete()
@@ -649,8 +649,8 @@ class WebHookTest(TembaTest):
                                         dict(url="http://webhook.url/", data="phone=250788383383&values=foo&bogus=2"))
             self.assertEqual(200, response.status_code)
             self.assertContains(response, "I am success")
-            self.assertTrue('values' in mock.call_args[1]['data'])
-            self.assertTrue('phone' in mock.call_args[1]['data'])
+            self.assertIn('values', mock.call_args[1]['data'])
+            self.assertIn('phone', mock.call_args[1]['data'])
             self.assertFalse('bogus' in mock.call_args[1]['data'])
 
             response = self.client.post(reverse('api.webhook_tunnel'), dict())

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -303,7 +303,7 @@ class WebHookTest(TembaTest):
         )
 
         # make sure we don't have an input
-        self.assertFalse('input' in data)
+        self.assertNotIn('input', data)
 
     @patch('temba.api.models.time.time')
     def test_webhook_result_timing(self, mock_time):
@@ -651,7 +651,7 @@ class WebHookTest(TembaTest):
             self.assertContains(response, "I am success")
             self.assertIn('values', mock.call_args[1]['data'])
             self.assertIn('phone', mock.call_args[1]['data'])
-            self.assertFalse('bogus' in mock.call_args[1]['data'])
+            self.assertNotIn('bogus', mock.call_args[1]['data'])
 
             response = self.client.post(reverse('api.webhook_tunnel'), dict())
             self.assertEqual(400, response.status_code)

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -127,7 +127,7 @@ class CampaignTest(TembaTest):
         # go create an event that based on a message
         url = '%s?campaign=%d' % (reverse('campaigns.campaignevent_create'), campaign.id)
         response = self.client.get(url)
-        self.assertTrue('base' in response.context['form'].fields)
+        self.assertIn('base', response.context['form'].fields)
 
         # should be no language list
         self.assertNotContains(response, 'show_language')
@@ -142,7 +142,7 @@ class CampaignTest(TembaTest):
         # now we should have ace as our primary
         response = self.client.get(url)
         self.assertFalse('base' in response.context['form'].fields)
-        self.assertTrue('ace' in response.context['form'].fields)
+        self.assertIn('ace', response.context['form'].fields)
 
         # add second language
         spa = Language.objects.create(org=self.org, name='Spanish', iso_code='spa',
@@ -150,8 +150,8 @@ class CampaignTest(TembaTest):
 
         response = self.client.get(url)
         self.assertFalse('base' in response.context['form'].fields)
-        self.assertTrue('ace' in response.context['form'].fields)
-        self.assertTrue('spa' in response.context['form'].fields)
+        self.assertIn('ace', response.context['form'].fields)
+        self.assertIn('spa', response.context['form'].fields)
 
         # and our language list should be there
         self.assertContains(response, 'show_language')
@@ -160,9 +160,9 @@ class CampaignTest(TembaTest):
         self.org.save()
 
         response = self.client.get(url)
-        self.assertTrue('base' in response.context['form'].fields)
-        self.assertTrue('spa' in response.context['form'].fields)
-        self.assertTrue('ace' in response.context['form'].fields)
+        self.assertIn('base', response.context['form'].fields)
+        self.assertIn('spa', response.context['form'].fields)
+        self.assertIn('ace', response.context['form'].fields)
 
         post_data = dict(relative_to=self.planting_date.pk, event_type='M', base="This is my message", spa="hola",
                          direction='B', offset=1, unit='W', flow_to_start='', delivery_hour=13)
@@ -203,7 +203,7 @@ class CampaignTest(TembaTest):
 
         # the base language needs to stay present since it's the true backdown
         response = self.client.get(url)
-        self.assertTrue('base' in response.context['form'].fields)
+        self.assertIn('base', response.context['form'].fields)
         self.assertEqual('This is my message', response.context['form'].fields['base'].initial)
         self.assertEqual('hola', response.context['form'].fields['spa'].initial)
         self.assertEqual('', response.context['form'].fields['ace'].initial)
@@ -224,7 +224,7 @@ class CampaignTest(TembaTest):
 
         # and still get the same settings, (it should use the base of the flow instead of just base here)
         response = self.client.get(url)
-        self.assertTrue('base' in response.context['form'].fields)
+        self.assertIn('base', response.context['form'].fields)
         self.assertEqual('This is my spanish @contact.planting_date', response.context['form'].fields['spa'].initial)
         self.assertEqual('', response.context['form'].fields['ace'].initial)
 
@@ -329,7 +329,7 @@ class CampaignTest(TembaTest):
         response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
 
         self.assertTrue(response.context['form'].errors)
-        self.assertTrue('A message is required' in six.text_type(response.context['form'].errors['__all__']))
+        self.assertIn('A message is required', six.text_type(response.context['form'].errors['__all__']))
 
         post_data = dict(relative_to=self.planting_date.pk, delivery_hour=-1, base='allo!' * 500, direction='A',
                          offset=2, unit='D', event_type='M', flow_to_start=self.reminder_flow.pk)
@@ -343,7 +343,7 @@ class CampaignTest(TembaTest):
         response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
 
         self.assertTrue(response.context['form'].errors)
-        self.assertTrue('Please select a flow' in response.context['form'].errors['flow_to_start'])
+        self.assertIn('Please select a flow', response.context['form'].errors['flow_to_start'])
 
         post_data = dict(relative_to=self.planting_date.pk, delivery_hour=-1, base='', direction='A', offset=2, unit='D', event_type='F', flow_to_start=self.reminder_flow.pk)
         response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -141,7 +141,7 @@ class CampaignTest(TembaTest):
 
         # now we should have ace as our primary
         response = self.client.get(url)
-        self.assertFalse('base' in response.context['form'].fields)
+        self.assertNotIn('base', response.context['form'].fields)
         self.assertIn('ace', response.context['form'].fields)
 
         # add second language
@@ -149,7 +149,7 @@ class CampaignTest(TembaTest):
                                       created_by=self.admin, modified_by=self.admin)
 
         response = self.client.get(url)
-        self.assertFalse('base' in response.context['form'].fields)
+        self.assertNotIn('base', response.context['form'].fields)
         self.assertIn('ace', response.context['form'].fields)
         self.assertIn('spa', response.context['form'].fields)
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -615,7 +615,7 @@ class ChannelTest(TembaTest):
         channel.save()
 
         response = self.client.get(update_url)
-        self.assertFalse('address' in response.context['form'].fields)
+        self.assertNotIn('address', response.context['form'].fields)
 
         # bring it back to android
         channel.channel_type = Channel.TYPE_ANDROID
@@ -3346,8 +3346,8 @@ class KannelTest(TembaTest):
             # assert verify was set to true
             self.assertEqual('No capital accented E!', mock.call_args[1]['params']['text'])
             self.assertEqual('788383383', mock.call_args[1]['params']['to'])
-            self.assertFalse('coding' in mock.call_args[1]['params'])
-            self.assertFalse('priority' in mock.call_args[1]['params'])
+            self.assertNotIn('coding', mock.call_args[1]['params'])
+            self.assertNotIn('priority', mock.call_args[1]['params'])
             self.clear_cache()
 
         incoming = Msg.create_incoming(self.channel, "tel:+250788383383", "start")
@@ -3390,8 +3390,8 @@ class KannelTest(TembaTest):
 
             # assert verify was set to true
             self.assertEqual("Normal", mock.call_args[1]['params']['text'])
-            self.assertFalse('coding' in mock.call_args[1]['params'])
-            self.assertFalse('charset' in mock.call_args[1]['params'])
+            self.assertNotIn('coding', mock.call_args[1]['params'])
+            self.assertNotIn('charset', mock.call_args[1]['params'])
             self.assertEqual('https://%s/c/kn/%s/status?id=%d&status=%%d' % (self.org.get_brand_domain(), self.channel.uuid, msg.id), mock.call_args[1]['params']['dlr-url'])
 
             self.clear_cache()

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -983,7 +983,7 @@ class ChannelTest(TembaTest):
                                     dict(claim_code=android1.claim_code, phone_number="0788123123"))
 
         # redirect to welcome page
-        self.assertTrue('success' in response.get('Location', None))
+        self.assertIn('success', response.get('Location', None))
         self.assertRedirect(response, reverse('public.public_welcome'))
 
         # channel is updated with org details and claim code is now blank
@@ -1236,8 +1236,8 @@ class ChannelTest(TembaTest):
         search_nexmo_url = reverse('channels.channel_search_nexmo')
 
         response = self.client.get(search_nexmo_url)
-        self.assertTrue('area_code' in response.context['form'].fields)
-        self.assertTrue('country' in response.context['form'].fields)
+        self.assertIn('area_code', response.context['form'].fields)
+        self.assertIn('country', response.context['form'].fields)
 
         with patch('requests.get') as nexmo_get:
             nexmo_get.side_effect = [MockResponse(200,
@@ -1501,8 +1501,8 @@ class ChannelTest(TembaTest):
         # assert that our first command is the two message broadcast
         cmd = cmds[0]
         self.assertEqual("How is it going?", cmd['msg'])
-        self.assertTrue('+250788382382' in [m['phone'] for m in cmd['to']])
-        self.assertTrue('+250788383383' in [m['phone'] for m in cmd['to']])
+        self.assertIn('+250788382382', [m['phone'] for m in cmd['to']])
+        self.assertIn('+250788383383', [m['phone'] for m in cmd['to']])
 
         self.assertTrue(msg1.pk in [m['id'] for m in cmd['to']])
         self.assertTrue(msg2.pk in [m['id'] for m in cmd['to']])
@@ -2702,7 +2702,7 @@ class ExternalTest(TembaTest):
             self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
 
-            self.assertTrue("text=Test+message" in mock.call_args[1]['data'])
+            self.assertIn("text=Test+message", mock.call_args[1]['data'])
 
             self.clear_cache()
 
@@ -2860,7 +2860,7 @@ class YoTest(TembaTest):
             self.assertEqual(SENT, msg.status)
             self.assertTrue(msg.sent_on)
 
-            self.assertTrue("sms_content=Test+message" in mock.call_args[0][0])
+            self.assertIn("sms_content=Test+message", mock.call_args[0][0])
 
             self.clear_cache()
 
@@ -3018,7 +3018,7 @@ class ShaqodoonTest(TembaTest):
             self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
 
-            self.assertTrue("msg=Test+message" in mock.call_args[0][0])
+            self.assertIn("msg=Test+message", mock.call_args[0][0])
 
             self.clear_cache()
 
@@ -4862,7 +4862,7 @@ class Hub9Test(TembaTest):
             self.assertTrue(msg.sent_on)
 
             self.assertTrue(mock.call_args[0][0].startswith(HUB9_ENDPOINT))
-            self.assertTrue("message=Test+message" in mock.call_args[0][0])
+            self.assertIn("message=Test+message", mock.call_args[0][0])
 
             self.clear_cache()
 
@@ -5027,7 +5027,7 @@ class DartMediaTest(TembaTest):
             self.assertEqual(SENT, msg.status)
             self.assertTrue(msg.sent_on)
 
-            self.assertTrue("message=Test+message" in mock.call_args[0][0])
+            self.assertIn("message=Test+message", mock.call_args[0][0])
 
             self.clear_cache()
 
@@ -5154,7 +5154,7 @@ class HighConnectionTest(TembaTest):
             self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
 
-            self.assertTrue("text=Test+message" in mock.call_args[0][0])
+            self.assertIn("text=Test+message", mock.call_args[0][0])
 
             self.clear_cache()
 
@@ -7596,7 +7596,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
         response = self.client.post(delivery_url, data=json.dumps({}),
                                     content_type='application/json')
         self.assertEqual(400, response.status_code)
-        self.assertTrue('Missing one of' in response.content)
+        self.assertIn('Missing one of', response.content)
 
     def test_status(self):
         # ok, what happens with an invalid uuid?
@@ -7704,7 +7704,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
         response = self.client.post(callback_url, json.dumps({}),
                                     content_type='application/json')
         self.assertEqual(400, response.status_code)
-        self.assertTrue('Missing one of' in response.content)
+        self.assertIn('Missing one of', response.content)
 
     def test_receive(self):
         data = self.mk_msg(content="événement")

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -2382,7 +2382,7 @@ class AfricasTalkingTest(TembaTest):
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
             # assert we didn't send the short code in our data
-            self.assertTrue('from' not in mock.call_args[1]['data'])
+            self.assertNotIn('from', mock.call_args[1]['data'])
             self.clear_cache()
 
         with patch('requests.post') as mock:
@@ -2456,7 +2456,7 @@ class RedRabbitTest(TembaTest):
                 mock.return_value = MockResponse(200, "Sent")
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
                 self.assertEqual(mock.call_args[0][0], 'http://http1.javna.com/epicenter/GatewaySendG.asp')
-                self.assertTrue('Msgtyp' not in mock.call_args[1]['params'])
+                self.assertNotIn('Msgtyp', mock.call_args[1]['params'])
 
         self.clear_cache()
 
@@ -7303,7 +7303,7 @@ class ChikkaTest(TembaTest):
 
                 # but when that fails, we should try again as a send
                 self.assertEqual(second_call_args['message_type'], 'SEND')
-                self.assertTrue('request_id' not in second_call_args)
+                self.assertNotIn('request_id', second_call_args)
 
                 # our message should be succeeded
                 msg.refresh_from_db()

--- a/temba/channels/types/nexmo/tests.py
+++ b/temba/channels/types/nexmo/tests.py
@@ -137,7 +137,7 @@ class NexmoTypeTest(TembaTest):
 
                 # make sure our number appears on the claim page
                 response = self.client.get(claim_nexmo)
-                self.assertFalse('account_trial' in response.context)
+                self.assertNotIn('account_trial', response.context)
                 self.assertContains(response, '360-788-4540')
 
                 # claim it
@@ -177,7 +177,7 @@ class NexmoTypeTest(TembaTest):
 
                 # make sure our number appears on the claim page
                 response = self.client.get(claim_nexmo)
-                self.assertFalse('account_trial' in response.context)
+                self.assertNotIn('account_trial', response.context)
                 self.assertContains(response, '579-788-4540')
 
                 # claim it

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -40,7 +40,7 @@ class PlivoTypeTest(TembaTest):
 
             # try hit the claim page, should be redirected; no credentials in session
             response = self.client.get(claim_plivo_url, follow=True)
-            self.assertFalse('account_trial' in response.context)
+            self.assertNotIn('account_trial', response.context)
             self.assertContains(response, connect_plivo_url)
 
         # let's add a number already connected to the account

--- a/temba/channels/types/twilio_messaging_service/tests.py
+++ b/temba/channels/types/twilio_messaging_service/tests.py
@@ -45,7 +45,7 @@ class TwilioMessagingServiceTypeTest(TembaTest):
         self.assertContains(response, claim_twilio_ms)
 
         response = self.client.get(claim_twilio_ms)
-        self.assertTrue('account_trial' in response.context)
+        self.assertIn('account_trial', response.context)
         self.assertFalse(response.context['account_trial'])
 
         with patch('temba.orgs.models.Org.get_twilio_client') as mock_get_twilio_client:
@@ -63,7 +63,7 @@ class TwilioMessagingServiceTypeTest(TembaTest):
             mock_get.return_value = MockTwilioClient.MockAccount('Trial')
 
             response = self.client.get(claim_twilio_ms)
-            self.assertTrue('account_trial' in response.context)
+            self.assertIn('account_trial', response.context)
             self.assertTrue(response.context['account_trial'])
 
         response = self.client.get(claim_twilio_ms)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -240,7 +240,7 @@ class ContactGroupTest(TembaTest):
         self.login(self.admin)
         filter_url = reverse('contacts.contact_filter', args=[group.uuid])
         response = self.client.get(filter_url)
-        self.assertFalse('unlabel' in response.context['actions'])
+        self.assertNotIn('unlabel', response.context['actions'])
 
     def test_evaluate_dynamic_groups_from_flow(self):
         flow = self.get_flow('initialize')
@@ -2480,7 +2480,7 @@ class ContactTest(TembaTest):
         # should no longer be in our update form either
         response = self.client.get(reverse('contacts.contact_update', args=[self.joe.id]))
         self.assertEqual(response.context['form'].fields['urn__tel__0'].initial, "+250781111111")
-        self.assertFalse('urn__tel__1' in response.context['form'].fields)
+        self.assertNotIn('urn__tel__1', response.context['form'].fields)
 
         # check that groups field isn't displayed when contact is blocked
         self.joe.block(self.user)
@@ -4014,13 +4014,13 @@ class ContactTest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(simulator_contact in response.context['object_list'])
         self.assertTrue(other_contact in response.context['object_list'])
-        self.assertFalse("Simulator Contact" in response.content)
+        self.assertNotIn("Simulator Contact", response.content)
 
         response = self.client.get(reverse('contacts.contact_filter', args=[group.uuid]))
         self.assertEqual(response.status_code, 200)
         self.assertFalse(simulator_contact in response.context['object_list'])
         self.assertTrue(other_contact in response.context['object_list'])
-        self.assertFalse("Simulator Contact" in response.content)
+        self.assertNotIn("Simulator Contact", response.content)
 
     def test_preferred_channel(self):
         from temba.msgs.tasks import process_message_task

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -2262,7 +2262,7 @@ class ContactTest(TembaTest):
 
         self.assertContains(response, update_url)
         response = self.client.get(update_url)
-        self.assertTrue('name' in response.context['form'].fields)
+        self.assertIn('name', response.context['form'].fields)
 
         response = self.client.post(update_url, dict(name="New Test"))
         self.assertRedirect(response, filter_url)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -4404,7 +4404,7 @@ class ContactFieldTest(TembaTest):
         # now we should be successful
         response = self.client.post(manage_fields_url, post_data, follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('form' not in response.context)
+        self.assertNotIn('form', response.context)
         self.assertEqual(before - 1, ContactField.objects.filter(org=self.org, is_active=True).count())
 
     def test_manage_fields(self):
@@ -4433,7 +4433,7 @@ class ContactFieldTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         # make sure we didn't have an error
-        self.assertTrue('form' not in response.context)
+        self.assertNotIn('form', response.context)
 
         # should still have three contact fields
         self.assertEqual(3, ContactField.objects.filter(org=self.org, is_active=True).count())
@@ -4457,7 +4457,7 @@ class ContactFieldTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         # make sure we didn't have an error
-        self.assertTrue('form' not in response.context)
+        self.assertNotIn('form', response.context)
 
         # first field was blank, so it should be inactive
         self.assertIsNone(ContactField.objects.filter(org=self.org, key="first", is_active=True).first())

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1115,7 +1115,7 @@ class FlowTest(TembaTest):
         self.assertTrue(self.flow.get_steps())
         self.assertTrue(Msg.objects.all())
         msg = Msg.objects.all()[0]
-        self.assertFalse("@extra.coupon" in msg.text)
+        self.assertNotIn("@extra.coupon", msg.text)
         self.assertEqual(msg.text, "text to get NEXUS4")
         self.assertEqual(PENDING, msg.status)
 
@@ -2487,10 +2487,10 @@ class FlowTest(TembaTest):
         self.assertFalse(flow_create_url in response.content)
         self.assertFalse(flowlabel_create_url in response.content)
         # verify the action buttons we have
-        self.assertFalse('object-btn-unlabel' in response.content)
-        self.assertFalse('object-btn-restore' in response.content)
-        self.assertFalse('object-btn-archive' in response.content)
-        self.assertFalse('object-btn-label' in response.content)
+        self.assertNotIn('object-btn-unlabel', response.content)
+        self.assertNotIn('object-btn-restore', response.content)
+        self.assertNotIn('object-btn-archive', response.content)
+        self.assertNotIn('object-btn-label', response.content)
         self.assertIn('object-btn-export', response.content)
 
         # can not label
@@ -7438,8 +7438,8 @@ class FlowMigrationTest(FlowFileTest):
 
         # make sure our rulesets no longer have 'webhook' or 'webhook_action'
         for ruleset in flow_def['rule_sets']:
-            self.assertFalse('webhook' in ruleset)
-            self.assertFalse('webhook_action' in ruleset)
+            self.assertNotIn('webhook', ruleset)
+            self.assertNotIn('webhook_action', ruleset)
 
         self.mockRequest('POST', '/code', '{"code": "ABABUUDDLRS"}', content_type='application/json')
 
@@ -8869,7 +8869,7 @@ class TypeTest(TembaTest):
         self.assertEqual('Rwanda > Eastern Province', results['state']['value'])
         self.assertEqual('I\'m in Eastern Province', results['state']['input'])
         self.assertEqual('state', results['state']['category'])
-        self.assertFalse('category_localized' in results['state'])
+        self.assertNotIn('category_localized', results['state'])
 
         self.assertEqual('District', results['district']['name'])
         self.assertEqual('Rwanda > Eastern Province > Gatsibo', results['district']['value'])

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2491,7 +2491,7 @@ class FlowTest(TembaTest):
         self.assertFalse('object-btn-restore' in response.content)
         self.assertFalse('object-btn-archive' in response.content)
         self.assertFalse('object-btn-label' in response.content)
-        self.assertTrue('object-btn-export' in response.content)
+        self.assertIn('object-btn-export', response.content)
 
         # can not label
         post_data = dict()
@@ -4225,7 +4225,7 @@ class FlowLabelTest(FlowFileTest):
 
         post_data = dict(name="sub_label ", parent=label_one.pk)
         response = self.client.post(create_url, post_data, follow=True)
-        self.assertTrue('form' in response.context)
+        self.assertIn('form', response.context)
         self.assertTrue(response.context['form'].errors)
         self.assertEqual('Name already used', response.context['form'].errors['name'][0])
 
@@ -7334,7 +7334,7 @@ class FlowMigrationTest(FlowFileTest):
 
         lang_path = new_definition['action_sets'][0]['actions'][0]['msg']
 
-        self.assertTrue('fra' in lang_path)
+        self.assertIn('fra', lang_path)
         self.assertEqual(len(lang_path), 3)
 
         lang_key_value = new_definition['action_sets'][1]['actions'][0]['lang']
@@ -7342,7 +7342,7 @@ class FlowMigrationTest(FlowFileTest):
         self.assertEqual(lang_key_value, 'fra')
 
         should_not_be_migrated_path = new_definition['action_sets'][2]['actions'][0]['msg']
-        self.assertTrue('fre' in should_not_be_migrated_path)
+        self.assertIn('fre', should_not_be_migrated_path)
 
         # we cannot migrate flows to version 11 without flow object (languages depend on flow.org)
         self.assertRaises(ValueError, migrate_to_version_11_1, definition)
@@ -7569,8 +7569,8 @@ class FlowMigrationTest(FlowFileTest):
         self.assertEqual(1, flow_json['metadata']['revision'])
         self.assertEqual('test flow', flow_json['metadata']['name'])
         self.assertEqual(720, flow_json['metadata']['expires'])
-        self.assertTrue('uuid' in flow_json['metadata'])
-        self.assertTrue('saved_on' in flow_json['metadata'])
+        self.assertIn('uuid', flow_json['metadata'])
+        self.assertIn('saved_on', flow_json['metadata'])
 
         # check that our replacements work
         self.assertEqual('@(CONCAT(parent.divided, parent.sky))', flow_json['action_sets'][0]['actions'][3]['value'])
@@ -7754,7 +7754,7 @@ class FlowMigrationTest(FlowFileTest):
 
         # make sure it is localized
         poll = self.org.flows.filter(name='Sample Flow - Simple Poll').first()
-        self.assertTrue('base' in poll.action_sets.all().order_by('y').first().get_actions()[0].msg)
+        self.assertIn('base', poll.action_sets.all().order_by('y').first().get_actions()[0].msg)
         self.assertEqual('base', poll.base_language)
 
         # check replacement

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1950,8 +1950,8 @@ class FlowTest(TembaTest):
 
         # keywords aren't an option for survey flows
         response = self.client.get(reverse('flows.flow_update', args=[flow.pk]))
-        self.assertTrue('keyword_triggers' not in response.context['form'].fields)
-        self.assertTrue('ignore_triggers' not in response.context['form'].fields)
+        self.assertNotIn('keyword_triggers', response.context['form'].fields)
+        self.assertNotIn('ignore_triggers', response.context['form'].fields)
 
         # send update with triggers and ignore flag anyways
         post_data = dict()
@@ -7644,7 +7644,7 @@ class FlowMigrationTest(FlowFileTest):
         voice_json = migrate_to_version_5(voice_json)
         voice_json = migrate_to_version_6(voice_json)
         definition = voice_json.get('definition')
-        self.assertTrue('recording' not in definition['action_sets'][0]['actions'][0])
+        self.assertNotIn('recording', definition['action_sets'][0]['actions'][0])
 
     def test_migrate_to_5_language(self):
 

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -43,7 +43,7 @@ class LocationTest(TembaTest):
         response_json = response.json()
 
         # should have features in it
-        self.assertTrue('features' in response_json)
+        self.assertIn('features', response_json)
 
         # should have our two top level states
         self.assertEqual(2, len(response_json['features']))
@@ -54,7 +54,7 @@ class LocationTest(TembaTest):
         response_json = response.json()
 
         # should have features in it
-        self.assertTrue('features' in response_json)
+        self.assertIn('features', response_json)
 
         # should have our single district in it
         self.assertEqual(1, len(response_json['features']))
@@ -136,7 +136,7 @@ class LocationTest(TembaTest):
         response_json = response.json()
         self.assertEqual(response_json[0].get('name'), self.state2.name)
         self.assertEqual(response_json[0].get('aliases'), 'Eastern P')
-        self.assertTrue('Kageyo Gat' in response_json[0].get('match'))
+        self.assertIn('Kageyo Gat', response_json[0].get('match'))
 
         # trigger wrong request data using bad json
         response = self.client.post(reverse('locations.adminboundary_boundaries', args=[self.country.osm_id]),

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -549,7 +549,7 @@ class MsgTest(TembaTest):
         # update our label name
         response = self.client.get(reverse('msgs.label_update', args=[label1.pk]))
         self.assertEqual(200, response.status_code)
-        self.assertTrue('folder' in response.context['form'].fields)
+        self.assertIn('folder', response.context['form'].fields)
 
         post_data = dict(name="Foo")
         response = self.client.post(reverse('msgs.label_update', args=[label1.pk]), post_data)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -142,7 +142,7 @@ class OrgTest(TembaTest):
         # update the name and slug of the organization
         data = dict(name="Temba", timezone="Africa/Kigali", date_format=DAYFIRST, slug="nice temba")
         response = self.client.post(reverse('orgs.org_edit'), data)
-        self.assertTrue('slug' in response.context['form'].errors)
+        self.assertIn('slug', response.context['form'].errors)
 
         data = dict(name="Temba", timezone="Africa/Kigali", date_format=MONTHFIRST, slug="nice-temba")
         response = self.client.post(reverse('orgs.org_edit'), data)
@@ -717,10 +717,10 @@ class OrgTest(TembaTest):
 
         # we have a form with 4 fields and one hidden 'loc'
         self.assertEqual(5, len(response.context['form'].fields))
-        self.assertTrue('first_name' in response.context['form'].fields)
-        self.assertTrue('last_name' in response.context['form'].fields)
-        self.assertTrue('email' in response.context['form'].fields)
-        self.assertTrue('password' in response.context['form'].fields)
+        self.assertIn('first_name', response.context['form'].fields)
+        self.assertIn('last_name', response.context['form'].fields)
+        self.assertIn('email', response.context['form'].fields)
+        self.assertIn('password', response.context['form'].fields)
 
         post_data = dict()
         post_data['first_name'] = "Norbert"
@@ -792,9 +792,9 @@ class OrgTest(TembaTest):
                          password='beastmode24', email='beastmode@seahawks.com',
                          surveyor_password='nyaruka')
         response = self.client.post(url, post_data)
-        self.assertTrue('token' in response.url)
-        self.assertTrue('beastmode' in response.url)
-        self.assertTrue('Temba' in response.url)
+        self.assertIn('token', response.url)
+        self.assertIn('beastmode', response.url)
+        self.assertIn('Temba', response.url)
 
         # try with a login that already exists
         post_data = dict(first_name='Resused', last_name='Email',
@@ -838,7 +838,7 @@ class OrgTest(TembaTest):
         response = self.client.get(choose_url)
         self.assertEqual(200, response.status_code)
 
-        self.assertTrue('organization' in response.context['form'].fields)
+        self.assertIn('organization', response.context['form'].fields)
 
         post_data = dict()
         post_data['organization'] = self.org2.pk
@@ -2204,7 +2204,7 @@ class OrgCRUDLTest(TembaTest):
 
         post_data['name'] = "Relieves World Rwanda"
         response = self.client.post(signup_url, post_data)
-        self.assertTrue('email' in response.context['form'].errors)
+        self.assertIn('email', response.context['form'].errors)
 
         # if we hit /login we'll be taken back to the channel page
         response = self.client.get(reverse('users.user_check_login'))
@@ -2242,13 +2242,13 @@ class OrgCRUDLTest(TembaTest):
         post_data = dict(email='myal@wr.org', current_password='HelloWorld')
         response = self.client.post(reverse('orgs.user_edit'), post_data)
         self.assertEqual(200, response.status_code)
-        self.assertTrue('current_password' in response.context['form'].errors)
+        self.assertIn('current_password', response.context['form'].errors)
 
         # bad new password
         post_data = dict(email='myal@wr.org', current_password='HelloWorld1', new_password='passwor')
         response = self.client.post(reverse('orgs.user_edit'), post_data)
         self.assertEqual(200, response.status_code)
-        self.assertTrue('new_password' in response.context['form'].errors)
+        self.assertIn('new_password', response.context['form'].errors)
 
         User.objects.create(username='bill@msn.com', email='bill@msn.com')
 
@@ -2256,7 +2256,7 @@ class OrgCRUDLTest(TembaTest):
         post_data = dict(email='bill@msn.com', current_password='HelloWorld1')
         response = self.client.post(reverse('orgs.user_edit'), post_data)
         self.assertEqual(200, response.status_code)
-        self.assertTrue('email' in response.context['form'].errors)
+        self.assertIn('email', response.context['form'].errors)
 
         post_data = dict(email='myal@wr.org', first_name="Myal", last_name="Greene", language="en-us", current_password='HelloWorld1')
         response = self.client.post(reverse('orgs.user_edit'), post_data)
@@ -2350,7 +2350,7 @@ class OrgCRUDLTest(TembaTest):
 
         # passwords stay case sensitive
         response = self.client.post(login_url, dict(username="withcaps", password="thepassword"), follow=True)
-        self.assertTrue('form' in response.context)
+        self.assertIn('form', response.context)
         self.assertTrue(response.context['form'].errors)
 
     def test_org_service(self):
@@ -2616,7 +2616,7 @@ class BulkExportTest(TembaTest):
         # make sure the created flow has the same action set
         flow = Flow.objects.filter(name="%s" % flow.name).first()
         actionset = ActionSet.objects.filter(flow=flow).order_by('y').first()
-        self.assertTrue('@contact.name' in actionset.get_actions()[0].groups)
+        self.assertIn('@contact.name', actionset.get_actions()[0].groups)
 
     def test_import_voice_flows_expiration_time(self):
         # all imported voice flows should have a max expiration time of 15 min
@@ -2908,8 +2908,8 @@ class CreditAlertTest(TembaTest):
                 # alert email is for out of credits type
                 sent_email = mail.outbox[0]
                 self.assertEqual(len(sent_email.to), 1)
-                self.assertTrue('RapidPro account for Temba' in sent_email.body)
-                self.assertTrue('is out of credit.' in sent_email.body)
+                self.assertIn('RapidPro account for Temba', sent_email.body)
+                self.assertIn('is out of credit.', sent_email.body)
 
                 # no new alert if one is sent and no new email
                 CreditAlert.check_org_credits()
@@ -2944,8 +2944,8 @@ class CreditAlertTest(TembaTest):
                     # email sent
                     sent_email = mail.outbox[2]
                     self.assertEqual(len(sent_email.to), 1)
-                    self.assertTrue('RapidPro account for Temba' in sent_email.body)
-                    self.assertTrue('is running low on credits' in sent_email.body)
+                    self.assertIn('RapidPro account for Temba', sent_email.body)
+                    self.assertIn('is running low on credits', sent_email.body)
 
                     # no new alert if one is sent and no new email
                     CreditAlert.check_org_credits()
@@ -2987,8 +2987,8 @@ class CreditAlertTest(TembaTest):
                         # email sent
                         sent_email = mail.outbox[4]
                         self.assertEqual(len(sent_email.to), 1)
-                        self.assertTrue('RapidPro account for Temba' in sent_email.body)
-                        self.assertTrue('expiring credits in less than one month.' in sent_email.body)
+                        self.assertIn('RapidPro account for Temba', sent_email.body)
+                        self.assertIn('expiring credits in less than one month.', sent_email.body)
 
                         # no new alert if one is sent and no new email
                         CreditAlert.check_org_credits()
@@ -3033,7 +3033,7 @@ class EmailContextProcessorsTest(SmartminTest):
             self.assertEqual(sent_email.to[0], 'nouser@nouser.com')
 
             # we have the domain of rapipro.io brand
-            self.assertTrue('app.rapidpro.io' in sent_email.body)
+            self.assertIn('app.rapidpro.io', sent_email.body)
 
 
 class StripeCreditsTest(TembaTest):
@@ -3065,9 +3065,9 @@ class StripeCreditsTest(TembaTest):
         self.assertEqual(1, len(mail.outbox))
         email = mail.outbox[0]
         self.assertEqual("RapidPro Receipt", email.subject)
-        self.assertTrue('Rudolph' in email.body)
-        self.assertTrue('Visa' in email.body)
-        self.assertTrue('$20' in email.body)
+        self.assertIn('Rudolph', email.body)
+        self.assertIn('Visa', email.body)
+        self.assertIn('$20', email.body)
 
     @patch('stripe.Customer.create')
     @patch('stripe.Charge.create')
@@ -3096,9 +3096,9 @@ class StripeCreditsTest(TembaTest):
         self.assertEqual(1, len(mail.outbox))
         email = mail.outbox[0]
         self.assertEqual("RapidPro Receipt", email.subject)
-        self.assertTrue('bitcoin' in email.body)
-        self.assertTrue('abcde' in email.body)
-        self.assertTrue('$20' in email.body)
+        self.assertIn('bitcoin', email.body)
+        self.assertIn('abcde', email.body)
+        self.assertIn('$20', email.body)
 
     @patch('stripe.Customer.create')
     def test_add_credits_fail(self, customer_create):
@@ -3190,9 +3190,9 @@ class StripeCreditsTest(TembaTest):
         self.assertEqual(1, len(mail.outbox))
         email = mail.outbox[0]
         self.assertEqual("RapidPro Receipt", email.subject)
-        self.assertTrue('Rudolph' in email.body)
-        self.assertTrue('Visa' in email.body)
-        self.assertTrue('$20' in email.body)
+        self.assertIn('Rudolph', email.body)
+        self.assertIn('Visa', email.body)
+        self.assertIn('$20', email.body)
 
         # try with an invalid card
         customer_retrieve.return_value.cards.throw = True

--- a/temba/public/tests.py
+++ b/temba/public/tests.py
@@ -43,7 +43,7 @@ class PublicTest(SmartminTest):
     def test_welcome(self):
         welcome_url = reverse('public.public_welcome')
         response = self.client.get(welcome_url, follow=True)
-        self.assertTrue('next' in response.request['QUERY_STRING'])
+        self.assertIn('next', response.request['QUERY_STRING'])
         self.assertEqual(response.request['PATH_INFO'], reverse('users.user_login'))
 
         self.login(self.user)

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -1170,7 +1170,7 @@ class TriggerTest(TembaTest):
         post_data = dict(channel=channel.pk, keyword='*keyword#', flow=flow.pk)
         response = self.client.post(reverse("triggers.trigger_ussd"), data=post_data)
         self.assertEqual(1, len(response.context['form'].errors))
-        self.assertTrue("keyword" in response.context['form'].errors)
+        self.assertIn("keyword", response.context['form'].errors)
         self.assertEqual(response.context['form'].errors['keyword'], [u'USSD code must contain only *,# and numbers'])
 
         # try a proper ussd code


### PR DESCRIPTION
 * Replace `assertTrue(x in y)` with `assertIn(x, y)`
 * Replace `assertFalse(x in y)` with `assertNotIn(x, y)`
 * Replace `assertTrue(x not in y)` with `assertNotIn(x, y)`

( Because it's a Friday afternoon, PyCharm 'Replace All' supports regex back references, and these make for nicer failure messages )