### PR TITLE
ጪ Correctly embed JS in templates

### DIFF
--- a/temba/utils/templatetags/temba.py
+++ b/temba/utils/templatetags/temba.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django.template import TemplateSyntaxError
 from django.template.defaultfilters import register
 from django.urls import reverse
+from django.utils.html import escapejs
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext, ugettext_lazy as _, ungettext_lazy
 
 from ...campaigns.models import Campaign
@@ -150,3 +152,19 @@ class LessBlockNode(template.Node):
 
 # register our tag
 lessblock = register.tag(lessblock)
+
+
+@register.filter
+def to_json(value):
+    """
+    To use a python variable in JS, we call json.dumps to serialize as JSON server-side and reconstruct using
+    JSON.parse. The serialized string must be escaped appropriately before dumping into the client-side code.
+
+    https://stackoverflow.com/a/14290542
+    """
+    if type(value) != str:
+        raise ValueError(f"Expected str got {type(value)} for to_json")
+
+    escaped_output = escapejs(value)
+
+    return mark_safe(f'JSON.parse("{escaped_output}")')

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -436,6 +436,8 @@ class TemplateTagTest(TembaTest):
         self.assertEqual("icon-tree", icon(flow))
         self.assertEqual("", icon(None))
 
+
+class TemplateTagTestSimple(TestCase):
     def test_format_seconds(self):
         from temba.utils.templatetags.temba import format_seconds
 
@@ -490,6 +492,25 @@ class TemplateTagTest(TembaTest):
         self.assertEqual(", ", oxford(forloop(1, 4)))
         self.assertEqual(", and ", oxford(forloop(2, 4)))
         self.assertEqual(".", oxford(forloop(3, 4), "."))
+
+    def test_to_json(self):
+        from temba.utils.templatetags.temba import to_json
+
+        # only works with plain str objects
+        self.assertRaises(ValueError, to_json, dict())
+
+        self.assertEqual(to_json(json.dumps({})), 'JSON.parse("{}")')
+        self.assertEqual(to_json(json.dumps({"a": 1})), 'JSON.parse("{\\u0022a\\u0022: 1}")')
+        self.assertEqual(
+            to_json(json.dumps({"special": '"'})),
+            'JSON.parse("{\\u0022special\\u0022: \\u0022\\u005C\\u0022\\u0022}")',
+        )
+
+        # ecapes special <script>
+        self.assertEqual(
+            to_json(json.dumps({"special": '<script>alert("XSS");</script>'})),
+            'JSON.parse("{\\u0022special\\u0022: \\u0022\\u003Cscript\\u003Ealert(\\u005C\\u0022XSS\\u005C\\u0022)\\u003B\\u003C/script\\u003E\\u0022}")',
+        )
 
 
 class CacheTest(TembaTest):

--- a/templates/campaigns/campaignevent_update.haml
+++ b/templates/campaigns/campaignevent_update.haml
@@ -1,6 +1,6 @@
 -extends "smartmin/form.html"
 
--load smartmin
+-load smartmin temba
 
 -block extra-script
   {{ block.super }}
@@ -32,8 +32,8 @@
 
       $('#id_unit').on('change', toggleDeliveryHour);
 
-      var completions = {{completions|safe}};
-      var function_completions = {{function_completions|safe}};
+      var completions = {{ completions|to_json }};
+      var function_completions = {{ function_completions|to_json }};
 
       $('#message-section textarea').each(function() {
 

--- a/templates/contacts/contact_customize.haml
+++ b/templates/contacts/contact_customize.haml
@@ -1,6 +1,6 @@
 - extends "contacts/contact_import.html"
 
-- load smartmin
+- load smartmin temba
 -load i18n
 
 - block import-status
@@ -51,7 +51,7 @@
       useFontCheckbox(".field-include-checkbox input[type=checkbox]" );
     });
 
-    var contactFields = {{contact_fields|safe}};
+    var contactFields = {{ contact_fields|to_json }};
     $('.smartmin-form .field-as-name input').select2({
        data:contactFields,
        width: 'element',

--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -1,5 +1,5 @@
 -extends "smartmin/list.html"
--load smartmin sms contacts
+-load smartmin sms contacts temba
 -load i18n humanize
 
 -block page-title
@@ -458,7 +458,7 @@
       var modal = new Modax('{% trans "Save Search as Group" %}', '{% url "contacts.contactgroup_create"%}');
       modal.setIcon('icon-users');
       modal.setListeners({
-        onFormLoaded: function() { $("#active-modal form input#id_group_query").val('{{ search|escapejs }}'); }
+        onFormLoaded: function() { $("#active-modal form input#id_group_query").val('{{ search|to_json }}'); }
       });
       modal.setRedirectOnSuccess(true);
       modal.show();

--- a/templates/msgs/msg_send_modal.haml
+++ b/templates/msgs/msg_send_modal.haml
@@ -1,4 +1,4 @@
--load i18n
+-load i18n temba
 
 #send-message.send-message.modal.hide.notice{data-dismiss:'modal'}
   .modal-header
@@ -54,7 +54,7 @@
 
   :javascript
     $(document).ready(function() {
-      new AutoComplete({{completions|safe}}, {{function_completions|safe}}).bind($('#id_text'));
+      new AutoComplete({{ completions|to_json }}, {{ function_completions|to_json }}).bind($('#id_text'));
       $("textarea").keyup(messageTextareaLengthCheck);
 
     });

--- a/templates/triggers/trigger_register.haml
+++ b/templates/triggers/trigger_register.haml
@@ -1,5 +1,5 @@
 -extends 'smartmin/form.html'
--load i18n
+-load i18n temba
 
 -block extra-style
   {{block.super}}
@@ -16,7 +16,7 @@
     $(document).ready(function() {
       select2div("#id_register_action_join_group", "520px", '{% trans "Group to join" %}', '{% trans "Add Group: " %}');
       select2div("#id_register_flow", "520px", '{% trans "Flow to start" %}');
-      new AutoComplete({{completions|safe}}, {{function_completions|safe}}).bind($('#id_register_response'));
+      new AutoComplete({{ completions|to_json }}, {{ function_completions|to_json }}).bind($('#id_register_response'));
     });
 
 -block summary

--- a/templates/triggers/trigger_update.haml
+++ b/templates/triggers/trigger_update.haml
@@ -1,5 +1,5 @@
 -extends 'smartmin/form.html'
--load i18n
+-load i18n temba
 -load humanize
 
 -block summary
@@ -147,7 +147,7 @@
         $('#id_groups').select2({ containerCssClass: "select2-temba-field" });
       {% endif %}
 
-      new AutoComplete({{completions|safe}}, {{function_completions|safe}}).bind($('#id_response'));
+      new AutoComplete({{ completions|to_json }}, {{ function_completions|to_json }}).bind($('#id_response'));
 
       $('#id_flow').select2({
         minimumResultsForSearch: -1


### PR DESCRIPTION
The correct way to embed JS in templates is to use `escapejs` and
`JSON.parse` to read data.