### PR TITLE
📶 fix simulator to field with empty value

### DIFF
--- a/static/coffee/simulator_go.coffee
+++ b/static/coffee/simulator_go.coffee
@@ -121,7 +121,10 @@ window.renderSimEvent = (event) ->
       window.addSimMessage("MT", "Broadcast sent with text \"" + event.translations[event.base_language].text + "\"")
 
     when "contact_field_changed"
-      window.addSimMessage("log", "Updated " + event.field.name + " to \"" + event.value.text + "\"")
+      text = ''
+      if event.value
+        text = event.value.text
+      window.addSimMessage("log", "Updated " + event.field.name + " to \"" + text + "\"")
 
     when "contact_groups_changed"
       if event.groups_added


### PR DESCRIPTION
Fixes when using @("")

Uncaught TypeError: Cannot read property 'text' of null
    at window.renderSimEvent (c75858dca344.js:398)
    at window.updateSimResults (c75858dca344.js:393)
    at Object.<anonymous> (c75858dca344.js:393)
    at fire (jquery.js:2913)
    at Object.fireWith [as resolveWith] (jquery.js:3025)
    at done (jquery.js:7400)
    at XMLHttpRequest.<anonymous> (jquery.js:7822)