### PR TITLE
Make WhatsApp template endpoint configurable

### DIFF
--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -113,7 +113,6 @@ def refresh_whatsapp_templates():
         CONFIG_FB_BUSINESS_ID,
         CONFIG_FB_ACCESS_TOKEN,
         CONFIG_FB_TEMPLATE_LIST_DOMAIN,
-        DEFAULT_FB_TEMPLATE_LIST_DOMAIN,
         LANGUAGE_MAPPING,
         STATUS_MAPPING,
         TEMPLATE_LIST_URL,
@@ -136,9 +135,7 @@ def refresh_whatsapp_templates():
             try:
                 # Retrieve the template domain, fallback to the default for channels
                 # that have been setup earlier for backwards compatibility
-                facebook_template_domain = channel.config.get(
-                    CONFIG_FB_TEMPLATE_LIST_DOMAIN, DEFAULT_FB_TEMPLATE_LIST_DOMAIN
-                )
+                facebook_template_domain = channel.config.get(CONFIG_FB_TEMPLATE_LIST_DOMAIN, "graph.facebook.com")
                 facebook_business_id = channel.config.get(CONFIG_FB_BUSINESS_ID)
                 # we should never need to paginate because facebook limits accounts to 255 templates
                 response = requests.get(

--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -112,6 +112,8 @@ def refresh_whatsapp_templates():
     from .type import (
         CONFIG_FB_BUSINESS_ID,
         CONFIG_FB_ACCESS_TOKEN,
+        CONFIG_FB_TEMPLATE_LIST_DOMAIN,
+        DEFAULT_FB_TEMPLATE_LIST_DOMAIN,
         LANGUAGE_MAPPING,
         STATUS_MAPPING,
         TEMPLATE_LIST_URL,
@@ -132,9 +134,15 @@ def refresh_whatsapp_templates():
 
             # fetch all our templates
             try:
+                # Retrieve the template domain, fallback to the default for channels
+                # that have been setup earlier for backwards compatibility
+                facebook_template_domain = channel.config.get(
+                    CONFIG_FB_TEMPLATE_LIST_DOMAIN, DEFAULT_FB_TEMPLATE_LIST_DOMAIN
+                )
+                facebook_business_id = channel.config.get(CONFIG_FB_BUSINESS_ID)
                 # we should never need to paginate because facebook limits accounts to 255 templates
                 response = requests.get(
-                    TEMPLATE_LIST_URL % channel.config[CONFIG_FB_BUSINESS_ID],
+                    TEMPLATE_LIST_URL % (facebook_template_domain, facebook_business_id),
                     params=dict(access_token=channel.config[CONFIG_FB_ACCESS_TOKEN], limit=255),
                 )
 

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -13,7 +13,8 @@ from .tasks import (
     refresh_whatsapp_templates,
     refresh_whatsapp_tokens,
 )
-from .type import CONFIG_FB_BUSINESS_ID, WhatsAppType
+from .type import CONFIG_FB_TEMPLATE_LIST_DOMAIN, CONFIG_FB_BUSINESS_ID, WhatsAppType
+from .views import FACEBOOK_HOSTED, SELF_HOSTED
 
 
 class WhatsAppTypeTest(TembaTest):
@@ -43,6 +44,7 @@ class WhatsAppTypeTest(TembaTest):
         post_data["facebook_namespace"] = "my-custom-app"
         post_data["facebook_business_id"] = "1234"
         post_data["facebook_access_token"] = "token123"
+        post_data["facebook_template_list_domain"] = FACEBOOK_HOSTED
 
         # will fail with invalid phone number
         response = self.client.post(url, post_data)
@@ -69,6 +71,9 @@ class WhatsAppTypeTest(TembaTest):
                 response = self.client.post(url, post_data)
                 self.assertEqual(200, response.status_code)
                 self.assertFalse(Channel.objects.all())
+                mock_get.assert_called_with(
+                    "https://graph.facebook.com/v3.3/1234/message_templates", params={"access_token": "token123"}
+                )
 
                 self.assertContains(response, "check user id and access token")
 
@@ -243,6 +248,10 @@ class WhatsAppTypeTest(TembaTest):
                 )
             ]
             refresh_whatsapp_templates()
+            mock_get.assert_called_with(
+                "https://graph.facebook.com/v3.3/1234/message_templates",
+                params={"access_token": "token123", "limit": 255},
+            )
 
             # should have two templates
             self.assertEqual(2, Template.objects.filter(org=self.org).count())
@@ -273,3 +282,52 @@ class WhatsAppTypeTest(TembaTest):
 
         # all our templates should be inactive now
         self.assertEqual(3, TemplateTranslation.objects.filter(channel=channel, is_active=False).count())
+
+    def test_claim_self_hosted_templates(self):
+        Channel.objects.all().delete()
+
+        url = reverse("channels.types.whatsapp.claim")
+        self.login(self.admin)
+
+        response = self.client.get(reverse("channels.channel_claim"))
+        self.assertNotContains(response, url)
+
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        post_data = response.context["form"].initial
+
+        post_data["number"] = "0788123123"
+        post_data["username"] = "temba"
+        post_data["password"] = "tembapasswd"
+        post_data["country"] = "RW"
+        post_data["base_url"] = "https://whatsapp.foo.bar"
+        post_data["facebook_namespace"] = "my-custom-app"
+        post_data["facebook_business_id"] = "1234"
+        post_data["facebook_access_token"] = "token123"
+        post_data["facebook_template_list_domain"] = SELF_HOSTED
+
+        # success claim
+        with patch("requests.post") as mock_post:
+            with patch("requests.get") as mock_get:
+
+                mock_post.return_value = MockResponse(200, '{"users": [{"token": "abc123"}]}')
+                mock_get.return_value = MockResponse(200, '{"data": []}')
+
+                response = self.client.post(url, post_data)
+                self.assertEqual(302, response.status_code)
+                mock_get.assert_called_with(
+                    "https://whatsapp.foo.bar/v3.3/1234/message_templates", params={"access_token": "token123"}
+                )
+
+        # test the template syncing task calls the correct domain
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = MockResponse(200, '{"data": []}')
+            refresh_whatsapp_templates()
+            mock_get.assert_called_with(
+                "https://whatsapp.foo.bar/v3.3/1234/message_templates",
+                params={"access_token": "token123", "limit": 255},
+            )
+
+        channel = Channel.objects.get()
+
+        self.assertEqual("whatsapp.foo.bar", channel.config[CONFIG_FB_TEMPLATE_LIST_DOMAIN])

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -93,8 +93,6 @@ CONFIG_FB_ACCESS_TOKEN = "fb_access_token"
 CONFIG_FB_NAMESPACE = "fb_namespace"
 CONFIG_FB_TEMPLATE_LIST_DOMAIN = "fb_template_list_domain"
 
-DEFAULT_FB_TEMPLATE_LIST_DOMAIN = "graph.facebook.com"
-
 TEMPLATE_LIST_URL = "https://%s/v3.3/%s/message_templates"
 
 

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -91,8 +91,11 @@ LANGUAGE_MAPPING = dict(
 CONFIG_FB_BUSINESS_ID = "fb_business_id"
 CONFIG_FB_ACCESS_TOKEN = "fb_access_token"
 CONFIG_FB_NAMESPACE = "fb_namespace"
+CONFIG_FB_TEMPLATE_LIST_DOMAIN = "fb_template_list_domain"
 
-TEMPLATE_LIST_URL = "https://graph.facebook.com/v3.3/%s/message_templates"
+DEFAULT_FB_TEMPLATE_LIST_DOMAIN = "graph.facebook.com"
+
+TEMPLATE_LIST_URL = "https://%s/v3.3/%s/message_templates"
 
 
 class WhatsAppType(ChannelType):

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -78,7 +78,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         facebook_template_list_domain = forms.CharField(
             label=_("Templates Domain"),
-            help_text=_("Which domain to retrieve the message templates from."),
+            help_text=_("Which domain to retrieve the message templates from"),
             initial="graph.facebook.com",
         )
 

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -1,7 +1,6 @@
 import requests
 from smartmin.views import SmartFormView, SmartReadView, SmartUpdateView
 
-from urllib.parse import urlparse
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
@@ -14,8 +13,6 @@ from temba.utils.views import PostOnlyMixin
 from ...models import Channel
 from ...views import ALL_COUNTRIES, ClaimViewMixin
 from .tasks import refresh_whatsapp_contacts
-
-from . import type
 
 
 class RefreshView(PostOnlyMixin, OrgPermsMixin, SmartUpdateView):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -46,7 +46,7 @@ FLOW_FROM_EMAIL = "no-reply@temba.io"
 # HTTP Headers using for outgoing requests to other services
 OUTGOING_REQUEST_HEADERS = {"User-agent": "RapidPro"}
 
-STORAGE_URL = "/media"  # may be local /media or AWS S3
+STORAGE_URL = None  # may be local /media or AWS S3
 STORAGE_ROOT_DIR = "test_orgs" if TESTING else "orgs"
 
 # -----------------------------------------------------------------------------------
@@ -805,8 +805,8 @@ TEST_EXCLUDE = ("smartmin",)
 _default_database_config = {
     "ENGINE": "django.contrib.gis.db.backends.postgis",
     "NAME": "temba",
-    "USER": "sdehaan",
-    "PASSWORD": "",
+    "USER": "temba",
+    "PASSWORD": "temba",
     "HOST": "localhost",
     "PORT": "5432",
     "ATOMIC_REQUESTS": True,

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -46,7 +46,7 @@ FLOW_FROM_EMAIL = "no-reply@temba.io"
 # HTTP Headers using for outgoing requests to other services
 OUTGOING_REQUEST_HEADERS = {"User-agent": "RapidPro"}
 
-STORAGE_URL = None  # may be local /media or AWS S3
+STORAGE_URL = "/media"  # may be local /media or AWS S3
 STORAGE_ROOT_DIR = "test_orgs" if TESTING else "orgs"
 
 # -----------------------------------------------------------------------------------
@@ -805,8 +805,8 @@ TEST_EXCLUDE = ("smartmin",)
 _default_database_config = {
     "ENGINE": "django.contrib.gis.db.backends.postgis",
     "NAME": "temba",
-    "USER": "temba",
-    "PASSWORD": "temba",
+    "USER": "sdehaan",
+    "PASSWORD": "",
     "HOST": "localhost",
     "PORT": "5432",
     "ATOMIC_REQUESTS": True,


### PR DESCRIPTION
This is a first stab at making the WhatsApp template endpoints configurable as per https://github.com/rapidpro/rapidpro/issues/928