### PR TITLE
🏴󠁧󠁢󠁷󠁬󠁳󠁿 Include default country in serialized environments used for simulation

### DIFF
--- a/temba/flows/server/serialize.py
+++ b/temba/flows/server/serialize.py
@@ -56,6 +56,7 @@ def serialize_environment(org):
         "timezone": str(org.timezone),
         "default_language": org.primary_language.iso_code if org.primary_language else None,
         "allowed_languages": list(org.get_language_codes()),
+        "default_country": org.get_country_code(),
         "redaction_policy": "urns" if org.is_anon else "none",
     }
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -11865,6 +11865,7 @@ class AssetServerTest(TembaTest):
                 "timezone": "Africa/Kigali",
                 "default_language": None,
                 "allowed_languages": [],
+                "default_country": "RW",
                 "redaction_policy": "none",
             },
         )


### PR DESCRIPTION
The real fix here might be a rethink on mailroom simulation and where the editor should be pulling environment from, but this will get phone number tests working again in simulation...

Fixes https://app.intercom.io/a/apps/l6e7tr01/inbox/inbox/unassigned/conversations/20423530793