### PR TITLE
🧯 Fix deletion of orgs and locations so that aliases are properly deleted

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -568,7 +568,6 @@ class APITest(TembaTest):
         self.assertEndpointAccess(url)
 
         BoundaryAlias.create(self.org, self.admin, self.state1, "Kigali")
-        BoundaryAlias.create(self.org, self.admin, self.state1, "Kigari")
         BoundaryAlias.create(self.org, self.admin, self.state2, "East Prov")
         BoundaryAlias.create(self.org2, self.admin2, self.state1, "Other Org")  # shouldn't be returned
 

--- a/temba/locations/models.py
+++ b/temba/locations/models.py
@@ -127,6 +127,7 @@ class AdminBoundary(MPTTModel, models.Model):
         for child_boundary in AdminBoundary.objects.filter(parent=self):  # pragma: no cover
             child_boundary.release()
 
+        self.aliases.all().delete()
         self.delete()
 
     @classmethod

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -74,13 +74,39 @@ class LocationTest(TembaTest):
         response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
         response_json = response.json()
 
-        self.assertEqual(1, len(response_json))
-
-        # should just be kigali, without any aliases
-        children = response_json[0]["children"]
-        self.assertEqual("Eastern Province", children[0]["name"])
-        self.assertEqual("Kigali City", children[1]["name"])
-        self.assertEqual("", children[1]["aliases"])
+        self.assertEqual(
+            [
+                {
+                    "osm_id": "171496",
+                    "name": "Rwanda",
+                    "level": 0,
+                    "aliases": "",
+                    "path": "Rwanda",
+                    "children": [
+                        {
+                            "osm_id": "171591",
+                            "name": "Eastern Province",
+                            "level": 1,
+                            "aliases": "",
+                            "path": "Rwanda > Eastern Province",
+                            "parent_osm_id": "171496",
+                            "has_children": True,
+                        },
+                        {
+                            "osm_id": "1708283",
+                            "name": "Kigali City",
+                            "level": 1,
+                            "aliases": "Kigari",
+                            "path": "Rwanda > Kigali City",
+                            "parent_osm_id": "171496",
+                            "has_children": True,
+                        },
+                    ],
+                    "has_children": True,
+                }
+            ],
+            response_json,
+        )
 
         # update our alias for kigali
         with self.assertNumQueries(17):

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -2049,6 +2049,7 @@ class Org(SmartModel):
         self.credit_alerts.all().delete()
         self.broadcast_set.all().delete()
         self.schedules.all().delete()
+        self.boundaryalias_set.all().delete()
 
         # needs to come after deletion of msgs and broadcasts as those insert new counts
         self.system_labels.all().delete()

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -18,7 +18,7 @@ from temba.channels.models import Channel, ChannelLog
 from temba.contacts.models import URN, Contact, ContactField, ContactGroup
 from temba.flows.models import Flow, FlowRevision, FlowRun, FlowSession, clear_flow_users
 from temba.ivr.models import IVRCall
-from temba.locations.models import AdminBoundary
+from temba.locations.models import AdminBoundary, BoundaryAlias
 from temba.msgs.models import HANDLED, INBOX, INCOMING, OUTGOING, PENDING, SENT, Broadcast, Label, Msg
 from temba.orgs.models import Org
 from temba.utils import json
@@ -108,6 +108,8 @@ class TembaTestMixin:
         self.ward1 = AdminBoundary.create(osm_id="171113181", name="Kageyo", level=3, parent=self.district1)
         self.ward2 = AdminBoundary.create(osm_id="171116381", name="Kabare", level=3, parent=self.district2)
         self.ward3 = AdminBoundary.create(osm_id="VMN.49.1_1", name="Bukure", level=3, parent=self.district4)
+
+        BoundaryAlias.create(self.org, self.admin, self.state1, "Kigari")
 
         self.country.update_path()
 


### PR DESCRIPTION
Fixes https://github.com/rapidpro/rapidpro/issues/1122 and deleting an org with a boundary alias