### PR TITLE
🔢Really fix aliases duplicates displayed on the form

### DIFF
--- a/temba/flows/server/tests.py
+++ b/temba/flows/server/tests.py
@@ -145,8 +145,11 @@ class SerializationTest(TembaTest):
         BoundaryAlias.create(self.org, self.admin, self.state2, "East Prov")
         BoundaryAlias.create(self.org2, self.admin2, self.state1, "Other Org")  # shouldn't be returned
 
+        with self.assertNumQueries(2):
+            locations = serialize_location_hierarchy(self.org)
+
         self.assertEqual(
-            serialize_location_hierarchy(self.org),
+            locations,
             {
                 "name": "Rwanda",
                 "children": [

--- a/temba/flows/server/tests.py
+++ b/temba/flows/server/tests.py
@@ -1,11 +1,19 @@
 from temba.channels.models import Channel
 from temba.contacts.models import ContactGroup
+from temba.locations.models import BoundaryAlias
 from temba.msgs.models import Label
 from temba.tests import TembaTest, matchers, skip_if_no_mailroom
 from temba.values.constants import Value
 
 from .assets import ChannelType, get_asset_type, get_asset_urls
-from .serialize import serialize_channel, serialize_field, serialize_flow, serialize_group, serialize_label
+from .serialize import (
+    serialize_channel,
+    serialize_field,
+    serialize_flow,
+    serialize_group,
+    serialize_label,
+    serialize_location_hierarchy,
+)
 
 TEST_ASSETS_BASE = "http://localhost:8000/flow/assets/"
 
@@ -127,5 +135,23 @@ class SerializationTest(TembaTest):
                 "roles": ["send", "receive"],
                 "schemes": ["tel"],
                 "country": "RW",
+            },
+        )
+
+    def test_serialize_location_hierarchy(self):
+        self.create_secondary_org()
+        BoundaryAlias.create(self.org, self.admin, self.state1, "Kigali")
+        BoundaryAlias.create(self.org, self.admin, self.state1, "Kigari")
+        BoundaryAlias.create(self.org, self.admin, self.state2, "East Prov")
+        BoundaryAlias.create(self.org2, self.admin2, self.state1, "Other Org")  # shouldn't be returned
+
+        self.assertEqual(
+            serialize_location_hierarchy(self.org),
+            {
+                "name": "Rwanda",
+                "children": [
+                    {"aliases": ["Kigari", "Kigali"], "children": [{"name": "Nyarugenge"}], "name": "Kigali City"},
+                    {"aliases": ["East Prov"], "name": "Eastern Province"},
+                ],
             },
         )

--- a/temba/locations/models.py
+++ b/temba/locations/models.py
@@ -75,13 +75,13 @@ class AdminBoundary(MPTTModel, models.Model):
         feature_collection = geojson.FeatureCollection(features)
         return geojson.dumps(feature_collection)
 
-    def as_json(self, org):
+    def as_json(self):
         result = dict(osm_id=self.osm_id, name=self.name, level=self.level, aliases="")
 
         if self.parent:
             result["parent_osm_id"] = self.parent.osm_id
 
-        aliases = "\n".join(sorted([alias.name for alias in self.aliases.filter(org=org)]))
+        aliases = "\n".join(sorted([alias.name for alias in self.aliases.all()]))
         result["aliases"] = aliases
         return result
 

--- a/temba/locations/models.py
+++ b/temba/locations/models.py
@@ -75,13 +75,13 @@ class AdminBoundary(MPTTModel, models.Model):
         feature_collection = geojson.FeatureCollection(features)
         return geojson.dumps(feature_collection)
 
-    def as_json(self):
+    def as_json(self, org):
         result = dict(osm_id=self.osm_id, name=self.name, level=self.level, aliases="")
 
         if self.parent:
             result["parent_osm_id"] = self.parent.osm_id
 
-        aliases = "\n".join(sorted([alias.name for alias in self.aliases.all()]))
+        aliases = "\n".join(sorted([alias.name for alias in self.aliases.filter(org=org)]))
         result["aliases"] = aliases
         return result
 

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from temba.tests import CaptureSTDOUT, TembaTest
 from temba.utils import json
 
-from .models import AdminBoundary
+from .models import AdminBoundary, BoundaryAlias
 
 
 class LocationTest(TembaTest):
@@ -101,6 +101,11 @@ class LocationTest(TembaTest):
         )
 
         self.assertEqual(200, response.status_code)
+
+        self.create_secondary_org()
+        BoundaryAlias.objects.create(
+            boundary=self.state1, org=self.org2, name="KGL", created_by=self.admin2, modified_by=self.admin2
+        )
 
         # fetch our aliases again
         response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -77,16 +77,18 @@ class LocationTest(TembaTest):
         self.assertEqual("", response_json[1]["aliases"])
 
         # update our alias for kigali
-        response = self.client.post(
-            reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]),
-            json.dumps([dict(osm_id=self.state1.osm_id, aliases="kigs\nkig")]),
-            content_type="application/json",
-        )
+        with self.assertNumQueries(15):
+            response = self.client.post(
+                reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]),
+                json.dumps([dict(osm_id=self.state1.osm_id, aliases="kigs\nkig")]),
+                content_type="application/json",
+            )
 
         self.assertEqual(200, response.status_code)
 
         # fetch our aliases again
-        response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
+        with self.assertNumQueries(32):
+            response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
         response_json = response.json()
 
         # now have kigs as an alias
@@ -94,11 +96,12 @@ class LocationTest(TembaTest):
         self.assertEqual("kig\nkigs", response_json[1]["aliases"])
 
         # update our alias for kigali with duplicates
-        response = self.client.post(
-            reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]),
-            json.dumps([dict(osm_id=self.state1.osm_id, aliases="kigs\nkig\nkig\nkigs\nkig")]),
-            content_type="application/json",
-        )
+        with self.assertNumQueries(15):
+            response = self.client.post(
+                reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]),
+                json.dumps([dict(osm_id=self.state1.osm_id, aliases="kigs\nkig\nkig\nkigs\nkig")]),
+                content_type="application/json",
+            )
 
         self.assertEqual(200, response.status_code)
 
@@ -108,7 +111,8 @@ class LocationTest(TembaTest):
         )
 
         # fetch our aliases again
-        response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
+        with self.assertNumQueries(32):
+            response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
         response_json = response.json()
 
         # now have kigs as an alias


### PR DESCRIPTION
Part 2 for https://github.com/nyaruka/rapidpro/pull/2358

Boundary unlike other models do not have an org field so their aliases should make sure the filter by org