### PR TITLE
👮 Use mailroom to interrupt runs when archiving or releasing a flow

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -878,10 +878,9 @@ class Flow(TembaModel):
         Releases this flow, marking it inactive. We interrupt all flow runs in a background process.
         We keep FlowRevisions and FlowStarts however.
         """
-        from .tasks import interrupt_flow_runs_task
 
         self.is_active = False
-        self.save()
+        self.save(update_fields=("is_active",))
 
         # release any campaign events that depend on this flow
         from temba.campaigns.models import CampaignEvent
@@ -899,8 +898,8 @@ class Flow(TembaModel):
         self.channel_dependencies.clear()
         self.label_dependencies.clear()
 
-        # interrupt our runs in the background
-        on_transaction_commit(lambda: interrupt_flow_runs_task.delay(self.id))
+        # queue mailroom to interrupt sessions where contact is currently in this flow
+        mailroom.queue_interrupt(self.org, flow=self)
 
     def get_category_counts(self):
         keys = [r["key"] for r in self.metadata["results"]]
@@ -1264,9 +1263,8 @@ class Flow(TembaModel):
         self.is_archived = True
         self.save(update_fields=["is_archived"])
 
-        from .tasks import interrupt_flow_runs_task
-
-        interrupt_flow_runs_task.delay(self.id)
+        # queue mailroom to interrupt sessions where contact is currently in this flow
+        mailroom.queue_interrupt(self.org, flow=self)
 
         # archive our triggers as well
         from temba.triggers.models import Trigger

--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -52,12 +52,6 @@ def continue_parent_flows(run_ids):
     FlowRun.continue_parent_flow_runs(runs)
 
 
-@task(track_started=True, name="interrupt_flow_runs_task")
-def interrupt_flow_runs_task(flow_id):
-    runs = FlowRun.objects.filter(is_active=True, exit_type=None, flow_id=flow_id)
-    FlowRun.bulk_exit(runs, FlowRun.EXIT_TYPE_INTERRUPTED)
-
-
 @task(track_started=True, name="export_flow_results_task")
 def export_flow_results_task(export_id):
     """

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -221,15 +221,25 @@ class FlowTest(TembaTest):
         self.create_secondary_org()
         self.assertEqual(Flow.get_unique_name(self.org2, "Sheep Poll"), "Sheep Poll")  # different org
 
-    @uses_legacy_engine
-    def test_archive_interrupt_runs(self):
-        self.flow.start([], [self.contact, self.contact2])
-        self.assertEqual(self.flow.runs.filter(exit_type=None).count(), 2)
-
+    @patch("temba.mailroom.queue_interrupt")
+    def test_archive(self, mock_queue_interrupt):
         self.flow.archive()
 
-        self.assertEqual(self.flow.runs.filter(exit_type=None).count(), 0)
-        self.assertEqual(self.flow.runs.filter(exit_type=FlowRun.EXIT_TYPE_INTERRUPTED).count(), 2)
+        mock_queue_interrupt.assert_called_once_with(self.org, flow=self.flow)
+
+        self.flow.refresh_from_db()
+        self.assertEqual(self.flow.is_archived, True)
+        self.assertEqual(self.flow.is_active, True)
+
+    @patch("temba.mailroom.queue_interrupt")
+    def test_release(self, mock_queue_interrupt):
+        self.flow.release()
+
+        mock_queue_interrupt.assert_called_once_with(self.org, flow=self.flow)
+
+        self.flow.refresh_from_db()
+        self.assertEqual(self.flow.is_archived, False)
+        self.assertEqual(self.flow.is_active, False)
 
     @patch("temba.flows.views.uuid4")
     def test_upload_media_action(self, mock_uuid):
@@ -5785,38 +5795,6 @@ class SimulationTest(FlowFileTest):
 
 
 class FlowsTest(FlowFileTest):
-    @uses_legacy_engine
-    def test_release(self):
-
-        # create a flow run
-        favorites = self.get_flow("favorites")
-        self.send_message(favorites, "green")
-
-        # now release our flow
-        favorites.release()
-
-        # flow should be inactive
-        self.assertFalse(Flow.objects.filter(id=favorites.id, is_active=True).exists())
-
-        # but all the runs should not be deleted
-        self.assertEqual(FlowRun.objects.all().count(), 1)
-
-    @uses_legacy_engine
-    def test_flow_with_runs_release(self):
-        # create a flow run
-        favorites = self.get_flow("favorites")
-        self.send_message(favorites, "green")
-
-        # now release our flow
-        favorites.release()
-        favorites.release_runs()
-
-        # flow should be inactive
-        self.assertFalse(Flow.objects.filter(id=favorites.id, is_active=True).exists())
-
-        # but all the runs should not be deleted
-        self.assertEqual(FlowRun.objects.all().count(), 0)
-
     def run_flowrun_deletion(self, delete_reason, test_cases):
         """
         Runs our favorites flow, then releases the run with the passed in delete_reason, asserting our final

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -117,18 +117,20 @@ def queue_flow_start(start):
     _queue_batch_task(org_id, BatchTask.START_FLOW, task, HIGH_PRIORITY)
 
 
-def queue_interrupt(org, *, contacts=None, channel=None):
+def queue_interrupt(org, *, contacts=None, channel=None, flow=None):
     """
     Queues an interrupt task for handling by mailroom
     """
 
-    assert contacts or channel, "must specify either a set of contacts or a channel"
+    assert contacts or channel or flow, "must specify either a set of contacts or a channel or a flow"
 
     task = {}
     if contacts:
         task["contact_ids"] = [c.id for c in contacts]
     if channel:
         task["channel_ids"] = [channel.id]
+    if flow:
+        task["flow_ids"] = [flow.id]
 
     _queue_batch_task(org.id, BatchTask.INTERRUPT_SESSIONS, task, HIGH_PRIORITY)
 

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -208,7 +208,7 @@ class MailroomQueueTest(TembaTest):
             },
         )
 
-    def test_queue_interrupt_contacts(self):
+    def test_queue_interrupt_by_contacts(self):
         jim = self.create_contact("Jim", "+12065551212")
         bob = self.create_contact("Bob", "+12065551313")
 
@@ -225,7 +225,7 @@ class MailroomQueueTest(TembaTest):
             },
         )
 
-    def test_queue_interrupt_channel(self):
+    def test_queue_interrupt_by_channel(self):
         self.channel.release()
 
         self.assert_org_queued(self.org, "batch")
@@ -235,6 +235,21 @@ class MailroomQueueTest(TembaTest):
                 "type": "interrupt_sessions",
                 "org_id": self.org.id,
                 "task": {"channel_ids": [self.channel.id]},
+                "queued_on": matchers.ISODate(),
+            },
+        )
+
+    def test_queue_interrupt_by_flow(self):
+        flow = self.get_flow("favorites")
+        flow.archive()
+
+        self.assert_org_queued(self.org, "batch")
+        self.assert_queued_batch_task(
+            self.org,
+            {
+                "type": "interrupt_sessions",
+                "org_id": self.org.id,
+                "task": {"flow_ids": [flow.id]},
                 "queued_on": matchers.ISODate(),
             },
         )


### PR DESCRIPTION
Technically this could be letting contacts sneak back into the old engine, but just a part of the engine that interrupts runs...