### PR TITLE
allow brands to specifiy includes for the document head

### DIFF
--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -162,6 +162,9 @@
       -block extra-less
       -block extra-style
 
+  -for incl in brand.head_includes
+    -include incl
+
   <!--[if lt IE 9]>
     %script{src:"//html5shim.googlecode.com/svn/trunk/html5.js"}
   <![endif]-->


### PR DESCRIPTION
Let brands specify a list of includes in the document head so they can have their own custom third party integrations.