### PR TITLE
Fix order for migrations on schedules

### DIFF
--- a/temba/schedules/migrations/0010_populate_org.py
+++ b/temba/schedules/migrations/0010_populate_org.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ("triggers", "0016_auto_20190816_1517"),
         ("msgs", "0134_remove_broadcast_purged"),
-        ("schedules", "0010_populate_days_of_week"),
+        ("schedules", "0009_auto_20190822_1823"),
     ]
 
     operations = [migrations.RunPython(populate_org, noop)]

--- a/temba/schedules/migrations/0011_populate_days_of_week.py
+++ b/temba/schedules/migrations/0011_populate_days_of_week.py
@@ -58,6 +58,6 @@ def populate_days_of_week(apps, schema_editor):  # pragma: no cover
 
 class Migration(migrations.Migration):
 
-    dependencies = [("schedules", "0009_auto_20190822_1823")]
+    dependencies = [("schedules", "0010_populate_org")]
 
     operations = [migrations.RunPython(populate_days_of_week, noop)]

--- a/temba/schedules/migrations/0012_auto_20190930_1347.py
+++ b/temba/schedules/migrations/0012_auto_20190930_1347.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [("schedules", "0011_populate_org")]
+    dependencies = [("schedules", "0011_populate_days_of_week")]
 
     operations = [
         migrations.RemoveField(model_name="schedule", name="repeat_days"),


### PR DESCRIPTION
Hi everyone, I'm opening this PR because of the `schedules.0011_populate_org` migrate must be first then `schedules.0010_populate_days_of_week`. When migrating populate_days_of_week first, all schedules objects hasn't been orgs associated yet.

Thanks a lot for your attention.
Regards
