### PR TITLE
🐌  Fix slow contact list pages

### DIFF
--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -257,13 +257,7 @@ class ContactListView(ContactListPaginationMixin, OrgPermsMixin, SmartListView):
                 return Contact.objects.none()
         else:
             # if user search is not defined, use DB to select contacts
-            test_contact_ids = Contact.objects.filter(org=org, is_test=True).values_list("id", flat=True)
-            return (
-                group.contacts.all()
-                .exclude(id__in=test_contact_ids)
-                .order_by("-id")
-                .prefetch_related("org", "all_groups")
-            )
+            return group.contacts.all().order_by("-id").prefetch_related("org", "all_groups")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Remove check on is_test which is now too slow due to index change.

```
SELECT "contacts_contact"."id", "contacts_contact"."is_active", "contacts_contact"."created_on", "contacts_contact"."modified_on", "contacts_contact"."uuid", "contacts_contact"."name", "contacts_contact"."org_id", "contacts_contact"."is_blocked", "contacts_contact"."is_test", "contacts_contact"."is_stopped", "contacts_contact"."language", "contacts_contact"."fields", "contacts_contact"."modified_by_id", "contacts_contact"."created_by_id" FROM "contacts_contact" INNER JOIN "contacts_contactgroup_contacts" ON ("contacts_contact"."id" = "contacts_contactgroup_contacts"."contact_id") WHERE ("contacts_contactgroup_contacts"."contactgroup_id" = xxx AND NOT ("contacts_contact"."id" IN (SELECT U0."id" FROM "contacts_contact" U0 WHERE (U0."is_test" = true AND U0."org_id" = xxx)))) ORDER BY "contacts_contact"."id" DESC  LIMIT 5
```

Was resulting in:



```
                                                                                                      QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3024.46..23946.29 rows=5 width=718) (actual time=2181.813..15627.143 rows=5 loops=1)
   ->  Nested Loop  (cost=3024.46..4819229.85 rows=1151 width=718) (actual time=2181.812..15627.139 rows=5 loops=1)
         ->  Index Scan Backward using contacts_contact_pkey on contacts_contact  (cost=3023.90..2075252.78 rows=3925990 width=718) (actual time=2.604..5004.286 rows=5067780 loops=1)
               Filter: (NOT (hashed SubPlan 1))
               SubPlan 1
                 ->  Index Scan using contacts_contact_org_id on contacts_contact u0  (cost=0.56..3023.46 rows=1 width=4) (actual time=2.586..2.586 rows=0 loops=1)
                       Index Cond: (org_id = 9687)
                       Filter: is_test
                       Rows Removed by Filter: 2654
         ->  Index Only Scan using contacts_contactgroup_cont_contactgroup_id_1b08ad0e5aceab9_uniq on contacts_contactgroup_contacts  (cost=0.56..0.69 rows=1 width=4) (actual time=0.002..0.002 rows=0 loops=5067780)
               Index Cond: ((contactgroup_id = xxx) AND (contact_id = contacts_contact.id))
               Heap Fetches: 5
 Planning time: 0.308 ms
 Execution time: 15627.196 ms
```