### PR TITLE
add task to retry errored messages

### DIFF
--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -7,9 +7,19 @@ from django.utils import timezone
 from celery.task import task
 
 from temba.utils import analytics
+from temba.channels.models import Channel
 from temba.utils.celery import nonoverlapping_task
 
-from .models import Broadcast, BroadcastMsgCount, ExportMessagesTask, LabelCount, Msg, SystemLabelCount
+from .models import (
+    Broadcast,
+    BroadcastMsgCount,
+    ExportMessagesTask,
+    LabelCount,
+    Msg,
+    SystemLabelCount,
+    OUTGOING,
+    ERRORED,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +131,21 @@ def export_messages_task(export_id):
     Export messages to a file and e-mail a link to the user
     """
     ExportMessagesTask.objects.get(id=export_id).perform()
+
+
+@nonoverlapping_task(track_started=True, name="retry_errored_messages", lock_timeout=300)
+def retry_errored_messages():
+    """
+    Requeues any messages that have errored and have a next attempt in the past
+    """
+    errored_msgs = (
+        Msg.objects.filter(direction=OUTGOING, status=ERRORED, next_attempt__lte=timezone.now())
+        .exclude(topup=None)
+        .exclude(channel__channel_type=Channel.TYPE_ANDROID)
+        .order_by("created_on")
+        .only("id")[:15000]
+    )
+    Msg.send_messages(errored_msgs)
 
 
 @nonoverlapping_task(track_started=True, name="squash_msgcounts", lock_timeout=7200)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -838,6 +838,7 @@ CELERYBEAT_SCHEDULE = {
     "check-credits": {"task": "check_credits_task", "schedule": timedelta(seconds=900)},
     "check-topup-expiration": {"task": "check_topup_expiration_task", "schedule": crontab(hour=2, minute=0)},
     "check-elasticsearch-lag": {"task": "check_elasticsearch_lag", "schedule": timedelta(seconds=300)},
+    "retry-errored-messages": {"task": "retry_errored_messages", "schedule": timedelta(seconds=60)},
     "fail-old-messages": {"task": "fail_old_messages", "schedule": crontab(hour=0, minute=0)},
     "trim-sync-events": {"task": "trim_sync_events_task", "schedule": crontab(hour=3, minute=0)},
     "trim-channel-log": {"task": "trim_channel_log_task", "schedule": crontab(hour=3, minute=0)},


### PR DESCRIPTION
Only retries explicit errors so no danger of walking on mailroom. Long term this should live in Courier.