### PR TITLE
do not allow dupe broadcasts to groups

### DIFF
--- a/temba/channels/migrations/0088_fix_twiml_configs.py
+++ b/temba/channels/migrations/0088_fix_twiml_configs.py
@@ -8,10 +8,11 @@ from temba.channels.models import Channel
 
 def update_twiml_configs(apps, schema_editor):
     for channel in Channel.objects.filter(is_active=True, channel_type='TW'):
-        # need to populate auth_token and account_sid from their uppercase versions
-        channel.config['auth_token'] = channel.config['ACCOUNT_TOKEN']
-        channel.config['account_sid'] = channel.config['ACCOUNT_SID']
-        channel.save(update_fields=['config'])
+        if 'ACCOUNT_TOKEN' in channel.config and 'ACCOUNT_SID' in channel.config:
+            # need to populate auth_token and account_sid from their uppercase versions
+            channel.config['auth_token'] = channel.config['ACCOUNT_TOKEN']
+            channel.config['account_sid'] = channel.config['ACCOUNT_SID']
+            channel.save(update_fields=['config'])
 
 
 class Migration(migrations.Migration):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -698,7 +698,7 @@ class MsgTest(TembaTest):
         bcast.send()
 
         bcast2 = Broadcast.create(self.org, self.admin, "This is my spam message", recipients=[group])
-        with self.assertRaises(expected_exception=Exception):
+        with self.assertRaises(Exception):
             bcast2.send()
 
     def test_failed(self):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2,36 +2,37 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
+from datetime import datetime, timedelta
+
 import pytz
 import six
-
-from datetime import datetime, timedelta
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.db import transaction, connection
+from django.test import override_settings
 from django.utils import timezone
 from django_redis import get_redis_connection
-from django.db import transaction, connection
-from django.contrib.auth.models import User
-from django.test import override_settings
 from mock import patch
 from openpyxl import load_workbook
-from temba.contacts.models import Contact, ContactField, ContactURN, TEL_SCHEME, STOP_CONTACT_EVENT
+
 from temba.channels.models import Channel, ChannelCount, ChannelEvent, ChannelLog
-from temba.locations.models import AdminBoundary
+from temba.contacts.models import Contact, ContactField, ContactURN, TEL_SCHEME, STOP_CONTACT_EVENT, ContactGroup
 from temba.flows.models import RuleSet
-from temba.msgs.models import Msg, ExportMessagesTask, RESENT, FAILED, OUTGOING, PENDING, WIRED, DELIVERED, ERRORED
-from temba.msgs.models import Broadcast, BroadcastRecipient, Label, SystemLabel, SystemLabelCount, UnreachableException
+from temba.locations.models import AdminBoundary
+from temba.msgs import models
 from temba.msgs.models import Attachment, HANDLED, QUEUED, SENT, INCOMING, INBOX, FLOW, HANDLE_EVENT_TASK
+from temba.msgs.models import Broadcast, BroadcastRecipient, Label, SystemLabel, SystemLabelCount, UnreachableException
 from temba.msgs.models import HANDLER_QUEUE, MSG_EVENT
+from temba.msgs.models import Msg, ExportMessagesTask, RESENT, FAILED, OUTGOING, PENDING, WIRED, DELIVERED, ERRORED
 from temba.orgs.models import Language, Debit, Org
 from temba.schedules.models import Schedule
 from temba.tests import TembaTest, AnonymousOrg
 from temba.utils import dict_to_struct, dict_to_json
 from temba.utils.dates import datetime_to_str, datetime_to_s
-from temba.utils.queues import push_task, DEFAULT_PRIORITY
 from temba.utils.expressions import get_function_listing
+from temba.utils.queues import push_task, DEFAULT_PRIORITY
 from temba.values.models import Value
-from temba.msgs import models
 from .management.commands.msg_console import MessageConsole
 from .tasks import squash_labelcounts, clear_old_msg_external_ids, purge_broadcasts_task, process_message_task
 from .templatetags.sms import as_icon
@@ -684,6 +685,21 @@ class MsgTest(TembaTest):
 
         self.assertEqual(set(response.context['object_list']), {msg3, msg2, msg1})
         self.assertEqual(response.context['actions'], ['label'])
+
+    def test_footgun(self):
+        # create a bunch of contacts
+        group = ContactGroup.get_or_create(org=self.org, user=self.admin, name="Spam")
+        for i in range(20):
+            (contact, urn) = Contact.get_or_create(org=self.org, urn="tel:+1206779%04d" % i, user=self.admin)
+            group.contacts.add(contact)
+
+        # create a broadcast and send it off
+        bcast = Broadcast.create(self.org, self.admin, "This is my spam message", recipients=[group])
+        bcast.send()
+
+        bcast2 = Broadcast.create(self.org, self.admin, "This is my spam message", recipients=[group])
+        with self.assertRaises(expected_exception=Exception):
+            bcast2.send()
 
     def test_failed(self):
         failed_url = reverse('msgs.msg_failed')

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -17,6 +17,11 @@ from .settings_common import *  # noqa
 
 DEBUG_TOOLBAR = False
 
+DATABASES = {
+    'default': DATABASES['direct'],
+    'direct': DATABASES['direct'],
+}
+
 # -----------------------------------------------------------------------------------
 # Add a custom brand for development
 # -----------------------------------------------------------------------------------

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -17,11 +17,6 @@ from .settings_common import *  # noqa
 
 DEBUG_TOOLBAR = False
 
-DATABASES = {
-    'default': DATABASES['direct'],
-    'direct': DATABASES['direct'],
-}
-
 # -----------------------------------------------------------------------------------
 # Add a custom brand for development
 # -----------------------------------------------------------------------------------

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -885,6 +885,11 @@ DATABASES = {
     'direct': _direct_database_config
 }
 
+# If we are testing, set both our connections as the same, Django seems to get
+# confused on Python 3.6 with transactional tests otherwise
+if TESTING:
+    DATABASES['default'] = _direct_database_config
+
 # -----------------------------------------------------------------------------------
 # Debug Toolbar
 # -----------------------------------------------------------------------------------

--- a/temba/utils/cache.py
+++ b/temba/utils/cache.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
+import pytz
 
 from datetime import timedelta
 from django.utils import timezone
@@ -113,3 +114,38 @@ class QueueRecord(object):
             pipe.execute()
 
         r.expire(self.today_set_key, 86400)  # 24 hours
+
+
+def check_and_mark_in_timerange(base_key, hours, value):
+    """
+    Utility function to check whether the passed in `value` has been set within the past `hours` (times 2).
+    If it has been set in that time period, returns True, otherwise False. (setting it for the future)
+    """
+    r = get_redis_connection()
+
+    # figure out our range
+    now = timezone.now().astimezone(pytz.utc)
+    now_range = now.hour / hours
+
+    prev = now - timedelta(hours=hours)
+    prev_range = prev.hour / hours
+
+    # build our keys
+    now_key = "%s_%s_%d" % (base_key, now.strftime("%y_%m_%d"), now_range)
+    prev_key = "%s_%s_%d" % (base_key, prev.strftime("%y_%m_%d"), prev_range)
+
+    # see it is set for either
+    with r.pipeline() as pipe:
+        pipe.sismember(now_key, value)
+        pipe.sismember(prev_key, value)
+        (now_found, prev_found) = pipe.execute()
+
+        if now_found or prev_found:
+            return True
+
+    with r.pipeline() as pipe:
+        pipe.sadd(now_key, value)
+        pipe.expire(now_key, 3600 * hours)
+        pipe.execute()
+
+    return False


### PR DESCRIPTION
Blows up when we try to send a broadcast with the same text to a group within the last two days.. times feels a little bit long.. maybe 12 hours is better?