### PR TITLE
Add refresh view to whatsapp view, restructure channel types views

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -134,13 +134,20 @@ class ChannelType(six.with_metaclass(ABCMeta)):
         """
         return Engine.get_default().from_string(self.claim_blurb)
 
+    def get_urls(self):
+        """
+        Returns all the URLs this channel exposes to Django, the URL should be relative.
+        """
+        if self.claim_view:
+            return [self.get_claim_url()]
+        else:
+            return []
+
     def get_claim_url(self):
         """
         Gets the URL/view configuration for this channel types's claim page
         """
-        rel_url = r'^claim/%s/' % self.slug
-        url_name = 'channels.claim_%s' % self.slug
-        return url(rel_url, self.claim_view.as_view(channel_type=self), name=url_name)
+        return url(r'^claim$', self.claim_view.as_view(channel_type=self), name='claim')
 
     def get_update_form(self):
         if self.update_form is None:

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -141,11 +141,11 @@ class ChannelTest(TembaTest):
         response = self.client.get(reverse('channels.channel_read', args=[self.tel_channel.uuid]))
         self.assertEqual(404, response.status_code)
 
-    def test_channelog_links(self):
+    def test_channellog_links(self):
         self.login(self.admin)
 
         channel_types = (
-            ('JN', Channel.DEFAULT_ROLE, 'Sending Log'),
+            ('JN', Channel.DEFAULT_ROLE, 'Channel Log'),
             ('JNU', Channel.ROLE_USSD, 'USSD Log'),
             ('T', Channel.ROLE_CALL, 'Call Log'),
             ('T', Channel.ROLE_SEND + Channel.ROLE_CALL, 'Channel Log')

--- a/temba/channels/types/africastalking/tests.py
+++ b/temba/channels/types/africastalking/tests.py
@@ -43,7 +43,7 @@ class AfricastalkingTypeTest(TembaTest):
         self.assertEqual('KE', channel.country)
         self.assertEqual('AT', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/africastalking/tests.py
+++ b/temba/channels/types/africastalking/tests.py
@@ -11,7 +11,7 @@ class AfricastalkingTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_africastalking')
+        url = reverse('channels.types.africastalking.claim')
         self.login(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim'))

--- a/temba/channels/types/arabiacell/tests.py
+++ b/temba/channels/types/arabiacell/tests.py
@@ -10,9 +10,9 @@ class ArabiaCellTest(TembaTest):
 
     def test_claim(self):
         self.login(self.admin)
-        response = self.client.get(reverse('channels.channel_claim'))
+        response = self.client.get(reverse('channels.channel.claim'))
 
-        claim_url = reverse('channels.claim_arabiacell')
+        claim_url = reverse('channels.types.arabiacell_claim')
         response = self.client.get(claim_url)
         post_data = response.context['form'].initial
 

--- a/temba/channels/types/arabiacell/tests.py
+++ b/temba/channels/types/arabiacell/tests.py
@@ -10,9 +10,9 @@ class ArabiaCellTest(TembaTest):
 
     def test_claim(self):
         self.login(self.admin)
-        response = self.client.get(reverse('channels.channel.claim'))
+        response = self.client.get(reverse('channels.channel_claim'))
 
-        claim_url = reverse('channels.types.arabiacell_claim')
+        claim_url = reverse('channels.types.arabiacell.claim')
         response = self.client.get(claim_url)
         post_data = response.context['form'].initial
 

--- a/temba/channels/types/blackmyna/tests.py
+++ b/temba/channels/types/blackmyna/tests.py
@@ -11,7 +11,7 @@ class BlackmynaTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_blackmyna')
+        url = reverse('channels.types.blackmyna.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/blackmyna/tests.py
+++ b/temba/channels/types/blackmyna/tests.py
@@ -44,7 +44,7 @@ class BlackmynaTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('BM', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/chikka/tests.py
+++ b/temba/channels/types/chikka/tests.py
@@ -46,7 +46,7 @@ class ChikkaTypeTest(TembaTest):
         self.assertEqual('PH', channel.country)
         self.assertEqual('CK', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/chikka/tests.py
+++ b/temba/channels/types/chikka/tests.py
@@ -11,7 +11,7 @@ class ChikkaTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_chikka')
+        url = reverse('channels.types.chikka.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/clickatell/tests.py
+++ b/temba/channels/types/clickatell/tests.py
@@ -13,7 +13,7 @@ class ClickatellTypeTest(TembaTest):
 
         self.login(self.admin)
 
-        url = reverse('channels.claim_clickatell')
+        url = reverse('channels.types.clickatell.claim')
 
         # should see the general channel claim page
         response = self.client.get(reverse('channels.channel_claim'))

--- a/temba/channels/types/clickatell/tests.py
+++ b/temba/channels/types/clickatell/tests.py
@@ -37,7 +37,7 @@ class ClickatellTypeTest(TembaTest):
         self.assertEqual('12345', channel.config['api_key'])
         self.assertEqual('CT', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/dartmedia/tests.py
+++ b/temba/channels/types/dartmedia/tests.py
@@ -13,7 +13,7 @@ class DartMediaTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_dartmedia')
+        url = reverse('channels.types.dartmedia.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/dartmedia/tests.py
+++ b/temba/channels/types/dartmedia/tests.py
@@ -49,7 +49,7 @@ class DartMediaTypeTest(TembaTest):
         self.assertEqual(post_data['password'], channel.config['password'])
         self.assertEqual('DA', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/dmark/tests.py
+++ b/temba/channels/types/dmark/tests.py
@@ -58,7 +58,7 @@ class DMarkTypeTest(TembaTest):
         self.assertEqual('CD', channel.country)
         self.assertEqual('DK', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/dmark/tests.py
+++ b/temba/channels/types/dmark/tests.py
@@ -13,7 +13,7 @@ class DMarkTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_dmark')
+        url = reverse('channels.types.dmark.claim')
         self.login(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim'))

--- a/temba/channels/types/external/tests.py
+++ b/temba/channels/types/external/tests.py
@@ -8,7 +8,7 @@ from ...models import Channel
 
 class ExternalTypeTest(TembaTest):
     def test_claim(self):
-        url = reverse('channels.claim_external')
+        url = reverse('channels.types.external.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/external/tests.py
+++ b/temba/channels/types/external/tests.py
@@ -44,7 +44,7 @@ class ExternalTypeTest(TembaTest):
         self.assertEqual(channel.config[Channel.CONFIG_MAX_LENGTH], 180)
         self.assertEqual(channel.channel_type, 'EX')
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/external/views.py
+++ b/temba/channels/types/external/views.py
@@ -53,7 +53,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
     title = "Connect External Service"
     permission = 'channels.channel_claim'
-    success_url = "id@channels.channel_configuration"
+    success_url = "uuid@channels.channel_configuration"
 
     def derive_initial(self):
         return {'body': Channel.CONFIG_DEFAULT_SEND_BODY}

--- a/temba/channels/types/facebook/tests.py
+++ b/temba/channels/types/facebook/tests.py
@@ -22,7 +22,7 @@ class FacebookTypeTest(TembaTest):
     @patch('requests.get')
     @patch('requests.post')
     def test_claim(self, mock_post, mock_get):
-        url = reverse('channels.claim_facebook')
+        url = reverse('channels.types.facebook.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/firebase/tests.py
+++ b/temba/channels/types/firebase/tests.py
@@ -19,7 +19,7 @@ class FirebaseCloudMessagingTypeTest(TembaTest):
 
     @patch('requests.get')
     def test_claim(self, mock_get):
-        url = reverse('channels.claim_firebase')
+        url = reverse('channels.types.firebase.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/firebase/tests.py
+++ b/temba/channels/types/firebase/tests.py
@@ -37,7 +37,7 @@ class FirebaseCloudMessagingTypeTest(TembaTest):
         }, follow=True)
 
         channel = Channel.objects.get(address='abcde12345')
-        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.id]))
+        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.uuid]))
         self.assertEqual(channel.channel_type, "FCM")
         self.assertEqual(
             channel.config,

--- a/temba/channels/types/globe/tests.py
+++ b/temba/channels/types/globe/tests.py
@@ -12,7 +12,7 @@ class GlobeTypeTest(TembaTest):
         self.org.channels.all().update(is_active=False)
 
         self.login(self.admin)
-        claim_url = reverse('channels.claim_globe')
+        claim_url = reverse('channels.types.globe.claim')
 
         response = self.client.get(reverse('channels.channel_claim'))
         self.assertNotContains(response, claim_url)

--- a/temba/channels/types/highconnection/tests.py
+++ b/temba/channels/types/highconnection/tests.py
@@ -11,7 +11,7 @@ class HighConnectionTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_high_connection')
+        url = reverse('channels.types.high_connection.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/highconnection/tests.py
+++ b/temba/channels/types/highconnection/tests.py
@@ -47,7 +47,7 @@ class HighConnectionTypeTest(TembaTest):
         self.assertEqual(post_data['password'], channel.config['password'])
         self.assertEqual('HX', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/hub9/tests.py
+++ b/temba/channels/types/hub9/tests.py
@@ -49,7 +49,7 @@ class Hub9TypeTest(TembaTest):
         self.assertEqual(post_data['password'], channel.config['password'])
         self.assertEqual('H9', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/hub9/tests.py
+++ b/temba/channels/types/hub9/tests.py
@@ -13,7 +13,7 @@ class Hub9TypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_hub9')
+        url = reverse('channels.types.hub9.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/infobip/tests.py
+++ b/temba/channels/types/infobip/tests.py
@@ -11,7 +11,7 @@ class InfobipTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_infobip')
+        url = reverse('channels.types.infobip.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/infobip/tests.py
+++ b/temba/channels/types/infobip/tests.py
@@ -38,7 +38,7 @@ class InfobipTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('IB', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/jasmin/tests.py
+++ b/temba/channels/types/jasmin/tests.py
@@ -40,7 +40,7 @@ class JasminTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('JS', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/jasmin/tests.py
+++ b/temba/channels/types/jasmin/tests.py
@@ -11,7 +11,7 @@ class JasminTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_jasmin')
+        url = reverse('channels.types.jasmin.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/jiochat/tests.py
+++ b/temba/channels/types/jiochat/tests.py
@@ -12,7 +12,7 @@ from temba.channels.types.jiochat.tasks import refresh_jiochat_access_tokens
 
 class JioChatTypeTest(TembaTest):
     def test_claim(self):
-        url = reverse('channels.claim_jiochat')
+        url = reverse('channels.types.jiochat.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/jiochat/tests.py
+++ b/temba/channels/types/jiochat/tests.py
@@ -39,7 +39,7 @@ class JioChatTypeTest(TembaTest):
             }
         )
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/junebug/tests.py
+++ b/temba/channels/types/junebug/tests.py
@@ -40,7 +40,7 @@ class JunebugTypeTest(TembaTest):
         self.assertEqual(channel.channel_type, 'JN')
         self.assertEqual(channel.role, Channel.DEFAULT_ROLE)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
@@ -76,7 +76,7 @@ class JunebugTypeTest(TembaTest):
         self.assertEqual(channel.channel_type, 'JN')
         self.assertEqual(channel.role, Channel.DEFAULT_ROLE)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/junebug/tests.py
+++ b/temba/channels/types/junebug/tests.py
@@ -11,7 +11,7 @@ class JunebugTypeTest(TembaTest):
         Channel.objects.all().delete()
         self.login(self.admin)
 
-        url = reverse('channels.claim_junebug')
+        url = reverse('channels.types.junebug.claim')
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse('channels.channel_claim'))

--- a/temba/channels/types/junebug_ussd/tests.py
+++ b/temba/channels/types/junebug_ussd/tests.py
@@ -13,7 +13,7 @@ class JunebugTypeTest(TembaTest):
         Channel.objects.all().delete()
         self.login(self.admin)
 
-        url = reverse('channels.claim_junebug_ussd')
+        url = reverse('channels.types.junebug_ussd.claim')
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse('channels.channel_claim'))

--- a/temba/channels/types/kannel/tests.py
+++ b/temba/channels/types/kannel/tests.py
@@ -17,7 +17,7 @@ class KannelTypeTest(TembaTest):
 
         self.login(self.admin)
 
-        url = reverse('channels.claim_kannel')
+        url = reverse('channels.types.kannel.claim')
 
         # should see the general channel claim page
         response = self.client.get(reverse('channels.channel_claim'))

--- a/temba/channels/types/kannel/tests.py
+++ b/temba/channels/types/kannel/tests.py
@@ -50,7 +50,7 @@ class KannelTypeTest(TembaTest):
         self.assertEqual(channel.config[Channel.CONFIG_CALLBACK_DOMAIN], "custom-brand.io")
         self.assertEqual('KN', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/line/tests.py
+++ b/temba/channels/types/line/tests.py
@@ -19,7 +19,7 @@ class LineTypeTest(TembaTest):
 
     @patch('requests.get')
     def test_claim(self, mock_get):
-        url = reverse('channels.claim_line')
+        url = reverse('channels.types.line.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/line/tests.py
+++ b/temba/channels/types/line/tests.py
@@ -34,7 +34,7 @@ class LineTypeTest(TembaTest):
         response = self.client.post(url, payload, follow=True)
 
         channel = Channel.objects.get(address='u1234567890')
-        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.id]))
+        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.uuid]))
         self.assertEqual(channel.config, {
             'auth_token': 'abcdef123456',
             'secret': '123456',

--- a/temba/channels/types/m3tech/tests.py
+++ b/temba/channels/types/m3tech/tests.py
@@ -11,7 +11,7 @@ class M3TechTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.types.m3tech_claim')
+        url = reverse('channels.types.m3tech.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/m3tech/tests.py
+++ b/temba/channels/types/m3tech/tests.py
@@ -44,7 +44,7 @@ class M3TechTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('M3', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/m3tech/tests.py
+++ b/temba/channels/types/m3tech/tests.py
@@ -11,7 +11,7 @@ class M3TechTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_m3tech')
+        url = reverse('channels.types.m3tech_claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/macrokiosk/tests.py
+++ b/temba/channels/types/macrokiosk/tests.py
@@ -11,7 +11,7 @@ class MacrokioskTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_macrokiosk')
+        url = reverse('channels.types.macrokiosk.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/macrokiosk/tests.py
+++ b/temba/channels/types/macrokiosk/tests.py
@@ -47,7 +47,7 @@ class MacrokioskTypeTest(TembaTest):
         self.assertEqual(channel.address, '250788123123')
         self.assertEqual(channel.channel_type, 'MK')
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/mblox/tests.py
+++ b/temba/channels/types/mblox/tests.py
@@ -38,7 +38,7 @@ class MbloxTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('MB', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/mblox/tests.py
+++ b/temba/channels/types/mblox/tests.py
@@ -11,7 +11,7 @@ class MbloxTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_mblox')
+        url = reverse('channels.types.mblox.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/mtarget/tests.py
+++ b/temba/channels/types/mtarget/tests.py
@@ -12,7 +12,7 @@ class MtargetTypeTest(TembaTest):
         self.login(self.admin)
         response = self.client.get(reverse('channels.channel_claim'))
 
-        claim_url = reverse('channels.claim_mtarget')
+        claim_url = reverse('channels.types.mtarget.claim')
         self.assertContains(response, claim_url)
 
         # claim it

--- a/temba/channels/types/nexmo/tests.py
+++ b/temba/channels/types/nexmo/tests.py
@@ -15,7 +15,7 @@ class NexmoTypeTest(TembaTest):
         mock_time_sleep.return_value = None
         self.login(self.admin)
 
-        claim_nexmo = reverse('channels.claim_nexmo')
+        claim_nexmo = reverse('channels.types.nexmo.claim')
 
         # remove any existing channels
         self.org.channels.update(is_active=False)

--- a/temba/channels/types/nexmo/tests.py
+++ b/temba/channels/types/nexmo/tests.py
@@ -189,7 +189,7 @@ class NexmoTypeTest(TembaTest):
                 # as is our old one
                 self.assertTrue(Channel.objects.filter(channel_type='NX', org=self.org, address='MTN').first())
 
-                config_url = reverse('channels.channel_configuration', args=[channel.pk])
+                config_url = reverse('channels.channel_configuration', args=[channel.uuid])
                 response = self.client.get(config_url)
                 self.assertEqual(200, response.status_code)
 

--- a/temba/channels/types/nexmo/views.py
+++ b/temba/channels/types/nexmo/views.py
@@ -56,7 +56,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         return reverse('channels.channel_search_nexmo')
 
     def get_claim_url(self):
-        return reverse('channels.types.nexmo_claim')
+        return reverse('channels.types.nexmo.claim')
 
     def get_supported_countries_tuple(self):
         return NEXMO_SUPPORTED_COUNTRIES

--- a/temba/channels/types/nexmo/views.py
+++ b/temba/channels/types/nexmo/views.py
@@ -56,7 +56,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         return reverse('channels.channel_search_nexmo')
 
     def get_claim_url(self):
-        return reverse('channels.claim_nexmo')
+        return reverse('channels.types.nexmo_claim')
 
     def get_supported_countries_tuple(self):
         return NEXMO_SUPPORTED_COUNTRIES

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -19,12 +19,12 @@ class PlivoTypeTest(TembaTest):
         self.org.channels.update(is_active=False)
 
         connect_plivo_url = reverse('orgs.org_plivo_connect')
-        claim_plivo_url = reverse('channels.claim_plivo')
+        claim_plivo_url = reverse('channels.types.plivo.claim')
 
         # make sure plivo is on the claim page
         response = self.client.get(reverse('channels.channel_claim'))
         self.assertContains(response, "Plivo")
-        self.assertContains(response, reverse('channels.claim_plivo'))
+        self.assertContains(response, claim_plivo_url)
 
         with patch('requests.get') as plivo_get:
             plivo_get.return_value = MockResponse(400, {})

--- a/temba/channels/types/plivo/views.py
+++ b/temba/channels/types/plivo/views.py
@@ -69,7 +69,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         return reverse('channels.channel_search_plivo')
 
     def get_claim_url(self):
-        return reverse('channels.claim_plivo')
+        return reverse('channels.types.plivo.claim')
 
     def get_supported_countries_tuple(self):
         return PLIVO_SUPPORTED_COUNTRIES

--- a/temba/channels/types/redrabbit/tests.py
+++ b/temba/channels/types/redrabbit/tests.py
@@ -11,7 +11,7 @@ class RedRabbitTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_redrabbit')
+        url = reverse('channels.types.redrabbit.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/redrabbit/tests.py
+++ b/temba/channels/types/redrabbit/tests.py
@@ -38,7 +38,7 @@ class RedRabbitTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('RR', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/shaqodoon/tests.py
+++ b/temba/channels/types/shaqodoon/tests.py
@@ -13,7 +13,7 @@ class ShaqodoonTypeTest(TembaTest):
 
         self.login(self.admin)
 
-        url = reverse('channels.claim_shaqodoon')
+        url = reverse('channels.types.shaqodoon.claim')
 
         response = self.client.get(reverse('channels.channel_claim'))
         self.assertNotContains(response, url)

--- a/temba/channels/types/shaqodoon/tests.py
+++ b/temba/channels/types/shaqodoon/tests.py
@@ -51,7 +51,7 @@ class ShaqodoonTypeTest(TembaTest):
         self.assertEqual(post_data['password'], channel.config['password'])
         self.assertEqual('SQ', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/smscentral/tests.py
+++ b/temba/channels/types/smscentral/tests.py
@@ -44,7 +44,7 @@ class SMSCentralTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('SC', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/smscentral/tests.py
+++ b/temba/channels/types/smscentral/tests.py
@@ -11,7 +11,7 @@ class SMSCentralTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_smscentral')
+        url = reverse('channels.types.smscentral.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/start/tests.py
+++ b/temba/channels/types/start/tests.py
@@ -45,7 +45,7 @@ class StartTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('ST', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/start/tests.py
+++ b/temba/channels/types/start/tests.py
@@ -11,7 +11,7 @@ class StartTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_start')
+        url = reverse('channels.types.start.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/telegram/tests.py
+++ b/temba/channels/types/telegram/tests.py
@@ -23,7 +23,7 @@ class TelegramTypeTest(TembaTest):
     @patch('telegram.Bot.get_me')
     @patch('telegram.Bot.set_webhook')
     def test_claim(self, mock_set_webhook, mock_get_me):
-        url = reverse('channels.claim_telegram')
+        url = reverse('channels.types.telegram.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/twilio/tests.py
+++ b/temba/channels/types/twilio/tests.py
@@ -19,7 +19,7 @@ class TwilioTypeTest(TembaTest):
     def test_claim(self):
         self.login(self.admin)
 
-        claim_twilio = reverse('channels.claim_twilio')
+        claim_twilio = reverse('channels.types.twilio.claim')
 
         # remove any existing channels
         self.org.channels.update(is_active=False)

--- a/temba/channels/types/twilio/views.py
+++ b/temba/channels/types/twilio/views.py
@@ -63,7 +63,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         return reverse('channels.channel_search_numbers')
 
     def get_claim_url(self):
-        return reverse('channels.claim_twilio')
+        return reverse('channels.types.twilio.claim')
 
     def get_context_data(self, **kwargs):
         context = super(ClaimView, self).get_context_data(**kwargs)

--- a/temba/channels/types/twilio_messaging_service/tests.py
+++ b/temba/channels/types/twilio_messaging_service/tests.py
@@ -74,7 +74,7 @@ class TwilioMessagingServiceTypeTest(TembaTest):
 
         response = self.client.post(claim_twilio_ms, dict(country='US', messaging_service_sid='MSG-SERVICE-SID'))
         channel = self.org.channels.get()
-        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.pk]))
+        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.uuid]))
         self.assertEqual(channel.channel_type, "TMS")
 
         channel_config = channel.config

--- a/temba/channels/types/twilio_messaging_service/tests.py
+++ b/temba/channels/types/twilio_messaging_service/tests.py
@@ -18,7 +18,7 @@ class TwilioMessagingServiceTypeTest(TembaTest):
 
         self.login(self.admin)
 
-        claim_twilio_ms = reverse('channels.claim_twilio_messaging_service')
+        claim_twilio_ms = reverse('channels.types.twilio_messaging_service.claim')
 
         # remove any existing channels
         self.org.channels.all().delete()

--- a/temba/channels/types/twiml_api/tests.py
+++ b/temba/channels/types/twiml_api/tests.py
@@ -17,7 +17,7 @@ class TwimlAPITypeTest(TembaTest):
         # remove any existing channels
         self.org.channels.update(is_active=False)
 
-        claim_url = reverse('channels.claim_twiml_api')
+        claim_url = reverse('channels.types.twiml_api.claim')
 
         response = self.client.get(reverse('channels.channel_claim'))
         self.assertContains(response, "TwiML")

--- a/temba/channels/types/twiml_api/tests.py
+++ b/temba/channels/types/twiml_api/tests.py
@@ -33,7 +33,7 @@ class TwimlAPITypeTest(TembaTest):
 
         response = self.client.post(claim_url, dict(country='US', number='12345678', url='https://twilio.com', role='SR', account_sid='abcd1234', account_token='abcd1234'))
         channel = self.org.channels.all().first()
-        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.pk]))
+        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.uuid]))
         self.assertEqual(channel.channel_type, "TW")
         self.assertEqual(
             channel.config, dict(
@@ -44,7 +44,7 @@ class TwimlAPITypeTest(TembaTest):
 
         response = self.client.post(claim_url, dict(country='US', number='12345678', url='https://twilio.com', role='SR', account_sid='abcd4321', account_token='abcd4321'))
         channel = self.org.channels.all().first()
-        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.pk]))
+        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.uuid]))
         self.assertEqual(channel.channel_type, "TW")
         self.assertEqual(
             channel.config, dict(
@@ -57,7 +57,7 @@ class TwimlAPITypeTest(TembaTest):
 
         response = self.client.post(claim_url, dict(country='US', number='8080', url='https://twilio.com', role='SR', account_sid='abcd1234', account_token='abcd1234'))
         channel = self.org.channels.all().first()
-        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.pk]))
+        self.assertRedirects(response, reverse('channels.channel_configuration', args=[channel.uuid]))
         self.assertEqual(channel.channel_type, "TW")
         self.assertEqual(
             channel.config, dict(

--- a/temba/channels/types/twitter/tests.py
+++ b/temba/channels/types/twitter/tests.py
@@ -20,7 +20,7 @@ class TwitterTypeTest(TembaTest):
     @patch('temba.utils.mage.MageClient.activate_twitter_stream')
     @patch('twython.Twython.get_authorized_tokens')
     def test_claim(self, mock_get_authorized_tokens, mock_activate_twitter_stream, mock_get_authentication_tokens):
-        url = reverse('channels.claim_twitter')
+        url = reverse('channels.types.twitter.claim')
 
         mock_get_authentication_tokens.return_value = {
             'oauth_token': 'abcde',

--- a/temba/channels/types/twitter/views.py
+++ b/temba/channels/types/twitter/views.py
@@ -66,7 +66,7 @@ class ClaimView(ClaimViewMixin, SmartTemplateView):
 
         # generate temp OAuth token and secret
         twitter = TembaTwython(settings.TWITTER_API_KEY, settings.TWITTER_API_SECRET)
-        callback_url = self.request.build_absolute_uri(reverse('channels.claim_twitter'))
+        callback_url = self.request.build_absolute_uri(reverse('channels.types.twitter.claim'))
         auth = twitter.get_authentication_tokens(callback_url=callback_url)
 
         # put in session for when we return from callback

--- a/temba/channels/types/twitter_activity/tests.py
+++ b/temba/channels/types/twitter_activity/tests.py
@@ -36,12 +36,12 @@ class TwitterActivityTypeTest(TembaTest):
 
         # check that channel is only available to beta users
         response = self.client.get(reverse('channels.channel_claim'))
-        self.assertNotContains(response, '/channels/types/twitter_activity/claim/')
+        self.assertNotContains(response, '/channels/types/twitter_activity/claim')
 
         Group.objects.get(name="Beta").user_set.add(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim'))
-        self.assertContains(response, '/channels/types/twitter_activity/claim/')
+        self.assertContains(response, '/channels/types/twitter_activity/claim')
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/temba/channels/types/twitter_activity/tests.py
+++ b/temba/channels/types/twitter_activity/tests.py
@@ -30,7 +30,7 @@ class TwitterActivityTypeTest(TembaTest):
     @patch('temba.utils.twitter.TembaTwython.register_webhook')
     @patch('twython.Twython.verify_credentials')
     def test_claim(self, mock_verify_credentials, mock_register_webhook, mock_subscribe_to_webhook):
-        url = reverse('channels.claim_twitter_activity')
+        url = reverse('channels.types.twitter_activity.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/twitter_activity/tests.py
+++ b/temba/channels/types/twitter_activity/tests.py
@@ -36,12 +36,12 @@ class TwitterActivityTypeTest(TembaTest):
 
         # check that channel is only available to beta users
         response = self.client.get(reverse('channels.channel_claim'))
-        self.assertNotContains(response, 'channels/claim/twitter_activity/')
+        self.assertNotContains(response, '/channels/types/twitter_activity/claim/')
 
         Group.objects.get(name="Beta").user_set.add(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim'))
-        self.assertContains(response, 'channels/claim/twitter_activity/')
+        self.assertContains(response, '/channels/types/twitter_activity/claim/')
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/temba/channels/types/verboice/tests.py
+++ b/temba/channels/types/verboice/tests.py
@@ -40,7 +40,7 @@ class VerboiceTypeTest(TembaTest):
         self.assertEqual('VB', channel.channel_type)
         self.assertEqual('CA', channel.role)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/verboice/tests.py
+++ b/temba/channels/types/verboice/tests.py
@@ -10,7 +10,7 @@ class VerboiceTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_verboice')
+        url = reverse('channels.types.verboice.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -20,7 +20,7 @@ class ViberPublicTypeTest(TembaTest):
     @override_settings(IS_PROD=True)
     @patch('requests.post')
     def test_claim(self, mock_post):
-        url = reverse('channels.claim_viber_public')
+        url = reverse('channels.types.viber_public.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/vumi/tests.py
+++ b/temba/channels/types/vumi/tests.py
@@ -50,7 +50,7 @@ class VumiTypeTest(TembaTest):
         self.assertEqual(channel.channel_type, 'VM')
         self.assertEqual(channel.role, Channel.DEFAULT_ROLE)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/vumi/tests.py
+++ b/temba/channels/types/vumi/tests.py
@@ -12,7 +12,7 @@ class VumiTypeTest(TembaTest):
 
     def test_claim(self):
         Channel.objects.all().delete()
-        url = reverse('channels.claim_vumi')
+        url = reverse('channels.types.vumi.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/vumi_ussd/tests.py
+++ b/temba/channels/types/vumi_ussd/tests.py
@@ -50,7 +50,7 @@ class VumiUSSDTypeTest(TembaTest):
         self.assertEqual(channel.channel_type, 'VMU')
         self.assertEqual(channel.role, Channel.ROLE_USSD)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/vumi_ussd/tests.py
+++ b/temba/channels/types/vumi_ussd/tests.py
@@ -13,7 +13,7 @@ class VumiUSSDTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_vumi_ussd')
+        url = reverse('channels.types.vumi_ussd.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import time
+import requests
+
+from celery.task import task
+from django_redis import get_redis_connection
+
+from temba.channels.models import Channel
+from temba.contacts.models import ContactURN, WHATSAPP_SCHEME
+from temba.utils import chunk_list
+
+
+@task(track_started=True, name='refresh_whatsapp_contacts')
+def refresh_whatsapp_contacts(channel_id):
+    r = get_redis_connection()
+    key = 'refresh_whatsapp_contacts_%d' % channel_id
+
+    # we can't use our non-overlapping task decorator as it creates a loop in the celery resolver when registering
+    if r.get(key):  # pragma: no cover
+        return
+
+    channel = Channel.objects.filter(id=channel_id, is_active=True).first()
+    if not channel:  # pragma: no cover
+        return
+
+    with r.lock(key, 3600):
+        # look up all whatsapp URNs for this channel
+        wa_urns = (
+            ContactURN.objects
+            .filter(org_id=channel.org_id, scheme=WHATSAPP_SCHEME, contact__is_stopped=False, contact__is_blocked=False)
+            .exclude(contact=None)
+            .only('id', 'path')
+        )
+
+        # 1,000 contacts at a time, we ask WhatsApp to look up our contacts based on the path
+        refreshed = 0
+
+        for urn_batch in chunk_list(wa_urns, 1000):
+            # need to wait 10 seconds between each batch of 1000
+            if refreshed > 0:
+                time.sleep(10)
+
+            # build a list of the fully qualified numbers we have
+            users = ["+%s" % u.path for u in urn_batch]
+            payload = {
+                "payload": {
+                    "blocking": "wait",
+                    "users": users
+                }
+            }
+
+            # go fetch our contacts
+            resp = requests.post(channel.config[Channel.CONFIG_BASE_URL] + '/api/check_contacts.php',
+                                 json=payload,
+                                 auth=(channel.config[Channel.CONFIG_USERNAME],
+                                       channel.config[Channel.CONFIG_PASSWORD]))
+
+            # if we had an error, break out
+            if resp.status_code != 200 or resp.json().get('error', True):
+                raise Exception("Received error refreshing contacts for %d", channel.id)
+
+            refreshed += len(urn_batch)
+
+        print("refreshed %d whatsapp urns for channel %d" % (refreshed, channel_id))

--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -39,7 +39,7 @@ def refresh_whatsapp_contacts(channel_id):
 
         for urn_batch in chunk_list(wa_urns, 1000):
             # need to wait 10 seconds between each batch of 1000
-            if refreshed > 0:
+            if refreshed > 0:  # pragma: no cover
                 time.sleep(10)
 
             # build a list of the fully qualified numbers we have

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -111,7 +111,7 @@ class WhatsAppTypeTest(TembaTest):
                 pass
 
         # ok, test our refreshing
-        refresh_url = reverse('channels.types.whatsapp.refresh', args=[channel.id])
+        refresh_url = reverse('channels.types.whatsapp.refresh', args=[channel.uuid])
         resp = self.client.get(refresh_url)
         self.assertEqual(405, resp.status_code)
 

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -110,10 +110,15 @@ class WhatsAppTypeTest(TembaTest):
             except ValidationError:
                 pass
 
+        # ok, test our refreshing
+        refresh_url = reverse('channels.types.whatsapp.refresh', args=[channel.id])
+        resp = self.client.get(refresh_url)
+        self.assertEqual(405, resp.status_code)
+
         with patch('requests.post') as mock_post:
             mock_post.side_effect = [MockResponse(200, '{ "error": false }')]
             self.create_contact("Joe", urn="whatsapp:250788382382")
-            refresh_whatsapp_contacts(channel.id)
+            self.client.post(refresh_url)
 
             self.assertEqual(mock_post.call_args_list[0][1]['json']['payload']['users'],
                              ['+250788382382'])

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -40,7 +40,7 @@ class WhatsAppType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            url(r'^refresh/(?P<pk>[0-9]+)/?$', RefreshView.as_view(), name='refresh')
+            url(r'^refresh/(?P<uuid>[a-z0-9\-]+)/?$', RefreshView.as_view(), name='refresh')
         ]
 
     def activate(self, channel):

--- a/temba/channels/types/yo/tests.py
+++ b/temba/channels/types/yo/tests.py
@@ -45,7 +45,7 @@ class YoTypeTest(TembaTest):
         self.assertEqual('+250788123123', channel.address)
         self.assertEqual('YO', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/yo/tests.py
+++ b/temba/channels/types/yo/tests.py
@@ -11,7 +11,7 @@ class YoTypeTest(TembaTest):
     def test_claim(self):
         Channel.objects.all().delete()
 
-        url = reverse('channels.claim_yo')
+        url = reverse('channels.types.yo.claim')
 
         self.login(self.admin)
 

--- a/temba/channels/types/zenvia/tests.py
+++ b/temba/channels/types/zenvia/tests.py
@@ -45,7 +45,7 @@ class ZenviaTypeTest(TembaTest):
         self.assertEqual(post_data['shortcode'], channel.address)
         self.assertEqual('ZV', channel.channel_type)
 
-        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        config_url = reverse('channels.channel_configuration', args=[channel.uuid])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)

--- a/temba/channels/types/zenvia/tests.py
+++ b/temba/channels/types/zenvia/tests.py
@@ -13,7 +13,7 @@ class ZenviaTypeTest(TembaTest):
         Channel.objects.all().delete()
 
         self.login(self.admin)
-        url = reverse('channels.claim_zenvia')
+        url = reverse('channels.types.zenvia.claim')
 
         # shouldn't be able to see the claim zenvia page if we aren't part of that group
         response = self.client.get(reverse('channels.channel_claim'))

--- a/temba/channels/urls.py
+++ b/temba/channels/urls.py
@@ -9,9 +9,6 @@ from .handlers import SMSCentralHandler, MageHandler, YoHandler, get_channel_han
 from .models import Channel
 from .views import ChannelCRUDL, ChannelEventCRUDL, ChannelLogCRUDL
 
-
-claim_page_urls = [ch_type.get_claim_url() for ch_type in Channel.get_types() if ch_type.claim_view]
-
 courier_urls = []
 handler_urls = []
 
@@ -24,15 +21,25 @@ for handler in get_channel_handlers():
     if rel_url:
         handler_urls.append(url(rel_url, handler.as_view(), name=url_name))
 
+# we iterate all our channel types, finding all the URLs they want to wire in
+type_urls = []
+for ch_type in Channel.get_types():
+    channel_urls = ch_type.get_urls()
+    for u in channel_urls:
+        u.name = 'channels.types.%s.%s' % (ch_type.slug, u.name)
+
+    if channel_urls:
+        type_urls.append(
+            url('^%s/' % ch_type.slug, include(channel_urls))
+        )
+
 urlpatterns = [
     url(r'^', include(ChannelEventCRUDL().as_urlpatterns())),
-
     url(r'^channels/', include(ChannelCRUDL().as_urlpatterns() + ChannelLogCRUDL().as_urlpatterns())),
-
-    url(r'^channels/', include(claim_page_urls)),
 
     url(r'^c/', include(courier_urls)),
     url(r'^handlers/', include(handler_urls)),
+    url(r'^channels/types/', include(type_urls)),
 
     # for backwards compatibility these channel handlers are exposed at /api/v1 as well
     url(r'^api/v1/', include([

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -763,7 +763,7 @@ class ClaimViewMixin(OrgPermsMixin):
 
     def get_success_url(self):
         if self.channel_type.show_config_page:
-            return reverse('channels.channel_configuration', args=[self.object.id])
+            return reverse('channels.channel_configuration', args=[self.object.uuid])
         else:
             return reverse('channels.channel_read', args=[self.object.uuid])
 
@@ -1510,6 +1510,7 @@ class ChannelCRUDL(SmartCRUDL):
             return reverse('orgs.org_home')
 
     class Configuration(OrgPermsMixin, SmartReadView):
+        slug_url_kwarg = 'uuid'
 
         def get_context_data(self, **kwargs):
             context = super(ChannelCRUDL.Configuration, self).get_context_data(**kwargs)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1218,7 +1218,7 @@ class OrgTest(TembaTest):
                     self.assertEqual(response.status_code, 302)
 
                     response = self.client.post(connect_url, post_data, follow=True)
-                    self.assertEqual(response.request['PATH_INFO'], reverse("channels.claim_twilio"))
+                    self.assertEqual(response.request['PATH_INFO'], reverse("channels.types.twilio.claim"))
 
                     self.org.refresh_from_db()
                     self.assertEqual(self.org.config['ACCOUNT_SID'], "AccountSid")
@@ -1729,7 +1729,7 @@ class OrgTest(TembaTest):
             self.assertEqual(response.status_code, 302)
 
             response = self.client.get(nexmo_configuration_url, follow=True)
-            self.assertEqual(response.request['PATH_INFO'], reverse('channels.claim_nexmo'))
+            self.assertEqual(response.request['PATH_INFO'], reverse('channels.types.nexmo.claim'))
 
         with patch('temba.utils.nexmo.NexmoClient.update_account') as mock_update_account:
             mock_update_account.side_effect = [nexmo.Error, nexmo.Error]

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -621,7 +621,7 @@ class OrgCRUDL(SmartCRUDL):
 
         form_class = TwilioConnectForm
         submit_button_name = "Save"
-        success_url = '@channels.claim_twilio'
+        success_url = '@channels.types.twilio.claim'
         field_config = dict(account_sid=dict(label=""), account_token=dict(label=""))
         success_message = "Twilio Account successfully connected."
 
@@ -652,7 +652,7 @@ class OrgCRUDL(SmartCRUDL):
                 nexmo_client.update_account('http://%s%s' % (domain, mo_path),
                                             'http://%s%s' % (domain, dl_path))
 
-                return HttpResponseRedirect(reverse("channels.claim_nexmo"))
+                return HttpResponseRedirect(reverse("channels.types.nexmo.claim"))
 
             except nexmo.Error:
                 return super(OrgCRUDL.NexmoConfiguration, self).get(request, *args, **kwargs)
@@ -810,7 +810,7 @@ class OrgCRUDL(SmartCRUDL):
 
         form_class = PlivoConnectForm
         submit_button_name = "Save"
-        success_url = '@channels.claim_plivo'
+        success_url = '@channels.types.plivo.claim'
         field_config = dict(auth_id=dict(label=""), auth_token=dict(label=""))
         success_message = "Plivo credentials verified. You can now add a Plivo channel."
 

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -2,7 +2,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django import forms
+from django.http import HttpResponse
+from django.views import View
 from django.utils.translation import ugettext_lazy as _
+
+
+class PostOnlyMixin(View):
+    """
+    Utility mixin to make a class based view be POST only
+    """
+    def get(self, *args, **kwargs):
+        return HttpResponse("Method Not Allowed", status=405)
 
 
 class BaseActionForm(forms.Form):

--- a/templates/channels/channel_bulk_sender_options.haml
+++ b/templates/channels/channel_bulk_sender_options.haml
@@ -49,7 +49,7 @@
 
   .row.claim-row
     .span3
-      %a.btn.btn-primary.btn-primary-muted.btn-claim.connect-external{href:"{% url 'channels.types.external_claim' %}?role=S&channel={{request.GET.channel}}"}
+      %a.btn.btn-primary.btn-primary-muted.btn-claim.connect-external{href:"{% url 'channels.types.external.claim' %}?role=S&channel={{request.GET.channel}}"}
         .claim-glyph.icon-channel-external
         %p.claim-text Connect External API
 

--- a/templates/channels/channel_bulk_sender_options.haml
+++ b/templates/channels/channel_bulk_sender_options.haml
@@ -49,7 +49,7 @@
 
   .row.claim-row
     .span3
-      %a.btn.btn-primary.btn-primary-muted.btn-claim.connect-external{href:"{% url 'channels.claim_external' %}?role=S&channel={{request.GET.channel}}"}
+      %a.btn.btn-primary.btn-primary-muted.btn-claim.connect-external{href:"{% url 'channels.types.external_claim' %}?role=S&channel={{request.GET.channel}}"}
         .claim-glyph.icon-channel-external
         %p.claim-text Connect External API
 

--- a/templates/channels/channel_claim.haml
+++ b/templates/channels/channel_claim.haml
@@ -25,7 +25,7 @@
         .claim-row.recommended
           .row
             .span3
-              %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.claim_'|add:ch_type.slug %}"}
+              %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}"}
                 .btn-container
                   .claim-glyph{class:"{{ ch_type.icon }}"}
                   %p.claim-text= ch_type.name
@@ -81,7 +81,7 @@
       .claim-row
         .row
           .span3
-            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.claim_'|add:ch_type.slug %}"}
+            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}"}
               .btn-container
                 .claim-glyph{class:"{{ ch_type.icon }}"}
                 %p.claim-text= ch_type.name
@@ -97,7 +97,7 @@
       .claim-row
         .row
           .span3
-            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.claim_'|add:ch_type.slug %}"}
+            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}"}
               .btn-container
                 .claim-glyph{class:"{{ ch_type.icon }}"}
                 %p.claim-text= ch_type.name
@@ -113,7 +113,7 @@
       .claim-row
         .row
           .span3
-            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.claim_'|add:ch_type.slug %}"}
+            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}"}
               .btn-container
                 .claim-glyph{class:"{{ ch_type.icon }}"}
                 %p.claim-text= ch_type.name
@@ -129,7 +129,7 @@
       .claim-row
         .row
           .span3
-            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.claim_'|add:ch_type.slug %}"}
+            %a.btn.btn-primary.btn-primary-muted.btn-claim{href:"{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}"}
               .btn-container
                 .claim-glyph{class:"{{ ch_type.icon }}"}
                 %p.claim-text= ch_type.name

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -37,15 +37,13 @@
             -trans "Voice calls enabled"
 
       -if object.get_type.show_config_page
-        <a class="btn btn-tiny" href="{% url 'channels.channel_configuration' channel.id %}">{%trans "Settings"%}</a>
+        <a class="btn btn-tiny" href="{% url 'channels.channel_configuration' channel.uuid %}">{%trans "Settings"%}</a>
 
 
       -if channel.has_channel_log
         -if not user_org.is_anon or perms.contacts.contact_break_anon
           -with channel.get_sender as sender and channel.get_caller as caller and channel.get_ussd_delegate as ussd
-            -if sender and not caller
-              <a class="btn btn-tiny" href="{% url 'channels.channellog_list' %}?channel={{ sender.id }}">{%trans "Sending Log"%}</a>
-            -if sender and sender == caller
+            -if sender
               <a class="btn btn-tiny" href="{% url 'channels.channellog_list' %}?channel={{ sender.id }}">{%trans "Channel Log"%}</a>
             - if caller and caller != sender
               <a class="btn btn-tiny" href="{% url 'channels.channellog_list' %}?channel={{ caller.id }}&sessions=1">{%trans "Call Log"%}</a>

--- a/templates/channels/types/twitter_activity/claim.haml
+++ b/templates/channels/types/twitter_activity/claim.haml
@@ -13,7 +13,7 @@
       %p
         This channel type uses the new <a href="https://dev.twitter.com/webhooks/account-activity">Twitter Activity API</a> which is
         still in beta. If your Twitter account has not been granted access to this API, then you can still
-        <a href="{% url 'channels.claim_twitter' %}">add a regular Twitter channel</a>.
+        <a href="{% url 'channels.types.twitter.claim' %}">add a regular Twitter channel</a>.
     %p
       -blocktrans with name=brand.name
         After connecting your account, any incoming direct messages will automatically be read by {{ name }},

--- a/templates/channels/types/whatsapp/config.haml
+++ b/templates/channels/types/whatsapp/config.haml
@@ -1,0 +1,12 @@
+-load i18n
+
+%h4
+  -blocktrans
+    Your WhatsApp channel is now connected, you should be able to send and receive messages as normal.
+
+%h4
+  -blocktrans
+    In the case of a new WhatsApp install or replacement of an existing WhatsApp channel you may need to refresh
+    the contacts on the WhatsApp application. This may take a few minutes.
+
+%a.btn.btn-primary.posterize(href="{% url 'channels.types.whatsapp.refresh' channel.id %}") Refresh Contacts

--- a/templates/channels/types/whatsapp/config.haml
+++ b/templates/channels/types/whatsapp/config.haml
@@ -9,4 +9,4 @@
     In the case of a new WhatsApp install or replacement of an existing WhatsApp channel you may need to refresh
     the contacts on the WhatsApp application. This may take a few minutes.
 
-%a.btn.btn-primary.posterize(href="{% url 'channels.types.whatsapp.refresh' channel.id %}") Refresh Contacts
+%a.btn.btn-primary.posterize(href="{% url 'channels.types.whatsapp.refresh' channel.uuid %}") Refresh Contacts

--- a/templates/orgs/org_nexmo_configuration.haml
+++ b/templates/orgs/org_nexmo_configuration.haml
@@ -53,7 +53,7 @@
       %h4
         -trans "Once the settings are succefully updated on Nexmo"
 
-      %a.btn.btn-primary{'href':"{% url 'channels.claim_nexmo' %}"}
+      %a.btn.btn-primary{'href':"{% url 'channels.types.nexmo.claim' %}"}
         -trans "Add a Nexmo Channel"
 
 


### PR DESCRIPTION
Channel types now can expose more than one view through `get_urls`

Changed the path and reverse names to be more consistent, ie, the claim for whatsapp is now at:
   `/channels/types/whatsapp/claim`

With a reverse of:
  `channels.types.whatsapp.claim`

The new view it introduced is similarly:
   `/channels/types/whatsapp/refresh`

With a reverse of:
   `channels.types.whatsapp.refresh`

Now just need to move all the templates out of the root `/templates` dir and I'll be happy.