### PR TITLE
🔩 Prevent deleting groups with active campaigns

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -169,6 +169,10 @@ class TembaModelField(serializers.RelatedField):
 class CampaignField(TembaModelField):
     model = Campaign
 
+    def get_queryset(self):
+        manager = getattr(self.model, self.model_manager)
+        return manager.filter(org=self.context["org"], is_active=True, is_archived=False)
+
 
 class CampaignEventField(TembaModelField):
     model = CampaignEvent

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -28,6 +28,7 @@ from temba.locations.models import BoundaryAlias
 from temba.msgs.models import Broadcast, Label, Msg
 from temba.orgs.models import Language
 from temba.tests import AnonymousOrg, ESMockWithScroll, TembaTest
+from temba.triggers.models import Trigger
 from temba.utils import json
 from temba.values.constants import Value
 
@@ -898,6 +899,33 @@ class APITest(TembaTest):
         response = self.postJSON(url, "uuid=%s" % spam.uuid, {"name": "Won't work", "group": spammers.uuid})
         self.assert404(response)
 
+    def test_campaigns_does_not_update_inactive_archived(self):
+        url = reverse("api.v2.campaigns")
+
+        self.assertEndpointAccess(url)
+
+        reporters = self.create_group("Reporters", [self.joe, self.frank])
+        campaign = Campaign.create(self.org, self.admin, "Reminders #1", reporters)
+
+        campaign.is_active = False
+        campaign.save(update_fields=("is_active",))
+
+        # can't update inactive or archived campaign
+        response = self.postJSON(
+            url, "uuid=%s" % campaign.uuid, data={"name": "Reminders III", "group": reporters.uuid}
+        )
+        self.assertEqual(response.status_code, 404)
+
+        campaign.is_active = True
+        campaign.is_archived = True
+        campaign.save(update_fields=("is_active", "is_archived"))
+
+        # can't update inactive or archived campaign
+        response = self.postJSON(
+            url, "uuid=%s" % campaign.uuid, data={"name": "Reminders III", "group": reporters.uuid}
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_campaign_events(self):
         url = reverse("api.v2.campaign_events")
 
@@ -1206,6 +1234,135 @@ class APITest(TembaTest):
 
         # should no longer have any events
         self.assertEqual(1, EventFire.objects.filter(contact=contact, event=event2).count())
+
+    def test_campaignevents_cant_modify_on_inactive_campaign(self):
+        url = reverse("api.v2.campaign_events")
+
+        self.login(self.admin)
+
+        reporters = self.create_group("Reporters", [self.joe, self.frank])
+        registration = ContactField.get_or_create(
+            self.org, self.admin, "registration", "Registration", value_type=Value.TYPE_DATETIME
+        )
+
+        campaign1 = Campaign.create(self.org, self.admin, "Reminders", reporters)
+        event1 = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign1,
+            registration,
+            1,
+            CampaignEvent.UNIT_DAYS,
+            "Don't forget to brush your teeth",
+        )
+
+        campaign1.is_active = False
+        campaign1.save(update_fields=("is_active",))
+
+        # fetch campaign event on inactive campaign
+        response = self.fetchJSON(url, "uuid=%s" % event1.uuid)
+        self.assertEqual(len(response.json()["results"]), 1)
+
+        # creating a new flow event on the inactive campaign does not work
+        response = self.postJSON(
+            url,
+            None,
+            {
+                "campaign": campaign1.uuid,
+                "relative_to": "registration",
+                "offset": 15,
+                "unit": "weeks",
+                "delivery_hour": -1,
+                "message": "Nice job",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"campaign": [f"No such object: {campaign1.uuid}"]})
+
+        # updating a flow event on the inactive campaign does not work
+        response = self.postJSON(
+            url,
+            f"uuid={event1.uuid}",
+            {
+                "campaign": campaign1.uuid,
+                "relative_to": "registration",
+                "offset": 15,
+                "unit": "weeks",
+                "delivery_hour": -1,
+                "message": "Nice job",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"campaign": [f"No such object: {campaign1.uuid}"]})
+
+        # we can delete an event on the inactive campaign
+        response = self.deleteJSON(url, "uuid=%s" % event1.uuid)
+        self.assertEqual(response.status_code, 204)
+
+    def test_campaignevents_on_archived_campaign(self):
+        url = reverse("api.v2.campaign_events")
+
+        self.login(self.admin)
+
+        reporters = self.create_group("Reporters", [self.joe, self.frank])
+        registration = ContactField.get_or_create(
+            self.org, self.admin, "registration", "Registration", value_type=Value.TYPE_DATETIME
+        )
+
+        campaign1 = Campaign.create(self.org, self.admin, "Reminders", reporters)
+        event1 = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign1,
+            registration,
+            1,
+            CampaignEvent.UNIT_DAYS,
+            "Don't forget to brush your teeth",
+        )
+
+        campaign1.is_active = True
+        campaign1.is_archived = True
+        campaign1.save(update_fields=("is_active", "is_archived"))
+
+        # creating a new flow event on the archived campaign does not work
+        response = self.postJSON(
+            url,
+            None,
+            {
+                "campaign": campaign1.uuid,
+                "relative_to": "registration",
+                "offset": 15,
+                "unit": "weeks",
+                "delivery_hour": -1,
+                "message": "Nice job",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"campaign": [f"No such object: {campaign1.uuid}"]})
+
+        # updating a flow event on the inactive campaign does not work
+        response = self.postJSON(
+            url,
+            f"uuid={event1.uuid}",
+            {
+                "campaign": campaign1.uuid,
+                "relative_to": "registration",
+                "offset": 15,
+                "unit": "weeks",
+                "delivery_hour": -1,
+                "message": "Nice job",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"campaign": [f"No such object: {campaign1.uuid}"]})
+
+        # fetch campaign event on archived campaign
+        response = self.fetchJSON(url, "uuid=%s" % event1.uuid)
+        self.assertEqual(len(response.json()["results"]), 1)
+
+        # we can delete an event on the archived campaign
+        response = self.deleteJSON(url, "uuid=%s" % event1.uuid)
+        self.assertEqual(response.status_code, 204)
 
     def test_channels(self):
         url = reverse("api.v2.channels")
@@ -2373,6 +2530,63 @@ class APITest(TembaTest):
         group1 = ContactGroup.user_groups.filter(org=self.org, name="group1").first()
         response = self.deleteJSON(url, "uuid=%s" % group1.uuid)
         self.assertEqual(response.status_code, 204)
+
+    def test_api_groups_cant_delete_with_trigger_dependency(self):
+        url = reverse("api.v2.groups")
+        self.login(self.admin)
+
+        flow = self.get_flow("dependencies")
+        cats = ContactGroup.user_groups.filter(name="Cat Facts").first()
+
+        trigger = Trigger.objects.create(
+            org=self.org, flow=flow, keyword="block_group", created_by=self.admin, modified_by=self.admin
+        )
+        trigger.groups.add(cats)
+
+        response = self.deleteJSON(url, "uuid=%s" % cats.uuid)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": "This group is used by active triggers. In order to delete it, first archive triggers: block_group"
+            },
+        )
+
+    def test_api_groups_cant_delete_with_flow_dependency(self):
+        url = reverse("api.v2.groups")
+        self.login(self.admin)
+
+        self.get_flow("dependencies")
+
+        cats = ContactGroup.user_groups.filter(name="Cat Facts").first()
+
+        response = self.deleteJSON(url, "uuid=%s" % cats.uuid)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"detail": "This group is used by active flows. In order to delete it, first archive flows: Dependencies"},
+        )
+
+    def test_api_groups_cant_delete_with_campaign_dependency(self):
+        url = reverse("api.v2.groups")
+        self.login(self.admin)
+
+        customers = self.create_group("Customers", [self.frank])
+
+        post_data = dict(name="Don't forget to ...", group=customers.pk)
+        self.client.post(reverse("campaigns.campaign_create"), post_data)
+
+        response = self.deleteJSON(url, "uuid=%s" % customers.uuid)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": "This group is used by active campaigns. In order to delete it, first archive campaigns: Don't forget to ..."
+            },
+        )
 
     @patch.object(Label, "MAX_ORG_LABELS", new=10)
     def test_labels(self):

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1,9 +1,7 @@
 import itertools
 from enum import Enum
-from uuid import UUID
 
-import iso8601
-from rest_framework import generics, mixins, status, views
+from rest_framework import generics, status, views
 from rest_framework.pagination import CursorPagination
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
@@ -13,23 +11,32 @@ from smartmin.views import SmartFormView, SmartTemplateView
 
 from django import forms
 from django.contrib.auth import authenticate, login
-from django.db import transaction
 from django.db.models import Prefetch, Q
 from django.http import HttpResponse, JsonResponse
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from temba.api.models import APIToken, Resthook, ResthookSubscriber, WebHookEvent
+from temba.api.v2.views_base import (
+    BaseAPIView,
+    BulkWriteAPIMixin,
+    CreatedOnCursorPagination,
+    DeleteAPIMixin,
+    ListAPIMixin,
+    ModifiedOnCursorPagination,
+    WriteAPIMixin,
+)
 from temba.archives.models import Archive
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel, ChannelEvent
-from temba.contacts.models import URN, Contact, ContactField, ContactGroup, ContactGroupCount, ContactURN
+from temba.contacts.models import Contact, ContactField, ContactGroup, ContactGroupCount, ContactURN
+from temba.contacts.tasks import release_group_task
 from temba.flows.models import Flow, FlowRun, FlowStart
 from temba.locations.models import AdminBoundary, BoundaryAlias
 from temba.msgs.models import Broadcast, Label, LabelCount, Msg, SystemLabel
-from temba.utils import splitting_getlist, str_to_bool
+from temba.utils import on_transaction_commit, splitting_getlist, str_to_bool
 
-from ..models import APIPermission, SSLPermission
+from ..models import SSLPermission
 from ..support import InvalidQueryError
 from .serializers import (
     AdminBoundaryReadSerializer,
@@ -288,243 +295,6 @@ class AuthenticateView(SmartFormView):
             return JsonResponse({"tokens": tokens})
         else:
             return HttpResponse(status=403)
-
-
-class CreatedOnCursorPagination(CursorPagination):
-    ordering = ("-created_on", "-id")
-    offset_cutoff = 1000000
-
-
-class ModifiedOnCursorPagination(CursorPagination):
-    ordering = ("-modified_on", "-id")
-    offset_cutoff = 1000000
-
-
-class BaseAPIView(generics.GenericAPIView):
-    """
-    Base class of all our API endpoints
-    """
-
-    permission_classes = (SSLPermission, APIPermission)
-    throttle_scope = "v2"
-    model = None
-    model_manager = "objects"
-    lookup_params = {"uuid": "uuid"}
-
-    @transaction.non_atomic_requests
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
-
-    def options(self, request, *args, **kwargs):
-        """
-        Disable the default behaviour of OPTIONS returning serializer fields since we typically have two serializers
-        per endpoint.
-        """
-        return self.http_method_not_allowed(request, *args, **kwargs)
-
-    def get_queryset(self):
-        org = self.request.user.get_org()
-        return getattr(self.model, self.model_manager).filter(org=org)
-
-    def get_lookup_values(self):
-        """
-        Extracts lookup_params from the request URL, e.g. {"uuid": "123..."}
-        """
-        lookup_values = {}
-        for param, field in self.lookup_params.items():
-            if param in self.request.query_params:
-                param_value = self.request.query_params[param]
-
-                # try to normalize URN lookup values
-                if param == "urn":
-                    param_value = self.normalize_urn(param_value)
-
-                lookup_values[field] = param_value
-
-        if len(lookup_values) > 1:
-            raise InvalidQueryError(
-                "URL can only contain one of the following parameters: " + ", ".join(sorted(self.lookup_params.keys()))
-            )
-
-        return lookup_values
-
-    def get_object(self):
-        queryset = self.get_queryset().filter(**self.lookup_values)
-
-        return generics.get_object_or_404(queryset)
-
-    def get_int_param(self, name):
-        param = self.request.query_params.get(name)
-        try:
-            return int(param) if param is not None else None
-        except ValueError:
-            raise InvalidQueryError("Value for %s must be an integer" % name)
-
-    def get_uuid_param(self, name):
-        param = self.request.query_params.get(name)
-        try:
-            return UUID(param) if param is not None else None
-        except ValueError:
-            raise InvalidQueryError("Value for %s must be a valid UUID" % name)
-
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        context["org"] = self.request.user.get_org()
-        context["user"] = self.request.user
-        return context
-
-    def normalize_urn(self, value):
-        if self.request.user.get_org().is_anon:
-            raise InvalidQueryError("URN lookups not allowed for anonymous organizations")
-
-        try:
-            return URN.identity(URN.normalize(value))
-        except ValueError:
-            raise InvalidQueryError("Invalid URN: %s" % value)
-
-
-class ListAPIMixin(mixins.ListModelMixin):
-    """
-    Mixin for any endpoint which returns a list of objects from a GET request
-    """
-
-    exclusive_params = ()
-
-    def get(self, request, *args, **kwargs):
-        return self.list(request, *args, **kwargs)
-
-    def list(self, request, *args, **kwargs):
-        self.check_query(self.request.query_params)
-
-        if not kwargs.get("format", None):
-            # if this is just a request to browse the endpoint docs, don't make a query
-            return Response([])
-        else:
-            return super().list(request, *args, **kwargs)
-
-    def check_query(self, params):
-        # check user hasn't provided values for more than one of any exclusive params
-        if sum([(1 if params.get(p) else 0) for p in self.exclusive_params]) > 1:
-            raise InvalidQueryError("You may only specify one of the %s parameters" % ", ".join(self.exclusive_params))
-
-    def filter_before_after(self, queryset, field):
-        """
-        Filters the queryset by the before/after params if are provided
-        """
-        before = self.request.query_params.get("before")
-        if before:
-            try:
-                before = iso8601.parse_date(before)
-                queryset = queryset.filter(**{field + "__lte": before})
-            except Exception:
-                queryset = queryset.filter(pk=-1)
-
-        after = self.request.query_params.get("after")
-        if after:
-            try:
-                after = iso8601.parse_date(after)
-                queryset = queryset.filter(**{field + "__gte": after})
-            except Exception:
-                queryset = queryset.filter(pk=-1)
-
-        return queryset
-
-    def paginate_queryset(self, queryset):
-        page = super().paginate_queryset(queryset)
-
-        # give views a chance to prepare objects for serialization
-        self.prepare_for_serialization(page)
-
-        return page
-
-    def prepare_for_serialization(self, page):
-        """
-        Views can override this to do things like bulk cache initialization of result objects
-        """
-        pass
-
-
-class WriteAPIMixin(object):
-    """
-    Mixin for any endpoint which can create or update objects with a write serializer. Our approach differs a bit from
-    the REST framework default way as we use POST requests for both create and update operations, and use separate
-    serializers for reading and writing.
-    """
-
-    write_serializer_class = None
-
-    def post_save(self, instance):
-        """
-        Can be overridden to add custom handling after object creation
-        """
-        pass
-
-    def post(self, request, *args, **kwargs):
-        self.lookup_values = self.get_lookup_values()
-
-        # determine if this is an update of an existing object or a create of a new object
-        if self.lookup_values:
-            instance = self.get_object()
-        else:
-            instance = None
-
-        context = self.get_serializer_context()
-        context["lookup_values"] = self.lookup_values
-        context["instance"] = instance
-
-        serializer = self.write_serializer_class(instance=instance, data=request.data, context=context)
-
-        if serializer.is_valid():
-            with transaction.atomic():
-                output = serializer.save()
-                self.post_save(output)
-                return self.render_write_response(output, context)
-        else:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-    def render_write_response(self, write_output, context):
-        response_serializer = self.serializer_class(instance=write_output, context=context)
-
-        # if we created a new object, notify caller by returning 201
-        status_code = status.HTTP_200_OK if context["instance"] else status.HTTP_201_CREATED
-
-        return Response(response_serializer.data, status=status_code)
-
-
-class BulkWriteAPIMixin(object):
-    """
-    Mixin for a bulk action endpoint which writes multiple objects in response to a POST but returns nothing.
-    """
-
-    def post(self, request, *args, **kwargs):
-        serializer = self.serializer_class(data=request.data, context=self.get_serializer_context())
-
-        if serializer.is_valid():
-            serializer.save()
-            return Response("", status=status.HTTP_204_NO_CONTENT)
-
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class DeleteAPIMixin(mixins.DestroyModelMixin):
-    """
-    Mixin for any endpoint that can delete objects with a DELETE request
-    """
-
-    def delete(self, request, *args, **kwargs):
-        self.lookup_values = self.get_lookup_values()
-
-        if not self.lookup_values:
-            raise InvalidQueryError(
-                "URL must contain one of the following parameters: " + ", ".join(sorted(self.lookup_params.keys()))
-            )
-
-        instance = self.get_object()
-        self.perform_destroy(instance)
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
-    def perform_destroy(self, instance):
-        instance.release()
 
 
 # ============================================================
@@ -919,9 +689,13 @@ class CampaignsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
     write_serializer_class = CampaignWriteSerializer
     pagination_class = CreatedOnCursorPagination
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        return queryset.filter(is_active=True, is_archived=False)
+
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        queryset = queryset.filter(is_active=True)
 
         # filter by UUID (optional)
         uuid = params.get("uuid")
@@ -2138,6 +1912,10 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
 
     A **DELETE** can be used to delete a contact group if you specify its UUID in the URL.
 
+    Notes:
+        - cannot delete groups with associated active campaigns, flows or triggers. You first need to delete related
+          objects through the web interface
+
     Example:
 
         DELETE /api/v2/groups.json?uuid=5f05311e-8f81-4a67-a5b5-1501b6d6496a
@@ -2172,6 +1950,44 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
         group_counts = ContactGroupCount.get_totals(object_list)
         for group in object_list:
             group.count = group_counts[group]
+
+    def delete(self, request, *args, **kwargs):
+        self.lookup_values = self.get_lookup_values()
+        if not self.lookup_values:
+            raise InvalidQueryError(
+                "URL must contain one of the following parameters: " + ", ".join(sorted(self.lookup_params.keys()))
+            )
+
+        instance = self.get_object()
+
+        # if there are still dependencies, give up
+        triggers = instance.trigger_set.filter(is_archived=False)
+        if triggers.count() > 0:
+            raise InvalidQueryError(
+                f"This group is used by active triggers. In order to delete it, first archive triggers: {', '.join(str(trigger) for trigger in triggers)}"
+            )
+
+        flows = Flow.objects.filter(org=instance.org, group_dependencies__in=[instance])
+        if flows.count():
+            raise InvalidQueryError(
+                f"This group is used by active flows. In order to delete it, first archive flows: {', '.join(str(flow) for flow in flows)}"
+            )
+
+        campaigns = instance.campaign_set.filter(is_archived=False)
+        if campaigns.exists():
+            raise InvalidQueryError(
+                f"This group is used by active campaigns. In order to delete it, first archive campaigns: {', '.join(str(campaign) for campaign in campaigns)}"
+            )
+
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def perform_destroy(self, instance):
+        instance.is_active = False
+        instance.save(update_fields=("is_active",))
+
+        # release the group in a background task
+        on_transaction_commit(lambda: release_group_task.delay(instance.id))
 
     @classmethod
     def get_read_explorer(cls):

--- a/temba/api/v2/views_base.py
+++ b/temba/api/v2/views_base.py
@@ -1,0 +1,249 @@
+from uuid import UUID
+
+import iso8601
+from rest_framework import generics, mixins, status
+from rest_framework.pagination import CursorPagination
+from rest_framework.response import Response
+
+from django.db import transaction
+
+from temba.api.models import APIPermission, SSLPermission
+from temba.api.support import InvalidQueryError
+from temba.contacts.models import URN
+
+
+class BaseAPIView(generics.GenericAPIView):
+    """
+    Base class of all our API endpoints
+    """
+
+    permission_classes = (SSLPermission, APIPermission)
+    throttle_scope = "v2"
+    model = None
+    model_manager = "objects"
+    lookup_params = {"uuid": "uuid"}
+
+    @transaction.non_atomic_requests
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
+    def options(self, request, *args, **kwargs):
+        """
+        Disable the default behaviour of OPTIONS returning serializer fields since we typically have two serializers
+        per endpoint.
+        """
+        return self.http_method_not_allowed(request, *args, **kwargs)
+
+    def get_queryset(self):
+        org = self.request.user.get_org()
+        return getattr(self.model, self.model_manager).filter(org=org)
+
+    def get_lookup_values(self):
+        """
+        Extracts lookup_params from the request URL, e.g. {"uuid": "123..."}
+        """
+        lookup_values = {}
+        for param, field in self.lookup_params.items():
+            if param in self.request.query_params:
+                param_value = self.request.query_params[param]
+
+                # try to normalize URN lookup values
+                if param == "urn":
+                    param_value = self.normalize_urn(param_value)
+
+                lookup_values[field] = param_value
+
+        if len(lookup_values) > 1:
+            raise InvalidQueryError(
+                "URL can only contain one of the following parameters: " + ", ".join(sorted(self.lookup_params.keys()))
+            )
+
+        return lookup_values
+
+    def get_object(self):
+        queryset = self.get_queryset().filter(**self.lookup_values)
+
+        return generics.get_object_or_404(queryset)
+
+    def get_int_param(self, name):
+        param = self.request.query_params.get(name)
+        try:
+            return int(param) if param is not None else None
+        except ValueError:
+            raise InvalidQueryError("Value for %s must be an integer" % name)
+
+    def get_uuid_param(self, name):
+        param = self.request.query_params.get(name)
+        try:
+            return UUID(param) if param is not None else None
+        except ValueError:
+            raise InvalidQueryError("Value for %s must be a valid UUID" % name)
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["org"] = self.request.user.get_org()
+        context["user"] = self.request.user
+        return context
+
+    def normalize_urn(self, value):
+        if self.request.user.get_org().is_anon:
+            raise InvalidQueryError("URN lookups not allowed for anonymous organizations")
+
+        try:
+            return URN.identity(URN.normalize(value))
+        except ValueError:
+            raise InvalidQueryError("Invalid URN: %s" % value)
+
+
+class ListAPIMixin(mixins.ListModelMixin):
+    """
+    Mixin for any endpoint which returns a list of objects from a GET request
+    """
+
+    exclusive_params = ()
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+    def list(self, request, *args, **kwargs):
+        self.check_query(self.request.query_params)
+
+        if not kwargs.get("format", None):
+            # if this is just a request to browse the endpoint docs, don't make a query
+            return Response([])
+        else:
+            return super().list(request, *args, **kwargs)
+
+    def check_query(self, params):
+        # check user hasn't provided values for more than one of any exclusive params
+        if sum([(1 if params.get(p) else 0) for p in self.exclusive_params]) > 1:
+            raise InvalidQueryError("You may only specify one of the %s parameters" % ", ".join(self.exclusive_params))
+
+    def filter_before_after(self, queryset, field):
+        """
+        Filters the queryset by the before/after params if are provided
+        """
+        before = self.request.query_params.get("before")
+        if before:
+            try:
+                before = iso8601.parse_date(before)
+                queryset = queryset.filter(**{field + "__lte": before})
+            except Exception:
+                queryset = queryset.filter(pk=-1)
+
+        after = self.request.query_params.get("after")
+        if after:
+            try:
+                after = iso8601.parse_date(after)
+                queryset = queryset.filter(**{field + "__gte": after})
+            except Exception:
+                queryset = queryset.filter(pk=-1)
+
+        return queryset
+
+    def paginate_queryset(self, queryset):
+        page = super().paginate_queryset(queryset)
+
+        # give views a chance to prepare objects for serialization
+        self.prepare_for_serialization(page)
+
+        return page
+
+    def prepare_for_serialization(self, page):
+        """
+        Views can override this to do things like bulk cache initialization of result objects
+        """
+        pass
+
+
+class WriteAPIMixin(object):
+    """
+    Mixin for any endpoint which can create or update objects with a write serializer. Our approach differs a bit from
+    the REST framework default way as we use POST requests for both create and update operations, and use separate
+    serializers for reading and writing.
+    """
+
+    write_serializer_class = None
+
+    def post_save(self, instance):
+        """
+        Can be overridden to add custom handling after object creation
+        """
+        pass
+
+    def post(self, request, *args, **kwargs):
+        self.lookup_values = self.get_lookup_values()
+
+        # determine if this is an update of an existing object or a create of a new object
+        if self.lookup_values:
+            instance = self.get_object()
+        else:
+            instance = None
+
+        context = self.get_serializer_context()
+        context["lookup_values"] = self.lookup_values
+        context["instance"] = instance
+
+        serializer = self.write_serializer_class(instance=instance, data=request.data, context=context)
+
+        if serializer.is_valid():
+            with transaction.atomic():
+                output = serializer.save()
+                self.post_save(output)
+                return self.render_write_response(output, context)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def render_write_response(self, write_output, context):
+        response_serializer = self.serializer_class(instance=write_output, context=context)
+
+        # if we created a new object, notify caller by returning 201
+        status_code = status.HTTP_200_OK if context["instance"] else status.HTTP_201_CREATED
+
+        return Response(response_serializer.data, status=status_code)
+
+
+class BulkWriteAPIMixin(object):
+    """
+    Mixin for a bulk action endpoint which writes multiple objects in response to a POST but returns nothing.
+    """
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data, context=self.get_serializer_context())
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response("", status=status.HTTP_204_NO_CONTENT)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class DeleteAPIMixin(mixins.DestroyModelMixin):
+    """
+    Mixin for any endpoint that can delete objects with a DELETE request
+    """
+
+    def delete(self, request, *args, **kwargs):
+        self.lookup_values = self.get_lookup_values()
+
+        if not self.lookup_values:
+            raise InvalidQueryError(
+                "URL must contain one of the following parameters: " + ", ".join(sorted(self.lookup_params.keys()))
+            )
+
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def perform_destroy(self, instance):
+        instance.release()
+
+
+class CreatedOnCursorPagination(CursorPagination):
+    ordering = ("-created_on", "-id")
+    offset_cutoff = 1000000
+
+
+class ModifiedOnCursorPagination(CursorPagination):
+    ordering = ("-modified_on", "-id")
+    offset_cutoff = 1000000

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -1016,6 +1016,224 @@ class CampaignTest(TembaTest):
         response = self.client.get(reverse("campaigns.campaign_read", args=[campaign.pk]))
         self.assertNotContains(response, "Color Flow")
 
+    def test_view_campaign_cant_modify_inactive_or_archive(self):
+        self.login(self.admin)
+
+        campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
+
+        response = self.client.get(reverse("campaigns.campaign_update", args=[campaign.pk]))
+
+        # sanity check, form is available in the response
+        self.assertContains(response, "Planting Reminders")
+        self.assertListEqual(list(response.context["form"].fields.keys()), ["name", "group", "loc"])
+
+        # archive the campaign
+        campaign.is_archived = True
+        campaign.save()
+
+        response = self.client.get(reverse("campaigns.campaign_update", args=[campaign.pk]))
+
+        # we should get 404 for the archived campaign
+        self.assertEqual(response.status_code, 404)
+
+        # deactivate the campaign
+        campaign.is_archived = False
+        campaign.is_active = False
+        campaign.save()
+
+        response = self.client.get(reverse("campaigns.campaign_update", args=[campaign.pk]))
+
+        # we should get 404 for the inactive campaign
+        self.assertEqual(response.status_code, 404)
+
+    def test_view_campaign_read_archived(self):
+        self.login(self.admin)
+
+        campaign = Campaign.create(self.org, self.admin, "Perform the rain dance", self.farmers)
+
+        response = self.client.get(reverse("campaigns.campaign_read", args=[campaign.pk]))
+
+        # page title and main content title should NOT contain (Archived)
+        self.assertContains(response, "Perform the rain dance", count=2)
+        self.assertContains(response, "(Archived)", count=0)
+
+        gear_links = response.context["view"].get_gear_links()
+        self.assertListEqual([gl["title"] for gl in gear_links], ["Add Event", "Edit", "Archive"])
+
+        # archive the campaign
+        campaign.is_archived = True
+        campaign.save()
+
+        response = self.client.get(reverse("campaigns.campaign_read", args=[campaign.pk]))
+
+        # page title and main content title should contain (Archived)
+        self.assertContains(response, "Perform the rain dance", count=2)
+        self.assertContains(response, "(Archived)", count=2)
+
+        gear_links = response.context["view"].get_gear_links()
+        self.assertListEqual([gl["title"] for gl in gear_links], ["Activate"])
+
+    def test_view_campaign_archive(self):
+        self.login(self.admin)
+
+        post_data = dict(name="Planting Reminders", group=self.farmers.pk)
+        self.client.post(reverse("campaigns.campaign_create"), post_data)
+
+        campaign = Campaign.objects.filter(is_active=True).first()
+
+        # archive the campaign
+        response = self.client.post(reverse("campaigns.campaign_archive", args=[campaign.pk]))
+
+        self.assertRedirect(response, f"/campaign/read/{campaign.pk}/")
+
+        campaign.refresh_from_db()
+        self.assertTrue(campaign.is_archived)
+
+    def test_view_campaign_activate(self):
+        self.login(self.admin)
+
+        post_data = dict(name="Planting Reminders", group=self.farmers.pk)
+        self.client.post(reverse("campaigns.campaign_create"), post_data)
+
+        campaign = Campaign.objects.filter(is_active=True).first()
+
+        # activate the campaign
+        response = self.client.post(reverse("campaigns.campaign_activate", args=[campaign.pk]))
+
+        self.assertRedirect(response, f"/campaign/read/{campaign.pk}/")
+
+        campaign.refresh_from_db()
+        self.assertFalse(campaign.is_archived)
+
+    def test_view_campaignevent_read_on_archived_campaign(self):
+        self.login(self.admin)
+
+        campaign = Campaign.create(self.org, self.admin, "Perform the rain dance", self.farmers)
+
+        # create a reminder for our first planting event
+        event = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, relative_to=self.planting_date, offset=3, unit="D", flow=self.reminder_flow
+        )
+
+        response = self.client.get(reverse("campaigns.campaignevent_read", args=[event.pk]))
+
+        # page title and main content title should NOT contain (Archived)
+        self.assertContains(response, "Perform the rain dance", count=2)
+        self.assertContains(response, "(Archived)", count=0)
+
+        gear_links = response.context["view"].get_gear_links()
+        self.assertListEqual([gl["title"] for gl in gear_links], ["Edit", "Delete"])
+
+        # archive the campaign
+        campaign.is_archived = True
+        campaign.save()
+
+        response = self.client.get(reverse("campaigns.campaignevent_read", args=[event.pk]))
+
+        # page title and main content title should contain (Archived)
+        self.assertContains(response, "Perform the rain dance", count=2)
+        self.assertContains(response, "(Archived)", count=1)
+
+        gear_links = response.context["view"].get_gear_links()
+        self.assertListEqual([gl["title"] for gl in gear_links], ["Delete"])
+
+    def test_view_campaignevent_update_on_archived_campaign(self):
+        self.login(self.admin)
+
+        campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
+
+        # create a reminder for our first planting event
+        event = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, relative_to=self.planting_date, offset=3, unit="D", flow=self.reminder_flow
+        )
+
+        response = self.client.get(reverse("campaigns.campaignevent_update", args=[event.pk]))
+
+        # sanity check, form is available in the response
+        self.assertContains(response, "Planting Reminder")
+        self.assertListEqual(
+            list(response.context["form"].fields.keys()),
+            [
+                "offset",
+                "unit",
+                "relative_to",
+                "event_type",
+                "delivery_hour",
+                "direction",
+                "flow_to_start",
+                "flow_start_mode",
+                "message_start_mode",
+                "eng",
+                "loc",
+            ],
+        )
+
+        # archive the campaign
+        campaign.is_archived = True
+        campaign.save()
+
+        response = self.client.get(reverse("campaigns.campaignevent_update", args=[campaign.pk]))
+
+        # we should get 404 for the archived campaign
+        self.assertEqual(response.status_code, 404)
+
+        # deactivate the campaign
+        campaign.is_archived = False
+        campaign.is_active = False
+        campaign.save()
+
+        response = self.client.get(reverse("campaigns.campaign_update", args=[campaign.pk]))
+
+        # we should get 404 for the inactive campaign
+        self.assertEqual(response.status_code, 404)
+
+    def test_view_campaignevent_create_on_archived_campaign(self):
+        self.login(self.admin)
+
+        campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
+
+        post_data = dict(
+            relative_to=self.planting_date.pk,
+            event_type="M",
+            base="This is my message",
+            spa="hola",
+            direction="B",
+            offset=1,
+            unit="W",
+            flow_to_start="",
+            delivery_hour=13,
+            message_start_mode="I",
+        )
+
+        response = self.client.post(
+            reverse("campaigns.campaignevent_create") + "?campaign=%d" % campaign.pk, post_data
+        )
+
+        self.assertRedirect(response, reverse("campaigns.campaign_read", args=[campaign.pk]))
+
+        # archive the campaign
+        campaign.is_archived = True
+        campaign.save()
+
+        response = self.client.post(
+            reverse("campaigns.campaignevent_create") + "?campaign=%d" % campaign.pk, post_data
+        )
+
+        # we should get 404 for the archived campaign
+        self.assertEqual(response.status_code, 404)
+
+        # deactivate the campaign
+        campaign.is_archived = False
+        campaign.is_active = False
+        campaign.save()
+
+        response = self.client.post(
+            reverse("campaigns.campaignevent_create") + "?campaign=%d" % campaign.pk, post_data
+        )
+
+        # we should get 404 for the inactive campaign
+        self.assertEqual(response.status_code, 404)
+
     def test_eventfire_get_relative_to_value(self):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
         field_created_on = self.org.contactfields.get(key="created_on")
@@ -1146,21 +1364,36 @@ class CampaignTest(TembaTest):
         self.assertEqual("15-8-2020", "%s-%s-%s" % (planting.day, planting.month, planting.year))
 
         # now update the campaign
-        self.farmers = ContactGroup.user_groups.filter(name="Farmers", is_active=True).first()
+        new_farmers = ContactGroup.user_groups.filter(name="Farmers", is_active=True).first()
+        new_campaign = Campaign.create(self.org, self.admin, "Planting Reminders", new_farmers)
+        new_planting_reminder = CampaignEvent.create_flow_event(
+            self.org,
+            self.admin,
+            new_campaign,
+            relative_to=self.planting_date,
+            offset=3,
+            unit="D",
+            flow=self.reminder_flow,
+        )
+
         self.login(self.admin)
-        post_data = dict(name="Planting Reminders", group=self.farmers.pk)
-        self.client.post(reverse("campaigns.campaign_update", args=[campaign.pk]), post_data)
+        post_data = dict(name="Planting Reminders", group=new_farmers.pk)
+
+        self.client.post(reverse("campaigns.campaign_update", args=[new_campaign.pk]), post_data)
+
+        self.farmer1.set_field(self.user, "planting_date", "13-08-2020 12:30:10")
+        self.farmer2.set_field(self.user, "planting_date", "18-08-2020 12:30:10")
 
         # should have two fresh new fires
         self.assertEqual(2, EventFire.objects.all().count())
 
         # check their new planting dates
-        scheduled = EventFire.objects.get(contact=self.farmer1, event=planting_reminder).scheduled
-        self.assertEqual("13-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+        scheduled = EventFire.objects.get(contact=self.farmer1, event=new_planting_reminder).scheduled
+        self.assertEqual("16-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
 
         # farmer two fire
-        scheduled = EventFire.objects.get(contact=self.farmer2, event=planting_reminder).scheduled
-        self.assertEqual("18-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+        scheduled = EventFire.objects.get(contact=self.farmer2, event=new_planting_reminder).scheduled
+        self.assertEqual("21-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
 
         # give our non farmer a planting date
         self.nonfarmer.set_field(self.user, "planting_date", "20-05-2020 12:30:10")
@@ -1168,7 +1401,7 @@ class CampaignTest(TembaTest):
         # now update to the non-farmer group
         self.nonfarmers = self.create_group("Not Farmers", [self.nonfarmer])
         post_data = dict(name="Planting Reminders", group=self.nonfarmers.pk)
-        self.client.post(reverse("campaigns.campaign_update", args=[campaign.pk]), post_data)
+        self.client.post(reverse("campaigns.campaign_update", args=[new_campaign.pk]), post_data)
 
         # only one fire for the non-farmer the previous two should be deleted by the group change
         self.assertEqual(1, EventFire.objects.filter(event__is_active=True).count())

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -3100,6 +3100,11 @@ class ContactGroup(TembaModel):
 
         Trigger.objects.filter(is_active=True, groups=self).update(is_active=False, is_archived=True)
 
+        # deactivate any campaigns that are related to this group
+        from temba.campaigns.models import Campaign
+
+        Campaign.objects.filter(is_active=True, group=self).update(is_active=False, is_archived=True)
+
     @property
     def is_dynamic(self):
         return self.query is not None

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1591,7 +1591,11 @@ class ContactGroupCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
-            context["triggers"] = self.get_object().trigger_set.filter(is_archived=False)
+            group = self.get_object()
+
+            context["triggers"] = group.trigger_set.filter(is_archived=False)
+            context["campaigns"] = group.campaign_set.filter(is_archived=False)
+
             return context
 
         def get_success_url(self):
@@ -1606,10 +1610,14 @@ class ContactGroupCRUDL(SmartCRUDL):
             triggers = group.trigger_set.filter(is_archived=False)
             if triggers.count() > 0:
                 return HttpResponseRedirect(smart_url(self.cancel_url, group))
+
             from temba.flows.models import Flow
 
             flows = Flow.objects.filter(org=group.org, group_dependencies__in=[group])
             if flows.count():
+                return HttpResponseRedirect(smart_url(self.cancel_url, group))
+
+            if group.campaign_set.filter(is_archived=False).exists():
                 return HttpResponseRedirect(smart_url(self.cancel_url, group))
 
             # deactivate the group, this makes it 'invisible'

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -316,7 +316,7 @@ PERMISSIONS = {
     "api.resthook": ("api", "list"),
     "api.webhookevent": ("api",),
     "api.resthooksubscriber": ("api",),
-    "campaigns.campaign": ("api", "archived"),
+    "campaigns.campaign": ("api", "archived", "archive", "activate"),
     "campaigns.campaignevent": ("api",),
     "contacts.contact": (
         "api",

--- a/templates/campaigns/campaign_read.haml
+++ b/templates/campaigns/campaign_read.haml
@@ -2,6 +2,8 @@
 -load smartmin sms temba compress humanize i18n
 -block page-title
   {{object.name}}
+  -if object.is_archived
+    -trans "(Archived)"
 
 -block title-icon
   .title-icon
@@ -11,6 +13,9 @@
   .title-text
     %h1
       {{title}}
+      -if object.is_archived
+        -trans "(Archived)"
+
     %h5
       .icon-users-2
       -if object.group.is_active

--- a/templates/campaigns/campaignevent_read.haml
+++ b/templates/campaigns/campaignevent_read.haml
@@ -19,6 +19,8 @@
     %h2
       %a{href:"{% url 'campaigns.campaign_read' object.campaign.pk %}"}
         {{object.campaign}}
+        -if object.campaign.is_archived
+          -trans "(Archived)"
     %h4
       -if object.offset < 0
         {{object.abs_offset}} {{object.get_unit_display|slice:"-1"}}{{object.offset|pluralize}} Before

--- a/templates/contacts/contactgroup_delete.haml
+++ b/templates/contacts/contactgroup_delete.haml
@@ -6,7 +6,7 @@
 
   -with flows=object.dependent_flows.all
 
-    -if flows or triggers
+    -if flows or triggers or campaigns
       -blocktrans with group_name=object.name
         Sorry, {{group_name}} cannot be deleted quite yet.
       %p
@@ -41,6 +41,21 @@
         flow.
       -plural
         flows.
+
+    -if campaigns
+      -blocktrans count counter=campaigns|length
+        There is an active campaign using this group. It cannot be deleted until it is removed from the
+
+        -plural
+          There are {{counter}} campaigns using this group. It cannot be deleted until it is removed from the
+
+      -for campaign in campaigns
+        <a href="{%url 'campaigns.campaign_read' campaign.id%}">{{campaign.name}}</a>{{forloop|oxford}}
+
+      -blocktrans count counter=campaigns|length
+        campaign.
+      -plural
+        campaigns.
 
       :javascript
         $(".modal-footer .btn.primary").hide();


### PR DESCRIPTION
This prevents users to delete contact groups that have active campaigns.
Initially we were only preventing users to delete contact groups that
had active triggers and active flows.

Two new actions, 'Activate' and 'Archive', have been added to the read
Campaign page. These actions enable users to quickly archive or activate
a campaign.

An archived campaign will get an "(Archived)" suffix to the title and
this is also visible on the read CampaignEvent page.

Gear actions depend on the *is_archived* status. For an archived
campaign we only show 'Activate' action, and for active campaign we show
'Add Event', 'Edit' and 'Archive' actions. CampaignEvent gear actions
for an archived campaign only allow users to delete a CampaignEvent.

Updates on the API endpoint for Campaign prevent users to modify
archived or inactive campaigns. We also don't allow updates of
CampaignEvents on archived Campaigns.

Group API endpoint has the same behavior as the Web view and now
prevents deletion of Groups that have related Triggers, Flows and
Campaigns. However at this time there is no API support for deleting
Triggers, Flows and Campaigns and users must do those actions using the
Web views.