### PR TITLE
add populating repeat_minute_of_hour to migration

### DIFF
--- a/temba/schedules/migrations/0010_populate_days_of_week.py
+++ b/temba/schedules/migrations/0010_populate_days_of_week.py
@@ -30,6 +30,12 @@ def populate_days_of_week(apps, schema_editor):
     if updated > 0:
         print(f"updated {updated} weekly schedules")
 
+    updated = (
+        Schedule.objects.exclude(repeat_period="O").filter(repeat_minute_of_hour=None).update(repeat_minute_of_hour=0)
+    )
+    if updated > 0:
+        print(f"updated {updated} schedules with missing minute of hour")
+
 
 class Migration(migrations.Migration):
 

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -451,7 +451,8 @@ class PopulateDaysAndOrgMigrationTest(MigrationTest):
         )
         self.weekly_schedule.repeat_days = 22
         self.weekly_schedule.repeat_days_of_week = None
-        self.weekly_schedule.save(update_fields=["repeat_days", "repeat_days_of_week"])
+        self.weekly_schedule.repeat_minute_of_hour = None
+        self.weekly_schedule.save(update_fields=["repeat_days", "repeat_days_of_week", "repeat_minute_of_hour"])
 
     def test_org_populated(self):
         self.bcast_schedule.refresh_from_db()
@@ -460,6 +461,7 @@ class PopulateDaysAndOrgMigrationTest(MigrationTest):
         self.trigger_schedule.refresh_from_db()
         self.assertEqual(self.org.id, self.trigger_schedule.org_id)
 
-    def test_days_of_week_populated(self):
+    def test_fields_populated(self):
         self.weekly_schedule.refresh_from_db()
         self.assertEqual("MTR", self.weekly_schedule.repeat_days_of_week)
+        self.assertEqual(0, self.weekly_schedule.repeat_minute_of_hour)


### PR DESCRIPTION
Prod boxes already updated so no rush to ship or anything.