### PR TITLE
simplify squash in a way that seems to be faster

### DIFF
--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -237,7 +237,7 @@ class SquashableModel(models.Model):
         start = time.time()
         num_sets = 0
 
-        for distinct_set in cls.get_unsquashed().distinct(*cls.SQUASH_OVER)[:5000]:
+        for distinct_set in cls.get_unsquashed().order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER)[:5000]:
             with connection.cursor() as cursor:
                 sql, params = cls.get_squash_query(distinct_set)
 

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -237,10 +237,7 @@ class SquashableModel(models.Model):
         start = time.time()
         num_sets = 0
 
-        # only distinct across 100000 rows at most
-        unsquashed_query = cls.get_unsquashed().filter(id__in=cls.get_unsquashed().values("id")[:100_000])
-
-        for distinct_set in unsquashed_query.order_by(*cls.SQUASH_OVER).distinct(*cls.SQUASH_OVER)[:5000]:
+        for distinct_set in cls.get_unsquashed().distinct(*cls.SQUASH_OVER)[:5000]:
             with connection.cursor() as cursor:
                 sql, params = cls.get_squash_query(distinct_set)
 


### PR DESCRIPTION
Theory of change:
 * previous attempt at subselecting rows was actually slower since we already have a perfect index
 * removing order by also simplifies things as postgres will just use the `_unsquashed` index which is already in the order we want.

In practice this does seem to work as well so there's that. :)