### PR TITLE
⚠️ Show Django warning if mailroom URL not configured

### DIFF
--- a/temba/flows/__init__.py
+++ b/temba/flows/__init__.py
@@ -1,0 +1,1 @@
+from .checks import *  # noqa

--- a/temba/flows/checks.py
+++ b/temba/flows/checks.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django.core.checks import Warning, register
+
+
+@register()
+def mailroom_url(app_configs, **kwargs):
+    if not settings.MAILROOM_URL:
+        return [
+            Warning(
+                "No mailroom URL set, simulation will not be available",
+                hint="Set MAILROOM_URL in your Django settings.",
+            )
+        ]
+    return []

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -36,6 +36,7 @@ from temba.utils import json
 from temba.utils.profiler import QueryTracker
 from temba.values.constants import Value
 
+from .checks import mailroom_url
 from .flow_migrations import (
     map_actions,
     migrate_export_to_version_9,
@@ -11214,3 +11215,12 @@ class AssetServerTest(TembaTest):
                 ]
             },
         )
+
+
+class SystemChecksTest(TembaTest):
+    def test_mailroom_url(self):
+        with override_settings(MAILROOM_URL="http://mailroom.io"):
+            self.assertEqual(len(mailroom_url(None)), 0)
+
+        with override_settings(MAILROOM_URL=None):
+            self.assertEqual(mailroom_url(None)[0].msg, "No mailroom URL set, simulation will not be available")

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -993,7 +993,7 @@ class FlowCRUDL(SmartCRUDL):
             context["static_url"] = static_url
             context["is_starting"] = flow.is_starting()
             context["has_airtime_service"] = bool(flow.org.is_connected_to_transferto())
-            context["has_mailroom"] = settings.MAILROOM_URL.startswith("http")
+            context["has_mailroom"] = bool(settings.MAILROOM_URL)
             return context
 
         def get_gear_links(self):


### PR DESCRIPTION
Added a system check previously to error if STORAGE_URL wasn't set and now this one checks if MAILROOM_URL isn't set and warns you that you won't be able to do simulation.

<img width="222" alt="captura de pantalla 2019-02-19 a la s 14 18 46" src="https://user-images.githubusercontent.com/675558/53041203-61d73580-3451-11e9-80e4-1700ed30a068.png">
