### PR TITLE
Tweaks to string tests

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -6371,6 +6371,7 @@ class HasEmailTest(Test):
         # split on whitespace
         words = text.split()
         for word in words:
+            word = word.strip(',.;:|()[]"\'<>?&*/\\')
             if is_valid_address(word):
                 return 1, word
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -6465,6 +6465,8 @@ class ContainsPhraseTest(ContainsTest):
 
         # tokenize our test
         tests = tokenize(test.lower())
+        if not tests:
+            return True, ""
 
         # tokenize our sms
         words = tokenize(text.lower())

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1380,6 +1380,13 @@ class FlowTest(TembaTest):
         sms.text = "this is an email email@foo.bar TODAY!!"
         self.assertTest(True, "email@foo.bar", test)
 
+        test = ContainsOnlyPhraseTest(test=dict(base=""))
+        sms.text = "  RESIST now "
+        self.assertTest(False, None, test)
+
+        sms.text = "  "
+        self.assertTest(True, "", test)
+
         test = ContainsPhraseTest(test=dict(base="resist now"))
         test = ContainsPhraseTest.from_json(self.org, test.as_json())
         sms.text = "we must resist! NOW "
@@ -1390,6 +1397,10 @@ class FlowTest(TembaTest):
 
         sms.text = "  RESIST now "
         self.assertTest(True, "RESIST now", test)
+
+        test = ContainsPhraseTest(test=dict(base=""))
+        sms.text = "  RESIST now "
+        self.assertTest(True, "", test)
 
         test = ContainsTest(test=dict(base="Green green %%$"))
         sms.text = "GReen is my favorite!, %%$"

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1380,6 +1380,12 @@ class FlowTest(TembaTest):
         sms.text = "this is an email email@foo.bar TODAY!!"
         self.assertTest(True, "email@foo.bar", test)
 
+        sms.text = "this is an email followed by a period email@foo.bar."
+        self.assertTest(True, "email@foo.bar", test)
+
+        sms.text = "this is an email surrounded by punctuation <email@foo.bar>,"
+        self.assertTest(True, "email@foo.bar", test)
+
         test = ContainsOnlyPhraseTest(test=dict(base=""))
         sms.text = "  RESIST now "
         self.assertTest(False, None, test)


### PR DESCRIPTION
ContainsPhraseTest shouldn't blow up if test string is empty, i.e.

"x" only contains the phrase ""... already evaluates to false
"" only contains the phrase ""... already evaluates to true
"x" contains the phrase ""... pretty sure this should evaluate to true?

https://sentry.io/nyaruka/textit/issues/416490098/
https://sentry.io/nyaruka/rapidpro/issues/459289471/

HasEmailTest should find email addresses with punctuation before and after: https://github.com/resistbot/rapidbot/issues/66
