### PR TITLE
#️⃣ Don't zero pad anon ids in context

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2024,7 +2024,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
         org = self.org
         context = {
-            "__default__": self.get_display(),
+            "__default__": self.get_display(for_expressions=True),
             Contact.NAME: self.name or "",
             Contact.FIRST_NAME: self.first_name(org),
             Contact.LANGUAGE: self.language,
@@ -2272,7 +2272,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         for group in self.user_groups.all():
             group.remove_contacts(user, [self])
 
-    def get_display(self, org=None, formatted=True, short=False):
+    def get_display(self, org=None, formatted=True, short=False, for_expressions=False):
         """
         Gets a displayable name or URN for the contact. If available, org can be provided to avoid having to fetch it
         again based on the contact.
@@ -2283,7 +2283,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         if self.name:
             res = self.name
         elif org.is_anon:
-            res = self.anon_identifier
+            res = self.id if for_expressions else self.anon_identifier
         else:
             res = self.get_urn_display(org=org, formatted=formatted)
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6029,6 +6029,7 @@ class ContactTest(TembaTest):
             self.assertEqual("********", context["tel"]["urn"])
             self.assertEqual("tel", context["tel"]["scheme"])
 
+            self.assertEqual(self.joe.id, context["__default__"])
             self.assertEqual(self.joe.id, context["id"])
 
     def test_urn_priority(self):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6029,8 +6029,14 @@ class ContactTest(TembaTest):
             self.assertEqual("********", context["tel"]["urn"])
             self.assertEqual("tel", context["tel"]["scheme"])
 
-            self.assertEqual(self.joe.id, context["__default__"])
+            self.assertEqual("Joe Blow", context["__default__"])
             self.assertEqual(self.joe.id, context["id"])
+
+            self.joe.name = ""
+            self.joe.save(update_fields=("name",), handle_update=False)
+            context = self.joe.build_expressions_context()
+
+            self.assertEqual(self.joe.id, context["__default__"])
 
     def test_urn_priority(self):
         bob = self.create_contact("Bob")


### PR DESCRIPTION
New world renders @contact as a simple number if they only have an anon id. Old world renders @contact.id as a simple number but @contact as a zero-padded value. PR makes anon ids always simple number values