### PR TITLE
Fix remap groups

### DIFF
--- a/temba/flows/flow_migrations.py
+++ b/temba/flows/flow_migrations.py
@@ -39,15 +39,12 @@ def migrate_to_version_11_6(json_flow, flow=None):
 
             # we haven't been mapped yet (also, non-uuid groups can't be mapped)
             if "uuid" not in group or group["uuid"] not in uuid_map:
-                group_instance = ContactGroup.get_or_create(
-                    flow.org, flow.created_by, group["name"], group.get("uuid", None)
-                )
-
-                # map group references that started with a uuid
-                if "uuid" in group:
-                    uuid_map[group["uuid"]] = group_instance.uuid
-
-                group["uuid"] = group_instance.uuid
+                group_instance = ContactGroup.get_user_group(flow.org, group["name"])
+                if group_instance:
+                    # map group references that started with a uuid
+                    if "uuid" in group:
+                        uuid_map[group["uuid"]] = group_instance.uuid
+                    group["uuid"] = group_instance.uuid
 
             # we were already mapped
             elif group["uuid"] in uuid_map:

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -9648,22 +9648,11 @@ class FlowMigrationTest(FlowFileTest):
         self.assertEqual(1, len(flow_json["rule_sets"]))
 
     def test_migrate_to_11_6(self):
+
+        flow = self.get_flow("migrate_to_11_6")
         flow_json = self.get_flow_json("migrate_to_11_6")
-        flow = Flow.create_instance(
-            dict(
-                name="Flow Container",
-                org=self.org,
-                created_by=self.admin,
-                modified_by=self.admin,
-                saved_by=self.admin,
-                version_number="11.6",
-            )
-        )
 
-        self.assertEqual(0, ContactGroup.user_groups.all().count())
         migrated = migrate_to_version_11_6(flow_json, flow)
-        self.assertEqual(5, ContactGroup.user_groups.all().count())
-
         migrated_groups = get_groups(migrated)
         for uuid, name in migrated_groups.items():
             self.assertTrue(ContactGroup.user_groups.filter(uuid=uuid, name=name).exists(), msg="Group UUID mismatch")


### PR DESCRIPTION
Flow migrations shouldn't create groups, creates zombie groups on revision migration