### PR TITLE
Increase maxDiff in tests

### DIFF
--- a/temba/tests/tests.py
+++ b/temba/tests/tests.py
@@ -190,6 +190,7 @@ class AddFlowServerTestsMeta(type):
 
 class TembaTest(six.with_metaclass(AddFlowServerTestsMeta, SmartminTest)):
     def setUp(self):
+        self.maxDiff = 4096
         self.mock_server = mock_server
 
         # if we are super verbose, turn on debug for sql queries


### PR DESCRIPTION
a.k.a the smallest PR

Now that we're comparing bigger dicts in our tests, we want to see the diffs, but default is only to show diffs up to 640 chars. I'm always upping this locally.