### PR TITLE
🥧 message_actions API endpoint should update messages that exist

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -119,7 +119,12 @@ class TembaModelField(serializers.RelatedField):
     model = None
     model_manager = "objects"
     lookup_fields = ("uuid",)
+
+    # lookup fields which should be matched case-insensitively
     ignore_case_for_fields = ()
+
+    # throw validation exception if any object not found, otherwise returns none
+    require_exists = True
 
     class LimitedSizeList(serializers.ManyRelatedField):
         def run_validation(self, data=serializers.empty):
@@ -160,7 +165,7 @@ class TembaModelField(serializers.RelatedField):
 
         obj = self.get_object(data)
 
-        if not obj:
+        if self.require_exists and not obj:
             raise serializers.ValidationError("No such object: %s" % data)
 
         return obj
@@ -249,6 +254,9 @@ class LabelField(TembaModelField):
 class MessageField(TembaModelField):
     model = Msg
     lookup_fields = ("id",)
+
+    # messages get archived automatically so don't error if a message doesn't exist
+    require_exists = False
 
     def get_queryset(self):
         return self.model.objects.filter(org=self.context["org"]).exclude(visibility=Msg.VISIBILITY_DELETED)

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -59,6 +59,18 @@ class WriteSerializer(serializers.Serializer):
         return super().run_validation(data)
 
 
+class BulkActionFailure:
+    """
+    Bulk action serializers can return a partial failure if some objects couldn't be acted on
+    """
+
+    def __init__(self, failures):
+        self.failures = failures
+
+    def as_json(self):
+        return {"failures": self.failures}
+
+
 # ============================================================
 # Serializers (A-Z)
 # ============================================================
@@ -1026,7 +1038,7 @@ class MsgBulkActionSerializer(WriteSerializer):
 
     def validate_messages(self, value):
         for msg in value:
-            if msg.direction != "I":
+            if msg and msg.direction != "I":
                 raise serializers.ValidationError("Not an incoming message: %d" % msg.id)
 
         return value
@@ -1052,10 +1064,21 @@ class MsgBulkActionSerializer(WriteSerializer):
         return data
 
     def save(self):
-        messages = self.validated_data["messages"]
         action = self.validated_data["action"]
         label = self.validated_data.get("label")
         label_name = self.validated_data.get("label_name")
+
+        requested_message_ids = self.initial_data["messages"]
+        requested_messages = self.validated_data["messages"]
+
+        # requested_messages contains nones where msg no longer exists so compile lists of real messages and missing ids
+        messages = []
+        missing_message_ids = []
+        for m, msg in enumerate(requested_messages):
+            if msg is not None:
+                messages.append(msg)
+            else:
+                missing_message_ids.append(requested_message_ids[m])
 
         if action == self.LABEL:
             if not label:
@@ -1076,6 +1099,8 @@ class MsgBulkActionSerializer(WriteSerializer):
                     msg.restore()
                 elif action == self.DELETE:
                     msg.release()
+
+        return BulkActionFailure(missing_message_ids) if missing_message_ids else None
 
 
 class ResthookReadSerializer(ReadSerializer):

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3277,9 +3277,13 @@ class APITest(TembaTest):
         self.assertEqual(set(Msg.objects.filter(visibility=Msg.VISIBILITY_ARCHIVED)), {msg3})
         self.assertFalse(Msg.objects.filter(id=msg2.id).exists())
 
-        # try to act on a deleted message
-        response = self.postJSON(url, None, {"messages": [msg2.id], "action": "restore"})
-        self.assertResponseError(response, "messages", "No such object: %d" % msg2.id)
+        # try to act on a a valid message and a deleted message
+        response = self.postJSON(url, None, {"messages": [msg2.id, msg3.id], "action": "restore"})
+
+        # should get a partial success
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'failures': [msg2.id]})
+        self.assertEqual(set(Msg.objects.filter(visibility=Msg.VISIBILITY_VISIBLE)), {msg1, msg3})
 
         # try to act on an outgoing message
         msg4 = Msg.create_outgoing(self.org, self.user, self.joe, "Hi Joe")

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3282,7 +3282,7 @@ class APITest(TembaTest):
 
         # should get a partial success
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {'failures': [msg2.id]})
+        self.assertEqual(response.json(), {"failures": [msg2.id]})
         self.assertEqual(set(Msg.objects.filter(visibility=Msg.VISIBILITY_VISIBLE)), {msg1, msg3})
 
         # try to act on an outgoing message

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2418,7 +2418,13 @@ class MessageActionsEndpoint(BulkWriteAPIMixin, BaseAPIView):
             "label": "Testing"
         }
 
-    You will receive an empty response with status code 204 if successful.
+    You will receive an empty response with status code 204 if successful. In the case that some messages couldn't be
+    updated because they no longer exist, the status code will be 200 and the body will include the failed message ids:
+
+    Example response:
+
+        {"failures": [2345, 3456]}
+
     """
 
     permission = "msgs.msg_api"

--- a/temba/api/v2/views_base.py
+++ b/temba/api/v2/views_base.py
@@ -12,6 +12,8 @@ from temba.api.support import InvalidQueryError
 from temba.contacts.models import URN
 from temba.utils.views import NonAtomicMixin
 
+from .serializers import BulkActionFailure
+
 
 class BaseAPIView(NonAtomicMixin, generics.GenericAPIView):
     """
@@ -209,8 +211,11 @@ class BulkWriteAPIMixin(object):
         serializer = self.serializer_class(data=request.data, context=self.get_serializer_context())
 
         if serializer.is_valid():
-            serializer.save()
-            return Response("", status=status.HTTP_204_NO_CONTENT)
+            result = serializer.save()
+            if isinstance(result, BulkActionFailure):
+                return Response(result.as_json(), status.HTTP_200_OK)
+            else:
+                return Response("", status=status.HTTP_204_NO_CONTENT)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
Act on the messages that exist, return the ids of those that don't