### PR TITLE
fix omnibox required behavior

### DIFF
--- a/temba/contacts/fields.py
+++ b/temba/contacts/fields.py
@@ -3,6 +3,7 @@ from django.forms import widgets
 
 from temba.utils import json
 
+from django.forms import ValidationError
 from .models import URN, Contact, ContactGroup, ContactURN
 
 
@@ -40,11 +41,14 @@ class OmniboxWidget(widgets.TextInput):
         self.__dict__["user"] = user
 
     def render(self, name, value, attrs=None, renderer=None):
+        # disable required attribute when rendering so that client side doesn't blow up from this field being hidden
+        if attrs is not None:
+            attrs["required"] = False
+
         value = self.get_json(value)
         return super().render(name, value, attrs)
 
     def get_json(self, value):
-
         if "user" not in self.__dict__:  # pragma: no cover
             raise ValueError(
                 "Omnibox requires a user, make sure you set one using field.set_user(user) in your form.__init__"
@@ -72,6 +76,13 @@ class OmniboxField(forms.Field):
     def set_user(self, user):
         self.user = user
         self.widget.set_user(user)
+
+    def validate(self, value):
+        if (
+            self.required
+            and len(value.get("groups", [])) + len(value.get("contacts", [])) + len(value.get("urns", [])) == 0
+        ):
+            raise ValidationError(self.error_messages["required"], code="required")
 
     def to_python(self, value):
         if "user" not in self.__dict__:  # pragma: no cover

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -78,7 +78,7 @@ def send_message_auto_complete_processor(request):
 
 
 class SendMessageForm(Form):
-    omnibox = OmniboxField()
+    omnibox = OmniboxField(required=False)
     text = forms.CharField(widget=forms.Textarea, max_length=640)
     schedule = forms.BooleanField(widget=forms.HiddenInput, required=False)
     step_node = forms.CharField(widget=forms.HiddenInput, max_length=36, required=False)


### PR DESCRIPTION
The JS error was Chrome being mad because it was trying to do client side validation on a hidden field and couldn't show the error message that nothing was in there. (omnibox puts its values in a hidden input field)

This fixes to render as not required (IE, the hidden field isn't required) and additionally properly validates that the field is populated when required. (this was broken and only client side validation was taking place)

fixes: https://github.com/rapidpro/rapidpro/issues/1032