### PR TITLE
Fix omnibox console error

### DIFF
--- a/templates/utils/forms/omnibox_choice.haml
+++ b/templates/utils/forms/omnibox_choice.haml
@@ -1,6 +1,6 @@
 <rp-omnibox
   {% include "django/forms/widgets/attrs.html" %}  
   name="{{widget.name}}"
-  value="{% if widget.value %}{{widget.value}}{%endif%}"
+  {% if widget.value %}value="{{widget.value}}"{%endif%}
   endpoint="/contact/omnibox/?types=cgu&v=2&search="
 ></rp-omnibox>


### PR DESCRIPTION
I don't believe this affects the user outside of a console error. 

Passed objects as attributes should be removed if empty
https://lit-element.polymer-project.org/guide/properties#conversion