### PR TITLE
Fix to display Export buttons on sent msgs folder and failed msgs folder

### DIFF
--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -721,6 +721,7 @@ class MsgTest(TembaTest):
 
         self.assertEqual(response.context['object_list'].count(), 3)
         self.assertEqual(response.context['actions'], ['resend'])
+        self.assertContains(response, "Export")
 
         self.assertContains(response, reverse('channels.channellog_read', args=[log.id]))
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -716,7 +716,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit failed page as an administrator
-        with self.assertNumQueries(61):
+        with self.assertNumQueries(64):
             response = self.fetch_protected(failed_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 3)

--- a/templates/msgs/msg_failed.haml
+++ b/templates/msgs/msg_failed.haml
@@ -10,3 +10,4 @@
   -if org_is_purged
     %i
       -trans "Only showing messages sent in the last 90 days"
+  {{ block.super }}

--- a/templates/msgs/msg_sent.haml
+++ b/templates/msgs/msg_sent.haml
@@ -5,3 +5,4 @@
   -if org_is_purged
     %i
       -trans "Only showing messages sent in the last 90 days"
+  {{ block.super }}


### PR DESCRIPTION
Fix the export buttons not currently visible