### PR TITLE
🦹 Raise API.ValidationError for inactive contacts

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -488,6 +488,9 @@ class ContactWriteSerializer(WriteSerializer):
         return value
 
     def validate(self, data):
+        if self.instance and not self.instance.is_active:
+            raise serializers.ValidationError("Inactive contacts can't be modified.")
+
         # we allow creation of contacts by URN used for lookup
         if not data.get("urns") and "urns__identity" in self.context["lookup_values"]:
             url_urn = self.context["lookup_values"]["urns__identity"]

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1586,6 +1586,9 @@ class APITest(TembaTest):
         jean.refresh_from_db()
         self.assertFalse(jean.is_active)
 
+        response = self.postJSON(url, "uuid=%s" % jean.uuid, {})
+        self.assertResponseError(response, "non_field_errors", "Inactive contacts can't be modified.")
+
         # create xavier
         response = self.postJSON(url, None, {"name": "Xavier", "urns": ["tel:+250-78-7777777", "twitter:XAVIER"]})
         self.assertEqual(response.status_code, 201)


### PR DESCRIPTION
Fixes https://sentry.io/nyaruka/textit/issues/564362751/

* this is not applicable for `ContactBulkActionSerializer` because it uses ContactField serializer that only reads valid contacts