### PR TITLE
Strip message text on events before doing flowserver trial comparison

### DIFF
--- a/temba/flows/server/trial.py
+++ b/temba/flows/server/trial.py
@@ -342,6 +342,10 @@ def reduce_events(events):
         new_event = copy_keys(event, {"type", "msg"})
         new_event["msg"] = copy_keys(event["msg"], {"text", "urn", "channel", "attachments"})
 
+        # legacy events are re-constructed from real messages which have their text stripped
+        if new_event["msg"]["text"]:
+            new_event["msg"]["text"] = new_event["msg"]["text"].strip()
+
         reduced.append(new_event)
     return reduced
 


### PR DESCRIPTION
Getting failing trials when message text ends with space