### PR TITLE
Fix surveyor run submission when action set has been deleted

### DIFF
--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -591,7 +591,6 @@ class FlowRunWriteSerializer(WriteSerializer):
         super().__init__(*args, **kwargs)
         self.contact_obj = None
         self.flow_obj = None
-        self.revision_nodes = {}
         self.submitted_by_obj = None
 
     def validate_submitted_by(self, value):
@@ -639,7 +638,7 @@ class FlowRunWriteSerializer(WriteSerializer):
             # look for a matching node for each step in our path
             if step["node"] not in node_uuids:
                 raise serializers.ValidationError(
-                    "No such node with UUID %s in flow '%s' (rev %d)" % (step["node"], self.flow_obj.name, revision)
+                    f"No such node with UUID {step['node']} in flow '{self.flow_obj.name}' (rev {revision})"
                 )
 
             rule = step.get("rule", None)

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -723,6 +723,132 @@ class APITest(TembaTest):
             ],
         )
 
+    def test_api_steps_with_deleted_actionset(self):
+        url = reverse("api.v1.steps")
+
+        # login as surveyor
+        self.login(self.surveyor)
+
+        flow = self.get_flow("color")
+        color_prompt = ActionSet.objects.get(x=1, y=1)
+        color_ruleset = flow.rule_sets.get(label="color")
+        orange_rule = color_ruleset.get_rules()[0]
+        color_reply = ActionSet.objects.get(x=2, y=2)
+
+        # replace the prompt actionset completely
+        flow_json = flow.as_json()
+        flow_json["action_sets"][0] = {
+            "y": 1,
+            "x": 1,
+            "destination": "bd531ace-911e-4722-8e53-6730d6122fe1",
+            "uuid": "385e0ce2-4e4b-465a-aedf-4028731b86a9",
+            "actions": [
+                {
+                    "msg": {"base": "Hello, do you have a favorite color?"},
+                    "send_all": False,
+                    "type": "reply",
+                    "uuid": "61dd8291-64eb-4e74-8c75-c48ab7f81d00",
+                }
+            ],
+        }
+        flow.update(flow_json)
+
+        data = {
+            "flow": str(flow.uuid),
+            "revision": 1,
+            "contact": self.joe.uuid,
+            "submitted_by": self.surveyor.username,
+            "started": "2015-08-25T11:09:29.088Z",
+            "steps": [
+                {
+                    "node": color_prompt.uuid,
+                    "arrived_on": "2015-08-25T11:09:30.088Z",
+                    "actions": [{"type": "reply", "msg": "What is your favorite color?"}],
+                },
+                {
+                    "node": color_ruleset.uuid,
+                    "arrived_on": "2015-08-25T11:11:30.088Z",
+                    "rule": {
+                        "uuid": orange_rule.uuid,
+                        "value": "orange",
+                        "category": "Orange",
+                        "text": "I like orange",
+                    },
+                },
+                {
+                    "node": color_reply.uuid,
+                    "arrived_on": "2015-08-25T11:13:30.088Z",
+                    "actions": [{"type": "reply", "msg": "I love orange too!"}],
+                },
+            ],
+            "completed": True,
+        }
+
+        with patch.object(timezone, "now", return_value=datetime(2015, 9, 15, 0, 0, 0, 0, pytz.UTC)):
+            self.postJSON(url, data)
+
+        run = FlowRun.objects.get()
+        self.assertEqual(run.exit_type, FlowRun.EXIT_TYPE_COMPLETED)
+        self.assertIsNotNone(run.exited_on)
+        self.assertEqual(
+            run.path,
+            [
+                {
+                    "uuid": matchers.UUID4String(),
+                    "node_uuid": color_prompt.uuid,
+                    "arrived_on": "2015-08-25T11:09:30.088000+00:00",
+                    "exit_uuid": color_prompt.exit_uuid,
+                },
+                {
+                    "uuid": matchers.UUID4String(),
+                    "node_uuid": color_ruleset.uuid,
+                    "arrived_on": "2015-08-25T11:11:30.088000+00:00",
+                    "exit_uuid": orange_rule.uuid,
+                },
+                {
+                    "uuid": matchers.UUID4String(),
+                    "node_uuid": color_reply.uuid,
+                    "arrived_on": "2015-08-25T11:13:30.088000+00:00",
+                },
+            ],
+        )
+        self.assertEqual(
+            run.results,
+            {
+                "color": {
+                    "node_uuid": color_ruleset.uuid,
+                    "name": "color",
+                    "category": "Orange",
+                    "value": "orange",
+                    "input": "I like orange",
+                    "created_on": matchers.ISODate(),
+                }
+            },
+        )
+        self.assertEqual(
+            run.events,
+            [
+                {
+                    "type": "msg_created",
+                    "created_on": matchers.ISODate(),
+                    "step_uuid": run.path[0]["uuid"],
+                    "msg": {"uuid": matchers.UUID4String(), "text": "What is your favorite color?"},
+                },
+                {
+                    "type": "msg_received",
+                    "created_on": matchers.ISODate(),
+                    "step_uuid": run.path[1]["uuid"],
+                    "msg": {"uuid": matchers.UUID4String(), "text": "I like orange"},
+                },
+                {
+                    "type": "msg_created",
+                    "created_on": matchers.ISODate(),
+                    "step_uuid": run.path[2]["uuid"],
+                    "msg": {"uuid": matchers.UUID4String(), "text": "I love orange too!"},
+                },
+            ],
+        )
+
     def test_api_steps_with_deleted_ruleset(self):
         url = reverse("api.v1.steps")
 
@@ -1115,7 +1241,9 @@ class APITest(TembaTest):
             response = self.postJSON(url, data)
             self.assertEqual(400, response.status_code)
             self.assertResponseError(
-                response, "non_field_errors", "No such node with UUID %s in flow 'Color Flow'" % new_node["uuid"]
+                response,
+                "non_field_errors",
+                "No such node with UUID %s in flow 'Color Flow' (rev 3)" % new_node["uuid"],
             )
 
             # this version doesn't exist
@@ -1139,50 +1267,6 @@ class APITest(TembaTest):
             response = self.postJSON(url, data)
             self.assertEqual(201, response.status_code)
             self.assertIsNotNone(self.joe.urns.filter(path="+13605551212").first())
-
-            # rule uuid not existing we should find the actual matching rule
-            data = dict(
-                flow=flow.uuid,
-                revision=2,
-                contact=self.joe.uuid,
-                started="2015-08-25T11:09:29.088Z",
-                submitted_by=self.admin.username,
-                steps=[
-                    dict(
-                        node=color_ruleset.uuid,
-                        arrived_on="2015-08-25T11:11:30.088Z",
-                        rule=dict(
-                            uuid="abc5fd71-027b-40e8-a819-151a0f8140e6",
-                            value="orange",
-                            category="Orange",
-                            text="I like orange",
-                        ),
-                    ),
-                    dict(
-                        node=color_reply.uuid,
-                        arrived_on="2015-08-25T11:13:30.088Z",
-                        actions=[dict(type="reply", msg="I love orange too!")],
-                    ),
-                    dict(
-                        node=new_node["uuid"],
-                        arrived_on="2015-08-25T11:15:30.088Z",
-                        actions=[
-                            dict(type="save", field="tel_e164", value="+12065551212"),
-                            dict(type="del_group", group=dict(name="Remove Me")),
-                        ],
-                    ),
-                ],
-                completed=True,
-            )
-
-            response = self.postJSON(url, data)
-            self.assertEqual(201, response.status_code)
-
-            with patch("temba.flows.models.RuleSet.find_matching_rule") as mock_find_matching_rule:
-                mock_find_matching_rule.return_value = None, None, None
-
-                with self.assertRaises(ValueError):
-                    self.postJSON(url, data)
 
     def test_api_contacts(self):
         url = reverse("api.v1.contacts")


### PR DESCRIPTION
Now both rulesets and actionsets are loaded from the specific flow revision. Should prevent errors like https://sentry.io/nyaruka/rapidpro/issues/618412808/events/25612811061/