### PR TITLE
Display quick replies option on external channel claim/config

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -259,7 +259,7 @@ class Channel(TembaModel):
     CONFIG_MT_RESPONSE_CHECK = "mt_response_check"
     CONFIG_DEFAULT_SEND_BODY = (
         "id={{id}}&text={{text}}&to={{to}}&to_no_plus={{to_no_plus}}&from={{from}}&from_no_plus={{from_no_plus}}"
-        "&channel={{channel}}{{quick_replies}}"
+        "&channel={{channel}}"
     )
     CONFIG_USERNAME = "username"
     CONFIG_PASSWORD = "password"

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -257,8 +257,10 @@ class Channel(TembaModel):
     CONFIG_SEND_METHOD = "method"
     CONFIG_SEND_BODY = "body"
     CONFIG_MT_RESPONSE_CHECK = "mt_response_check"
-    CONFIG_DEFAULT_SEND_BODY = "id={{id}}&text={{text}}&to={{to}}&to_no_plus={{to_no_plus}}&from={{from}}" \
-                               "&from_no_plus={{from_no_plus}}&channel={{channel}}{{quick_replies}}"
+    CONFIG_DEFAULT_SEND_BODY = (
+        "id={{id}}&text={{text}}&to={{to}}&to_no_plus={{to_no_plus}}&from={{from}}&from_no_plus={{from_no_plus}}"
+        "&channel={{channel}}{{quick_replies}}"
+    )
     CONFIG_USERNAME = "username"
     CONFIG_PASSWORD = "password"
     CONFIG_KEY = "key"

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -257,7 +257,8 @@ class Channel(TembaModel):
     CONFIG_SEND_METHOD = "method"
     CONFIG_SEND_BODY = "body"
     CONFIG_MT_RESPONSE_CHECK = "mt_response_check"
-    CONFIG_DEFAULT_SEND_BODY = "id={{id}}&text={{text}}&to={{to}}&to_no_plus={{to_no_plus}}&from={{from}}&from_no_plus={{from_no_plus}}&channel={{channel}}"
+    CONFIG_DEFAULT_SEND_BODY = "id={{id}}&text={{text}}&to={{to}}&to_no_plus={{to_no_plus}}&from={{from}}" \
+                               "&from_no_plus={{from_no_plus}}&channel={{channel}}{{quick_replies}}"
     CONFIG_USERNAME = "username"
     CONFIG_PASSWORD = "password"
     CONFIG_KEY = "key"

--- a/temba/channels/types/external/tests.py
+++ b/temba/channels/types/external/tests.py
@@ -97,6 +97,12 @@ class ExternalTypeTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEqual(response.status_code, 200)
 
+        channel.config[Channel.CONFIG_CONTENT_TYPE] = Channel.CONTENT_TYPE_XML
+        channel.save()
+
+        response = self.client.get(config_url)
+        self.assertEqual(response.status_code, 200)
+
     def test_claim_bulk_sender(self):
         url = reverse("channels.types.external.claim") + "?role=S&channel=%s" % self.channel.pk
 

--- a/temba/channels/types/external/type.py
+++ b/temba/channels/types/external/type.py
@@ -29,6 +29,8 @@ class ExternalType(ChannelType):
         context = dict(channel=channel, ip_addresses=settings.IP_ADDRESSES)
 
         config = channel.config
+        send_method = config.get(Channel.CONFIG_SEND_METHOD)
+        content_type = config.get(Channel.CONFIG_CONTENT_TYPE)
         send_url = config[Channel.CONFIG_SEND_URL]
         send_body = config.get(Channel.CONFIG_SEND_BODY, Channel.CONFIG_DEFAULT_SEND_BODY)
 
@@ -47,4 +49,25 @@ class ExternalType(ChannelType):
         context["example_url"] = Channel.replace_variables(send_url, example_payload)
         context["example_body"] = Channel.replace_variables(send_body, example_payload, content_type)
 
+        quick_replies_payload = {}
+
+        if (send_method == "POST" or send_method == "PUT") and content_type == Channel.CONTENT_TYPE_JSON:
+            quick_replies_payload["quick_replies"] = '["One","Two","Three"]'
+        elif (send_method == "POST" or send_method == "PUT") and content_type == Channel.CONTENT_TYPE_XML:
+            quick_replies_payload["quick_replies"] = "<item>One</item><item>Two</item><item>Three</item>"
+        else:
+            quick_replies_payload["quick_replies"] = "&quick_reply=One&quick_reply=Two&quick_reply=Three"
+
+        content_type_dont_encode = "don't encode"
+
+        context["example_url"] = Channel.replace_variables(
+            context["example_url"],
+            quick_replies_payload,
+            content_type_dont_encode
+        )
+        context["example_body"] = Channel.replace_variables(
+            context["example_body"],
+            quick_replies_payload,
+            content_type_dont_encode
+        )
         return context

--- a/temba/channels/types/external/type.py
+++ b/temba/channels/types/external/type.py
@@ -30,7 +30,6 @@ class ExternalType(ChannelType):
 
         config = channel.config
         send_method = config.get(Channel.CONFIG_SEND_METHOD)
-        content_type = config.get(Channel.CONFIG_CONTENT_TYPE)
         send_url = config[Channel.CONFIG_SEND_URL]
         send_body = config.get(Channel.CONFIG_SEND_BODY, Channel.CONFIG_DEFAULT_SEND_BODY)
 
@@ -58,16 +57,10 @@ class ExternalType(ChannelType):
         else:
             quick_replies_payload["quick_replies"] = "&quick_reply=One&quick_reply=Two&quick_reply=Three"
 
-        content_type_dont_encode = "don't encode"
-
         context["example_url"] = Channel.replace_variables(
-            context["example_url"],
-            quick_replies_payload,
-            content_type_dont_encode
+            context["example_url"], quick_replies_payload, "don't encode"
         )
         context["example_body"] = Channel.replace_variables(
-            context["example_body"],
-            quick_replies_payload,
-            content_type_dont_encode
+            context["example_body"], quick_replies_payload, "don't encode"
         )
         return context

--- a/templates/channels/types/external/claim.haml
+++ b/templates/channels/types/external/claim.haml
@@ -42,11 +42,7 @@
         If using POST or PUT, you can specify the body of the request using the same variables.
 
     %p
-      %trans The variable
-      <code>{% templatetag openbrace %}{% templatetag openbrace %}quick_replies{% templatetag closebrace %}{% templatetag closebrace %}</code>
-      %trans with method POST or content type URL Encoded will be replaced by
-      <code>&quick_reply=(reply)</code>
-      %trans for each quick reply.
+      %trans The <code>{% templatetag openbrace %}{% templatetag openbrace %}quick_replies{% templatetag closebrace %}{% templatetag closebrace %}</code> variable with method POST or content type URL Encoded will be replaced by <code>&quick_reply=(reply)</code> for each quick reply.
 
     %p
       -blocktrans trimmed with brand.name as brand

--- a/templates/channels/types/external/claim.haml
+++ b/templates/channels/types/external/claim.haml
@@ -42,7 +42,7 @@
         If using POST or PUT, you can specify the body of the request using the same variables.
 
     %p
-      %trans The <code>{% templatetag openbrace %}{% templatetag openbrace %}quick_replies{% templatetag closebrace %}{% templatetag closebrace %}</code> variable with method POST or content type URL Encoded will be replaced by <code>&quick_reply=(reply)</code> for each quick reply.
+      %trans The <code>{% templatetag openbrace %}{% templatetag openbrace %}quick_replies{% templatetag closebrace %}{% templatetag closebrace %}</code> variable with method GET or content type URL Encoded will be replaced by <code>&quick_reply=(reply)</code> for each quick reply.
 
     %p
       -blocktrans trimmed with brand.name as brand

--- a/templates/channels/types/external/claim.haml
+++ b/templates/channels/types/external/claim.haml
@@ -27,17 +27,26 @@
         %trans the phone number or URN this message is addressed to, with leading +'s removed
       %li <code>{% templatetag openbrace %}{% templatetag openbrace %}id{% templatetag closebrace %}{% templatetag closebrace %}</code> -
         %trans the unique id for this message
+      %li <code>{% templatetag openbrace %}{% templatetag openbrace %}quick_replies{% templatetag closebrace %}{% templatetag closebrace %}</code> -
+        %trans the quick replies for this message, formatted according to send method and content type.
 
     %p
       -blocktrans trimmed
         An example that would substitute variables in the URL:
 
     %pre<
-      http://myservice.com/send.php?from={% templatetag openbrace %}{% templatetag openbrace %}from{% templatetag closebrace %}{% templatetag closebrace %}&text={% templatetag openbrace %}{% templatetag openbrace %}text{% templatetag closebrace %}{% templatetag closebrace %}&to={% templatetag openbrace %}{% templatetag openbrace %}to{% templatetag closebrace %}{% templatetag closebrace %}
+      http://myservice.com/send.php?from={% templatetag openbrace %}{% templatetag openbrace %}from{% templatetag closebrace %}{% templatetag closebrace %}&text={% templatetag openbrace %}{% templatetag openbrace %}text{% templatetag closebrace %}{% templatetag closebrace %}&to={% templatetag openbrace %}{% templatetag openbrace %}to{% templatetag closebrace %}{% templatetag closebrace %}{% templatetag openbrace %}{% templatetag openbrace %}quick_replies{% templatetag closebrace %}{% templatetag closebrace %}{% templatetag closebrace %}
 
     %p
       -blocktrans trimmed
         If using POST or PUT, you can specify the body of the request using the same variables.
+
+    %p
+      %trans The variable
+      <code>{% templatetag openbrace %}{% templatetag openbrace %}quick_replies{% templatetag closebrace %}{% templatetag closebrace %}</code>
+      %trans with method POST or content type URL Encoded will be replaced by
+      <code>&quick_reply=(reply)</code>
+      %trans for each quick reply.
 
     %p
       -blocktrans trimmed with brand.name as brand


### PR DESCRIPTION
This PR is related to enabling quick replies on Courier's external channel: https://github.com/nyaruka/courier/pull/275