### PR TITLE
🧮 Fix format_number to be able to handle decimals with more digits 

### DIFF
--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -1,6 +1,5 @@
 import locale
 import resource
-from decimal import Decimal
 from itertools import islice
 
 import iso8601

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -42,9 +42,7 @@ def format_number(val):
     if not val.is_finite():
         return ""
 
-    # convert our decimal to a value without exponent
-    val = val.quantize(Decimal(1)) if val == val.to_integral() else val.normalize()
-    val = str(val)
+    val = format(val, "f")
 
     if "." in val:
         val = val.rstrip("0").rstrip(".")  # e.g. 12.3000 -> 12.3

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -170,6 +170,10 @@ class InitTest(TembaTest):
         self.assertEqual("-12300", format_number(Decimal("-123E+2")))
         self.assertEqual("-12350", format_number(Decimal("-123.5E+2")))
         self.assertEqual("-1.235", format_number(Decimal("-123.5E-2")))
+        self.assertEqual(
+            "-1000000000000001467812345696542157800075344236445874615",
+            format_number(Decimal("-1000000000000001467812345696542157800075344236445874615")),
+        )
         self.assertEqual("", format_number(Decimal("NaN")))
 
     def test_slugify_with(self):


### PR DESCRIPTION
than the current context precision. Fixes https://sentry.io/organizations/nyaruka/issues/1105935574/?project=21956&referrer=alert_email which is currently breaking upartners syncing

I think what's happening here is that the postgres JSON adapter is giving us a decimal with more digits (not sure how it got there in the first place) than `getcontext().prec`.. so then `quantize` blows up. Tried finding a way to reduce the precision but the only thing I could get to work was just letting `Decimal.__format__` decide how it should be formatted.