### PR TITLE
🔘 Ensure input is string in org.parse_number

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -944,7 +944,7 @@ class APITest(TembaTest):
         # create our contact and set a registration date
         contact = self.create_contact("Joe", "+12065551515")
         reporters.contacts.add(contact)
-        contact.set_field(self.admin, "registration", timezone.now())
+        contact.set_field(self.admin, "registration", self.org.format_datetime(timezone.now()))
 
         campaign1 = Campaign.create(self.org, self.admin, "Reminders", reporters)
         event1 = CampaignEvent.create_message_event(

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -1259,7 +1259,7 @@ class CampaignTest(TembaTest):
         event = CampaignEvent.create_flow_event(
             self.org, self.admin, campaign, relative_to=self.planting_date, offset=3, unit="D", flow=self.reminder_flow
         )
-        self.farmer1.set_field(self.admin, "planting_date", timezone.now())
+        self.farmer1.set_field(self.admin, "planting_date", self.org.format_datetime(timezone.now()))
 
         trimDate = timezone.now() - timedelta(days=settings.EVENT_FIRE_TRIM_DAYS + 1)
         ev = EventFire.objects.create(event=event, contact=self.farmer1, scheduled=trimDate, fired=trimDate)
@@ -1281,7 +1281,7 @@ class CampaignTest(TembaTest):
         planting_date = timezone.now()
         field_created_on = self.org.contactfields.get(key="created_on")
 
-        self.farmer1.set_field(self.admin, "planting_date", planting_date)
+        self.farmer1.set_field(self.admin, "planting_date", self.org.format_datetime(planting_date))
 
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -115,10 +115,10 @@ class ContactCRUDLTest(TembaTestMixin, _CRUDLTest):
 
     def testList(self):
         self.joe, urn_obj = Contact.get_or_create(self.org, "tel:123", user=self.user, name="Joe")
-        self.joe.set_field(self.user, "age", 20)
+        self.joe.set_field(self.user, "age", "20")
         self.joe.set_field(self.user, "home", "Kigali")
         self.frank, urn_obj = Contact.get_or_create(self.org, "tel:124", user=self.user, name="Frank")
-        self.frank.set_field(self.user, "age", 18)
+        self.frank.set_field(self.user, "age", "18")
 
         response = self._do_test_view("list")
         self.assertEqual(set(response.context["object_list"]), {self.frank, self.joe})
@@ -289,9 +289,9 @@ class ContactGroupTest(TembaTest):
         name = ContactField.system_fields.filter(org=self.org, key="name").get()
         age = ContactField.get_or_create(self.org, self.admin, "age", value_type=Value.TYPE_NUMBER)
         gender = ContactField.get_or_create(self.org, self.admin, "gender", priority=10)
-        self.joe.set_field(self.admin, "age", 17)
+        self.joe.set_field(self.admin, "age", "17")
         self.joe.set_field(self.admin, "gender", "male")
-        self.mary.set_field(self.admin, "age", 21)
+        self.mary.set_field(self.admin, "age", "21")
         self.mary.set_field(self.admin, "gender", "female")
 
         # create a dynamic group using a query
@@ -1549,7 +1549,7 @@ class ContactTest(TembaTest):
             self.org, self.admin, "nick", "Nickname", value_type="T", show_in_table=False
         )
 
-        self.joe.set_field(self.user, "age", 32)
+        self.joe.set_field(self.user, "age", "32")
         self.joe.set_field(self.user, "nick", "Joey")
         self.joe = Contact.objects.get(pk=self.joe.pk)
 
@@ -1686,7 +1686,7 @@ class ContactTest(TembaTest):
         self.assertFalse(evaluate_query(self.org, 'age != ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'age = ""', contact_json=self.joe.as_search_json()))
 
-        self.joe.set_field(self.admin, "age", 18)
+        self.joe.set_field(self.admin, "age", "18")
         self.assertTrue(evaluate_query(self.org, 'age != ""', contact_json=self.joe.as_search_json()))
         self.assertFalse(evaluate_query(self.org, 'age = ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, "age = 18", contact_json=self.joe.as_search_json()))
@@ -3075,7 +3075,7 @@ class ContactTest(TembaTest):
 
         # field update works as expected
         contact.set_field(self.user, "gender", "male")
-        contact.set_field(self.user, "age", 20)
+        contact.set_field(self.user, "age", "20")
 
         self.assertCountEqual(
             [group.name for group in contact.user_groups.filter(is_active=True).all()],
@@ -6215,7 +6215,7 @@ class ContactTest(TembaTest):
         self.assertEqual(None, self.joe.get_field_serialized(abc))
 
         # try storing an integer, should get turned into a string
-        self.joe.set_field(self.user, "abc_1234", 1)
+        self.joe.set_field(self.user, "abc_1234", "1")
         self.assertEqual("1", self.joe.get_field_serialized(abc))
 
         # we should have a field with the key
@@ -6270,7 +6270,7 @@ class ContactTest(TembaTest):
         self.assertEqual(joe.get_field_display(registration_field), "")
 
         joe.set_field(self.user, "registration_date", "2014-12-31T01:04:00Z")
-        joe.set_field(self.user, "weight", 75.888888)
+        joe.set_field(self.user, "weight", "75.888888")
         joe.set_field(self.user, "color", "green")
         joe.set_field(self.user, "state", "kigali city")
 
@@ -6534,17 +6534,17 @@ class ContactTest(TembaTest):
 
             self.mary = self.create_contact("Mary", "+250783333333")
             self.mary.set_field(self.user, "gender", "Female")
-            self.mary.set_field(self.user, "age", 21)
+            self.mary.set_field(self.user, "age", "21")
             self.mary.set_field(self.user, "joined", "31/12/2013")
             self.annie = self.create_contact("Annie", "7879")
             self.annie.set_field(self.user, "gender", "Female")
-            self.annie.set_field(self.user, "age", 9)
+            self.annie.set_field(self.user, "age", "9")
             self.annie.set_field(self.user, "joined", "31/12/2013")
             self.joe.set_field(self.user, "gender", "Male")
-            self.joe.set_field(self.user, "age", 25)
+            self.joe.set_field(self.user, "age", "25")
             self.joe.set_field(self.user, "joined", "1/1/2014")
             self.frank.set_field(self.user, "gender", "Male")
-            self.frank.set_field(self.user, "age", 50)
+            self.frank.set_field(self.user, "age", "50")
             self.frank.set_field(self.user, "joined", "1/1/2014")
 
             # create more groups based on fields (checks that contacts are added correctly on group create)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6270,7 +6270,7 @@ class ContactTest(TembaTest):
         self.assertEqual(joe.get_field_display(registration_field), "")
 
         joe.set_field(self.user, "registration_date", "2014-12-31T01:04:00Z")
-        joe.set_field(self.user, "weight", "75.888888")
+        joe.set_field(self.user, "weight", 75.888888)
         joe.set_field(self.user, "color", "green")
         joe.set_field(self.user, "state", "kigali city")
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2042,7 +2042,7 @@ class FlowTest(TembaTest):
 
         # test export with a contact field
         age = ContactField.get_or_create(self.org, self.admin, "age", "Age")
-        self.contact.set_field(self.admin, "age", 36)
+        self.contact.set_field(self.admin, "age", "36")
 
         with self.assertNumQueries(43):
             workbook = self.export_flow_results(
@@ -2055,7 +2055,7 @@ class FlowTest(TembaTest):
             )
 
         # try setting the field again
-        self.contact.set_field(self.admin, "age", 36)
+        self.contact.set_field(self.admin, "age", "36")
 
         tz = self.org.timezone
         sheet_runs, = workbook.worksheets
@@ -8055,7 +8055,7 @@ class FlowsTest(FlowFileTest):
         flow = self.get_flow("numeric_rule_allows_variables")
 
         zinedine = self.create_contact("Zinedine", "+12065550100")
-        zinedine.set_field(self.user, "age", 25)
+        zinedine.set_field(self.user, "age", "25")
 
         self.assertEqual("Good count", self.send_message(flow, "35", contact=zinedine))
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1105,17 +1105,18 @@ class Org(SmartModel):
         return datetime_to_str(datetime, format, self.timezone)
 
     def parse_datetime(self, datetime_string):
-        if isinstance(datetime_string, datetime):
-            return datetime_string
+        if not (isinstance(datetime_string, str)):
+            raise ValueError(f"parse_datetime called with param of type: {type(datetime_string)}, expected string")
 
         return str_to_datetime(datetime_string, self.timezone, self.get_dayfirst())
 
     def parse_number(self, decimal_string):
-        parsed = None
+        if not (isinstance(decimal_string, str)):
+            raise ValueError(f"parse_number called with param of type: {type(decimal_string)}, expected string")
 
+        parsed = None
         try:
-            # cast to string, decimal of a float, Decimal(1.1) ~= 1.100000000000000088817841970012523233890533447265625
-            parsed = Decimal(str(decimal_string))
+            parsed = Decimal(decimal_string)
 
             if not parsed.is_finite() or parsed > Decimal("999999999999999999999999"):
                 parsed = None

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1114,7 +1114,9 @@ class Org(SmartModel):
         parsed = None
 
         try:
-            parsed = Decimal(decimal_string)
+            # cast to string, decimal of a float, Decimal(1.1) ~= 1.100000000000000088817841970012523233890533447265625
+            parsed = Decimal(str(decimal_string))
+
             if not parsed.is_finite() or parsed > Decimal("999999999999999999999999"):
                 parsed = None
         except Exception:

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -4316,3 +4316,4 @@ class ParsingTest(TembaTest):
         self.assertEqual(self.org.parse_number(""), None)
         self.assertEqual(self.org.parse_number("NaN"), None)
         self.assertEqual(self.org.parse_number("Infinity"), None)
+        self.assertEqual(self.org.parse_number(0.001), Decimal("0.001"))

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 from datetime import timedelta
 from decimal import Decimal
@@ -4307,7 +4308,7 @@ class ParsingTest(TembaTest):
         self.assertEqual(self.org.parse_location_path("Nigeria > Lagos "), lagos)
         self.assertEqual(self.org.parse_location_path(" Nigeria > Lagos "), lagos)
 
-    def test_parse_decimal(self):
+    def test_parse_number(self):
         self.assertEqual(self.org.parse_number("Not num"), None)
         self.assertEqual(self.org.parse_number("00.123"), Decimal("0.123"))
         self.assertEqual(self.org.parse_number("6e33"), None)
@@ -4316,4 +4317,14 @@ class ParsingTest(TembaTest):
         self.assertEqual(self.org.parse_number(""), None)
         self.assertEqual(self.org.parse_number("NaN"), None)
         self.assertEqual(self.org.parse_number("Infinity"), None)
-        self.assertEqual(self.org.parse_number(0.001), Decimal("0.001"))
+
+        self.assertRaises(ValueError, self.org.parse_number, 0.001)
+
+    def test_parse_datetime(self):
+        self.assertEqual(self.org.parse_datetime("Not num"), None)
+        self.assertEqual(
+            self.org.parse_datetime("0001-01-09T03:25:12.000Z"),
+            datetime.datetime(1, 1, 9, 3, 25, 12, tzinfo=datetime.timezone.utc),
+        )
+
+        self.assertRaises(ValueError, self.org.parse_datetime, timezone.now())

--- a/temba/utils/json.py
+++ b/temba/utils/json.py
@@ -1,5 +1,7 @@
 import datetime
 
+import psycopg2.extensions
+import psycopg2.extras
 import pytz
 import simplejson
 
@@ -52,3 +54,19 @@ class TembaEncoder(simplejson.JSONEncoder):
             return encode_datetime(o)
         else:
             return super().default(o)
+
+
+class TembaJsonAdapter(psycopg2.extras.Json):
+    """
+    Json adapter for psycopg2 that uses Temba specific `dumps` that serializes numbers as Decimal types
+    """
+
+    def dumps(self, o, **kwargs):
+        return dumps(o, **kwargs)
+
+
+# register UJsonAdapter for all dict Python types
+psycopg2.extensions.register_adapter(dict, TembaJsonAdapter)
+# register global json python encoders
+psycopg2.extras.register_default_jsonb(loads=loads, globally=True)
+psycopg2.extras.register_default_json(loads=loads, globally=True)


### PR DESCRIPTION
When using input parameter of type float for Decimal we get a memory
representation of that number which is 'correct' but confusing to users.

If value is a float, the binary floating point value is losslessly
converted to its exact decimal equivalent. This conversion can often
require 53 or more digits of precision. For example,
`Decimal(float('1.1'))`
converts to
`Decimal('1.100000000000000088817841970012523233890533447265625')`.

(https://docs.python.org/3.6/library/decimal.html#decimal-objects)

Fixes: https://github.com/rapidpro/rapidpro/issues/914