### PR TITLE
🏵️ fallback to org domain when no channel domain set

### DIFF
--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -51,7 +51,7 @@ class TwilioType(ChannelType):
         client = org.get_twilio_client()
         config = channel.config
 
-        base_url = "https://" + config[Channel.CONFIG_CALLBACK_DOMAIN]
+        base_url = "https://" + config.get(Channel.CONFIG_CALLBACK_DOMAIN, org.get_brand_domain())
 
         # build our URLs
         channel_uuid = str(channel.uuid)


### PR DESCRIPTION
Older channels don't have this attribute set on them, so use the org setting instead.