### PR TITLE
Add missing block super in extra script blocks

### DIFF
--- a/templates/orgs/org_chatbase.haml
+++ b/templates/orgs/org_chatbase.haml
@@ -52,6 +52,7 @@
     %a#disconnect-chatbase-form.posterize{href:'{% url "orgs.org_chatbase" %}?disconnect=true'}
 
 -block extra-script
+  {{block.super}}
   :javascript
     $(document).ready(function() {
       select2div('#id_type');

--- a/templates/orgs/org_country.haml
+++ b/templates/orgs/org_country.haml
@@ -24,6 +24,7 @@
         -trans "Edit Aliases"
 
 -block extra-script
+  {{block.super}}
   :javascript
     $(document).ready(function() {
 

--- a/templates/orgs/org_edit.haml
+++ b/templates/orgs/org_edit.haml
@@ -38,6 +38,7 @@
     {% endblocktrans%}
 
 -block extra-script
+  {{block.super}}
   :javascript
     $(document).ready(function() {
 

--- a/templates/orgs/org_nexmo_account.haml
+++ b/templates/orgs/org_nexmo_account.haml
@@ -44,6 +44,7 @@
         -trans "Connect Nexmo"
 
 -block extra-script
+  {{block.super}}
   :javascript
     function confirmNexmoDisconnect() {
       removalConfirmation("disconnect-nexmo", "Disconnect");

--- a/templates/orgs/org_smtp_server.haml
+++ b/templates/orgs/org_smtp_server.haml
@@ -39,6 +39,7 @@
   %hr
 
 -block extra-script
+  {{block.super}}
   :javascript
     function confirmSMTPRemove() {
       removalConfirmation("remove-smtp", "Remove");

--- a/templates/orgs/org_transfer_to_account.haml
+++ b/templates/orgs/org_transfer_to_account.haml
@@ -59,6 +59,7 @@
     -trans " on the TransferTo site."
 
 -block extra-script
+  {{block.super}}
   :javascript
     function confirmTransferToDisconnect() {
       removalConfirmation("disconnect-transferto", "Disconnect");

--- a/templates/orgs/org_twilio_account.haml
+++ b/templates/orgs/org_twilio_account.haml
@@ -42,6 +42,7 @@
         Connect Twilio
 
 -block extra-script
+  {{block.super}}
   :javascript
     function confirmTwilioDisconnect() {
       removalConfirmation("disconnect-twilio", "Disconnect");

--- a/templates/orgs/user_edit.haml
+++ b/templates/orgs/user_edit.haml
@@ -31,6 +31,7 @@
     Your email address is <span class='attn'>{{email}}</span>.
 
 -block extra-script
+  {{block.super}}
   :javascript
     $(document).ready(function() {
       select2div('#id_language');


### PR DESCRIPTION
Addresses https://github.com/rapidpro/rapidpro/issues/1052 

These are the views used by the formax which really need the block super to that the formax container includes a form with CSRF token