### PR TITLE
🐦 Make twitter activity API the default Twitter channel type

### DIFF
--- a/temba/channels/types/twitter/tests.py
+++ b/temba/channels/types/twitter/tests.py
@@ -1,6 +1,7 @@
 
 from mock import patch
 
+from django.contrib.auth.models import Group
 from django.test import override_settings
 from django.urls import reverse
 
@@ -34,20 +35,8 @@ class TwitterTypeTest(TembaTest):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
-        self.login(self.user)
-
-        # also can't access if just a regular user
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-
+        Group.objects.get(name="Beta").user_set.add(self.admin)
         self.login(self.admin)
-
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
-        # check that claim page URL appears on claim list page
-        response = self.client.get(reverse("channels.channel_claim"))
-        self.assertContains(response, url)
 
         # can fetch the claim page
         response = self.client.get(url)

--- a/temba/channels/types/twitter/type.py
+++ b/temba/channels/types/twitter/type.py
@@ -40,6 +40,9 @@ class TwitterType(ChannelType):
         "users who are not following you",
     )  # handle no longer follows us
 
+    def is_available_to(self, user):
+        return user.is_beta()
+
     def activate(self, channel):
         # tell Mage to activate this channel
         notify_mage_task.delay(channel.uuid, MageStreamAction.activate.name)

--- a/temba/channels/types/twitter_activity/tests.py
+++ b/temba/channels/types/twitter_activity/tests.py
@@ -1,7 +1,6 @@
 
 from mock import patch
 
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from django.urls import reverse
 
@@ -41,21 +40,14 @@ class TwitterActivityTypeTest(TembaTest):
     @patch("twython.Twython.verify_credentials")
     def test_claim(self, mock_verify_credentials, mock_register_webhook, mock_subscribe_to_webhook):
         url = reverse("channels.types.twitter_activity.claim")
-
         self.login(self.admin)
-
-        # check that channel is only available to beta users
-        response = self.client.get(reverse("channels.channel_claim"))
-        self.assertNotContains(response, "/channels/types/twitter_activity/claim")
-
-        Group.objects.get(name="Beta").user_set.add(self.admin)
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, "/channels/types/twitter_activity/claim")
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Connect Twitter Activity API")
+        self.assertContains(response, "Connect Twitter")
 
         self.assertEqual(
             list(response.context["form"].fields.keys()),

--- a/temba/channels/types/twitter_activity/type.py
+++ b/temba/channels/types/twitter_activity/type.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class TwitterActivityType(ChannelType):
     """
-    A Twitter channel which uses Twitter's new Activity API (currently in beta) to stream DMs.
+    A Twitter channel which uses Twitter's Account Activity API to send and receive direct messages.
     """
 
     code = "TWT"
@@ -23,12 +23,13 @@ class TwitterActivityType(ChannelType):
 
     courier_url = r"^twt/(?P<uuid>[a-z0-9\-]+)/receive$"
 
-    name = "Twitter Activity API"
+    name = "Twitter"
     icon = "icon-twitter"
 
     claim_blurb = _(
-        """If you have access to the new <a href="https://dev.twitter.com/webhooks/account-activity">Twitter
-    Activity API</a> which is currently in beta, you can add a Twitter channel for that here."""
+        """Send and receive messages on Twitter using their
+        <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/overview">
+        Twitter Activity API.</a> You will have to apply for Twitter API access and create a Twitter application."""
     )
     claim_view = ClaimView
 
@@ -37,9 +38,6 @@ class TwitterActivityType(ChannelType):
     schemes = [TWITTER_SCHEME, TWITTERID_SCHEME]
     show_config_page = False
     free_sending = True
-
-    def is_available_to(self, user):
-        return user.is_beta()
 
     def activate(self, channel):
         config = channel.config

--- a/templates/channels/types/twitter_activity/claim.haml
+++ b/templates/channels/types/twitter_activity/claim.haml
@@ -10,10 +10,11 @@
 -block pre-form
   .info
     .important
-      %p
-        This channel type uses the new <a href="https://dev.twitter.com/webhooks/account-activity">Twitter Activity API</a> which is
-        still in beta. If your Twitter account has not been granted access to this API, then you can still
-        <a href="{% url 'channels.types.twitter.claim' %}">add a regular Twitter channel</a>.
+      This channel type uses the new <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/overview">Twitter Activity API.</a>
+      You will need to <a href="https://developer.twitter.com/en/apply-for-access">apply for access</a> and
+      <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/guides/getting-started-with-webhooks">create a
+      Twitter application.</a>
+
     %p
       -blocktrans with name=brand.name
         After connecting your account, any incoming direct messages will automatically be read by {{ name }},


### PR DESCRIPTION
Old Twitter only available to Beta users (until we remove it entirely with Mage)