### PR TITLE
🌥 Fix flow results export to read old archive format

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -5643,7 +5643,11 @@ class ExportFlowResultsTask(BaseExportTask):
             contact = contacts_by_uuid.get(run["contact"]["uuid"])
 
             # get this run's results by node UUID
-            results_by_node = {result["node"]: result for result in run["values"].values()}
+            run_values = run["values"]
+            if isinstance(run_values, list):
+                results_by_node = {result["node"]: result for item in run_values for result in item.values()}
+            else:
+                results_by_node = {result["node"]: result for result in run_values.values()}
 
             # generate contact info columns
             contact_values = [

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1732,11 +1732,16 @@ class FlowTest(TembaTest):
             period="D",
             build_time=23425,
         )
+
+        # prepare 'old' archive format that used a list of values
+        old_archive_format = contact2_run.as_archive_json()
+        old_archive_format["values"] = [old_archive_format["values"]]
+
         mock_s3 = MockS3Client()
         mock_s3.put_jsonl(
             "test-bucket",
             "archive1.jsonl.gz",
-            [contact1_run.as_archive_json(), contact2_run.as_archive_json(), contact2_other_flow.as_archive_json()],
+            [contact1_run.as_archive_json(), old_archive_format, contact2_other_flow.as_archive_json()],
         )
 
         contact1_run.release()


### PR DESCRIPTION
Initially we have archived flow run.values as a list. Current archive
format uses a more natural object mapping. We need to support
flow run exports from archives and support the older format.