### PR TITLE
🧹 Remove some more use of legacy engine in tests

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3097,7 +3097,8 @@ class APITest(TembaTest):
 
         start1 = FlowStart.create(flow1, self.admin, contacts=[self.joe], restart_participants=True)
 
-        joe_run1, = start1.start()
+        start1.async_start()
+        joe_run1 = start1.runs.get()
         frank_run1, = flow1.start([], [self.frank])
         self.create_msg(direction="I", contact=self.joe, text="it is blue").handle()
         self.create_msg(direction="I", contact=self.frank, text="Indigo").handle()

--- a/temba/flows/legacy.py
+++ b/temba/flows/legacy.py
@@ -11,6 +11,29 @@ from temba.utils.http import http_headers
 logger = logging.getLogger(__name__)
 
 
+def flow_start_start(start):
+    from temba.flows.models import FlowStart
+
+    groups = list(start.groups.all())
+    contacts = list(start.contacts.all())
+
+    # load up our extra if any
+    extra = start.extra if start.extra else None
+
+    start.flow.start(
+        groups,
+        contacts,
+        flow_start=start,
+        extra=extra,
+        restart_participants=start.restart_participants,
+        include_active=start.include_active,
+        campaign_event=start.campaign_event,
+    )
+
+    start.status = FlowStart.STATUS_COMPLETE
+    start.save(update_fields=("status",))
+
+
 def call_webhook(run, webhook_url, ruleset, msg, action="POST", resthook=None, headers=None):
     from temba.api.models import WebHookEvent, WebHookResult
     from temba.flows.models import Flow

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4057,10 +4057,6 @@ class FlowTest(TembaTest):
         # we should have a flow start
         start = FlowStart.objects.get(flow=self.flow)
 
-        # should be in a completed state
-        self.assertEqual(FlowStart.STATUS_COMPLETE, start.status)
-        self.assertEqual(1, start.contact_count)
-
         # do so again but don't restart the participants
         del post_data["restart_participants"]
 
@@ -4070,7 +4066,6 @@ class FlowTest(TembaTest):
         new_start = FlowStart.objects.filter(flow=self.flow).order_by("-created_on").first()
         self.assertNotEqual(start, new_start)
         self.assertEqual(FlowStart.STATUS_COMPLETE, new_start.status)
-        self.assertEqual(0, new_start.contact_count)
 
         # mark that start as incomplete
         new_start.status = FlowStart.STATUS_STARTING
@@ -5812,7 +5807,7 @@ class FlowsTest(FlowFileTest):
         rule_set1, rule_set2 = favorites.rule_sets.order_by("y")[:2]
 
         start = FlowStart.create(favorites, self.admin, contacts=[self.contact])
-        start.start()
+        start.async_start()
 
         Msg.create_incoming(self.channel, "tel:+12065552020", "I like red")
         Msg.create_incoming(self.channel, "tel:+12065552020", "primus")
@@ -8218,7 +8213,7 @@ class FlowsTest(FlowFileTest):
         start = FlowStart.objects.create(flow=parent, created_by=self.admin, modified_by=self.admin)
         for contact in contacts:
             start.contacts.add(contact)
-        start.start()
+        start.async_start()
 
         # all our contacts should have a name of Greg now (set in the child flow)
         for contact in contacts:

--- a/temba/utils/management/commands/test_db.py
+++ b/temba/utils/management/commands/test_db.py
@@ -792,7 +792,7 @@ class Command(BaseCommand):
             )
 
             start = FlowStart.create(flow, user, groups=[group], restart_participants=True)
-            start.start()
+            start.async_start()
         else:
             # start a random individual without a flow start
             if not org.cache["contacts"]:
@@ -803,7 +803,8 @@ class Command(BaseCommand):
 
             self._log(" > Starting flow %s for contact #%d in org %s\n" % (flow.name, contact.id, org.name))
 
-            flow.start([], [contact], restart_participants=True)
+            start = FlowStart.create(flow, user, contacts=[contact], restart_participants=True)
+            start.async_start()
 
         org.cache["activity"] = {"flow": flow, "unresponded": contacts_started, "started": list(contacts_started)}
 


### PR DESCRIPTION
* Reworks some more tests to not use legacy engine
* Remove `FlowStart.start` so there's only `FlowStart.async_start` which queues to mailroom or invokes a simplified legacy version for tests
* Don't update `FlowStart.contact_count`
