### PR TITLE
Remove contact filtering from flow results page

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -22,7 +22,7 @@ from temba.archives.models import Archive
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.channels.models import Channel
 from temba.classifiers.models import Classifier
-from temba.contacts.models import FACEBOOK_SCHEME, WHATSAPP_SCHEME, Contact, ContactField, ContactGroup
+from temba.contacts.models import FACEBOOK_SCHEME, WHATSAPP_SCHEME, ContactField, ContactGroup
 from temba.globals.models import Global
 from temba.mailroom import FlowValidationException, MailroomException
 from temba.msgs.models import Label
@@ -3358,13 +3358,6 @@ class FlowCRUDLTest(TembaTest):
             counts = response.json()["counts"]
             self.assertEqual("Color", counts[0]["name"])
             self.assertEqual(2, counts[0]["total"])
-
-            # test a search on our runs
-            with patch.object(Contact, "query_elasticsearch_for_ids", return_value=[pete.id]):
-                response = self.client.get("%s?q=pete" % reverse("flows.flow_run_table", args=[flow.id]))
-                self.assertEqual(len(response.context["runs"]), 1)
-                self.assertContains(response, "Pete")
-                self.assertNotContains(response, "Jimmy")
 
             # fetch our intercooler rows for the run table
             response = self.client.get(reverse("flows.flow_run_table", args=[flow.id]))

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -36,15 +36,7 @@ from temba import mailroom
 from temba.archives.models import Archive
 from temba.channels.models import Channel
 from temba.classifiers.models import Classifier
-from temba.contacts.models import (
-    FACEBOOK_SCHEME,
-    TEL_SCHEME,
-    WHATSAPP_SCHEME,
-    Contact,
-    ContactField,
-    ContactGroup,
-    ContactURN,
-)
+from temba.contacts.models import FACEBOOK_SCHEME, TEL_SCHEME, WHATSAPP_SCHEME, ContactField, ContactGroup, ContactURN
 from temba.contacts.omnibox import omnibox_deserialize
 from temba.flows import legacy
 from temba.flows.legacy.expressions import get_function_listing
@@ -1559,25 +1551,10 @@ class FlowCRUDL(SmartCRUDL):
         def get_context_data(self, *args, **kwargs):
             context = super().get_context_data(*args, **kwargs)
             flow = self.get_object()
-            org = self.derive_org()
-
             runs = flow.runs.all()
 
             if str_to_bool(self.request.GET.get("responded", "true")):
                 runs = runs.filter(responded=True)
-
-            query = self.request.GET.get("q", None)
-            contact_ids = []
-            if query:
-                try:
-                    # search for contact ids based on name or telephone
-                    query = query.strip()
-                    query = f"name ~ {query} OR tel ~ {query}"
-                    contact_ids = Contact.query_elasticsearch_for_ids(org, query)
-                except Exception:  # pragma: no cover
-                    # if we cant parse it, then no matches
-                    pass
-                runs = runs.filter(contact__in=contact_ids)
 
             # paginate
             modified_on = self.request.GET.get("modified_on", None)

--- a/templates/flows/flow_results.haml
+++ b/templates/flows/flow_results.haml
@@ -616,16 +616,6 @@
                                       ic-indicator:"#indicator"}
             -trans "Responded"
             
-          .input-group
-            %input.contact-search{type:"text", name:"q", placeholder:"Search Contacts",
-                                      ic-get-from:"/flow/run_table/{{object.id}}/",
-                                      ic-on-beforeSend:'$("#results_run_table").empty()',
-                                      ic-trigger-on:"keyup changed",
-                                      ic-local-vars: "responded",
-                                      ic-trigger-delay:"500ms",
-                                      ic-target:"#results_run_table",
-                                      ic-indicator:"#indicator"}
-
           .add-columns.select
             .selection
               %input#columns{type:'hidden', style:'width:150px'}


### PR DESCRIPTION
If you want a contact's results, go to their contact page.