### PR TITLE
🔥 View absolute attachments in old editor

### DIFF
--- a/static/coffee/flows/directives.coffee
+++ b/static/coffee/flows/directives.coffee
@@ -169,12 +169,16 @@ app.directive "action", [ "Plumb", "Flow", "$log", (Plumb, Flow, $log) ->
         if action.media and action.media[iso_code]
           parts = action.media[iso_code].split(/:(.+)/)
 
+          url = parts[1]
+          if not url.startsWith('http')
+            url = window.mediaURL + parts[1]
+
           if parts.length >= 2
             mime_parts = parts[0].split('/')
             if mime_parts.length > 1
               action._media =
                 mime: parts[0]
-                url:  window.mediaURL + parts[1]
+                url: url
                 type: mime_parts[0]
             else
               action._attachURL = parts[1]


### PR DESCRIPTION
Definitions are fine, but viewing them isn't.