### PR TITLE
Add API endpoint to view failed messages

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2086,6 +2086,7 @@ class APITest(TembaTest):
         joe_msg3 = self.create_msg(direction='I', msg_type='F', text="Good", contact=self.joe,
                                    attachments=['image/jpeg:https://example.com/test.jpg'])
         frank_msg3 = self.create_msg(direction='I', msg_type='I', text="Bien", contact=self.frank, channel=self.twitter, visibility='A')
+        frank_msg4 = self.create_msg(direction='O', msg_type='I', text="Ça va?", contact=self.frank, status='F')
 
         # add a surveyor message (no URN etc)
         joe_msg4 = self.create_msg(direction='O', msg_type='F', text="Surveys!", contact=self.joe, contact_urn=None,
@@ -2146,6 +2147,10 @@ class APITest(TembaTest):
         # filter by folder (sent)
         response = self.fetchJSON(url, 'folder=sent')
         self.assertResultsById(response, [joe_msg4, frank_msg2])
+
+        # filter by folder (failed)
+        response = self.fetchJSON(url, 'folder=failed')
+        self.assertResultsById(response, [frank_msg4])
 
         # filter by invalid view
         response = self.fetchJSON(url, 'folder=invalid')

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2187,7 +2187,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
      * **created_on** - when this message was either received by the channel or created (datetime) (filterable as `before` and `after`).
      * **sent_on** - for outgoing messages, when the channel sent the message (null if not yet sent or an incoming message) (datetime).
 
-    You can also filter by `folder` where folder is one of `inbox`, `flows`, `archived`, `outbox`, `incoming` or `sent`.
+    You can also filter by `folder` where folder is one of `inbox`, `flows`, `archived`, `outbox`, `incoming`, 'failed' or `sent`.
     Note that you cannot filter by more than one of `contact`, `folder`, `label` or `broadcast` at the same time.
 
     The sort order for all folders save for `incoming` is the message creation date. For the `incoming` folder (which
@@ -2246,6 +2246,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
                       'flows': SystemLabel.TYPE_FLOWS,
                       'archived': SystemLabel.TYPE_ARCHIVED,
                       'outbox': SystemLabel.TYPE_OUTBOX,
+                      'failed': SystemLabel.TYPE_FAILED,
                       'sent': SystemLabel.TYPE_SENT}
 
     def get_queryset(self):


### PR DESCRIPTION
In response to ticket.. we have indexes for this so should be safe as an API endpoint.