### PR TITLE
Disallow group flows

### DIFF
--- a/media/test_flows/action_packed.json
+++ b/media/test_flows/action_packed.json
@@ -247,7 +247,13 @@
               "uuid": "38b07089-ab02-48a7-9065-ec2d8f02104f"
             }, 
             {
-              "uuid": "0b387b74-cf44-461d-9970-054c5892eecf", 
+              "uuid": "0b387b74-cf44-461d-9970-054c5892eecf",
+              "groups": [
+                {
+                  "name": "Dog Facts",
+                  "uuid": "abcd1eef-b7aa-4959-ab90-3e33e0d3b1f9"
+                }
+              ],
               "contacts": [
                 {
                   "urns": [
@@ -265,7 +271,6 @@
                 "name": "Favorite Color", 
                 "uuid": "e1fa3c52-3616-499e-b1be-c759f4645247"
               }, 
-              "groups": [], 
               "type": "trigger-flow"
             }
           ]

--- a/media/test_flows/action_packed.json
+++ b/media/test_flows/action_packed.json
@@ -278,6 +278,27 @@
           "destination": "10d41071-dd84-42a5-b579-430c52774d1f", 
           "actions": [
             {
+              "uuid": "4c729279-b30f-471d-8995-cd1667117194",
+              "contacts": [{
+                  "urns": [
+                    {
+                      "priority": 50,
+                      "path": "+12065552121",
+                      "scheme": "tel"
+                    }
+                  ],
+                  "name": "Oprah Winfrey"
+                }],
+              "media": {},
+              "variables": [{"id": "+12065551212"}],
+              "groups": [],
+              "msg": {
+                "spa": "Hola Opraho!",
+                "eng": "Hey Oprah!"
+              },
+              "type": "send"
+            },
+            {
               "type": "del_group", 
               "uuid": "b4c7c2c7-987d-47e2-8b6c-fd30ef3196c0", 
               "groups": [

--- a/media/test_flows/action_packed.json
+++ b/media/test_flows/action_packed.json
@@ -278,23 +278,6 @@
           "destination": "10d41071-dd84-42a5-b579-430c52774d1f", 
           "actions": [
             {
-              "uuid": "4c729279-b30f-471d-8995-cd1667117194", 
-              "contacts": [], 
-              "media": {}, 
-              "variables": [{"id": "+12065551212"}],
-              "groups": [
-                {
-                  "name": "Females", 
-                  "uuid": "f8f2ce18-b585-4969-8e58-237c1aa26d88"
-                }
-              ], 
-              "msg": {
-                "spa": "Hola chicas!", 
-                "eng": "Hey ladies."
-              }, 
-              "type": "send"
-            }, 
-            {
               "type": "del_group", 
               "uuid": "b4c7c2c7-987d-47e2-8b6c-fd30ef3196c0", 
               "groups": [

--- a/media/test_flows/migrate_to_9.json
+++ b/media/test_flows/migrate_to_9.json
@@ -54,13 +54,8 @@
                   "name": "Trey Anastasio"
                 }
               ],
-              "groups": [
-                {
-                  "id": group_id, 
-                  "name": "Phans"
-                }
-              ],
-              "variables": [], 
+              "groups": [],
+              "variables": [],
               "msg": {
                 "base": "You're phantastic"
               }, 

--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -633,8 +633,10 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
             if statusCode == 400
               $rootScope.saving = false
-              if UserVoice
-                UserVoice.push(['set', 'ticket_custom_fields', {'Error': data.description}]);
+              try
+                if UserVoice
+                  UserVoice.push(['set', 'ticket_custom_fields', {'Error': data.description}]);
+              catch e
 
               resolveObj =
                 type: -> "error"

--- a/temba/channels/migrations/0087_migrate_twilio_endpoints.py
+++ b/temba/channels/migrations/0087_migrate_twilio_endpoints.py
@@ -17,7 +17,7 @@ def update_application_urls(Channel):
     for channel in Channel.objects.filter(is_active=True, channel_type='T').select_related('org'):
         if 'account_sid' not in channel.config or 'auth_token' not in channel.config or 'application_sid' not in channel.config:
             print("Skipping app migration for %s, missing settings in %s" % (channel.uuid, channel.config))
-            return
+            continue
 
         try:
             prefix = "https://" + channel.callback_domain

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -6452,6 +6452,8 @@ class SendAction(VariableContactAction):
         groups = VariableContactAction.parse_groups(org, json_obj)
         contacts = VariableContactAction.parse_contacts(org, json_obj)
         variables = VariableContactAction.parse_variables(org, json_obj)
+        if groups:
+            raise FlowException('SendAction no longer allows sending to groups')
 
         return cls(json_obj.get(cls.UUID), json_obj.get(cls.MESSAGE), groups, contacts, variables,
                    json_obj.get(cls.MEDIA, None))
@@ -6460,6 +6462,10 @@ class SendAction(VariableContactAction):
         contact_ids = [dict(uuid=_.uuid) for _ in self.contacts]
         group_ids = [dict(uuid=_.uuid, name=_.name) for _ in self.groups]
         variables = [dict(id=_) for _ in self.variables]
+
+        if group_ids:
+            raise FlowException('SendAction no longer allows sending to groups')
+
         return dict(type=self.TYPE, uuid=self.uuid, msg=self.msg,
                     contacts=contact_ids, groups=group_ids, variables=variables,
                     media=self.media)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2950,7 +2950,13 @@ class ActionPackedTest(FlowFileTest):
 
     @also_in_flowserver
     def test_labeling(self):
-        self.start_flow()
+
+        # start contact as a single member of a group
+        contact_group = self.create_group('Lonely Group', [self.contact])
+        self.flow.start([contact_group], [], restart_participants=True)
+        self.send("Trey Anastasio")
+        self.send("Male")
+
         msg = Msg.objects.filter(direction=INCOMING, text='Male').order_by('-id').first()
         self.assertEqual('Friends', msg.labels.all().first().name)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2950,13 +2950,7 @@ class ActionPackedTest(FlowFileTest):
 
     @also_in_flowserver
     def test_labeling(self):
-
-        # start contact as a single member of a group
-        contact_group = self.create_group('Lonely Group', [self.contact])
-        self.flow.start([contact_group], [], restart_participants=True)
-        self.send("Trey Anastasio")
-        self.send("Male")
-
+        self.start_flow()
         msg = Msg.objects.filter(direction=INCOMING, text='Male').order_by('-id').first()
         self.assertEqual('Friends', msg.labels.all().first().name)
 
@@ -2964,12 +2958,16 @@ class ActionPackedTest(FlowFileTest):
     def test_trigger_flow_action(self):
 
         self.create_contact('Oprah Winfrey', '+12065552121')
+        lonely = self.create_contact('Lonely Contact', '+12065550001')
+
+        dog_facts = ContactGroup.user_groups.filter(name='Dog Facts').first()
+        dog_facts.contacts.add(lonely)
 
         self.start_flow()
 
         # we should have fired off a new flow run for a total of two
-        self.assertEqual(2, Contact.objects.all().count())
-        self.assertEqual(2, FlowRun.objects.all().count())
+        self.assertEqual(3, Contact.objects.all().count())
+        self.assertEqual(3, FlowRun.objects.all().count())
 
         # our newest flow run should be down the triggered flow
         triggered_run = FlowRun.objects.all().order_by('-id').first()

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -46,8 +46,8 @@ from temba.utils.expressions import get_function_listing
 from temba.utils.goflow import get_client
 from temba.utils.views import BaseActionForm
 from uuid import uuid4
-from .models import FlowStep, RuleSet, ActionLog, ExportFlowResultsTask, FlowLabel, FlowPathRecentRun
-from .models import FlowUserConflictException, FlowVersionConflictException, FlowInvalidCycleException
+from .models import Action, FlowStep, RuleSet, ActionLog, ExportFlowResultsTask, FlowLabel, FlowPathRecentRun
+from .models import FlowException, FlowUserConflictException, FlowVersionConflictException, FlowInvalidCycleException
 
 logger = logging.getLogger(__name__)
 
@@ -394,6 +394,23 @@ class FlowCRUDL(SmartCRUDL):
     class Copy(OrgObjPermsMixin, SmartUpdateView):
         fields = []
         success_message = ''
+
+        def pre_process(self, request, *args, **kwargs):
+
+            try:
+                flow = self.get_object()
+
+                # make sure actions can be parsed before allowing a copy
+                flow_json = flow.as_json()
+                for actionset in flow_json.get(Flow.ACTION_SETS):
+                    Action.from_json_array(flow.org, actionset.get(Flow.ACTIONS))
+
+            except FlowException:
+                messages.error(self.request, _("Sorry, your flow could not be copied. Please try again"
+                                               " or contact support if the problem persists."))
+                return HttpResponseRedirect(reverse('flows.flow_editor', args=[flow.uuid]))
+
+            return super(FlowCRUDL.Copy, self).pre_process(request, *args, **kwargs)
 
         def form_valid(self, form):
             # copy our current object

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -161,6 +161,7 @@
 
 -block page-top
 
+
 -block page-container
 
   -include "msgs/msg_send_modal.html"
@@ -221,6 +222,12 @@
         -elif flow.flow_type == 'S'
           .icon-mobile
         {{ flow.name }}
+
+      -if messages
+        #messages
+          -for msg in messages
+            %div{class:"alert alert-{{ message.tags }}"}
+              {{ msg }}
 
       #pending{ng-show:'is_starting'}
         %div{class:"alert alert-info"}


### PR DESCRIPTION
Reduce likelihood of group broadcast flows by not allowing them to be imported or copied

👣 🔫 