### PR TITLE
🧪 Include migrations in coverage checks?

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,7 +20,6 @@ exclude_lines =
     if __name__ == .__main__.:
 
 omit =
-    */migrations/*
     */gen/*
     */tests*
     *__init__*

--- a/.coveragerc_todo
+++ b/.coveragerc_todo
@@ -19,7 +19,6 @@ exclude_lines =
     if __name__ == .__main__.:
 
 omit =
-    */migrations/*
     */gen/*
     */tests*
     *__init__*

--- a/temba/auth_tweaks/migrations/0002_ensure_anon_user.py
+++ b/temba/auth_tweaks/migrations/0002_ensure_anon_user.py
@@ -8,7 +8,7 @@ from django.db import migrations
 
 
 def ensure_anon_user_exists(apps, schema_editor):
-    if not User.objects.filter(username=settings.ANONYMOUS_USER_NAME).exists():
+    if not User.objects.filter(username=settings.ANONYMOUS_USER_NAME).exists():  # pragma: no cover
         user = User(username=settings.ANONYMOUS_USER_NAME)
         user.set_unusable_password()
         user.save()


### PR DESCRIPTION
Would mean you have to write a migration test for your new data migration or accept the shame of covering it with `#pragma: no cover`