### PR TITLE
fix styling on create flow dialog

### DIFF
--- a/templates/flows/flow_create.haml
+++ b/templates/flows/flow_create.haml
@@ -1,6 +1,15 @@
 -extends 'flows/flow_update.haml'
 
 
+-block fields
+
+  :css
+    .modal .modal-body {
+        max-height: 445px;
+    }
+
+  {{block.super}}
+
 -block modal-script
   {{block.super}}
 

--- a/templates/flows/flow_create.haml
+++ b/templates/flows/flow_create.haml
@@ -5,7 +5,7 @@
 
   :css
     .modal .modal-body {
-        max-height: 445px;
+        max-height: 450px;
     }
 
   {{block.super}}


### PR DESCRIPTION
Wasn't tall enough when language was shown, causing scroll bars and dual scrolling for me and just invisible scroll bars for rest.