### PR TITLE
🔥  populate account sid and and auth token on twilio callers when added

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -29,7 +29,15 @@ from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext_lazy as _
 
 from temba import mailroom
-from temba.orgs.models import NEXMO_APP_ID, NEXMO_APP_PRIVATE_KEY, NEXMO_KEY, NEXMO_SECRET, Org, ACCOUNT_SID, ACCOUNT_TOKEN
+from temba.orgs.models import (
+    NEXMO_APP_ID,
+    NEXMO_APP_PRIVATE_KEY,
+    NEXMO_KEY,
+    NEXMO_SECRET,
+    Org,
+    ACCOUNT_SID,
+    ACCOUNT_TOKEN,
+)
 from temba.utils import analytics, get_anonymous_user, json, on_transaction_commit
 from temba.utils.email import send_template_email
 from temba.utils.gsm7 import calculate_num_segments
@@ -667,10 +675,7 @@ class Channel(TembaModel):
             address=channel.address,
             role=Channel.ROLE_CALL,
             parent=channel,
-            config={
-                "account_sid": org.config[ACCOUNT_SID],
-                "auth_token": org.config[ACCOUNT_TOKEN],
-            },
+            config={"account_sid": org.config[ACCOUNT_SID], "auth_token": org.config[ACCOUNT_TOKEN]},
         )
 
     @classmethod

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -29,7 +29,7 @@ from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext_lazy as _
 
 from temba import mailroom
-from temba.orgs.models import NEXMO_APP_ID, NEXMO_APP_PRIVATE_KEY, NEXMO_KEY, NEXMO_SECRET, Org
+from temba.orgs.models import NEXMO_APP_ID, NEXMO_APP_PRIVATE_KEY, NEXMO_KEY, NEXMO_SECRET, Org, ACCOUNT_SID, ACCOUNT_TOKEN
 from temba.utils import analytics, get_anonymous_user, json, on_transaction_commit
 from temba.utils.email import send_template_email
 from temba.utils.gsm7 import calculate_num_segments
@@ -667,6 +667,10 @@ class Channel(TembaModel):
             address=channel.address,
             role=Channel.ROLE_CALL,
             parent=channel,
+            config={
+                "account_sid": org.config[ACCOUNT_SID],
+                "auth_token": org.config[ACCOUNT_TOKEN],
+            },
         )
 
     @classmethod

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -186,6 +186,11 @@ class ChannelTest(TembaTest):
         post_data = dict(channel=self.tel_channel.pk, connection="T")
         response = self.client.post(reverse("channels.channel_create_caller"), post_data)
 
+        # get the caller, make sure config options are set
+        caller = Channel.objects.get(org=self.org, role="C")
+        self.assertEqual("AccountSid", caller.config["account_sid"])
+        self.assertEqual("AccountToken", caller.config["auth_token"])
+
         # now we should be IVR capable
         self.assertTrue(self.org.supports_ivr())
 


### PR DESCRIPTION
Mailroom doesn't look at org configs, only channel configs (that way people can have multiple twilio accounts connected if they wanted in the future)

This sets the appropriate config options for callers when created off of the org settings. 