### PR TITLE
Fix django migrations which can lead to locks 

### DIFF
--- a/temba/api/migrations/0015_webhookresult_contact.py
+++ b/temba/api/migrations/0015_webhookresult_contact.py
@@ -11,6 +11,8 @@ def backfill_webhook_result_contact(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
+    atomic = False
+
     dependencies = [
         ('contacts', '0067_auto_20170808_1852'),
         ('api', '0014_auto_20170410_0731'),

--- a/temba/campaigns/migrations/0015_campaignevent_message_new.py
+++ b/temba/campaigns/migrations/0015_campaignevent_message_new.py
@@ -28,6 +28,8 @@ def populate_message_new(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
+    atomic = False
+
     dependencies = [
         ('campaigns', '0014_auto_20170228_0837'),
     ]


### PR DESCRIPTION
Because it adds a field and populates it in same transaction