### PR TITLE
🚦 Don't make groups available until they're ready

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2499,10 +2499,13 @@ class APITest(TembaTest):
             developers = self.create_group("Developers", query="isdeveloper = YES")
 
             # a group which is being re-evaluated
-            unready = self.create_group("Big Group", query="isdeveloper=NO")
+            dynamic = self.create_group("Big Group", query="isdeveloper=NO")
 
-        unready.status = ContactGroup.STATUS_EVALUATING
-        unready.save(update_fields=("status",))
+        dynamic.status = ContactGroup.STATUS_EVALUATING
+        dynamic.save(update_fields=("status",))
+
+        # an initializing group
+        ContactGroup.create_static(self.org, self.admin, "Initializing", status=ContactGroup.STATUS_INITIALIZING)
 
         # group belong to other org
         spammers = ContactGroup.get_or_create(self.org2, self.admin2, "Spammers")
@@ -2518,7 +2521,7 @@ class APITest(TembaTest):
             resp_json["results"],
             [
                 {
-                    "uuid": unready.uuid,
+                    "uuid": dynamic.uuid,
                     "name": "Big Group",
                     "query": 'isdeveloper = "NO"',
                     "status": "evaluating",

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1967,7 +1967,7 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
         if name:
             queryset = queryset.filter(name__iexact=name)
 
-        return queryset.filter(is_active=True)
+        return queryset.filter(is_active=True).exclude(status=ContactGroup.STATUS_INITIALIZING)
 
     def prepare_for_serialization(self, object_list):
         group_counts = ContactGroupCount.get_totals(object_list)

--- a/temba/contacts/omnibox.py
+++ b/temba/contacts/omnibox.py
@@ -78,7 +78,7 @@ def omnibox_mixed_search(org, search, types):
     results = []
 
     if SEARCH_ALL_GROUPS in search_types or SEARCH_STATIC_GROUPS in search_types:
-        groups = ContactGroup.get_user_groups(org)
+        groups = ContactGroup.get_user_groups(org, ready_only=True)
 
         # exclude dynamic groups if not searching all groups
         if SEARCH_ALL_GROUPS not in search_types:

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -297,7 +297,12 @@ class ContactListView(ContactListPaginationMixin, OrgPermsMixin, SmartListView):
         return context
 
     def get_user_groups(self, org):
-        groups = ContactGroup.get_user_groups(org, ready_only=False).select_related("org").order_by(Upper("name"))
+        groups = (
+            ContactGroup.get_user_groups(org, ready_only=False)
+            .exclude(status=ContactGroup.STATUS_INITIALIZING)
+            .select_related("org")
+            .order_by(Upper("name"))
+        )
         group_counts = ContactGroupCount.get_totals(groups)
 
         rendered = []


### PR DESCRIPTION
- Group being imported into should be in `status=INITIALIZING` whilst being populated
- Hide such groups in the UI, don't return them from API, omnibox queries, etc