### PR TITLE
🚽 Release campaign events on import

### DIFF
--- a/media/test_flows/survey_campaign.json
+++ b/media/test_flows/survey_campaign.json
@@ -1,0 +1,96 @@
+{
+  "version": "11.4",
+  "site": "https://app.rapidpro.io",
+  "flows": [
+    {
+      "entry": "2618298e-fce9-4b3f-8152-118b06cb6d2b",
+      "action_sets": [
+        {
+          "uuid": "2618298e-fce9-4b3f-8152-118b06cb6d2b",
+          "x": 100,
+          "y": 0,
+          "destination": "0c70dfec-78b6-4210-9485-37806c5deebc",
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "7b3ba21e-e83b-4dcf-ba4b-7dea06485423",
+              "msg": {
+                "base": "Hi this is a survey. Which color is best? Red, Green, or Blue?"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            }
+          ],
+          "exit_uuid": "bd76d746-e0fc-43b0-a0c6-aef3015c7ba6"
+        }
+      ],
+      "rule_sets": [
+        {
+          "uuid": "0c70dfec-78b6-4210-9485-37806c5deebc",
+          "x": 85,
+          "y": 155,
+          "label": "Color",
+          "rules": [
+            {
+              "uuid": "5a304369-c86d-40b9-8b81-43c74eaee994",
+              "category": {
+                "base": "All Responses"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "true"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "wait_message",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {}
+        }
+      ],
+      "base_language": "base",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "name": "Survey One",
+        "saved_on": "2018-06-28T21:45:01.821820Z",
+        "revision": 4,
+        "uuid": "6d8250f9-3781-40f5-b76c-35fe2a2c9712",
+        "expires": 10080
+      }
+    }
+  ],
+  "campaigns": [
+    {
+      "name": "Survey Campaign",
+      "uuid": "17da8fee-8c29-4b12-a3f5-f2be042d00a5",
+      "group": {
+        "uuid": "1019499d-fcee-4910-b05c-ca18ccdcbadb",
+        "name": "Survey Group"
+      },
+      "events": [
+        {
+          "uuid": "bc7b249c-f5f4-4b9f-9193-f4ef007b0d77",
+          "offset": 15,
+          "unit": "D",
+          "event_type": "F",
+          "delivery_hour": 12,
+          "message": null,
+          "relative_to": {
+            "label": "Survey Start",
+            "key": "survey_start"
+          },
+          "flow": {
+            "uuid": "6d8250f9-3781-40f5-b76c-35fe2a2c9712",
+            "name": "Survey One"
+          }
+        }
+      ]
+    }
+  ],
+  "triggers": []
+}

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1141,8 +1141,7 @@ class APITest(TembaTest):
         response = self.deleteJSON(url, "uuid=%s" % event1.uuid)
         self.assertEqual(response.status_code, 204)
 
-        event1.refresh_from_db()
-        self.assertFalse(event1.is_active)
+        self.assertFalse(CampaignEvent.objects.filter(id=event1.id).exists())
 
         # should no longer have any events
         self.assertEqual(1, EventFire.objects.filter(contact=contact, event=event2).count())

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -443,16 +443,19 @@ class CampaignEvent(TembaModel):
         """
         Removes this event.. also takes care of removing any event fires that were scheduled and unfired
         """
-        # mark ourselves inactive
-        self.is_active = False
-        self.save()
 
-        # delete any pending event fires
-        EventFire.update_eventfires_for_event(self)
+        # we need to be inactive so our message flows don't try to circle back and release us
+        self.is_active = False
+        self.save(update_fields=("is_active",))
+
+        # delete any event fires
+        self.event_fires.all().delete()
 
         # if our flow is a single message flow, release that too
         if self.flow.flow_type == Flow.MESSAGE:
             self.flow.release()
+
+        self.delete()
 
     def calculate_scheduled_fire(self, contact):
         return self.calculate_scheduled_fire_for_value(contact.get_field_value(self.relative_to), timezone.now())

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -93,13 +93,9 @@ class Campaign(TembaModel):
                     campaign.group = group
                     campaign.save()
 
-                # we want to nuke old single message flows
+                # release all of our events, we'll recreate these
                 for event in campaign.events.all():
-                    if event.flow.flow_type == Flow.MESSAGE:
-                        event.flow.release()
-
-                # and all of the events, we'll recreate these
-                campaign.events.all().delete()
+                    event.release()
 
                 # fill our campaign with events
                 for event_spec in campaign_spec["events"]:

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -321,11 +321,9 @@ class CampaignTest(TembaTest):
 
         # delete the event
         self.client.post(reverse("campaigns.campaignevent_delete", args=[event.pk]), dict())
-        self.assertFalse(CampaignEvent.objects.get(id=event.id).is_active)
+        self.assertFalse(CampaignEvent.objects.filter(id=event.id).exists())
 
         # our single message flow should be released and take its dependencies with it
-        event.flow.refresh_from_db()
-        self.assertFalse(event.flow.is_active)
         self.assertEqual(0, event.flow.field_dependencies.all().count())
 
     def test_views(self):
@@ -656,9 +654,9 @@ class CampaignTest(TembaTest):
         self.assertEqual(response.context["scheduled_event_fires_count"], 0)
         self.assertEqual(len(response.context["scheduled_event_fires"]), 2)
 
-        # delete an event
+        # delete the event
         self.client.post(reverse("campaigns.campaignevent_delete", args=[event.pk]), dict())
-        self.assertFalse(CampaignEvent.objects.all()[0].is_active)
+        self.assertFalse(CampaignEvent.objects.all().exists())
         response = self.client.get(reverse("campaigns.campaign_read", args=[campaign.pk]))
         self.assertNotContains(response, "Color Flow")
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -7838,8 +7838,7 @@ class FlowsTest(FlowFileTest):
         self.assertEqual(flow.runs.count(), 0)
 
         # our campaign event should no longer be active
-        event1.refresh_from_db()
-        self.assertFalse(event1.is_active)
+        self.assertFalse(CampaignEvent.objects.filter(id=event1.id).exists())
 
         # nor should our trigger
         self.assertFalse(Trigger.objects.filter(id=trigger.id).exists())


### PR DESCRIPTION
Properly release previous events when reimporting campaigns
See: https://sentry.io/nyaruka/textit/issues/577362138/