### PR TITLE
finalize contact imports

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -112,7 +112,7 @@ rjsmin==1.0.12            # via django-compressor
 s3transfer==0.1.10        # via boto3
 selenium==3.4.3
 six==1.10.0               # via analytics-python, cryptography, django-extensions, django-hamlpy, django-rosetta, librato-bg, librato-metrics, microsofttranslator, mock, python-dateutil, rapidpro-expressions, responses, smartmin, twilio
-smartmin==1.11.8
+smartmin==1.12.0
 sqlparse==0.2.3           # via django-debug-toolbar, smartmin
 stop-words==2015.2.23.1
 stripe==1.59.0

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1490,6 +1490,11 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         return records
 
     @classmethod
+    def finalize_import(cls, task, records):
+        for chunk in chunk_list(records, 1000):
+            Contact.objects.filter(id__in=[c.id for c in chunk]).update(modified_on=timezone.now())
+
+    @classmethod
     def import_csv(cls, task, log=None):
         import pyexcel
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3516,6 +3516,12 @@ class ContactTest(TembaTest):
             if expected_results.get('records', 0):
                 self.assertIsNotNone(response.context['group'])
 
+            # assert all contacts in the group have the same modified_on
+            group = response.context['group']
+            if group.contacts.first():
+                first_modified_on = group.contacts.first().modified_on
+                self.assertEqual(group.contacts.count(), group.contacts.filter(modified_on=first_modified_on).count())
+
         return response
 
     @patch.object(ContactGroup, "MAX_ORG_CONTACTGROUPS", new=10)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3518,7 +3518,7 @@ class ContactTest(TembaTest):
 
             # assert all contacts in the group have the same modified_on
             group = response.context['group']
-            if group.contacts.first():
+            if group and group.contacts.first():
                 first_modified_on = group.contacts.first().modified_on
                 self.assertEqual(group.contacts.count(), group.contacts.filter(modified_on=first_modified_on).count())
 


### PR DESCRIPTION
So that imports don't create contacts with a modified on in the past.