### PR TITLE
🖍 Embed script only if `View.refresh` is set

### DIFF
--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -668,6 +668,9 @@ class MsgTest(TembaTest):
         with self.assertNumQueries(63):
             response = self.fetch_protected(inbox_url + "?refresh=10000", self.admin)
 
+        # make sure that we embed refresh script if View.refresh is set
+        self.assertContains(response, "function refresh")
+
         self.assertEqual(response.context["refresh"], 20000)
         self.assertEqual(response.context["object_list"].count(), 5)
         self.assertEqual(response.context["folders"][0]["url"], "/msg/inbox/")

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2811,6 +2811,9 @@ class OrgCRUDLTest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertIn("name", response.context["form"].fields)
 
+        # make sure that we don't embed refresh script if View.refresh is not set
+        self.assertNotContains(response, "function refresh")
+
         # submit with missing fields
         response = self.client.post(signup_url, {})
         self.assertFormError(response, "form", "name", "This field is required.")

--- a/templates/smartmin/base.html
+++ b/templates/smartmin/base.html
@@ -107,6 +107,8 @@
 
 </script>
 
+{# embed refresh script if refresh is active #}
+{% if refresh %}
 <script>
 var refreshTimeout = 10000;
 function refresh(onSuccess, forceReload){
@@ -131,7 +133,6 @@ function refresh(onSuccess, forceReload){
   });
 }
 
-{% if refresh %}
 refreshTimeout = {{ refresh }};
 function scheduleRefresh() {
     window.setTimeout(refresh, {{ refresh }});
@@ -140,9 +141,8 @@ function scheduleRefresh() {
 $(document).ready(function(){
     scheduleRefresh();
 });
-{% endif %}
 </script>
-
+{% endif %}
 {% endblock %}
 
 


### PR DESCRIPTION
Stop embedding refresh code on pages that don't require it.

This fixes XSS issues on public facing pages.