### PR TITLE
📛 Default page title when contact has no name or URN

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -238,7 +238,7 @@ class ContactCRUDLTest(TembaTestMixin, _CRUDLTest):
         # contact without name or urn
         nameless = Contact.objects.create(org=self.org)
         response = self.client.get(reverse("contacts.contact_read", args=[nameless.uuid]))
-        self.assertContains(response, "Unnamed Contact")
+        self.assertContains(response, "Contact Details")
 
         # invalid uuid should return 404
         response = self.client.get(reverse("contacts.contact_read", args=["invalid-uuid"]))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -73,7 +73,7 @@ from .tasks import check_elasticsearch_lag, squash_contactgroupcounts
 from .templatetags.contacts import activity_icon, contact_field, history_class
 
 
-class ContactCRUDLTest(_CRUDLTest):
+class ContactCRUDLTest(TembaTestMixin, _CRUDLTest):
     def setUp(self):
         from temba.contacts.views import ContactCRUDL
 
@@ -229,6 +229,16 @@ class ContactCRUDLTest(_CRUDLTest):
         # can no longer access
         response = self.client.get(read_url)
         self.assertEqual(response.status_code, 404)
+
+        # contact with only a urn
+        nameless = self.create_contact("", twitter="bobby_anon")
+        response = self.client.get(reverse("contacts.contact_read", args=[nameless.uuid]))
+        self.assertContains(response, "bobby_anon")
+
+        # contact without name or urn
+        nameless = Contact.objects.create(org=self.org)
+        response = self.client.get(reverse("contacts.contact_read", args=[nameless.uuid]))
+        self.assertContains(response, "Unnamed Contact")
 
         # invalid uuid should return 404
         response = self.client.get(reverse("contacts.contact_read", args=["invalid-uuid"]))

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -134,7 +134,7 @@ class ESMockWithScrollMultiple(ESMockWithScroll):
         return patched_object()
 
 
-class TembaTestMixin(object):
+class TembaTestMixin:
     def clear_cache(self):
         """
         Clears the redis cache. We are extra paranoid here and check that redis host is 'localhost'

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -6,7 +6,7 @@
 -block buttons
 
 -block page-title
-  {{contact|name_or_urn:user_org}}
+  {{contact|name_or_urn:user_org|default:"Unnamed Contact"}}
 
 -block title
   -if contact.is_blocked

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -6,7 +6,7 @@
 -block buttons
 
 -block page-title
-  {{contact|name_or_urn:user_org|default:"Unnamed Contact"}}
+  {{contact|name_or_urn:user_org|default:"Contact Details"}}
 
 -block title
   -if contact.is_blocked
@@ -16,7 +16,7 @@
   -else
     .medium-help.icon-user{style:"float:left"}
   %h2.header-margin
-    {{contact|name_or_urn:user_org}}
+    {{contact|name_or_urn:user_org|default:"Contact Details"}}
 
   %h5.header-margin{style:"margin-bottom: 10px"}
     -if user_org.is_anon


### PR DESCRIPTION
just noticed this from testing surveyor contacts who often don't have any identifying info

<img width="138" alt="captura de pantalla 2019-02-07 a la s 11 11 49" src="https://user-images.githubusercontent.com/675558/52426960-09a54880-2acd-11e9-9c5a-09ade76cefa3.png">
