### PR TITLE
📣 No more celery for starting flows and sending broadcasts

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -28,7 +28,7 @@ from django.utils import timezone
 from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext_lazy as _
 
-from temba.mailroom.queue import queue_mailroom_mo_miss_task
+from temba import mailroom
 from temba.orgs.models import NEXMO_APP_ID, NEXMO_APP_PRIVATE_KEY, NEXMO_KEY, NEXMO_SECRET, Org
 from temba.utils import analytics, get_anonymous_user, json, on_transaction_commit
 from temba.utils.email import send_template_email
@@ -1436,7 +1436,7 @@ class ChannelEvent(models.Model):
 
         if event_type == cls.TYPE_CALL_IN_MISSED:
             # pass off handling of the message to mailroom after we commit
-            on_transaction_commit(lambda: queue_mailroom_mo_miss_task(event))
+            on_transaction_commit(lambda: mailroom.queue_mo_miss_event(event))
 
         return event
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2443,31 +2443,6 @@ class ContactURN(models.Model):
     auth = models.TextField(null=True, help_text=_("Any authentication information needed by this URN"))
 
     @classmethod
-    def get_urns_for_contacts(self, contact_ids, schemes, all_urns=False):
-        """
-        Optimized call that fetches the preferred URN for the passed in contacts within the passed in
-        schemes.
-        """
-        urns = list()
-        distinct = "" if all_urns else "DISTINCT ON(contact_id)"
-
-        for chunk in chunk_list(contact_ids, 1000):
-            chunk_urns = ContactURN.objects.raw(
-                f"""
-                SELECT {distinct} contact_id, *
-                FROM contacts_contacturn
-                WHERE contact_id = ANY (%s) AND scheme = ANY (%s)
-                ORDER BY contact_id, priority DESC;
-                """,
-                [chunk, list(schemes)],
-            )
-
-            for urn in chunk_urns:
-                urns.append(urn)
-
-        return urns
-
-    @classmethod
     def get_or_create(cls, org, contact, urn_as_string, channel=None, auth=None):
         urn = cls.lookup(org, urn_as_string)
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3589,7 +3589,7 @@ class ContactTest(TembaTest):
             )
 
             # fetch our contact history
-            with self.assertNumQueries(68):
+            with self.assertNumQueries(67):
                 response = self.fetch_protected(url, self.admin)
 
             # activity should include all messages in the last 90 days, the channel event, the call, and the flow run

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1881,7 +1881,9 @@ class Flow(TembaModel):
                 broadcast.org = self.org
 
                 # create the messages
-                broadcast.send(expressions_context=expressions_context_base, response_to=start_msg, msg_type=FLOW)
+                broadcast.send(
+                    expressions_context=expressions_context_base, response_to=start_msg, msg_type=FLOW, run_map=run_map
+                )
 
                 # map all the messages we just created back to our contact
                 for msg in broadcast.msgs.all().select_related("channel", "contact_urn"):

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1508,7 +1508,7 @@ class Flow(TembaModel):
 
             run_context = run.fields
             flow_context = run.build_expressions_context(contact_context, message_context.get("text"))
-        else:
+        else:  # pragma: no cover
             run_context = {}
             flow_context = {}
 
@@ -1945,30 +1945,6 @@ class Flow(TembaModel):
 
         run.current_node_uuid = run.path[-1][FlowRun.PATH_NODE_UUID]
         run.save(update_fields=update_fields)
-
-    def get_entry_send_actions(self):
-        """
-        Returns all the entry actions (the first actions in a flow) that are reply actions. This is used
-        for grouping all our outgoing messages into a single Broadcast.
-        """
-        if not self.entry_uuid or self.entry_type != Flow.NODE_TYPE_ACTIONSET:
-            return []
-
-        # get our entry actions
-        entry_actions = ActionSet.objects.filter(uuid=self.entry_uuid).first()
-        send_actions = []
-
-        if entry_actions:
-            actions = entry_actions.get_actions()
-
-            for action in actions:
-                # if this isn't a reply action, bail, they might be modifying the contact
-                if not isinstance(action, ReplyAction):
-                    break
-
-                send_actions.append(action)
-
-        return send_actions
 
     def get_dependencies(self):
         """
@@ -2967,7 +2943,7 @@ class FlowRun(RequireUpdateFieldsMixin, models.Model):
         context["__default__"] = "\n".join(default_lines)
 
         # if we don't have a contact context, build one
-        if not contact_context:
+        if not contact_context:  # pragma: no cover
             self.contact.org = self.org
             contact_context = self.contact.build_expressions_context()
 

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from datetime import timedelta
 
 import iso8601
@@ -10,16 +9,14 @@ from django.utils.timesince import timesince
 
 from celery.task import task
 
-from temba.msgs.models import BROADCAST_BATCH, HANDLE_EVENT_TASK, TIMEOUT_EVENT, Broadcast, Msg
+from temba.msgs.models import HANDLE_EVENT_TASK, TIMEOUT_EVENT
 from temba.orgs.models import Org
 from temba.utils.cache import QueueRecord
 from temba.utils.dates import datetime_to_epoch
-from temba.utils.queues import Queue, complete_task, nonoverlapping_task, push_task, start_task
+from temba.utils.queues import Queue, nonoverlapping_task, push_task
 
 from .models import (
-    FLOW_BATCH,
     ExportFlowResultsTask,
-    Flow,
     FlowCategoryCount,
     FlowNodeCount,
     FlowPathCount,
@@ -116,64 +113,6 @@ def export_flow_results_task(export_id):
 def start_flow_task(start_id):
     flow_start = FlowStart.objects.get(pk=start_id)
     flow_start.start()
-
-
-@task(track_started=True, name="start_msg_flow_batch")
-def start_msg_flow_batch_task():
-    # pop off the next task
-    org_id, task_obj = start_task(Flow.START_MSG_FLOW_BATCH)
-
-    # it is possible that somehow we might get None back if more workers were started than tasks got added, bail if so
-    if task_obj is None:  # pragma: needs cover
-        return
-
-    start = time.time()
-
-    try:
-        task_type = task_obj.get("task_type", FLOW_BATCH)
-
-        if task_type == FLOW_BATCH:
-            # instantiate all the objects we need that were serialized as JSON
-            flow = Flow.objects.filter(pk=task_obj["flow"], is_active=True, is_archived=False).first()
-            if not flow:  # pragma: needs cover
-                return
-
-            broadcasts = [] if not task_obj["broadcasts"] else Broadcast.objects.filter(pk__in=task_obj["broadcasts"])
-            started_flows = [] if not task_obj["started_flows"] else task_obj["started_flows"]
-            start_msg = None if not task_obj["start_msg"] else Msg.objects.filter(id=task_obj["start_msg"]).first()
-            extra = task_obj["extra"]
-            flow_start = (
-                None if not task_obj["flow_start"] else FlowStart.objects.filter(pk=task_obj["flow_start"]).first()
-            )
-            contacts = task_obj["contacts"]
-
-            # and go do our work
-            flow.start_msg_flow_batch(
-                contacts,
-                broadcasts=broadcasts,
-                started_flows=started_flows,
-                start_msg=start_msg,
-                extra=extra,
-                flow_start=flow_start,
-            )
-
-            print(
-                "Started batch of %d contacts in flow %d [%d] in %0.3fs"
-                % (len(contacts), flow.id, flow.org_id, time.time() - start)
-            )
-
-        elif task_type == BROADCAST_BATCH:
-            broadcast = Broadcast.objects.filter(org_id=org_id, id=task_obj["broadcast"]).first()
-            if broadcast:
-                broadcast.send_batch(**task_obj["kwargs"])
-
-            print(
-                "Sent batch of %d messages in broadcast [%d] in %0.3fs"
-                % (len(task_obj["kwargs"]["urn_ids"]), broadcast.id, time.time() - start)
-            )
-
-    finally:
-        complete_task(Flow.START_MSG_FLOW_BATCH, org_id)
 
 
 @nonoverlapping_task(

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -24,7 +24,6 @@ from .models import (
     FlowRun,
     FlowRunCount,
     FlowSession,
-    FlowStart,
     FlowStartCount,
 )
 
@@ -107,12 +106,6 @@ def export_flow_results_task(export_id):
     Export a flow to a file and e-mail a link to the user
     """
     ExportFlowResultsTask.objects.select_related("org").get(id=export_id).perform()
-
-
-@task(track_started=True, name="start_flow_task")
-def start_flow_task(start_id):
-    flow_start = FlowStart.objects.get(pk=start_id)
-    flow_start.start()
 
 
 @nonoverlapping_task(

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -130,7 +130,6 @@ from .tasks import (
     check_flows_task,
     squash_flowpathcounts,
     squash_flowruncounts,
-    start_flow_task,
     trim_flow_sessions,
     update_run_expirations_task,
 )
@@ -11588,14 +11587,7 @@ class FlowTriggerTest(TembaTest):
         )
         group_trigger.groups.add(group)
 
-        real_func = start_flow_task.apply_async
-        with patch("temba.flows.tasks.start_flow_task.apply_async") as mock_start_flow_task:
-            mock_start_flow_task.side_effect = real_func
-
-            group_trigger.fire()
-
-            start = FlowStart.objects.get()
-            mock_start_flow_task.assert_called_once_with(args=[start.id], queue="handler")
+        group_trigger.fire()
 
         # contact should be added to flow again
         self.assertEqual(2, FlowRun.objects.filter(flow=flow, contact=contact).count())

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -69,9 +69,10 @@ def queue_mailroom_broadcast_task(broadcast):
     """
 
     task = {
-        "translations": dict(broadcast.text),
+        "translations": {lang: {"text": text} for lang, text in broadcast.text.items()},
+        "template_state": "legacy",
         "base_language": broadcast.base_language,
-        "urns": list(broadcast.urns.all()),
+        "urns": [u.urn for u in broadcast.urns.all()],
         "contact_ids": list(broadcast.contacts.values_list("id", flat=True)),
         "group_ids": list(broadcast.groups.values_list("id", flat=True)),
         "broadcast_id": broadcast.id,

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -169,8 +169,6 @@ class MailroomQueueTest(TembaTest):
 
     def test_queue_flow_start(self):
         flow = self.get_flow("favorites")
-        flow.flow_server_enabled = True
-
         jim = self.create_contact("Jim", "+12065551212")
         bobs = self.create_group("Bobs", [self.create_contact("Bob", "+12065551313")])
 
@@ -183,7 +181,9 @@ class MailroomQueueTest(TembaTest):
             extra={"foo": "bar"},
             include_active=True,
         )
-        start.async_start()
+
+        with override_settings(TESTING=False):
+            start.async_start()
 
         self.assert_org_queued(self.org, "batch")
         self.assert_queued_batch_task(

--- a/temba/msgs/legacy.py
+++ b/temba/msgs/legacy.py
@@ -1,9 +1,7 @@
 from temba.orgs.models import Language
 
 
-def send_broadcast(
-    bcast, *, expressions_context=None, response_to=None, msg_type="I", run_map=None, high_priority=False
-):
+def send_broadcast(bcast, *, expressions_context=None, response_to=None, msg_type="I", high_priority=False):
     """
     Only used for testing to approximate how mailroom sends a broadcast
     """
@@ -36,14 +34,6 @@ def send_broadcast(
                 message_context["contact"] = contact.build_expressions_context()
         else:
             message_context = None
-
-        # add in our parent context if the message references @parent
-        if run_map:
-            run = run_map.get(contact.id, None)
-            if run:
-                if "parent" in text:
-                    if run.parent:
-                        message_context.update(dict(parent=run.parent.build_expressions_context()))
 
         try:
             Msg.create_outgoing(

--- a/temba/msgs/legacy.py
+++ b/temba/msgs/legacy.py
@@ -1,0 +1,88 @@
+from temba.orgs.models import Language
+
+
+def send_broadcast(
+    bcast, *, expressions_context=None, response_to=None, msg_type="I", run_map=None, high_priority=False
+):
+    """
+    Only used for testing to approximate how mailroom sends a broadcast
+    """
+
+    from temba.msgs.models import Msg, SENT
+
+    contacts = set(bcast.contacts.all())
+    for group in bcast.groups.all():
+        contacts.update(group.contacts.all())
+
+    urns = set(bcast.urns.all())
+    for contact in contacts:
+        if bcast.send_all:
+            urns.update(contact.urns.all())
+        else:
+            urns.add(contact.urns.first())
+
+    for urn in urns:
+        text = bcast.get_translated_text(urn.contact)
+        media = get_translated_media(bcast, urn.contact)
+        quick_replies = get_translated_quick_replies(bcast, urn.contact)
+
+        if expressions_context is not None:
+            message_context = expressions_context.copy()
+            if "contact" not in message_context:
+                message_context["contact"] = urn.contact.build_expressions_context()
+        else:
+            message_context = None
+
+        # add in our parent context if the message references @parent
+        if run_map:
+            run = run_map.get(urn.contact.id, None)
+            if run and run.flow:
+                # a bit kludgy here, but should avoid most unnecessary context creations.
+                # since this path is an optimization for flow starts, we don't need to
+                # worry about the @child context.
+                if "parent" in text:
+                    if run.parent:
+                        message_context.update(dict(parent=run.parent.build_expressions_context()))
+
+        Msg.create_outgoing(
+            bcast.org,
+            bcast.created_by,
+            urn,
+            text,
+            bcast,
+            attachments=[media] if media else None,
+            quick_replies=quick_replies,
+            response_to=response_to,
+            high_priority=high_priority,
+            msg_type=msg_type,
+            expressions_context=message_context,
+        )
+
+    bcast.recipient_count = len(urns)
+    bcast.status = SENT
+    bcast.save(update_fields=("recipient_count", "status"))
+
+    bcast.org.trigger_send(bcast.msgs.all())
+
+
+def get_translated_media(bcast, contact, org=None):
+    """
+    Gets the appropriate media for the given contact
+    """
+    preferred_languages = bcast._get_preferred_languages(contact, org)
+    return Language.get_localized_text(bcast.media, preferred_languages)
+
+
+def get_translated_quick_replies(bcast, contact, org=None):
+    """
+    Gets the appropriate quick replies translation for the given contact
+    """
+    preferred_languages = bcast._get_preferred_languages(contact, org)
+    language_metadata = []
+    metadata = bcast.metadata
+
+    for item in metadata.get(bcast.METADATA_QUICK_REPLIES, []):
+        text = Language.get_localized_text(text_translations=item, preferred_languages=preferred_languages)
+        language_metadata.append(text)
+
+    return language_metadata

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -29,7 +29,6 @@ from temba.mailroom.queue import queue_mailroom_broadcast_task, queue_mailroom_m
 from temba.orgs.models import Language, Org, TopUp
 from temba.schedules.models import Schedule
 from temba.utils import analytics, chunk_list, extract_constants, get_anonymous_user, json, on_transaction_commit
-from temba.utils.cache import check_and_mark_in_timerange
 from temba.utils.dates import datetime_to_s, datetime_to_str, get_datetime_format
 from temba.utils.export import BaseExportAssetStore, BaseExportTask
 from temba.utils.expressions import evaluate_template
@@ -300,216 +299,53 @@ class Broadcast(models.Model):
         Sends this broadcast, taking care of creating multiple jobs to send it if necessary
         """
 
-        if not settings.TESTING:  # pragma: no cover
-            queue_mailroom_broadcast_task(self)
+        # for the purposes of testing.. just create some almost correct messages
+        if settings.TESTING:
+            contacts = set(self.contacts.all())
+            for group in self.groups.all():
+                contacts.update(group.contacts.all())
 
-        # if we are sending to groups and any of them are big, make sure we aren't spamming
-        for group in self.groups.all():
-            if group.get_member_count() > 30:
-                bcast_value = "%d_%s" % (group.id, self.text)
+            urns = set(self.urns.all())
+            for contact in contacts:
+                if self.send_all:
+                    urns.update(contact.urns.all())
+                else:
+                    urns.add(contact.urns.first())
 
-                # have we sent this exact message in the past few hours?
-                if check_and_mark_in_timerange("bcasts", 1, bcast_value):
-                    self.status = FAILED
-                    self.save(update_fields=["status"])
-                    raise Exception("Not sending broadcast %d due to duplicate" % self.id)
+            for urn in urns:
+                text = self.get_translated_text(urn.contact)
+                media = self.get_translated_media(urn.contact)
+                quick_replies = self._get_translated_quick_replies(urn.contact)
 
-        schemes = set(self.channel.schemes) if self.channel else self.org.get_schemes(Channel.ROLE_SEND)
+                if expressions_context is not None:
+                    message_context = expressions_context.copy()
+                    if "contact" not in message_context:
+                        message_context["contact"] = urn.contact.build_expressions_context()
+                else:
+                    message_context = None
 
-        # calculate a more accurate recipient count, each of these will map to a message created
-        contact_ids = self._get_unique_contact_ids(groups=self.groups.all(), contacts=self.contacts.all())
-        urns = set(ContactURN.get_urns_for_contacts(contact_ids, schemes, all_urns=self.send_all))
-
-        # add in any URNs as well (a URN specified is always honored, even if that means two msgs for a contact)
-        for urn in self.urns.all():
-            urns.add(urn)
-
-        # update our recipient count
-        self.recipient_count = len(urns)
-        self.save(update_fields=["recipient_count"])
-
-        # if we are fewer than on batch, send right away
-        if len(urns) <= BATCH_SIZE:
-            self.send_batch(
-                urns=urns,
-                trigger_send=True,
-                expressions_context=expressions_context,
-                response_to=response_to,
-                msg_type=msg_type,
-                run_map=run_map,
-                high_priority=high_priority,
-            )
-
-        # otherwise, create batches and fire those off
-        else:
-            from temba.flows.models import Flow
-
-            for batch in chunk_list(urns, BATCH_SIZE):
-                kwargs = dict(
-                    urn_ids=[u.id for u in batch],
-                    trigger_send=True,
-                    expressions_context=expressions_context,
-                    response_to=response_to,
-                    msg_type=msg_type,
-                    run_map=run_map,
-                    high_priority=high_priority,
-                )
-                push_task(
-                    self.org,
-                    Queue.FLOWS,
-                    Flow.START_MSG_FLOW_BATCH,
-                    dict(task_type=BROADCAST_BATCH, broadcast=self.id, kwargs=kwargs),
-                )
-
-    def send_batch(
-        self,
-        *,
-        urn_ids=None,
-        urns=None,
-        contacts=None,
-        trigger_send=True,
-        expressions_context=None,
-        response_to=None,
-        status=PENDING,
-        msg_type=INBOX,
-        run_map=None,
-        high_priority=False,
-    ):
-        """
-        Sends this broadcast to the passed in URNs
-        """
-        # load urns if we have ids
-        if urn_ids:
-            urns = ContactURN.objects.filter(org=self.org, id__in=urn_ids)
-
-        # can pass either contacts or urns, not both
-        if (contacts and urns) or (contacts is None and urns is None):
-            raise ValueError("Must pass either contacts or urns")
-
-        # the count of recipients we are batching
-        batch_count = len(urns) if urns is not None else len(contacts)
-
-        # Update the number of recipients that have been batched for this broadcast. This can't be counted via
-        # our squashable model as not all recipients end up resolving to a message being created (due to duplicates
-        # between groups/contacts for example or because they aren't addressable by any channel)
-        bcast_key = f"bcast_{self.id}_count"
-        r = get_redis_connection()
-        with r.pipeline() as pipe:
-            pipe.incrby(bcast_key, batch_count)
-            pipe.expire(bcast_key, 60 * 60)
-            pipe.execute()
-
-        # ignore mock messages
-        if response_to and not response_to.id:  # pragma: no cover
-            response_to = None
-
-        schemes = set(self.channel.schemes) if self.channel else self.org.get_schemes(Channel.ROLE_SEND)
-
-        # if we are passed URNs, map them to contacts
-        if urns is not None:
-            # build our list of contacts that map to our URNs
-            contact_map = {c.id: c for c in Contact.objects.filter(urns__in=urns)}
-
-            # bulk initialize them
-            Contact.bulk_cache_initialize(self.org, contact_map.values())
-
-        # otherwise build our list of URNs we are sending to from our contacts
-        else:
-            contact_map = {}
-            urns = []
-            for c in contacts:
-                contact_map[c.id] = c
-                contact_urn = c.get_urn(schemes)
-
-                # if we can address this contact, add it to our list of urns to send to
-                if contact_urn:
-                    urns.append(contact_urn)
-
-        batch = []
-        batch_ids = []
-
-        for urn in urns:
-            contact = contact_map[urn.contact_id]
-            contact.org = self.org
-            urn.contact = contact
-
-            # get the appropriate translation for this contact
-            text = self.get_translated_text(contact)
-
-            # get the appropriate quick replies translation for this contact
-            quick_replies = self._get_translated_quick_replies(contact)
-
-            media = self.get_translated_media(contact)
-            if media:
-                media_type, media_url = media.split(":", 1)
-                # arbitrary media urls don't have a full content type, so only
-                # make uploads into fully qualified urls
-                if media_url and len(media_type.split("/")) > 1:
-                    media = f"{media_type}:{settings.STORAGE_URL}/{media_url}"
-
-            # build our message specific context
-            if expressions_context is not None:
-                message_context = expressions_context.copy()
-                if "contact" not in message_context:
-                    message_context["contact"] = contact.build_expressions_context()
-            else:
-                message_context = None
-
-            # add in our parent context if the message references @parent
-            if run_map:
-                run = run_map.get(contact.pk, None)
-                if run and run.flow:
-                    # a bit kludgy here, but should avoid most unnecessary context creations.
-                    # since this path is an optimization for flow starts, we don't need to
-                    # worry about the @child context.
-                    if "parent" in text:
-                        if run.parent:
-                            run.parent.org = self.org
-                            message_context.update(dict(parent=run.parent.build_expressions_context()))
-
-            try:
-                msg = Msg.create_outgoing(
+                Msg.create_outgoing(
                     self.org,
                     self.created_by,
                     urn,
                     text,
-                    broadcast=self,
-                    channel=self.channel,
-                    response_to=response_to,
-                    expressions_context=message_context,
-                    status=status,
-                    msg_type=msg_type,
-                    high_priority=high_priority,
-                    insert_object=False,
+                    self,
                     attachments=[media] if media else None,
                     quick_replies=quick_replies,
+                    response_to=response_to,
+                    high_priority=high_priority,
+                    msg_type=msg_type,
+                    expressions_context=message_context,
                 )
 
-            except UnreachableException:
-                # there was no way to reach this contact, do not create a message
-                msg = None
-
-            # only add it to our batch if it was legit
-            if msg:
-                batch.append(msg)
-
-        # commit any remaining objects
-        if batch:
-            batch_msgs = Msg.objects.bulk_create(batch)
-            batch_ids = [m.id for m in batch_msgs]
-
-            if trigger_send:
-                self.org.trigger_send(
-                    Msg.objects.filter(id__in=batch_ids).select_related("contact", "contact_urn", "channel")
-                )
-
-        # mark ourselves as sent if appropriate
-        sent_count = int(r.get(bcast_key)) if r.get(bcast_key) else 0
-        if sent_count >= self.recipient_count:
+            self.recipient_count = len(urns)
             self.status = SENT
-            self.save(update_fields=("status",))
+            self.save(update_fields=("recipient_count", "status"))
 
-        return batch_ids
+            self.org.trigger_send(self.msgs.all())
+            return
+
+        queue_mailroom_broadcast_task(self)
 
     def has_pending_fire(self):  # pragma: needs cover
         return self.schedule and self.schedule.has_pending_fire()

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -295,7 +295,7 @@ class Broadcast(models.Model):
 
         return broadcast
 
-    def send(self, *, expressions_context=None, response_to=None, msg_type=INBOX, run_map=None, high_priority=False):
+    def send(self, *, expressions_context=None, response_to=None, msg_type=INBOX, high_priority=False):
         """
         Sends this broadcast, taking care of creating multiple jobs to send it if necessary
         """
@@ -306,7 +306,6 @@ class Broadcast(models.Model):
                 expressions_context=expressions_context,
                 response_to=response_to,
                 msg_type=msg_type,
-                run_map=run_map,
                 high_priority=high_priority,
             )
         else:  # pragma: no cover

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -300,7 +300,6 @@ class Broadcast(models.Model):
         Sends this broadcast, taking care of creating multiple jobs to send it if necessary
         """
 
-        # for the purposes of testing.. just create some almost correct messages
         if settings.TESTING:
             legacy.send_broadcast(
                 self,
@@ -310,9 +309,8 @@ class Broadcast(models.Model):
                 run_map=run_map,
                 high_priority=high_priority,
             )
-            return
-
-        mailroom.queue_broadcast(self)
+        else:  # pragma: no cover
+            mailroom.queue_broadcast(self)
 
     def has_pending_fire(self):  # pragma: needs cover
         return self.schedule and self.schedule.has_pending_fire()

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -25,7 +25,7 @@ from temba.assets.models import register_asset_store
 from temba.channels.courier import push_courier_msgs
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
 from temba.contacts.models import URN, Contact, ContactGroup, ContactGroupCount, ContactURN
-from temba.mailroom.queue import queue_mailroom_msg_task
+from temba.mailroom.queue import queue_mailroom_broadcast_task, queue_mailroom_msg_task
 from temba.orgs.models import Language, Org, TopUp
 from temba.schedules.models import Schedule
 from temba.utils import analytics, chunk_list, extract_constants, get_anonymous_user, json, on_transaction_commit
@@ -299,6 +299,10 @@ class Broadcast(models.Model):
         """
         Sends this broadcast, taking care of creating multiple jobs to send it if necessary
         """
+
+        if not settings.TESTING:  # pragma: no cover
+            queue_mailroom_broadcast_task(self)
+
         # if we are sending to groups and any of them are big, make sure we aren't spamming
         for group in self.groups.all():
             if group.get_member_count() > 30:

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -419,8 +419,8 @@ class Broadcast(models.Model):
 
         return preferred_languages
 
-    def __str__(self):
-        return f"Broadcast[{self.pk}]{self.text}"
+    def __str__(self):  # pragma: no cover
+        return f"Broadcast[id={self.id}, text={self.text}]"
 
 
 class Attachment(object):

--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -304,7 +304,6 @@ def check_messages_task():  # pragma: needs cover
     """
     from .models import INCOMING, PENDING
     from temba.orgs.models import Org
-    from temba.flows.tasks import start_msg_flow_batch_task
 
     now = timezone.now()
     five_minutes_ago = now - timedelta(minutes=5)
@@ -321,7 +320,6 @@ def check_messages_task():  # pragma: needs cover
     # (these will be no-ops if there is nothing to do)
     for i in range(100):
         handle_event_task.apply_async(queue=Queue.HANDLER)
-        start_msg_flow_batch_task.apply_async(queue=Queue.FLOWS)
 
     # also check any incoming messages that are still pending somehow, reschedule them to be handled
     unhandled_messages = Msg.objects.filter(direction=INCOMING, status=PENDING, created_on__lte=five_minutes_ago)

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2286,6 +2286,11 @@ class BroadcastTest(TembaTest):
         self.assertEqual(4, broadcast.recipient_count)
         self.assertEqual(broadcast.get_message_count(), 4)
 
+        broadcast.release()
+
+        self.assertEqual(Msg.objects.count(), 0)
+        self.assertEqual(Broadcast.objects.count(), 0)
+
         with self.assertRaises(ValueError):
             Broadcast.create(self.org, self.user, "no recipients")
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 
 from temba.archives.models import Archive
 from temba.channels.models import Channel, ChannelCount, ChannelEvent, ChannelLog
-from temba.contacts.models import STOP_CONTACT_EVENT, TEL_SCHEME, Contact, ContactField, ContactGroup, ContactURN
+from temba.contacts.models import STOP_CONTACT_EVENT, TEL_SCHEME, Contact, ContactField, ContactURN
 from temba.flows.models import RuleSet
 from temba.msgs.models import (
     DELIVERED,
@@ -840,21 +840,6 @@ class MsgTest(TembaTest):
 
         self.assertEqual(set(response.context["object_list"]), {msg3, msg2, msg1})
         self.assertEqual(response.context["actions"], ["label"])
-
-    def test_footgun(self):
-        # create a bunch of contacts
-        group = ContactGroup.get_or_create(org=self.org, user=self.admin, name="Spam")
-        for i in range(51):
-            (contact, urn) = Contact.get_or_create(org=self.org, urn="tel:+1206779%04d" % i, user=self.admin)
-            group.contacts.add(contact)
-
-        # create a broadcast and send it off
-        bcast = Broadcast.create(self.org, self.admin, "This is my spam message", groups=[group])
-        bcast.send()
-
-        bcast2 = Broadcast.create(self.org, self.admin, "This is my spam message", groups=[group])
-        with self.assertRaises(Exception):
-            bcast2.send()
 
     def test_failed(self):
         failed_url = reverse("msgs.msg_failed")
@@ -2290,42 +2275,6 @@ class BroadcastTest(TembaTest):
             }
         )
 
-    @patch("temba.msgs.models.BATCH_SIZE", 2)
-    def test_broadcast_batch(self):
-        # create a contact we can't reach
-        tg_contact, __ = Contact.get_or_create(self.org, "telegram:12345", user=self.admin)
-        broadcast = Broadcast.create(
-            self.org, self.user, "Broadcast", groups=[self.joe_and_frank], contacts=[self.kevin, tg_contact]
-        )
-
-        # downsize our batches and send it (this tests other code paths)
-        self.assertEqual(4, broadcast.recipient_count)
-        broadcast.send()
-        broadcast.refresh_from_db()
-
-        # should have 3 recipients and 3 messages sent
-        self.assertEqual(3, broadcast.recipient_count)
-        self.assertEqual(broadcast.get_message_count(), 3)
-        self.assertEqual(SENT, broadcast.status)
-
-        # do it again but add contacts by hand (like flow batch starts)
-        broadcast = Broadcast.create(
-            self.org, self.user, "Flow broadcast", contacts=[tg_contact.id, self.kevin.id, self.joe.id, self.frank.id]
-        )
-        self.assertEqual(4, broadcast.recipient_count)
-        broadcast.send_batch(contacts=[tg_contact, self.kevin, self.joe, self.frank])
-        broadcast.refresh_from_db()
-
-        # 4 recipients, but only 3 messages sent, but we end up as sent
-        self.assertEqual(f"Broadcast[{broadcast.id}]{broadcast.text}", str(broadcast))
-        self.assertEqual(4, broadcast.recipient_count)
-        self.assertEqual(broadcast.get_message_count(), 3)
-        self.assertEqual(SENT, broadcast.status)
-
-        # release the broadcast
-        broadcast.release()
-        self.assertFalse(Broadcast.objects.filter(id=broadcast.id))
-
     def test_broadcast_model(self):
         broadcast = Broadcast.create(
             self.org, self.user, "Like a tweet", groups=[self.joe_and_frank], contacts=[self.kevin, self.lucy]
@@ -2339,10 +2288,6 @@ class BroadcastTest(TembaTest):
 
         with self.assertRaises(ValueError):
             Broadcast.create(self.org, self.user, "no recipients")
-
-        with self.assertRaises(ValueError):
-            broadcast = Broadcast.create(self.org, self.user, "batch", contacts=[self.kevin, self.lucy])
-            broadcast.send_batch()
 
     def test_send(self):
         # remove all channels first
@@ -2463,53 +2408,6 @@ class BroadcastTest(TembaTest):
         self.assertEqual(broadcast.groups.count(), 0)
         self.assertEqual(broadcast.contacts.count(), 1)
         self.assertTrue(self.joe in broadcast.contacts.all())
-
-    def test_unreachable(self):
-        no_urns = Contact.get_or_create_by_urns(self.org, self.admin, name="Ben Haggerty", urns=[])
-        tel_contact = self.create_contact("Ryan Lewis", number="+12067771234")
-        twitter_contact = self.create_contact("Lucy", twitter="lucy", force_urn_update=True)
-
-        # send a broadcast to all (org has a tel and a twitter channel)
-        broadcast = Broadcast.create(
-            self.org, self.admin, "Want to go thrift shopping?", contacts=[no_urns, tel_contact, twitter_contact]
-        )
-        broadcast.send()
-
-        # should have only messages for Ryan and Lucy
-        msgs = broadcast.msgs.all()
-        self.assertEqual(len(msgs), 2)
-        self.assertEqual(sorted([m.contact.name for m in msgs]), ["Lucy", "Ryan Lewis"])
-
-        # send another broadcast to all and force use of the twitter channel
-        broadcast = Broadcast.create(
-            self.org,
-            self.admin,
-            "Want to go thrift shopping?",
-            contacts=[no_urns, tel_contact, twitter_contact],
-            channel=self.twitter,
-        )
-        broadcast.send()
-
-        # should have only one message created to Lucy
-        msgs = broadcast.msgs.all()
-        self.assertEqual(len(msgs), 1)
-        self.assertTrue(msgs[0].contact, twitter_contact)
-
-        # remove twitter relayer
-        self.twitter.release(trigger_sync=False)
-        self.org.clear_cached_channels()
-
-        # send another broadcast to all
-        broadcast = Broadcast.create(
-            self.org, self.admin, "Want to go thrift shopping?", contacts=[no_urns, tel_contact, twitter_contact]
-        )
-        broadcast.send()
-        self.assertEqual(1, broadcast.recipient_count)
-
-        # should have only one message created to Ryan
-        msgs = broadcast.msgs.all()
-        self.assertEqual(len(msgs), 1)
-        self.assertTrue(msgs[0].contact, tel_contact)
 
     def test_message_parts(self):
         contact = self.create_contact("Matt", "+12067778811")
@@ -3280,8 +3178,8 @@ class BroadcastLanguageTest(TembaTest):
         eng_msg = "Please see attachment"
         fra_msg = "SVP regardez l'attachement."
 
-        eng_attachment = "image/jpeg:attachments/eng_picture.jpg"
-        fra_attachment = "image/jpeg:attachments/fre_picture.jpg"
+        eng_attachment = f"image/jpeg:{settings.STORAGE_URL}/attachments/eng_picture.jpg"
+        fra_attachment = f"image/jpeg:{settings.STORAGE_URL}/attachments/fre_picture.jpg"
 
         # now create a broadcast with a couple contacts, one with an explicit language, the other not
         bcast = Broadcast.create(
@@ -3299,19 +3197,15 @@ class BroadcastLanguageTest(TembaTest):
         greg_media = Msg.objects.filter(contact=self.greg).order_by("-created_on").first()
         wilbert_media = Msg.objects.filter(contact=self.wilbert).order_by("-created_on").first()
 
-        francois_media_url = f"image/jpeg:{settings.STORAGE_URL}/{fra_attachment.split(':', 1)[1]}"
-        greg_media_url = f"image/jpeg:{settings.STORAGE_URL}/{eng_attachment.split(':', 1)[1]}"
-        wilbert_media_url = f"image/jpeg:{settings.STORAGE_URL}/{fra_attachment.split(':', 1)[1]}"
-
         # assert the right language was used for each contact on both text and media
         self.assertEqual(francois_media.text, fra_msg)
-        self.assertEqual(francois_media.attachments, [francois_media_url])
+        self.assertEqual(francois_media.attachments, [fra_attachment])
 
         self.assertEqual(greg_media.text, eng_msg)
-        self.assertEqual(greg_media.attachments, [greg_media_url])
+        self.assertEqual(greg_media.attachments, [eng_attachment])
 
         self.assertEqual(wilbert_media.text, fra_msg)
-        self.assertEqual(wilbert_media.attachments, [wilbert_media_url])
+        self.assertEqual(wilbert_media.attachments, [fra_attachment])
 
 
 class SystemLabelTest(TembaTest):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -864,7 +864,6 @@ CELERYBEAT_SCHEDULE = {
 # Mapping of task name to task function path, used when CELERY_ALWAYS_EAGER is set to True
 CELERY_TASK_MAP = {
     "send_msg_task": "temba.channels.tasks.send_msg_task",
-    "start_msg_flow_batch": "temba.flows.tasks.start_msg_flow_batch_task",
     "handle_event_task": "temba.msgs.tasks.handle_event_task",
 }
 

--- a/temba/utils/queues.py
+++ b/temba/utils/queues.py
@@ -15,7 +15,6 @@ from temba.utils import json
 # celery queue names
 class Queue:
     CELERY = "celery"
-    FLOWS = "flows"
     HANDLER = "handler"
 
 


### PR DESCRIPTION
* Sends broadcasts by creating a mailroom task
* Uses a simplified send function to continue sending broadcasts in tests
* Simplify `Flow.start` to no longer use `start_msg_flow_batch`
* Removes `start_msg_flow_batch` celery task (flows queue should be empty now)
* Moves code only used by legacy engine to `temba.msgs.legacy`