### PR TITLE
Don't try to prefetch steps on msg views

### DIFF
--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -448,7 +448,7 @@ class MsgTest(TembaTest):
         broadcast1.send(trigger_send=False)
         (msg1,) = tuple(Msg.objects.filter(broadcast=broadcast1))
 
-        with self.assertNumQueries(43):
+        with self.assertNumQueries(42):
             response = self.client.get(reverse('msgs.msg_outbox'))
 
         self.assertContains(response, "Outbox (1)")
@@ -461,7 +461,7 @@ class MsgTest(TembaTest):
         broadcast2.send(trigger_send=False)
         msg4, msg3, msg2 = tuple(Msg.objects.filter(broadcast=broadcast2).order_by('-created_on', '-id'))
 
-        with self.assertNumQueries(38):
+        with self.assertNumQueries(37):
             response = self.client.get(reverse('msgs.msg_outbox'))
 
         self.assertContains(response, "Outbox (4)")
@@ -594,7 +594,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit archived page as a manager of the organization
-        with self.assertNumQueries(54):
+        with self.assertNumQueries(53):
             response = self.fetch_protected(archive_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 1)
@@ -680,7 +680,7 @@ class MsgTest(TembaTest):
         # org viewer can
         self.login(self.admin)
 
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(40):
             response = self.client.get(url)
 
         self.assertEqual(set(response.context['object_list']), {msg3, msg2, msg1})
@@ -732,7 +732,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit failed page as an administrator
-        with self.assertNumQueries(64):
+        with self.assertNumQueries(63):
             response = self.fetch_protected(failed_url, self.admin)
 
         self.assertEqual(response.context['object_list'].count(), 3)

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -608,7 +608,7 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_queryset(self, **kwargs):
             qs = super(MsgCRUDL.Flow, self).get_queryset(**kwargs)
-            return qs.prefetch_related('labels', 'steps__run__flow').select_related('contact')
+            return qs.prefetch_related('labels').select_related('contact')
 
     class Archived(MsgActionMixin, InboxView):
         title = _("Archived")
@@ -619,7 +619,7 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_queryset(self, **kwargs):
             qs = super(MsgCRUDL.Archived, self).get_queryset(**kwargs)
-            return qs.prefetch_related('labels', 'steps__run__flow').select_related('contact')
+            return qs.prefetch_related('labels').select_related('contact')
 
     class Outbox(MsgActionMixin, InboxView):
         title = _("Outbox Messages")
@@ -631,7 +631,7 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_queryset(self, **kwargs):
             qs = super(MsgCRUDL.Outbox, self).get_queryset(**kwargs)
-            return qs.prefetch_related('channel_logs', 'steps__run__flow').select_related('contact')
+            return qs.prefetch_related('channel_logs').select_related('contact')
 
     class Sent(MsgActionMixin, InboxView):
         title = _("Sent Messages")
@@ -643,7 +643,7 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_queryset(self, **kwargs):  # pragma: needs cover
             qs = super(MsgCRUDL.Sent, self).get_queryset(**kwargs)
-            return qs.prefetch_related('channel_logs', 'steps__run__flow').select_related('contact')
+            return qs.prefetch_related('channel_logs').select_related('contact')
 
     class Failed(MsgActionMixin, InboxView):
         title = _("Failed Outgoing Messages")
@@ -656,7 +656,7 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_queryset(self, **kwargs):
             qs = super(MsgCRUDL.Failed, self).get_queryset(**kwargs)
-            return qs.prefetch_related('channel_logs', 'steps__run__flow').select_related('contact')
+            return qs.prefetch_related('channel_logs').select_related('contact')
 
     class Filter(MsgActionMixin, InboxView):
         template_name = 'msgs/msg_filter.haml'
@@ -696,7 +696,7 @@ class MsgCRUDL(SmartCRUDL):
             qs = super(MsgCRUDL.Filter, self).get_queryset(**kwargs)
             qs = self.derive_label().filter_messages(qs).filter(visibility=Msg.VISIBILITY_VISIBLE)
 
-            return qs.prefetch_related('labels', 'steps__run__flow').select_related('contact')
+            return qs.prefetch_related('labels').select_related('contact')
 
 
 class BaseLabelForm(forms.ModelForm):

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -307,7 +307,7 @@ class Trigger(SmartModel):
         # skip if message contact is currently active in a flow
         active_run_qs = FlowRun.objects.filter(is_active=True, contact=msg.contact,
                                                flow__is_active=True, flow__is_archived=False)
-        active_run = active_run_qs.prefetch_related('steps').order_by("-created_on", "-pk").first()
+        active_run = active_run_qs.order_by("-created_on", "-pk").first()
 
         if active_run and active_run.flow.ignore_triggers and not active_run.is_completed():
             return False


### PR DESCRIPTION
We haven't been displaying flow names on messages for a while now so I think these still being pretched is just an oversight (see https://github.com/nyaruka/rapidpro/commit/16eaf5034db5f79c3ab56a0cff90681d8909a364#diff-3e1211851df539d5e91a77aed0d52b6b)