### PR TITLE
properly format whatsapp numbers and add icon

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -136,8 +136,12 @@ class URN(object):
         """
         scheme, path, query, display = cls.to_parts(urn)
 
-        if scheme == TEL_SCHEME and formatted:
+        if scheme in [TEL_SCHEME, WHATSAPP_SCHEME] and formatted:
             try:
+                # whatsapp scheme is E164 without a leading +, add it so parsing works
+                if scheme == WHATSAPP_SCHEME:
+                    path = "+" + path
+
                 if path and path[0] == "+":
                     phone_format = phonenumbers.PhoneNumberFormat.NATIONAL
                     if international:

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -14,6 +14,7 @@ from temba.contacts.models import (
     TWILIO_SCHEME,
     TWITTER_SCHEME,
     TWITTERID_SCHEME,
+    WHATSAPP_SCHEME,
     ContactField,
     ContactURN,
 )
@@ -33,6 +34,7 @@ URN_SCHEME_ICONS = {
     LINE_SCHEME: "icon-line",
     EXTERNAL_SCHEME: "icon-channel-external",
     FCM_SCHEME: "icon-fcm",
+    WHATSAPP_SCHEME: "icon-whatsapp",
 }
 
 ACTIVITY_ICONS = {

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6656,6 +6656,11 @@ class ContactURNTest(TembaTest):
         )
         self.assertEqual(urn.get_display(self.org), "billy_bob")
 
+        urn = ContactURN.objects.create(
+            org=self.org, scheme="whatsapp", path="12065551212", identity="whatsapp:12065551212", priority=50
+        )
+        self.assertEqual(urn.get_display(self.org), "(206) 555-1212")
+
 
 class ContactFieldTest(TembaTest):
     def setUp(self):


### PR DESCRIPTION
Anon orgs didn't have any icon to give a clue on how a contact is communicating without this. Also formats the same as phone numbers for those orgs that AREN'T anon.