### PR TITLE
🔧 Replace flow/validate mailroom call with flow/inspect

### DIFF
--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -96,17 +96,6 @@ class MailroomClient:
 
         return self._request("flow/clone", payload)
 
-    def flow_validate(self, org, definition):
-        payload = {"flow": definition}
-
-        # during tests do validation without org because mailroom can't see unit test data created in a transaction
-        if org and not settings.TESTING:
-            payload["org_id"] = org.id
-
-        validated = self._request("flow/validate", payload)
-        validated["_ui"] = definition.get("_ui", {})
-        return validated
-
     def sim_start(self, payload):
         return self._request("sim/start", payload)
 

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -43,14 +43,14 @@ class MailroomClientTest(TembaTest):
             mock_post.return_value = MockResponse(422, '{"error":"flow don\'t look right"}')
 
             with self.assertRaises(FlowValidationException) as e:
-                get_client().flow_validate(self.org, '{"nodes:[]"}')
+                get_client().flow_inspect({"nodes": []}, validate_with_org=self.org)
 
         self.assertEqual(str(e.exception), "flow don't look right")
         self.assertEqual(
             e.exception.as_json(),
             {
-                "endpoint": "flow/validate",
-                "request": {"flow": '{"nodes:[]"}', "org_id": self.org.id},
+                "endpoint": "flow/inspect",
+                "request": {"flow": {"nodes": []}, "validate_with_org_id": self.org.id},
                 "response": {"error": "flow don't look right"},
             },
         )

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -421,7 +421,7 @@ class Org(SmartModel):
 
         # with all the flows and dependencies committed, we can now have mailroom do full validation
         for flow in new_flows:
-            mailroom.get_client().flow_validate(self, flow.as_json())
+            mailroom.get_client().flow_inspect(flow.as_json(), validate_with_org=self)
 
     @classmethod
     def export_definitions(cls, site_link, components, include_fields=True, include_groups=True):


### PR DESCRIPTION
The latter is from when we were stuffing validation results inside flow definitions