### PR TITLE
⚛ Flow server trial tweaks

### DIFF
--- a/temba/flows/server/client.py
+++ b/temba/flows/server/client.py
@@ -264,7 +264,13 @@ class Output(object):
 
 
 class FlowServerException(Exception):
-    pass
+    def __init__(self, endpoint, request, response):
+        self.endpoint = endpoint
+        self.request = request
+        self.response = response
+
+    def as_json(self):
+        return {"endpoint": self.endpoint, "request": self.request, "response": self.response}
 
 
 class FlowServerClient(object):
@@ -308,8 +314,7 @@ class FlowServerClient(object):
             print("[GOFLOW]=============== /%s response ===============" % endpoint)
 
         if 400 <= response.status_code < 500:
-            errors = "\n".join(resp_json["errors"])
-            raise FlowServerException("Invalid request: " + errors)
+            raise FlowServerException(endpoint, payload, resp_json)
 
         response.raise_for_status()
 

--- a/temba/flows/server/tests.py
+++ b/temba/flows/server/tests.py
@@ -10,7 +10,7 @@ from temba.channels.models import Channel
 from temba.contacts.models import Contact
 from temba.flows.models import Flow, FlowRun
 from temba.msgs.models import Label, Msg
-from temba.tests import MockResponse, TembaTest, skip_if_no_flowserver
+from temba.tests import MockResponse, TembaTest, matchers, skip_if_no_flowserver
 from temba.values.constants import Value
 
 from . import trial
@@ -128,7 +128,10 @@ class ClientTest(TembaTest):
         with self.assertRaises(FlowServerException) as e:
             self.client.request_builder(self.org, 1234).start_manual(contact, flow)
 
-        self.assertEqual(str(e.exception), "Invalid request: Bad request\nDoh!")
+            self.assertEqual(
+                e.exception.as_json(),
+                {"endpoint": "start", "request": matchers.Dict, "response": {"errors": ["Bad request", "Doh!"]}},
+            )
 
 
 class TrialTest(TembaTest):

--- a/temba/flows/server/trial.py
+++ b/temba/flows/server/trial.py
@@ -14,7 +14,7 @@ from jsondiff import diff as jsondiff
 from django.conf import settings
 from django.utils import timezone
 
-from .client import Events, get_client
+from .client import Events, FlowServerException, get_client
 from .serialize import serialize_channel_ref, serialize_contact, serialize_environment
 
 logger = logging.getLogger(__name__)
@@ -96,6 +96,9 @@ def end_resume(trial, msg_in=None, expired_child_run=None):
             report_success(trial)
             return True
 
+    except FlowServerException as e:
+        logger.error("trial resume in flowserver caused server error", extra=e.as_json())
+        return False
     except Exception as e:
         logger.error(
             "flowserver exception during trial resumption of run %s: %s" % (str(trial.run.uuid), str(e)), exc_info=True

--- a/temba/flows/server/trial.py
+++ b/temba/flows/server/trial.py
@@ -107,18 +107,23 @@ def report_success(trial):  # pragma: no cover
     """
     Reports a trial success... essentially a noop but useful for mocking in tests
     """
-    print("Flowserver trial resume for run %s in flow '%s' succeeded" % (str(trial.run.uuid), trial.run.flow.name))
+    print(f"Flowserver trial resume for run {str(trial.run.uuid)} in flow '{trial.run.flow.name}' succeeded")
 
 
 def report_failure(trial):  # pragma: no cover
     """
     Reports a trial failure to sentry
     """
-    print("Flowserver trial resume for run %s in flow '%s' failed" % (str(trial.run.uuid), trial.run.flow.name))
+    print(f"Flowserver trial resume for run {str(trial.run.uuid)} in flow '{trial.run.flow.name}' failed")
 
     logger.error(
         "trial resume in flowserver produced different output",
-        extra={"run_id": trial.run.id, "differences": trial.differences},
+        extra={
+            "org": trial.run.org.name,
+            "flow": {"uuid": str(trial.run.flow.uuid), "name": trial.run.flow.name},
+            "run_id": trial.run.id,
+            "differences": trial.differences,
+        },
     )
 
 

--- a/temba/flows/server/trial.py
+++ b/temba/flows/server/trial.py
@@ -314,13 +314,7 @@ def reduce_path(path):
     """
     Reduces path to just node/exit. Other fields are datetimes or generated step UUIDs which are non-deterministic
     """
-    reduced = [copy_keys(step, {"node_uuid", "exit_uuid"}) for step in path]
-
-    # rapidpro doesn't set exit_uuid on terminal actions
-    if "exit_uuid" in reduced[-1]:
-        del reduced[-1]["exit_uuid"]
-
-    return reduced
+    return [copy_keys(step, {"node_uuid", "exit_uuid"}) for step in path]
 
 
 def reduce_results(results):

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -11022,7 +11022,7 @@ class FlowServerTest(TembaTest):
 
         # when flowserver returns an error
         with patch("temba.flows.server.FlowServerClient.start") as mock_start:
-            mock_start.side_effect = FlowServerException("nope")
+            mock_start.side_effect = FlowServerException("start", {}, {"errors": ["Nope"]})
 
             self.assertEqual(flow.start([], [self.contact], restart_participants=True), [])
 
@@ -11042,7 +11042,7 @@ class FlowServerTest(TembaTest):
 
         # when flowserver returns an error
         with patch("temba.flows.server.FlowServerClient.resume") as mock_resume:
-            mock_resume.side_effect = FlowServerException("nope")
+            mock_resume.side_effect = FlowServerException("start", {}, {"errors": ["Nope"]})
 
             msg2 = self.create_msg(direction="I", text="Primus", contact=self.contact)
             run1.session.resume_by_input(msg2)

--- a/temba/tests/matchers.py
+++ b/temba/tests/matchers.py
@@ -29,11 +29,6 @@ class String(MatcherMixin, str):
         return True
 
 
-class Dict(MatcherMixin, dict):
-    def __eq__(self, other):
-        return isinstance(other, dict)
-
-
 class ISODate(String):
     """
     Matches any ISO8601 formatted datetime string
@@ -50,3 +45,12 @@ class UUID4String(String):
 
     def __new__(cls):
         return super().__new__(cls, pattern=UUID4_REGEX)
+
+
+class Dict(MatcherMixin, dict):
+    """
+    Matches any dict
+    """
+
+    def __eq__(self, other):
+        return isinstance(other, dict)

--- a/temba/tests/matchers.py
+++ b/temba/tests/matchers.py
@@ -29,6 +29,11 @@ class String(MatcherMixin, str):
         return True
 
 
+class Dict(MatcherMixin, dict):
+    def __eq__(self, other):
+        return isinstance(other, dict)
+
+
 class ISODate(String):
     """
     Matches any ISO8601 formatted datetime string

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -1969,6 +1969,12 @@ class MatchersTest(TembaTest):
         self.assertNotEqual(None, matchers.UUID4String())
         self.assertNotEqual("abc", matchers.UUID4String())
 
+    def test_dict(self):
+        self.assertEqual({}, matchers.Dict())
+        self.assertEqual({"a": "b"}, matchers.Dict())
+        self.assertNotEqual(None, matchers.Dict())
+        self.assertNotEqual([], matchers.Dict())
+
 
 class NonBlockingLockTest(TestCase):
     def test_nonblockinglock(self):


### PR DESCRIPTION
* Don't ignore last exit_uuid when comparing paths in flow server trials
* Improve reporting of trial differences (include org name etc)
* Improve reporting of 400 errors from flow server (include full request)