### PR TITLE
🔬 Fix reconstructing sessions for runs being trialled in the flowserver

### DIFF
--- a/media/test_flows/hierarchy.json
+++ b/media/test_flows/hierarchy.json
@@ -1,0 +1,374 @@
+{
+  "version": "11.4",
+  "site": "https://app.rapidpro.io",
+  "flows": [
+    {
+      "entry": "f97fc787-6f52-43fc-801c-235fcee02473",
+      "action_sets": [
+        {
+          "uuid": "f97fc787-6f52-43fc-801c-235fcee02473",
+          "x": 99,
+          "y": 0,
+          "destination": null,
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "4b165364-aedc-4f19-8f60-cbc4d4b866de",
+              "msg": {
+                "eng": "Hi from Hierarchy 1"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            },
+            {
+              "type": "flow",
+              "uuid": "498b437c-a210-439f-9897-59ad8eb75da8",
+              "flow": {
+                "uuid": "30810992-80c8-4cc8-a751-e4db7d98a461",
+                "name": "Hierarchy 2"
+              }
+            }
+          ],
+          "exit_uuid": "1f9a3b02-c3f7-42ca-8327-567f4c281b4a"
+        }
+      ],
+      "rule_sets": [],
+      "base_language": "eng",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "name": "Hierarchy 1",
+        "saved_on": "2018-06-28T16:13:14.378659Z",
+        "revision": 5,
+        "uuid": "92e85302-92cc-4fd9-9e4f-69d66a59f863",
+        "expires": 10080
+      }
+    },
+    {
+      "entry": "a283939d-dd6c-468c-bca5-f751bc05e5b6",
+      "action_sets": [
+        {
+          "uuid": "a283939d-dd6c-468c-bca5-f751bc05e5b6",
+          "x": 100,
+          "y": 0,
+          "destination": null,
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "a1ae42cd-cbdd-458b-ac82-57b8e8650311",
+              "msg": {
+                "eng": "Hi from Hierarchy 2"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            },
+            {
+              "type": "trigger-flow",
+              "uuid": "94a7b7fa-31d3-43f5-ab84-e3f6ee1c89d3",
+              "flow": {
+                "uuid": "dec5ab03-ba4e-41ea-91de-ce46409923b2",
+                "name": "Subflow 1"
+              },
+              "contacts": [
+                {
+                  "urns": [
+                    {
+                      "priority": 50,
+                      "path": "+12065552121",
+                      "scheme": "tel"
+                    }
+                  ],
+                  "name": "Oprah Winfrey"
+                }
+              ],
+              "groups": [],
+              "variables": []
+            }
+          ],
+          "exit_uuid": "f192a0a7-d7de-4de7-a2f3-61a9f379eaa0"
+        }
+      ],
+      "rule_sets": [],
+      "base_language": "eng",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "name": "Hierarchy 2",
+        "saved_on": "2018-06-28T16:14:18.095267Z",
+        "revision": 2,
+        "uuid": "30810992-80c8-4cc8-a751-e4db7d98a461",
+        "expires": 10080
+      }
+    },
+    {
+      "entry": "2020c366-ced1-4850-a4fd-c1c94bcabaa9",
+      "action_sets": [
+        {
+          "uuid": "2020c366-ced1-4850-a4fd-c1c94bcabaa9",
+          "x": 100,
+          "y": 0,
+          "destination": "d9b89bcc-8e9a-47ba-a85e-3e6e013320d8",
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "ef3d834d-e3df-402a-beb0-bd6563b55709",
+              "msg": {
+                "eng": "Hi from Subflow 1"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            }
+          ],
+          "exit_uuid": "da93c5c0-7310-4837-b963-cf6cedc521f6"
+        }
+      ],
+      "rule_sets": [
+        {
+          "uuid": "d9b89bcc-8e9a-47ba-a85e-3e6e013320d8",
+          "x": 237,
+          "y": 134,
+          "label": "Response 1",
+          "rules": [
+            {
+              "uuid": "3cd60e51-7f2a-4d72-8b80-eedaf011fd16",
+              "category": {
+                "eng": "Completed"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "subflow",
+                "exit_type": "completed"
+              },
+              "label": null
+            },
+            {
+              "uuid": "e095679d-d0e6-456e-a58d-ce3b802f8a31",
+              "category": {
+                "eng": "Expired"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "subflow",
+                "exit_type": "expired"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "subflow",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {
+            "flow": {
+              "name": "Subflow 2",
+              "uuid": "336015c4-8884-4a30-b89a-ad434dbbc192"
+            }
+          }
+        }
+      ],
+      "base_language": "eng",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "name": "Subflow 1",
+        "saved_on": "2018-06-28T16:17:00.190313Z",
+        "revision": 3,
+        "uuid": "dec5ab03-ba4e-41ea-91de-ce46409923b2",
+        "expires": 10080
+      }
+    },
+    {
+      "entry": "1b9dae8b-9b6b-459c-aa21-02e9d343e61a",
+      "action_sets": [
+        {
+          "uuid": "1b9dae8b-9b6b-459c-aa21-02e9d343e61a",
+          "x": 100,
+          "y": 0,
+          "destination": "7afaa065-ecd6-4e39-a16f-0f018a73301a",
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "705beed3-cb59-4531-80b8-0d1a176ad874",
+              "msg": {
+                "eng": "Hi from Subflow 2"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            }
+          ],
+          "exit_uuid": "6dd1549a-7433-40b9-819d-eb9b07576606"
+        }
+      ],
+      "rule_sets": [
+        {
+          "uuid": "7afaa065-ecd6-4e39-a16f-0f018a73301a",
+          "x": 247,
+          "y": 99,
+          "label": "Response 1",
+          "rules": [
+            {
+              "uuid": "4a962945-251b-4c0f-b850-95cdded2e2f2",
+              "category": {
+                "eng": "Completed"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "subflow",
+                "exit_type": "completed"
+              },
+              "label": null
+            },
+            {
+              "uuid": "eca559ee-92e2-44f4-8954-ddc272768db5",
+              "category": {
+                "eng": "Expired"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "subflow",
+                "exit_type": "expired"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "subflow",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {
+            "flow": {
+              "name": "Subflow 3",
+              "uuid": "529f2d1c-c8f5-4831-962f-e3aaf6e76a26"
+            }
+          }
+        }
+      ],
+      "base_language": "eng",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "name": "Subflow 2",
+        "saved_on": "2018-06-28T16:16:15.700129Z",
+        "revision": 4,
+        "uuid": "336015c4-8884-4a30-b89a-ad434dbbc192",
+        "expires": 10080
+      }
+    },
+    {
+      "entry": "80d1642e-0c7a-4414-90f5-3d58d27b05cf",
+      "action_sets": [
+        {
+          "uuid": "80d1642e-0c7a-4414-90f5-3d58d27b05cf",
+          "x": 79,
+          "y": 0,
+          "destination": "e8bf5f48-05f5-4657-a156-0476155def0a",
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "a6fd5c94-1b0b-461a-9f95-c2eec5664bc8",
+              "msg": {
+                "eng": "What's your favorite color?"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            }
+          ],
+          "exit_uuid": "53469b5f-d81f-43dd-ab38-c1217f89e59d"
+        }
+      ],
+      "rule_sets": [
+        {
+          "uuid": "e8bf5f48-05f5-4657-a156-0476155def0a",
+          "x": 272,
+          "y": 118,
+          "label": "Color",
+          "rules": [
+            {
+              "uuid": "43c83087-da28-4579-af11-1834a2c87e48",
+              "category": {
+                "eng": "Red"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "contains_any",
+                "test": {
+                  "eng": "red"
+                }
+              },
+              "label": null
+            },
+            {
+              "uuid": "04636819-6781-4305-ae2f-5c8058caf4cb",
+              "category": {
+                "eng": "Green"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "contains_any",
+                "test": {
+                  "eng": "green"
+                }
+              },
+              "label": null
+            },
+            {
+              "uuid": "cada1a75-86ed-4c1f-bc6c-37c926477803",
+              "category": {
+                "eng": "Blue"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "contains_any",
+                "test": {
+                  "eng": "blue"
+                }
+              },
+              "label": null
+            },
+            {
+              "uuid": "ef24c76d-cb83-4e23-bd02-ee2438208d99",
+              "category": {
+                "eng": "Other"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "true"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "wait_message",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {}
+        }
+      ],
+      "base_language": "eng",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "name": "Subflow 3",
+        "saved_on": "2018-06-28T16:15:41.678606Z",
+        "revision": 5,
+        "uuid": "529f2d1c-c8f5-4831-962f-e3aaf6e76a26",
+        "expires": 10080
+      }
+    }
+  ],
+  "campaigns": [],
+  "triggers": []
+}


### PR DESCRIPTION
So that we include all ancestor runs and not just the immediate parent

We've been seeing this manifest itself as errors from the flow server complaining it can't find a parent run.