### PR TITLE
use brand when granting orgs, not host

### DIFF
--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1954,7 +1954,7 @@ class OrgCRUDL(SmartCRUDL):
 
             slug = Org.get_unique_slug(self.form.cleaned_data["name"])
             obj.slug = slug
-            obj.brand = self.request.branding.get("host", settings.DEFAULT_BRAND)
+            obj.brand = self.request.branding.get("brand", settings.DEFAULT_BRAND)
 
             if obj.timezone.zone in pytz.country_timezones("US"):
                 obj.date_format = Org.DATE_FORMAT_MONTH_FIRST


### PR DESCRIPTION
"host" is the whitelabel install (textit / rapid), brand is what we are really after here.