### PR TITLE
🇲🇰  unify max contact fields

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -696,12 +696,12 @@ class ContactFieldWriteSerializer(WriteSerializer):
 
     def validate(self, data):
 
-        fields_count = ContactField.user_fields.count_active_for_org(org=self.context["org"])
-        if not self.instance and fields_count >= ContactField.MAX_ORG_CONTACTFIELDS:
+        field_count = ContactField.user_fields.count_active_for_org(org=self.context["org"])
+        if not self.instance and field_count >= settings.MAX_ACTIVE_CONTACTFIELDS_PER_ORG:
             raise serializers.ValidationError(
                 "This org has %s contact fields and the limit is %s. "
                 "You must delete existing ones before you can "
-                "create new ones." % (fields_count, ContactField.MAX_ORG_CONTACTFIELDS)
+                "create new ones." % (field_count, settings.MAX_ACTIVE_CONTACTFIELDS_PER_ORG)
             )
 
         return data

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2324,7 +2324,7 @@ class APITest(TembaTest):
         response = self.fetchJSON(url, "flow_uuid=%s&campaign_uuid=%s&dependencies=xx" % (flow.uuid, campaign.uuid))
         self.assertResponseError(response, None, "dependencies must be one of none, flows, all")
 
-    @patch.object(ContactField, "MAX_ORG_CONTACTFIELDS", new=10)
+    @override_settings(MAX_ACTIVE_CONTACTFIELDS_PER_ORG=10)
     def test_fields(self):
         url = reverse("api.v2.fields")
 
@@ -2393,7 +2393,7 @@ class APITest(TembaTest):
 
         ContactField.user_fields.all().delete()
 
-        for i in range(ContactField.MAX_ORG_CONTACTFIELDS):
+        for i in range(settings.MAX_ACTIVE_CONTACTFIELDS_PER_ORG):
             ContactField.get_or_create(self.org, self.admin, "field%d" % i, "Field%d" % i)
 
         response = self.postJSON(url, None, {"label": "Age", "value_type": "numeric"})

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -415,7 +415,6 @@ class ContactField(SmartModel):
 
     MAX_KEY_LEN = 36
     MAX_LABEL_LEN = 36
-    MAX_ORG_CONTACTFIELDS = 200
 
     # fields that cannot be updated by user
     IMMUTABLE_FIELDS = ("id", "created_on")

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1747,9 +1747,8 @@ class CreateContactFieldForm(ContactFieldFormMixin, forms.ModelForm):
     def clean(self):
         super().clean()
 
-        cnt_active_userfields_per_org = ContactField.user_fields.count_active_for_org(org=self.org)
-
-        if cnt_active_userfields_per_org >= settings.MAX_ACTIVE_CONTACTFIELDS_PER_ORG:
+        field_count = ContactField.user_fields.count_active_for_org(org=self.org)
+        if field_count >= settings.MAX_ACTIVE_CONTACTFIELDS_PER_ORG:
             raise forms.ValidationError(
                 _(
                     f"Cannot create a new Contact Field, maximum allowed per org: {settings.MAX_ACTIVE_CONTACTFIELDS_PER_ORG}"


### PR DESCRIPTION
We had two concepts of max # of fields, a constant on ContactField and a setting.

This just changes us to use the setting everywhere. Fixes: https://github.com/rapidpro/rapidpro/issues/985

