### PR TITLE
📅 Cleanup encoding of ISO datetimes

### DIFF
--- a/temba/api/v1/serializers.py
+++ b/temba/api/v1/serializers.py
@@ -12,7 +12,6 @@ from temba.flows.models import Flow, FlowRun, RuleSet
 from temba.locations.models import AdminBoundary
 from temba.msgs.models import Broadcast, Msg
 from temba.utils import json
-from temba.utils.json import datetime_to_json_date
 from temba.values.constants import Value
 
 # Maximum number of items that can be passed to bulk action endpoint. We don't currently enforce this for messages but
@@ -24,7 +23,7 @@ def format_datetime(value):
     """
     Datetime fields are limited to millisecond accuracy for v1
     """
-    return datetime_to_json_date(value, micros=False) if value else None
+    return json.encode_datetime(value, micros=False) if value else None
 
 
 def validate_bulk_fetch(fetched, uuids):

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -23,7 +23,6 @@ from temba.msgs.models import Msg
 from temba.orgs.models import Language
 from temba.tests import AnonymousOrg, TembaTest, matchers
 from temba.utils import json
-from temba.utils.json import datetime_to_json_date
 from temba.values.constants import Value
 
 from .serializers import (
@@ -393,7 +392,7 @@ class APITest(TembaTest):
                         label="color",
                     )
                 ],
-                created_on=datetime_to_json_date(flow.created_on),
+                created_on=json.encode_datetime(flow.created_on),
                 expires=flow.expires_after_minutes,
                 archived=False,
             ),
@@ -1628,17 +1627,17 @@ class APITest(TembaTest):
         self.assertResultCount(response, 2)
 
         after_dre = drdre.modified_on + timedelta(microseconds=2000)
-        response = self.fetchJSON(url, "after=" + datetime_to_json_date(after_dre))
+        response = self.fetchJSON(url, "after=" + json.encode_datetime(after_dre))
         self.assertResultCount(response, 1)
         self.assertContains(response, "Jay-Z")
 
         before_jayz = jay_z.modified_on - timedelta(microseconds=2000)
-        response = self.fetchJSON(url, "before=" + datetime_to_json_date(before_jayz))
+        response = self.fetchJSON(url, "before=" + json.encode_datetime(before_jayz))
         self.assertResultCount(response, 1)
         self.assertContains(response, "Dr Dre")
 
         response = self.fetchJSON(
-            url, "after=%s&before=%s" % (datetime_to_json_date(after_dre), datetime_to_json_date(before_jayz))
+            url, "after=%s&before=%s" % (json.encode_datetime(after_dre), json.encode_datetime(before_jayz))
         )
         self.assertResultCount(response, 0)
 

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -12,7 +12,6 @@ from temba.locations.models import AdminBoundary
 from temba.msgs.models import PENDING, QUEUED, Broadcast, Label, Msg
 from temba.msgs.tasks import send_broadcast_task
 from temba.utils import extract_constants, json, on_transaction_commit
-from temba.utils.json import datetime_to_json_date
 from temba.values.constants import Value
 
 from . import fields
@@ -23,7 +22,7 @@ def format_datetime(value):
     """
     Datetime fields are formatted with microsecond accuracy for v2
     """
-    return datetime_to_json_date(value, micros=True) if value else None
+    return json.encode_datetime(value, micros=True) if value else None
 
 
 class ReadSerializer(serializers.ModelSerializer):

--- a/temba/channels/courier.py
+++ b/temba/channels/courier.py
@@ -3,7 +3,6 @@ import time
 from django_redis import get_redis_connection
 
 from temba.utils import analytics, json
-from temba.utils.dates import datetime_to_str
 
 
 def push_courier_msgs(channel, msgs, high_priority=False):
@@ -59,11 +58,11 @@ def msg_as_task(msg):
         response_to_external_id=msg.response_to.external_id if msg.response_to else "",
         external_id=msg.external_id,
         tps_cost=msg.channel.calculate_tps_cost(msg),
-        next_attempt=datetime_to_str(msg.next_attempt, ms=True),
-        created_on=datetime_to_str(msg.created_on, ms=True),
-        modified_on=datetime_to_str(msg.modified_on, ms=True),
-        queued_on=datetime_to_str(msg.queued_on, ms=True),
-        sent_on=datetime_to_str(msg.sent_on, ms=True),
+        next_attempt=msg.next_attempt.isoformat() if msg.next_attempt else None,
+        created_on=msg.created_on.isoformat(),
+        modified_on=msg.modified_on.isoformat(),
+        queued_on=msg.queued_on.isoformat() if msg.queued_on else None,
+        sent_on=msg.sent_on.isoformat() if msg.sent_on else None,
     )
 
     if msg.contact_urn.auth:  # pragma: no cover

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1595,14 +1595,14 @@ class ContactTest(TembaTest):
         self.assertTrue(
             evaluate_query(self.org, f'created_on = "{query_created_on}"', contact_json=self.joe.as_search_json())
         )
-        query_created_on = datetime_to_str(self.joe.created_on - timedelta(days=6), tz=self.org.timezone)
+        query_created_on = (self.joe.created_on - timedelta(days=6)).astimezone(self.org.timezone).date().isoformat()
         self.assertTrue(
             evaluate_query(self.org, f'created_on > "{query_created_on}"', contact_json=self.joe.as_search_json())
         )
         self.assertTrue(
             evaluate_query(self.org, f'created_on >= "{query_created_on}"', contact_json=self.joe.as_search_json())
         )
-        query_created_on = datetime_to_str(self.joe.created_on + timedelta(days=6), tz=self.org.timezone)
+        query_created_on = (self.joe.created_on + timedelta(days=6)).astimezone(self.org.timezone).date().isoformat()
         self.assertTrue(
             evaluate_query(self.org, f'created_on < "{query_created_on}"', contact_json=self.joe.as_search_json())
         )

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -60,7 +60,7 @@ from temba.msgs.models import (
 )
 from temba.orgs.models import Language, Org, get_current_export_version
 from temba.utils import analytics, chunk_list, json, on_transaction_commit
-from temba.utils.dates import datetime_to_str, str_to_datetime
+from temba.utils.dates import str_to_datetime
 from temba.utils.email import is_valid_address
 from temba.utils.export import BaseExportAssetStore, BaseExportTask
 from temba.utils.expressions import ContactFieldCollector
@@ -2556,7 +2556,7 @@ class Flow(TembaModel):
             last_saved = self.modified_on
 
         metadata[Flow.NAME] = self.name
-        metadata[Flow.SAVED_ON] = datetime_to_str(last_saved)
+        metadata[Flow.SAVED_ON] = json.encode_datetime(last_saved, micros=True)
         metadata[Flow.REVISION] = revision.revision if revision else 1
         metadata[Flow.UUID] = self.uuid
         metadata[Flow.EXPIRES] = self.expires_after_minutes
@@ -5071,12 +5071,11 @@ class FlowRevision(SmartModel):
             definition = FlowRevision.migrate_definition(definition, self.flow)
         return definition
 
-    def as_json(self, include_definition=False):
-
+    def as_json(self):
         name = self.created_by.get_full_name()
         return dict(
             user=dict(email=self.created_by.email, name=name),
-            created_on=datetime_to_str(self.created_on),
+            created_on=json.encode_datetime(self.created_on, micros=True),
             id=self.pk,
             version=self.spec_version,
             revision=self.revision,

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -41,7 +41,6 @@ from temba.tests.s3 import MockS3Client
 from temba.triggers.models import Trigger
 from temba.ussd.models import USSDSession
 from temba.utils import json
-from temba.utils.dates import datetime_to_str
 from temba.utils.profiler import QueryTracker
 from temba.values.constants import Value
 
@@ -1935,7 +1934,7 @@ class FlowTest(TembaTest):
                 revision=1,
                 expires=60,
                 uuid=copy.uuid,
-                saved_on=datetime_to_str(copy.saved_on),
+                saved_on=json.encode_datetime(copy.saved_on, micros=True),
             ),
             copy_json["metadata"],
         )
@@ -2047,7 +2046,7 @@ class FlowTest(TembaTest):
             {
                 "name": self.flow.name,
                 "author": "Ryan Lewis",
-                "saved_on": datetime_to_str(self.flow.saved_on),
+                "saved_on": json.encode_datetime(self.flow.saved_on, micros=True),
                 "revision": 1,
                 "expires": self.flow.expires_after_minutes,
                 "uuid": self.flow.uuid,
@@ -3356,7 +3355,7 @@ class FlowTest(TembaTest):
         ActionSet.objects.get(flow=self.flow)
 
         # can't save with an invalid uuid
-        json_dict["metadata"]["saved_on"] = datetime_to_str(timezone.now())
+        json_dict["metadata"]["saved_on"] = json.encode_datetime(timezone.now(), micros=True)
         json_dict["action_sets"][0]["destination"] = "notthere"
 
         response = self.client.post(

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -52,7 +52,7 @@ from temba.orgs.views import ModalMixin, OrgObjPermsMixin, OrgPermsMixin
 from temba.triggers.models import Trigger
 from temba.ussd.models import USSDSession
 from temba.utils import analytics, chunk_list, json, on_transaction_commit, str_to_bool
-from temba.utils.dates import datetime_to_ms, datetime_to_str
+from temba.utils.dates import datetime_to_ms
 from temba.utils.expressions import get_function_listing
 from temba.utils.s3 import public_file_storage
 from temba.utils.views import BaseActionForm
@@ -273,8 +273,6 @@ class FlowCRUDL(SmartCRUDL):
 
     class RecentMessages(OrgObjPermsMixin, SmartReadView):
         def get(self, request, *args, **kwargs):
-            flow = self.get_object()
-
             exit_uuids = request.GET.get("exits", "").split(",")
             to_uuid = request.GET.get("to")
 
@@ -283,10 +281,7 @@ class FlowCRUDL(SmartCRUDL):
             if exit_uuids and to_uuid:
                 for recent_run in FlowPathRecentRun.get_recent(exit_uuids, to_uuid):
                     recent_messages.append(
-                        {
-                            "sent": datetime_to_str(recent_run["visited_on"], tz=flow.org.timezone),
-                            "text": recent_run["text"],
-                        }
+                        {"sent": json.encode_datetime(recent_run["visited_on"]), "text": recent_run["text"]}
                     )
 
             return JsonResponse(recent_messages, safe=False)
@@ -1670,7 +1665,11 @@ class FlowCRUDL(SmartCRUDL):
                 flow = self.get_object(self.get_queryset())
                 revision = flow.update(json_dict, user=self.request.user)
                 return JsonResponse(
-                    {"status": "success", "saved_on": datetime_to_str(flow.saved_on), "revision": revision.revision},
+                    {
+                        "status": "success",
+                        "saved_on": json.encode_datetime(flow.saved_on, micros=True),
+                        "revision": revision.revision,
+                    },
                     status=200,
                 )
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1122,7 +1122,7 @@ class Org(SmartModel):
         """
         formats = get_datetime_format(self.get_dayfirst())
         format = formats[1] if show_time else formats[0]
-        return datetime_to_str(datetime, format, False, self.timezone)
+        return datetime_to_str(datetime, format, self.timezone)
 
     def parse_datetime(self, datetime_string):
         if isinstance(datetime_string, datetime):

--- a/temba/utils/analytics.py
+++ b/temba/utils/analytics.py
@@ -11,7 +11,7 @@ from librato_bg import Client as LibratoClient
 from django.conf import settings
 from django.utils import timezone
 
-from temba.utils.json import datetime_to_json_date
+from temba.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ def identify_org(org, attributes=None):
         _intercom.companies.create(
             company_id=org.id,
             name=org.name,
-            created_at=datetime_to_json_date(org.created_on),
+            created_at=json.encode_datetime(org.created_on),
             custom_attributes=attributes,
             **intercom_attributes,
         )
@@ -138,7 +138,7 @@ def identify(user, brand, org):
                 dict(
                     company_id=org.id,
                     name=org.name,
-                    created_at=datetime_to_json_date(org.created_on),
+                    created_at=json.encode_datetime(org.created_on),
                     custom_attributes=dict(brand=org.brand, org_id=org.id),
                 )
             ]
@@ -182,7 +182,7 @@ def change_consent(email, consent):
 
     if _intercom:
         try:
-            change_date = datetime_to_json_date(timezone.now())
+            change_date = json.encode_datetime(timezone.now())
 
             user = get_intercom_user(email)
 

--- a/temba/utils/dates.py
+++ b/temba/utils/dates.py
@@ -21,45 +21,24 @@ YYYY_MM_DD = regex.compile(r"\b([0-9]{4}|[0-9]{2})[-.\\/_ ]([0-9]{1,2})[-.\\/_ ]
 HH_MM_SS = regex.compile(r"\b([0-9]{1,2}):([0-9]{2})(:([0-9]{2})(\.(\d+))?)?\W*([aApP][mM])?\b")
 
 
-def datetime_to_str(date_obj, format=None, ms=True, tz=None):
+def datetime_to_str(date_obj, format, tz):
     """
     Formats a datetime or date as a string
     :param date_obj: the datetime or date
-    :param format: the format (defaults to ISO8601)
-    :param ms: whether to include microseconds
+    :param format: the format
     :param tz: the timezone to localize in
     :return: the formatted date string
     """
     if not date_obj:
         return None
 
-    if not tz:
-        tz = timezone.utc
-
     if type(date_obj) == datetime.date:
         date_obj = tz.localize(datetime.datetime.combine(date_obj, datetime.time(0, 0, 0)))
-
-    if date_obj.year < 1900:  # pragma: no cover
-        return "%d-%d-%dT%d:%d:%d.%dZ" % (
-            date_obj.year,
-            date_obj.month,
-            date_obj.day,
-            date_obj.hour,
-            date_obj.minute,
-            date_obj.second,
-            date_obj.microsecond,
-        )
 
     if isinstance(date_obj, datetime.datetime):
         date_obj = timezone.localtime(date_obj, tz)
 
-    if not format or not tz:
-        if ms:
-            return date_obj.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-        else:
-            return date_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
-    else:
-        return date_obj.strftime(format)
+    return date_obj.strftime(format)
 
 
 def str_to_datetime(date_str, tz, dayfirst=True, fill_time=True):

--- a/temba/utils/json.py
+++ b/temba/utils/json.py
@@ -1,7 +1,6 @@
 import datetime
 
 import pytz
-
 import simplejson
 
 
@@ -21,9 +20,10 @@ def dumps(value, *args, **kwargs):
     return simplejson.dumps(value, *args, cls=TembaEncoder, use_decimal=True, **kwargs)
 
 
-def datetime_to_json_date(dt, micros=False):
+def encode_datetime(dt, micros=False):
     """
-    Formats a datetime as a string for inclusion in JSON
+    Formats a datetime as a string for inclusion in JSON using the format 2018-08-31T12:13:30.123Z which is parseable
+    on all modern browsers.
     :param dt: the datetime to format
     :param micros: whether to include microseconds
     """
@@ -41,6 +41,6 @@ class TembaEncoder(simplejson.JSONEncoder):
     def default(self, o):
         # See "Date Time String Format" in the ECMA-262 specification.
         if isinstance(o, datetime.datetime):
-            return datetime_to_json_date(o)
+            return encode_datetime(o)
         else:
             return super().default(o)

--- a/temba/utils/management/commands/perf_test.py
+++ b/temba/utils/management/commands/perf_test.py
@@ -1,9 +1,9 @@
-# coding=utf-8
-
 import fnmatch
 import sys
 import time
 from datetime import datetime, timedelta
+
+import pytz
 
 from django.core.management.base import BaseCommand, CommandError
 from django.test import Client
@@ -34,7 +34,9 @@ ALLOWED_CHANGE_PERCENTAGE = 5
 URL_CONTEXT_TEMPLATE = {
     "first-group": lambda org: ContactGroup.user_groups.filter(org=org).order_by("id").first().uuid,
     "last-group": lambda org: ContactGroup.user_groups.filter(org=org).order_by("-id").first().uuid,
-    "1-year-ago": lambda org: datetime_to_str(now() - timedelta(days=365), get_datetime_format(org.get_dayfirst())[0]),
+    "1-year-ago": lambda org: datetime_to_str(
+        now() - timedelta(days=365), get_datetime_format(org.get_dayfirst())[0], pytz.UTC
+    ),
 }
 
 TEST_URLS = (

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -230,11 +230,8 @@ class DatesTest(TembaTest):
         tz = pytz.timezone("Africa/Kigali")
         d2 = tz.localize(datetime.datetime(2014, 1, 2, 3, 4, 5, 6))
 
-        self.assertEqual(datetime_to_str(d2), "2014-01-02T01:04:05.000006Z")  # no format
-        self.assertEqual(datetime_to_str(d2, format="%Y-%m-%d"), "2014-01-02")  # format provided
-        self.assertEqual(datetime_to_str(d2, tz=tz), "2014-01-02T03:04:05.000006Z")  # in specific timezone
-        self.assertEqual(datetime_to_str(d2, ms=False), "2014-01-02T01:04:05Z")  # no ms
-        self.assertEqual(datetime_to_str(d2.date()), "2014-01-02T00:00:00.000000Z")  # no ms
+        self.assertEqual(datetime_to_str(d2, "%Y-%m-%d %H:%M", tz=tz), "2014-01-02 03:04")
+        self.assertEqual(datetime_to_str(d2, "%Y/%m/%d %H:%M", tz=pytz.UTC), "2014/01/02 01:04")
 
     def test_datetime_to_epoch(self):
         dt = iso8601.parse_date("2014-01-02T01:04:05.000Z")
@@ -690,7 +687,7 @@ class JsonTest(TembaTest):
         encoded = json.dumps(source)
 
         self.assertEqual(
-            json.loads(encoded), {"name": "Date Test", "age": Decimal("10"), "now": json.datetime_to_json_date(now)}
+            json.loads(encoded), {"name": "Date Test", "age": Decimal("10"), "now": json.encode_datetime(now)}
         )
 
         # test the same using our object mocking


### PR DESCRIPTION
You can currently pass a date to `datetime_to_str` or `datetime_to_json_date` or even call `.isoformat()` to get an ISO formatted string - tho the first option doesn't work correctly when the datetime isn't in UTC. This PR cleans up where we use those so that:

- Anything being sent to courier/goflow uses `.isoformat()`
- Anything being sent to the editor uses `json.encode_datetime`
- `datetime_to_str` is only for formatting in a provided format and timezone

Also fixes https://github.com/rapidpro/rapidpro/issues/673