### PR TITLE
switch to python verson on bionic (3.6.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: true
 
 language: python
 python:
-  - "3.7"
+  - "3.6.8"
 
 services:
   - redis-server


### PR DESCRIPTION
I was wrong in previous PR that switched to bionic on Travis, Python is 3.6.8 on Bionic Beaver, not 3.7.