### PR TITLE
Fixes for test contact activity

### DIFF
--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1285,7 +1285,7 @@ class FlowCRUDL(SmartCRUDL):
                 for msg in messages_and_logs:
                     messages_json.append(msg.simulator_json())
 
-            (active, visited) = flow.get_activity(simulation=True)
+            (active, visited) = flow.get_activity(test_contact)
             response = dict(messages=messages_json, activity=active, visited=visited)
 
             # if we are at a ruleset, include it's details


### PR DESCRIPTION
* Only show current test contact activity (instead of all test contacts)
* Don't blow up if old path data is missing exits

Fixes: https://sentry.io/nyaruka/rapidpro/issues/480677178/events/16580633977/