### PR TITLE
🥴 Prevent users from updating dynamic groups if query is invalid

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2849,7 +2849,7 @@ class ContactGroup(TembaModel):
         """
         Updates the query for a dynamic group
         """
-        from .search import extract_fields, parse_query
+        from .search import extract_fields, parse_query, SearchException
         from .tasks import reevaluate_dynamic_group
 
         if not self.is_dynamic:
@@ -2858,6 +2858,12 @@ class ContactGroup(TembaModel):
             raise ValueError("Cannot update query on a group which is currently re-evaluating")
 
         parsed_query = parse_query(text=query)
+
+        # check if query is valid, raise ValueError if it's not
+        try:
+            parsed_query.as_elasticsearch(self.org)
+        except SearchException as e:
+            raise ValueError(str(e))
 
         if not parsed_query.can_be_dynamic_group():
             raise ValueError("Cannot use query '%s' as a dynamic group")

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -126,6 +126,10 @@ class ContactGroupForm(forms.ModelForm):
     def clean_query(self):
         try:
             parsed_query = parse_query(text=self.cleaned_data["query"], as_anon=self.org.is_anon)
+
+            # try to prepare query as it would be used, might raise errors for invalid search operators
+            parsed_query.as_elasticsearch(self.org)
+
             cleaned_query = parsed_query.as_text()
 
             if (
@@ -141,8 +145,7 @@ class ContactGroupForm(forms.ModelForm):
                 raise forms.ValidationError(_('You cannot create a dynamic group based on "name" or "id".'))
         except forms.ValidationError as e:
             raise e
-
-        except Exception as e:
+        except SearchException as e:
             raise forms.ValidationError(str(e))
 
     class Meta:


### PR DESCRIPTION
If query is invalid a user will see an error message.

Fixes: https://sentry.io/nyaruka/textit/issues/878003816/