### PR TITLE
Split Flow.GOFLOW_VERSION into 2 more useful constants

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -231,7 +231,7 @@ class Flow(TembaModel):
     ]
 
     FINAL_LEGACY_VERSION = VERSIONS[-1]
-    INITIAL_NEW_VERSION = "13.0.0"  # initial version of flow spec to use new engine
+    INITIAL_GOFLOW_VERSION = "13.0.0"  # initial version of flow spec to use new engine
     CURRENT_SPEC_VERSION = "13.0.0"  # current flow spec version
 
     DEFAULT_EXPIRES_AFTER = 60 * 12
@@ -1041,7 +1041,7 @@ class Flow(TembaModel):
         """
         Returns whether this flow still uses a legacy definition
         """
-        return Version(self.version_number) < Version(Flow.INITIAL_NEW_VERSION)
+        return Version(self.version_number) < Version(Flow.INITIAL_GOFLOW_VERSION)
 
     def as_export_ref(self):
         return {Flow.DEFINITION_UUID: str(self.uuid), Flow.DEFINITION_NAME: self.name}
@@ -1300,7 +1300,7 @@ class Flow(TembaModel):
         """
         Saves a new revision for this flow, validation will be done on the definition first
         """
-        if Version(definition.get(Flow.DEFINITION_SPEC_VERSION)) < Version(Flow.INITIAL_NEW_VERSION):
+        if Version(definition.get(Flow.DEFINITION_SPEC_VERSION)) < Version(Flow.INITIAL_GOFLOW_VERSION):
             raise FlowVersionConflictException(definition.get(Flow.DEFINITION_SPEC_VERSION))
 
         current_revision = self.get_current_revision()
@@ -2479,7 +2479,7 @@ class FlowRevision(SmartModel):
             if version == to_version:
                 break
 
-        if Version(to_version) >= Version(Flow.INITIAL_NEW_VERSION):
+        if Version(to_version) >= Version(Flow.INITIAL_GOFLOW_VERSION):
             json_flow = mailroom.get_client().flow_migrate(json_flow)
 
         return json_flow

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -231,7 +231,8 @@ class Flow(TembaModel):
     ]
 
     FINAL_LEGACY_VERSION = VERSIONS[-1]
-    GOFLOW_VERSION = "13.0.0"
+    INITIAL_NEW_VERSION = "13.0.0"  # initial version of flow spec to use new engine
+    CURRENT_SPEC_VERSION = "13.0.0"  # current flow spec version
 
     DEFAULT_EXPIRES_AFTER = 60 * 12
 
@@ -334,7 +335,7 @@ class Flow(TembaModel):
             saved_by=user,
             created_by=user,
             modified_by=user,
-            version_number=Flow.GOFLOW_VERSION if use_new_editor else Flow.FINAL_LEGACY_VERSION,
+            version_number=Flow.CURRENT_SPEC_VERSION if use_new_editor else Flow.FINAL_LEGACY_VERSION,
             **kwargs,
         )
 
@@ -345,7 +346,7 @@ class Flow(TembaModel):
                     {
                         Flow.DEFINITION_NAME: flow.name,
                         Flow.DEFINITION_UUID: flow.uuid,
-                        Flow.DEFINITION_SPEC_VERSION: Flow.GOFLOW_VERSION,
+                        Flow.DEFINITION_SPEC_VERSION: Flow.CURRENT_SPEC_VERSION,
                         Flow.DEFINITION_LANGUAGE: base_language,
                         Flow.DEFINITION_TYPE: Flow.GOFLOW_TYPES[flow_type],
                         Flow.DEFINITION_NODES: [],
@@ -381,7 +382,7 @@ class Flow(TembaModel):
 
         name = Flow.get_unique_name(org, "Join %s" % group.name)
         flow = Flow.create(org, user, name, base_language=base_language)
-        flow.version_number = Flow.GOFLOW_VERSION
+        flow.version_number = "13.0.0"
         flow.save(update_fields=("version_number",))
 
         node_uuid = str(uuid4())
@@ -963,7 +964,7 @@ class Flow(TembaModel):
         assert translations and base_language in translations, "must include translation for base language"
 
         self.base_language = base_language
-        self.version_number = Flow.GOFLOW_VERSION
+        self.version_number = "13.0.0"
         self.save(update_fields=("name", "base_language", "version_number"))
 
         translations = translations.copy()  # don't modify instance being saved on event object
@@ -1040,7 +1041,7 @@ class Flow(TembaModel):
         """
         Returns whether this flow still uses a legacy definition
         """
-        return Version(self.version_number) < Version(Flow.GOFLOW_VERSION)
+        return Version(self.version_number) < Version(Flow.INITIAL_NEW_VERSION)
 
     def as_export_ref(self):
         return {Flow.DEFINITION_UUID: str(self.uuid), Flow.DEFINITION_NAME: self.name}
@@ -1299,7 +1300,7 @@ class Flow(TembaModel):
         """
         Saves a new revision for this flow, validation will be done on the definition first
         """
-        if Version(definition.get(Flow.DEFINITION_SPEC_VERSION)) < Version(Flow.GOFLOW_VERSION):
+        if Version(definition.get(Flow.DEFINITION_SPEC_VERSION)) < Version(Flow.INITIAL_NEW_VERSION):
             raise FlowVersionConflictException(definition.get(Flow.DEFINITION_SPEC_VERSION))
 
         current_revision = self.get_current_revision()
@@ -1337,7 +1338,7 @@ class Flow(TembaModel):
             }
             self.saved_by = user
             self.saved_on = timezone.now()
-            self.version_number = Flow.GOFLOW_VERSION
+            self.version_number = Flow.CURRENT_SPEC_VERSION
             self.save(update_fields=["metadata", "version_number", "base_language", "saved_by", "saved_on"])
 
             # create our new revision
@@ -1345,7 +1346,7 @@ class Flow(TembaModel):
                 definition=definition,
                 created_by=user,
                 modified_by=user,
-                spec_version=Flow.GOFLOW_VERSION,
+                spec_version=Flow.CURRENT_SPEC_VERSION,
                 revision=revision,
             )
 
@@ -2478,7 +2479,7 @@ class FlowRevision(SmartModel):
             if version == to_version:
                 break
 
-        if Version(to_version) >= Version(Flow.GOFLOW_VERSION):
+        if Version(to_version) >= Version(Flow.INITIAL_NEW_VERSION):
             json_flow = mailroom.get_client().flow_migrate(json_flow)
 
         return json_flow

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -502,7 +502,7 @@ class FlowTest(TembaTest):
         self.login(self.admin)
         self.client.post(reverse("flows.flow_create"), {"name": "Go Flow", "flow_type": Flow.TYPE_MESSAGE})
         flow = Flow.objects.get(
-            org=self.org, name="Go Flow", flow_type=Flow.TYPE_MESSAGE, version_number=Flow.GOFLOW_VERSION
+            org=self.org, name="Go Flow", flow_type=Flow.TYPE_MESSAGE, version_number=Flow.CURRENT_SPEC_VERSION
         )
 
         # can't save older spec version over newer
@@ -513,7 +513,7 @@ class FlowTest(TembaTest):
             flow.save_revision(self.admin, definition)
 
         # can't save older revision over newer
-        definition["spec_version"] = Flow.GOFLOW_VERSION
+        definition["spec_version"] = Flow.CURRENT_SPEC_VERSION
         definition["revision"] = 0
 
         with self.assertRaises(FlowUserConflictException):
@@ -2870,7 +2870,7 @@ class FlowCRUDLTest(TembaTest):
         self.login(self.admin)
         self.client.post(reverse("flows.flow_create"), data=dict(name="Go Flow", flow_type=Flow.TYPE_MESSAGE))
         flow = Flow.objects.get(
-            org=self.org, name="Go Flow", flow_type=Flow.TYPE_MESSAGE, version_number=Flow.GOFLOW_VERSION
+            org=self.org, name="Go Flow", flow_type=Flow.TYPE_MESSAGE, version_number=Flow.CURRENT_SPEC_VERSION
         )
         response = self.client.get(reverse("flows.flow_revisions", args=[flow.uuid]))
         self.assertEqual(1, len(response.json()))
@@ -3560,7 +3560,7 @@ class FlowCRUDLTest(TembaTest):
         )
 
         flow = Flow.objects.get(
-            org=self.org, name="New Flow", flow_type=Flow.TYPE_MESSAGE, version_number=Flow.GOFLOW_VERSION
+            org=self.org, name="New Flow", flow_type=Flow.TYPE_MESSAGE, version_number=Flow.CURRENT_SPEC_VERSION
         )
 
         # now loading the editor page should redirect

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -316,7 +316,7 @@ class FlowCRUDL(SmartCRUDL):
                 for revision in flow.revisions.filter(spec_version__in=versions).order_by("-revision")[:25]:
 
                     # our goflow versions are already validated
-                    if Version(revision.spec_version) >= Version(Flow.INITIAL_NEW_VERSION):
+                    if Version(revision.spec_version) >= Version(Flow.INITIAL_GOFLOW_VERSION):
                         revisions.append(revision.as_json())
                         continue
 
@@ -1028,7 +1028,7 @@ class FlowCRUDL(SmartCRUDL):
                 flow.save(update_fields=("version_number",))
 
             # require update permissions
-            if Version(flow.version_number) >= Version(Flow.INITIAL_NEW_VERSION):
+            if Version(flow.version_number) >= Version(Flow.INITIAL_GOFLOW_VERSION):
                 return HttpResponseRedirect(reverse("flows.flow_editor_next", args=[self.get_object().uuid]))
 
             return super().get(request, *args, **kwargs)
@@ -1214,7 +1214,7 @@ class FlowCRUDL(SmartCRUDL):
             links = []
             flow = self.object
 
-            versions = Flow.get_versions_before(Flow.INITIAL_NEW_VERSION)
+            versions = Flow.get_versions_before(Flow.INITIAL_GOFLOW_VERSION)
             has_legacy_revision = flow.revisions.filter(spec_version__in=versions).exists()
 
             if (

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -301,7 +301,7 @@ class FlowCRUDL(SmartCRUDL):
         def get(self, request, *args, **kwargs):
             flow = self.get_object()
 
-            flow_version = request.GET.get("version", Flow.GOFLOW_VERSION)
+            flow_version = request.GET.get("version", Flow.CURRENT_SPEC_VERSION)
             revision_id = self.kwargs["revision_id"]
 
             if revision_id:
@@ -316,7 +316,7 @@ class FlowCRUDL(SmartCRUDL):
                 for revision in flow.revisions.filter(spec_version__in=versions).order_by("-revision")[:25]:
 
                     # our goflow versions are already validated
-                    if revision.spec_version == Flow.GOFLOW_VERSION:
+                    if Version(revision.spec_version) >= Version(Flow.INITIAL_NEW_VERSION):
                         revisions.append(revision.as_json())
                         continue
 
@@ -1028,7 +1028,7 @@ class FlowCRUDL(SmartCRUDL):
                 flow.save(update_fields=("version_number",))
 
             # require update permissions
-            if Version(flow.version_number) >= Version(Flow.GOFLOW_VERSION):
+            if Version(flow.version_number) >= Version(Flow.INITIAL_NEW_VERSION):
                 return HttpResponseRedirect(reverse("flows.flow_editor_next", args=[self.get_object().uuid]))
 
             return super().get(request, *args, **kwargs)
@@ -1214,7 +1214,7 @@ class FlowCRUDL(SmartCRUDL):
             links = []
             flow = self.object
 
-            versions = Flow.get_versions_before(Flow.GOFLOW_VERSION)
+            versions = Flow.get_versions_before(Flow.INITIAL_NEW_VERSION)
             has_legacy_revision = flow.revisions.filter(spec_version__in=versions).exists()
 
             if (

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -74,7 +74,7 @@ class MailroomClient:
         from temba.flows.models import Flow
 
         if not to_version:
-            to_version = Flow.GOFLOW_VERSION
+            to_version = Flow.CURRENT_SPEC_VERSION
 
         return self._request("flow/migrate", {"flow": definition, "to_version": to_version})
 


### PR DESCRIPTION
Started on https://github.com/rapidpro/rapidpro/issues/1123 and then realised I'm touching the same code as https://github.com/nyaruka/rapidpro/pull/2648 needs to be updated to change..

So making this as a precursor PR to both of those. `Flow.GOFLOW_VERSION` currently has two meanings and will have soon have two values - so replaced that with two different constants.