### PR TITLE
🚄 Throttle API endpoints by user 

### DIFF
--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -4,7 +4,6 @@ from rest_framework import exceptions, status
 from rest_framework.authentication import BasicAuthentication, TokenAuthentication
 from rest_framework.exceptions import APIException
 from rest_framework.renderers import BrowsableAPIRenderer
-from rest_framework.throttling import ScopedRateThrottle
 
 from django.conf import settings
 from django.http import HttpResponseServerError
@@ -66,21 +65,6 @@ class APIBasicAuthentication(BasicAuthentication):
             return token.user, token
 
         raise exceptions.AuthenticationFailed("Invalid token or email")
-
-
-class OrgRateThrottle(ScopedRateThrottle):
-    """
-    Throttle class which rate limits across an org
-    """
-
-    def get_cache_key(self, request, view):
-        ident = None
-        if request.user.is_authenticated:
-            org = request.user.get_org()
-            if org:
-                ident = org.pk
-
-        return self.cache_format % {"scope": self.scope, "ident": ident or self.get_ident(request)}
 
 
 class DocumentationRenderer(BrowsableAPIRenderer):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -898,7 +898,7 @@ REST_FRAMEWORK = {
         "temba.api.support.APITokenAuthentication",
         "temba.api.support.APIBasicAuthentication",
     ),
-    "DEFAULT_THROTTLE_CLASSES": ("temba.api.support.OrgRateThrottle",),
+    "DEFAULT_THROTTLE_CLASSES": ("rest_framework.throttling.UserRateThrottle",),
     "DEFAULT_THROTTLE_RATES": {
         "v2": "2500/hour",
         "v2.contacts": "2500/hour",

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -898,7 +898,7 @@ REST_FRAMEWORK = {
         "temba.api.support.APITokenAuthentication",
         "temba.api.support.APIBasicAuthentication",
     ),
-    "DEFAULT_THROTTLE_CLASSES": ("rest_framework.throttling.UserRateThrottle",),
+    "DEFAULT_THROTTLE_CLASSES": ("rest_framework.throttling.ScopedRateThrottle",),
     "DEFAULT_THROTTLE_RATES": {
         "v2": "2500/hour",
         "v2.contacts": "2500/hour",

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -898,7 +898,7 @@ REST_FRAMEWORK = {
         "temba.api.support.APITokenAuthentication",
         "temba.api.support.APIBasicAuthentication",
     ),
-    "DEFAULT_THROTTLE_CLASSES": ("rest_framework.throttling.ScopedRateThrottle",),
+    "DEFAULT_THROTTLE_CLASSES": ("temba.api.support.OrgUserRateThrottle",),
     "DEFAULT_THROTTLE_RATES": {
         "v2": "2500/hour",
         "v2.contacts": "2500/hour",


### PR DESCRIPTION
Currently different dashboards can't honor the rate limit back downs because they don't know about each other