### PR TITLE
🔥 disable ivr tasks

### DIFF
--- a/temba/ivr/tasks.py
+++ b/temba/ivr/tasks.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from celery.task import task
 
+from django.conf import settings
 from temba.channels.models import Channel, ChannelLog
 from temba.utils.celery import nonoverlapping_task
 from temba.utils.http import HttpEvent
@@ -16,6 +17,9 @@ from .models import IVRCall
 
 @task(bind=True, name="start_call_task", max_retries=3)
 def start_call_task(self, call_pk):
+    if not settings.TESTING:
+        return
+
     call = IVRCall.objects.select_related("channel").get(pk=call_pk)
 
     lock_key = f"ivr_call_start_task_contact_{call.contact_id}"
@@ -32,6 +36,9 @@ def start_call_task(self, call_pk):
 
 @nonoverlapping_task(track_started=True, name="check_calls_task", time_limit=900)
 def check_calls_task():
+    if not settings.TESTING:
+        return
+
     from .models import IVRCall
 
     now = timezone.now()
@@ -62,6 +69,9 @@ def check_calls_task():
 
 @nonoverlapping_task(track_started=True, name="check_failed_calls_task", time_limit=900)
 def check_failed_calls_task():
+    if not settings.TESTING:
+        return
+
     from .models import IVRCall
 
     # calls that have failed and have a `error_count` value are going to be retried
@@ -90,6 +100,9 @@ def check_failed_calls_task():
 
 @nonoverlapping_task(track_started=True, name="task_enqueue_call_events", time_limit=900)
 def task_enqueue_call_events():
+    if not settings.TESTING:
+        return
+
     from .models import IVRCall
 
     r = get_redis_connection()


### PR DESCRIPTION
Gates all IVR tasks with TESTING until they are ripped out entirely. These are all handled within Mailroom now and these firing was causing issues for calls that failed in Mailroom for one reason or another. 