### PR TITLE
Test tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
 
   # check we can collect and compress all static files
   - python manage.py collectstatic --noinput --verbosity=0
-  - (! python manage.py compress --extension=".haml" --settings=temba.settings_travis | grep 'Error') || exit 1
+  - (! python manage.py compress --extension=".haml" --settings=temba.settings_compress | grep 'Error') || exit 1
 
   # fire up goflow
   - ./flowserver &

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
   - jobs
     
   # run our Python tests
-  - coverage run manage.py test --noinput --verbosity=2
+  - coverage run manage.py test --settings=temba.settings_travis --noinput --verbosity=2
 
   - set +e
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -40,7 +40,8 @@ from temba.ivr.models import IVRCall
 from temba.msgs.models import MSG_SENT_KEY, SystemLabel
 from temba.orgs.models import Org, ALL_EVENTS, ACCOUNT_SID, ACCOUNT_TOKEN, APPLICATION_SID, NEXMO_KEY, NEXMO_SECRET, FREE_PLAN, NEXMO_UUID, \
     NEXMO_APP_ID, NEXMO_APP_PRIVATE_KEY
-from temba.tests import TembaTest, MockResponse, MockTwilioClient, MockRequestValidator, AnonymousOrg
+from temba.tests import TembaTest, MockResponse, AnonymousOrg
+from temba.tests.twilio import MockTwilioClient, MockRequestValidator
 from temba.triggers.models import Trigger
 from temba.utils import dict_to_struct, get_anonymous_user
 from temba.utils.dates import datetime_to_str, datetime_to_ms, ms_to_datetime

--- a/temba/channels/types/twilio/tests.py
+++ b/temba/channels/types/twilio/tests.py
@@ -9,7 +9,8 @@ from twilio import TwilioRestException
 
 from temba.channels.models import Channel
 from temba.orgs.models import ACCOUNT_SID, ACCOUNT_TOKEN
-from temba.tests import TembaTest, MockTwilioClient, MockRequestValidator
+from temba.tests import TembaTest
+from temba.tests.twilio import MockTwilioClient, MockRequestValidator
 
 
 class TwilioTypeTest(TembaTest):
@@ -57,14 +58,14 @@ class TwilioTypeTest(TembaTest):
             response = self.client.get(claim_twilio)
             self.assertRedirects(response, reverse('orgs.org_twilio_connect'))
 
-        with patch('temba.tests.MockTwilioClient.MockAccounts.get') as mock_get:
+        with patch('temba.tests.twilio.MockTwilioClient.MockAccounts.get') as mock_get:
             mock_get.return_value = MockTwilioClient.MockAccount('Trial')
 
             response = self.client.get(claim_twilio)
             self.assertIn('account_trial', response.context)
             self.assertTrue(response.context['account_trial'])
 
-        with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.search') as mock_search:
+        with patch('temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.search') as mock_search:
             search_url = reverse('channels.channel_search_numbers')
 
             # try making empty request
@@ -95,10 +96,10 @@ class TwilioTypeTest(TembaTest):
             self.assertEqual(json.loads(response.content)['error'],
                              "Sorry, no numbers found, please enter another pattern and try again.")
 
-        with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
+        with patch('temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
             mock_numbers.return_value = [MockTwilioClient.MockPhoneNumber('+12062345678')]
 
-            with patch('temba.tests.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
+            with patch('temba.tests.twilio.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
                 mock_short_codes.return_value = []
 
                 response = self.client.get(claim_twilio)
@@ -120,10 +121,10 @@ class TwilioTypeTest(TembaTest):
                 self.assertTrue(channel_config[Channel.CONFIG_NUMBER_SID])
 
         # voice only number
-        with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
+        with patch('temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
             mock_numbers.return_value = [MockTwilioClient.MockPhoneNumber('+554139087835')]
 
-            with patch('temba.tests.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
+            with patch('temba.tests.twilio.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
                 mock_short_codes.return_value = []
                 Channel.objects.all().delete()
 
@@ -138,10 +139,10 @@ class TwilioTypeTest(TembaTest):
                 channel = Channel.objects.get(channel_type='T', org=self.org)
                 self.assertEqual(channel.role, Channel.ROLE_CALL + Channel.ROLE_ANSWER)
 
-        with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
+        with patch('temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
             mock_numbers.return_value = [MockTwilioClient.MockPhoneNumber('+4545335500')]
 
-            with patch('temba.tests.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
+            with patch('temba.tests.twilio.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
                 mock_short_codes.return_value = []
 
                 Channel.objects.all().delete()
@@ -156,10 +157,10 @@ class TwilioTypeTest(TembaTest):
                 # make sure it is actually connected
                 Channel.objects.get(channel_type='T', org=self.org)
 
-        with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
+        with patch('temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
             mock_numbers.return_value = []
 
-            with patch('temba.tests.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
+            with patch('temba.tests.twilio.MockTwilioClient.MockShortCodes.list') as mock_short_codes:
                 mock_short_codes.return_value = [MockTwilioClient.MockShortCode('8080')]
                 Channel.objects.all().delete()
 
@@ -184,7 +185,7 @@ class TwilioTypeTest(TembaTest):
         self.assertEqual('T', twilio_channel.channel_type)
 
         with self.settings(IS_PROD=True):
-            with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.update') as mock_numbers:
+            with patch('temba.tests.twilio.MockTwilioClient.MockPhoneNumbers.update') as mock_numbers:
                 # our twilio channel removal should fail on bad auth
                 mock_numbers.side_effect = TwilioRestException(401, 'http://twilio', msg='Authentication Failure',
                                                                code=20003)

--- a/temba/channels/types/twilio_messaging_service/tests.py
+++ b/temba/channels/types/twilio_messaging_service/tests.py
@@ -7,7 +7,8 @@ from twilio import TwilioRestException
 
 from temba.channels.views import TWILIO_SUPPORTED_COUNTRIES
 from temba.orgs.models import ACCOUNT_SID, ACCOUNT_TOKEN, APPLICATION_SID
-from temba.tests import TembaTest, MockTwilioClient, MockRequestValidator
+from temba.tests import TembaTest
+from temba.tests.twilio import MockTwilioClient, MockRequestValidator
 
 
 class TwilioMessagingServiceTypeTest(TembaTest):
@@ -58,7 +59,7 @@ class TwilioMessagingServiceTypeTest(TembaTest):
             response = self.client.get(claim_twilio_ms)
             self.assertRedirects(response, reverse('orgs.org_twilio_connect'))
 
-        with patch('temba.tests.MockTwilioClient.MockAccounts.get') as mock_get:
+        with patch('temba.tests.twilio.MockTwilioClient.MockAccounts.get') as mock_get:
             mock_get.return_value = MockTwilioClient.MockAccount('Trial')
 
             response = self.client.get(claim_twilio_ms)

--- a/temba/channels/types/twiml_api/tests.py
+++ b/temba/channels/types/twiml_api/tests.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django.urls import reverse
 from mock import patch
 
-from temba.tests import TembaTest, MockTwilioClient, MockRequestValidator
+from temba.tests import TembaTest
+from temba.tests.twilio import MockTwilioClient, MockRequestValidator
 
 
 class TwimlAPITypeTest(TembaTest):

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -9142,6 +9142,7 @@ class AssetServerTest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), [])
 
+    @skip_if_no_flowserver
     def test_flows(self):
         flow1 = self.get_flow('color')
         flow2 = self.get_flow('favorites')

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -30,7 +30,7 @@ from temba.ussd.models import USSDSession
 from temba.locations.models import AdminBoundary, BoundaryAlias
 from temba.msgs.models import Broadcast, Label, Msg, INCOMING, PENDING, WIRED, OUTGOING, FAILED
 from temba.orgs.models import Language, get_current_export_version
-from temba.tests import TembaTest, MockResponse, FlowFileTest, also_in_flowserver, matchers
+from temba.tests import TembaTest, MockResponse, FlowFileTest, also_in_flowserver, skip_if_no_flowserver, matchers
 from temba.triggers.models import Trigger
 from temba.utils.dates import datetime_to_str
 from temba.utils.goflow import FlowServerException
@@ -9040,6 +9040,7 @@ class FlowServerTest(TembaTest):
 
         self.contact = self.create_contact("Joe", "+250788373373")
 
+    @skip_if_no_flowserver
     @override_settings(FLOW_SERVER_AUTH_TOKEN='1234', FLOW_SERVER_FORCE=True)
     def test_session_bulk_start(self):
         flow = self.get_flow('favorites')
@@ -9089,6 +9090,7 @@ class FlowServerTest(TembaTest):
 
             self.assertEqual(flow.start([], [self.contact], restart_participants=True), [])
 
+    @skip_if_no_flowserver
     @override_settings(FLOW_SERVER_AUTH_TOKEN='1234', FLOW_SERVER_FORCE=True)
     def test_session_resume(self):
         flow = self.get_flow('favorites')

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -19,7 +19,8 @@ from temba.contacts.models import Contact
 from temba.flows.models import Flow, FlowRun, ActionLog, FlowStep, FlowRevision
 from temba.msgs.models import Msg, IVR, OUTGOING, PENDING
 from temba.orgs.models import get_current_export_version
-from temba.tests import FlowFileTest, MockTwilioClient, MockRequestValidator, MockResponse
+from temba.tests import FlowFileTest, MockResponse
+from temba.tests.twilio import MockTwilioClient, MockRequestValidator
 from six.moves.urllib.parse import urlparse
 from .clients import IVRException
 from .models import IVRCall

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -31,7 +31,8 @@ from temba.locations.models import AdminBoundary
 from temba.middleware import BrandingMiddleware
 from temba.msgs.models import Label, Msg, INCOMING
 from temba.orgs.models import UserSettings, NEXMO_SECRET, NEXMO_KEY
-from temba.tests import TembaTest, MockResponse, MockTwilioClient, MockRequestValidator
+from temba.tests import TembaTest, MockResponse
+from temba.tests.twilio import MockTwilioClient, MockRequestValidator
 from temba.triggers.models import Trigger
 from temba.utils.email import link_components
 from temba.utils import languages, dict_to_struct
@@ -1175,7 +1176,7 @@ class OrgTest(TembaTest):
     @patch('temba.orgs.views.TwilioRestClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
     def test_twilio_connect(self):
-        with patch('temba.tests.MockTwilioClient.MockAccounts.get') as mock_get:
+        with patch('temba.tests.twilio.MockTwilioClient.MockAccounts.get') as mock_get:
             mock_get.return_value = MockTwilioClient.MockAccount('Full')
 
             connect_url = reverse("orgs.org_twilio_connect")
@@ -1196,7 +1197,7 @@ class OrgTest(TembaTest):
             post_data['account_token'] = "AccountToken"
 
             # but with an unexpected exception
-            with patch('temba.tests.MockTwilioClient.__init__') as mock:
+            with patch('temba.tests.twilio.MockTwilioClient.__init__') as mock:
                 mock.side_effect = Exception('Unexpected')
                 response = self.client.post(connect_url, post_data)
                 self.assertFormError(response, 'form', '__all__', 'The Twilio account SID and Token seem invalid. '
@@ -1209,7 +1210,7 @@ class OrgTest(TembaTest):
             self.assertEqual(self.org.config['ACCOUNT_TOKEN'], "AccountToken")
 
             # when the user submit the secondary token, we use it to get the primary one from the rest API
-            with patch('temba.tests.MockTwilioClient.MockAccounts.get') as mock_get_primary:
+            with patch('temba.tests.twilio.MockTwilioClient.MockAccounts.get') as mock_get_primary:
                 with patch('twilio.rest.resources.ListResource.get') as mock_list_resource_get:
                     mock_get_primary.return_value = MockTwilioClient.MockAccount('Full', 'PrimaryAccountToken')
                     mock_list_resource_get.return_value = MockTwilioClient.MockAccount('Full', 'PrimaryAccountToken')

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -85,9 +85,3 @@ warnings.filterwarnings('error', r"DateTimeField .* received a naive datetime",
 # Make our sitestatic URL be our static URL on development
 # -----------------------------------------------------------------------------------
 STATIC_URL = '/sitestatic/'
-
-# -----------------------------------------------------------------------------------
-# GoFlow
-# -----------------------------------------------------------------------------------
-FLOW_SERVER_URL = 'http://localhost:8080'
-FLOW_SERVER_DEBUG = False

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1211,7 +1211,7 @@ SUCCESS_LOGS_TRIM_TIME = 48
 ALL_LOGS_TRIM_TIME = 24 * 30
 
 # -----------------------------------------------------------------------------------
-# GoFlow
+# Flowserver - disabled by default. GoFlow defaults to http://localhost:8080
 # -----------------------------------------------------------------------------------
 FLOW_SERVER_URL = None
 FLOW_SERVER_AUTH_TOKEN = None

--- a/temba/settings_compress.py
+++ b/temba/settings_compress.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .settings import STATIC_URL
+from .settings import *  # noqa
+
+COMPRESS_ENABLED = True
+COMPRESS_OFFLINE = True
+COMPRESS_CSS_HASHING_METHOD = 'content'
+COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL,
+                                base_template='frame.html',
+                                brand=BRANDING[DEFAULT_BRAND],
+                                debug=False,
+                                testing=False)

--- a/temba/settings_travis.py
+++ b/temba/settings_travis.py
@@ -1,16 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from .settings import STATIC_URL
 from .settings import *  # noqa
 
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
-COMPRESS_CSS_HASHING_METHOD = 'content'
-COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL,
-                                base_template='frame.html',
-                                brand=BRANDING[DEFAULT_BRAND],
-                                debug=False,
-                                testing=False)
 
+# -----------------------------------------------------------------------------------
+# Flowserver - on Travis we start a GoFlow instance at http://localhost:8080
+# -----------------------------------------------------------------------------------
 FLOW_SERVER_URL = 'http://localhost:8080'

--- a/temba/settings_travis.py
+++ b/temba/settings_travis.py
@@ -12,3 +12,5 @@ COMPRESS_OFFLINE_CONTEXT = dict(STATIC_URL=STATIC_URL,
                                 brand=BRANDING[DEFAULT_BRAND],
                                 debug=False,
                                 testing=False)
+
+FLOW_SERVER_URL = 'http://localhost:8080'

--- a/temba/tests/__init__.py
+++ b/temba/tests/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals, absolute_import
 
-from .tests import *  # noqa
+from .base import *  # noqa

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import inspect
@@ -12,9 +11,7 @@ import shutil
 import string
 import six
 import time
-from six.moves.urllib.parse import urlparse
 
-from cgi import parse_header, parse_multipart
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib.auth.models import User, Group
@@ -25,7 +22,6 @@ from django.test import LiveServerTestCase, override_settings
 from django.test.runner import DiscoverRunner
 from django.utils import timezone
 from future.moves.html.parser import HTMLParser
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from selenium.webdriver.firefox.webdriver import WebDriver
 from smartmin.tests import SmartminTest
 from temba.contacts.models import Contact, ContactGroup, ContactField, URN
@@ -37,95 +33,10 @@ from temba.ivr.clients import TwilioClient
 from temba.msgs.models import Msg, INCOMING
 from temba.utils import dict_to_struct, get_anonymous_user
 from temba.values.models import Value
-from threading import Thread
 from twilio.util import RequestValidator
+from unittest import skipIf
 from uuid import uuid4
-
-
-class MockServerRequestHandler(BaseHTTPRequestHandler):
-    """
-    A simple HTTP handler which responds to a request with a matching mocked request
-    """
-    def _handle_request(self, method, data=None):
-
-        if not self.server.mocked_requests:
-            raise ValueError("unexpected request %s %s with no mock configured" % (method, self.path))
-
-        mock = self.server.mocked_requests[0]
-        if mock.method != method or mock.path != self.path:
-            raise ValueError("expected request %s %s but received %s %s" % (mock.method, mock.path, method, self.path))
-
-        # add some stuff to the mock from the request that the caller might want to check
-        mock.requested = True
-        mock.data = data
-        mock.headers = self.headers.dict
-
-        # remove this mocked request now that it has been made
-        self.server.mocked_requests = self.server.mocked_requests[1:]
-
-        self.send_response(mock.status)
-        self.send_header("Content-type", mock.content_type)
-        self.end_headers()
-        self.wfile.write(mock.content.encode('utf-8'))
-
-    def do_GET(self):
-        return self._handle_request('GET')
-
-    def do_POST(self):
-        ctype, pdict = parse_header(self.headers['content-type'])
-        if ctype == 'multipart/form-data':
-            data = parse_multipart(self.rfile, pdict)
-        elif ctype == 'application/x-www-form-urlencoded':
-            length = int(self.headers['content-length'])
-            data = urlparse.parse_qs(self.rfile.read(length), keep_blank_values=1)
-        elif ctype == 'application/json':
-            length = int(self.headers['content-length'])
-            data = json.loads(self.rfile.read(length))
-        else:
-            data = {}
-
-        return self._handle_request('POST', data)
-
-
-class MockServer(HTTPServer):
-    """
-    Webhook calls may call out to external HTTP servers so a instance of this server runs alongside the test suite
-    and provides a mechanism for mocking requests to particular URLs
-    """
-    @six.python_2_unicode_compatible
-    class Request(object):
-        def __init__(self, method, path, content, content_type, status):
-            self.method = method
-            self.path = path
-            self.content = content
-            self.content_type = content_type
-            self.status = status
-
-            self.requested = False
-            self.data = None
-            self.headers = None
-
-        def __str__(self):
-            return '%s %s -> %s' % (self.method, self.path, self.content)
-
-    def __init__(self):
-        HTTPServer.__init__(self, ('localhost', 49999), MockServerRequestHandler)
-
-        self.base_url = 'http://localhost:49999'
-        self.mocked_requests = []
-
-    def start(self):
-        """
-        Starts running mock server in a daemon thread which will automatically shut down when the main process exits
-        """
-        t = Thread(target=self.serve_forever)
-        t.setDaemon(True)
-        t.start()
-
-    def mock_request(self, method, path, content, content_type, status):
-        request = MockServer.Request(method, path, content, content_type, status)
-        self.mocked_requests.append(request)
-        return request
+from .http import MockServer
 
 
 mock_server = MockServer()
@@ -160,6 +71,13 @@ class TembaTestRunner(DiscoverRunner):
 
 def add_testing_flag_to_context(*args):
     return dict(testing=settings.TESTING)
+
+
+def skip_if_no_flowserver(test):
+    """
+    Skip a test if flow server isn't configured
+    """
+    return skipIf(settings.FLOW_SERVER_URL is None, "this test can't be run without a flowserver instance")(test)
 
 
 def also_in_flowserver(test_func):
@@ -880,118 +798,3 @@ class AnonymousOrg(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.org.is_anon = False
         self.org.save(update_fields=('is_anon',))
-
-
-class MockRequestValidator(RequestValidator):
-
-    def __init__(self, token):
-        pass
-
-    def validate(self, url, post, signature):
-        return True
-
-
-class MockTwilioClient(TwilioClient):
-
-    def __init__(self, sid, token, org=None, base=None):
-        self.org = org
-        self.base = base
-        self.applications = MockTwilioClient.MockApplications()
-        self.calls = MockTwilioClient.MockCalls()
-        self.accounts = MockTwilioClient.MockAccounts()
-        self.phone_numbers = MockTwilioClient.MockPhoneNumbers()
-        self.sms = MockTwilioClient.MockSMS()
-        self.auth = ['', 'FakeRequestToken']
-
-    def validate(self, request):
-        return True
-
-    class MockShortCode(object):
-        def __init__(self, short_code):
-            self.short_code = short_code
-            self.sid = "ShortSid"
-
-    class MockShortCodes(object):
-        def __init__(self, *args):
-            pass
-
-        def list(self, short_code=None):
-            return [MockTwilioClient.MockShortCode(short_code)]
-
-        def update(self, sid, **kwargs):
-            print("Updating short code with sid %s" % sid)
-
-    class MockSMS(object):
-        def __init__(self, *args):
-            self.uri = "/SMS"
-            self.short_codes = MockTwilioClient.MockShortCodes()
-
-    class MockCall(object):
-        def __init__(self, to=None, from_=None, url=None, status_callback=None):
-            self.to = to
-            self.from_ = from_
-            self.url = url
-            self.status_callback = status_callback
-            self.sid = 'CallSid'
-
-    class MockApplication(object):
-        def __init__(self, friendly_name):
-            self.friendly_name = friendly_name
-            self.sid = 'TwilioTestSid'
-
-    class MockPhoneNumber(object):
-        def __init__(self, phone_number):
-            self.phone_number = phone_number
-            self.sid = 'PhoneNumberSid'
-
-    class MockAccount(object):
-        def __init__(self, account_type, auth_token='AccountToken'):
-            self.type = account_type
-            self.auth_token = auth_token
-            self.sid = 'AccountSid'
-
-    class MockAccounts(object):
-        def __init__(self, *args):
-            pass
-
-        def get(self, account_type):
-            return MockTwilioClient.MockAccount(account_type)
-
-    class MockPhoneNumbers(object):
-        def __init__(self, *args):
-            pass
-
-        def list(self, phone_number=None):
-            return [MockTwilioClient.MockPhoneNumber(phone_number)]
-
-        def search(self, **kwargs):
-            return []
-
-        def update(self, sid, **kwargs):
-            print("Updating phone number with sid %s" % sid)
-
-    class MockApplications(object):
-        def __init__(self, *args):
-            pass
-
-        def create(self, **kwargs):
-            return MockTwilioClient.MockApplication('temba.io/1234')
-
-        def list(self, friendly_name=None):
-            return [MockTwilioClient.MockApplication(friendly_name)]
-
-        def delete(self, **kwargs):
-            return True
-
-    class MockCalls(object):
-        def __init__(self):
-            self.events = []
-
-        def create(self, to=None, from_=None, url=None, status_callback=None):
-            return MockTwilioClient.MockCall(to=to, from_=from_, url=url, status_callback=status_callback)
-
-        def hangup(self, external_id):
-            print("Hanging up %s on Twilio" % external_id)
-
-        def update(self, external_id, url):
-            print("Updating call for %s to url %s" % (external_id, url))

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -29,11 +29,9 @@ from temba.orgs.models import Org
 from temba.channels.models import Channel
 from temba.locations.models import AdminBoundary
 from temba.flows.models import Flow, ActionSet, RuleSet, FlowStep, FlowRevision, clear_flow_users
-from temba.ivr.clients import TwilioClient
 from temba.msgs.models import Msg, INCOMING
 from temba.utils import dict_to_struct, get_anonymous_user
 from temba.values.models import Value
-from twilio.util import RequestValidator
 from unittest import skipIf
 from uuid import uuid4
 from .http import MockServer

--- a/temba/tests/http.py
+++ b/temba/tests/http.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import six
+
+from cgi import parse_header, parse_multipart
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from six.moves.urllib.parse import urlparse
+from threading import Thread
+
+
+class MockServerRequestHandler(BaseHTTPRequestHandler):
+    """
+    A simple HTTP handler which responds to a request with a matching mocked request
+    """
+    def _handle_request(self, method, data=None):
+
+        if not self.server.mocked_requests:
+            raise ValueError("unexpected request %s %s with no mock configured" % (method, self.path))
+
+        mock = self.server.mocked_requests[0]
+        if mock.method != method or mock.path != self.path:
+            raise ValueError("expected request %s %s but received %s %s" % (mock.method, mock.path, method, self.path))
+
+        # add some stuff to the mock from the request that the caller might want to check
+        mock.requested = True
+        mock.data = data
+        mock.headers = self.headers.dict
+
+        # remove this mocked request now that it has been made
+        self.server.mocked_requests = self.server.mocked_requests[1:]
+
+        self.send_response(mock.status)
+        self.send_header("Content-type", mock.content_type)
+        self.end_headers()
+        self.wfile.write(mock.content.encode('utf-8'))
+
+    def do_GET(self):
+        return self._handle_request('GET')
+
+    def do_POST(self):
+        ctype, pdict = parse_header(self.headers['content-type'])
+        if ctype == 'multipart/form-data':
+            data = parse_multipart(self.rfile, pdict)
+        elif ctype == 'application/x-www-form-urlencoded':
+            length = int(self.headers['content-length'])
+            data = urlparse.parse_qs(self.rfile.read(length), keep_blank_values=1)
+        elif ctype == 'application/json':
+            length = int(self.headers['content-length'])
+            data = json.loads(self.rfile.read(length))
+        else:
+            data = {}
+
+        return self._handle_request('POST', data)
+
+
+class MockServer(HTTPServer):
+    """
+    Webhook calls may call out to external HTTP servers so a instance of this server runs alongside the test suite
+    and provides a mechanism for mocking requests to particular URLs
+    """
+    @six.python_2_unicode_compatible
+    class Request(object):
+        def __init__(self, method, path, content, content_type, status):
+            self.method = method
+            self.path = path
+            self.content = content
+            self.content_type = content_type
+            self.status = status
+
+            self.requested = False
+            self.data = None
+            self.headers = None
+
+        def __str__(self):
+            return '%s %s -> %s' % (self.method, self.path, self.content)
+
+    def __init__(self):
+        HTTPServer.__init__(self, ('localhost', 49999), MockServerRequestHandler)
+
+        self.base_url = 'http://localhost:49999'
+        self.mocked_requests = []
+
+    def start(self):
+        """
+        Starts running mock server in a daemon thread which will automatically shut down when the main process exits
+        """
+        t = Thread(target=self.serve_forever)
+        t.setDaemon(True)
+        t.start()
+
+    def mock_request(self, method, path, content, content_type, status):
+        request = MockServer.Request(method, path, content, content_type, status)
+        self.mocked_requests.append(request)
+        return request

--- a/temba/tests/twilio.py
+++ b/temba/tests/twilio.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from temba.ivr.clients import TwilioClient
+from twilio.util import RequestValidator
+
+
+class MockRequestValidator(RequestValidator):
+
+    def __init__(self, token):
+        pass
+
+    def validate(self, url, post, signature):
+        return True
+
+
+class MockTwilioClient(TwilioClient):
+
+    def __init__(self, sid, token, org=None, base=None):
+        self.org = org
+        self.base = base
+        self.applications = MockTwilioClient.MockApplications()
+        self.calls = MockTwilioClient.MockCalls()
+        self.accounts = MockTwilioClient.MockAccounts()
+        self.phone_numbers = MockTwilioClient.MockPhoneNumbers()
+        self.sms = MockTwilioClient.MockSMS()
+        self.auth = ['', 'FakeRequestToken']
+
+    def validate(self, request):
+        return True
+
+    class MockShortCode(object):
+        def __init__(self, short_code):
+            self.short_code = short_code
+            self.sid = "ShortSid"
+
+    class MockShortCodes(object):
+        def __init__(self, *args):
+            pass
+
+        def list(self, short_code=None):
+            return [MockTwilioClient.MockShortCode(short_code)]
+
+        def update(self, sid, **kwargs):
+            print("Updating short code with sid %s" % sid)
+
+    class MockSMS(object):
+        def __init__(self, *args):
+            self.uri = "/SMS"
+            self.short_codes = MockTwilioClient.MockShortCodes()
+
+    class MockCall(object):
+        def __init__(self, to=None, from_=None, url=None, status_callback=None):
+            self.to = to
+            self.from_ = from_
+            self.url = url
+            self.status_callback = status_callback
+            self.sid = 'CallSid'
+
+    class MockApplication(object):
+        def __init__(self, friendly_name):
+            self.friendly_name = friendly_name
+            self.sid = 'TwilioTestSid'
+
+    class MockPhoneNumber(object):
+        def __init__(self, phone_number):
+            self.phone_number = phone_number
+            self.sid = 'PhoneNumberSid'
+
+    class MockAccount(object):
+        def __init__(self, account_type, auth_token='AccountToken'):
+            self.type = account_type
+            self.auth_token = auth_token
+            self.sid = 'AccountSid'
+
+    class MockAccounts(object):
+        def __init__(self, *args):
+            pass
+
+        def get(self, account_type):
+            return MockTwilioClient.MockAccount(account_type)
+
+    class MockPhoneNumbers(object):
+        def __init__(self, *args):
+            pass
+
+        def list(self, phone_number=None):
+            return [MockTwilioClient.MockPhoneNumber(phone_number)]
+
+        def search(self, **kwargs):
+            return []
+
+        def update(self, sid, **kwargs):
+            print("Updating phone number with sid %s" % sid)
+
+    class MockApplications(object):
+        def __init__(self, *args):
+            pass
+
+        def create(self, **kwargs):
+            return MockTwilioClient.MockApplication('temba.io/1234')
+
+        def list(self, friendly_name=None):
+            return [MockTwilioClient.MockApplication(friendly_name)]
+
+        def delete(self, **kwargs):
+            return True
+
+    class MockCalls(object):
+        def __init__(self):
+            self.events = []
+
+        def create(self, to=None, from_=None, url=None, status_callback=None):
+            return MockTwilioClient.MockCall(to=to, from_=from_, url=url, status_callback=status_callback)
+
+        def hangup(self, external_id):
+            print("Hanging up %s on Twilio" % external_id)
+
+        def update(self, external_id, url):
+            print("Updating call for %s to url %s" % (external_id, url))


### PR DESCRIPTION
 * Change settings so that by default no flowserver is configured 
 * Update travis build so that it does still run flowserver tests
 * Add test `@skip_if_no_flowserver` decorator to skip flowserver tests when no flowserver is configured 
 * Split `tests/tests.py` into `base.py`, `http.py` and `twilio.py`