### PR TITLE
🥄 Use provided flow definition when simulating

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -5851,7 +5851,8 @@ class SimulationTest(FlowFileTest):
         flow = self.get_flow("favorites")
 
         # create our payload
-        payload = dict(version=2, trigger={})
+        payload = dict(version=2, trigger={}, flow={})
+
         url = reverse("flows.flow_simulate", args=[flow.pk])
 
         with patch("requests.post") as mock_post:
@@ -5871,9 +5872,10 @@ class SimulationTest(FlowFileTest):
             )
             self.assertEqual("https://mailroom.temba.io/mr/sim/start", mock_post.call_args_list[0][0][0])
             self.assertEqual("Token sesame", mock_post.call_args_list[0][1]["headers"]["Authorization"])
+            self.assertEqual(1, len(mock_post.call_args_list[0][1]["json"]["flows"]))
 
         # try a resume
-        payload = dict(version=2, session={}, resume={})
+        payload = dict(version=2, session={}, resume={}, flow={})
 
         with patch("requests.post") as mock_post:
             mock_post.return_value = MockResponse(400, '{"session": {}}')
@@ -5891,6 +5893,7 @@ class SimulationTest(FlowFileTest):
             )
             self.assertEqual("https://mailroom.temba.io/mr/sim/resume", mock_post.call_args_list[0][0][0])
             self.assertEqual("Token sesame", mock_post.call_args_list[0][1]["headers"]["Authorization"])
+            self.assertEqual(1, len(mock_post.call_args_list[0][1]["json"]["flows"]))
 
     def test_release_action_logs(self):
         flow = self.get_flow("group_split")

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1499,6 +1499,9 @@ class FlowCRUDL(SmartCRUDL):
                     payload["trigger"] = json_dict["trigger"]
                     payload["trigger"]["environment"] = serialize_environment(flow.org)
 
+                    if "flow" in json_dict:
+                        payload["flows"] = [{"uuid": flow.uuid, "definition": json_dict["flow"]}]
+
                     try:
                         return JsonResponse(client.sim_start(payload))
                     except mailroom.MailroomException:
@@ -1509,6 +1512,9 @@ class FlowCRUDL(SmartCRUDL):
                     payload["resume"] = json_dict["resume"]
                     payload["resume"]["environment"] = serialize_environment(flow.org)
                     payload["session"] = json_dict["session"]
+
+                    if "flow" in json_dict:
+                        payload["flows"] = [{"uuid": flow.uuid, "definition": json_dict["flow"]}]
 
                     try:
                         return JsonResponse(client.sim_resume(payload))


### PR DESCRIPTION
Allow posts to the simulation endpoint to include the definition to use during each sprint