### PR TITLE
🎽 exit sessions in bulk exit, ignore mailroom flow starts

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -6783,11 +6783,21 @@ class FlowsTest(FlowFileTest):
         self.assertEqual(6, FlowRun.objects.filter(is_active=True).count())
         self.assertEqual(FlowRunCount.get_totals(flow), {"A": 6, "C": 0, "E": 6, "I": 0})
 
+        # create a flow session for our first one
+        first = FlowRun.objects.filter(is_active=True).first()
+        session = FlowSession.objects.create(org=self.org, contact=first.contact, status=FlowSession.STATUS_WAITING)
+        first.session = session
+        first.save(update_fields=["session"])
+
         # stop them all
         FlowRun.bulk_exit(FlowRun.objects.filter(is_active=True), FlowRun.EXIT_TYPE_INTERRUPTED)
 
         self.assertEqual(FlowRun.objects.filter(is_active=False, exit_type="I").exclude(exited_on=None).count(), 6)
         self.assertEqual(FlowRunCount.get_totals(flow), {"A": 0, "C": 0, "E": 6, "I": 6})
+
+        session.refresh_from_db()
+        self.assertEqual(FlowSession.STATUS_INTERRUPTED, session.status)
+        self.assertIsNotNone(session.ended_on)
 
         # squash our counts
         squash_flowruncounts()

--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -320,7 +320,7 @@ def check_messages_task():  # pragma: needs cover
 
     # also check any incoming messages that are still pending somehow, reschedule them to be handled
     unhandled_messages = Msg.objects.filter(direction=INCOMING, status=PENDING, created_on__lte=five_minutes_ago)
-    unhandled_messages = unhandled_messages.exclude(channel__is_active=False)
+    unhandled_messages = unhandled_messages.exclude(channel__is_active=False, org__flow_server_enabled=False)
     unhandled_count = unhandled_messages.count()
 
     if unhandled_count:

--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -306,7 +306,7 @@ def check_messages_task():  # pragma: needs cover
     r = get_redis_connection()
 
     # for any org that sent messages in the past five minutes, check for pending messages
-    for org in Org.objects.filter(msgs__created_on__gte=five_minutes_ago).distinct():
+    for org in Org.objects.filter(msgs__created_on__gte=five_minutes_ago, flow_server_enabled=False).distinct():
         # more than 1,000 messages queued? don't do anything, wait for our queue to go down
         queued = r.zcard("send_message_task:%d" % org.id)
         if queued < 1000:


### PR DESCRIPTION
 * exits sessions in bulk exit when we are being interrupted (say from the user archiving a flow)
 * ignores flow starts created by mailroom (null created_on) when figuring out if there is already a start