### PR TITLE
🌐 Webhook changes and latest goflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
   - ln -s $TRAVIS_BUILD_DIR/temba/settings.py.dev $TRAVIS_BUILD_DIR/temba/settings.py
 
   # setup a goflow server instance
-  - GOFLOW_VERSION=0.17.0
+  - GOFLOW_VERSION=0.17.1
   - wget https://github.com/nyaruka/goflow/releases/download/v${GOFLOW_VERSION}/goflow_${GOFLOW_VERSION}_linux_amd64.tar.gz
   - tar -xvf goflow_${GOFLOW_VERSION}_linux_amd64.tar.gz
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
   - ln -s $TRAVIS_BUILD_DIR/temba/settings.py.dev $TRAVIS_BUILD_DIR/temba/settings.py
 
   # setup a goflow server instance
-  - GOFLOW_VERSION=0.15.1
+  - GOFLOW_VERSION=0.17.0
   - wget https://github.com/nyaruka/goflow/releases/download/v${GOFLOW_VERSION}/goflow_${GOFLOW_VERSION}_linux_amd64.tar.gz
   - tar -xvf goflow_${GOFLOW_VERSION}_linux_amd64.tar.gz
 

--- a/media/test_flows/migrate_to_11_5.json
+++ b/media/test_flows/migrate_to_11_5.json
@@ -1,0 +1,221 @@
+{
+  "version": "11.4",
+  "site": "https://app.rapidpro.io",
+  "flows": [
+    {
+      "entry": "2831f7ad-23e6-4ab3-91d9-936f14fcf35e",
+      "action_sets": [
+        {
+          "uuid": "35707236-5dd6-487d-bea4-6a73822852bf",
+          "x": 122,
+          "y": 458,
+          "destination": "51956031-9f42-475f-9d43-3ab2f87f4dd2",
+          "actions": [
+            {
+              "type": "reply",
+              "uuid": "c82df796-9d8f-4e9b-b76c-97027fa74ef7",
+              "msg": {
+                "eng": "@flow.response_1\n@flow.response_1.value\n@flow.response_1.category\n@(upper(flow.response_1))\n@(upper(flow.response_1.category))\n\n@flow.response_2\n@flow.response_2.value\n@flow.response_2.category\n@(upper(flow.response_2))\n@(upper(flow.response_2.category))\n\n@flow.response_3\n@flow.response_3.value\n@flow.response_3.category\n@(upper(flow.response_3))\n@(upper(flow.response_3.category))"
+              },
+              "media": {},
+              "quick_replies": [],
+              "send_all": false
+            }
+          ],
+          "exit_uuid": "65af1dca-b48e-4b36-867c-2ace47038093"
+        }
+      ],
+      "rule_sets": [
+        {
+          "uuid": "2831f7ad-23e6-4ab3-91d9-936f14fcf35e",
+          "x": 100,
+          "y": 0,
+          "label": "Response 1",
+          "rules": [
+            {
+              "uuid": "c799def9-345b-46f9-a838-a59191cdb181",
+              "category": {
+                "eng": "Success"
+              },
+              "destination": "7e0afb0a-8ca2-479f-8f72-49f8c1081d60",
+              "destination_type": "R",
+              "test": {
+                "type": "webhook_status",
+                "status": "success"
+              },
+              "label": null
+            },
+            {
+              "uuid": "1ace9344-3053-4dc2-aced-9a6e3c8a6e9d",
+              "category": {
+                "eng": "Failure"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "webhook_status",
+                "status": "failure"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "webhook",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {
+            "webhook": "http://example.com/webhook1",
+            "webhook_action": "GET",
+            "webhook_headers": []
+          }
+        },
+        {
+          "uuid": "7e0afb0a-8ca2-479f-8f72-49f8c1081d60",
+          "x": 103,
+          "y": 125,
+          "label": "Response 2",
+          "rules": [
+            {
+              "uuid": "ce50f51d-f052-4ff1-8a9b-a79faa62dfc2",
+              "category": {
+                "eng": "Success"
+              },
+              "destination": "5906c8f3-46f2-4319-8743-44fb26f2b109",
+              "destination_type": "R",
+              "test": {
+                "type": "webhook_status",
+                "status": "success"
+              },
+              "label": null
+            },
+            {
+              "uuid": "338e6c08-3597-4d22-beef-80d27b870a93",
+              "category": {
+                "eng": "Failure"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "webhook_status",
+                "status": "failure"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "webhook",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {
+            "webhook": "http://example.com/webhook2",
+            "webhook_action": "GET",
+            "webhook_headers": []
+          }
+        },
+        {
+          "uuid": "5906c8f3-46f2-4319-8743-44fb26f2b109",
+          "x": 105,
+          "y": 243,
+          "label": "Response 2",
+          "rules": [
+            {
+              "uuid": "6328e346-49c6-4607-a573-e8dc6e60bfcd",
+              "category": {
+                "eng": "All Responses"
+              },
+              "destination": "728a9a97-f28e-4fb3-a96a-7a7a8d5e5a4c",
+              "destination_type": "R",
+              "test": {
+                "type": "true"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "expression",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {}
+        },
+        {
+          "uuid": "728a9a97-f28e-4fb3-a96a-7a7a8d5e5a4c",
+          "x": 112,
+          "y": 346,
+          "label": "Response 3",
+          "rules": [
+            {
+              "uuid": "fb64dd04-8dd3-4e28-8607-468d1748a81f",
+              "category": {
+                "eng": "Success"
+              },
+              "destination": "35707236-5dd6-487d-bea4-6a73822852bf",
+              "destination_type": "A",
+              "test": {
+                "type": "webhook_status",
+                "status": "success"
+              },
+              "label": null
+            },
+            {
+              "uuid": "992c7429-221a-40f0-80be-fd6fbe858f57",
+              "category": {
+                "eng": "Failure"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "webhook_status",
+                "status": "failure"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "resthook",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {
+            "resthook": "test-resthook-event"
+          }
+        },
+        {
+          "uuid": "51956031-9f42-475f-9d43-3ab2f87f4dd2",
+          "x": 411,
+          "y": 513,
+          "label": "Response 5",
+          "rules": [
+            {
+              "uuid": "c06fb4fe-09a0-4990-b32e-e233de7edfda",
+              "category": {
+                "eng": "All Responses"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "true"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "expression",
+          "response_type": "",
+          "operand": "@(flow.response_1 & flow.response_2 & flow.response_3)",
+          "config": {}
+        }
+      ],
+      "base_language": "eng",
+      "flow_type": "M",
+      "version": "11.4",
+      "metadata": {
+        "name": "Migrate to 11.5 Test",
+        "saved_on": "2018-09-20T21:20:16.198634Z",
+        "revision": 60,
+        "uuid": "915144c5-605e-46f3-afa3-53aae2c9b8ee",
+        "expires": 10080
+      }
+    }
+  ],
+  "campaigns": [],
+  "triggers": []
+}

--- a/media/test_flows/migrate_to_11_5.json
+++ b/media/test_flows/migrate_to_11_5.json
@@ -23,6 +23,29 @@
             }
           ],
           "exit_uuid": "65af1dca-b48e-4b36-867c-2ace47038093"
+        },
+        {
+          "uuid": "ab700bd7-480b-4e34-bd59-5be7c453aa4e",
+          "x": 412,
+          "y": 814,
+          "destination": null,
+          "actions": [
+            {
+              "type": "api",
+              "uuid": "9b46779a-f680-450f-8f3c-005f3b7efccd",
+              "webhook": "http://example.com/?thing=@flow.response_1&foo=bar",
+              "action": "GET",
+              "webhook_headers": []
+            },
+            {
+              "type": "save",
+              "uuid": "e0ecf2a5-0429-45ec-a9d7-e2c122274484",
+              "label": "Contact Name",
+              "field": "name",
+              "value": "@flow.response_3.value"
+            }
+          ],
+          "exit_uuid": "25d8d2ae-ea82-4214-9561-42e0bf420a93"
         }
       ],
       "rule_sets": [
@@ -214,12 +237,27 @@
               "category": {
                 "eng": "Yes"
               },
-              "destination": null,
-              "destination_type": null,
+              "destination": "0e0c0e1f-e4ae-4531-ba19-48300de0f86d",
+              "destination_type": "R",
               "test": {
                 "type": "contains_any",
                 "test": {
                   "eng": "yes"
+                }
+              },
+              "label": null
+            },
+            {
+              "uuid": "8e55e70f-acf0-45a2-b7f9-2f95ccbbfc4d",
+              "category": {
+                "eng": "Matching"
+              },
+              "destination": "0e0c0e1f-e4ae-4531-ba19-48300de0f86d",
+              "destination_type": "R",
+              "test": {
+                "type": "contains_any",
+                "test": {
+                  "eng": "@flow.response_1"
                 }
               },
               "label": null
@@ -242,6 +280,49 @@
           "response_type": "",
           "operand": "@flow.response_1",
           "config": {}
+        },
+        {
+          "uuid": "0e0c0e1f-e4ae-4531-ba19-48300de0f86d",
+          "x": 489,
+          "y": 722,
+          "label": "Response 7",
+          "rules": [
+            {
+              "uuid": "234fff68-780f-442f-a1c6-757131fbc213",
+              "category": {
+                "eng": "Success"
+              },
+              "destination": "ab700bd7-480b-4e34-bd59-5be7c453aa4e",
+              "destination_type": "A",
+              "test": {
+                "type": "webhook_status",
+                "status": "success"
+              },
+              "label": null
+            },
+            {
+              "uuid": "70b79516-40a5-439c-9dee-45b242d6bb8b",
+              "category": {
+                "eng": "Failure"
+              },
+              "destination": "ab700bd7-480b-4e34-bd59-5be7c453aa4e",
+              "destination_type": "A",
+              "test": {
+                "type": "webhook_status",
+                "status": "failure"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "webhook",
+          "response_type": "",
+          "operand": "@step.value",
+          "config": {
+            "webhook": "http://example.com/?thing=@flow.response_1.value",
+            "webhook_action": "GET",
+            "webhook_headers": []
+          }
         }
       ],
       "base_language": "eng",
@@ -249,8 +330,8 @@
       "version": "11.4",
       "metadata": {
         "name": "Migrate to 11.5 Test",
-        "saved_on": "2018-09-21T21:25:41.540842Z",
-        "revision": 71,
+        "saved_on": "2018-09-25T14:57:23.429081Z",
+        "revision": 97,
         "uuid": "915144c5-605e-46f3-afa3-53aae2c9b8ee",
         "expires": 10080,
         "notes": [
@@ -283,6 +364,30 @@
             "y": 498,
             "title": "New Note",
             "body": "operand should be migrated too"
+          },
+          {
+            "x": 717,
+            "y": 608,
+            "title": "New Note",
+            "body": "rule test should be migrated"
+          },
+          {
+            "x": 747,
+            "y": 712,
+            "title": "New Note",
+            "body": "webhook URL in config should be migrated"
+          },
+          {
+            "x": 681,
+            "y": 830,
+            "title": "New Note",
+            "body": "webhook URL on action should be migrated"
+          },
+          {
+            "x": 682,
+            "y": 934,
+            "title": "New Note",
+            "body": "field value should be migrated"
           }
         ]
       }

--- a/media/test_flows/migrate_to_11_5.json
+++ b/media/test_flows/migrate_to_11_5.json
@@ -189,8 +189,8 @@
               "category": {
                 "eng": "All Responses"
               },
-              "destination": null,
-              "destination_type": null,
+              "destination": "f39a6d73-57d9-4d10-9055-57446addc87a",
+              "destination_type": "R",
               "test": {
                 "type": "true"
               },
@@ -202,6 +202,46 @@
           "response_type": "",
           "operand": "@(flow.response_1 & flow.response_2 & flow.response_3)",
           "config": {}
+        },
+        {
+          "uuid": "f39a6d73-57d9-4d10-9055-57446addc87a",
+          "x": 414,
+          "y": 625,
+          "label": "Response 6",
+          "rules": [
+            {
+              "uuid": "820f0020-0c72-44cd-9c12-a2b05c13e470",
+              "category": {
+                "eng": "Yes"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "contains_any",
+                "test": {
+                  "eng": "yes"
+                }
+              },
+              "label": null
+            },
+            {
+              "uuid": "d1c61a49-64f5-4ff6-b17f-1f22472f829f",
+              "category": {
+                "eng": "Other"
+              },
+              "destination": null,
+              "destination_type": null,
+              "test": {
+                "type": "true"
+              },
+              "label": null
+            }
+          ],
+          "finished_key": null,
+          "ruleset_type": "flow_field",
+          "response_type": "",
+          "operand": "@flow.response_1",
+          "config": {}
         }
       ],
       "base_language": "eng",
@@ -209,10 +249,42 @@
       "version": "11.4",
       "metadata": {
         "name": "Migrate to 11.5 Test",
-        "saved_on": "2018-09-20T21:20:16.198634Z",
-        "revision": 60,
+        "saved_on": "2018-09-21T21:25:41.540842Z",
+        "revision": 71,
         "uuid": "915144c5-605e-46f3-afa3-53aae2c9b8ee",
-        "expires": 10080
+        "expires": 10080,
+        "notes": [
+          {
+            "x": 357,
+            "y": 0,
+            "title": "New Note",
+            "body": "@flow.response_1"
+          },
+          {
+            "x": 358,
+            "y": 117,
+            "title": "New Note",
+            "body": "flow.response_2"
+          },
+          {
+            "x": 358,
+            "y": 236,
+            "title": "New Note",
+            "body": "reuses flow.response_2"
+          },
+          {
+            "x": 360,
+            "y": 346,
+            "title": "New Note",
+            "body": "@flow.response_3"
+          },
+          {
+            "x": 671,
+            "y": 498,
+            "title": "New Note",
+            "body": "operand should be migrated too"
+          }
+        ]
       }
     }
   ],

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -322,6 +322,9 @@ class WebHookEvent(SmartModel):
                 body = "Skipped actual send"
                 status_code = 200
 
+            run.update_fields({"webhook": body}, do_save=False)
+            new_extra = {}
+
             # process the webhook response
             try:
                 response_json = json.loads(body)
@@ -330,10 +333,12 @@ class WebHookEvent(SmartModel):
                 if not isinstance(response_json, dict) and not isinstance(response_json, list):
                     raise ValueError("Response must be a JSON dictionary or list, ignoring response.")
 
-                run.update_fields(response_json)
+                new_extra = response_json
                 message = "Webhook called successfully."
             except ValueError:
                 message = "Response must be a JSON dictionary, ignoring response."
+
+            run.update_fields(new_extra)
 
             if 200 <= status_code < 300:
                 webhook_event.status = cls.STATUS_COMPLETE

--- a/temba/flows/flow_migrations.py
+++ b/temba/flows/flow_migrations.py
@@ -30,7 +30,7 @@ def migrate_to_version_11_5(json_flow, flow=None):
     non_webhook_rulesets = set()
     for r in rule_sets:
         slug = Flow.label_to_slug(r["label"])
-        if not slug:
+        if not slug:  # pragma: no cover
             continue
         if r["ruleset_type"] in (RuleSet.TYPE_WEBHOOK, RuleSet.TYPE_RESTHOOK):
             webhook_rulesets.add(slug)
@@ -74,9 +74,6 @@ def migrate_to_version_11_4(json_flow, flow=None):
     # figure out which rulesets aren't waits
     rule_sets = json_flow.get("rule_sets", [])
     non_waiting = {Flow.label_to_slug(r["label"]) for r in rule_sets if r["ruleset_type"] not in RuleSet.TYPE_WAIT}
-
-    if not non_waiting:
-        return json_flow
 
     # make a regex that matches a context reference to the .text on any result from these
     replace_pattern = r"flow\.(" + "|".join(non_waiting) + ")\.text"

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4734,7 +4734,7 @@ class RuleSet(models.Model):
 
                 (evaled_url, errors) = Msg.evaluate_template(url, context, org=run.flow.org, url_encode=True)
                 result = WebHookEvent.trigger_flow_webhook(
-                    run, evaled_url, self.uuid, msg, action, resthook=resthook, headers=header
+                    run, evaled_url, self, msg, action, resthook=resthook, headers=header
                 )
 
                 # our subscriber is no longer interested, remove this URL as a subscriber
@@ -6273,7 +6273,7 @@ class WebhookAction(Action):
             for item in self.webhook_headers:
                 headers[item.get("name")] = item.get("value")
 
-        WebHookEvent.trigger_flow_webhook(run, value, actionset_uuid, msg, self.action, headers=headers)
+        WebHookEvent.trigger_flow_webhook(run, value, None, msg, self.action, headers=headers)
         return []
 
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -5713,7 +5713,9 @@ class WebhookTest(TembaTest):
 
         run6, = flow.start([], [contact], restart_participants=True)
         run6.refresh_from_db()
-        self.assertEqual(run6.fields, {"webhook": "asdfasdfasdf"})
+
+        if not in_flowserver:
+            self.assertEqual(run6.fields, {"webhook": "asdfasdfasdf"})
 
         results = run6.results
         self.assertEqual(len(results), 2)
@@ -5727,7 +5729,8 @@ class WebhookTest(TembaTest):
         run7, = flow.start([], [contact], restart_participants=True)
         run7.refresh_from_db()
 
-        self.assertEqual(run7.fields, {"webhook": "Server Error"})
+        if not in_flowserver:
+            self.assertEqual(run7.fields, {"webhook": "Server Error"})
         self.assertEqual(
             run7.results,
             {
@@ -6478,6 +6481,10 @@ class FlowsTest(FlowFileTest):
         self.assertEqual("tel:+12065552020", fallback_post.data["contact"]["urn"])
 
         def assert_payload(payload, path_length, result_count, results):
+            print("============================")
+            print(json.dumps(payload["results"], indent=2))
+            print("============================")
+
             self.assertEqual(
                 dict(name="Ben Haggerty", uuid=self.contact.uuid, urn="tel:+12065552020"), payload["contact"]
             )

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -9548,6 +9548,20 @@ class FlowMigrationTest(FlowFileTest):
         self.assertEqual(rs["operand"], "@extra.response_1")
         self.assertEqual(rs["ruleset_type"], "expression")
 
+        # check rule test was updated
+        self.assertEqual(flow_json["rule_sets"][5]["rules"][1]["test"]["test"]["eng"], "@extra.response_1")
+
+        # check webhook URL on ruleset was updated
+        self.assertEqual(flow_json["rule_sets"][6]["config"]["webhook"], "http://example.com/?thing=@extra.response_1")
+
+        # check webhook field on webhook action was updsated
+        self.assertEqual(
+            flow_json["action_sets"][1]["actions"][0]["webhook"], "http://example.com/?thing=@extra.response_1&foo=bar"
+        )
+
+        # check value field on save action was updsated
+        self.assertEqual(flow_json["action_sets"][1]["actions"][1]["value"], "@extra.response_3")
+
     def test_migrate_to_11_4(self):
         flow = self.get_flow("migrate_to_11_4")
         flow_json = flow.as_json()

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -5680,8 +5680,6 @@ class WebhookTest(TembaTest):
         run3, = flow.start([], [contact], restart_participants=True)
         run3.refresh_from_db()
 
-        self.maxDiff = None
-
         if not in_flowserver:
             self.assertEqual(run3.fields, {"0": "zero", "1": "one", "2": "two", "webhook": '["zero", "one", "two"]'})
 
@@ -6481,10 +6479,6 @@ class FlowsTest(FlowFileTest):
         self.assertEqual("tel:+12065552020", fallback_post.data["contact"]["urn"])
 
         def assert_payload(payload, path_length, result_count, results):
-            print("============================")
-            print(json.dumps(payload["results"], indent=2))
-            print("============================")
-
             self.assertEqual(
                 dict(name="Ben Haggerty", uuid=self.contact.uuid, urn="tel:+12065552020"), payload["contact"]
             )

--- a/temba/utils/http.py
+++ b/temba/utils/http.py
@@ -1,3 +1,8 @@
+from http.client import HTTPResponse
+from io import BytesIO
+
+import urllib3
+
 from django.conf import settings
 
 
@@ -24,3 +29,21 @@ class HttpEvent(object):
 
     def __str__(self):  # pragma: no cover
         return "%s %s %s %s %s" % (self.method, self.url, self.status_code, self.response_body, self.request_body)
+
+
+def parse_response(data):
+    """
+    Parses a saved HTTP response trace, e.g. "HTTP/1.1 200 OK\r\n\r\n{\"errors\":[]}"
+    """
+
+    class BytesIOSocket:
+        def __init__(self, content):
+            self.handle = BytesIO(content)
+
+        def makefile(self, mode):
+            return self.handle
+
+    response = HTTPResponse(BytesIOSocket(data.encode("utf-8")))
+    response.begin()
+
+    return urllib3.HTTPResponse.from_httplib(response)


### PR DESCRIPTION
 * Result value from webhook/resthook rulesets becomes status code 
 * Response body is instead saved to `@extra.<result-name>`
 * Flow migration to rewrite expressions involving `@flow.response_1` or `@flow.response_1.value` where `response_1` is from a webhook/resthook ruleset to use `@extra.response_1` instead