### PR TITLE
fix weekly buttons resetting on form validation

### DIFF
--- a/templates/triggers/trigger_schedule.haml
+++ b/templates/triggers/trigger_schedule.haml
@@ -71,24 +71,24 @@
     .repeat-period
       %p.instructions
         -render_field 'repeat_period'
-    .weekly-repeat-options{class:'{% if form.initial.repeat_period == "W" %}{% else%}hide{%endif%}'}
+    .weekly-repeat-options{class:'{% if form.repeat_period.value == "W" %}{% else%}hide{%endif%}'}
       .btn-group{'data-toggle':'buttons-checkbox'}
-        #mon.btn{value:"M", class:'{% if "M" in days %}active{% endif %}'}
+        #mon.btn{value:"M", class:'{% if "M" in form.repeat_days_of_week.value %}active{% endif %}'}
           -trans "Mon"
-        #tue.btn{value:"T", class:'{% if "T" in days %}active{% endif %}'}
+        #tue.btn{value:"T", class:'{% if "T" in form.repeat_days_of_week.value %}active{% endif %}'}
           -trans "Tue"
-        #wed.btn{value:"W", class:'{% if "W" in days %}active{% endif %}'}
+        #wed.btn{value:"W", class:'{% if "W" in form.repeat_days_of_week.value %}active{% endif %}'}
           -trans "Wed"
-        #thu.btn{value:"R", class:'{% if "R" in days %}active{% endif %}'}
+        #thu.btn{value:"R", class:'{% if "R" in form.repeat_days_of_week.value %}active{% endif %}'}
           -trans "Thu"
-        #fri.btn{value:"F", class:'{% if "F" in days %}active{% endif %}'}
+        #fri.btn{value:"F", class:'{% if "F" in form.repeat_days_of_week.value %}active{% endif %}'}
           -trans "Fri"
-        #sat.btn{value:"S", class:'{% if "S" in days %}active{% endif %}'}
+        #sat.btn{value:"S", class:'{% if "S" in form.repeat_days_of_week.value %}active{% endif %}'}
           -trans "Sat"
-        #sun.btn{value:"U", class:'{% if "U" in days %}active{% endif %}'}
+        #sun.btn{value:"U", class:'{% if "U" in form.repeat_days_of_week.value %}active{% endif %}'}
           -trans "Sun"
 
-      %input#repeat-days-value{name:'repeat_days_of_week', type:'hidden', value:'{{days}}'}
+      %input#repeat-days-value{name:'repeat_days_of_week', type:'hidden', value:'{{form.repeat_days_of_week.value}}'}
 
 -load humanize
 


### PR DESCRIPTION
fixes: https://github.com/rapidpro/rapidpro/issues/1068

but note that: https://github.com/rapidpro/rapidpro/issues/1069 remains.

Fought with that a bit and ya, maybe we should find a new datetime picker. @ericnewcomer want to try? :)