### PR TITLE
🌹 Support != search operator

### DIFF
--- a/temba/contacts/search/parser.py
+++ b/temba/contacts/search/parser.py
@@ -177,6 +177,8 @@ class Condition(QueryNode):
 
                 if self.comparator == "=":
                     return contact_value == query_value
+                elif self.comparator == "!=":
+                    return contact_value != query_value
                 else:
                     raise SearchException(_(f"Unknown text comparator: '{self.comparator}'"))
 
@@ -258,6 +260,8 @@ class Condition(QueryNode):
 
                 if self.comparator == "=":
                     return contact_value == query_value
+                elif self.comparator == "!=":
+                    return contact_value != query_value
                 else:
                     raise SearchException(_(f"Unsupported comparator '{self.comparator}' for location field"))
 
@@ -293,6 +297,8 @@ class Condition(QueryNode):
                     contact_value = raw_contact_value.upper()
                 if self.comparator == "=":
                     return contact_value == query_value
+                elif self.comparator == "!=":
+                    return contact_value != query_value
                 else:
                     raise SearchException(_(f"Unknown language comparator: '{self.comparator}'"))
             elif field_key == "created_on":
@@ -323,6 +329,8 @@ class Condition(QueryNode):
                     return contact_value == query_value
                 elif self.comparator == "~":
                     return query_value in contact_value
+                elif self.comparator == "!=":
+                    return contact_value != query_value
                 else:  # pragma: no cover
                     raise SearchException(_(f"Unknown name comparator: '{self.comparator}'"))
             else:
@@ -342,7 +350,8 @@ class Condition(QueryNode):
 
                 if self.comparator == "=":
                     es_query &= es_Q("term", **{"fields.text": query_value})
-
+                elif self.comparator == "!=":
+                    es_query &= ~es_Q("term", **{"fields.text": query_value})
                 else:
                     raise SearchException(_(f"Unknown text comparator: '{self.comparator}'"))
 
@@ -396,6 +405,9 @@ class Condition(QueryNode):
                 if self.comparator == "=":
                     field_name += "_keyword"
                     es_query &= es_Q("term", **{field_name: query_value})
+                elif self.comparator == "!=":
+                    field_name += "_keyword"
+                    es_query &= ~es_Q("term", **{field_name: query_value})
                 else:
                     raise SearchException(_(f"Unsupported comparator '{self.comparator}' for location field"))
 
@@ -416,6 +428,9 @@ class Condition(QueryNode):
                 elif self.comparator == "~":
                     field_name = "name"
                     es_query = es_Q("match", **{field_name: query_value})
+                elif self.comparator == "!=":
+                    field_name = "name.keyword"
+                    es_query = ~es_Q("term", **{field_name: query_value})
                 else:
                     raise SearchException(_(f"Unknown attribute comparator: '{self.comparator}'"))
             elif field_key == "id":
@@ -424,6 +439,9 @@ class Condition(QueryNode):
                 if self.comparator == "=":
                     field_name = "language"
                     es_query = es_Q("term", **{field_name: query_value})
+                elif self.comparator == "!=":
+                    field_name = "language"
+                    es_query = ~es_Q("term", **{field_name: query_value})
                 else:
                     raise SearchException(_(f"Unknown attribute comparator: '{self.comparator}'"))
             elif field_key == "created_on":

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -7,9 +7,6 @@ from unittest.mock import PropertyMock, patch
 
 import pytz
 from openpyxl import load_workbook
-from smartmin.csv_imports.models import ImportTask
-from smartmin.models import SmartImportRowError
-from smartmin.tests import SmartminTestMixin, _CRUDLTest
 
 from django.conf import settings
 from django.core.files.base import ContentFile
@@ -20,6 +17,9 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from smartmin.csv_imports.models import ImportTask
+from smartmin.models import SmartImportRowError
+from smartmin.tests import SmartminTestMixin, _CRUDLTest
 from temba.api.models import WebHookEvent, WebHookResult
 from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
@@ -1576,6 +1576,8 @@ class ContactTest(TembaTest):
         self.assertTrue(evaluate_query(self.org, "name ~ blow", contact_json=self.joe.as_search_json()))
         self.assertFalse(evaluate_query(self.org, 'name = ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'name != ""', contact_json=self.joe.as_search_json()))
+        self.assertTrue(evaluate_query(self.org, 'name != "Bob"', contact_json=self.joe.as_search_json()))
+        self.assertFalse(evaluate_query(self.org, 'name != "Joe Blow"', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'name = ""', contact_json={}))
         self.assertFalse(evaluate_query(self.org, 'name != ""', contact_json={}))
         # nothing to compare
@@ -1585,6 +1587,9 @@ class ContactTest(TembaTest):
         self.joe.language = "eng"
         self.joe.save(update_fields=("language",), handle_update=False)
         self.assertTrue(evaluate_query(self.org, 'language = "eng"', contact_json=self.joe.as_search_json()))
+
+        self.assertFalse(evaluate_query(self.org, 'language != "eng"', contact_json=self.joe.as_search_json()))
+        self.assertTrue(evaluate_query(self.org, 'language != "ita"', contact_json=self.joe.as_search_json()))
 
         self.assertFalse(evaluate_query(self.org, 'language = ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'language != ""', contact_json=self.joe.as_search_json()))
@@ -1646,6 +1651,9 @@ class ContactTest(TembaTest):
         self.assertFalse(evaluate_query(self.org, "gender = Female", contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'gender != ""', contact_json=self.joe.as_search_json()))
         self.assertFalse(evaluate_query(self.org, 'gender = ""', contact_json=self.joe.as_search_json()))
+
+        self.assertTrue(evaluate_query(self.org, "gender != female", contact_json=self.joe.as_search_json()))
+        self.assertFalse(evaluate_query(self.org, "gender != male", contact_json=self.joe.as_search_json()))
 
         # test DECIMAL field type
         self.assertFalse(evaluate_query(self.org, 'age != ""', contact_json=self.joe.as_search_json()))
@@ -1711,6 +1719,10 @@ class ContactTest(TembaTest):
         self.assertTrue(evaluate_query(self.org, 'ward != ""', contact_json=self.joe.as_search_json()))
         self.assertFalse(evaluate_query(self.org, 'ward = ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'ward = "bUKuRE"', contact_json=self.joe.as_search_json()))
+
+        self.assertTrue(evaluate_query(self.org, 'ward != "Rwamagana"', contact_json=self.joe.as_search_json()))
+        self.assertFalse(evaluate_query(self.org, 'ward != "Bukure"', contact_json=self.joe.as_search_json()))
+
         self.assertRaises(
             SearchException, evaluate_query, self.org, 'ward ~ "ukur"', contact_json=self.joe.as_search_json()
         )
@@ -1733,6 +1745,9 @@ class ContactTest(TembaTest):
         self.assertFalse(evaluate_query(self.org, 'district = ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'district = "Rwamagana"', contact_json=self.joe.as_search_json()))
 
+        self.assertTrue(evaluate_query(self.org, 'district != "Bukure"', contact_json=self.joe.as_search_json()))
+        self.assertFalse(evaluate_query(self.org, 'district != "Rwamagana"', contact_json=self.joe.as_search_json()))
+
         self.assertFalse(
             evaluate_query(self.org, 'district = "cedevita is not a district"', contact_json=self.joe.as_search_json())
         )
@@ -1749,6 +1764,14 @@ class ContactTest(TembaTest):
         self.joe.set_field(self.admin, "state", "Rwanda > Eastern Province")
         self.assertTrue(evaluate_query(self.org, 'state != ""', contact_json=self.joe.as_search_json()))
         self.assertFalse(evaluate_query(self.org, 'state = ""', contact_json=self.joe.as_search_json()))
+
+        self.assertTrue(
+            evaluate_query(self.org, 'state != "Western Province"', contact_json=self.joe.as_search_json())
+        )
+        self.assertFalse(
+            evaluate_query(self.org, 'state != "Eastern Province"', contact_json=self.joe.as_search_json())
+        )
+
         self.assertRaises(
             SearchException, evaluate_query, self.org, 'state ~ "stern"', contact_json=self.joe.as_search_json()
         )
@@ -1896,6 +1919,7 @@ class ContactTest(TembaTest):
         # property conditions
         self.assertEqual(parse_query("name=will"), ContactQuery(Condition("name", "=", "will")))
         self.assertEqual(parse_query('name ~ "felix"'), ContactQuery(Condition("name", "~", "felix")))
+        self.assertEqual(parse_query('name != "felix"'), ContactQuery(Condition("name", "!=", "felix")))
 
         # empty string conditions
         self.assertEqual(parse_query('name is ""'), ContactQuery(IsSetCondition("name", "is")))
@@ -2091,6 +2115,24 @@ class ContactTest(TembaTest):
             }
         ]
         actual_search, _ = contact_es_search(self.org, 'gender = "unknown"')
+        self.assertEqual(actual_search.to_dict(), expected_search)
+
+        # text term does not match
+        expected_search = copy.deepcopy(base_search)
+        expected_search["query"]["bool"]["must"] = [
+            {
+                "nested": {
+                    "path": "fields",
+                    "query": {
+                        "bool": {
+                            "must_not": [{"term": {"fields.text": "unknown"}}],
+                            "must": [{"term": {"fields.field": str(gender.uuid)}}],
+                        }
+                    },
+                }
+            }
+        ]
+        actual_search, _ = contact_es_search(self.org, 'gender != "unknown"')
         self.assertEqual(actual_search.to_dict(), expected_search)
 
         # decimal range matches
@@ -2309,6 +2351,25 @@ class ContactTest(TembaTest):
         actual_search, _ = contact_es_search(self.org, 'ward = "Bukure"')
         self.assertEqual(actual_search.to_dict(), expected_search)
 
+        # ward does not match
+        expected_search = copy.deepcopy(base_search)
+        expected_search["query"]["bool"]["must"] = [
+            {
+                "nested": {
+                    "path": "fields",
+                    "query": {
+                        "bool": {
+                            "must_not": [{"term": {"fields.ward_keyword": "bukure"}}],
+                            "must": [{"term": {"fields.field": str(ward.uuid)}}],
+                        }
+                    },
+                }
+            }
+        ]
+
+        actual_search, _ = contact_es_search(self.org, 'ward != "Bukure"')
+        self.assertEqual(actual_search.to_dict(), expected_search)
+
         self.assertRaises(SearchException, contact_es_search, self.org, 'ward ~ "Bukure"')
 
         # district matches
@@ -2330,6 +2391,25 @@ class ContactTest(TembaTest):
         ]
         actual_search, _ = contact_es_search(self.org, 'district = "Rwamagana"')
         self.assertEqual(actual_search.to_dict(), expected_search)
+
+        # district does not match
+        expected_search = copy.deepcopy(base_search)
+        expected_search["query"]["bool"]["must"] = [
+            {
+                "nested": {
+                    "path": "fields",
+                    "query": {
+                        "bool": {
+                            "must_not": [{"term": {"fields.district_keyword": "rwamagana"}}],
+                            "must": [{"term": {"fields.field": str(district.uuid)}}],
+                        }
+                    },
+                }
+            }
+        ]
+        actual_search, _ = contact_es_search(self.org, 'district != "Rwamagana"')
+        self.assertEqual(actual_search.to_dict(), expected_search)
+
         self.assertRaises(SearchException, contact_es_search, self.org, 'district ~ "Rwamagana"')
 
         # state matches
@@ -2350,6 +2430,24 @@ class ContactTest(TembaTest):
             }
         ]
         actual_search, _ = contact_es_search(self.org, 'state = "Eastern Province"')
+        self.assertEqual(actual_search.to_dict(), expected_search)
+
+        # state does not match
+        expected_search = copy.deepcopy(base_search)
+        expected_search["query"]["bool"]["must"] = [
+            {
+                "nested": {
+                    "path": "fields",
+                    "query": {
+                        "bool": {
+                            "must_not": [{"term": {"fields.state_keyword": "eastern province"}}],
+                            "must": [{"term": {"fields.field": str(state.uuid)}}],
+                        }
+                    },
+                }
+            }
+        ]
+        actual_search, _ = contact_es_search(self.org, 'state != "Eastern Province"')
         self.assertEqual(actual_search.to_dict(), expected_search)
 
         self.assertRaises(SearchException, contact_es_search, self.org, 'state ~ "Eastern Province"')
@@ -2434,13 +2532,28 @@ class ContactTest(TembaTest):
 
         expected_search = copy.deepcopy(base_search)
         expected_search["query"]["bool"]["must"] = [{"term": {"name.keyword": "joe blow"}}]
+
         actual_search, _ = contact_es_search(self.org, 'name = "joe Blow"')
+        self.assertEqual(actual_search.to_dict(), expected_search)
+
+        expected_search = copy.deepcopy(base_search)
+        del expected_search["query"]["bool"]["must"]
+        expected_search["query"]["bool"]["must_not"] = [{"term": {"name.keyword": "joe blow"}}]
+
+        actual_search, _ = contact_es_search(self.org, 'name != "joe Blow"')
         self.assertEqual(actual_search.to_dict(), expected_search)
 
         # test `language` contact attribute
         expected_search = copy.deepcopy(base_search)
         expected_search["query"]["bool"]["must"] = [{"term": {"language": "eng"}}]
         actual_search, _ = contact_es_search(self.org, 'language = "eng"')
+        self.assertEqual(actual_search.to_dict(), expected_search)
+
+        expected_search = copy.deepcopy(base_search)
+        del expected_search["query"]["bool"]["must"]
+        expected_search["query"]["bool"]["must_not"] = [{"term": {"language": "eng"}}]
+
+        actual_search, _ = contact_es_search(self.org, 'language != "eng"')
         self.assertEqual(actual_search.to_dict(), expected_search)
 
         # operator not supported
@@ -7986,7 +8099,7 @@ class ESIntegrationTest(TembaTestMixin, SmartminTestMixin, TransactionTestCase):
             contact.set_field(self.admin, "home", districts[i % len(districts)])
             contact.set_field(self.admin, "ward", wards[i % len(wards)])
 
-            contact.set_field(self.admin, "isureporter", "yes")
+            contact.set_field(self.admin, "isureporter", "yes" if i % 2 == 0 else "no")
             contact.set_field(self.admin, "hasbirth", "no")
 
             if i % 3 == 0:
@@ -8025,6 +8138,7 @@ class ESIntegrationTest(TembaTestMixin, SmartminTestMixin, TransactionTestCase):
         self.assertEqual(q('name != ""'), 60)
         self.assertEqual(q('NAME = ""'), 30)
         self.assertEqual(q("name ~ Mi"), 15)
+        self.assertEqual(q('name != "Mike"'), 75)
 
         # URN as property
         self.assertEqual(q("tel is +250188382011"), 1)
@@ -8053,6 +8167,7 @@ class ESIntegrationTest(TembaTestMixin, SmartminTestMixin, TransactionTestCase):
         self.assertEqual(q('state is "Eastern Province"'), 90)
         self.assertEqual(q("HOME is Kayônza"), 30)
         self.assertEqual(q("ward is kageyo"), 30)
+        self.assertEqual(q("ward != kageyo"), 60)
 
         self.assertEqual(q('home is ""'), 0)
         self.assertEqual(q('profession = ""'), 60)
@@ -8060,9 +8175,10 @@ class ESIntegrationTest(TembaTestMixin, SmartminTestMixin, TransactionTestCase):
         self.assertEqual(q('profession != ""'), 30)
 
         # contact fields beginning with 'is' or 'has'
-        self.assertEqual(q('isureporter = "yes"'), 90)
-        self.assertEqual(q("isureporter = yes"), 90)
-        self.assertEqual(q("isureporter = no"), 0)
+        self.assertEqual(q('isureporter = "yes"'), 45)
+        self.assertEqual(q("isureporter = yes"), 45)
+        self.assertEqual(q("isureporter = no"), 45)
+        self.assertEqual(q("isureporter != no"), 45)
 
         self.assertEqual(q('hasbirth = "no"'), 90)
         self.assertEqual(q("hasbirth = no"), 90)


### PR DESCRIPTION
Closes: https://github.com/rapidpro/rapidpro/issues/868

Add support for `!=` operator for system fields: name and language, and
for contact fields that have: text, state, district or ward type.