### PR TITLE
Date parsing should accept ISO dates with up to 9 second fraction digits

### DIFF
--- a/temba/utils/dates.py
+++ b/temba/utils/dates.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 MAX_UTC_OFFSET = 14 * 60 * 60
 
 # pattern for any date which should be parsed by the ISO8601 library (assumed to be not human-entered)
-FULL_ISO8601_REGEX = regex.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.(\d{6}|\d{9}))?([\+\-]\d{2}:\d{2}|Z)$')
+FULL_ISO8601_REGEX = regex.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.(\d{,9}))?([\+\-]\d{2}:\d{2}|Z)$')
 
 # patterns for date and time formats supported for human-entered data
 DD_MM_YYYY = regex.compile(r'\b([0-9]{1,2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]([0-9]{4}|[0-9]{2})\b')

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -240,6 +240,8 @@ class DatesTest(TembaTest):
                              str_to_datetime('2013-02-01T04:38:09.100000+02:00', tz, dayfirst=True))  # ISO in other tz
             self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 7, 8, 9, 100000)),
                              str_to_datetime('2013-02-01T00:38:09.100000-02:00', tz, dayfirst=True))  # ISO in other tz
+            self.assertEqual(datetime.datetime(2013, 2, 1, 7, 8, 9, 0, tzinfo=pytz.UTC),
+                             str_to_datetime('2013-02-01T07:08:09Z', tz, dayfirst=True))  # with no second fraction
             self.assertEqual(datetime.datetime(2013, 2, 1, 7, 8, 9, 198000, tzinfo=pytz.UTC),
                              str_to_datetime('2013-02-01T07:08:09.198Z', tz, dayfirst=True))  # with milliseconds
             self.assertEqual(datetime.datetime(2013, 2, 1, 7, 8, 9, 198537, tzinfo=pytz.UTC),
@@ -1817,6 +1819,7 @@ class MatchersTest(TembaTest):
         self.assertEqual("2018-02-21T20:34:07.198537686Z", matchers.ISODate())
         self.assertEqual("2018-02-21T20:34:07.19853768Z", matchers.ISODate())
         self.assertEqual("2018-02-21T20:34:07.198Z", matchers.ISODate())
+        self.assertEqual("2018-02-21T20:34:07Z", matchers.ISODate())
         self.assertEqual("2013-02-01T07:08:09.100000Z", matchers.ISODate())
         self.assertNotEqual(None, matchers.ISODate())
         self.assertNotEqual("abc", matchers.ISODate())

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -240,8 +240,12 @@ class DatesTest(TembaTest):
                              str_to_datetime('2013-02-01T04:38:09.100000+02:00', tz, dayfirst=True))  # ISO in other tz
             self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 7, 8, 9, 100000)),
                              str_to_datetime('2013-02-01T00:38:09.100000-02:00', tz, dayfirst=True))  # ISO in other tz
+            self.assertEqual(datetime.datetime(2013, 2, 1, 7, 8, 9, 198000, tzinfo=pytz.UTC),
+                             str_to_datetime('2013-02-01T07:08:09.198Z', tz, dayfirst=True))  # with milliseconds
             self.assertEqual(datetime.datetime(2013, 2, 1, 7, 8, 9, 198537, tzinfo=pytz.UTC),
                              str_to_datetime('2013-02-01T07:08:09.198537686Z', tz, dayfirst=True))  # with nanoseconds
+            self.assertEqual(datetime.datetime(2013, 2, 1, 7, 8, 9, 198500, tzinfo=pytz.UTC),
+                             str_to_datetime('2013-02-01T07:08:09.1985Z', tz, dayfirst=True))  # with 4 second fraction digits
             self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 7, 8, 9, 100000)),
                              str_to_datetime('2013-02-01T07:08:09.100000+04:30.', tz, dayfirst=True))  # trailing period
             self.assertEqual(tz.localize(datetime.datetime(2013, 2, 1, 0, 0, 0, 0)),
@@ -1811,6 +1815,8 @@ class MatchersTest(TembaTest):
     def test_isodate(self):
         self.assertEqual("2013-02-01T07:08:09.100000+04:30", matchers.ISODate())
         self.assertEqual("2018-02-21T20:34:07.198537686Z", matchers.ISODate())
+        self.assertEqual("2018-02-21T20:34:07.19853768Z", matchers.ISODate())
+        self.assertEqual("2018-02-21T20:34:07.198Z", matchers.ISODate())
         self.assertEqual("2013-02-01T07:08:09.100000Z", matchers.ISODate())
         self.assertNotEqual(None, matchers.ISODate())
         self.assertNotEqual("abc", matchers.ISODate())


### PR DESCRIPTION
Looks like dates from goflow sometimes have a trailing zero removed so you have 1/10 chance of getting a second fraction with 8 digits