### PR TITLE
🌐 Fix passing false/true to archived param of flows API endpoint

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2209,6 +2209,9 @@ class APITest(TembaTest):
         response = self.fetchJSON(url, "archived=0")
         self.assertResultsByUUID(response, [color, survey])
 
+        response = self.fetchJSON(url, "archived=false")
+        self.assertResultsByUUID(response, [color, survey])
+
         # filter by before
         response = self.fetchJSON(url, "before=%s" % format_datetime(color.modified_on))
         self.assertResultsByUUID(response, [color, survey])

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2026,7 +2026,7 @@ class FlowsEndpoint(ListAPIMixin, BaseAPIView):
         # filter by archived (optional)
         archived = params.get("archived")
         if archived:
-            queryset = queryset.filter(is_archived=archived)
+            queryset = queryset.filter(is_archived=str_to_bool(archived))
 
         queryset = queryset.prefetch_related("labels")
 


### PR DESCRIPTION
Surveyor does this