### PR TITLE
🐦 tweaks to twitter activity claiming 

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -107,6 +107,10 @@ class ChannelType(metaclass=ABCMeta):
 
     ivr_protocol = None
 
+    # Whether this channel should be activated in the a celery task, useful to turn off if there's a chance for errors
+    #  during activation. Channels should make sure their claim view is non-atomic if a callback will be involved
+    async_activation = True
+
     def is_available_to(self, user):
         """
         Determines whether this channel type is available to the given user, e.g. check timezone
@@ -551,7 +555,16 @@ class Channel(TembaModel):
             org.normalize_contact_tels()
 
         if settings.IS_PROD:
-            on_transaction_commit(lambda: channel_type.activate(channel))
+            if channel_type.async_activation:
+                on_transaction_commit(lambda: channel_type.activate(channel))
+            else:
+                try:
+                    channel_type.activate(channel)
+
+                except Exception as e:
+                    # release our channel, raise error upwards
+                    channel.release()
+                    raise e
 
         return channel
 

--- a/temba/channels/types/twitter_activity/tests.py
+++ b/temba/channels/types/twitter_activity/tests.py
@@ -30,15 +30,28 @@ class TwitterActivityTypeTest(TembaTest):
                 "access_token": "at1",
                 "access_token_secret": "ats1",
                 "handle_id": "h123456",
+                "webhook_id": "1234567",
                 "env_name": "beta",
             },
         )
 
     @override_settings(IS_PROD=True)
+    @patch("temba.utils.twitter.TembaTwython.get_webhooks")
+    @patch("temba.utils.twitter.TembaTwython.delete_webhook")
     @patch("temba.utils.twitter.TembaTwython.subscribe_to_webhook")
     @patch("temba.utils.twitter.TembaTwython.register_webhook")
     @patch("twython.Twython.verify_credentials")
-    def test_claim(self, mock_verify_credentials, mock_register_webhook, mock_subscribe_to_webhook):
+    def test_claim(
+        self,
+        mock_verify_credentials,
+        mock_register_webhook,
+        mock_subscribe_to_webhook,
+        mock_delete_webhook,
+        mock_get_webhooks,
+    ):
+        mock_get_webhooks.return_value = [{"id": "webhook_id"}]
+        mock_delete_webhook.return_value = {"ok", True}
+
         url = reverse("channels.types.twitter_activity.claim")
         self.login(self.admin)
 
@@ -71,17 +84,8 @@ class TwitterActivityTypeTest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, "form", None, "The provided Twitter credentials do not appear to be valid.")
 
-        # try submitting for handle which already has a channel
-        mock_verify_credentials.side_effect = None
-        mock_verify_credentials.return_value = {"id": "345678", "screen_name": "beta_bob"}
-
-        response = self.client.post(
-            url, {"api_key": "ak", "api_secret": "as", "access_token": "at", "access_token_secret": "ats"}
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertFormError(response, "form", None, "A Twitter channel already exists for that handle.")
-
         # try a valid submission
+        mock_verify_credentials.side_effect = None
         mock_verify_credentials.return_value = {"id": "87654", "screen_name": "jimmy"}
         mock_register_webhook.return_value = {"id": "1234567"}
 
@@ -107,6 +111,7 @@ class TwitterActivityTypeTest(TembaTest):
                 "access_token": "at",
                 "env_name": "beta",
                 "access_token_secret": "ats",
+                "webhook_id": "1234567",
                 "callback_domain": channel.callback_domain,
             },
         )
@@ -120,7 +125,7 @@ class TwitterActivityTypeTest(TembaTest):
     @patch("temba.utils.twitter.TembaTwython.delete_webhook")
     def test_release(self, mock_delete_webhook):
         self.channel.release()
-        mock_delete_webhook.assert_called_once_with("beta")
+        mock_delete_webhook.assert_called_once_with("beta", "1234567")
 
     @patch("twython.Twython.lookup_user")
     def test_resolve(self, mock_lookup_user):

--- a/temba/channels/types/twitter_activity/type.py
+++ b/temba/channels/types/twitter_activity/type.py
@@ -64,7 +64,8 @@ class TwitterActivityType(ChannelType):
 
     def deactivate(self, channel):
         config = channel.config
-        client = TembaTwython(
-            config["api_key"], config["api_secret"], config["access_token"], config["access_token_secret"]
-        )
-        client.delete_webhook(config["env_name"], config["webhook_id"])
+        if "webhook_id" in config:
+            client = TembaTwython(
+                config["api_key"], config["api_secret"], config["access_token"], config["access_token_secret"]
+            )
+            client.delete_webhook(config["env_name"], config["webhook_id"])

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1474,7 +1474,7 @@ class ChannelCRUDL(SmartCRUDL):
                         ),
                     )
                 else:
-                    messages.info(request, _("Your phone number has been removed."))
+                    messages.info(request, _("Your channel has been removed."))
 
                 return HttpResponseRedirect(self.get_success_url())
 

--- a/temba/utils/twitter.py
+++ b/temba/utils/twitter.py
@@ -130,20 +130,15 @@ class TembaTwython(Twython):  # pragma: no cover
         """
         return self.get("https://api.twitter.com/1.1/account_activity/all/%s/webhooks.json" % env_name)
 
-    def delete_webhook(self, env_name):
+    def delete_webhook(self, env_name, webhook_id):
         """
         Deletes the webhook for the current app / user and passed in environment name.
         Docs: https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-standard-all
         """
-        # grab our current webhooks
-        resp = self.get_webhooks(env_name)
-
-        # if we have one, delete it
-        if len(resp) > 0:
-            self.request(
-                "https://api.twitter.com/1.1/account_activity/all/%s/webhooks/%s.json" % (env_name, resp[0]["id"]),
-                method="DELETE",
-            )
+        self.request(
+            "https://api.twitter.com/1.1/account_activity/all/%s/webhooks/%s.json" % (env_name, webhook_id),
+            method="DELETE",
+        )
 
     def register_webhook(self, env_name, url):
         """

--- a/templates/channels/types/twitter_activity/claim.haml
+++ b/templates/channels/types/twitter_activity/claim.haml
@@ -13,7 +13,7 @@
       This channel type uses the new <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/overview">Twitter Activity API.</a>
       You will need to <a href="https://developer.twitter.com/en/apply-for-access">apply for access</a> and
       <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/guides/getting-started-with-webhooks">create a
-      Twitter application.</a>
+      Twitter application</a>. Make sure your Twitter application has "Read, Write and Direct Message" permissions.
 
     %p
       -blocktrans with name=brand.name
@@ -65,4 +65,14 @@
 
     .form-group {
       margin-bottom:15px;
+    }
+
+    .controls input[type="checkbox"] {
+      display: inline-block;
+      margin-top: -3px;
+    }
+
+    .field_clear_webhooks p {
+      display: inline-block;
+      margin-left:3px;
     }


### PR DESCRIPTION
 * deletes existing webhooks if there is only one webhook registered
 * saves webhook id so we release the right webhook
 * activate the channel at the same time we claim so any errors are immediately surfaced to user
