### PR TITLE
Channel and GoGlow Contact tweaks

### DIFF
--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -261,7 +261,7 @@ class ContactWriteSerializer(WriteSerializer):
             for urn in value:
                 try:
                     normalized = URN.normalize(urn)
-                    scheme, path, display = URN.to_parts(normalized)
+                    scheme, path, query, display = URN.to_parts(normalized)
                     # for backwards compatibility we don't validate phone numbers here
                     if scheme != TEL_SCHEME and not URN.validate(normalized):  # pragma: needs cover
                         raise ValueError()
@@ -778,7 +778,7 @@ class MsgCreateSerializer(WriteSerializer):
             country = channel.country
             for urn in phones:
                 try:
-                    tel, phone, display = URN.to_parts(urn)
+                    tel, phone, query, display = URN.to_parts(urn)
                     normalized = phonenumbers.parse(phone, country.code)
                     if not phonenumbers.is_possible_number(normalized):  # pragma: needs cover
                         raise serializers.ValidationError("Invalid phone number: '%s'" % phone)

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -2409,7 +2409,7 @@ class GlobeHandler(BaseChannelHandler):
                     return HttpResponse("Missing one of dateTime, senderAddress, message, messageId or destinationAddress in message", status=400)
 
                 try:
-                    scheme, destination, display = URN.to_parts(inbound_msg['destinationAddress'])
+                    scheme, destination, query, display = URN.to_parts(inbound_msg['destinationAddress'])
                 except ValueError as v:
                     return HttpResponse("Error parsing destination address: " + str(v), status=400)
 
@@ -2419,7 +2419,7 @@ class GlobeHandler(BaseChannelHandler):
 
                 # parse our sender address out, it is a URN looking thing
                 try:
-                    scheme, sender_tel, display = URN.to_parts(inbound_msg['senderAddress'])
+                    scheme, sender_tel, query, display = URN.to_parts(inbound_msg['senderAddress'])
                 except ValueError as v:
                     return HttpResponse("Error parsing sender address: " + str(v), status=400)
 

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -244,7 +244,6 @@ class ChannelType(six.with_metaclass(ABCMeta)):
 @six.python_2_unicode_compatible
 class Channel(TembaModel):
     TYPE_ANDROID = 'A'
-    TYPE_DUMMY = 'DM'
 
     # keys for various config options stored in the channel config dict
     CONFIG_BASE_URL = 'base_url'
@@ -304,6 +303,14 @@ class Channel(TembaModel):
 
     DEFAULT_ROLE = ROLE_SEND + ROLE_RECEIVE
 
+    ROLE_CONFIG = {
+        ROLE_SEND: 'send',
+        ROLE_RECEIVE: 'receive',
+        ROLE_CALL: 'call',
+        ROLE_ANSWER: 'answer',
+        ROLE_USSD: 'ussd',
+    }
+
     # how many outgoing messages we will queue at once
     SEND_QUEUE_DEPTH = 500
 
@@ -334,11 +341,9 @@ class Channel(TembaModel):
     # various hard coded settings for the channel types
     CHANNEL_SETTINGS = {
         TYPE_ANDROID: dict(schemes=['tel'], max_length=-1),
-        TYPE_DUMMY: dict(schemes=['tel'], max_length=160),
     }
 
-    TYPE_CHOICES = ((TYPE_ANDROID, "Android"),
-                    (TYPE_DUMMY, "Dummy"))
+    TYPE_CHOICES = ((TYPE_ANDROID, "Android"),)
 
     TYPE_ICONS = {
         TYPE_ANDROID: "icon-channel-android",
@@ -1098,21 +1103,6 @@ class Channel(TembaModel):
                                       CHATBASE_TYPE_AGENT)
 
     @classmethod
-    def send_dummy_message(cls, channel, msg, text):  # pragma: no cover
-        from temba.msgs.models import WIRED
-
-        delay = channel.config.get('delay', 1000)
-        start = time.time()
-
-        # sleep that amount
-        time.sleep(delay / float(1000))
-
-        event = HttpEvent('GET', 'http://fake')
-
-        # record the message as sent
-        Channel.success(channel, msg, WIRED, start, event=event)
-
-    @classmethod
     def get_pending_messages(cls, org):
         """
         We want all messages that are:
@@ -1322,10 +1312,6 @@ STATUS_CHARGING = "CHA"
 STATUS_DISCHARGING = "DIS"
 STATUS_NOT_CHARGING = "NOT"
 STATUS_FULL = "FUL"
-
-SEND_FUNCTIONS = {
-    Channel.TYPE_DUMMY: Channel.send_dummy_message,
-}
 
 
 @six.python_2_unicode_compatible

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -39,7 +39,6 @@ from temba.orgs.models import Org, CHATBASE_TYPE_AGENT, NEXMO_APP_ID, NEXMO_APP_
 from temba.utils import analytics, dict_to_struct, dict_to_json, on_transaction_commit, get_anonymous_user
 from temba.utils.email import send_template_email
 from temba.utils.gsm7 import is_gsm7, replace_non_gsm7_accents, calculate_num_segments
-from temba.utils.http import HttpEvent
 from temba.utils.nexmo import NCCOResponse
 from temba.utils.models import SquashableModel, TembaModel, generate_uuid, JSONAsTextField
 from temba.utils.text import random_string
@@ -316,10 +315,6 @@ class Channel(TembaModel):
 
     # how big each batch of outgoing messages can be
     SEND_BATCH_SIZE = 100
-
-    YO_API_URL_1 = 'http://smgw1.yo.co.ug:9100/sendsms'
-    YO_API_URL_2 = 'http://41.220.12.201:9100/sendsms'
-    YO_API_URL_3 = 'http://164.40.148.210:9100/sendsms'
 
     CONTENT_TYPE_URLENCODED = 'urlencoded'
     CONTENT_TYPE_JSON = 'json'

--- a/temba/channels/types/__init__.py
+++ b/temba/channels/types/__init__.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 
 from temba.channels.views import TYPE_UPDATE_FORM_CLASSES
-from ..models import Channel, ChannelType, SEND_FUNCTIONS
+from ..models import Channel, ChannelType
 
 TYPES = OrderedDict({})
 
@@ -45,7 +45,7 @@ def reload_channel_types():
             attachment_support=False,
             free_sending=False,
             update_form=TYPE_UPDATE_FORM_CLASSES.get(code),
-            send=SEND_FUNCTIONS.get(code),
+            send=None,
             ivr_protocol=None
         ))
         register_channel_type(dyn_type_class)

--- a/temba/channels/types/twitter/type.py
+++ b/temba/channels/types/twitter/type.py
@@ -53,7 +53,7 @@ class TwitterType(ChannelType):
 
         try:
             urn = getattr(msg, 'urn', URN.from_twitter(msg.urn_path))
-            (scheme, path, display) = URN.to_parts(urn)
+            (scheme, path, query, display) = URN.to_parts(urn)
 
             # this is a legacy URN (no display), the path is our screen name
             if scheme == TWITTER_SCHEME:

--- a/temba/channels/types/yo/type.py
+++ b/temba/channels/types/yo/type.py
@@ -2,13 +2,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import time
-from six.moves.urllib.parse import parse_qs
 import requests
 import six
 
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
-
+from six.moves.urllib.parse import parse_qs
 from temba.channels.types.yo.views import ClaimView
 from temba.contacts.models import Contact, TEL_SCHEME
 from temba.msgs.models import SENT
@@ -57,6 +56,10 @@ class YoType(ChannelType):
         ),
     )
 
+    YO_API_URL_1 = 'http://smgw1.yo.co.ug:9100/sendsms'
+    YO_API_URL_2 = 'http://41.220.12.201:9100/sendsms'
+    YO_API_URL_3 = 'http://164.40.148.210:9100/sendsms'
+
     def is_available_to(self, user):
         org = user.get_org()
         return org.timezone and six.text_type(org.timezone) in ["Africa/Kampala"]
@@ -80,7 +83,7 @@ class YoType(ChannelType):
         fatal = False
         events = []
 
-        for send_url in [YO_API_URL_1, YO_API_URL_2, YO_API_URL_3]:
+        for send_url in [YoType.YO_API_URL_1, YoType.YO_API_URL_2, YoType.YO_API_URL_3]:
             url = send_url + '?' + urlencode(params)
             log_url = send_url + '?' + urlencode(log_params)
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -122,7 +122,7 @@ class URN(object):
         if parsed.scheme not in cls.VALID_SCHEMES:
             raise ValueError("URN contains an invalid scheme component: '%s'" % parsed.scheme)
 
-        return parsed.scheme, parsed.path, parsed.fragment or None
+        return parsed.scheme, parsed.path, parsed.query or None, parsed.fragment or None
 
     @classmethod
     def validate(cls, urn, country_code=None):
@@ -130,7 +130,7 @@ class URN(object):
         Validates a normalized URN
         """
         try:
-            scheme, path, display = cls.to_parts(urn)
+            scheme, path, query, display = cls.to_parts(urn)
         except ValueError:
             return False
 
@@ -251,7 +251,7 @@ class URN(object):
 
     @classmethod
     def identity(cls, urn):
-        scheme, path, display = URN.to_parts(urn)
+        scheme, path, query, display = URN.to_parts(urn)
         return URN.from_parts(scheme, path)
 
     @classmethod
@@ -2102,7 +2102,7 @@ class ContactURN(models.Model):
 
     @classmethod
     def create(cls, org, contact, urn_as_string, channel=None, priority=None, auth=None):
-        scheme, path, display = URN.to_parts(urn_as_string)
+        scheme, path, query, display = URN.to_parts(urn_as_string)
         urn_as_string = URN.from_parts(scheme, path)
 
         if not priority:
@@ -2120,7 +2120,7 @@ class ContactURN(models.Model):
             urn_as_string = URN.normalize(urn_as_string, country_code)
 
         identity = URN.identity(urn_as_string)
-        (scheme, path, display) = URN.to_parts(urn_as_string)
+        (scheme, path, query, display) = URN.to_parts(urn_as_string)
 
         existing = cls.objects.filter(org=org, identity=identity).select_related('contact').first()
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -20,6 +20,7 @@ from django.db.models import Count, Max, Q, Sum
 from django.utils import timezone
 from django.utils.translation import ugettext, ugettext_lazy as _
 from itertools import chain
+from six.moves.urllib.parse import urlencode
 from smartmin.models import SmartModel, SmartImportRowError
 from smartmin.csv_imports.models import ImportTask
 from temba.assets.models import register_asset_store
@@ -96,7 +97,7 @@ class URN(object):
         raise ValueError("Class shouldn't be instantiated")
 
     @classmethod
-    def from_parts(cls, scheme, path, display=None):
+    def from_parts(cls, scheme, path, display=None, query=None):
         """
         Formats a URN scheme and path as single URN string, e.g. tel:+250783835665
         """
@@ -106,10 +107,14 @@ class URN(object):
         if not path:
             raise ValueError("Invalid path component: '%s'" % path)
 
+        urn = "%s:%s" % (scheme, path)
+
+        if query:
+            urn += '?%s' % urlencode(query)
         if display:
-            return '%s:%s#%s' % (scheme, path, display)
-        else:
-            return '%s:%s' % (scheme, path)
+            urn += '#%s' % display
+
+        return urn
 
     @classmethod
     def to_parts(cls, urn):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -4632,6 +4632,11 @@ class URNTest(TembaTest):
         self.assertEqual(URN.from_parts("tel", "+12345"), "tel:+12345")
         self.assertEqual(URN.from_parts("tel", "(917) 992-5253"), "tel:(917) 992-5253")
         self.assertEqual(URN.from_parts("mailto", "a_b+c@d.com"), "mailto:a_b+c@d.com")
+        self.assertEqual(URN.from_parts("twitterid", "2352362611", display="bobby"), "twitterid:2352362611#bobby")
+        self.assertEqual(
+            URN.from_parts("twitterid", "2352362611", display="bobby", query={'channel': "my-twitter-channel"}),
+            "twitterid:2352362611?channel=my-twitter-channel#bobby"
+        )
 
         self.assertEqual(URN.from_tel("+12345"), "tel:+12345")
         self.assertEqual(URN.from_twitter("abc_123"), "twitter:abc_123")

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -4637,8 +4637,8 @@ class URNTest(TembaTest):
         self.assertEqual(URN.from_parts("mailto", "a_b+c@d.com"), "mailto:a_b+c@d.com")
         self.assertEqual(URN.from_parts("twitterid", "2352362611", display="bobby"), "twitterid:2352362611#bobby")
         self.assertEqual(
-            URN.from_parts("twitterid", "2352362611", query={'channel': "my-twitter-channel"}, display="bobby"),
-            "twitterid:2352362611?channel=my-twitter-channel#bobby"
+            URN.from_parts("twitterid", "2352362611", query='foo=ba?r', display="bobby"),
+            "twitterid:2352362611?foo=ba%3Fr#bobby"
         )
 
         self.assertEqual(URN.from_tel("+12345"), "tel:+12345")
@@ -4653,14 +4653,14 @@ class URNTest(TembaTest):
         self.assertRaises(ValueError, URN.from_parts, "xxx", "12345")
 
     def test_to_parts(self):
-        self.assertEqual(URN.to_parts("tel:12345"), ("tel", "12345", None))
-        self.assertEqual(URN.to_parts("tel:+12345"), ("tel", "+12345", None))
-        self.assertEqual(URN.to_parts("twitter:abc_123"), ("twitter", "abc_123", None))
-        self.assertEqual(URN.to_parts("mailto:a_b+c@d.com"), ("mailto", "a_b+c@d.com", None))
-        self.assertEqual(URN.to_parts("facebook:12345"), ("facebook", "12345", None))
-        self.assertEqual(URN.to_parts("telegram:12345"), ("telegram", "12345", None))
-        self.assertEqual(URN.to_parts("telegram:12345#foobar"), ("telegram", "12345", "foobar"))
-        self.assertEqual(URN.to_parts("ext:Aa0()+,-.:=@;$_!*'"), ("ext", "Aa0()+,-.:=@;$_!*'", None))
+        self.assertEqual(URN.to_parts("tel:12345"), ("tel", "12345", None, None))
+        self.assertEqual(URN.to_parts("tel:+12345"), ("tel", "+12345", None, None))
+        self.assertEqual(URN.to_parts("twitter:abc_123"), ("twitter", "abc_123", None, None))
+        self.assertEqual(URN.to_parts("mailto:a_b+c@d.com"), ("mailto", "a_b+c@d.com", None, None))
+        self.assertEqual(URN.to_parts("facebook:12345"), ("facebook", "12345", None, None))
+        self.assertEqual(URN.to_parts("telegram:12345"), ("telegram", "12345", None, None))
+        self.assertEqual(URN.to_parts("telegram:12345#foobar"), ("telegram", "12345", None, "foobar"))
+        self.assertEqual(URN.to_parts("ext:Aa0()+,-.:=@;$_!*'"), ("ext", "Aa0()+,-.:=@;$_!*'", None, None))
 
         self.assertRaises(ValueError, URN.to_parts, "tel")
         self.assertRaises(ValueError, URN.to_parts, "tel:")  # missing scheme

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3024,7 +3024,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
 
         # don't really update URNs on test contacts
         if self.contact.is_test:
-            scheme, path, display = URN.to_parts(event['urn'])
+            scheme, path, query, display = URN.to_parts(event['urn'])
             ActionLog.info(self, _("Added %s as @contact.%s - skipped in simulator" % (path, scheme)))
         else:
             self.contact.update_urns(user, urns)

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1462,7 +1462,7 @@ class FlowCRUDL(SmartCRUDL):
                 return org.country
 
         resources = {
-            'channel': Resource(Channel.objects.filter(is_active=True), goflow.serialize_channel),
+            'channel': Resource(Channel.objects.filter(is_active=True).select_related('parent'), goflow.serialize_channel),
             'field': Resource(ContactField.objects.filter(is_active=True), goflow.serialize_field),
             'flow': Resource(Flow.objects.filter(is_active=True, is_archived=False), goflow.serialize_flow),
             'group': Resource(ContactGroup.user_groups.filter(is_active=True, status=ContactGroup.STATUS_READY), goflow.serialize_group),

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1572,7 +1572,7 @@ class Msg(models.Model):
                 contact = recipient.contact
                 contact_urn = recipient
         elif isinstance(recipient, six.string_types):
-            scheme, path, display = URN.to_parts(recipient)
+            scheme, path, query, display = URN.to_parts(recipient)
             if scheme in resolved_schemes:
                 contact, contact_urn = Contact.get_or_create(org, recipient, user=user)
         else:  # pragma: no cover

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1203,8 +1203,8 @@ ALL_LOGS_TRIM_TIME = 24 * 30
 # -----------------------------------------------------------------------------------
 # Flowserver - disabled by default. GoFlow defaults to http://localhost:8080
 # -----------------------------------------------------------------------------------
-FLOW_SERVER_URL = None
-FLOW_SERVER_AUTH_TOKEN = None
+FLOW_SERVER_URL = 'http://localhost:8080'
+FLOW_SERVER_AUTH_TOKEN = 1234
 FLOW_SERVER_DEBUG = False
 FLOW_SERVER_FORCE = False
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1203,8 +1203,8 @@ ALL_LOGS_TRIM_TIME = 24 * 30
 # -----------------------------------------------------------------------------------
 # Flowserver - disabled by default. GoFlow defaults to http://localhost:8080
 # -----------------------------------------------------------------------------------
-FLOW_SERVER_URL = 'http://localhost:8080'
-FLOW_SERVER_AUTH_TOKEN = 1234
+FLOW_SERVER_URL = None
+FLOW_SERVER_AUTH_TOKEN = None
 FLOW_SERVER_DEBUG = False
 FLOW_SERVER_FORCE = False
 

--- a/temba/utils/goflow/serialize.py
+++ b/temba/utils/goflow/serialize.py
@@ -67,7 +67,7 @@ def serialize_contact(contact):
     # augment URN values with preferred channel UUID as a parameter
     urn_values = []
     for u in contact.urns.order_by('-priority', 'id'):
-        scheme, path, display = URN.to_parts(u.urn)
+        scheme, path, query, display = URN.to_parts(u.urn)
         query = urlencode({'channel': str(u.channel.uuid)}) if u.channel_id else None
         urn_values.append(URN.from_parts(scheme, path, query=query, display=display))
 

--- a/temba/utils/goflow/serialize.py
+++ b/temba/utils/goflow/serialize.py
@@ -69,10 +69,10 @@ def serialize_contact(contact):
     serialized = {
         'uuid': contact.uuid,
         'name': contact.name,
-        'urns': [urn.urn for urn in contact.urns.all()],
-        'group_uuids': [group.uuid for group in contact.user_groups.all()],
-        'timezone': "UTC",
         'language': contact.language,
+        'timezone': "UTC",
+        'urns': [urn.urn for urn in contact.urns.all()],
+        'groups': [serialize_group_ref(group) for group in contact.user_groups.all()],
         'fields': field_values
     }
 
@@ -102,6 +102,10 @@ def serialize_field(field):
 
 def serialize_group(group):
     return {'uuid': str(group.uuid), 'name': group.name, 'query': group.query}
+
+
+def serialize_group_ref(group):
+    return {'uuid': str(group.uuid), 'name': group.name}
 
 
 def serialize_label(label):

--- a/temba/utils/goflow/tests.py
+++ b/temba/utils/goflow/tests.py
@@ -81,7 +81,7 @@ class ClientTest(TembaTest):
                     },
                     'group_uuids': [],
                     'language': None,
-                    'channel_uuid': str(self.channel.uuid),
+                    'channel': {'uuid': str(self.channel.uuid), 'name': "Test Channel"},
                     'timezone': 'UTC',
                 }
             }])

--- a/temba/utils/goflow/tests.py
+++ b/temba/utils/goflow/tests.py
@@ -60,6 +60,7 @@ class ClientTest(TembaTest):
         self.gender = self.create_field('gender', "Gender", Value.TYPE_TEXT)
         self.age = self.create_field('age', "Age", Value.TYPE_DECIMAL)
         self.contact = self.create_contact("Bob", number="+12345670987")
+        self.testers = self.create_group("Testers", [self.contact])
         self.client = get_client()
 
     def test_add_contact_changed(self):
@@ -79,7 +80,9 @@ class ClientTest(TembaTest):
                         'gender': {'value': 'M', 'created_on': "2018-01-18T14:24:30+00:00"},
                         'age': {'value': '36', 'created_on': "2018-01-18T14:24:30+00:00"}
                     },
-                    'group_uuids': [],
+                    'groups': [
+                        {'uuid': str(self.testers.uuid), 'name': "Testers"}
+                    ],
                     'language': None,
                     'channel': {'uuid': str(self.channel.uuid), 'name': "Test Channel"},
                     'timezone': 'UTC',

--- a/temba/utils/goflow/tests.py
+++ b/temba/utils/goflow/tests.py
@@ -5,10 +5,11 @@ import pytz
 
 from datetime import datetime
 from mock import patch
+from temba.channels.models import Channel
 from temba.msgs.models import Label
 from temba.tests import TembaTest, MockResponse
 from temba.values.models import Value
-from .client import serialize_field, serialize_label, get_client, FlowServerException
+from .client import serialize_field, serialize_label, serialize_channel, get_client, FlowServerException
 
 
 class SerializationTest(TembaTest):
@@ -30,6 +31,26 @@ class SerializationTest(TembaTest):
     def test_serialize_label(self):
         spam = Label.get_or_create(self.org, self.admin, "Spam")
         self.assertEqual(serialize_label(spam), {'uuid': str(spam.uuid), 'name': "Spam"})
+
+    def test_serialize_channel(self):
+        self.assertEqual(serialize_channel(self.channel), {
+            'uuid': str(self.channel.uuid),
+            'name': "Test Channel",
+            'address': '+250785551212',
+            'roles': ['send', 'receive'],
+            'schemes': ['tel'],
+        })
+
+        bulk_sender = Channel.create(self.org, self.admin, "RW", "NX", "Bulk Sender", role='S', parent=self.channel)
+
+        self.assertEqual(serialize_channel(bulk_sender), {
+            'uuid': str(bulk_sender.uuid),
+            'name': "Bulk Sender",
+            'address': None,
+            'roles': ['send'],
+            'schemes': ['tel'],
+            'parent': {'uuid': str(self.channel.uuid), 'name': "Test Channel"}
+        })
 
 
 class ClientTest(TembaTest):


### PR DESCRIPTION
* Add some extra fields to goflow/editor serialization that we need in goflow for picking channels
* Replace contact.channel in goflow serialization with URN query params for each URN's channel
* Move Yo constants into the Yo type
* Remove the never-used (?) Dummy channel type
