### PR TITLE
🗑️ Remove remaining is_test checks

### DIFF
--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -744,7 +744,7 @@ class EventFire(Model):
             scheduled = event.calculate_scheduled_fire(contact)
 
             # and if we have a date, then schedule it
-            if scheduled and not contact.is_test:
+            if scheduled:
                 EventFire.objects.create(event=event, contact=contact, scheduled=scheduled)
 
     @classmethod
@@ -764,7 +764,7 @@ class EventFire(Model):
                 scheduled = event.calculate_scheduled_fire(contact)
 
                 # and if we have a date, then schedule it
-                if scheduled and not contact.is_test:
+                if scheduled:
                     EventFire.objects.create(event=event, contact=contact, scheduled=scheduled)
 
     def __str__(self):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2079,10 +2079,6 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         if channel is None or (Channel.ROLE_SEND not in channel.role and Channel.ROLE_CALL not in channel.role):
             return
 
-        # don't set preferred channels for test contacts
-        if self.is_test:
-            return
-
         urns = self.get_urns()
 
         # make sure all urns of the same scheme use this channel (only do this for TEL, others are channel specific)
@@ -2236,7 +2232,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         from .search import evaluate_query
 
         # blocked, stopped or test contacts can't be in dynamic groups
-        if self.is_blocked or self.is_stopped or self.is_test:
+        if self.is_blocked or self.is_stopped:
             return set()
 
         # cache contact search json

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6412,12 +6412,6 @@ class ContactTest(TembaTest):
         twitter = Channel.create(self.org, self.user, None, "TT", name="Twitter Channel", address="@rapidpro")
         Channel.create(self.org, self.user, None, "TG", name="Twitter Channel", address="@rapidpro")
 
-        # can't set preferred channel for test contacts
-        self.test_contact = self.create_contact(name="Test Contact", number="+12065551212", is_test=True)
-        self.test_contact.update_urns(self.admin, ["tel:+12065551212", "telegram:12515", "twitter:macklemore"])
-        self.test_contact.set_preferred_channel(twitter)
-        self.assertEqual(self.test_contact.urns.all()[0].scheme, TEL_SCHEME)
-
         # update our contact URNs, give them telegram and twitter with telegram being preferred
         self.joe.update_urns(self.admin, ["telegram:12515", "twitter:macklemore"])
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -247,7 +247,6 @@ class TembaTestMixin:
 
         kwargs["name"] = name
         kwargs["urns"] = urns
-        kwargs["is_test"] = is_test
 
         if "org" not in kwargs:
             kwargs["org"] = self.org
@@ -283,8 +282,7 @@ class TembaTestMixin:
         if "created_on" not in kwargs:
             kwargs["created_on"] = timezone.now()
 
-        if not kwargs["contact"].is_test:
-            (kwargs["topup_id"], amount) = kwargs["org"].decrement_credit()
+        (kwargs["topup_id"], amount) = kwargs["org"].decrement_credit()
 
         return Msg.objects.create(**kwargs)
 


### PR DESCRIPTION
Except in querysets - as we still need to hit db indexes that use `is_test=True`

Previously removed these from the engine components but not elsewhere.