### PR TITLE
🧯 Fix API runs serializer when result doesn't have category

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -810,7 +810,7 @@ class FlowRunReadSerializer(ReadSerializer):
             created_on = iso8601.parse_date(result[FlowRun.RESULT_CREATED_ON])
             return {
                 "value": result[FlowRun.RESULT_VALUE],
-                "category": result[FlowRun.RESULT_CATEGORY],
+                "category": result.get(FlowRun.RESULT_CATEGORY),
                 "node": result[FlowRun.RESULT_NODE_UUID],
                 "time": format_datetime(created_on),
                 "input": result.get(FlowRun.RESULT_INPUT),


### PR DESCRIPTION
i.e. from a `save_run_result` action