### PR TITLE
Make testing with flowserver dependent on configuring FLOW_SERVER_URL

### DIFF
--- a/temba/tests.py
+++ b/temba/tests.py
@@ -176,12 +176,13 @@ class AddFlowServerTestsMeta(type):
     engine, and a new one called test_foo_flowserver with is run using the flowserver.
     """
     def __new__(mcs, name, bases, dct):
-        new_tests = {}
-        for key, val in six.iteritems(dct):
-            if key.startswith('test_') and getattr(val, '_also_in_flowserver', False):
-                new_func = override_settings(FLOW_SERVER_AUTH_TOKEN='1234', FLOW_SERVER_FORCE=True)(val)
-                new_tests[key + '_flowserver'] = new_func
-        dct.update(new_tests)
+        if settings.FLOW_SERVER_URL:
+            new_tests = {}
+            for key, val in six.iteritems(dct):
+                if key.startswith('test_') and getattr(val, '_also_in_flowserver', False):
+                    new_func = override_settings(FLOW_SERVER_AUTH_TOKEN='1234', FLOW_SERVER_FORCE=True)(val)
+                    new_tests[key + '_flowserver'] = new_func
+            dct.update(new_tests)
 
         return super(AddFlowServerTestsMeta, mcs).__new__(mcs, name, bases, dct)
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -1662,7 +1662,6 @@ class MakeTestDBTest(SimpleTestCase):
         def assertOrgCounts(qs, counts):
             self.assertEqual([qs.filter(org=o).count() for o in (org1, org2, org3)], counts)
 
-        print(User.objects.all())
         self.assertEqual(User.objects.exclude(username__in=["AnonymousUser", "root", "rapidpro_flow", "temba_flow"]).count(), 12)
         assertOrgCounts(ContactField.objects.all(), [6, 6, 6])
         assertOrgCounts(ContactGroup.user_groups.all(), [10, 10, 10])


### PR DESCRIPTION
This isn't configured in our TextIt settings yet so flowserver tests won't be created if you're using that settings file 