### PR TITLE
🧼 Honour Flow.is_active on the Web view 

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -313,6 +313,30 @@ class FlowTest(TembaTest):
         response = self.client.get(reverse("flows.flow_revisions", args=[self.flow.pk]))
         self.assertEqual(0, len(response.json()))
 
+    def test_revision_history_of_inactive_flow(self):
+        self.flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_revisions", args=[self.flow.pk]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_flow_activity_of_inactive_flow(self):
+        self.flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_activity", args=[self.flow.pk]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_flow_json_of_inactive_flow(self):
+        self.flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_json", args=[self.flow.id]))
+
+        self.assertEqual(response.status_code, 404)
+
     def test_get_localized_text(self):
 
         text_translations = dict(eng="Hello", spa="Hola", fra="Salut")
@@ -551,6 +575,48 @@ class FlowTest(TembaTest):
             f"/org/service/?organization={self.flow.org_id}&redirect_url=/flow/editor/{self.flow.uuid}/",
         )
         self.assertTrue(gear_links[-2]["divider"])
+
+        self.assertListEqual(
+            [link.get("title") for link in gear_links],
+            [
+                "Start Flow",
+                "Results",
+                None,
+                "Edit",
+                "Copy",
+                "Export",
+                None,
+                "Revision History",
+                "Delete",
+                None,
+                "Service",
+            ],
+        )
+
+    def test_flow_editor_for_archived_flow(self):
+        self.flow.archive()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_editor", args=[self.flow.uuid]))
+
+        gear_links = response.context["view"].get_gear_links()
+
+        self.assertFalse(response.context["mutable"])
+        self.assertFalse(response.context["can_start"])
+
+        # cannot 'Edit' an archived Flow
+        self.assertListEqual(
+            [link.get("title") for link in gear_links],
+            ["Results", "Copy", "Export", None, "Revision History", "Delete"],
+        )
+
+    def test_flow_editor_for_inactive_flow(self):
+        self.flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_editor", args=[self.flow.uuid]))
+
+        self.assertEqual(response.status_code, 404)
 
     def test_states(self):
         # set our flow
@@ -3593,6 +3659,29 @@ class FlowTest(TembaTest):
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.request["PATH_INFO"], reverse("flows.flow_editor", args=[language_flow.uuid]))
         self.assertEqual(language_flow.base_language, language.iso_code)
+
+    def test_flow_update_of_inactive_flow(self):
+        flow = self.get_flow("favorites")
+        # release the flow
+        flow.release()
+
+        post_data = {"name": "Flow that does not exist"}
+
+        self.login(self.admin)
+        response = self.client.post(reverse("flows.flow_update", args=[flow.pk]), post_data)
+
+        # can't delete already released flow
+        self.assertEqual(response.status_code, 404)
+
+    def test_flow_results_of_inactive_flow(self):
+        flow = self.get_flow("favorites")
+        # release the flow
+        flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_results", args=[flow.uuid]))
+
+        self.assertEqual(response.status_code, 404)
 
     def test_mailroom_starts(self):
         self.login(self.admin)
@@ -7049,6 +7138,36 @@ class FlowsTest(FlowFileTest):
         self.assertEqual(24, len(response.context["hod"]))
         self.assertEqual(7, len(response.context["dow"]))
 
+    def test_flow_activity_chart_of_inactive_flow(self):
+        flow = self.get_flow("favorites")
+        # release the flow
+        flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_activity_chart", args=[flow.pk]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_flow_run_table_of_inactive_flow(self):
+        flow = self.get_flow("favorites")
+        # release the flow
+        flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_run_table", args=[flow.pk]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_flow_category_counts_of_inactive_flow(self):
+        flow = self.get_flow("favorites")
+        # release the flow
+        flow.release()
+
+        self.login(self.admin)
+        response = self.client.get(reverse("flows.flow_category_counts", args=[flow.uuid]))
+
+        self.assertEqual(response.status_code, 404)
+
     def test_send_all_replies(self):
         flow = self.get_flow("send_all")
 
@@ -8269,6 +8388,18 @@ class FlowsTest(FlowFileTest):
         chw = self.contact
         sms = Msg.objects.filter(contact=chw).order_by("-created_on")[0]
         self.assertEqual("Please follow up with Judy Pottier, she has reported she is in pain.", sms.text)
+
+    def test_flow_delete_of_inactive_flow(self):
+        flow = self.get_flow("favorites")
+
+        # release the flow
+        flow.release()
+
+        self.login(self.admin)
+        response = self.client.post(reverse("flows.flow_delete", args=[flow.pk]))
+
+        # can't delete already released flow
+        self.assertEqual(response.status_code, 404)
 
     def test_flow_delete(self):
         from temba.campaigns.models import Campaign, CampaignEvent

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -274,6 +274,11 @@ class FlowCRUDL(SmartCRUDL):
 
     model = Flow
 
+    class AllowOnlyActiveFlowMixin(object):
+        def get_queryset(self):
+            initial_queryset = super().get_queryset()
+            return initial_queryset.filter(is_active=True)
+
     class RecentMessages(OrgObjPermsMixin, SmartReadView):
         def get(self, request, *args, **kwargs):
             exit_uuids = request.GET.get("exits", "").split(",")
@@ -289,7 +294,7 @@ class FlowCRUDL(SmartCRUDL):
 
             return JsonResponse(recent_messages, safe=False)
 
-    class Revisions(OrgObjPermsMixin, SmartReadView):
+    class Revisions(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartReadView):
         def get(self, request, *args, **kwargs):
             flow = self.get_object()
 
@@ -430,7 +435,7 @@ class FlowCRUDL(SmartCRUDL):
 
             return obj
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class Delete(AllowOnlyActiveFlowMixin, ModalMixin, OrgObjPermsMixin, SmartDeleteView):
         fields = ("id",)
         cancel_url = "uuid@flows.flow_editor"
         success_message = ""
@@ -470,7 +475,7 @@ class FlowCRUDL(SmartCRUDL):
             # redirect to the newly created flow
             return HttpResponseRedirect(reverse("flows.flow_editor", args=[copy.uuid]))
 
-    class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(AllowOnlyActiveFlowMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
         class BaseUpdateFlowFormMixin:
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
@@ -965,7 +970,7 @@ class FlowCRUDL(SmartCRUDL):
                 dict(message_completions=messages_completions, function_completions=function_completions)
             )
 
-    class Editor(OrgObjPermsMixin, SmartReadView):
+    class Editor(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartReadView):
         slug_url_kwarg = "uuid"
 
         def derive_title(self):
@@ -977,7 +982,7 @@ class FlowCRUDL(SmartCRUDL):
         def get_context_data(self, *args, **kwargs):
             context = super().get_context_data(*args, **kwargs)
 
-            flow = self.get_object(self.get_queryset())
+            flow = self.object
             org = self.request.user.get_org()
 
             # hangup any test calls if we have them
@@ -989,23 +994,28 @@ class FlowCRUDL(SmartCRUDL):
             if org:
                 languages = org.languages.all().order_by("orgs")
                 for lang in languages:
-                    if self.get_object().base_language == lang.iso_code:
+                    if flow.base_language == lang.iso_code:
                         context["base_language"] = lang
 
                 context["languages"] = languages
 
+            if flow.is_archived:
+                context["mutable"] = False
+                context["can_start"] = False
+            else:
+                context["mutable"] = self.has_org_perm("flows.flow_update") and not self.request.user.is_superuser
+                context["can_start"] = flow.flow_type != Flow.TYPE_VOICE or flow.org.supports_ivr()
+
             context["has_ussd_channel"] = bool(org and org.get_ussd_channel())
             context["media_url"] = "%s://%s/" % ("http" if settings.DEBUG else "https", settings.AWS_BUCKET_DOMAIN)
             context["is_starting"] = flow.is_starting()
-            context["mutable"] = self.has_org_perm("flows.flow_update") and not self.request.user.is_superuser
             context["has_airtime_service"] = bool(flow.org.is_connected_to_transferto())
-            context["can_start"] = flow.flow_type != Flow.TYPE_VOICE or flow.org.supports_ivr()
             context["has_mailroom"] = settings.MAILROOM_URL.startswith("http")
             return context
 
         def get_gear_links(self):
             links = []
-            flow = self.get_object()
+            flow = self.object
 
             if (
                 flow.flow_type not in [Flow.TYPE_SURVEY, Flow.TYPE_USSD]
@@ -1023,7 +1033,7 @@ class FlowCRUDL(SmartCRUDL):
             if len(links) > 1:
                 links.append(dict(divider=True))
 
-            if self.has_org_perm("flows.flow_update"):
+            if self.has_org_perm("flows.flow_update") and not flow.is_archived:
                 links.append(dict(title=_("Edit"), js_class="update-rulesflow", href="#"))
 
             if self.has_org_perm("flows.flow_copy"):
@@ -1224,7 +1234,7 @@ class FlowCRUDL(SmartCRUDL):
                 response["REDIRECT"] = self.get_success_url()
                 return response
 
-    class ActivityChart(OrgObjPermsMixin, SmartReadView):
+    class ActivityChart(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartReadView):
         """
         Intercooler helper that renders a chart of activity by a given period
         """
@@ -1346,7 +1356,7 @@ class FlowCRUDL(SmartCRUDL):
 
             return context
 
-    class RunTable(OrgObjPermsMixin, SmartReadView):
+    class RunTable(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartReadView):
         """
         Intercooler helper which renders rows of runs to be embedded in an existing table with infinite scrolling
         """
@@ -1405,13 +1415,13 @@ class FlowCRUDL(SmartCRUDL):
             context["paginate_by"] = self.paginate_by
             return context
 
-    class CategoryCounts(OrgObjPermsMixin, SmartReadView):
+    class CategoryCounts(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartReadView):
         slug_url_kwarg = "uuid"
 
         def render_to_response(self, context, **response_kwargs):
             return JsonResponse(self.get_object().get_category_counts())
 
-    class Results(OrgObjPermsMixin, SmartReadView):
+    class Results(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartReadView):
         slug_url_kwarg = "uuid"
 
         def get_gear_links(self):
@@ -1442,7 +1452,7 @@ class FlowCRUDL(SmartCRUDL):
             context["utcoffset"] = int(datetime.now(flow.org.timezone).utcoffset().total_seconds() // 60)
             return context
 
-    class Activity(OrgObjPermsMixin, SmartReadView):
+    class Activity(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartReadView):
         def get(self, request, *args, **kwargs):
             flow = self.get_object(self.get_queryset())
             (active, visited) = flow.get_activity()
@@ -1634,7 +1644,7 @@ class FlowCRUDL(SmartCRUDL):
 
             return JsonResponse(dict(status="success", description="Message sent to Flow", **response))
 
-    class Json(OrgObjPermsMixin, SmartUpdateView):
+    class Json(AllowOnlyActiveFlowMixin, OrgObjPermsMixin, SmartUpdateView):
         success_message = ""
 
         def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Added `AllowOnlyActiveFlowMixin` that filters flows on is_active=True.
This prevents users from accessing released flows through the Web view.

Archived flows are can't be started or edited.