### PR TITLE
Fixes for contact release

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -49,6 +49,7 @@ END_TEST_CONTACT_PATH = 12065550199
 # how many sequential contacts on import triggers suspension
 SEQUENTIAL_CONTACTS_THRESHOLD = 250
 
+DELETED_SCHEME = "deleted"
 EMAIL_SCHEME = "mailto"
 EXTERNAL_SCHEME = "ext"
 FACEBOOK_SCHEME = "facebook"
@@ -1787,9 +1788,9 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
                 # prep our urns for deletion so our old path creates a new urn
                 for urn in self.urns.all():
                     path = str(uuid.uuid4())
-                    urn.identity = path
+                    urn.identity = f"{DELETED_SCHEME}:{path}"
                     urn.path = path
-                    urn.scheme = "deleted"
+                    urn.scheme = DELETED_SCHEME
                     urn.channel = None
                     urn.save(update_fields=("identity", "path", "scheme", "channel"))
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -25,6 +25,7 @@ from django.utils import timezone
 from temba.api.models import WebHookEvent, WebHookResult
 from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
+from temba.contacts.models import DELETED_SCHEME
 from temba.contacts.search import contact_es_search, evaluate_query, is_phonenumber
 from temba.contacts.views import ContactListView
 from temba.flows.models import Flow, FlowRun
@@ -1102,8 +1103,7 @@ class ContactTest(TembaTest):
         self.assertEqual(2, contact.urns.all().count())
         for urn in contact.urns.all():
             uuid.UUID(urn.path, version=4)
-            uuid.UUID(urn.identity, version=4)
-            self.assertEqual("deleted", urn.scheme)
+            self.assertEqual(DELETED_SCHEME, urn.scheme)
 
         # a new contact arrives with those urns
         new_contact = self.create_contact("URN Thief", "+12065552000", "tweettweet")

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3,6 +3,7 @@ import copy
 import json
 import subprocess
 import time
+import uuid
 from datetime import date, datetime, timedelta
 
 import pytz
@@ -18,6 +19,7 @@ from django.core.urlresolvers import reverse
 from django.db.models import Value as DbValue
 from django.db.models.functions import Concat, Substr
 from django.test import TestCase, TransactionTestCase
+from django.test.utils import override_settings
 from django.utils import timezone
 
 from temba.api.models import WebHookEvent, WebHookResult
@@ -32,6 +34,7 @@ from temba.msgs.models import INCOMING, Broadcast, BroadcastRecipient, Label, Ms
 from temba.orgs.models import Org
 from temba.schedules.models import Schedule
 from temba.tests import AnonymousOrg, ESMockWithScroll, TembaTest, TembaTestMixin
+from temba.tests.twilio import MockRequestValidator, MockTwilioClient
 from temba.triggers.models import Trigger
 from temba.utils.dates import datetime_to_ms, datetime_to_str, get_datetime_format
 from temba.utils.es import ES
@@ -1043,6 +1046,8 @@ class ContactTest(TembaTest):
         self.assertIsNotNone(out_msgs.filter(contact_urn__path="stephen").first())
         self.assertIsNotNone(out_msgs.filter(contact_urn__path="+12078778899").first())
 
+    @patch("temba.ivr.clients.TwilioClient", MockTwilioClient)
+    @patch("twilio.util.RequestValidator", MockRequestValidator)
     def test_release(self):
         flow = self.get_flow("favorites")
         contact = self.create_contact("Joe", "+12065552000", "tweettweet")
@@ -1068,15 +1073,47 @@ class ContactTest(TembaTest):
         send("red")
         send("primus")
 
+        with override_settings(SEND_CALLS=True):
+            # simulate an ivr call to test session release
+            self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
+            self.org.save()
+
+            # twiml api config
+            config = {
+                Channel.CONFIG_SEND_URL: "https://api.twilio.com",
+                Channel.CONFIG_ACCOUNT_SID: "TEST_SID",
+                Channel.CONFIG_AUTH_TOKEN: "TEST_TOKEN",
+            }
+
+            Channel.create(self.org, self.org.get_user(), "BR", "TW", "+558299990000", "+558299990000", config, "AC")
+
+            flow = self.get_flow("call_me_maybe")
+            flow.start([], [contact])
+
+        self.assertEqual(1, contact.sessions.all().count())
         self.assertEqual(1, contact.addressed_broadcasts.all().count())
         self.assertEqual(2, contact.urns.all().count())
-        self.assertEqual(1, contact.runs.all().count())
+        self.assertEqual(2, contact.runs.all().count())
         self.assertEqual(6, contact.msgs.all().count())
         self.assertEqual(2, len(contact.fields))
 
-        contact.release(self.admin)
-        contact.refresh_from_db()
+        # first try a deactivate and check our urns are anonymized
+        contact.deactivate(self.admin)
+        self.assertEqual(2, contact.urns.all().count())
+        for urn in contact.urns.all():
+            uuid.UUID(urn.path, version=4)
+            uuid.UUID(urn.identity, version=4)
+            self.assertEqual("deleted", urn.scheme)
 
+        # a new contact arrives with those urns
+        new_contact = self.create_contact("URN Thief", "+12065552000", "tweettweet")
+        self.assertEqual(2, new_contact.urns.all().count())
+
+        # now lets go for a full release
+        contact.release(self.admin)
+
+        contact.refresh_from_db()
+        self.assertEqual(0, contact.sessions.all().count())
         self.assertEqual(0, contact.addressed_broadcasts.all().count())
         self.assertEqual(0, contact.urns.all().count())
         self.assertEqual(0, contact.runs.all().count())


### PR DESCRIPTION
 - anonymize urns before deleting to avoid collisions with new inbound
 - release sessions before releasing urns