### PR TITLE
Return error message if non-existent asset requested from assets endpoint

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -9414,6 +9414,11 @@ class AssetServerTest(TembaTest):
         resp_json = response.json()
         self.assertEqual(resp_json['uuid'], str(flow2.uuid))
 
+        # try to get a non-existent flow
+        response = self.client.get('/flow/assets/%d/1234/flow/%s/' % (self.org.id, str(uuid4())))
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', response.json())
+
     def test_channels(self):
         self.login(self.admin)
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1527,6 +1527,9 @@ class FlowCRUDL(SmartCRUDL):
             resource = self.resources[resource_type]
             if uuid:
                 result = resource.get_item(org, uuid)
+
+                if result is None:
+                    return JsonResponse({'error': f"no such {resource_type} with UUID '{uuid}'"}, status=400)
             else:
                 result = resource.get_root(org)
 


### PR DESCRIPTION
To avoid https://sentry.io/nyaruka/rapidpro/issues/563381730/ which seems to be an inactive flow being requested as a subflow