### PR TITLE
Use authenticated user for events on Org.signup

### DIFF
--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2039,7 +2039,7 @@ class OrgCRUDL(SmartCRUDL):
 
             # setup user tracking before creating Org in super().post_save
             analytics.identify(user, brand=self.request.branding["slug"], org=obj)
-            analytics.track(self.request.user.username, "temba.org_signup", dict(org=obj.name))
+            analytics.track(email=user.username, event_name="temba.org_signup", properties=dict(org=obj.name))
 
             obj = super().post_save(obj)
 


### PR DESCRIPTION
Fixes: https://sentry.io/nyaruka/textit/issues/563557980

At the moment user signups for an account the `request.user` is an
Anonymous user (no email).

To track a `temba.org_signup` event we must use authenticated user
object.