### PR TITLE
🎑 Add "modified_on" to save methods to track when object was last modified

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -100,7 +100,7 @@ class Resthook(SmartModel):
     def add_subscriber(self, url, user):
         subscriber = self.subscribers.create(target_url=url, created_by=user, modified_by=user)
         self.modified_by = user
-        self.save(update_fields=["modified_on", "modified_by"])
+        self.save(update_fields=("modified_on", "modified_by"))
         return subscriber
 
     def remove_subscriber(self, url, user):
@@ -109,7 +109,7 @@ class Resthook(SmartModel):
             is_active=False, modified_on=now, modified_by=user
         )
         self.modified_by = user
-        self.save(update_fields=["modified_on", "modified_by"])
+        self.save(update_fields=("modified_on", "modified_by"))
 
     def release(self, user):
         # release any active subscribers
@@ -119,7 +119,7 @@ class Resthook(SmartModel):
         # then ourselves
         self.is_active = False
         self.modified_by = user
-        self.save(update_fields=["is_active", "modified_on", "modified_by"])
+        self.save(update_fields=("is_active", "modified_on", "modified_by"))
 
     def as_select2(self):
         return dict(text=self.slug, id=self.slug)
@@ -145,11 +145,11 @@ class ResthookSubscriber(SmartModel):
     def release(self, user):
         self.is_active = False
         self.modified_by = user
-        self.save(update_fields=["is_active", "modified_on", "modified_by"])
+        self.save(update_fields=("is_active", "modified_on", "modified_by"))
 
         # update our parent as well
         self.resthook.modified_by = user
-        self.resthook.save(update_fields=["modified_on", "modified_by"])
+        self.resthook.save(update_fields=("modified_on", "modified_by"))
 
 
 class WebHookEvent(models.Model):

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -231,7 +231,8 @@ class CampaignWriteSerializer(WriteSerializer):
         if self.instance:
             self.instance.name = name
             self.instance.group = group
-            self.instance.save(update_fields=("name", "group"))
+            self.modified_by = self.context["request"].user
+            self.instance.save(update_fields=("name", "group", "modified_on", "modified_by"))
         else:
             self.instance = Campaign.create(self.context["org"], self.context["user"], name, group)
 
@@ -540,6 +541,8 @@ class ContactWriteSerializer(WriteSerializer):
                 changed.append("language")
 
             if changed:
+                changed.extend(("modified_on", "modified_by"))
+                self.instance.modified_by = self.context["request"].user
                 self.instance.save(update_fields=changed, handle_update=True)
 
             if "urns" in self.validated_data and urns is not None:
@@ -666,7 +669,8 @@ class ContactGroupWriteSerializer(WriteSerializer):
 
         if self.instance:
             self.instance.name = name
-            self.instance.save(update_fields=("name",))
+            self.instance.modified_by = self.context["request"].user
+            self.instance.save(update_fields=("name", "modified_on", "modified_by"))
             return self.instance
         else:
             return ContactGroup.get_or_create(self.context["org"], self.context["user"], name)
@@ -964,7 +968,8 @@ class LabelWriteSerializer(WriteSerializer):
 
         if self.instance:
             self.instance.name = name
-            self.instance.save(update_fields=("name",))
+            self.instance.modified_by = self.context["request"].user
+            self.instance.save(update_fields=("name", "modified_on", "modified_by"))
             return self.instance
         else:
             return Label.get_or_create(self.context["org"], self.context["user"], name)

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -232,7 +232,7 @@ class CampaignWriteSerializer(WriteSerializer):
             self.instance.name = name
             self.instance.group = group
             self.modified_by = self.context["request"].user
-            self.instance.save(update_fields=("name", "group", "modified_on", "modified_by"))
+            self.instance.save(update_fields=("name", "group", "modified_by"))
         else:
             self.instance = Campaign.create(self.context["org"], self.context["user"], name, group)
 
@@ -541,7 +541,7 @@ class ContactWriteSerializer(WriteSerializer):
                 changed.append("language")
 
             if changed:
-                changed.extend(("modified_on", "modified_by"))
+                changed.append("modified_by")
                 self.instance.modified_by = self.context["request"].user
                 self.instance.save(update_fields=changed, handle_update=True)
 
@@ -670,7 +670,7 @@ class ContactGroupWriteSerializer(WriteSerializer):
         if self.instance:
             self.instance.name = name
             self.instance.modified_by = self.context["request"].user
-            self.instance.save(update_fields=("name", "modified_on", "modified_by"))
+            self.instance.save(update_fields=("name", "modified_by"))
             return self.instance
         else:
             return ContactGroup.get_or_create(self.context["org"], self.context["user"], name)

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -198,7 +198,7 @@ class APITest(TembaTest):
 
         self.assertEqual(field.to_internal_value(self.channel.uuid), self.channel)
         self.channel.is_active = False
-        self.channel.save()
+        self.channel.save(update_fields=("is_active",))
         self.assertRaises(serializers.ValidationError, field.to_internal_value, self.channel.uuid)
 
         field = fields.ContactField(source="test")
@@ -247,7 +247,7 @@ class APITest(TembaTest):
         self.assertEqual(field.to_internal_value({"base": "Hello"}), ({"base": "Hello"}, "base"))
 
         self.org.primary_language = Language.create(self.org, self.user, "Kinyarwanda", "kin")
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         self.assertEqual(field.to_internal_value("Hello"), ({"kin": "Hello"}, "kin"))
         self.assertEqual(
@@ -584,7 +584,7 @@ class APITest(TembaTest):
 
         # if org doesn't have a country, just return no results
         self.org.country = None
-        self.org.save()
+        self.org.save(update_fields=("country",))
 
         response = self.fetchJSON(url)
         self.assertEqual(response.json()["results"], [])
@@ -2482,7 +2482,7 @@ class APITest(TembaTest):
 
         # inactive flows are never returned
         archived.is_active = False
-        archived.save()
+        archived.save(update_fields=("is_active",))
 
         response = self.fetchJSON(url)
         self.assertResultsByUUID(response, [color, survey])
@@ -3211,14 +3211,14 @@ class APITest(TembaTest):
 
         # doesn't work if flow is inactive
         flow1.is_active = False
-        flow1.save()
+        flow1.save(update_fields=("is_active",))
 
         response = self.fetchJSON(url, "flow=%s" % flow1.uuid)
         self.assertResultsById(response, [])
 
         # restore to active
         flow1.is_active = True
-        flow1.save()
+        flow1.save(update_fields=("is_active",))
 
         # filter by invalid flow
         response = self.fetchJSON(url, "flow=invalid")

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2008,7 +2008,7 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
     def perform_destroy(self, instance):
         instance.is_active = False
         instance.modified_by = self.request.user
-        instance.save(update_fields=("is_active", "modified_on", "modified_by"))
+        instance.save(update_fields=("is_active", "modified_by"))
 
         # release the group in a background task
         on_transaction_commit(lambda: release_group_task.delay(instance.id))

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2007,7 +2007,8 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
 
     def perform_destroy(self, instance):
         instance.is_active = False
-        instance.save(update_fields=("is_active",))
+        instance.modified_by = self.request.user
+        instance.save(update_fields=("is_active", "modified_on", "modified_by"))
 
         # release the group in a background task
         on_transaction_commit(lambda: release_group_task.delay(instance.id))

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -412,7 +412,7 @@ class CampaignEvent(TembaModel):
             return
 
         self.flow.name = "Single Message (%d)" % self.pk
-        self.flow.save(update_fields=["name"])
+        self.flow.save(update_fields=("name", "modified_on"))
 
     def single_unit_display(self):
         return self.get_unit_display()[:-1]
@@ -529,7 +529,7 @@ class CampaignEvent(TembaModel):
 
         # we need to be inactive so our fires are noops
         self.is_active = False
-        self.save(update_fields=("is_active",))
+        self.save(update_fields=("is_active", "modified_on"))
 
         # detach any associated flow starts
         self.flow_starts.all().update(campaign_event=None)

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -235,7 +235,7 @@ class CampaignTest(TembaTest):
         )
 
         self.org.primary_language = ace
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         # now we should have ace as our primary
         response = self.client.get(url)
@@ -256,7 +256,7 @@ class CampaignTest(TembaTest):
         self.assertContains(response, "show_language")
 
         self.org.primary_language = None
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         response = self.client.get(url)
         self.assertIn("base", response.context["form"].fields)
@@ -314,7 +314,7 @@ class CampaignTest(TembaTest):
 
         # promote spanish to our primary language
         self.org.primary_language = spa
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         # the base language needs to stay present since it's the true backdown
         response = self.client.get(url)
@@ -345,7 +345,7 @@ class CampaignTest(TembaTest):
 
         # now we can remove our primary language
         self.org.primary_language = None
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         # and still get the same settings, (it should use the base of the flow instead of just base here)
         event = CampaignEvent.objects.all().order_by("-pk").first()
@@ -752,7 +752,7 @@ class CampaignTest(TembaTest):
 
         # archive the campaign
         campaign.is_archived = True
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         response = self.client.get(reverse("campaigns.campaign_update", args=[campaign.pk]))
 
@@ -762,7 +762,7 @@ class CampaignTest(TembaTest):
         # deactivate the campaign
         campaign.is_archived = False
         campaign.is_active = False
-        campaign.save()
+        campaign.save(update_fields=("is_archived", "is_active"))
 
         response = self.client.get(reverse("campaigns.campaign_update", args=[campaign.pk]))
 
@@ -802,7 +802,7 @@ class CampaignTest(TembaTest):
 
         # archive the campaign
         campaign.is_archived = True
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         response = self.client.get(reverse("campaigns.campaign_read", args=[campaign.pk]))
 
@@ -866,7 +866,7 @@ class CampaignTest(TembaTest):
 
         # archive the campaign
         campaign.is_archived = True
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         response = self.client.get(reverse("campaigns.campaignevent_read", args=[event.pk]))
 
@@ -910,7 +910,7 @@ class CampaignTest(TembaTest):
 
         # archive the campaign
         campaign.is_archived = True
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         response = self.client.get(reverse("campaigns.campaignevent_update", args=[campaign.pk]))
 
@@ -920,7 +920,7 @@ class CampaignTest(TembaTest):
         # deactivate the campaign
         campaign.is_archived = False
         campaign.is_active = False
-        campaign.save()
+        campaign.save(update_fields=("is_archived", "is_active"))
 
         response = self.client.get(reverse("campaigns.campaign_update", args=[campaign.pk]))
 
@@ -953,7 +953,7 @@ class CampaignTest(TembaTest):
 
         # archive the campaign
         campaign.is_archived = True
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         response = self.client.post(
             reverse("campaigns.campaignevent_create") + "?campaign=%d" % campaign.pk, post_data
@@ -965,7 +965,7 @@ class CampaignTest(TembaTest):
         # deactivate the campaign
         campaign.is_archived = False
         campaign.is_active = False
-        campaign.save()
+        campaign.save(update_fields=("is_archived", "is_active"))
 
         response = self.client.post(
             reverse("campaigns.campaignevent_create") + "?campaign=%d" % campaign.pk, post_data
@@ -1156,7 +1156,7 @@ class CampaignTest(TembaTest):
         # set our timezone to something that honors DST
         eastern = pytz.timezone("US/Eastern")
         self.org.timezone = eastern
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # create our campaign and event
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
@@ -1394,7 +1394,7 @@ class CampaignTest(TembaTest):
 
         flow.archive()
         campaign.is_archived = True
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         self.assertTrue(campaign.is_archived)
         self.assertTrue(Flow.objects.filter(is_archived=True))

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -80,6 +80,7 @@ class CampaignCRUDL(SmartCRUDL):
         fields = ("name", "group")
         success_message = ""
         form_class = UpdateCampaignForm
+        exclude = ("id",)
 
         def pre_process(self, request, *args, **kwargs):
             campaign_id = kwargs.get("pk")
@@ -103,7 +104,10 @@ class CampaignCRUDL(SmartCRUDL):
 
             # save our campaign
             self.object = form.save(commit=False)
-            self.save(self.object)
+
+            fields = [f.name for f in self.object._meta.concrete_fields if f.name not in self.exclude]
+            self.object.save(update_fields=fields)
+            self.save_m2m()
 
             # if our group changed, create our new fires
             if new_group != previous_group:

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -128,7 +128,17 @@ class TWIMLCallHandler(BaseChannelHandler):
                     call.update_status(
                         request.POST.get("CallStatus", None), request.POST.get("CallDuration", None), "T"
                     )
-                    call.save()
+                    call.save(
+                        update_fields=(
+                            "status",
+                            "duration",
+                            "error_count",
+                            "next_attempt",
+                            "retry_count",
+                            "ended_on",
+                            "started_on",
+                        )
+                    )
 
                     FlowRun.create(flow, contact, session=session, connection=call)
                     response = Flow.handle_call(call)
@@ -161,7 +171,17 @@ class TWIMLCallHandler(BaseChannelHandler):
                     call.update_status(
                         request.POST.get("CallStatus", None), request.POST.get("CallDuration", None), "TW"
                     )
-                    call.save()
+                    call.save(
+                        update_fields=(
+                            "status",
+                            "duration",
+                            "error_count",
+                            "next_attempt",
+                            "retry_count",
+                            "ended_on",
+                            "started_on",
+                        )
+                    )
                     return HttpResponse("Call status updated")
             return HttpResponse("No call found")
 
@@ -234,7 +254,7 @@ class NexmoCallHandler(BaseChannelHandler):
                 call = IVRCall.objects.filter(external_id=conversation_uuid).first()
                 if call:
                     call.external_id = call_uuid
-                    call.save()
+                    call.save(update_fields=("external_id",))
                 else:
                     response = dict(message="Call not found for %s" % call_uuid)
                     return JsonResponse(response)
@@ -242,7 +262,17 @@ class NexmoCallHandler(BaseChannelHandler):
             channel = call.channel
             channel_type = channel.channel_type
             call.update_status(status, duration, channel_type)
-            call.save()
+            call.save(
+                update_fields=(
+                    "status",
+                    "duration",
+                    "error_count",
+                    "next_attempt",
+                    "retry_count",
+                    "ended_on",
+                    "started_on",
+                )
+            )
 
             response = dict(
                 description="Updated call status", call=dict(status=call.get_status_display(), duration=call.duration)
@@ -297,6 +327,17 @@ class NexmoCallHandler(BaseChannelHandler):
                 response = Flow.handle_call(call)
                 channel_type = channel.channel_type
                 call.update_status("answered", None, channel_type)
+                call.save(
+                    update_fields=(
+                        "status",
+                        "duration",
+                        "error_count",
+                        "next_attempt",
+                        "retry_count",
+                        "ended_on",
+                        "started_on",
+                    )
+                )
 
                 event = HttpEvent(request_method, request_path, request_body, 200, str(response))
                 ChannelLog.log_ivr_interaction(call, "Incoming request for call", event)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -41,7 +41,14 @@ from temba.orgs.models import (
 from temba.utils import get_anonymous_user, json, on_transaction_commit
 from temba.utils.email import send_template_email
 from temba.utils.gsm7 import calculate_num_segments
-from temba.utils.models import JSONAsTextField, SquashableModel, TembaModel, generate_uuid
+from temba.utils.models import (
+    AddModifiedOnMixin,
+    JSONAsTextField,
+    RequireUpdateFieldsMixin,
+    SquashableModel,
+    TembaModel,
+    generate_uuid,
+)
 from temba.utils.nexmo import NCCOResponse
 from temba.utils.text import random_string
 
@@ -268,7 +275,7 @@ class UnsupportedAndroidChannelError(Exception):
         self.message = message
 
 
-class Channel(TembaModel):
+class Channel(RequireUpdateFieldsMixin, AddModifiedOnMixin, TembaModel):
     """
     Notes:
         - we want to reuse keys as much as possible (2018-10-11)
@@ -701,14 +708,14 @@ class Channel(TembaModel):
             existing.secret = cls.generate_secret()
             existing.country = country
             existing.device = device
-            existing.save(update_fields=("config", "secret", "claim_code", "country", "device", "modified_on"))
+            existing.save(update_fields=("config", "secret", "claim_code", "country", "device"))
 
             return existing
 
         # if any inactive channel has this UUID, we can steal it
         for ch in Channel.objects.filter(uuid=uuid, is_active=False):
             ch.uuid = generate_uuid()
-            ch.save(update_fields=("uuid", "modified_on"))
+            ch.save(update_fields=("uuid",))
 
         # generate random secret and claim code
         claim_code = cls.generate_claim_code()
@@ -906,12 +913,12 @@ class Channel(TembaModel):
         # create a claim code if we don't have one
         if not self.claim_code:
             self.claim_code = self.generate_claim_code()
-            self.save(update_fields=("claim_code", "modified_on"))
+            self.save(update_fields=("claim_code",))
 
         # create a secret if we don't have one
         if not self.secret:
             self.secret = self.generate_secret()
-            self.save(update_fields=("secret", "modified_on"))
+            self.save(update_fields=("secret",))
 
         # return our command
         return dict(cmd="reg", relayer_claim_code=self.claim_code, relayer_secret=self.secret, relayer_id=self.id)
@@ -1019,7 +1026,7 @@ class Channel(TembaModel):
         self.is_active = True
         self.claim_code = None
         self.address = phone
-        self.save()
+        self.save(update_fields=("alert_email", "org", "is_active", "claim_code", "address"))
 
         org.normalize_contact_tels()
 
@@ -1064,7 +1071,7 @@ class Channel(TembaModel):
         # make the channel inactive
         self.config.pop(Channel.CONFIG_FCM_ID, None)
         self.is_active = False
-        self.save(update_fields=["is_active", "config", "modified_on"])
+        self.save(update_fields=("is_active", "config"))
 
         # mark any messages in sending mode as failed for this channel
         from temba.msgs.models import Msg, OUTGOING, PENDING, QUEUED, ERRORED, FAILED
@@ -1127,7 +1134,7 @@ class Channel(TembaModel):
             if registration_id not in valid_registration_ids:
                 # this fcm id is invalid now, clear it out
                 channel.config.pop(Channel.CONFIG_FCM_ID, None)
-                channel.save(update_fields=("config", "modified_on"))
+                channel.save(update_fields=("config",))
 
     @classmethod
     def replace_variables(cls, text, variables, content_type=CONTENT_TYPE_URLENCODED):
@@ -1596,7 +1603,7 @@ class SyncEvent(SmartModel):
         if channel.device != device or channel.os != os:  # pragma: no cover
             channel.device = device
             channel.os = os
-            channel.save(update_fields=("device", "os", "modified_on"))
+            channel.save(update_fields=("device", "os"))
 
         args = dict()
 
@@ -1871,7 +1878,7 @@ def get_alert_user():
         return user
 
 
-class ChannelConnection(models.Model):
+class ChannelConnection(RequireUpdateFieldsMixin, AddModifiedOnMixin, models.Model):
     """
     Base for IVR sessions which require a connection to specific channel
     """

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -701,14 +701,14 @@ class Channel(TembaModel):
             existing.secret = cls.generate_secret()
             existing.country = country
             existing.device = device
-            existing.save(update_fields=("config", "secret", "claim_code", "country", "device"))
+            existing.save(update_fields=("config", "secret", "claim_code", "country", "device", "modified_on"))
 
             return existing
 
         # if any inactive channel has this UUID, we can steal it
         for ch in Channel.objects.filter(uuid=uuid, is_active=False):
             ch.uuid = generate_uuid()
-            ch.save(update_fields=("uuid",))
+            ch.save(update_fields=("uuid", "modified_on"))
 
         # generate random secret and claim code
         claim_code = cls.generate_claim_code()
@@ -906,12 +906,12 @@ class Channel(TembaModel):
         # create a claim code if we don't have one
         if not self.claim_code:
             self.claim_code = self.generate_claim_code()
-            self.save(update_fields=("claim_code",))
+            self.save(update_fields=("claim_code", "modified_on"))
 
         # create a secret if we don't have one
         if not self.secret:
             self.secret = self.generate_secret()
-            self.save(update_fields=("secret",))
+            self.save(update_fields=("secret", "modified_on"))
 
         # return our command
         return dict(cmd="reg", relayer_claim_code=self.claim_code, relayer_secret=self.secret, relayer_id=self.id)
@@ -1087,7 +1087,7 @@ class Channel(TembaModel):
         # and any triggers associated with our channel get archived
         for trigger in Trigger.objects.filter(org=self.org, channel=self).all():
             trigger.channel = None
-            trigger.save(update_fields=("channel",))
+            trigger.save(update_fields=("channel", "modified_on"))
             trigger.archive(self.modified_by)
 
     def trigger_sync(self, registration_id=None):  # pragma: no cover
@@ -1127,7 +1127,7 @@ class Channel(TembaModel):
             if registration_id not in valid_registration_ids:
                 # this fcm id is invalid now, clear it out
                 channel.config.pop(Channel.CONFIG_FCM_ID, None)
-                channel.save(update_fields=["config"])
+                channel.save(update_fields=("config", "modified_on"))
 
     @classmethod
     def replace_variables(cls, text, variables, content_type=CONTENT_TYPE_URLENCODED):
@@ -1596,7 +1596,7 @@ class SyncEvent(SmartModel):
         if channel.device != device or channel.os != os:  # pragma: no cover
             channel.device = device
             channel.os = os
-            channel.save(update_fields=["device", "os"])
+            channel.save(update_fields=("device", "os", "modified_on"))
 
         args = dict()
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 from urllib.parse import quote
 
 from django_redis import get_redis_connection
-from smartmin.tests import SmartminTest
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -21,6 +20,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text
 
+from smartmin.tests import SmartminTest
 from temba.channels.views import channel_status_processor
 from temba.contacts.models import TEL_SCHEME, TWITTER_SCHEME, URN, Contact, ContactGroup, ContactURN
 from temba.ivr.models import IVRCall
@@ -271,7 +271,7 @@ class ChannelTest(TembaTest):
         # add a voice caller
         self.org.config["ACCOUNT_SID"] = "accountSID"
         self.org.config["ACCOUNT_TOKEN"] = "accountToken"
-        self.org.save()
+        self.org.save(update_fields=("config",))
         caller = Channel.add_call_channel(self.org, self.user, self.tel_channel)
 
         # set our affinity to the caller (ie, they were on an ivr call)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -153,7 +153,7 @@ class ChannelTest(TembaTest):
     def test_deactivate(self):
         self.login(self.admin)
         self.tel_channel.is_active = False
-        self.tel_channel.save()
+        self.tel_channel.save(update_fields=("is_active",))
         response = self.client.get(reverse("channels.channel_read", args=[self.tel_channel.uuid]))
         self.assertEqual(404, response.status_code)
 
@@ -180,7 +180,7 @@ class ChannelTest(TembaTest):
 
         # pretend we are connected to twiliko
         self.org.config = dict(ACCOUNT_SID="AccountSid", ACCOUNT_TOKEN="AccountToken", APPLICATION_SID="AppSid")
-        self.org.save()
+        self.org.save(update_fields=("config",))
 
         # add a delegate caller
         post_data = dict(channel=self.tel_channel.pk, connection="T")
@@ -233,7 +233,7 @@ class ChannelTest(TembaTest):
         # make our default tel channel MTN
         mtn = self.tel_channel
         mtn.name = "MTN"
-        mtn.save()
+        mtn.save(update_fields=("name",))
 
         # create a channel for Tigo too
         tigo = Channel.create(
@@ -280,9 +280,9 @@ class ChannelTest(TembaTest):
 
         # change channel numbers to be shortcodes, i.e. no overlap with contact numbers
         mtn.address = "1234"
-        mtn.save()
+        mtn.save(update_fields=("address",))
         tigo.address = "1235"
-        tigo.save()
+        tigo.save(update_fields=("address",))
 
         self.org.clear_cached_channels()
 
@@ -293,7 +293,7 @@ class ChannelTest(TembaTest):
 
         # if we have prefixes matching set should honor those
         mtn.config = {Channel.CONFIG_SHORTCODE_MATCHING_PREFIXES: ["25078", "25072"]}
-        mtn.save()
+        mtn.save(update_fields=("config",))
 
         self.org.clear_cached_channels()
 
@@ -314,7 +314,7 @@ class ChannelTest(TembaTest):
 
     def test_ensure_normalization(self):
         self.tel_channel.country = "RW"
-        self.tel_channel.save()
+        self.tel_channel.save(update_fields=("country",))
 
         contact1 = self.create_contact("contact1", "0788111222")
         contact2 = self.create_contact("contact2", "+250788333444")
@@ -523,7 +523,7 @@ class ChannelTest(TembaTest):
 
         # re-activate one of the channels so org has a single channel
         self.tel_channel.is_active = True
-        self.tel_channel.save()
+        self.tel_channel.save(update_fields=("is_active",))
 
         # list page now redirects to channel read page
         self.login(self.user)
@@ -538,7 +538,7 @@ class ChannelTest(TembaTest):
 
         # re-activate other channel so org now has two channels
         self.twitter_channel.is_active = True
-        self.twitter_channel.save()
+        self.twitter_channel.save(update_fields=("is_active",))
 
         # no-more redirection for anyone
         self.login(self.user)
@@ -549,7 +549,7 @@ class ChannelTest(TembaTest):
         # clear out the phone and name for the Android channel
         self.tel_channel.name = None
         self.tel_channel.address = None
-        self.tel_channel.save()
+        self.tel_channel.save(update_fields=("name", "address"))
         response = self.client.get(reverse("channels.channel_list"))
         self.assertContains(response, "Unknown")
         self.assertContains(response, "Android Phone")
@@ -631,7 +631,7 @@ class ChannelTest(TembaTest):
 
         success_msg.sent_on = timezone.now() - timedelta(hours=2)
         success_msg.status = "S"
-        success_msg.save()
+        success_msg.save(update_fields=("sent_on", "status"))
         response = self.client.get("/", Follow=True)
         self.assertIn("delayed_syncevents", response.context)
         self.assertNotIn("unsent_msgs", response.context, msg="Found unsent_msgs in context")
@@ -713,14 +713,14 @@ class ChannelTest(TembaTest):
 
         # if we change the channel to a twilio type, shouldn't be able to edit our address
         channel.channel_type = "T"
-        channel.save()
+        channel.save(update_fields=("channel_type",))
 
         response = self.client.get(update_url)
         self.assertNotIn("address", response.context["form"].fields)
 
         # bring it back to android
         channel.channel_type = Channel.TYPE_ANDROID
-        channel.save()
+        channel.save(update_fields=("channel_type",))
 
         # visit the channel's update page as administrator
         self.org.administrators.add(self.user)
@@ -768,9 +768,8 @@ class ChannelTest(TembaTest):
         channel.channel_type = "TWT"
         channel.schemes = [TWITTER_SCHEME]
         channel.address = "billy_bob"
-        channel.scheme = "twitter"
         channel.config = {"handle_id": 12345, "oauth_token": "abcdef", "oauth_token_secret": "23456"}
-        channel.save()
+        channel.save(update_fields=("channel_type", "schemes", "address", "config", "address"))
 
         self.assertEqual("@billy_bob", channel.get_address_display())
         self.assertEqual("@billy_bob", channel.get_address_display(e164=True))
@@ -850,7 +849,7 @@ class ChannelTest(TembaTest):
         config = self.org.config
         config.update(twilio_config)
         self.org.config = config
-        self.org.save(update_fields=["config"])
+        self.org.save(update_fields=("config",))
 
         response = self.fetch_protected(reverse("orgs.org_home"), self.admin)
         self.assertTrue(self.org.is_connected_to_twilio())
@@ -860,7 +859,7 @@ class ChannelTest(TembaTest):
 
         # make sure our channel is old enough to trigger alerts
         self.tel_channel.created_on = two_hours_ago
-        self.tel_channel.save()
+        self.tel_channel.save(update_fields=("created_on",))
 
         # delayed sync status
         for sync in SyncEvent.objects.all():
@@ -918,7 +917,7 @@ class ChannelTest(TembaTest):
 
         # test cases for IVR messaging, make our relayer accept calls
         self.tel_channel.role = "SCAR"
-        self.tel_channel.save()
+        self.tel_channel.save(update_fields=("role",))
 
         # now let's create an ivr interaction
         Msg.create_incoming(self.tel_channel, str(joe.get_urn()), "incoming ivr", msg_type=IVR)
@@ -989,7 +988,7 @@ class ChannelTest(TembaTest):
         self.assertEqual(response.context["channel_types"]["PHONE"][4].code, "EX")
 
         self.org.timezone = "Canada/Central"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertEqual(200, response.status_code)
@@ -1007,7 +1006,7 @@ class ChannelTest(TembaTest):
     def test_register_unsupported_android(self):
         # remove our explicit country so it needs to be derived from channels
         self.org.country = None
-        self.org.save()
+        self.org.save(update_fields=("country",))
 
         Channel.objects.all().delete()
 
@@ -1037,7 +1036,7 @@ class ChannelTest(TembaTest):
     def test_register_and_claim_android(self):
         # remove our explicit country so it needs to be derived from channels
         self.org.country = None
-        self.org.save()
+        self.org.save(update_fields=("country",))
 
         Channel.objects.all().delete()
 
@@ -1239,7 +1238,7 @@ class ChannelTest(TembaTest):
             with patch("nexmo.Client.create_application") as create_app:
                 create_app.return_value = dict(id="app-id", keys=dict(private_key="private-key\n"))
                 self.org.connect_nexmo("123", "456", self.admin)
-                self.org.save()
+
         self.assertTrue(self.org.is_connected_to_nexmo())
 
         # now adding Nexmo bulk sender should work
@@ -1284,7 +1283,7 @@ class ChannelTest(TembaTest):
 
         # set back to RW...
         android2.country = "RW"
-        android2.save()
+        android2.save(update_fields=("country",))
 
         # our country is RW
         self.assertEqual(self.org.get_country_code(), "RW")
@@ -1389,7 +1388,7 @@ class ChannelTest(TembaTest):
         config = org.config
         config.update(nexmo_config)
         org.config = config
-        org.save()
+        org.save(update_fields=("config",))
 
         search_nexmo_url = reverse("channels.channel_search_nexmo")
 
@@ -1488,7 +1487,6 @@ class ChannelTest(TembaTest):
             with patch("nexmo.Client.create_application") as create_app:
                 create_app.return_value = dict(id="app-id", keys=dict(private_key="private-key\n"))
                 self.org.connect_nexmo("123", "456", self.admin)
-                self.org.save()
 
         claim_nexmo_url = reverse("channels.channel_create_bulk_sender") + "?connection=NX&channel=%d" % android.pk
         self.client.post(claim_nexmo_url, dict(connection="NX", channel=android.pk))
@@ -1515,7 +1513,7 @@ class ChannelTest(TembaTest):
         android.refresh_from_db()
         # simulate no FCM ID
         android.config.pop(Channel.CONFIG_FCM_ID, None)
-        android.save()
+        android.save(update_fields=("config",))
 
         android.release()
 
@@ -1561,7 +1559,7 @@ class ChannelTest(TembaTest):
 
         # try syncing against the unclaimed channel that has a secret
         self.unclaimed_channel.secret = "999"
-        self.unclaimed_channel.save()
+        self.unclaimed_channel.save(update_fields=("secret",))
 
         response = self.sync(self.unclaimed_channel, post_data=post_data)
         response = response.json()
@@ -1571,7 +1569,7 @@ class ChannelTest(TembaTest):
 
         # claim the channel on the site
         self.unclaimed_channel.org = self.org
-        self.unclaimed_channel.save()
+        self.unclaimed_channel.save(update_fields=("org",))
 
         post_data = dict(
             cmds=[
@@ -1607,7 +1605,7 @@ class ChannelTest(TembaTest):
     def test_quota_exceeded(self):
         # set our org to be on the trial plan
         self.org.plan = FREE_PLAN
-        self.org.save()
+        self.org.save(update_fields=("plan",))
         self.org.topups.all().update(credits=10)
 
         self.assertEqual(10, self.org.get_credits_remaining())
@@ -1703,7 +1701,7 @@ class ChannelTest(TembaTest):
         # an incoming message that should not be included even if it is still pending
         incoming_message = Msg.create_incoming(self.tel_channel, "tel:+250788382382", "hey")
         incoming_message.status = PENDING
-        incoming_message.save()
+        incoming_message.save(update_fields=("status",))
 
         self.org.administrators.add(self.user)
         self.user.set_org(self.org)
@@ -1739,7 +1737,7 @@ class ChannelTest(TembaTest):
         six_mins_ago = timezone.now() - timedelta(minutes=6)
         self.tel_channel.last_seen = six_mins_ago
         self.tel_channel.config["FCM_ID"] = "old_fcm_id"
-        self.tel_channel.save(update_fields=["last_seen", "config"])
+        self.tel_channel.save(update_fields=("last_seen", "config"))
 
         post_data = dict(
             cmds=[
@@ -1827,7 +1825,7 @@ class ChannelTest(TembaTest):
 
         # set an email on our channel
         self.tel_channel.alert_email = "fred@worldrelif.org"
-        self.tel_channel.save()
+        self.tel_channel.save(update_fields=("alert_email",))
 
         # We should not have an alert this time
         self.assertEqual(0, Alert.objects.all().count())
@@ -2109,10 +2107,9 @@ class ChannelTest(TembaTest):
         self.assertIsNone(channel.get_ivr_client())
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         channel.channel_type = "NX"
-        channel.save()
+        channel.save(update_fields=("channel_type",))
 
         self.assertIsNotNone(channel.get_ivr_client())
 
@@ -2235,7 +2232,7 @@ class ChannelAlertTest(TembaTest):
     def test_no_alert_email(self):
         # set our last seen to a while ago
         self.channel.last_seen = timezone.now() - timedelta(minutes=40)
-        self.channel.save()
+        self.channel.save(update_fields=("last_seen",))
 
         check_channels_task()
         self.assertTrue(len(mail.outbox) == 0)
@@ -2244,7 +2241,7 @@ class ChannelAlertTest(TembaTest):
         self.channel.alert_email = "fred@unicef.org"
         self.channel.org = None
         self.channel.last_seen = timezone.now()
-        self.channel.save()
+        self.channel.save(update_fields=("org", "last_seen", "alert_email"))
         check_channels_task()
 
         self.assertTrue(len(mail.outbox) == 0)
@@ -2252,21 +2249,21 @@ class ChannelAlertTest(TembaTest):
 
 class ChannelSyncTest(TembaTest):
     @patch("temba.channels.models.Channel.trigger_sync")
-    def test_sync_old_seen_chaanels(self, mock_trigger_sync):
+    def test_sync_old_seen_channels(self, mock_trigger_sync):
         self.channel.last_seen = timezone.now() - timedelta(days=40)
-        self.channel.save()
+        self.channel.save(update_fields=("last_seen",))
 
         sync_old_seen_channels_task()
         self.assertFalse(mock_trigger_sync.called)
 
         self.channel.last_seen = timezone.now() - timedelta(minutes=5)
-        self.channel.save()
+        self.channel.save(update_fields=("last_seen",))
 
         sync_old_seen_channels_task()
         self.assertFalse(mock_trigger_sync.called)
 
         self.channel.last_seen = timezone.now() - timedelta(hours=3)
-        self.channel.save()
+        self.channel.save(update_fields=("last_seen",))
 
         sync_old_seen_channels_task()
         self.assertTrue(mock_trigger_sync.called)
@@ -2278,7 +2275,7 @@ class ChannelClaimTest(TembaTest):
         # set our last seen to a while ago
         self.channel.alert_email = "fred@unicef.org"
         self.channel.last_seen = timezone.now() - timedelta(minutes=40)
-        self.channel.save()
+        self.channel.save(update_fields=("alert_email", "last_seen"))
 
         branding = copy.deepcopy(settings.BRANDING)
         branding["rapidpro.io"]["from_email"] = "support@mybrand.com"
@@ -2317,7 +2314,7 @@ class ChannelClaimTest(TembaTest):
 
         # ok, let's have the channel show up again
         self.channel.last_seen = timezone.now() + timedelta(minutes=5)
-        self.channel.save()
+        self.channel.save(update_fields=("last_seen",))
 
         check_channels_task()
 
@@ -2358,7 +2355,7 @@ class ChannelClaimTest(TembaTest):
         self.channel.last_seen = timezone.now()
         self.channel.alert_email = "fred@unicef.org"
         self.channel.org = self.org
-        self.channel.save()
+        self.channel.save(update_fields=("last_seen", "alert_email", "org"))
 
         # ok check on our channel
         check_channels_task()
@@ -2392,7 +2389,7 @@ class ChannelClaimTest(TembaTest):
 
         # consider the sent message was sent before our queued msg
         sent_msg.sent_on = three_hours_ago
-        sent_msg.save()
+        sent_msg.save(update_fields=("sent_on",))
 
         msg1.delete()
         msg1 = self.create_msg(text="Message One", contact=contact, created_on=two_hours_ago, status="Q")
@@ -2404,7 +2401,7 @@ class ChannelClaimTest(TembaTest):
         self.assertEqual(Alert.objects.all().count(), 1)
 
         sent_msg.sent_on = six_hours_ago
-        sent_msg.save()
+        sent_msg.save(update_fields=("sent_on",))
 
         alert = Alert.objects.all()[0]
         alert.created_on = six_hours_ago
@@ -2432,7 +2429,7 @@ class ChannelClaimTest(TembaTest):
 
         # fix our message
         msg1.status = "D"
-        msg1.save()
+        msg1.save(update_fields=("status",))
 
         # run again, our alert should end
         check_channels_task()
@@ -2543,14 +2540,14 @@ class ChannelLogTest(TembaTest):
         )
         success_log.response = ""
         success_log.request = "POST https://foo.bar/send?msg=failed+message"
-        success_log.save(update_fields=["request", "response"])
+        success_log.save(update_fields=("request", "response"))
 
         failed_msg = Msg.create_outgoing(self.org, self.admin, self.contact, "failed message", channel=self.channel)
         failed_log = ChannelLog.log_error(dict_to_struct("MockMsg", failed_msg.as_task_json()), "Error Sending")
 
         failed_log.response = json.dumps(dict(error="invalid credentials"))
         failed_log.request = "POST https://foo.bar/send?msg=failed+message"
-        failed_log.save(update_fields=["request", "response"])
+        failed_log.save(update_fields=("request", "response"))
 
         # can't see the view without logging in
         list_url = reverse("channels.channellog_list", args=[self.channel.uuid])
@@ -2590,7 +2587,7 @@ class ChannelLogTest(TembaTest):
 
         # disconnect our msg
         failed_log.msg = None
-        failed_log.save(update_fields=["msg"])
+        failed_log.save(update_fields=("msg",))
         response = self.client.get(read_url)
         self.assertContains(response, "failed+message")
         self.assertContains(response, "invalid credentials")
@@ -2604,7 +2601,7 @@ class ChannelLogTest(TembaTest):
 
         # change our org to anonymous
         self.org.is_anon = True
-        self.org.save()
+        self.org.save(update_fields=("is_anon",))
 
         # should no longer be able to see read page
         response = self.client.get(read_url)
@@ -2669,7 +2666,7 @@ class CourierTest(TembaTest):
     @override_settings(SEND_MESSAGES=True)
     def test_queue_to_courier(self):
         self.channel.channel_type = "T"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         bob = self.create_contact("Bob", urn="tel:+12065551111")
         incoming = self.create_msg(contact=bob, text="Hello", direction="I", external_id="external-id")

--- a/temba/channels/types/africastalking/tests.py
+++ b/temba/channels/types/africastalking/tests.py
@@ -13,13 +13,13 @@ class AfricastalkingTypeTest(TembaTest):
         self.login(self.admin)
 
         self.org.timezone = "Africa/Cairo"  # not supported
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertNotContains(response, url)
 
         self.org.timezone = "Africa/Nairobi"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/blackmyna/tests.py
+++ b/temba/channels/types/blackmyna/tests.py
@@ -17,7 +17,7 @@ class BlackmynaTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Asia/Kathmandu"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/bongolive/tests.py
+++ b/temba/channels/types/bongolive/tests.py
@@ -17,7 +17,7 @@ class BongoLiveTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Africa/Dar_es_Salaam"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/chikka/tests.py
+++ b/temba/channels/types/chikka/tests.py
@@ -17,7 +17,7 @@ class ChikkaTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Asia/Manila"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/dartmedia/tests.py
+++ b/temba/channels/types/dartmedia/tests.py
@@ -19,7 +19,7 @@ class DartMediaTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Asia/Jakarta"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/dmark/tests.py
+++ b/temba/channels/types/dmark/tests.py
@@ -18,7 +18,7 @@ class DMarkTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Africa/Kinshasa"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/external/tests.py
+++ b/temba/channels/types/external/tests.py
@@ -92,7 +92,7 @@ class ExternalTypeTest(TembaTest):
 
         # raw content type should be loaded on setting page as is
         channel.config[Channel.CONFIG_CONTENT_TYPE] = "application/x-www-form-urlencoded; charset=utf-8"
-        channel.save()
+        channel.save(update_fields=("config",))
 
         response = self.client.get(config_url)
         self.assertEqual(response.status_code, 200)

--- a/temba/channels/types/globe/tests.py
+++ b/temba/channels/types/globe/tests.py
@@ -17,7 +17,7 @@ class GlobeTypeTest(TembaTest):
         self.assertNotContains(response, claim_url)
 
         self.org.timezone = "Asia/Manila"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/highconnection/tests.py
+++ b/temba/channels/types/highconnection/tests.py
@@ -17,7 +17,7 @@ class HighConnectionTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Europe/Paris"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/hormuud/tests.py
+++ b/temba/channels/types/hormuud/tests.py
@@ -17,7 +17,7 @@ class HormuudTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Africa/Mogadishu"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/hub9/tests.py
+++ b/temba/channels/types/hub9/tests.py
@@ -19,7 +19,7 @@ class Hub9TypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Asia/Jakarta"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/kannel/tests.py
+++ b/temba/channels/types/kannel/tests.py
@@ -11,7 +11,7 @@ class KannelTypeTest(TembaTest):
 
         # override the ORG brand
         self.org.brand = "custom-brand.io"
-        self.org.save()
+        self.org.save(update_fields=("brand",))
 
         self.login(self.admin)
 

--- a/temba/channels/types/kannel/views.py
+++ b/temba/channels/types/kannel/views.py
@@ -94,6 +94,6 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             config[Channel.CONFIG_PASSWORD] = str(uuid4())
 
         self.object.config = config
-        self.object.save()
+        self.object.save(update_fields=("config",))
 
         return super().form_valid(form)

--- a/temba/channels/types/m3tech/tests.py
+++ b/temba/channels/types/m3tech/tests.py
@@ -17,7 +17,7 @@ class M3TechTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Asia/Karachi"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/macrokiosk/tests.py
+++ b/temba/channels/types/macrokiosk/tests.py
@@ -17,7 +17,7 @@ class MacrokioskTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Asia/Kuala_Lumpur"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, url)

--- a/temba/channels/types/messangi/tests.py
+++ b/temba/channels/types/messangi/tests.py
@@ -23,7 +23,7 @@ class MessangiTypeTest(TembaTest):
 
         # but if we are in the proper time zone
         self.org.timezone = pytz.timezone("America/Jamaica")
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, "Messangi")

--- a/temba/channels/types/nexmo/tests.py
+++ b/temba/channels/types/nexmo/tests.py
@@ -34,7 +34,7 @@ class NexmoTypeTest(TembaTest):
             NEXMO_APP_PRIVATE_KEY="nexmo-app-private-key\n",
         )
         self.org.config = nexmo_config
-        self.org.save()
+        self.org.save(update_fields=("config",))
 
         # hit the claim page, should now have a claim nexmo link
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/novo/tests.py
+++ b/temba/channels/types/novo/tests.py
@@ -20,7 +20,7 @@ class NovoTypeTest(TembaTest):
 
         # but if we are in the proper time zone
         self.org.timezone = pytz.timezone("America/Port_of_Spain")
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, "Novo")

--- a/temba/channels/types/playmobile/tests.py
+++ b/temba/channels/types/playmobile/tests.py
@@ -20,7 +20,7 @@ class PlayMobileTypeTest(TembaTest):
 
         # but if we are in the proper time zone
         self.org.timezone = pytz.timezone("Asia/Tashkent")
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, "Play Mobile")

--- a/temba/channels/types/shaqodoon/tests.py
+++ b/temba/channels/types/shaqodoon/tests.py
@@ -17,7 +17,7 @@ class ShaqodoonTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Africa/Mogadishu"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/smscentral/tests.py
+++ b/temba/channels/types/smscentral/tests.py
@@ -17,7 +17,7 @@ class SMSCentralTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Asia/Kathmandu"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/start/tests.py
+++ b/temba/channels/types/start/tests.py
@@ -18,7 +18,7 @@ class StartTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Europe/Kiev"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/twilio/tests.py
+++ b/temba/channels/types/twilio/tests.py
@@ -32,7 +32,7 @@ class TwilioTypeTest(TembaTest):
 
         # attach a Twilio accont to the org
         self.org.config = {ACCOUNT_SID: "account-sid", ACCOUNT_TOKEN: "account-token"}
-        self.org.save()
+        self.org.save(update_fields=("config",))
 
         # hit the claim page, should now have a claim twilio link
         response = self.client.get(reverse("channels.channel_claim"))
@@ -174,7 +174,7 @@ class TwilioTypeTest(TembaTest):
                     Channel.objects.all().delete()
 
                     self.org.timezone = "America/New_York"
-                    self.org.save()
+                    self.org.save(update_fields=("timezone",))
 
                     response = self.client.get(claim_twilio)
                     self.assertContains(response, "8080")
@@ -192,7 +192,7 @@ class TwilioTypeTest(TembaTest):
         twilio_channel = self.org.channels.all().first()
         # make channel support both sms and voice to check we clear both applications
         twilio_channel.role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE + Channel.ROLE_ANSWER + Channel.ROLE_CALL
-        twilio_channel.save()
+        twilio_channel.save(update_fields=("role",))
         self.assertEqual("T", twilio_channel.channel_type)
 
         with self.settings(IS_PROD=True):
@@ -225,7 +225,7 @@ class TwilioTypeTest(TembaTest):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
         twilio_channel = self.org.channels.all().first()
         twilio_channel.channel_type = "T"
-        twilio_channel.save()
+        twilio_channel.save(update_fields=("channel_type",))
 
         # mock an authentication failure during the release process
         with self.settings(IS_PROD=True):
@@ -247,7 +247,7 @@ class TwilioTypeTest(TembaTest):
         channel.channel_type = "T"
         channel.config["callback_domain"] = "temba.io"
         channel.config["application_sid"] = "twilio_app_sid"
-        channel.save()
+        channel.save(update_fields=("channel_type", "config"))
 
         # mock an authentication failure during the release process
         with patch("temba.tests.twilio.MockTwilioClient.MockApplication.update") as mock_application:
@@ -257,7 +257,7 @@ class TwilioTypeTest(TembaTest):
             self.assertEqual(mock_application.call_count, 0)
 
             channel.role = Channel.ROLE_ANSWER
-            channel.save()
+            channel.save(update_fields=("role",))
 
             ttype.enable_flow_server(channel)
 

--- a/temba/channels/types/twilio_messaging_service/tests.py
+++ b/temba/channels/types/twilio_messaging_service/tests.py
@@ -37,7 +37,7 @@ class TwilioMessagingServiceTypeTest(TembaTest):
         twilio_config[APPLICATION_SID] = "TwilioTestSid"
 
         self.org.config = twilio_config
-        self.org.save()
+        self.org.save(update_fields=("config",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, claim_twilio_ms)

--- a/temba/channels/types/twitter_activity/tasks.py
+++ b/temba/channels/types/twitter_activity/tasks.py
@@ -59,7 +59,7 @@ def resolve_twitter_ids():
                             and new_urn.contact.created_on > old_urn.contact.created_on
                         ):
                             new_urn.contact = old_urn.contact
-                            new_urn.save(update_fields=["contact"])
+                            new_urn.save(update_fields=("contact",))
 
                         # get rid of our old URN
                         ContactURN.objects.filter(id=old_urn.id).update(contact=None)

--- a/temba/channels/types/twitter_activity/type.py
+++ b/temba/channels/types/twitter_activity/type.py
@@ -57,7 +57,7 @@ class TwitterActivityType(ChannelType):
 
             resp = client.register_webhook(config["env_name"], callback_url)
             channel.config["webhook_id"] = resp["id"]
-            channel.save(update_fields=["config"])
+            channel.save(update_fields=("config", "modified_on"))
             client.subscribe_to_webhook(config["env_name"])
         except Exception as e:  # pragma: no cover
             logger.error(f"Unable to activate TwitterActivity: {str(e)}", exc_info=True)

--- a/temba/channels/types/twitter_activity/type.py
+++ b/temba/channels/types/twitter_activity/type.py
@@ -57,7 +57,7 @@ class TwitterActivityType(ChannelType):
 
             resp = client.register_webhook(config["env_name"], callback_url)
             channel.config["webhook_id"] = resp["id"]
-            channel.save(update_fields=("config", "modified_on"))
+            channel.save(update_fields=("config",))
             client.subscribe_to_webhook(config["env_name"])
         except Exception as e:  # pragma: no cover
             logger.error(f"Unable to activate TwitterActivity: {str(e)}", exc_info=True)

--- a/temba/channels/types/wavy/tests.py
+++ b/temba/channels/types/wavy/tests.py
@@ -17,7 +17,7 @@ class WavyTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "America/Sao_Paulo"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -84,7 +84,7 @@ def refresh_whatsapp_tokens():
                 continue
 
             channel.config["auth_token"] = resp.json()["users"][0]["token"]
-            channel.save(update_fields=["config"])
+            channel.save(update_fields=("config", "modified_on"))
 
 
 VARIABLE_RE = re.compile(r"{{(\d+)}}")

--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -84,7 +84,7 @@ def refresh_whatsapp_tokens():
                 continue
 
             channel.config["auth_token"] = resp.json()["users"][0]["token"]
-            channel.save(update_fields=("config", "modified_on"))
+            channel.save(update_fields=("config",))
 
 
 VARIABLE_RE = re.compile(r"{{(\d+)}}")

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -277,7 +277,7 @@ class WhatsAppTypeTest(TembaTest):
 
         # clear our FB ids, should cause refresh to be noop (but not fail)
         del channel.config[CONFIG_FB_BUSINESS_ID]
-        channel.save(update_fields=["config", "modified_on"])
+        channel.save(update_fields=("config", "modified_on"))
         refresh_whatsapp_templates()
 
         # deactivate our channel

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -7,14 +7,14 @@ from django.utils.translation import ugettext_lazy as _
 from temba.contacts.models import URN
 from temba.orgs.views import OrgPermsMixin
 from temba.templates.models import TemplateTranslation
-from temba.utils.views import PostOnlyMixin
+from temba.utils.views import PostOnlyMixin, UpdateFieldsSaveMixin
 
 from ...models import Channel
 from ...views import ALL_COUNTRIES, ClaimViewMixin
 from .tasks import refresh_whatsapp_contacts
 
 
-class RefreshView(PostOnlyMixin, OrgPermsMixin, SmartUpdateView):
+class RefreshView(UpdateFieldsSaveMixin, PostOnlyMixin, OrgPermsMixin, SmartUpdateView):
     """
     Responsible for firing off our contact refresh task
     """

--- a/temba/channels/types/yo/tests.py
+++ b/temba/channels/types/yo/tests.py
@@ -17,7 +17,7 @@ class YoTypeTest(TembaTest):
         self.assertNotContains(response, url)
 
         self.org.timezone = "Africa/Kampala"
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         # check that claim page URL appears on claim list page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/channels/types/zenvia/tests.py
+++ b/temba/channels/types/zenvia/tests.py
@@ -20,7 +20,7 @@ class ZenviaTypeTest(TembaTest):
 
         # but if we are in the proper time zone
         self.org.timezone = pytz.timezone("America/Sao_Paulo")
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, "Zenvia")

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -838,7 +838,6 @@ def sync(request, channel_id):
                     elif keyword == "reset":
                         # release this channel
                         channel.release(False)
-                        # channel.save()
 
                         # ack that things got handled
                         handled = True

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -752,7 +752,7 @@ def sync(request, channel_id):
     # update our last seen on our channel if we haven't seen this channel in a bit
     if not channel.last_seen or timezone.now() - channel.last_seen > timedelta(minutes=5):
         channel.last_seen = timezone.now()
-        channel.save(update_fields=["last_seen"])
+        channel.save(update_fields=("last_seen", "modified_on"))
 
     sync_event = None
 
@@ -829,7 +829,7 @@ def sync(request, channel_id):
                         config.update({Channel.CONFIG_FCM_ID: cmd["fcm_id"]})
                         channel.config = config
                         channel.uuid = cmd.get("uuid", None)
-                        channel.save(update_fields=["uuid", "config"])
+                        channel.save(update_fields=("uuid", "config", "modified_on"))
 
                         # no acking the fcm
                         handled = False
@@ -1722,7 +1722,7 @@ class ChannelCRUDL(SmartCRUDL):
                 for channel in obj.get_delegate_channels():  # pragma: needs cover
                     channel.address = obj.address
                     channel.bod = e164_phone_number
-                    channel.save(update_fields=("address", "bod"))
+                    channel.save(update_fields=("address", "bod", "modified_on"))
 
             return obj
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2633,6 +2633,7 @@ class ContactGroup(RequireUpdateFieldsMixin, AddModifiedOnMixin, TembaModel):
     """
     A static or dynamic group of contacts
     """
+
     MAX_NAME_LEN = 64
     MAX_ORG_CONTACTGROUPS = 250
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2875,7 +2875,7 @@ class ContactGroup(TembaModel):
 
         self.query = parsed_query.as_text()
         self.status = ContactGroup.STATUS_INITIALIZING
-        self.save(update_fields=("query", "status"))
+        self.save(update_fields=("query", "status", "modified_on"))
 
         # update the set of contact fields that this query depends on
         self.query_fields.clear()
@@ -2902,7 +2902,7 @@ class ContactGroup(TembaModel):
                 raise ValueError("Cannot re-evaluate a group which is currently re-evaluating")
 
             self.status = ContactGroup.STATUS_EVALUATING
-            self.save(update_fields=("status",))
+            self.save(update_fields=("status", "modified_on"))
 
             new_group_members = set(self._get_dynamic_members())
             existing_member_ids = set(self.contacts.values_list("id", flat=True))
@@ -3023,7 +3023,7 @@ class ContactGroup(TembaModel):
         # if group is still active, deactivate it
         if self.is_active is True:
             self.is_active = False
-            self.save(update_fields=("is_active",))
+            self.save(update_fields=("is_active", "modified_on"))
 
         # delete all counts for this group
         self.counts.all().delete()

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -32,7 +32,14 @@ from temba.utils.dates import str_to_datetime
 from temba.utils.export import BaseExportAssetStore, BaseExportTask, TableExporter
 from temba.utils.languages import _get_language_name_iso6393
 from temba.utils.locks import NonBlockingLock
-from temba.utils.models import JSONField, RequireUpdateFieldsMixin, SquashableModel, TembaModel, mapEStoDB
+from temba.utils.models import (
+    AddModifiedOnMixin,
+    JSONField,
+    RequireUpdateFieldsMixin,
+    SquashableModel,
+    TembaModel,
+    mapEStoDB,
+)
 from temba.utils.text import truncate
 from temba.utils.urns import ParsedURN, parse_urn
 from temba.values.constants import Value
@@ -646,7 +653,7 @@ NEW_CONTACT_VARIABLE = "@new_contact"
 MAX_HISTORY = 50
 
 
-class Contact(RequireUpdateFieldsMixin, TembaModel):
+class Contact(RequireUpdateFieldsMixin, AddModifiedOnMixin, TembaModel):
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="contacts")
 
     name = models.CharField(
@@ -1907,7 +1914,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         from temba.triggers.models import Trigger
 
         self.is_stopped = True
-        self.save(update_fields=["is_stopped", "modified_on"], handle_update=False)
+        self.save(update_fields=("is_stopped", "modified_on"), handle_update=False)
 
         self.clear_all_groups(user)
 
@@ -1918,7 +1925,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         Unstops this contact, re-adding them to any dynamic groups they belong to
         """
         self.is_stopped = False
-        self.save(update_fields=["is_stopped", "modified_on"], handle_update=False)
+        self.save(update_fields=("is_stopped", "modified_on"), handle_update=False)
 
         # re-add them to any dynamic groups they would belong to
         self.reevaluate_dynamic_groups()
@@ -2109,7 +2116,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
             for urn in urns:
                 if urn.scheme in channel.schemes and urn.channel_id != channel.id:
                     urn.channel = channel
-                    urn.save(update_fields=["channel"])
+                    urn.save(update_fields=("channel",))
 
         # if our scheme isn't the highest priority
         if urns and urns[0].scheme not in channel.schemes:
@@ -2117,7 +2124,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
             for urn in urns[1:]:
                 if urn.scheme in channel.schemes:
                     urn.priority = urns[0].priority + 1
-                    urn.save(update_fields=["priority"])
+                    urn.save(update_fields=("priority",))
 
                     # clear our URN cache, order is different now
                     self.clear_urn_cache()
@@ -2545,7 +2552,7 @@ class ContactURN(models.Model):
     def update_auth(self, auth):
         if auth and auth != self.auth:
             self.auth = auth
-            self.save(update_fields=["auth"])
+            self.save(update_fields=("auth",))
 
     def update_affinity(self, channel):
         """
@@ -2553,7 +2560,7 @@ class ContactURN(models.Model):
         """
         if channel and self.channel != channel:
             self.channel = channel
-            self.save(update_fields=["channel"])
+            self.save(update_fields=("channel",))
 
     def ensure_number_normalization(self, country_code):
         """
@@ -2570,7 +2577,7 @@ class ContactURN(models.Model):
             if not ContactURN.objects.filter(identity=norm_urn, org_id=self.org_id).exclude(id=self.id):
                 self.identity = norm_urn
                 self.path = norm_number
-                self.save(update_fields=["identity", "path"])
+                self.save(update_fields=("identity", "path"))
 
         return self
 
@@ -2622,11 +2629,10 @@ class UserContactGroupManager(models.Manager):
         return super().get_queryset().filter(group_type=ContactGroup.TYPE_USER_DEFINED, is_active=True)
 
 
-class ContactGroup(TembaModel):
+class ContactGroup(RequireUpdateFieldsMixin, AddModifiedOnMixin, TembaModel):
     """
     A static or dynamic group of contacts
     """
-
     MAX_NAME_LEN = 64
     MAX_ORG_CONTACTGROUPS = 250
 
@@ -2875,7 +2881,7 @@ class ContactGroup(TembaModel):
 
         self.query = parsed_query.as_text()
         self.status = ContactGroup.STATUS_INITIALIZING
-        self.save(update_fields=("query", "status", "modified_on"))
+        self.save(update_fields=("query", "status"))
 
         # update the set of contact fields that this query depends on
         self.query_fields.clear()
@@ -2902,7 +2908,7 @@ class ContactGroup(TembaModel):
                 raise ValueError("Cannot re-evaluate a group which is currently re-evaluating")
 
             self.status = ContactGroup.STATUS_EVALUATING
-            self.save(update_fields=("status", "modified_on"))
+            self.save(update_fields=("status",))
 
             new_group_members = set(self._get_dynamic_members())
             existing_member_ids = set(self.contacts.values_list("id", flat=True))
@@ -2949,7 +2955,7 @@ class ContactGroup(TembaModel):
                 lock.extend(additional_time=lock_timeout)
 
             self.status = ContactGroup.STATUS_READY
-            self.save(update_fields=("status", "modified_on"))
+            self.save(update_fields=("status",))
 
     def _get_dynamic_members(self):
         """
@@ -3023,7 +3029,7 @@ class ContactGroup(TembaModel):
         # if group is still active, deactivate it
         if self.is_active is True:
             self.is_active = False
-            self.save(update_fields=("is_active", "modified_on"))
+            self.save(update_fields=("is_active",))
 
         # delete all counts for this group
         self.counts.all().delete()

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -435,7 +435,7 @@ class ContactGroupTest(TembaTest):
         static = ContactGroup.create_static(self.org, self.admin, "Static")
         deleted = ContactGroup.create_static(self.org, self.admin, "Deleted")
         deleted.is_active = False
-        deleted.save()
+        deleted.save(update_fields=("is_active",))
 
         with ESMockWithScroll():
             dynamic = ContactGroup.create_dynamic(self.org, self.admin, "Dynamic", "gender=M")
@@ -1135,7 +1135,7 @@ class ContactTest(TembaTest):
 
         # configure our org for ivr
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
+
         config = {
             Channel.CONFIG_SEND_URL: "https://api.twilio.com",
             Channel.CONFIG_ACCOUNT_SID: "TEST_SID",
@@ -3601,7 +3601,7 @@ class ContactTest(TembaTest):
             # mark an outgoing message as failed
             failed = Msg.objects.get(direction="O", contact=self.joe)
             failed.status = "F"
-            failed.save()
+            failed.save(update_fields=("status",))
             log = ChannelLog.objects.create(
                 channel=failed.channel, msg=failed, is_error=True, description="It didn't send!!"
             )
@@ -4596,7 +4596,7 @@ class ContactTest(TembaTest):
 
         # check updating when org is anon
         self.org.is_anon = True
-        self.org.save()
+        self.org.save(update_fields=("is_anon",))
 
         post_data = dict(name="Joe X", groups=[self.just_joe.id])
         self.client.post(reverse("contacts.contact_update", args=[self.joe.id]), post_data, follow=True)
@@ -4747,7 +4747,7 @@ class ContactTest(TembaTest):
 
         contact3 = self.create_contact(name=None, number="0788111222")
         self.channel.country = "RW"
-        self.channel.save()
+        self.channel.save(update_fields=("country",))
 
         normalized = contact3.get_urn(TEL_SCHEME).ensure_number_normalization(self.channel)
         self.assertEqual(normalized.path, "+250788111222")
@@ -5900,7 +5900,7 @@ class ContactTest(TembaTest):
         ballers = self.create_group("Ballers")
 
         self.campaign.group = ballers
-        self.campaign.save()
+        self.campaign.save(update_fields=("group",))
 
         field_created_on = self.org.contactfields.get(key="created_on")
 
@@ -5940,7 +5940,7 @@ class ContactTest(TembaTest):
             ballers = self.create_group("Ballers", query="team = ballers")
 
         self.campaign.group = ballers
-        self.campaign.save()
+        self.campaign.save(update_fields=("group",))
 
         self.assertEqual(self.campaign.group, ballers)
 
@@ -6874,7 +6874,7 @@ class ContactFieldTest(TembaTest):
         with ESMockWithScroll():
             group2 = self.create_group("Dynamic", query="tel is 1234")
         group2.status = ContactGroup.STATUS_EVALUATING
-        group2.save()
+        group2.save(update_fields=("status",))
 
         # create a dummy export task so that we won't be able to export
         blocking_export = ExportContactsTask.create(self.org, self.admin)
@@ -7743,11 +7743,11 @@ class ContactFieldTest(TembaTest):
     def test_view_featured(self):
         featured1 = ContactField.user_fields.get(key="first")
         featured1.show_in_table = True
-        featured1.save(update_fields=["show_in_table"])
+        featured1.save(update_fields=("show_in_table",))
 
         featured2 = ContactField.user_fields.get(key="second")
         featured2.show_in_table = True
-        featured2.save(update_fields=["show_in_table"])
+        featured2.save(update_fields=("show_in_table",))
 
         self.login(self.admin)
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -44,7 +44,7 @@ from temba.utils import analytics, json, languages, on_transaction_commit
 from temba.utils.dates import datetime_to_ms, ms_to_datetime
 from temba.utils.fields import Select2Field
 from temba.utils.text import slugify_with
-from temba.utils.views import BaseActionForm, ContactListPaginationMixin
+from temba.utils.views import BaseActionForm, ContactListPaginationMixin, UpdateFieldsSaveMixin
 from temba.values.constants import Value
 
 from .models import (
@@ -1586,7 +1586,7 @@ class ContactGroupCRUDL(SmartCRUDL):
             kwargs["user"] = self.request.user
             return kwargs
 
-    class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(UpdateFieldsSaveMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = ContactGroupForm
         fields = ("name",)
         success_url = "uuid@contacts.contact_filter"
@@ -1651,7 +1651,7 @@ class ContactGroupCRUDL(SmartCRUDL):
 
             # deactivate the group, this makes it 'invisible'
             group.is_active = False
-            group.save()
+            group.save(update_fields=("is_active",))
 
             # release the group in a background task
             on_transaction_commit(lambda: release_group_task.delay(group.id))

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2352,7 +2352,8 @@ class Flow(RequireUpdateFieldsMixin, AddModifiedOnMixin, TembaModel):
                         "version_number",
                         "entry_uuid",
                         "entry_type",
-                    ))
+                    )
+                )
 
                 # clear property cache
                 self.clear_props_cache()

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -50,6 +50,7 @@ from temba.utils.email import is_valid_address
 from temba.utils.export import BaseExportAssetStore, BaseExportTask
 from temba.utils.http import HttpEvent
 from temba.utils.models import (
+    AddModifiedOnMixin,
     JSONAsTextField,
     JSONField,
     RequireUpdateFieldsMixin,
@@ -137,7 +138,7 @@ class FlowPropsCache(Enum):
     category_nodes = 2
 
 
-class Flow(TembaModel):
+class Flow(RequireUpdateFieldsMixin, AddModifiedOnMixin, TembaModel):
     UUID = "uuid"
     ENTRY = "entry"
     RULE_SETS = "rule_sets"
@@ -393,7 +394,7 @@ class Flow(TembaModel):
         name = Flow.get_unique_name(org, "Join %s" % group.name)
         flow = Flow.create(org, user, name, base_language=base_language)
         flow.version_number = "11.2"
-        flow.save(update_fields=("version_number", "modified_on"))
+        flow.save(update_fields=("version_number",))
 
         entry_uuid = str(uuid4())
         definition = {
@@ -556,7 +557,7 @@ class Flow(TembaModel):
 
         # copy our expiration as well
         copy.expires_after_minutes = flow.expires_after_minutes
-        copy.save()
+        copy.save(update_fields=("expires_after_minutes",))
 
         return copy
 
@@ -926,14 +927,14 @@ class Flow(TembaModel):
                         started_flows.remove(flow.id)
 
                         run.child_context = child_run.build_expressions_context(contact_context=str(run.contact.uuid))
-                        run.save(update_fields=("child_context", "modified_on"))
+                        run.save(update_fields=("child_context",))
                     else:
                         return dict(handled=True, destination=None, destination_type=None, msgs=msgs_out)
 
             else:
                 child_run = FlowRun.objects.filter(parent=run, contact=run.contact).order_by("created_on").last()
                 run.child_context = child_run.build_expressions_context(contact_context=str(run.contact.uuid))
-                run.save(update_fields=("child_context", "modified_on"))
+                run.save(update_fields=("child_context",))
 
         # find a matching rule
         result_rule, result_value, result_input = ruleset.find_matching_rule(run, msg_in)
@@ -1018,7 +1019,7 @@ class Flow(TembaModel):
         from .tasks import interrupt_flow_runs_task
 
         self.is_active = False
-        self.save()
+        self.save(update_fields=("is_active",))
 
         # release any campaign events that depend on this flow
         from temba.campaigns.models import CampaignEvent
@@ -1399,7 +1400,7 @@ class Flow(TembaModel):
 
     def archive(self):
         self.is_archived = True
-        self.save(update_fields=("is_archived", "modified_on"))
+        self.save(update_fields=("is_archived",))
 
         from .tasks import interrupt_flow_runs_task
 
@@ -1416,7 +1417,7 @@ class Flow(TembaModel):
                 raise FlowException("%s requires a Twilio number")
 
         self.is_archived = False
-        self.save(update_fields=("is_archived", "modified_on"))
+        self.save(update_fields=("is_archived",))
 
     def update_single_message_flow(self, translations, base_language):
         if base_language not in translations:  # pragma: no cover
@@ -1598,7 +1599,7 @@ class Flow(TembaModel):
 
         if start_msg and start_msg.id:
             start_msg.msg_type = FLOW
-            start_msg.save(update_fields=("msg_type", "modified_on"))
+            start_msg.save(update_fields=("msg_type",))
 
         all_contact_ids = list(
             Contact.objects.filter(Q(all_groups__in=group_qs) | Q(id__in=contact_qs))
@@ -1648,7 +1649,7 @@ class Flow(TembaModel):
         # update our total flow count on our flow start so we can keep track of when it is finished
         if flow_start:
             flow_start.contact_count = contact_count
-            flow_start.save(update_fields=("contact_count", "modified_on"))
+            flow_start.save(update_fields=("contact_count",))
 
         # if there are no contacts to start this flow, then update our status and exit this flow
         if contact_count == 0:
@@ -1705,7 +1706,7 @@ class Flow(TembaModel):
             # save away our created call
             run.session = session
             run.connection = call
-            run.save(update_fields=("connection", "modified_on"))
+            run.save(update_fields=("connection", "session"))
 
             # update our expiration date on our run initially to 7 days for IVR, that will be adjusted when the call is answered
             next_week = timezone.now() + timedelta(days=IVRCall.DEFAULT_MAX_IVR_EXPIRATION_WINDOW_DAYS)
@@ -1946,7 +1947,7 @@ class Flow(TembaModel):
         if len(run.path) > FlowRun.PATH_MAX_STEPS:
             run.path = run.path[len(run.path) - FlowRun.PATH_MAX_STEPS :]
 
-        update_fields = ["path", "current_node_uuid", "modified_on"]
+        update_fields = ["path", "current_node_uuid"]
 
         if msgs:
             run.add_messages(msgs, do_save=False)
@@ -2265,9 +2266,7 @@ class Flow(TembaModel):
             self.saved_by = user
             self.saved_on = timezone.now()
             self.version_number = Flow.GOFLOW_VERSION
-            self.save(
-                update_fields=("metadata", "version_number", "base_language", "saved_by", "saved_on", "modified_on")
-            )
+            self.save(update_fields=("metadata", "version_number", "base_language", "saved_by", "saved_on"))
 
             # create our new revision
             revision = self.revisions.create(
@@ -2344,7 +2343,16 @@ class Flow(TembaModel):
                     self.saved_on = timezone.now()
 
                 self.version_number = Flow.FINAL_LEGACY_VERSION
-                self.save()
+                self.save(
+                    update_fields=(
+                        "base_language",
+                        "metadata",
+                        "saved_by",
+                        "saved_on",
+                        "version_number",
+                        "entry_uuid",
+                        "entry_type",
+                    ))
 
                 # clear property cache
                 self.clear_props_cache()
@@ -2743,7 +2751,7 @@ class FlowSession(models.Model):
         return str(self.contact)
 
 
-class FlowRun(RequireUpdateFieldsMixin, models.Model):
+class FlowRun(RequireUpdateFieldsMixin, AddModifiedOnMixin, models.Model):
     STATE_ACTIVE = "A"
 
     EXIT_TYPE_COMPLETED = "C"
@@ -3094,7 +3102,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
             # incoming non-IVR messages won't have a type yet so update that
             if not msg.msg_type or msg.msg_type == INBOX:
                 msg.msg_type = FLOW
-                msg.save(update_fields=("msg_type", "modified_on"))
+                msg.save(update_fields=("msg_type",))
 
             # if message is from contact, mark run as responded
             if msg.direction == INCOMING:
@@ -3102,7 +3110,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
                     self.responded = True
 
         if needs_update and do_save:
-            self.save(update_fields=("responded", "events", "modified_on"))
+            self.save(update_fields=("responded", "events"))
 
     def get_events_of_type(self, event_types):
         """
@@ -3167,7 +3175,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
         # TODO: Remove this in favor of responded on session
         if run.responded and not run.parent.responded:
             run.parent.responded = True
-            run.parent.save(update_fields=("responded", "modified_on"))
+            run.parent.save(update_fields=("responded",))
 
         # if our child was interrupted, so shall we be
         if run.exit_type == FlowRun.EXIT_TYPE_INTERRUPTED and run.contact.id == run.parent.contact_id:
@@ -3204,7 +3212,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
             msg.contact = run.contact
 
         run.parent.child_context = run.build_expressions_context(contact_context=str(run.contact.uuid))
-        run.parent.save(update_fields=("child_context", "modified_on"))
+        run.parent.save(update_fields=("child_context",))
 
         # finally, trigger our parent flow
         (handled, msgs) = Flow.find_and_handle(
@@ -3250,7 +3258,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
         with transaction.atomic():
             if delete_reason:
                 self.delete_reason = delete_reason
-                self.save(update_fields=("delete_reason", "modified_on"))
+                self.save(update_fields=("delete_reason",))
 
             # delete any action logs associated with us
             ActionLog.objects.filter(run=self).delete()
@@ -3333,7 +3341,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
             self.expires_on = point_in_time + timedelta(minutes=self.flow.expires_after_minutes)
 
             # save our updated fields
-            self.save(update_fields=["expires_on", "modified_on"])
+            self.save(update_fields=("expires_on", "modified_on"))
 
         # parent should always have a later expiration than the children
         if self.parent:
@@ -3358,7 +3366,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
             self.fields = existing_map
 
         if do_save:
-            self.save(update_fields=("fields", "modified_on"))
+            self.save(update_fields=("fields",))
 
     def is_completed(self):
         return self.exit_type == FlowRun.EXIT_TYPE_COMPLETED
@@ -3435,7 +3443,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
 
         self.results = results
         self.modified_on = timezone.now()
-        self.save(update_fields=["results", "modified_on"])
+        self.save(update_fields=("results", "modified_on"))
 
     def as_archive_json(self):
         def convert_step(step):
@@ -4847,7 +4855,7 @@ class FlowStart(SmartModel):
 
     def start(self):
         self.status = FlowStart.STATUS_STARTING
-        self.save(update_fields=("status", "modified_on"))
+        self.save(update_fields=("status",))
 
         try:
             groups = list(self.groups.all())
@@ -4870,14 +4878,14 @@ class FlowStart(SmartModel):
             logger.error(f"Unable to start Flow: {str(e)}", exc_info=True)
 
             self.status = FlowStart.STATUS_FAILED
-            self.save(update_fields=("status", "modified_on"))
+            self.save(update_fields=("status",))
             raise e
 
     def update_status(self):
         # only update our status to complete if we have started as many runs as our total contact count
         if FlowStartCount.get_count(self) == self.contact_count:
             self.status = FlowStart.STATUS_COMPLETE
-            self.save(update_fields=("status", "modified_on"))
+            self.save(update_fields=("status",))
 
     def __str__(self):  # pragma: no cover
         return "FlowStart %d (Flow %d)" % (self.id, self.flow_id)
@@ -5614,9 +5622,9 @@ class VariableContactAction(Action):
                 contact = Contact.get_or_create_by_urns(org, org.created_by, name=None, urns=urns)
 
                 # if they don't have a name use the one in our action
-                if name and not contact.name:  # pragma: needs cover
+                if name and not contact.name:
                     contact.name = name
-                    contact.save(update_fields=("name", "modified_on"), handle_update=True)
+                    contact.save(update_fields=("name",), handle_update=True)
 
             if contact:
                 contacts.append(contact)
@@ -5760,7 +5768,7 @@ class SetLanguageAction(Action):
 
         if old_value != new_lang:
             run.contact.language = new_lang
-            run.contact.save(update_fields=("language", "modified_on"), handle_update=True)
+            run.contact.save(update_fields=("language",), handle_update=True)
 
         return []
 

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -393,7 +393,7 @@ class Flow(TembaModel):
         name = Flow.get_unique_name(org, "Join %s" % group.name)
         flow = Flow.create(org, user, name, base_language=base_language)
         flow.version_number = "11.2"
-        flow.save(update_fields=("version_number",))
+        flow.save(update_fields=("version_number", "modified_on"))
 
         entry_uuid = str(uuid4())
         definition = {
@@ -504,7 +504,7 @@ class Flow(TembaModel):
                 if flow:  # pragma: needs cover
                     flow.expires_after_minutes = flow_expires
                     flow.name = Flow.get_unique_name(org, flow_name, ignore=flow)
-                    flow.save(update_fields=("name", "expires_after_minutes"))
+                    flow.save(update_fields=("name", "expires_after_minutes", "modified_on"))
 
             # if it's not of our world, let's try by name
             if not flow:
@@ -926,14 +926,14 @@ class Flow(TembaModel):
                         started_flows.remove(flow.id)
 
                         run.child_context = child_run.build_expressions_context(contact_context=str(run.contact.uuid))
-                        run.save(update_fields=("child_context",))
+                        run.save(update_fields=("child_context", "modified_on"))
                     else:
                         return dict(handled=True, destination=None, destination_type=None, msgs=msgs_out)
 
             else:
                 child_run = FlowRun.objects.filter(parent=run, contact=run.contact).order_by("created_on").last()
                 run.child_context = child_run.build_expressions_context(contact_context=str(run.contact.uuid))
-                run.save(update_fields=("child_context",))
+                run.save(update_fields=("child_context", "modified_on"))
 
         # find a matching rule
         result_rule, result_value, result_input = ruleset.find_matching_rule(run, msg_in)
@@ -1399,7 +1399,7 @@ class Flow(TembaModel):
 
     def archive(self):
         self.is_archived = True
-        self.save(update_fields=["is_archived"])
+        self.save(update_fields=("is_archived", "modified_on"))
 
         from .tasks import interrupt_flow_runs_task
 
@@ -1416,7 +1416,7 @@ class Flow(TembaModel):
                 raise FlowException("%s requires a Twilio number")
 
         self.is_archived = False
-        self.save(update_fields=["is_archived"])
+        self.save(update_fields=("is_archived", "modified_on"))
 
     def update_single_message_flow(self, translations, base_language):
         if base_language not in translations:  # pragma: no cover
@@ -1424,7 +1424,7 @@ class Flow(TembaModel):
 
         self.base_language = base_language
         self.version_number = Flow.FINAL_LEGACY_VERSION
-        self.save(update_fields=("name", "base_language", "version_number"))
+        self.save(update_fields=("name", "base_language", "version_number", "modified_on"))
 
         entry_uuid = str(uuid4())
         definition = {
@@ -1598,7 +1598,7 @@ class Flow(TembaModel):
 
         if start_msg and start_msg.id:
             start_msg.msg_type = FLOW
-            start_msg.save(update_fields=["msg_type"])
+            start_msg.save(update_fields=("msg_type", "modified_on"))
 
         all_contact_ids = list(
             Contact.objects.filter(Q(all_groups__in=group_qs) | Q(id__in=contact_qs))
@@ -1648,7 +1648,7 @@ class Flow(TembaModel):
         # update our total flow count on our flow start so we can keep track of when it is finished
         if flow_start:
             flow_start.contact_count = contact_count
-            flow_start.save(update_fields=["contact_count"])
+            flow_start.save(update_fields=("contact_count", "modified_on"))
 
         # if there are no contacts to start this flow, then update our status and exit this flow
         if contact_count == 0:
@@ -1705,7 +1705,7 @@ class Flow(TembaModel):
             # save away our created call
             run.session = session
             run.connection = call
-            run.save(update_fields=["connection"])
+            run.save(update_fields=("connection", "modified_on"))
 
             # update our expiration date on our run initially to 7 days for IVR, that will be adjusted when the call is answered
             next_week = timezone.now() + timedelta(days=IVRCall.DEFAULT_MAX_IVR_EXPIRATION_WINDOW_DAYS)
@@ -1946,7 +1946,7 @@ class Flow(TembaModel):
         if len(run.path) > FlowRun.PATH_MAX_STEPS:
             run.path = run.path[len(run.path) - FlowRun.PATH_MAX_STEPS :]
 
-        update_fields = ["path", "current_node_uuid"]
+        update_fields = ["path", "current_node_uuid", "modified_on"]
 
         if msgs:
             run.add_messages(msgs, do_save=False)
@@ -2265,7 +2265,9 @@ class Flow(TembaModel):
             self.saved_by = user
             self.saved_on = timezone.now()
             self.version_number = Flow.GOFLOW_VERSION
-            self.save(update_fields=["metadata", "version_number", "base_language", "saved_by", "saved_on"])
+            self.save(
+                update_fields=("metadata", "version_number", "base_language", "saved_by", "saved_on", "modified_on")
+            )
 
             # create our new revision
             revision = self.revisions.create(
@@ -3092,7 +3094,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
             # incoming non-IVR messages won't have a type yet so update that
             if not msg.msg_type or msg.msg_type == INBOX:
                 msg.msg_type = FLOW
-                msg.save(update_fields=["msg_type"])
+                msg.save(update_fields=("msg_type", "modified_on"))
 
             # if message is from contact, mark run as responded
             if msg.direction == INCOMING:
@@ -3100,7 +3102,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
                     self.responded = True
 
         if needs_update and do_save:
-            self.save(update_fields=("responded", "events"))
+            self.save(update_fields=("responded", "events", "modified_on"))
 
     def get_events_of_type(self, event_types):
         """
@@ -3165,7 +3167,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
         # TODO: Remove this in favor of responded on session
         if run.responded and not run.parent.responded:
             run.parent.responded = True
-            run.parent.save(update_fields=["responded"])
+            run.parent.save(update_fields=("responded", "modified_on"))
 
         # if our child was interrupted, so shall we be
         if run.exit_type == FlowRun.EXIT_TYPE_INTERRUPTED and run.contact.id == run.parent.contact_id:
@@ -3202,7 +3204,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
             msg.contact = run.contact
 
         run.parent.child_context = run.build_expressions_context(contact_context=str(run.contact.uuid))
-        run.parent.save(update_fields=("child_context",))
+        run.parent.save(update_fields=("child_context", "modified_on"))
 
         # finally, trigger our parent flow
         (handled, msgs) = Flow.find_and_handle(
@@ -3248,7 +3250,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
         with transaction.atomic():
             if delete_reason:
                 self.delete_reason = delete_reason
-                self.save(update_fields=["delete_reason"])
+                self.save(update_fields=("delete_reason", "modified_on"))
 
             # delete any action logs associated with us
             ActionLog.objects.filter(run=self).delete()
@@ -3356,7 +3358,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
             self.fields = existing_map
 
         if do_save:
-            self.save(update_fields=["fields"])
+            self.save(update_fields=("fields", "modified_on"))
 
     def is_completed(self):
         return self.exit_type == FlowRun.EXIT_TYPE_COMPLETED
@@ -4845,7 +4847,7 @@ class FlowStart(SmartModel):
 
     def start(self):
         self.status = FlowStart.STATUS_STARTING
-        self.save(update_fields=["status"])
+        self.save(update_fields=("status", "modified_on"))
 
         try:
             groups = list(self.groups.all())
@@ -4868,14 +4870,14 @@ class FlowStart(SmartModel):
             logger.error(f"Unable to start Flow: {str(e)}", exc_info=True)
 
             self.status = FlowStart.STATUS_FAILED
-            self.save(update_fields=["status"])
+            self.save(update_fields=("status", "modified_on"))
             raise e
 
     def update_status(self):
         # only update our status to complete if we have started as many runs as our total contact count
         if FlowStartCount.get_count(self) == self.contact_count:
             self.status = FlowStart.STATUS_COMPLETE
-            self.save(update_fields=["status"])
+            self.save(update_fields=("status", "modified_on"))
 
     def __str__(self):  # pragma: no cover
         return "FlowStart %d (Flow %d)" % (self.id, self.flow_id)
@@ -5614,7 +5616,7 @@ class VariableContactAction(Action):
                 # if they don't have a name use the one in our action
                 if name and not contact.name:  # pragma: needs cover
                     contact.name = name
-                    contact.save(update_fields=["name"], handle_update=True)
+                    contact.save(update_fields=("name", "modified_on"), handle_update=True)
 
             if contact:
                 contacts.append(contact)
@@ -5758,7 +5760,7 @@ class SetLanguageAction(Action):
 
         if old_value != new_lang:
             run.contact.language = new_lang
-            run.contact.save(update_fields=["language"], handle_update=True)
+            run.contact.save(update_fields=("language", "modified_on"), handle_update=True)
 
         return []
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -427,7 +427,7 @@ class FlowTest(TembaTest):
 
         # flow language used regardless of whether it's an org language
         self.flow.base_language = "eng"
-        self.flow.save(update_fields=["base_language"])
+        self.flow.save(update_fields=("base_language",))
         self.flow.org.set_languages(self.admin, ["eng"], "eng")
         self.assertEqual(self.flow.get_localized_text(text_translations, self.contact), "Hello")
 
@@ -457,7 +457,7 @@ class FlowTest(TembaTest):
 
         # and archive it right off the bat
         flow2.is_archived = True
-        flow2.save()
+        flow2.save(update_fields=("is_archived",))
 
         flow3 = Flow.create(self.org, self.admin, "Flow 3", base_language="base")
 
@@ -605,19 +605,19 @@ class FlowTest(TembaTest):
 
         # change our channel to use a whatsapp scheme
         self.channel.schemes = [WHATSAPP_SCHEME]
-        self.channel.save()
+        self.channel.save(update_fields=("schemes",))
 
         # clear dependencies, this will cause our flow to look like it isn't using templates
         metadata = flow.metadata
         flow.metadata = {}
-        flow.save(update_fields=["metadata"])
+        flow.save(update_fields=("metadata",))
 
         response = self.client.get(reverse("flows.flow_broadcast", args=[flow.id]))
         self.assertContains(response, "does not use message")
 
         # restore our dependency
         flow.metadata = metadata
-        flow.save(update_fields=["metadata"])
+        flow.save(update_fields=("metadata",))
 
         # template doesn't exit, will be warned
         response = self.client.get(reverse("flows.flow_broadcast", args=[flow.id]))
@@ -664,7 +664,7 @@ class FlowTest(TembaTest):
         self.assertFalse(flow.is_archived)
 
         campaign.is_archived = True
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         # can archive if the campaign is archived
         changed = Flow.apply_action_archive(self.admin, Flow.objects.filter(pk=flow.pk))
@@ -675,10 +675,10 @@ class FlowTest(TembaTest):
         self.assertTrue(flow.is_archived)
 
         campaign.is_archived = False
-        campaign.save()
+        campaign.save(update_fields=("is_archived",))
 
         flow.is_archived = False
-        flow.save()
+        flow.save(update_fields=("is_archived",))
 
         campaign_event.is_active = False
         campaign_event.save()
@@ -771,7 +771,7 @@ class FlowTest(TembaTest):
         # viewing flows that are archived can't be started
         self.login(self.admin)
         self.flow.is_archived = True
-        self.flow.save()
+        self.flow.save(update_fields=("is_archived",))
 
         response = self.client.get(reverse("flows.flow_editor_next", args=[self.flow.uuid]))
         self.assertFalse(response.context["mutable"])
@@ -936,7 +936,7 @@ class FlowTest(TembaTest):
 
         # set the flow as inactive, shouldn't react to replies
         self.flow.is_archived = True
-        self.flow.save()
+        self.flow.save(update_fields=("is_archived",))
 
         # create and send a reply
         incoming = self.create_msg(direction=INCOMING, contact=self.contact, text="Orange")
@@ -951,7 +951,7 @@ class FlowTest(TembaTest):
 
         # ok, make our flow active again
         self.flow.is_archived = False
-        self.flow.save()
+        self.flow.save(update_fields=("is_archived",))
 
         # simulate a response from contact #1
         incoming = self.create_msg(direction=INCOMING, contact=self.contact, text="orange")
@@ -1116,7 +1116,7 @@ class FlowTest(TembaTest):
 
     def test_anon_export_results(self):
         self.org.is_anon = True
-        self.org.save()
+        self.org.save(update_fields=("is_anon",))
 
         (run1,) = self.flow.start([], [self.contact])
 
@@ -2133,7 +2133,7 @@ class FlowTest(TembaTest):
 
         # test we can export archived flows
         self.flow.is_archived = True
-        self.flow.save()
+        self.flow.save(update_fields=("is_archived",))
 
         workbook = self.export_flow_results(self.flow)
 
@@ -2402,7 +2402,7 @@ class FlowTest(TembaTest):
 
     def test_export_results_with_surveyor_msgs(self):
         self.flow.flow_type = Flow.TYPE_SURVEY
-        self.flow.save()
+        self.flow.save(update_fields=("flow_type",))
         run = self.flow.start([], [self.contact])[0]
 
         # no urn or channel
@@ -2497,7 +2497,7 @@ class FlowTest(TembaTest):
         # pick a really long name so we have to concatenate
         self.flow.name = "Color Flow is a long name to use for something like this"
         self.flow.expires_after_minutes = 60
-        self.flow.save()
+        self.flow.save(update_fields=("name", "expires_after_minutes"))
 
         # make sure our metadata got saved
         metadata = self.flow.metadata
@@ -2813,7 +2813,7 @@ class FlowTest(TembaTest):
 
         # remove our org country, should no longer match things
         self.org.country = None
-        self.org.save()
+        self.org.save(update_fields=("country",))
 
         sms.text = "Kigali City"
         self.assertTest(False, None, state_test)
@@ -3400,7 +3400,7 @@ class FlowTest(TembaTest):
         results = run.results
         del results["color"]["category"]
         results["color"]["created_on"] = timezone.now()
-        run.save(update_fields=["results", "modified_on"])
+        run.save(update_fields=("results", "modified_on"))
 
         # should have added a negative one now
         self.assertEqual(2, FlowCategoryCount.objects.filter(category_name="Blue", result_name="color").count())
@@ -3529,7 +3529,7 @@ class FlowTest(TembaTest):
         self.login(self.admin)
         flow = Flow.create(self.org, self.admin, "Flow")
         flow.flow_type = Flow.TYPE_SURVEY
-        flow.save()
+        flow.save(update_fields=("flow_type",))
 
         # keywords aren't an option for survey flows
         response = self.client.get(reverse("flows.flow_update", args=[flow.pk]))
@@ -3661,7 +3661,7 @@ class FlowTest(TembaTest):
         actions[0]["groups"] = [dict(uuid=group.uuid, name=group.name)]
         actions[0]["contacts"] = []
         actionset.actions = actions
-        actionset.save(update_fields=["actions"])
+        actionset.save(update_fields=("actions",))
 
         # we should allow copy of flows with group sends
         response = self.client.post(reverse("flows.flow_copy", args=[self.flow.id]))
@@ -3898,7 +3898,7 @@ class FlowTest(TembaTest):
 
         # make us a survey flow
         flow3.flow_type = Flow.TYPE_SURVEY
-        flow3.save()
+        flow3.save(update_fields=("flow_type",))
 
         # we should get the contact creation option, and test if form has expected fields
         response = self.client.get(reverse("flows.flow_update", args=[flow3.pk]))
@@ -4064,7 +4064,7 @@ class FlowTest(TembaTest):
 
         # test ivr flow creation
         self.channel.role = "SRCA"
-        self.channel.save()
+        self.channel.save(update_fields=("role",))
 
         post_data = dict(name="Message flow", expires_after_minutes=5, flow_type=Flow.TYPE_MESSAGE)
         response = self.client.post(reverse("flows.flow_create"), post_data, follow=True)
@@ -4086,7 +4086,7 @@ class FlowTest(TembaTest):
         # create the language for our org
         language = Language.create(self.org, self.flow.created_by, "English", "eng")
         self.org.primary_language = language
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         post_data = dict(
             name="Language Flow", expires_after_minutes=5, base_language=language.iso_code, flow_type=Flow.TYPE_MESSAGE
@@ -4199,7 +4199,7 @@ class FlowTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         self.flow.is_archived = True
-        self.flow.save()
+        self.flow.save(update_fields=("is_archived",))
 
         response = self.client.get(flow_list_url)
         self.assertEqual(0, len(response.context["object_list"]))
@@ -4357,7 +4357,7 @@ class FlowTest(TembaTest):
         self.assertTrue(FlowRun.objects.filter(flow=self.flow2, contact=self.contact))
 
         self.flow.ignore_triggers = True
-        self.flow.save()
+        self.flow.save(update_fields=("ignore_triggers",))
         self.flow.start([], [self.contact], restart_participants=True)
 
         other_incoming = self.create_msg(direction=INCOMING, contact=self.contact, text="kiva")
@@ -4464,7 +4464,7 @@ class ActionPackedTest(FlowFileTest):
         # adding to inactive group
         customers = ContactGroup.user_groups.filter(name="Customers").first()
         customers.is_active = False
-        customers.save()
+        customers.save(update_fields=("is_active",))
         self.assertIsNone(ContactGroup.user_groups.filter(name="Customers", is_active=True).first())
 
     def test_labeling(self):
@@ -4900,7 +4900,7 @@ class ActionTest(TembaTest):
         Channel.create(self.org, self.admin, "US", "EX", schemes=["tel"])
         delattr(self.org, "_country_code")
         self.org.country = None
-        self.org.save()
+        self.org.save(update_fields=("country",))
 
         # set a contact field with another phone number
         self.contact.set_field(self.admin, "other_contact_tel", "+12065551212", "Other Contact Tel")
@@ -4933,7 +4933,7 @@ class ActionTest(TembaTest):
 
         # delete the group
         self.other_group.is_active = False
-        self.other_group.save()
+        self.other_group.save(update_fields=("is_active",))
 
         self.assertTrue(action.groups)
         self.assertTrue(self.other_group.pk in [g.pk for g in action.groups])
@@ -5252,7 +5252,7 @@ class ActionTest(TembaTest):
 
     def test_start_flow_action(self):
         self.flow.name = "Parent"
-        self.flow.save()
+        self.flow.save(update_fields=("name",))
 
         self.flow.start([], [self.contact])
 
@@ -5316,7 +5316,7 @@ class ActionTest(TembaTest):
         # try when group is inactive
         action = DeleteFromGroupAction(str(uuid4()), [group])
         group.is_active = False
-        group.save()
+        group.save(update_fields=("is_active",))
         self.org.clear_cached_groups()
 
         self.assertIn(group, action.groups)
@@ -5677,7 +5677,7 @@ class FlowLabelTest(FlowFileTest):
         self.assertContains(response, "Edit")
 
         favorites.is_active = False
-        favorites.save()
+        favorites.save(update_fields=("is_active",))
 
         response = self.client.get(reverse("flows.flow_filter", args=[label.pk]))
         self.assertFalse(response.context["object_list"])
@@ -6564,7 +6564,7 @@ class FlowsTest(FlowFileTest):
     def test_start_flow_queueing(self):
         self.get_flow("start_flow_queued")
         self.channel.channel_type = "EX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         # trigger Flow A
         self.send("flowa")
@@ -7323,7 +7323,7 @@ class FlowsTest(FlowFileTest):
         first = FlowRun.objects.filter(is_active=True).first()
         session = FlowSession.objects.create(org=self.org, contact=first.contact, status=FlowSession.STATUS_WAITING)
         first.session = session
-        first.save(update_fields=["session"])
+        first.save(update_fields=("session",))
 
         # stop them all
         FlowRun.bulk_exit(FlowRun.objects.filter(is_active=True), FlowRun.EXIT_TYPE_INTERRUPTED)
@@ -8276,7 +8276,7 @@ class FlowsTest(FlowFileTest):
         # create an inactive group with the same name, to test that this doesn't blow up our import
         group = ContactGroup.get_or_create(self.org, self.admin, "Survey Audience")
         group.is_active = False
-        group.save()
+        group.save(update_fields=("is_active",))
 
         # and create another as well
         ContactGroup.get_or_create(self.org, self.admin, "Survey Audience")
@@ -8567,7 +8567,7 @@ class FlowsTest(FlowFileTest):
 
         # now add a primary language to our org
         self.org.primary_language = spanish
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         flow = Flow.objects.get(pk=flow.pk)
 
@@ -8578,7 +8578,7 @@ class FlowsTest(FlowFileTest):
         )
 
         self.org.primary_language = None
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
         flow = Flow.objects.get(pk=flow.pk)
 
         # no longer spanish on our org
@@ -8589,7 +8589,7 @@ class FlowsTest(FlowFileTest):
 
         # back to spanish
         self.org.primary_language = spanish
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
         flow = Flow.objects.get(pk=flow.pk)
 
         # but set our contact's language explicitly should keep us at english
@@ -8676,7 +8676,7 @@ class FlowsTest(FlowFileTest):
 
         # now let's expire them out of the flow prematurely
         flow.expires_after_minutes = 5
-        flow.save()
+        flow.save(update_fields=("expires_after_minutes",))
 
         # this normally gets run on FlowCRUDL.Update
         update_run_expirations_task(flow.id)
@@ -9038,7 +9038,7 @@ class FlowsTest(FlowFileTest):
         # create the language for our org
         language = Language.create(self.org, flow.created_by, "English", "eng")
         self.org.primary_language = language
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         # start our flow without a message (simulating it being fired by a trigger or the simulator)
         # this will evaluate requires_step() to make sure it handles localized flows
@@ -9669,7 +9669,7 @@ class FlowMigrationTest(FlowFileTest):
 
     def test_migrate_to_11_12_with_valid_channels(self):
         self.channel.name = "1234"
-        self.channel.save()
+        self.channel.save(update_fields=("name",))
 
         self.org = self.channel.org
         flow = self.get_flow("migrate_to_11_12")
@@ -9785,11 +9785,11 @@ class FlowMigrationTest(FlowFileTest):
 
         invalid1 = Flow.objects.get(name="Invalid1")
         invalid1.is_archived = True
-        invalid1.save()
+        invalid1.save(update_fields=("is_archived",))
 
         invalid2 = Flow.objects.get(name="Invalid2")
         invalid2.is_active = False
-        invalid2.save()
+        invalid2.save(update_fields=("is_active",))
 
         flow = Flow.objects.get(name="Master")
         flow_json = flow.as_json()
@@ -10676,7 +10676,7 @@ class ChannelSplitTest(FlowFileTest):
 
         # update our channel to have a 206 address
         self.channel.address = "+12065551212"
-        self.channel.save()
+        self.channel.save(update_fields=("address",))
 
     def test_initial_channel_split(self):
         flow = self.get_flow("channel_split")
@@ -10840,7 +10840,7 @@ class SendActionTest(FlowFileTest):
             modified_by=self.admin,
         )
         flow.version_number = "8"
-        flow.save()
+        flow.save(update_fields=("version_number",))
 
         migrated = revision.get_definition_json()
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -8033,7 +8033,7 @@ class FlowsTest(FlowFileTest):
 
     def test_channel_dependencies(self):
         self.channel.name = "1234"
-        self.channel.save()
+        self.channel.save(update_fields=("name",))
 
         self.get_flow("migrate_to_11_12_one_node")
         flow = Flow.objects.filter(name="channel").first()

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -50,7 +50,7 @@ from temba.triggers.models import Trigger
 from temba.utils import analytics, json, on_transaction_commit, str_to_bool
 from temba.utils.expressions import get_function_listing
 from temba.utils.s3 import public_file_storage
-from temba.utils.views import BaseActionForm, NonAtomicMixin
+from temba.utils.views import BaseActionForm, NonAtomicMixin, UpdateFieldsSaveMixin
 
 from .models import (
     ExportFlowResultsTask,
@@ -532,7 +532,7 @@ class FlowCRUDL(SmartCRUDL):
             # redirect to the newly created flow
             return HttpResponseRedirect(reverse("flows.flow_editor", args=[copy.uuid]))
 
-    class Update(AllowOnlyActiveFlowMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(UpdateFieldsSaveMixin, AllowOnlyActiveFlowMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
         class BaseUpdateFlowFormMixin:
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)

--- a/temba/ivr/clients.py
+++ b/temba/ivr/clients.py
@@ -75,7 +75,7 @@ class NexmoClient(NexmoCli):
 
             # the call was successfully sent to the IVR provider
             call.status = IVRCall.WIRED
-            call.save()
+            call.save(update_fields=("external_id", "status"))
 
             for event in self.events:
                 ChannelLog.log_ivr_interaction(call, "Started call", event)
@@ -85,7 +85,7 @@ class NexmoClient(NexmoCli):
             ChannelLog.log_ivr_interaction(call, "Call start failed", event, is_error=True)
 
             call.status = IVRCall.FAILED
-            call.save()
+            call.save(update_fields=("status",))
 
             raise IVRException(_("Nexmo call failed, with error %s") % str(e))
 
@@ -147,7 +147,7 @@ class TwilioClient(TembaTwilioRestClient):
 
             # the call was successfully sent to the IVR provider
             call.status = IVRCall.WIRED
-            call.save()
+            call.save(update_fields=("external_id", "status"))
 
             for event in self.events:
                 ChannelLog.log_ivr_interaction(call, "Started call", event)
@@ -161,7 +161,7 @@ class TwilioClient(TembaTwilioRestClient):
             ChannelLog.log_ivr_interaction(call, "Call start failed", event, is_error=True)
 
             call.status = IVRCall.FAILED
-            call.save()
+            call.save(update_fields=("status",))
 
             raise IVRException(message)
 
@@ -234,7 +234,7 @@ class VerboiceClient:  # pragma: needs cover
 
         if "call_id" not in response:
             call.status = IVRCall.FAILED
-            call.save()
+            call.save(update_fields=("status",))
 
             raise IVRException(_("Verboice connection failed."))
 
@@ -243,4 +243,4 @@ class VerboiceClient:  # pragma: needs cover
 
         # the call was successfully sent to the IVR provider
         call.status = IVRCall.WIRED
-        call.save()
+        call.save(update_fields=("status", "external_id"))

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -115,7 +115,7 @@ class IVRCall(ChannelConnection):
                 )
 
                 self.status = self.FAILED
-                self.save(update_fields=("status", "modified_on"))
+                self.save(update_fields=("status",))
 
         # client or domain are not known
         else:

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -76,7 +76,7 @@ class IVRCall(ChannelConnection):
             # mark us as interrupted
             self.status = ChannelConnection.INTERRUPTED
             self.ended_on = timezone.now()
-            self.save(update_fields=("status", "ended_on"))
+            self.save(update_fields=("status", "ended_on", "modified_on"))
 
             self.unregister_active_event()
 
@@ -115,7 +115,7 @@ class IVRCall(ChannelConnection):
                 )
 
                 self.status = self.FAILED
-                self.save(update_fields=("status",))
+                self.save(update_fields=("status", "modified_on"))
 
         # client or domain are not known
         else:
@@ -126,7 +126,7 @@ class IVRCall(ChannelConnection):
             )
 
             self.status = self.FAILED
-            self.save(update_fields=("status",))
+            self.save(update_fields=("status", "modified_on"))
 
     def schedule_call_retry(self, backoff_minutes: int):
         # retry the call if it has not been retried maximum number of times

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -34,7 +34,7 @@ class IVRTests(FlowFileTest):
         # configure our account to be IVR enabled
         self.channel.channel_type = "T"
         self.channel.role = Channel.ROLE_CALL + Channel.ROLE_ANSWER + Channel.ROLE_SEND
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type", "role"))
         self.admin.groups.add(Group.objects.get(name="Beta"))
         self.login(self.admin)
 
@@ -54,7 +54,6 @@ class IVRTests(FlowFileTest):
 
         # connect it and check our client is configured
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         flow = self.get_flow("call_me_maybe")
 
@@ -70,7 +69,6 @@ class IVRTests(FlowFileTest):
 
         # connect Nexmo instead
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         # manually create a Nexmo channel
         nexmo = Channel.create(
@@ -132,7 +130,6 @@ class IVRTests(FlowFileTest):
     def test_call_logging(self):
         # create our ivr setup
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         with patch("twilio.rest.Client.request") as mock:
             mock.return_value = MockResponse(200, '{"sid": "CAa346467ca321c71dbd5e12f627deb854"}')
@@ -168,7 +165,6 @@ class IVRTests(FlowFileTest):
     def test_disable_calls_twilio(self):
         with self.settings(SEND_CALLS=False):
             self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-            self.org.save()
 
             with patch("twilio.rest.api.v2010.account.call.CallList.create") as mock:
                 self.import_file("call_me_maybe")
@@ -190,10 +186,9 @@ class IVRTests(FlowFileTest):
 
         with self.settings(SEND_CALLS=False):
             self.org.connect_nexmo("123", "456", self.admin)
-            self.org.save()
 
             self.channel.channel_type = "NX"
-            self.channel.save()
+            self.channel.save(update_fields=("channel_type",))
 
             # import an ivr flow
             self.import_file("gather_digits")
@@ -214,7 +209,6 @@ class IVRTests(FlowFileTest):
     def test_bogus_call(self):
         # create our ivr setup
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
         self.import_file("capture_recording")
 
         # post to a bogus call id
@@ -239,7 +233,7 @@ class IVRTests(FlowFileTest):
 
         # create our ivr setup
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
+
         self.import_file("capture_recording")
         flow = Flow.objects.filter(name="Capture Recording").first()
 
@@ -341,10 +335,9 @@ class IVRTests(FlowFileTest):
 
         # connect Nexmo
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         self.import_file("capture_recording")
         flow = Flow.objects.filter(name="Capture Recording").first()
@@ -583,7 +576,6 @@ class IVRTests(FlowFileTest):
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
     def test_ivr_start_flow(self):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         msg_flow = self.get_flow("ivr_child_flow")
         ivr_flow = Flow.objects.get(name="Voice Flow")
@@ -613,7 +605,6 @@ class IVRTests(FlowFileTest):
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
     def test_ivr_call_redirect(self):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # import our flows
         self.get_flow("ivr_call_redirect")
@@ -646,7 +637,6 @@ class IVRTests(FlowFileTest):
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
     def test_text_trigger_ivr(self):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # import our flows
         self.get_flow("text_trigger_ivr")
@@ -679,7 +669,6 @@ class IVRTests(FlowFileTest):
     def test_non_blocking_rule_ivr(self):
 
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # flow goes: passive -> recording -> msg
         flow = self.get_flow("non_blocking_rule_ivr")
@@ -730,7 +719,6 @@ class IVRTests(FlowFileTest):
     def test_ivr_digit_gather(self):
 
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # import an ivr flow
         self.import_file("gather_digits")
@@ -788,10 +776,9 @@ class IVRTests(FlowFileTest):
         mock_create_call.return_value = dict(uuid="12345")
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         # import an ivr flow
         self.import_file("gather_digits")
@@ -840,10 +827,9 @@ class IVRTests(FlowFileTest):
         request.method = "PUT"
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         # import an ivr flow
         self.import_file("gather_digits")
@@ -896,10 +882,9 @@ class IVRTests(FlowFileTest):
         mock_create_call.return_value = dict(uuid="12345")
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         # import an ivr flow
         self.import_file("ivr_subflow")
@@ -990,7 +975,7 @@ class IVRTests(FlowFileTest):
 
         # connect it and check our client is configured
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
+
         self.assertTrue(self.org.is_connected_to_twilio())
         self.assertIsNotNone(self.org.get_twilio_client())
 
@@ -1128,14 +1113,34 @@ class IVRTests(FlowFileTest):
         flow.start([], [eric])
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).order_by("-pk").first()
         call.update_status("completed", 30, "T")
-        call.save()
+        call.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         call.refresh_from_db()
 
         self.assertEqual(call.duration, 30)
 
         # now look at implied duration
         call.update_status("in-progress", None, "T")
-        call.save()
+        call.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         call.refresh_from_db()
         self.assertIsNotNone(call.get_duration())
         self.assertEqual(timedelta(seconds=30), call.get_duration())
@@ -1143,7 +1148,7 @@ class IVRTests(FlowFileTest):
         # even if no duration is set with started_on
         call.duration = None
         call.started_on = timezone.now() - timedelta(seconds=23)
-        call.save()
+        call.save(update_fields=("duration", "started_on"))
         call.refresh_from_db()
         self.assertIsNotNone(call.get_duration())
         self.assertEqual(timedelta(seconds=23), call.get_duration())
@@ -1154,7 +1159,17 @@ class IVRTests(FlowFileTest):
         def test_status_update(call_to_update, twilio_status, temba_status, channel_type):
             call_to_update.ended_on = None
             call_to_update.update_status(twilio_status, 0, channel_type)
-            call_to_update.save()
+            call_to_update.save(
+                update_fields=(
+                    "status",
+                    "duration",
+                    "error_count",
+                    "next_attempt",
+                    "retry_count",
+                    "ended_on",
+                    "started_on",
+                )
+            )
             call_to_update.refresh_from_db()
             self.assertEqual(temba_status, IVRCall.objects.get(pk=call_to_update.pk).status)
 
@@ -1165,7 +1180,6 @@ class IVRTests(FlowFileTest):
 
         # connect it and check our client is configured
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # twiml api config
         config = {
@@ -1218,7 +1232,6 @@ class IVRTests(FlowFileTest):
     def test_rule_first_ivr_flow(self):
         # connect it and check our client is configured
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # import an ivr flow
         flow = self.get_flow("rule_first_ivr")
@@ -1254,12 +1267,11 @@ class IVRTests(FlowFileTest):
 
         # connect it and check our client is configured
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # import an ivr flow
         flow = self.get_flow("call_me_maybe")
         flow.version_number = 3
-        flow.save()
+        flow.save(update_fields=("version_number",))
 
         # go back to our original version
         flow_json = self.get_flow_json("call_me_maybe")["definition"]
@@ -1312,7 +1324,7 @@ class IVRTests(FlowFileTest):
 
         # now try an inbound call after remove our channel
         self.channel.is_active = False
-        self.channel.save()
+        self.channel.save(update_fields=("is_active",))
         response = self.client.post(reverse("handlers.twilio_handler", args=["voice", self.channel.uuid]), post_data)
         self.assertContains(response, "no channel configured to take this call")
         self.assertEqual(200, response.status_code)
@@ -1325,7 +1337,6 @@ class IVRTests(FlowFileTest):
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
     def test_incoming_start(self):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         self.get_flow("call_me_start")
 
@@ -1349,10 +1360,9 @@ class IVRTests(FlowFileTest):
         mock_update_call.return_value = dict(uuid="12345")
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         nexmo_uuid = self.org.config["NEXMO_UUID"]
 
@@ -1397,17 +1407,16 @@ class IVRTests(FlowFileTest):
         mock_create_application.return_value = dict(id="app-id", keys=dict(private_key="private-key\n"))
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         nexmo_uuid = self.org.config["NEXMO_UUID"]
 
         # import an ivr flow
         flow = self.get_flow("call_me_maybe")
         flow.version_number = 3
-        flow.save()
+        flow.save(update_fields=("version_number",))
 
         # go back to our original version
         flow_json = self.get_flow_json("call_me_maybe")["definition"]
@@ -1518,7 +1527,6 @@ class IVRTests(FlowFileTest):
         mock_create_application.return_value = dict(id="app-id", keys=dict(private_key="private-key\n"))
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         nexmo_uuid = self.org.config["NEXMO_UUID"]
 
@@ -1551,7 +1559,6 @@ class IVRTests(FlowFileTest):
         mock_create_application.return_value = dict(id="app-id", keys=dict(private_key="private-key\n"))
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         nexmo_uuid = self.org.config["NEXMO_UUID"]
 
@@ -1580,10 +1587,9 @@ class IVRTests(FlowFileTest):
         mock_create_application.return_value = dict(id="app-id", keys=dict(private_key="private-key\n"))
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         nexmo_uuid = self.org.config["NEXMO_UUID"]
 
@@ -1611,7 +1617,6 @@ class IVRTests(FlowFileTest):
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
     def test_no_channel_for_call(self):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # remove our channel
         self.channel.release()
@@ -1632,7 +1637,6 @@ class IVRTests(FlowFileTest):
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
     def test_no_flow_for_incoming(self):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         flow = self.get_flow("missed_call_flow")
 
@@ -1664,7 +1668,6 @@ class IVRTests(FlowFileTest):
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
     def test_download_media_twilio(self):
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         with patch("requests.get") as response:
             mock1 = MockResponse(404, "No such file")
@@ -1705,10 +1708,9 @@ class IVRTests(FlowFileTest):
         ]
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         # import an ivr flow
         self.import_file("gather_digits")
@@ -1721,7 +1723,7 @@ class IVRTests(FlowFileTest):
         flow.start([], [eric])
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
         call.external_id = "ext-id"
-        call.save()
+        call.save(update_fields=("external_id",))
 
         nexmo_client = self.org.get_nexmo_client()
 
@@ -1761,10 +1763,9 @@ class IVRTests(FlowFileTest):
         mock_jwt_encode.return_value = b"TOKEN"
 
         self.org.connect_nexmo("123", "456", self.admin)
-        self.org.save()
 
         self.channel.channel_type = "NX"
-        self.channel.save()
+        self.channel.save(update_fields=("channel_type",))
 
         # import an ivr flow
         self.import_file("gather_digits")
@@ -1779,7 +1780,7 @@ class IVRTests(FlowFileTest):
             flow.start([], [eric])
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
         call.external_id = "ext-id"
-        call.save()
+        call.save(update_fields=("external_id",))
 
         nexmo_client = self.org.get_nexmo_client()
 
@@ -1820,7 +1821,7 @@ class IVRTests(FlowFileTest):
         # call should not be retried if we are over IVRCall.MAX_RETRY_ATTEMPTS
         total_retries = IVRCall.MAX_RETRY_ATTEMPTS + 33
         call1.retry_count = total_retries
-        call1.save()
+        call1.save(update_fields=("retry_count", "next_attempt"))
 
         call1.schedule_call_retry(60)
         self.assertIsNone(call1.next_attempt)
@@ -1843,31 +1844,91 @@ class IVRTests(FlowFileTest):
 
         # twilio
         call1.update_status("busy", 0, "T")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
 
         call1.next_attempt = None
         call1.retry_count = 0
         call1.update_status("in-progress", 0, "T")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
 
         call1.update_status("no-answer", 0, "T")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
 
         call1.next_attempt = None
         call1.retry_count = 0
         call1.update_status("in-progress", 0, "T")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
 
         # we should not change call_retry if we got the same status
         call1.update_status("busy", 0, "T")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
         self.assertEqual(call1.retry_count, 1)
 
         call1.update_status("no-answer", 0, "T")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertEqual(call1.retry_count, 1)
 
     def test_update_status_for_call_retry_nexmo(self):
@@ -1887,58 +1948,178 @@ class IVRTests(FlowFileTest):
 
         # nexmo
         call1.update_status("busy", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
 
         call1.next_attempt = None
         call1.retry_count = 0
         call1.update_status("answered", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
 
         call1.update_status("rejected", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
 
         call1.next_attempt = None
         call1.retry_count = 0
         call1.update_status("answered", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
 
         call1.update_status("unanswered", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
 
         call1.next_attempt = None
         call1.retry_count = 0
         call1.update_status("answered", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
 
         call1.update_status("timeout", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
 
         call1.next_attempt = None
         call1.retry_count = 0
         call1.update_status("answered", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
 
         call1.update_status("cancelled", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
 
         call1.next_attempt = None
         call1.retry_count = 0
         call1.update_status("answered", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
 
         # we should not change call_retry if we got the same status
         call1.update_status("cancelled", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertTrue(call1.next_attempt > timezone.now())
         self.assertEqual(call1.retry_count, 1)
 
         call1.update_status("cancelled", 0, "NX")
-        call1.save()
+        call1.save(
+            update_fields=(
+                "status",
+                "duration",
+                "error_count",
+                "next_attempt",
+                "retry_count",
+                "ended_on",
+                "started_on",
+            )
+        )
         self.assertEqual(call1.retry_count, 1)
 
     def test_IVR_view_request_handler(self):
@@ -2020,7 +2201,6 @@ class IVRTests(FlowFileTest):
 
         # connect it and check our client is configured
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # twiml api config
         config = {
@@ -2120,7 +2300,6 @@ class IVRTests(FlowFileTest):
     def test_unknown_domain(self):
         # connect it and check our client is configured
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         # import an ivr flow
         self.import_file("call_me_maybe")

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -513,7 +513,6 @@ class IVRTests(FlowFileTest):
     def test_ivr_subflow(self):
 
         self.org.connect_twilio("TEST_SID", "TEST_TOKEN", self.admin)
-        self.org.save()
 
         self.get_flow("ivr_subflow")
         parent_flow = Flow.objects.filter(name="Parent Flow").first()

--- a/temba/ivr/views.py
+++ b/temba/ivr/views.py
@@ -79,7 +79,17 @@ class CallHandler(View):
             # nexmo does not set status for some callbacks
             if status is not None:
                 call.update_status(status, duration, channel_type)  # update any calls we have spawned with the same
-                call.save()
+                call.save(
+                    update_fields=(
+                        "status",
+                        "duration",
+                        "error_count",
+                        "next_attempt",
+                        "retry_count",
+                        "ended_on",
+                        "started_on",
+                    )
+                )
 
             resume = request.GET.get("resume", 0)
             user_response = request.POST.copy()

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -21,7 +21,7 @@ class LocationTest(TembaTest):
 
         # clear our country on our org
         self.org.country = None
-        self.org.save()
+        self.org.save(update_fields=("country",))
 
         # try stripping path on our country, will fail
         with self.assertRaises(Exception):
@@ -38,7 +38,7 @@ class LocationTest(TembaTest):
 
         # now set it to rwanda
         self.org.country = self.country
-        self.org.save()
+        self.org.save(update_fields=("country",))
 
         # our country is set to rwanda, we should get it as the main object
         response = self.client.get(reverse("locations.adminboundary_alias"))

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -31,7 +31,15 @@ from temba.utils import analytics, chunk_list, extract_constants, get_anonymous_
 from temba.utils.dates import datetime_to_str, get_datetime_format
 from temba.utils.export import BaseExportAssetStore, BaseExportTask
 from temba.utils.expressions import evaluate_template
-from temba.utils.models import JSONAsTextField, SquashableModel, TembaModel, TranslatableField
+from temba.utils.models import (
+    AddModifiedOnMixin,
+    JSONAsTextField,
+    RequireUpdateFieldsMixin,
+    SquashableModel,
+    TembaModel,
+    TranslatableField,
+)
+from temba.utils.queues import HIGH_PRIORITY, Queue, push_task
 from temba.utils.text import clean_string
 
 from . import legacy
@@ -368,7 +376,7 @@ class Broadcast(models.Model):
 
         # set an estimate of our number of recipients, we calculate this more carefully when actually sent
         self.recipient_count = recipient_count
-        self.save(update_fields=("recipient_count", "modified_on"))
+        self.save(update_fields=("recipient_count",))
 
     def _get_preferred_languages(self, contact=None, org=None):
         """
@@ -416,7 +424,7 @@ class Attachment(object):
         return self.content_type == other.content_type and self.url == other.url
 
 
-class Msg(models.Model):
+class Msg(RequireUpdateFieldsMixin, AddModifiedOnMixin, models.Model):
     """
     Messages are the main building blocks of a RapidPro application. Channels send and receive
     these, Triggers and Flows handle them when appropriate.
@@ -684,7 +692,7 @@ class Msg(models.Model):
                     if not settings.SEND_MESSAGES:
                         msg.status = WIRED
                         msg.sent_on = timezone.now()
-                        msg.save(update_fields=("status", "sent_on", "modified_on"))
+                        msg.save(update_fields=("status", "sent_on"))
                         logger.debug(f"FAKED SEND for [{msg.id}]")
                         continue
 
@@ -907,7 +915,7 @@ class Msg(models.Model):
             handled = True
 
         self.save(
-            update_fields=["status", "sent_on", "modified_on"]
+            update_fields=("status", "sent_on")
         )  # first save message status before updating the broadcast status
 
         return handled
@@ -969,7 +977,7 @@ class Msg(models.Model):
         # mark ourselves as resent
         self.status = RESENT
         self.topup = None
-        self.save()
+        self.save(update_fields=("status", "topup"))
 
         # send our message
         self.org.trigger_send([cloned])
@@ -1419,7 +1427,7 @@ class Msg(models.Model):
 
         if delete_reason:
             self.delete_reason = delete_reason
-            self.save(update_fields=("delete_reason", "modified_on"))
+            self.save(update_fields=("delete_reason",))
 
         # delete this object
         self.delete()

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -368,7 +368,7 @@ class Broadcast(models.Model):
 
         # set an estimate of our number of recipients, we calculate this more carefully when actually sent
         self.recipient_count = recipient_count
-        self.save(update_fields=["recipient_count"])
+        self.save(update_fields=("recipient_count", "modified_on"))
 
     def _get_preferred_languages(self, contact=None, org=None):
         """
@@ -684,7 +684,7 @@ class Msg(models.Model):
                     if not settings.SEND_MESSAGES:
                         msg.status = WIRED
                         msg.sent_on = timezone.now()
-                        msg.save(update_fields=("status", "sent_on"))
+                        msg.save(update_fields=("status", "sent_on", "modified_on"))
                         logger.debug(f"FAKED SEND for [{msg.id}]")
                         continue
 
@@ -907,7 +907,7 @@ class Msg(models.Model):
             handled = True
 
         self.save(
-            update_fields=["status", "sent_on"]
+            update_fields=["status", "sent_on", "modified_on"]
         )  # first save message status before updating the broadcast status
 
         return handled
@@ -1419,7 +1419,7 @@ class Msg(models.Model):
 
         if delete_reason:
             self.delete_reason = delete_reason
-            self.save(update_fields=["delete_reason"])
+            self.save(update_fields=("delete_reason", "modified_on"))
 
         # delete this object
         self.delete()

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -39,7 +39,6 @@ from temba.utils.models import (
     TembaModel,
     TranslatableField,
 )
-from temba.utils.queues import HIGH_PRIORITY, Queue, push_task
 from temba.utils.text import clean_string
 
 from . import legacy

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -478,7 +478,7 @@ class MsgTest(TembaTest):
         eng = Language.create(self.org, self.admin, "English", "eng")
         Language.create(self.org, self.admin, "French", "fra")
         self.org.primary_language = eng
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         broadcast = Broadcast.create(
             self.org,
@@ -540,7 +540,7 @@ class MsgTest(TembaTest):
         )
 
         broadcast4.schedule = Schedule.create_schedule(timezone.now(), "D", self.admin)
-        broadcast4.save(update_fields=["schedule"])
+        broadcast4.save(update_fields=("schedule",))
 
         with self.assertNumQueries(39):
             response = self.client.get(reverse("msgs.msg_outbox"))
@@ -590,7 +590,7 @@ class MsgTest(TembaTest):
         # msg6 is still pending
         msg6.status = PENDING
         msg6.msg_type = None
-        msg6.save()
+        msg6.save(update_fields=("msg_type",))
 
         # visit inbox page  as a user not in the organization
         self.login(self.non_org_user)
@@ -772,7 +772,7 @@ class MsgTest(TembaTest):
 
         msg1 = Msg.create_outgoing(self.org, self.admin, self.joe, "message number 1")
         msg1.status = "F"
-        msg1.save()
+        msg1.save(update_fields=("status",))
 
         # create a log for it
         log = ChannelLog.objects.create(channel=msg1.channel, msg=msg1, is_error=True, description="Failed")
@@ -792,7 +792,7 @@ class MsgTest(TembaTest):
         # message without a broadcast
         msg3 = Msg.create_outgoing(self.org, self.admin, self.joe, "messsage number 3")
         msg3.status = "F"
-        msg3.save()
+        msg3.save(update_fields=("status",))
 
         # visit fail page  as a user not in the organization
         self.login(self.non_org_user)
@@ -840,7 +840,7 @@ class MsgTest(TembaTest):
         self.joe.save(update_fields=("name",), handle_update=False)
 
         self.org.created_on = datetime(2017, 1, 1, 9, tzinfo=pytz.UTC)
-        self.org.save()
+        self.org.save(update_fields=("created_on",))
 
         msg1 = self.create_msg(
             contact=self.joe,
@@ -929,7 +929,7 @@ class MsgTest(TembaTest):
 
         # archive last message
         msg3.visibility = Msg.VISIBILITY_ARCHIVED
-        msg3.save()
+        msg3.save(update_fields=("visibility",))
 
         # archive 5 msgs
         Archive.objects.create(
@@ -1461,7 +1461,7 @@ class MsgTest(TembaTest):
 
         # archive last message
         msg3.visibility = Msg.VISIBILITY_ARCHIVED
-        msg3.save()
+        msg3.save(update_fields=("visibility",))
 
         # create a dummy export task so that we won't be able to export
         blocking_export = ExportMessagesTask.create(self.org, self.admin, SystemLabel.TYPE_INBOX)
@@ -2500,7 +2500,7 @@ class BroadcastTest(TembaTest):
 
         # add some attachments to this message
         msg.attachments = ["image/jpeg:http://e.com/test.jpg", "audio/mp3:http://e.com/test.mp3"]
-        msg.save()
+        msg.save(update_fields=("attachments",))
         context = msg.build_expressions_context()
 
         self.assertEqual(
@@ -2512,7 +2512,7 @@ class BroadcastTest(TembaTest):
 
         # clear the text of the message
         msg.text = ""
-        msg.save()
+        msg.save(update_fields=("text",))
         context = msg.build_expressions_context()
 
         self.assertEqual(context["__default__"], "http://e.com/test.jpg\nhttp://e.com/test.mp3")
@@ -3060,7 +3060,7 @@ class BroadcastLanguageTest(TembaTest):
         eng = Language.create(self.org, self.admin, "English", "eng")
         Language.create(self.org, self.admin, "French", "fra")
         self.org.primary_language = eng
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         eng_msg = "This is my message"
         fra_msg = "Ceci est mon message"

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -44,7 +44,7 @@ from temba.utils.cache import get_cacheable_attr, get_cacheable_result, incrby_e
 from temba.utils.currencies import currency_for_country
 from temba.utils.dates import datetime_to_str, get_datetime_format, str_to_datetime
 from temba.utils.email import send_custom_smtp_email, send_simple_email, send_template_email
-from temba.utils.models import JSONAsTextField, SquashableModel
+from temba.utils.models import AddModifiedOnMixin, JSONAsTextField, RequireUpdateFieldsMixin, SquashableModel
 from temba.utils.s3 import public_file_storage
 from temba.utils.text import random_string
 from temba.values.constants import Value
@@ -146,7 +146,7 @@ class OrgCache(Enum):
     credits = 2
 
 
-class Org(SmartModel):
+class Org(RequireUpdateFieldsMixin, AddModifiedOnMixin, SmartModel):
     """
     An Org can have several users and is the main component that holds all Flows, Messages, Contacts, etc. Orgs
     know their country so they can deal with locally formatted numbers (numbers provided without a country code). As such,
@@ -787,13 +787,13 @@ class Org(SmartModel):
         config.update({SMTP_SERVER: f"smtp://{quote(username)}:{quote(password, safe='')}@{host}:{port}/?{query}"})
         self.config = config
         self.modified_by = user
-        self.save()
+        self.save(update_fields=("config", "modified_by"))
 
     def remove_smtp_config(self, user):
         if self.config:
             self.config.pop(SMTP_SERVER)
             self.modified_by = user
-            self.save()
+            self.save(update_fields=("config", "modified_by"))
 
     def has_smtp_config(self):
         if self.config:
@@ -836,7 +836,7 @@ class Org(SmartModel):
         config.update(transferto_config)
         self.config = config
         self.modified_by = user
-        self.save()
+        self.save(update_fields=("config", "modified_by"))
 
     def refresh_transferto_account_currency(self):
         config = self.config
@@ -852,7 +852,7 @@ class Org(SmartModel):
         account_currency = parsed_response.get("currency", "")
         config.update({TRANSFERTO_ACCOUNT_CURRENCY: account_currency})
         self.config = config
-        self.save()
+        self.save(update_fields=("config",))
 
     def is_connected_to_transferto(self):
         if self.config:
@@ -869,7 +869,7 @@ class Org(SmartModel):
             self.config[TRANSFERTO_AIRTIME_API_TOKEN] = ""
             self.config[TRANSFERTO_ACCOUNT_CURRENCY] = ""
             self.modified_by = user
-            self.save()
+            self.save(update_fields=("config", "modified_by"))
 
     def connect_nexmo(self, api_key, api_secret, user):
         from nexmo import Client as NexmoClient
@@ -905,7 +905,7 @@ class Org(SmartModel):
         config.update(nexmo_config)
         self.config = config
         self.modified_by = user
-        self.save()
+        self.save(update_fields=("config", "modified_by"))
 
     def nexmo_uuid(self):
         config = self.config
@@ -918,7 +918,7 @@ class Org(SmartModel):
         config.update(twilio_config)
         self.config = config
         self.modified_by = user
-        self.save()
+        self.save(update_fields=("config", "modified_by"))
 
     def is_connected_to_nexmo(self):
         if self.config:
@@ -947,7 +947,7 @@ class Org(SmartModel):
             self.config[NEXMO_KEY] = ""
             self.config[NEXMO_SECRET] = ""
             self.modified_by = user
-            self.save()
+            self.save(update_fields=("modified_by", "config"))
 
     def remove_twilio_account(self, user):
         if self.config:
@@ -959,7 +959,7 @@ class Org(SmartModel):
             self.config[ACCOUNT_TOKEN] = ""
             self.config[APPLICATION_SID] = ""
             self.modified_by = user
-            self.save()
+            self.save(update_fields=("modified_by", "config"))
 
     def connect_chatbase(self, agent_name, api_key, version, user):
         chatbase_config = {CHATBASE_AGENT_NAME: agent_name, CHATBASE_API_KEY: api_key, CHATBASE_VERSION: version}
@@ -968,7 +968,7 @@ class Org(SmartModel):
         config.update(chatbase_config)
         self.config = config
         self.modified_by = user
-        self.save()
+        self.save(update_fields=("config", "modified_by"))
 
     def remove_chatbase_account(self, user):
         config = self.config
@@ -984,7 +984,7 @@ class Org(SmartModel):
 
         self.config = config
         self.modified_by = user
-        self.save()
+        self.save(update_fields=("config", "modified_by"))
 
     def get_chatbase_credentials(self):
         if self.config:
@@ -1782,7 +1782,7 @@ class Org(SmartModel):
 
                 stripe_customer = customer.id
                 self.stripe_customer = stripe_customer
-                self.save()
+                self.save(update_fields=("stripe_customer",))
 
             # update the stripe card to the one they just entered
             else:

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -380,7 +380,7 @@ class Org(SmartModel):
         config = self.config
         config[ORG_STATUS] = status
         self.config = config
-        self.save(update_fields=["config"])
+        self.save(update_fields=("config", "modified_on"))
 
     def set_suspended(self):
         self.set_status(SUSPENDED)
@@ -1067,12 +1067,12 @@ class Org(SmartModel):
 
             if iso_code == primary:
                 self.primary_language = language
-                self.save(update_fields=("primary_language",))
+                self.save(update_fields=("primary_language", "modified_on"))
 
         # unset the primary language if not in the new list of codes
         if self.primary_language and self.primary_language.iso_code not in iso_codes:
             self.primary_language = None
-            self.save(update_fields=("primary_language",))
+            self.save(update_fields=("primary_language", "modified_on"))
 
         # remove any languages that are not in the new list
         self.languages.exclude(iso_code__in=iso_codes).delete()

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1161,7 +1161,7 @@ class OrgCRUDL(SmartCRUDL):
         def get_created_by(self, obj):  # pragma: needs cover
             return "%s %s - %s" % (obj.created_by.first_name, obj.created_by.last_name, obj.created_by.email)
 
-    class Update(SmartUpdateView):
+    class Update(UpdateFieldsSaveMixin, SmartUpdateView):
         fields = ("name", "brand", "parent", "is_anon")
 
         class OrgUpdateForm(forms.ModelForm):
@@ -1242,7 +1242,7 @@ class OrgCRUDL(SmartCRUDL):
                 return HttpResponseRedirect(self.get_success_url())
             return super().post(request, *args, **kwargs)
 
-    class Accounts(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Accounts(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class PasswordForm(forms.ModelForm):
             surveyor_password = forms.CharField(max_length=128)
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -55,7 +55,7 @@ from temba.utils.email import is_valid_address
 from temba.utils.http import http_headers
 from temba.utils.text import random_string
 from temba.utils.timezones import TimeZoneFormField
-from temba.utils.views import NonAtomicMixin
+from temba.utils.views import NonAtomicMixin, UpdateFieldsSaveMixin
 
 from .models import (
     ACCOUNT_SID,
@@ -721,7 +721,7 @@ class OrgCRUDL(SmartCRUDL):
 
             return non_single_buckets, singles
 
-    class TwilioConnect(ModalMixin, InferOrgMixin, OrgPermsMixin, SmartFormView):
+    class TwilioConnect(UpdateFieldsSaveMixin, ModalMixin, InferOrgMixin, OrgPermsMixin, SmartFormView):
         class TwilioConnectForm(forms.Form):
             account_sid = forms.CharField(help_text=_("Your Twilio Account SID"))
             account_token = forms.CharField(help_text=_("Your Twilio Account Token"))
@@ -762,7 +762,6 @@ class OrgCRUDL(SmartCRUDL):
 
             org = self.get_object()
             org.connect_twilio(account_sid, account_token, self.request.user)
-            org.save()
 
             return HttpResponseRedirect(self.get_success_url())
 
@@ -804,7 +803,7 @@ class OrgCRUDL(SmartCRUDL):
 
             return context
 
-    class NexmoAccount(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class NexmoAccount(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         success_message = ""
 
         class NexmoKeys(forms.ModelForm):
@@ -914,8 +913,6 @@ class OrgCRUDL(SmartCRUDL):
 
             org.connect_nexmo(api_key, api_secret, self.request.user)
 
-            org.save()
-
             return HttpResponseRedirect(self.get_success_url())
 
     class PlivoConnect(ModalMixin, InferOrgMixin, OrgPermsMixin, SmartFormView):
@@ -959,7 +956,7 @@ class OrgCRUDL(SmartCRUDL):
 
             return HttpResponseRedirect(self.get_success_url())
 
-    class SmtpServer(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class SmtpServer(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         success_message = ""
 
         class SmtpConfig(forms.ModelForm):
@@ -1267,7 +1264,7 @@ class OrgCRUDL(SmartCRUDL):
         title = "User Accounts"
         fields = ("surveyor_password",)
 
-    class ManageAccounts(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class ManageAccounts(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class AccountsForm(forms.ModelForm):
             invite_emails = forms.CharField(label=_("Invite people to your organization"), required=False)
             invite_group = forms.ChoiceField(
@@ -1652,7 +1649,7 @@ class OrgCRUDL(SmartCRUDL):
 
             return HttpResponseRedirect(self.get_success_url())
 
-    class CreateLogin(SmartUpdateView):
+    class CreateLogin(UpdateFieldsSaveMixin, SmartUpdateView):
         title = ""
         form_class = OrgSignupForm
         fields = ("first_name", "last_name", "email", "password")
@@ -2053,7 +2050,7 @@ class OrgCRUDL(SmartCRUDL):
 
             return obj
 
-    class Resthooks(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Resthooks(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class ResthookForm(forms.ModelForm):
             resthook = forms.SlugField(
                 required=False, label=_("New Event"), help_text="Enter a name for your event. ex: new-registration"
@@ -2130,7 +2127,7 @@ class OrgCRUDL(SmartCRUDL):
             context["failed_webhooks"] = WebHookResult.get_recent_errored(self.request.user.get_org()).exists()
             return context
 
-    class Chatbase(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Chatbase(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class ChatbaseForm(forms.ModelForm):
             agent_name = forms.CharField(
                 max_length=255, label=_("Agent Name"), required=False, help_text="Enter your Chatbase Agent's name"
@@ -2323,7 +2320,7 @@ class OrgCRUDL(SmartCRUDL):
             # show archives
             formax.add_section("archives", reverse("archives.archive_message"), icon="icon-box", action="link")
 
-    class TransferToAccount(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class TransferToAccount(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
 
         success_message = ""
 
@@ -2402,7 +2399,7 @@ class OrgCRUDL(SmartCRUDL):
                 org.refresh_transferto_account_currency()
                 return super().form_valid(form)
 
-    class TwilioAccount(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class TwilioAccount(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
 
         success_message = ""
 
@@ -2475,7 +2472,7 @@ class OrgCRUDL(SmartCRUDL):
                 org.connect_twilio(account_sid, account_token, user)
                 return super().form_valid(form)
 
-    class Edit(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Edit(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class OrgForm(forms.ModelForm):
             name = forms.CharField(max_length=128, label=_("The name of your organization"), help_text="")
             timezone = TimeZoneFormField(label=_("Your organization's timezone"), help_text="")
@@ -2588,7 +2585,7 @@ class OrgCRUDL(SmartCRUDL):
             response["Temba-Success"] = self.get_success_url()
             return response
 
-    class Country(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Country(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class CountryForm(forms.ModelForm):
             country = forms.ModelChoiceField(
                 Org.get_possible_countries(),
@@ -2608,7 +2605,7 @@ class OrgCRUDL(SmartCRUDL):
             self.org = self.derive_org()
             return self.request.user.has_perm("orgs.org_country") or self.has_org_perm("orgs.org_country")
 
-    class Languages(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Languages(UpdateFieldsSaveMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class LanguagesForm(forms.ModelForm):
             primary_lang = forms.CharField(
                 required=False,

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -389,7 +389,7 @@ class ScheduleTest(TembaTest):
     def test_calculating_next_fire(self):
 
         self.org.timezone = pytz.timezone("US/Eastern")
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
 
         tz = self.org.timezone
         eleven_fifteen_est = tz.localize(datetime(2013, 1, 3, hour=23, minute=15, second=0, microsecond=0))
@@ -410,7 +410,7 @@ class ScheduleTest(TembaTest):
     def test_update_near_day_boundary(self):
 
         self.org.timezone = pytz.timezone("US/Eastern")
-        self.org.save()
+        self.org.save(update_fields=("timezone",))
         tz = self.org.timezone
 
         sched = create_schedule(self.admin, "D")

--- a/temba/templates/models.py
+++ b/temba/templates/models.py
@@ -109,7 +109,7 @@ class TemplateTranslation(models.Model):
                 )
             else:
                 template.modified_on = timezone.now()
-                template.save(update_fields=["modified_on"])
+                template.save(update_fields=("modified_on",))
 
             existing = TemplateTranslation.objects.create(
                 template=template,
@@ -130,10 +130,10 @@ class TemplateTranslation(models.Model):
                 existing.content = content
                 existing.variable_count = variable_count
                 existing.is_active = True
-                existing.save(update_fields=["status", "content", "is_active", "variable_count"])
+                existing.save(update_fields=("status", "content", "is_active", "variable_count"))
 
                 existing.template.modified_on = timezone.now()
-                existing.template.save(update_fields=["modified_on"])
+                existing.template.save(update_fields=("modified_on",))
 
         return existing
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -318,7 +318,7 @@ class TembaTestMixin:
             }
 
         flow.version_number = definition["version"]
-        flow.save()
+        flow.save(update_fields=("version_number",))
 
         json_flow = FlowRevision.migrate_definition(definition, flow)
         flow.update(json_flow)

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -37,7 +37,7 @@ class TriggerTest(TembaTest):
         voice_flow = self.create_flow()
         voice_flow.flow_type = "V"
         voice_flow.name = "IVR Flow"
-        voice_flow.save()
+        voice_flow.save(update_fields=("flow_type", "name"))
 
         # flow options should show sms and voice flows
         response = self.client.get(reverse("triggers.trigger_keyword"))
@@ -168,7 +168,7 @@ class TriggerTest(TembaTest):
 
         # make our channel support ivr
         self.channel.role += Channel.ROLE_CALL + Channel.ROLE_ANSWER
-        self.channel.save()
+        self.channel.save(update_fields=("role",))
 
         # flow is required
         response = self.client.post(reverse("triggers.trigger_inbound_call"), dict())
@@ -183,7 +183,7 @@ class TriggerTest(TembaTest):
         # now lets create our first valid inbound call trigger
         guitarist_flow = self.create_flow()
         guitarist_flow.flow_type = Flow.TYPE_VOICE
-        guitarist_flow.save()
+        guitarist_flow.save(update_fields=("flow_type",))
 
         post_data = dict(flow=guitarist_flow.pk)
         response = self.client.post(reverse("triggers.trigger_inbound_call"), post_data)
@@ -201,7 +201,7 @@ class TriggerTest(TembaTest):
         # flow specific to our group
         bassist_flow = self.create_flow()
         bassist_flow.flow_type = Flow.TYPE_VOICE
-        bassist_flow.save()
+        bassist_flow.save(update_fields=("flow_type",))
 
         post_data = dict(flow=bassist_flow.pk, groups=[bassists.pk])
         response = self.client.post(reverse("triggers.trigger_inbound_call"), post_data)
@@ -313,13 +313,13 @@ class TriggerTest(TembaTest):
 
         # survey flows should not be an option
         flow.flow_type = Flow.TYPE_SURVEY
-        flow.save()
+        flow.save(update_fields=("flow_type",))
         response = self.client.get(reverse("triggers.trigger_schedule"))
         self.assertEqual(0, response.context["form"].fields["flow"].queryset.all().count())
 
         # back to normal flow type
         flow.flow_type = Flow.TYPE_MESSAGE
-        flow.save()
+        flow.save(update_fields=("flow_type",))
         self.assertEqual(1, response.context["form"].fields["flow"].queryset.all().count())
 
         post_data = dict()
@@ -502,7 +502,7 @@ class TriggerTest(TembaTest):
         # try creating a join group on an org with a language
         language = Language.create(self.org, self.admin, "Klingon", "kli")
         self.org.primary_language = language
-        self.org.save()
+        self.org.save(update_fields=("primary_language",))
 
         # now create another group trigger
         group = self.create_group(name="Lang Group", contacts=[])
@@ -529,7 +529,7 @@ class TriggerTest(TembaTest):
 
             # now change to a system flow
             pick.is_system = True
-            pick.save()
+            pick.save(update_fields=("is_system",))
 
             # our flow should no longer be an option
             trigger_form = form(self.admin)

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -342,7 +342,7 @@ class Command(BaseCommand):
                 modified_by=user,
             )
             field.uuid = f["uuid"]
-            field.save(update_fields=["uuid"])
+            field.save(update_fields=("uuid",))
 
         self._log(self.style.SUCCESS("OK") + "\n")
 
@@ -355,7 +355,7 @@ class Command(BaseCommand):
             else:
                 group = ContactGroup.create_static(org, user, g["name"])
             group.uuid = g["uuid"]
-            group.save(update_fields=["uuid"])
+            group.save(update_fields=("uuid",))
 
         self._log(self.style.SUCCESS("OK") + "\n")
 
@@ -451,7 +451,7 @@ class Command(BaseCommand):
         for c in spec["contacts"]:
             contact = Contact.get_or_create_by_urns(org, user, c["name"], c["urns"])
             contact.uuid = c["uuid"]
-            contact.save(update_fields=["uuid"], handle_update=False)
+            contact.save(update_fields=("uuid",), handle_update=False)
 
             # add to any groups we belong to
             for g in c.get("groups", []):

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -216,12 +216,12 @@ class AddModifiedOnMixin(object):
 
     def save(self, *args, **kwargs):
         if self.id:
-            update_fields = kwargs.get("update_fields")
+            update_fields = kwargs.get("update_fields", None)
 
-            if "modified_on" not in update_fields:
+            if update_fields is not None and "modified_on" not in update_fields:
                 update_fields += ("modified_on",)
 
-            kwargs["update_fields"] = update_fields
+                kwargs["update_fields"] = update_fields
 
         super().save(*args, **kwargs)
 

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -209,7 +209,28 @@ class TembaModel(SmartModel):
         abstract = True
 
 
+class AddModifiedOnMixin(object):
+    """
+    Add field `modified_on` to the set of model fields that will be updated
+    """
+
+    def save(self, *args, **kwargs):
+        if self.id:
+            update_fields = kwargs.get("update_fields")
+
+            if "modified_on" not in update_fields:
+                update_fields += ("modified_on",)
+
+            kwargs["update_fields"] = update_fields
+
+        super().save(*args, **kwargs)
+
+
 class RequireUpdateFieldsMixin(object):
+    """
+    Require developers to define `update_fields` when updating a model
+    """
+
     def save(self, *args, **kwargs):
         if self.id and "update_fields" not in kwargs:
             raise ValueError("Updating without specifying update_fields is disabled for this model")

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -480,7 +480,7 @@ class TemplateTagTest(TembaTest):
 
         with patch.object(timezone, "now", return_value=datetime.datetime(2015, 9, 15, 0, 0, 0, 0, pytz.UTC)):
             self.org.date_format = "D"
-            self.org.save()
+            self.org.save(update_fields=("date_format",))
 
             context = dict(user_org=self.org)
 
@@ -493,7 +493,7 @@ class TemplateTagTest(TembaTest):
 
             # the org has month first configured
             self.org.date_format = "M"
-            self.org.save()
+            self.org.save(update_fields=("date_format",))
 
             # date without timezone
             test_date = datetime.datetime(2012, 7, 20, 17, 5, 0, 0)
@@ -505,7 +505,7 @@ class TemplateTagTest(TembaTest):
     def test_short_datetime(self):
         with patch.object(timezone, "now", return_value=datetime.datetime(2015, 9, 15, 0, 0, 0, 0, pytz.UTC)):
             self.org.date_format = "D"
-            self.org.save()
+            self.org.save(update_fields=("date_format",))
 
             context = dict(user_org=self.org)
 
@@ -533,7 +533,7 @@ class TemplateTagTest(TembaTest):
 
             # the org has month first configured
             self.org.date_format = "M"
-            self.org.save()
+            self.org.save(update_fields=("date_format",))
 
             # given the time as now, should display "Hour:Minutes AM|PM" eg. "5:05 pm"
             now = timezone.now()

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -13,6 +13,20 @@ from temba.utils.es import ModelESSearch
 from temba.utils.models import ProxyQuerySet, mapEStoDB
 
 
+class UpdateFieldsSaveMixin:
+    exclude_default = ("id",)
+
+    def _calc_update_fields(self, obj):
+        excludes = set(self.exclude_default) | set(getattr(self, "exclude", []))
+
+        return [f.name for f in obj._meta.concrete_fields if f.name not in excludes]
+
+    def save(self, obj):
+        obj.save(update_fields=self._calc_update_fields(obj))
+
+        self.save_m2m()
+
+
 class PostOnlyMixin(View):
     """
     Utility mixin to make a class based view be POST only


### PR DESCRIPTION
Fixes: https://github.com/rapidpro/rapidpro/issues/906

Models that now use `RequireUpdateFieldsMixin`: Campaign, Channel,
ChannelConnection, ContactGroup, Flow, IVRCall, Msg, Org

Unified `update_fields` parameter values to be tuples, as it was a mix
of tuples and list.