### PR TITLE
😽 Replace traceback.print_exc() with logger.error

### DIFF
--- a/temba/airtime/models.py
+++ b/temba/airtime/models.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import time
 
 import requests
@@ -12,6 +13,8 @@ from temba.channels.models import Channel
 from temba.contacts.models import TEL_SCHEME, Contact
 from temba.orgs.models import TRANSFERTO_ACCOUNT_CURRENCY, TRANSFERTO_ACCOUNT_LOGIN, TRANSFERTO_AIRTIME_API_TOKEN, Org
 from temba.utils import get_country_code_by_name, json
+
+logger = logging.getLogger(__name__)
 
 
 class AirtimeTransfer(SmartModel):
@@ -267,9 +270,7 @@ class AirtimeTransfer(SmartModel):
             airtime.status = AirtimeTransfer.SUCCESS
 
         except Exception as e:
-            import traceback
-
-            traceback.print_exc()
+            logger.error(f"Could not trigger AirtimeEvent: {str(e)}", exc_info=True)
 
             airtime.status = AirtimeTransfer.FAILED
             message = "Error transferring airtime: %s" % str(e)

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -1,4 +1,5 @@
 import hmac
+import logging
 import time
 import uuid
 from datetime import timedelta
@@ -25,6 +26,8 @@ from temba.utils import json, on_transaction_commit, prepped_request_to_str
 from temba.utils.cache import get_cacheable_attr
 from temba.utils.http import http_headers
 from temba.utils.models import JSONAsTextField
+
+logger = logging.getLogger(__name__)
 
 
 class APIPermission(BasePermission):
@@ -355,9 +358,7 @@ class WebHookEvent(SmartModel):
                 raise Exception("Got non 200 response (%d) from webhook." % response.status_code)
 
         except Exception as e:
-            import traceback
-
-            traceback.print_exc()
+            logger.error(f"Could not trigger flow webhook: {str(e)}", exc_info=True)
 
             webhook_event.status = cls.STATUS_FAILED
             message = "Error calling webhook: %s" % str(e)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1034,7 +1034,7 @@ class Channel(TembaModel):
 
             except Exception as e:  # pragma: no cover
                 # proceed with removing this channel but log the problem
-                logger.exception(str(e))
+                logger.error(f"Unable to deactivate a channel: {str(e)}", exc_info=True)
 
             # hangup all its calls
             from temba.ivr.models import IVRCall

--- a/temba/channels/types/twitter_activity/type.py
+++ b/temba/channels/types/twitter_activity/type.py
@@ -60,7 +60,7 @@ class TwitterActivityType(ChannelType):
             channel.save(update_fields=["config"])
             client.subscribe_to_webhook(config["env_name"])
         except Exception as e:  # pragma: no cover
-            logger.exception(str(e))
+            logger.error(f"Unable to activate TwitterActivity: {str(e)}", exc_info=True)
             raise ValidationError(e)
 
     def deactivate(self, channel):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -99,8 +99,8 @@ COUNTRY_CALLING_CODES = {
     "TD": (235,),  # Chad
     "CL": (56,),  # Chile
     "CN": (86,),  # China
-    "CX": (6189164,),  # Christmas Island
-    "CC": (6189162,),  # Cocos (Keeling) Islands
+    "CX": (6_189_164,),  # Christmas Island
+    "CC": (6_189_162,),  # Cocos (Keeling) Islands
     "CO": (57,),  # Colombia
     "KM": (269,),  # Comoros
     "CD": (243,),  # Congo (the Democratic Republic of the)
@@ -144,13 +144,13 @@ COUNTRY_CALLING_CODES = {
     "GP": (590,),  # Guadeloupe
     "GU": (1671,),  # Guam
     "GT": (502,),  # Guatemala
-    "GG": (441481, 447781, 447839, 447911),  # Guernsey
+    "GG": (441_481, 447_781, 447_839, 447_911),  # Guernsey
     "GN": (224,),  # Guinea
     "GW": (245,),  # Guinea-Bissau
     "GY": (592,),  # Guyana
     "HT": (509,),  # Haiti
     "HM": (),  # Heard Island and McDonald Islands
-    "VA": (379, 3906698),  # Holy See
+    "VA": (379, 3_906_698),  # Holy See
     "HN": (504,),  # Honduras
     "HK": (852,),  # Hong Kong
     "HU": (36,),  # Hungary
@@ -160,12 +160,12 @@ COUNTRY_CALLING_CODES = {
     "IR": (98,),  # Iran (Islamic Republic of)
     "IQ": (964,),  # Iraq
     "IE": (353,),  # Ireland
-    "IM": (441624, 447524, 447624, 447924),  # Isle of Man
+    "IM": (441_624, 447_524, 447_624, 447_924),  # Isle of Man
     "IL": (972,),  # Israel
     "IT": (39,),  # Italy
     "JM": (1876,),  # Jamaica
     "JP": (81,),  # Japan
-    "JE": (441534,),  # Jersey
+    "JE": (441_534,),  # Jersey
     "JO": (962,),  # Jordan
     "KZ": (76, 77),  # Kazakhstan
     "KE": (254,),  # Kenya
@@ -195,7 +195,7 @@ COUNTRY_CALLING_CODES = {
     "MQ": (596,),  # Martinique
     "MR": (222,),  # Mauritania
     "MU": (230,),  # Mauritius
-    "YT": (262269, 262639),  # Mayotte
+    "YT": (262_269, 262_639),  # Mayotte
     "MX": (52,),  # Mexico
     "FM": (691,),  # Micronesia (Federated States of)
     "MD": (373,),  # Moldova (the Republic of)
@@ -1041,9 +1041,8 @@ class BaseClaimNumberMixin(ClaimViewMixin):
 
             return HttpResponseRedirect("%s?success" % reverse("public.public_welcome"))
         except Exception as e:  # pragma: needs cover
-            import traceback
+            logger.error(f"Unable to claim a number: {str(e)}", exc_info=True)
 
-            traceback.print_exc()
             message = str(e)
             if message:
                 form._errors["phone_number"] = form.error_class([message])

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -744,7 +744,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
             es_search = search_object.source(include=["id"]).using(ES).scan()
             return mapEStoDB(Contact, es_search, only_ids=True)
         except SearchException:
-            logger.exception("Error evaluating query", exc_info=True)
+            logger.error("Error evaluating query", exc_info=True)
             raise  # reraise the exception
 
     @classmethod
@@ -2310,9 +2310,9 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
             try:
                 should_add = evaluate_query(self.org, dynamic_group.query, contact_json=contact_search_json)
-            except Exception:  # pragma: no cover
+            except Exception as e:  # pragma: no cover
                 should_add = False
-                logger.exception("Error evaluating query", exc_info=True)
+                logger.error(f"Error evaluating query: {str(e)}", exc_info=True)
 
             changed_set.update(dynamic_group._update_contacts(user, [self], add=should_add))
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from datetime import datetime, timedelta
 from functools import cmp_to_key
 from itertools import chain
@@ -312,9 +311,11 @@ class FlowCRUDL(SmartCRUDL):
                         # "expected" error in the def, silently cull it
                         pass
 
-                    except Exception:
+                    except Exception as e:
                         # something else, we still cull, but report it to sentry
-                        logger.exception("Error validating flow revision: %s [%d]" % (flow.uuid, revision.id))
+                        logger.error(
+                            f"Error validating flow revision ({flow.uuid} [{revision.id}]): {str(e)}", exc_info=True
+                        )
                         pass
 
                 return JsonResponse(revisions, safe=False)
@@ -1573,7 +1574,7 @@ class FlowCRUDL(SmartCRUDL):
                     )
                 except Exception as e:  # pragma: needs cover
 
-                    traceback.print_exc()
+                    logger.error(f"Could not create incoming message: {str(e)}", exc_info=True)
                     return JsonResponse(
                         dict(status="error", description="Error creating message: %s" % str(e)), status=400
                     )

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 from django_redis import get_redis_connection
@@ -10,6 +11,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from temba.channels.models import Channel, ChannelConnection, ChannelLog, ChannelType
 from temba.utils.http import HttpEvent
+
+logger = logging.getLogger(__name__)
 
 
 class IVRManager(models.Manager):
@@ -129,18 +132,14 @@ class IVRCall(ChannelConnection):
                 client.start_call(self, to=tel, from_=self.channel.address, status_callback=url)
 
             except IVRException as e:
-                import traceback
-
-                traceback.print_exc()
+                logger.error(f"Could not start IVR call: {str(e)}", exc_info=True)
 
                 if self.contact.is_test:
                     run = FlowRun.objects.filter(connection=self)
                     ActionLog.create(run[0], "Call ended. %s" % str(e))
 
             except Exception as e:  # pragma: no cover
-                import traceback
-
-                traceback.print_exc()
+                logger.error(f"Could not start IVR call: {str(e)}", exc_info=True)
 
                 ChannelLog.log_ivr_interaction(
                     self, "Call failed unexpectedly", HttpEvent(method="INTERNAL", url=None, response_body=str(e))

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -1,4 +1,5 @@
 import cProfile
+import logging
 import pstats
 import traceback
 from io import StringIO
@@ -11,6 +12,8 @@ from django.utils import timezone, translation
 from temba.contacts.models import Contact
 from temba.orgs.models import Org
 from temba.policies.models import Policy
+
+logger = logging.getLogger(__name__)
 
 
 class ExceptionMiddleware:
@@ -60,8 +63,8 @@ class BrandingMiddleware:
         host = "localhost"
         try:
             host = request.get_host()
-        except Exception:  # pragma: needs cover
-            traceback.print_exc()
+        except Exception as e:  # pragma: needs cover
+            logger.error(f"Could not get host: {host}, {str(e)}", exc_info=True)
 
         request.branding = BrandingMiddleware.get_branding_for_host(host)
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import traceback
 from array import array
 from datetime import date, datetime, timedelta
 from uuid import uuid4
@@ -102,8 +101,8 @@ def get_message_handlers():
             try:
                 cls = MessageHandler.find(handler_class)
                 handlers.append(cls())
-            except Exception:  # pragma: no cover
-                traceback.print_exc()
+            except Exception as e:  # pragma: no cover
+                logger.error(f"Unable to get message handlers: {str(e)}", exc_info=True)
 
         __message_handlers = handlers
 
@@ -1042,10 +1041,7 @@ class Msg(models.Model):
                     if handled:
                         break
                 except Exception as e:  # pragma: no cover
-                    import traceback
-
-                    traceback.print_exc()
-                    logger.exception("Error in message handling: %s" % e)
+                    logger.error(f"Error in message handling: {str(e)}", exc_info=True)
 
         cls.mark_handled(msg)
 

--- a/temba/utils/export.py
+++ b/temba/utils/export.py
@@ -1,4 +1,5 @@
 import gc
+import logging
 import os
 import time
 from datetime import datetime, timedelta
@@ -17,6 +18,8 @@ from . import analytics
 from .email import send_template_email
 from .models import TembaModel
 from .text import clean_string
+
+logger = logging.getLogger(__name__)
 
 
 class BaseExportAssetStore(BaseAssetStore):
@@ -93,9 +96,7 @@ class BaseExportTask(TembaModel):
                 os.unlink(temp_file.name)
 
         except Exception as e:
-            import traceback
-
-            traceback.print_exc()
+            logger.error(f"Unable to perform export: {str(e)}", exc_info=True)
             self.update_status(self.STATUS_FAILED)
             print(f"Failed to complete {self.analytics_key} with ID {self.id}")
 


### PR DESCRIPTION
This is more flexible because we utilize standard Python logging
framework to push exceptions to Sentry or log them to a file.