### PR TITLE
🔢 Fix boundary aliases duplicates creation

### DIFF
--- a/temba/locations/models.py
+++ b/temba/locations/models.py
@@ -81,7 +81,7 @@ class AdminBoundary(MPTTModel, models.Model):
         if self.parent:
             result["parent_osm_id"] = self.parent.osm_id
 
-        aliases = "\n".join([alias.name for alias in self.aliases.all()])
+        aliases = "\n".join(sorted([alias.name for alias in self.aliases.all()]))
         result["aliases"] = aliases
         return result
 

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -93,6 +93,23 @@ class LocationTest(TembaTest):
         self.assertEqual("Kigali City", response_json[1]["name"])
         self.assertEqual("kig\nkigs", response_json[1]["aliases"])
 
+        # update our alias for kigali with duplicates
+        response = self.client.post(
+            reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]),
+            json.dumps([dict(osm_id=self.state1.osm_id, aliases="kigs\nkig\nkig\nkigs\nkig")]),
+            content_type="application/json",
+        )
+
+        self.assertEqual(200, response.status_code)
+
+        # fetch our aliases again
+        response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
+        response_json = response.json()
+
+        # now have kigs as an alias
+        self.assertEqual("Kigali City", response_json[1]["name"])
+        self.assertEqual("kig\nkigs", response_json[1]["aliases"])
+
         # test nested admin level aliases update
         geo_data = [
             dict(

--- a/temba/locations/views.py
+++ b/temba/locations/views.py
@@ -79,7 +79,8 @@ class BoundaryCRUDL(SmartCRUDL):
             def update_aliases(boundary, new_aliases):
                 # for now, nuke and recreate all aliases
                 BoundaryAlias.objects.filter(boundary=boundary, org=org).delete()
-                for new_alias in new_aliases.split("\n"):
+                unique_new_aliases = list(set(new_aliases.split("\n")))
+                for new_alias in unique_new_aliases:
                     if new_alias:
                         BoundaryAlias.objects.create(
                             boundary=boundary,


### PR DESCRIPTION
Not clear why the are even duplicated on the form but as first step prevent the duplicates to be inserted in the DB
