### PR TITLE
💾 Move action log delete to flow run release

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4133,6 +4133,9 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
                 self.delete_reason = delete_reason
                 self.save(update_fields=["delete_reason"])
 
+            # delete any action logs associated with us
+            ActionLog.objects.filter(run=self).delete()
+
             # clear any runs that reference us
             FlowRun.objects.filter(parent=self).update(parent=None)
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1483,9 +1483,6 @@ class FlowCRUDL(SmartCRUDL):
                 if runs and runs.first().created_on < timezone.now() - timedelta(hours=24):  # pragma: needs cover
                     analytics.track(user.username, "temba.flow_simulated")
 
-                action_log_ids = list(ActionLog.objects.filter(run__in=runs).values_list("id", flat=True))
-                ActionLog.objects.filter(id__in=action_log_ids).delete()
-
                 msg_ids = list(Msg.objects.filter(contact=test_contact).only("id").values_list("id", flat=True))
 
                 for batch in chunk_list(msg_ids, 25):


### PR DESCRIPTION
Unit test already exists for this, just moving functionality so runs deleted outside of simulation endpoint do the right thing (such as Flow deletion)

See: https://sentry.io/nyaruka/textit/issues/593697011/