### PR TITLE
📉 Setup user tracking before creating an Org

### DIFF
--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2035,14 +2035,17 @@ class OrgCRUDL(SmartCRUDL):
             return welcome_topup_size
 
         def post_save(self, obj):
-            obj = super().post_save(obj)
-            self.request.session["org_id"] = obj.pk
-
             user = authenticate(username=self.user.username, password=self.form.cleaned_data["password"])
-            login(self.request, user)
 
+            # setup user tracking before creating Org in super().post_save
             analytics.identify(user, brand=self.request.branding["slug"], org=obj)
             analytics.track(self.request.user.username, "temba.org_signup", dict(org=obj.name))
+
+            obj = super().post_save(obj)
+
+            self.request.session["org_id"] = obj.pk
+
+            login(self.request, user)
 
             return obj
 

--- a/temba/utils/analytics.py
+++ b/temba/utils/analytics.py
@@ -114,7 +114,7 @@ def identify(user, brand, org):
         return
 
     attributes = dict(
-        email=user.email, first_name=user.first_name, segment=randint(1, 10), last_name=user.last_name, brand=brand
+        email=user.username, first_name=user.first_name, segment=randint(1, 10), last_name=user.last_name, brand=brand
     )
     user_name = f"{user.first_name} {user.last_name}"
     if org:
@@ -123,7 +123,7 @@ def identify(user, brand, org):
 
     # post to segment if configured
     if _segment:  # pragma: no cover
-        segment_analytics.identify(user.email, attributes)
+        segment_analytics.identify(user.username, attributes)
 
     # post to intercom if configured
     if _intercom:
@@ -132,7 +132,7 @@ def identify(user, brand, org):
             for key in ("first_name", "last_name", "email"):
                 attributes.pop(key, None)
 
-            intercom_user = _intercom.users.create(email=user.email, name=user_name, custom_attributes=attributes)
+            intercom_user = _intercom.users.create(email=user.username, name=user_name, custom_attributes=attributes)
 
             intercom_user.companies = [
                 dict(

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -2022,7 +2022,9 @@ class AnalyticsTest(TestCase):
         self.org = SimpleNamespace(
             id=1000, name="Some Org", brand="Some Brand", created_on=timezone.now(), account_value=lambda: 1000
         )
-        self.admin = SimpleNamespace(first_name="", last_name="", email="admin@example.com")
+        self.admin = SimpleNamespace(
+            username="admin@example.com", first_name="", last_name="", email="admin@example.com"
+        )
 
         self.intercom_mock = MagicMock()
         temba.utils.analytics._intercom = self.intercom_mock


### PR DESCRIPTION
Fixes: https://sentry.io/nyaruka/textit/issues/563557980

Initial fix solved only part of the problem. I was not aware that in
`super().post_save()` we create the Org and create example Flows for the
Org. The issue is that for every flow create we track the event
`nyaruka.flow_created` which causes *User Not Found* error on Intercom
service.