### PR TITLE
Add Bothub classifier on mailroom_db

### DIFF
--- a/temba/classifiers/types/bothub/tests.py
+++ b/temba/classifiers/types/bothub/tests.py
@@ -58,7 +58,7 @@ class BotHubTypeTest(TembaTest):
         response = self.client.get(url)
 
         # should have url for claiming our type
-        url = reverse("classifiers.types.bh.connect")
+        url = reverse("classifiers.types.bothub.connect")
         self.assertContains(response, url)
 
         response = self.client.get(url)
@@ -89,5 +89,5 @@ class BotHubTypeTest(TembaTest):
 
             c = Classifier.objects.get()
             self.assertEqual("Bothub Test Repository", c.name)
-            self.assertEqual("bh", c.classifier_type)
+            self.assertEqual("bothub", c.classifier_type)
             self.assertEqual("123456789", c.config[BotHubType.CONFIG_ACCESS_TOKEN])

--- a/temba/classifiers/types/bothub/type.py
+++ b/temba/classifiers/types/bothub/type.py
@@ -16,7 +16,7 @@ class BotHubType(ClassifierType):
     CONFIG_ACCESS_TOKEN = "access_token"
 
     name = "BotHub"
-    slug = "bh"
+    slug = "bothub"
     icon = "icon-bothub"
 
     connect_view = ConnectView

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -53,7 +53,7 @@ ORG1 = dict(
         ),
         dict(
             uuid="859b436d-3005-4e43-9ad5-3de5f26ede4c",
-            classifier_type="bh",
+            classifier_type="bothub",
             name="BotHub",
             config=dict(access_token="access_token"),
             intents=(dict(name="intent", external_id="intent"),),

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -51,6 +51,13 @@ ORG1 = dict(
             config=dict(app_id="67890", access_token="sesame"),
             intents=(dict(name="register", external_id="register"),),
         ),
+        dict(
+            uuid="859b436d-3005-4e43-9ad5-3de5f26ede4c",
+            classifier_type="bh",
+            name="BotHub",
+            config=dict(access_token="access_token"),
+            intents=(dict(name="intent", external_id="intent"),),
+        ),
     ),
     channels=(
         dict(


### PR DESCRIPTION
Hi @nicpottier , I open this PR, to create a Bothub classifier object in the database. When running tests for the mailroom, get a list and verify if Bothub classifier type exists.

Thanks a lot for your attention.
Regards