### PR TITLE
update middlewares to Django defaults

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -166,11 +166,13 @@ if TESTING:
     TEMPLATES[0]['OPTIONS']['context_processors'] += ('temba.tests.add_testing_flag_to_context', )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'temba.middleware.BrandingMiddleware',
     'temba.middleware.OrgTimezoneMiddleware',
     'temba.middleware.FlowSimulationMiddleware',

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -180,6 +180,10 @@ MIDDLEWARE_CLASSES = (
     'temba.middleware.OrgHeaderMiddleware',
 )
 
+# security middleware configuration
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+
 ROOT_URLCONF = 'temba.urls'
 
 # other urls to add


### PR DESCRIPTION
Just created a new django project, then copied in their default middlewares. That includes the clickjacking prevention and the nice-sounding "SecurityMiddleware"