### PR TITLE
🛡️ Releasing Nexmo channel shouldn't blow up if API call fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
 
   # install mailroom
-  - MAILROOM_VERSION=2.0.9
+  - MAILROOM_VERSION=2.0.19
   - wget https://github.com/nyaruka/mailroom/releases/download/v${MAILROOM_VERSION}/mailroom_${MAILROOM_VERSION}_linux_amd64.tar.gz
   - tar -xvf mailroom_${MAILROOM_VERSION}_linux_amd64.tar.gz mailroom
 

--- a/temba/channels/types/nexmo/client.py
+++ b/temba/channels/types/nexmo/client.py
@@ -82,7 +82,11 @@ class Client:
         return app_id, app_private_key
 
     def delete_application(self, app_id):
-        self._with_retry("delete_application", application_id=app_id)
+        try:
+            self._with_retry("delete_application", application_id=app_id)
+        except nexmo.ClientError:
+            # possible application no longer exists
+            pass
 
     def _with_retry(self, action, **kwargs):
         """


### PR DESCRIPTION
Fixes https://sentry.io/organizations/nyaruka/issues/1142731925/?project=21956 (which was me testing stuff)