### PR TITLE
Fix schedule trigger validation bug

### DIFF
--- a/templates/triggers/trigger_update.haml
+++ b/templates/triggers/trigger_update.haml
@@ -78,7 +78,7 @@
       .repeat-period
         %p.instructions
           -render_field 'repeat_period'
-      .weekly-repeat-options{class:'{% if form.initial.repeat_period == "W" %}{% else%}hide{%endif%}'}
+      .weekly-repeat-options{class:'{% if form.repeat_period.value == "W" %}{% else%}hide{%endif%}'}
         .btn-group{'data-toggle':'buttons-checkbox'}
           #mon.btn{value:"M", class:'{% if "M" in days %}active{% endif %}'}
             -trans "Mon"


### PR DESCRIPTION
When submitting a schedule trigger update form with a validation failure, the day of week picker would be shown based on the initial form instead of the current state. This fix bases that off of the current form state instead.