### PR TITLE
🐖 Update Django to 2.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # use container-based Ubuntu Trusty
-dist: trusty
+dist: xenial
 sudo: true
 
 language: python
@@ -18,15 +18,19 @@ cache:
     - "$HOME/.cache/pip"
 
 before_install:
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install postgresql-$PGDB postgresql-client-$PGDB postgresql-$PGDB-postgis-2.4 postgresql-$PGDB-postgis-2.4-scripts
+  - sudo -E sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
+  - sudo -E sed -i 's/port = 5433/port = 5432/' /etc/postgresql/*/main/postgresql.conf
   - sudo -E service postgresql stop 9.2
   - sudo -E service postgresql stop 9.3
   - sudo -E service postgresql stop 9.4
   - sudo -E service postgresql stop 9.5
   - sudo -E service postgresql stop 9.6
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install postgresql-$PGDB postgresql-client-$PGDB postgresql-$PGDB-postgis-2.4 postgresql-$PGDB-postgis-2.4-scripts
-  - sudo -E sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
-  - sudo -E sed -i 's/port = 5433/port = 5432/' /etc/postgresql/*/main/postgresql.conf
-  - sudo -E service postgresql restart $PGDB
+  - sudo -E service postgresql stop 10
+  - sudo -E service postgresql stop 11
+  - sudo -E ps axuwww |grep -i postg
+  - sudo -E systemctl -l restart postgresql@$PGDB-main
+  - sudo -E systemctl -l status postgresql@$PGDB-main
 
 install:
   # install Elasticsearch

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -32,7 +32,7 @@ django-mptt==0.8.7
 django-redis==4.10.0
 django-storages==1.7.1
 django-timezone-field==3.0
-django==2.1.10
+django==2.2.3
 djangorestframework==3.9.2
 docutils==0.13.1          # via botocore
 elasticsearch-dsl==6.3.1

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -134,4 +134,4 @@ class WebHookCRUDLTest(TembaTest):
 
         response = self.fetch_protected(url, self.admin)
 
-        self.assertEqual(response.context["object_list"].count(), 4)
+        self.assertEqual(len(response.context["object_list"]), 4)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 from urllib.parse import quote
 
 from django_redis import get_redis_connection
-from smartmin.tests import SmartminTest
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -21,6 +20,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text
 
+from smartmin.tests import SmartminTest
 from temba.channels.views import channel_status_processor
 from temba.contacts.models import TEL_SCHEME, TWITTER_SCHEME, URN, Contact, ContactGroup, ContactURN
 from temba.ivr.models import IVRCall
@@ -2185,7 +2185,7 @@ class ChannelEventCRUDLTest(TembaTest):
 
         response = self.fetch_protected(list_url, self.user)
 
-        self.assertEqual(response.context["object_list"].count(), 2)
+        self.assertEqual(len(response.context["object_list"]), 2)
         self.assertContains(response, "Missed Incoming Call")
         self.assertContains(response, "Incoming Call (600 seconds)")
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -227,7 +227,7 @@ class FlowTest(TembaTest):
 
         def assert_media_upload(filename, expected_type, expected_path):
             with open(filename, "rb") as data:
-                post_data = dict(file=data, action=None, HTTP_X_FORWARDED_HTTPS="https")
+                post_data = dict(file=data, action="", HTTP_X_FORWARDED_HTTPS="https")
                 response = self.client.post(upload_media_action_url, post_data)
 
                 self.assertEqual(response.status_code, 200)

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -605,7 +605,7 @@ class MsgTest(TembaTest):
         self.assertContains(response, "function refresh")
 
         self.assertEqual(response.context["refresh"], 20000)
-        self.assertEqual(response.context["object_list"].count(), 5)
+        self.assertEqual(len(response.context["object_list"]), 5)
         self.assertEqual(response.context["folders"][0]["url"], "/msg/inbox/")
         self.assertEqual(response.context["folders"][0]["count"], 5)
         self.assertEqual(response.context["actions"], ["archive", "label"])
@@ -613,7 +613,7 @@ class MsgTest(TembaTest):
         # visit inbox page as administrator
         response = self.fetch_protected(inbox_url, self.admin)
 
-        self.assertEqual(response.context["object_list"].count(), 5)
+        self.assertEqual(len(response.context["object_list"]), 5)
         self.assertEqual(response.context["actions"], ["archive", "label"])
 
         # let's add some labels
@@ -682,7 +682,7 @@ class MsgTest(TembaTest):
         with self.assertNumQueries(54):
             response = self.fetch_protected(archive_url, self.admin)
 
-        self.assertEqual(response.context["object_list"].count(), 1)
+        self.assertEqual(len(response.context["object_list"]), 1)
         self.assertEqual(response.context["actions"], ["restore", "label", "delete"])
 
         # check that the inbox does not contains archived messages
@@ -695,7 +695,7 @@ class MsgTest(TembaTest):
         # visit inbox page as an admin of the organization
         response = self.fetch_protected(inbox_url, self.admin)
 
-        self.assertEqual(response.context["object_list"].count(), 4)
+        self.assertEqual(len(response.context["object_list"]), 4)
         self.assertEqual(response.context["actions"], ["archive", "label"])
 
         # test restoring an archived message back to inbox
@@ -705,25 +705,25 @@ class MsgTest(TembaTest):
 
         response = self.client.get(inbox_url)
         self.assertEqual(Msg.objects.all().count(), 6)
-        self.assertEqual(response.context["object_list"].count(), 5)
+        self.assertEqual(len(response.context["object_list"]), 5)
 
         # archiving a message removes it from the inbox
         Msg.apply_action_archive(self.user, [msg1])
 
         response = self.client.get(inbox_url)
-        self.assertEqual(response.context["object_list"].count(), 4)
+        self.assertEqual(len(response.context["object_list"]), 4)
 
         # and moves it to the Archived page
         response = self.client.get(archive_url)
-        self.assertEqual(response.context["object_list"].count(), 1)
+        self.assertEqual(len(response.context["object_list"]), 1)
 
         # deleting it removes it from the Archived page
         response = self.client.post(archive_url, dict(action="delete", objects=[msg1.pk]), follow=True)
-        self.assertEqual(response.context["object_list"].count(), 0)
+        self.assertEqual(len(response.context["object_list"]), 0)
 
         # now check inbox as viewer user
         response = self.fetch_protected(inbox_url, self.user)
-        self.assertEqual(response.context["object_list"].count(), 4)
+        self.assertEqual(len(response.context["object_list"]), 4)
 
         # check that viewer user cannot label messages
         post_data = dict(action="label", objects=[msg5.pk], label=label1.pk, add=True)
@@ -803,7 +803,7 @@ class MsgTest(TembaTest):
         with self.assertNumQueries(65):
             response = self.fetch_protected(failed_url, self.admin)
 
-        self.assertEqual(response.context["object_list"].count(), 3)
+        self.assertEqual(len(response.context["object_list"]), 3)
         self.assertEqual(response.context["actions"], ["resend"])
         self.assertContains(response, "Export")
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -12,7 +12,6 @@ import stripe
 import stripe.error
 from bs4 import BeautifulSoup
 from dateutil.relativedelta import relativedelta
-from smartmin.tests import SmartminTest
 
 from django.conf import settings
 from django.contrib.auth.models import Group, User
@@ -23,6 +22,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from smartmin.tests import SmartminTest
 from temba import mailroom
 from temba.airtime.models import AirtimeTransfer
 from temba.api.models import APIToken, Resthook, WebHookEvent, WebHookResult
@@ -726,7 +726,7 @@ class OrgTest(TembaTest):
             "editors": [self.editor.id],
             "administrators": [self.admin.id],
             "surveyors": [self.surveyor.id],
-            "surveyor_password": None,
+            "surveyor_password": "",
         }
 
         response = self.client.post(update_url, post_data)


### PR DESCRIPTION
Release notes: https://docs.djangoproject.com/en/2.2/releases/2.2/

There is a really subtle change that failed a few tests. When using a
Paginator `object_list` is no longer a QuerySet, but a list object. This
change was introduced in https://github.com/django/django/commit/3767c7ff391d5f277e25bca38ef3730ddf9cea9c

`.count()` now gets the length of a `self.object_list` which evaluates
the QuerySet and caches it as a list, so any following calls to
`self.object_list` return that cached object. One of those is https://github.com/django/django/blob/master/django/views/generic/list.py#L70-L70
that returns a page.object_list. Prior to the change this was a
QuerySet.count() which did not cache self.object_list