### PR TITLE
➗ Update to latest expressions

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -101,7 +101,7 @@ python-intercom==3.1.0
 python-magic==0.4.15
 python-telegram-bot==6.1.0
 pytz==2017.2
-rapidpro-expressions==1.6
+rapidpro-expressions==1.7
 raven==6.9.0
 rcssmin==1.0.6            # via django-compressor
 redis==2.10.5

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2305,7 +2305,7 @@ class FlowTest(TembaTest):
 
         test = ContainsTest(test=dict(base="Green green %%$"))
         sms.text = "GReen is my favorite!, %%$"
-        self.assertTest(True, "GReen", test)
+        self.assertTest(True, "GReen $", test)
 
         # variable substitution
         test = ContainsTest(test=dict(base="@extra.color"))
@@ -2389,10 +2389,10 @@ class FlowTest(TembaTest):
 
         test = ContainsAnyTest(test=dict(base="%%$, &&,"))
         sms.text = "blue white, allo$%%"
-        self.assertTest(False, None, test)
+        self.assertTest(True, "$", test)
 
         sms.text = "%%$"
-        self.assertTest(False, None, test)
+        self.assertTest(True, "$", test)
 
         test = LtTest(test="5")
         self.assertTest(False, None, test)


### PR DESCRIPTION
 * Fixes `can't` matching `can` (https://github.com/rapidpro/expressions/pull/31)
 * Fixes booleans in the context becoming ints (https://github.com/rapidpro/expressions/pull/32)