### PR TITLE
💦 Replace deprecated `all()` with `list()` method, Stripe Python API

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1772,7 +1772,7 @@ class Org(SmartModel):
                 # remove existing cards
                 # TODO: this is all a bit wonky because we are using the Stripe JS widget..
                 # if we instead used on our mechanism to display / edit cards we could be a bit smarter
-                existing_cards = [c for c in customer.cards.all().data]
+                existing_cards = [c for c in customer.cards.list().data]
                 for card in existing_cards:
                     card.delete()
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -4194,7 +4194,7 @@ class StripeCreditsTest(TembaTest):
             def __init__(self):
                 self.throw = False
 
-            def all(self):
+            def list(self):
                 return dict_to_struct("MockCardData", dict(data=[MockCard(), MockCard()]))
 
             def create(self, card):


### PR DESCRIPTION
Fixes Sentry error: https://sentry.io/nyaruka/textit/issues/863324930/

`.all()` method was deprecated in 2016 and replaced by a `list()` method

 * https://github.com/stripe/stripe-python/blob/master/CHANGELOG.md#1280---2016-01-04