### PR TITLE
💬 Flowserver trial fixes

### DIFF
--- a/media/test_flows/keywords.json
+++ b/media/test_flows/keywords.json
@@ -1,0 +1,129 @@
+{
+  "version": "11.4",
+  "site": "https://textit.in",
+  "flows": [
+    {
+      "entry": "cdc2398e-47a1-470a-b85d-59df63c25f01",
+      "action_sets": [
+        {
+          "uuid": "cdc2398e-47a1-470a-b85d-59df63c25f01",
+          "x": 60,
+          "y": 0,
+          "destination": null,
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "3f106deb-8d42-411f-bc00-ceb3967acb9a",
+              "msg": {
+                "base": "Hi there @contact.name"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            }
+          ],
+          "exit_uuid": "aa61220b-db4a-4996-8bcf-743ee7158bdc"
+        }
+      ],
+      "rule_sets": [],
+      "base_language": "base",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "notes": [],
+        "saved_on": "2018-09-04T16:41:56.240490Z",
+        "uuid": "9fc0450e-adbc-4560-8708-53e363853dd9",
+        "name": "Replier",
+        "revision": 1
+      }
+    },
+    {
+      "entry": "583a308e-9bc4-4626-9c03-a699b3ef2ea5",
+      "action_sets": [
+        {
+          "uuid": "edfaf625-6824-48e7-9bed-6553a2a8e9c4",
+          "x": 194,
+          "y": 116,
+          "destination": null,
+          "actions": [
+            {
+              "type": "flow",
+              "uuid": "1795e11d-eec4-4f07-b814-08759d9fc6fe",
+              "flow": {
+                "uuid": "9fc0450e-adbc-4560-8708-53e363853dd9",
+                "name": "Greatwall"
+              }
+            }
+          ],
+          "exit_uuid": "6e515402-971f-4be4-902a-933d943377d1"
+        }
+      ],
+      "rule_sets": [
+        {
+          "uuid": "583a308e-9bc4-4626-9c03-a699b3ef2ea5",
+          "x": 237,
+          "y": 0,
+          "label": "Keyword",
+          "rules": [
+            {
+              "uuid": "d35f5c61-9f6c-4bf1-b0bd-4c2a29bcbcb9",
+              "category": {
+                "base": "Start"
+              },
+              "destination": "edfaf625-6824-48e7-9bed-6553a2a8e9c4",
+              "destination_type": "A",
+              "test": {
+                "type": "contains_phrase",
+                "test": {
+                  "base": "start"
+                }
+              },
+              "label": null
+            },
+            {
+              "uuid": "e56eea44-debf-40be-8d06-f9505e2dde10",
+              "category": {
+                "base": "Other"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "true"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "expression",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {}
+        }
+      ],
+      "base_language": "base",
+      "flow_type": "F",
+      "version": "11.4",
+      "metadata": {
+        "uuid": "e5345114-50da-4b9e-9255-599f821d09fd",
+        "notes": [],
+        "expires": 10080,
+        "name": "Keywords",
+        "saved_on": "2018-09-04T16:41:53.091719Z",
+        "revision": 28
+      }
+    }
+  ],
+  "campaigns": [],
+  "triggers": [
+    {
+      "trigger_type": "C",
+      "keyword": null,
+      "flow": {
+        "uuid": "e5345114-50da-4b9e-9255-599f821d09fd",
+        "name": "Keywords"
+      },
+      "groups": [],
+      "channel": null
+    }
+  ]
+}

--- a/temba/flows/handlers.py
+++ b/temba/flows/handlers.py
@@ -10,5 +10,5 @@ class FlowHandler(MessageHandler):
 
     def handle(self, msg):
         # hand off to our Flow object to handle
-        (handled, msgs) = Flow.find_and_handle(msg)
+        (handled, msgs) = Flow.find_and_handle(msg, allow_trial=True)
         return handled

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -957,7 +957,7 @@ class Flow(TembaModel):
         msg,
         started_flows=None,
         voice_response=None,
-        allow_trial=True,
+        allow_trial=False,
         triggered_start=False,
         resume_parent_run=False,
         expired_child_run=None,

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1163,7 +1163,7 @@ class Flow(TembaModel):
 
         # actually execute all the actions in our actionset
         msgs = actionset.execute_actions(run, msg, started_flows)
-        run.add_messages(msgs)
+        run.add_messages([m for m in msgs if not getattr(m, "from_other_run", False)])
 
         # and onto the destination
         destination = Flow.get_node(actionset.flow, actionset.destination, actionset.destination_type)
@@ -7097,7 +7097,9 @@ class StartFlowAction(Action):
                 [], [run.contact], started_flows=started_flows, restart_participants=True, extra=extra, parent_run=run
             )
             for run in child_runs:
-                msgs += run.start_msgs
+                for msg in run.start_msgs:
+                    msg.from_other_run = True
+                    msgs.append(msg)
 
         self.logger(run)
         return msgs

--- a/temba/flows/server/trial/tests.py
+++ b/temba/flows/server/trial/tests.py
@@ -311,6 +311,17 @@ class ResumeTest(TembaTest):
         self.assertEqual(mock_report_success.call_count, 1)
         self.assertEqual(mock_report_failure.call_count, 0)
 
+    @skip_if_no_flowserver
+    @override_settings(FLOW_SERVER_TRIAL="always")
+    @patch("temba.flows.server.trial.resumes.report_failure")
+    @patch("temba.flows.server.trial.resumes.report_success")
+    def test_no_trial_for_triggers(self, mock_report_success, mock_report_failure):
+        self.get_flow("keywords")
+        Msg.create_incoming(self.channel, "tel:+12065552020", "Start")
+
+        mock_report_success.assert_not_called()
+        mock_report_failure.assert_not_called()
+
 
 class MessageFlowTest(TembaTest):
     def setUp(self):

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -6333,6 +6333,49 @@ class FlowsTest(FlowFileTest):
         self.assertEqual(run.exit_type, "C")
         self.assertEqual(run.path[2]["exit_uuid"], str(ben_rule["uuid"]))
 
+    @also_in_flowserver
+    def test_noninteractive_subflow(self, in_flowserver):
+        self.get_flow("keywords")
+
+        msg_in = Msg.create_incoming(self.channel, "tel:+12065552020", "Start!")
+
+        parent_run, child_run = FlowRun.objects.order_by("id")
+        msg_out = Msg.objects.get(direction="O")
+
+        self.assertEqual(
+            parent_run.events,
+            [
+                {
+                    "type": "msg_received",
+                    "created_on": matchers.ISODate(),
+                    "step_uuid": parent_run.path[0]["uuid"],
+                    "msg": {
+                        "uuid": str(msg_in.uuid),
+                        "text": "Start!",
+                        "urn": "tel:+12065552020",
+                        "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
+                    },
+                }
+            ],
+        )
+
+        self.assertEqual(
+            child_run.events,
+            [
+                {
+                    "type": "msg_created",
+                    "created_on": matchers.ISODate(),
+                    "step_uuid": child_run.path[0]["uuid"],
+                    "msg": {
+                        "uuid": str(msg_out.uuid),
+                        "text": "Hi there Ben Haggerty",
+                        "urn": "tel:+12065552020",
+                        "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
+                    },
+                }
+            ],
+        )
+
     def test_resuming_run_with_old_uuidless_message(self):
         favorites = self.get_flow("favorites")
         run, = favorites.start([], [self.contact])


### PR DESCRIPTION
Two sorta unrelated fixes but I found them both looking at a flowserver trial of the same flow, and created a test flow based on that:
 * Starting messages from subflows shouldn't be added to the parent run
 * Don't start a flowserver trial when Flow.find_and_handle is called from a trigger - i.e. that's not a resume event.