### PR TITLE
🌤 Refresh Contacts.list after managing fields

### DIFF
--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -481,7 +481,24 @@
         onFormLoaded:function() {
           useFontCheckbox("input[type=checkbox]", false);
         },
-        onSuccess: function() { refresh(function() { recheckIds(); }, true); }
+        onSuccess: function() {
+            // grab the current search string, sort_on/page/...
+            var url = window.location.search;
+
+            if (!url) {
+                url = '?'
+            }
+
+            // bust cache
+            url += '&ts=' + new Date().getTime();
+
+            fetchPJAXContent(url, '#pjax', {
+                forceReload: true,
+                onSuccess: function () {
+                    recheckIds();
+                }
+            })
+        }
       });
       modal.show();
     });


### PR DESCRIPTION
After gating refresh function in base.html to prevent XSS attacks, we
broke Contacts.managefields modal. A successful contact field update is
going to refresh the PJAX content on the page.

Prevents: https://sentry.io/nyaruka/textit/issues/704642216/