### PR TITLE
Contact Protect Luxe and Reduxe

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -107,7 +107,7 @@ class URN(object):
         """
         Formats a URN scheme and path as single URN string, e.g. tel:+250783835665
         """
-        if not scheme or scheme not in cls.VALID_SCHEMES:
+        if not scheme or (scheme not in cls.VALID_SCHEMES and scheme != DELETED_SCHEME):
             raise ValueError("Invalid scheme component: '%s'" % scheme)
 
         if not path:
@@ -125,7 +125,7 @@ class URN(object):
         except ValueError:
             raise ValueError("URN strings must contain scheme and path components")
 
-        if parsed.scheme not in cls.VALID_SCHEMES:
+        if parsed.scheme not in cls.VALID_SCHEMES and parsed.scheme != DELETED_SCHEME:
             raise ValueError("URN contains an invalid scheme component: '%s'" % parsed.scheme)
 
         return parsed.scheme, parsed.path, parsed.query or None, parsed.fragment or None

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1833,6 +1833,13 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
             # any urns currently owned by us
             for urn in self.urns.all():
+
+                # release any messages attached with each urn,
+                # these could include messages that began life
+                # on a different contact
+                for msg in urn.msgs.all():
+                    msg.release()
+
                 urn.release()
 
             # release our channel events

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6749,6 +6749,8 @@ class URNTest(TembaTest):
         self.assertFalse(URN.validate("whatsapp:+12065551212"))
 
     def test_from_parts(self):
+
+        self.assertEqual(URN.from_parts("deleted", "12345"), "deleted:12345")
         self.assertEqual(URN.from_parts("tel", "12345"), "tel:12345")
         self.assertEqual(URN.from_parts("tel", "+12345"), "tel:+12345")
         self.assertEqual(URN.from_parts("tel", "(917) 992-5253"), "tel:(917) 992-5253")
@@ -6771,6 +6773,7 @@ class URNTest(TembaTest):
         self.assertRaises(ValueError, URN.from_parts, "xxx", "12345")
 
     def test_to_parts(self):
+        self.assertEqual(URN.to_parts("deleted:12345"), ("deleted", "12345", None, None))
         self.assertEqual(URN.to_parts("tel:12345"), ("tel", "12345", None, None))
         self.assertEqual(URN.to_parts("tel:+12345"), ("tel", "+12345", None, None))
         self.assertEqual(URN.to_parts("twitter:abc_123"), ("twitter", "abc_123", None, None))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1073,7 +1073,7 @@ class ContactTest(TembaTest):
         # steal his urn into a new contact
         contact = self.create_contact("Joe", "tweettweet")
         urn.contact = contact
-        urn.save(update_fields=('contact',))
+        urn.save(update_fields=("contact",))
 
         contact.fields = {"gender": "Male", "age": 40}
         contact.save(update_fields=("fields",))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1050,16 +1050,8 @@ class ContactTest(TembaTest):
     @patch("temba.ivr.clients.TwilioClient", MockTwilioClient)
     @patch("twilio.util.RequestValidator", MockRequestValidator)
     def test_release(self):
-        flow = self.get_flow("favorites")
-        contact = self.create_contact("Joe", "+12065552000", "tweettweet")
-        contact.fields = {"gender": "Male", "age": 40}
-        contact.save(update_fields=("fields",))
 
-        flow.start([], [contact])
-        broadcast = Broadcast.create(self.org, self.admin, "Test Broadcast", [contact])
-        broadcast.send()
-
-        def send(message):
+        def send(message, contact):
             msg = Msg.objects.create(
                 org=self.org,
                 direction=INCOMING,
@@ -1071,8 +1063,27 @@ class ContactTest(TembaTest):
             )
             Flow.find_and_handle(msg)
 
-        send("red")
-        send("primus")
+        flow = self.get_flow("favorites")
+
+        # create a contact with a message
+        old_contact = self.create_contact("Jose", "+12065552000")
+        send("hola mundo", old_contact)
+        urn = old_contact.get_urn()
+
+        # steal his urn into a new contact
+        contact = self.create_contact("Joe", "tweettweet")
+        urn.contact = contact
+        urn.save(update_fields=('contact',))
+
+        contact.fields = {"gender": "Male", "age": 40}
+        contact.save(update_fields=("fields",))
+
+        flow.start([], [contact])
+        broadcast = Broadcast.create(self.org, self.admin, "Test Broadcast", [contact])
+        broadcast.send()
+
+        send("red", contact)
+        send("primus", contact)
 
         with override_settings(SEND_CALLS=True):
             # simulate an ivr call to test session release


### PR DESCRIPTION
- Release messages connected to urns even if they are attached to a different contact
- Don't blow up when trying to parse or form a deleted scheme