### PR TITLE
Update FB

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -7759,7 +7759,7 @@ class FacebookWhitelistTest(TembaTest):
             mock.return_value = MockResponse(200, '{ "ok": "true" }')
             response = self.client.post(whitelist_url, dict(whitelisted_domain='https://foo.bar'))
 
-            mock.assert_called_once_with('https://graph.facebook.com/v2.6/me/thread_settings?access_token=auth',
+            mock.assert_called_once_with('https://graph.facebook.com/v2.12/me/thread_settings?access_token=auth',
                                          json=dict(setting_type='domain_whitelisting',
                                                    whitelisted_domains=['https://foo.bar'],
                                                    domain_action_type='add'))

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8355,7 +8355,7 @@ class FacebookTest(TembaTest):
             self.assertEqual(msg.external_id, 'mid.external')
             self.clear_cache()
 
-            self.assertEqual(mock.call_args[0][0], 'https://graph.facebook.com/v2.5/me/messages')
+            self.assertEqual(mock.call_args[0][0], 'https://graph.facebook.com/v2.12/me/messages')
             self.assertEqual(json.loads(mock.call_args[0][1]),
                              dict(recipient=dict(id="1234"), message=dict(text="Facebook Msg")))
 
@@ -8403,13 +8403,13 @@ class FacebookTest(TembaTest):
 
             self.assertEqual(mock.call_count, 2)
 
-            self.assertEqual(mock.call_args_list[0][0][0], 'https://graph.facebook.com/v2.5/me/messages')
+            self.assertEqual(mock.call_args_list[0][0][0], 'https://graph.facebook.com/v2.12/me/messages')
 
             self.assertEqual(json.loads(mock.call_args_list[0][0][1]),
                              dict(recipient=dict(id="1234"),
                                   message=dict(text="Facebook Msg")))
 
-            self.assertEqual(mock.call_args_list[1][0][0], 'https://graph.facebook.com/v2.5/me/messages')
+            self.assertEqual(mock.call_args_list[1][0][0], 'https://graph.facebook.com/v2.12/me/messages')
 
             self.assertEqual(json.loads(mock.call_args_list[1][0][1]),
                              dict(recipient=dict(id="1234"),
@@ -8463,7 +8463,7 @@ class FacebookTest(TembaTest):
             self.assertEqual(msg.external_id, 'mid.external')
             self.clear_cache()
 
-            self.assertEqual(mock.call_args[0][0], 'https://graph.facebook.com/v2.5/me/messages')
+            self.assertEqual(mock.call_args[0][0], 'https://graph.facebook.com/v2.12/me/messages')
 
             self.assertEqual(json.loads(mock.call_args[0][1])['recipient']['id'], '1234')
             self.assertEqual(json.loads(mock.call_args[0][1])['message']['text'], 'Facebook Msg')
@@ -8486,7 +8486,7 @@ class FacebookTest(TembaTest):
                 msg.refresh_from_db()
                 self.clear_cache()
 
-                self.assertEqual(mock.call_args[0][0], 'https://graph.facebook.com/v2.5/me/messages')
+                self.assertEqual(mock.call_args[0][0], 'https://graph.facebook.com/v2.12/me/messages')
                 self.assertEqual(json.loads(mock.call_args[0][1])['recipient']['id'], '12345')
                 self.assertEqual(json.loads(mock.call_args[0][1])['message']['text'], 'Facebook Msg')
                 self.assertEqual(json.loads(mock.call_args[0][1])['message']['quick_replies'][0]['title'], 'Yes')

--- a/temba/channels/types/facebook/tests.py
+++ b/temba/channels/types/facebook/tests.py
@@ -98,7 +98,7 @@ class FacebookTypeTest(TembaTest):
         mock_delete.return_value = MockResponse(200, json.dumps({'success': True}))
         self.channel.release()
 
-        mock_delete.assert_called_once_with('https://graph.facebook.com/v2.5/me/subscribed_apps',
+        mock_delete.assert_called_once_with('https://graph.facebook.com/v2.12/me/subscribed_apps',
                                             params={'access_token': '09876543'})
 
     @override_settings(IS_PROD=True)
@@ -110,7 +110,7 @@ class FacebookTypeTest(TembaTest):
 
         trigger = Trigger.create(self.org, self.admin, Trigger.TYPE_NEW_CONVERSATION, flow, self.channel)
 
-        mock_post.assert_called_once_with('https://graph.facebook.com/v2.6/12345/thread_settings', json={
+        mock_post.assert_called_once_with('https://graph.facebook.com/v2.12/12345/thread_settings', json={
             'setting_type': 'call_to_actions',
             'thread_state': 'new_thread',
             'call_to_actions': [{"payload": "get_started"}]
@@ -119,7 +119,7 @@ class FacebookTypeTest(TembaTest):
 
         trigger.archive(self.admin)
 
-        mock_post.assert_called_once_with('https://graph.facebook.com/v2.6/12345/thread_settings', json={
+        mock_post.assert_called_once_with('https://graph.facebook.com/v2.12/12345/thread_settings', json={
             'setting_type': 'call_to_actions',
             'thread_state': 'new_thread',
             'call_to_actions': []
@@ -128,7 +128,7 @@ class FacebookTypeTest(TembaTest):
 
         trigger.restore(self.admin)
 
-        mock_post.assert_called_once_with('https://graph.facebook.com/v2.6/12345/thread_settings', json={
+        mock_post.assert_called_once_with('https://graph.facebook.com/v2.12/12345/thread_settings', json={
             'setting_type': 'call_to_actions',
             'thread_state': 'new_thread',
             'call_to_actions': [{"payload": "get_started"}]

--- a/temba/channels/types/facebook/type.py
+++ b/temba/channels/types/facebook/type.py
@@ -38,7 +38,7 @@ class FacebookType(ChannelType):
 
     def deactivate(self, channel):
         config = channel.config
-        requests.delete('https://graph.facebook.com/v2.5/me/subscribed_apps', params={
+        requests.delete('https://graph.facebook.com/v2.12/me/subscribed_apps', params={
             'access_token': config[Channel.CONFIG_AUTH_TOKEN]
         })
 
@@ -145,7 +145,7 @@ class FacebookType(ChannelType):
     @staticmethod
     def _set_call_to_action(channel, payload):
         # register for get_started events
-        url = 'https://graph.facebook.com/v2.6/%s/thread_settings' % channel.address
+        url = 'https://graph.facebook.com/v2.12/%s/thread_settings' % channel.address
         body = {'setting_type': 'call_to_actions', 'thread_state': 'new_thread', 'call_to_actions': []}
 
         # if we have a payload, set it, otherwise, clear it

--- a/temba/channels/types/facebook/type.py
+++ b/temba/channels/types/facebook/type.py
@@ -70,7 +70,7 @@ class FacebookType(ChannelType):
         else:
             payload['recipient'] = dict(id=msg.urn_path)
 
-        url = "https://graph.facebook.com/v2.5/me/messages"
+        url = "https://graph.facebook.com/v2.12/me/messages"
         params = {'access_token': channel.config[Channel.CONFIG_AUTH_TOKEN]}
         headers = {'Content-Type': 'application/json'}
         start = time.time()

--- a/temba/channels/types/facebook/views.py
+++ b/temba/channels/types/facebook/views.py
@@ -20,7 +20,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             value = self.cleaned_data['page_access_token']
 
             # hit the FB graph, see if we can load the page attributes
-            response = requests.get('https://graph.facebook.com/v2.5/me', params={'access_token': value})
+            response = requests.get('https://graph.facebook.com/v2.12/me', params={'access_token': value})
             response_json = response.json()
             if response.status_code != 200:
                 default_error = _("Invalid page access token, please check it and try again.")

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1288,9 +1288,9 @@ class ChannelCRUDL(SmartCRUDL):
             #  "setting_type" : "domain_whitelisting",
             #  "whitelisted_domains" : ["https://petersfancyapparel.com"],
             #  "domain_action_type": "add"
-            # }' "https://graph.facebook.com/v2.6/me/thread_settings?access_token=PAGE_ACCESS_TOKEN"
+            # }' "https://graph.facebook.com/v2.12/me/thread_settings?access_token=PAGE_ACCESS_TOKEN"
             access_token = self.object.config[Channel.CONFIG_AUTH_TOKEN]
-            response = requests.post('https://graph.facebook.com/v2.6/me/thread_settings?access_token=' + access_token,
+            response = requests.post('https://graph.facebook.com/v2.12/me/thread_settings?access_token=' + access_token,
                                      json=dict(setting_type='domain_whitelisting',
                                                whitelisted_domains=[self.form.cleaned_data['whitelisted_domain']],
                                                domain_action_type='add'))


### PR DESCRIPTION
The API version we were going against will stop working April 12th. Don't see any differences, so just increments the endpoint version.