### PR TITLE
🔒 More testing with another org

### DIFF
--- a/temba/airtime/tests.py
+++ b/temba/airtime/tests.py
@@ -97,6 +97,10 @@ class AirtimeCRUDLTest(TembaTest):
             self.assertEqual(self.transfer1, response.context["object"])
             self.assertFalse(response.context["show_logs"])
 
+        # can't view transfer from other org
+        response = self.client.get(reverse("airtime.airtimetransfer_read", args=[self.transfer3.id]))
+        self.assertEqual(404, response.status_code)
+
 
 class DTOneClientTest(TembaTest):
     def setUp(self):

--- a/temba/airtime/tests.py
+++ b/temba/airtime/tests.py
@@ -11,8 +11,6 @@ class AirtimeCRUDLTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.setUpSecondaryOrg()
-
         contact = self.create_contact("Ben Haggerty", "+250700000003")
 
         self.transfer1 = AirtimeTransfer.objects.create(

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -14,8 +14,6 @@ class APITokenTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.setUpSecondaryOrg()
-
         self.admins_group = Group.objects.get(name="Administrators")
         self.editors_group = Group.objects.get(name="Editors")
         self.surveyors_group = Group.objects.get(name="Surveyors")

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -123,13 +123,15 @@ class WebHookTest(TembaTest):
 
 class WebHookCRUDLTest(TembaTest):
     def test_list(self):
-        WebHookResult.objects.create(org=self.org, status_code=200, created_on=timezone.now())
-        WebHookResult.objects.create(org=self.org, status_code=201, created_on=timezone.now())
-        WebHookResult.objects.create(org=self.org, status_code=202, created_on=timezone.now())
-        WebHookResult.objects.create(org=self.org, status_code=404, created_on=timezone.now())
+        res1 = WebHookResult.objects.create(org=self.org, status_code=200, created_on=timezone.now())
+        res2 = WebHookResult.objects.create(org=self.org, status_code=201, created_on=timezone.now())
+        res3 = WebHookResult.objects.create(org=self.org, status_code=202, created_on=timezone.now())
+        res4 = WebHookResult.objects.create(org=self.org, status_code=404, created_on=timezone.now())
+
+        # create result for other org
+        WebHookResult.objects.create(org=self.org2, status_code=200, created_on=timezone.now())
 
         url = reverse("api.webhookresult_list")
 
         response = self.fetch_protected(url, self.admin)
-
-        self.assertEqual(response.context["object_list"].count(), 4)
+        self.assertEqual([res4, res3, res2, res1], list(response.context["object_list"]))

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2112,7 +2112,7 @@ class APITest(TembaTest):
         self.assertEndpointAccess(url, fetch_returns=405)
 
         # create some contacts to act on
-        self.releaseContacts(delete=True)
+        self.bulk_release([self.joe, self.frank], user=self.admin, delete=True)
         contact1 = self.create_contact("Ann", "+250788000001")
         contact2 = self.create_contact("Bob", "+250788000002")
         contact3 = self.create_contact("Cat", "+250788000003")
@@ -2224,8 +2224,8 @@ class APITest(TembaTest):
         # unblock contact 1
         response = self.postJSON(url, None, {"contacts": [contact1.uuid], "action": "unblock"})
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(set(Contact.objects.filter(is_blocked=False)), {contact1, contact5})
-        self.assertEqual(set(Contact.objects.filter(is_blocked=True)), {contact2, contact3, contact4})
+        self.assertEqual(set(self.org.contacts.filter(is_blocked=False)), {contact1, contact5})
+        self.assertEqual(set(self.org.contacts.filter(is_blocked=True)), {contact2, contact3, contact4})
 
         # interrupt any active runs of contacts 1 and 2
         with patch("temba.mailroom.queue_interrupt") as mock_queue_interrupt:
@@ -2243,8 +2243,8 @@ class APITest(TembaTest):
         # delete contacts 1 and 2
         response = self.postJSON(url, None, {"contacts": [contact1.uuid, contact2.uuid], "action": "delete"})
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(set(Contact.objects.filter(is_active=False)), {contact1, contact2, contact5})
-        self.assertEqual(set(Contact.objects.filter(is_active=True)), {contact3, contact4})
+        self.assertEqual(set(self.org.contacts.filter(is_active=False)), {contact1, contact2, contact5})
+        self.assertEqual(set(self.org.contacts.filter(is_active=True)), {contact3, contact4})
         self.assertFalse(Msg.objects.filter(contact__in=[contact1, contact2]).exclude(visibility="D").exists())
         self.assertTrue(Msg.objects.filter(contact=contact3).exclude(visibility="D").exists())
 
@@ -2850,7 +2850,7 @@ class APITest(TembaTest):
         response = self.deleteJSON(url, "uuid=%s" % spammers.uuid)
         self.assert404(response)
 
-        self.release(ContactGroup.user_groups.all())
+        self.bulk_release(ContactGroup.user_groups.all())
 
         for i in range(ContactGroup.MAX_ORG_CONTACTGROUPS):
             ContactGroup.create_static(self.org2, self.admin2, "group%d" % i)

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -58,7 +58,6 @@ class APITest(TembaTest):
             self.org, self.user, None, "TT", name="Twitter Channel", address="billy_bob", role="SR"
         )
 
-        self.setUpSecondaryOrg()
         self.hans = self.create_contact("Hans Gruber", "+4921551511", org=self.org2)
 
         self.org2channel = Channel.create(self.org2, self.user, "RW", "A", name="Org2Channel")

--- a/temba/assets/tests.py
+++ b/temba/assets/tests.py
@@ -73,10 +73,9 @@ class AssetTest(TembaTest):
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # add our admin to another org
-        self.setUpSecondaryOrg()
         self.org2.administrators.add(self.admin)
-
         self.admin.set_org(self.org2)
+
         s = self.client.session
         s["org_id"] = self.org2.pk
         s.save()

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -58,7 +58,6 @@ class CampaignTest(TembaTest):
         )
         self.assertEqual(campaign3.name, "Reminders 3")
 
-        self.setUpSecondaryOrg()
         self.assertEqual(Campaign.get_unique_name(self.org2, "Reminders"), "Reminders")  # different org
 
     def test_get_sorted_events(self):

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -1702,3 +1702,132 @@ class CampaignTest(TembaTest):
         self.assertEqual(campaign_event.event_type, "M")
         self.assertEqual(campaign_event.message, {"base": "oy, pancake man, come back"})
         self.assertEqual(campaign_event.delivery_hour, -1)
+
+
+class CampaignEventCRUDLTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+
+        self.campaign1 = self.create_campaign(self.org)
+        self.other_org_campaign = self.create_campaign(self.org2)
+
+    def create_campaign(self, org):
+        user = org.get_user()
+        group = self.create_group("Reporters", contacts=[], org=org)
+        registered = self.create_field("registered", "Registered", value_type="D", org=org)
+        flow = self.create_flow(org=org)
+        campaign = Campaign.create(org, user, "Welcomes", group)
+        CampaignEvent.create_flow_event(
+            org, user, campaign, registered, offset=1, unit="W", flow=flow, delivery_hour="13"
+        )
+        CampaignEvent.create_flow_event(
+            org, user, campaign, registered, offset=2, unit="W", flow=flow, delivery_hour="13"
+        )
+        return campaign
+
+    def test_read(self):
+        event1 = self.campaign1.events.order_by("id").first()
+        other_org_event1 = self.other_org_campaign.events.order_by("id").first()
+
+        read_url = reverse("campaigns.campaignevent_read", args=[event1.id])
+
+        # can't view event if not logged in
+        response = self.client.get(read_url)
+        self.assertLoginRedirect(response)
+
+        self.login(self.admin)
+
+        response = self.client.get(read_url)
+        self.assertContains(response, "Welcomes")
+        self.assertContains(response, "1 Week After")
+        self.assertContains(response, "Registered")
+
+        # can't view event from other org
+        response = self.client.get(reverse("campaigns.campaignevent_read", args=[other_org_event1.id]))
+        self.assertLoginRedirect(response)
+
+    def test_update(self):
+        event1, event2 = self.campaign1.events.order_by("id")
+        other_org_event1 = self.other_org_campaign.events.order_by("id").first()
+
+        update_url = reverse("campaigns.campaignevent_update", args=[event1.id])
+
+        # can't view update form if not logged in
+        response = self.client.get(update_url)
+        self.assertLoginRedirect(response)
+
+        self.login(self.admin)
+
+        response = self.client.get(update_url)
+        self.assertEqual(
+            [
+                "event_type",
+                "relative_to",
+                "offset",
+                "unit",
+                "delivery_hour",
+                "direction",
+                "flow_to_start",
+                "flow_start_mode",
+                "message_start_mode",
+                "eng",
+                "loc",
+            ],
+            list(response.context["form"].fields.keys()),
+        )
+
+        # can't view update form for event from other org
+        response = self.client.get(reverse("campaigns.campaignevent_update", args=[other_org_event1.id]))
+        self.assertLoginRedirect(response)
+
+        accepted = self.create_field("accepted", "Accepted", value_type="D")
+
+        # update the first event
+        response = self.client.post(
+            update_url,
+            {
+                "relative_to": accepted.id,
+                "event_type": "M",
+                "eng": "Hi there",
+                "direction": "B",
+                "offset": 2,
+                "unit": "D",
+                "flow_to_start": "",
+                "delivery_hour": 11,
+            },
+        )
+        self.assertEqual(302, response.status_code)
+
+        # original event will be unchanged.. except to be inactive
+        event1.refresh_from_db()
+        self.assertEqual("F", event1.event_type)
+        self.assertFalse(event1.is_active)
+
+        # but will have a new replacement event
+        new_event1 = self.campaign1.events.filter(id__gt=event2.id).get()
+
+        self.assertEqual(accepted, new_event1.relative_to)
+        self.assertEqual("M", new_event1.event_type)
+        self.assertEqual(-2, new_event1.offset)
+        self.assertEqual("D", new_event1.unit)
+
+        # can't update event in other org
+        response = self.client.post(
+            update_url,
+            {
+                "relative_to": other_org_event1.relative_to,
+                "event_type": "M",
+                "eng": "Hi there",
+                "direction": "B",
+                "offset": 2,
+                "unit": "D",
+                "flow_to_start": "",
+                "delivery_hour": 11,
+            },
+        )
+        self.assertEqual(404, response.status_code)
+
+        # check event is unchanged
+        other_org_event1.refresh_from_db()
+        self.assertEqual("F", other_org_event1.event_type)
+        self.assertTrue(other_org_event1.is_active)

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -594,7 +594,7 @@ class CampaignEventCRUDL(SmartCRUDL):
         def get_cancel_url(self):  # pragma: needs cover
             return reverse("campaigns.campaign_read", args=[self.object.campaign.pk])
 
-    class Update(OrgPermsMixin, ModalMixin, SmartUpdateView):
+    class Update(OrgObjPermsMixin, ModalMixin, SmartUpdateView):
         success_message = ""
         form_class = CampaignEventForm
         submit_button_name = _("Update Event")
@@ -620,6 +620,9 @@ class CampaignEventCRUDL(SmartCRUDL):
             kwargs = super().get_form_kwargs()
             kwargs["user"] = self.request.user
             return kwargs
+
+        def get_object_org(self):
+            return self.get_object().campaign.org
 
         def get_context_data(self, **kwargs):
             return super().get_context_data(**kwargs)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -524,7 +524,6 @@ class ChannelTest(TembaTest):
 
         # test that editors have the channel of the the org the are using
         other_user = self.create_user("Other")
-        self.setUpSecondaryOrg()
         self.org2.administrators.add(other_user)
         self.org.editors.add(other_user)
         self.assertFalse(self.org2.channels.all())
@@ -1978,7 +1977,6 @@ class ChannelCountTest(TembaTest):
 class ChannelLogTest(TembaTest):
     def test_channellog_views(self):
         contact = self.create_contact("Fred Jones", "+12067799191")
-        self.setUpSecondaryOrg(100_000)
 
         # create unrelated incoming message
         self.create_incoming_msg(contact, "incoming msg")

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1019,7 +1019,8 @@ class ChannelTest(TembaTest):
         # Nexmo delegate should have been released as well
         nexmo.refresh_from_db()
         self.assertFalse(nexmo.is_active)
-        self.releaseChannels(delete=True)
+
+        Channel.objects.all().delete()
 
         # check we queued session interrupt tasks for each channel
         mock_queue_interrupt.assert_has_calls(calls=[call(self.org, channel=nexmo), call(self.org, channel=android)])

--- a/temba/channels/types/android/tests.py
+++ b/temba/channels/types/android/tests.py
@@ -330,7 +330,6 @@ class AndroidTypeTest(TembaTest):
         )
 
         # create channel in another org
-        self.setUpSecondaryOrg()
         Channel.create(self.org2, self.admin2, "RW", "A", "", "+250788382382")
 
         # can claim it with this number, and because it's a fully qualified RW number, doesn't matter that channel is US

--- a/temba/classifiers/tests.py
+++ b/temba/classifiers/tests.py
@@ -44,7 +44,6 @@ INTENT_RESPONSE = """
 class ClassifierTest(TembaTest):
     def setUp(self):
         super().setUp()
-        self.setUpSecondaryOrg()
 
         # create some classifiers
         self.c1 = Classifier.create(self.org, self.admin, WitType.slug, "Booker", {}, sync=False)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -772,7 +772,6 @@ class ContactGroupCRUDLTest(TembaTest):
 
         ContactGroup.user_groups.get(org=self.org, name="Frank", query="tel = 1234")
 
-        self.setUpSecondaryOrg()
         self.release(ContactGroup.user_groups.all())
 
         for i in range(ContactGroup.MAX_ORG_CONTACTGROUPS):
@@ -2645,7 +2644,6 @@ class ContactTest(TembaTest):
             self.assertContains(response, "file.mp4")
 
             # can't view history of contact in another org
-            self.setUpSecondaryOrg()
             hans = self.create_contact("Hans", twitter="hans", org=self.org2)
             response = self.client.get(reverse("contacts.contact_history", args=[hans.uuid]))
             self.assertLoginRedirect(response)
@@ -3132,7 +3130,6 @@ class ContactTest(TembaTest):
             )
 
         # can't view contact in another org
-        self.setUpSecondaryOrg()
         hans = self.create_contact("Hans", twitter="hans", org=self.org2)
         response = self.client.get(reverse("contacts.contact_read", args=[hans.uuid]))
         self.assertLoginRedirect(response)
@@ -6862,9 +6859,6 @@ class ContactFieldTest(TembaTest):
     def test_json(self):
         contact_field_json_url = reverse("contacts.contactfield_json")
 
-        self.org2 = Org.objects.create(
-            name="kLab", timezone="Africa/Kigali", created_by=self.admin, modified_by=self.admin
-        )
         for i in range(30):
             key = "key%d" % i
             label = "label%d" % i

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -70,6 +70,8 @@ class ContactCRUDLTest(TembaTest):
         ContactField.get_or_create(self.org, self.user, "age", "Age", value_type="N")
         ContactField.get_or_create(self.org, self.user, "home", "Home", value_type="S", priority=10)
 
+        self.org.create_sample_flows("https://api.rapidpro.io")
+
     def test_list(self):
         self.login(self.user)
         list_url = reverse("contacts.contact_list")

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1888,7 +1888,7 @@ class ContactFieldCRUDL(SmartCRUDL):
             response["Temba-Success"] = self.get_success_url()
             return response
 
-    class Update(ModalMixin, OrgPermsMixin, SmartUpdateView):
+    class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
         queryset = ContactField.user_fields
         form_class = UpdateContactFieldForm
         success_message = ""

--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -479,7 +479,6 @@ class FlowMigrationTest(TembaTest):
 
     def test_migrate_to_11_12_other_org_new_flow(self):
         # change ownership of the channel it's referencing
-        self.setUpSecondaryOrg()
         self.channel.org = self.org2
         self.channel.save(update_fields=("org",))
 
@@ -499,7 +498,6 @@ class FlowMigrationTest(TembaTest):
         self.assertEqual(flow.revisions.order_by("revision").last().spec_version, "11.11")
 
         # change ownership of the channel it's referencing
-        self.setUpSecondaryOrg()
         self.channel.org = self.org2
         self.channel.save(update_fields=("org",))
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1451,7 +1451,8 @@ class FlowTest(TembaTest):
         str(FlowCategoryCount.objects.all().first())
 
         # and if we delete our runs, things zero out
-        self.releaseRuns()
+        for run in FlowRun.objects.all():
+            run.release()
 
         counts = favorites.get_category_counts()
         assertCount(counts, "beer", "Turbo King", 0)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -94,7 +94,6 @@ class FlowTest(TembaTest):
         flow3 = Flow.create(self.org, self.admin, Flow.get_unique_name(self.org, "Sheep Poll"), base_language="base")
         self.assertEqual(flow3.name, "Sheep Poll 3")
 
-        self.setUpSecondaryOrg()
         self.assertEqual(Flow.get_unique_name(self.org2, "Sheep Poll"), "Sheep Poll")  # different org
 
     @patch("temba.mailroom.queue_interrupt")
@@ -1829,8 +1828,6 @@ class FlowTest(TembaTest):
         self.org.viewers.add(self.viewer)
         self.viewer.set_org(self.org)
 
-        self.setUpSecondaryOrg()
-
         # create a flow for another org and a flow label
         flow2 = Flow.create(self.org2, self.admin2, "Flow2")
         flow_label = FlowLabel.objects.create(name="one", org=self.org, parent=None)
@@ -2428,8 +2425,6 @@ class FlowCRUDLTest(TembaTest):
     def test_views(self):
         contact = self.create_contact("Eric", "+250788382382")
         flow = self.get_flow("color", legacy=True)
-
-        self.setUpSecondaryOrg()
 
         # create a flow for another org
         other_flow = Flow.create(self.org2, self.admin2, "Flow2", base_language="base")

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -144,7 +144,6 @@ class LocationTest(TembaTest):
 
         self.assertEqual(200, response.status_code)
 
-        self.setUpSecondaryOrg()
         BoundaryAlias.objects.create(
             boundary=self.state1, org=self.org2, name="KGL", created_by=self.admin2, modified_by=self.admin2
         )

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2688,7 +2688,6 @@ class LabelCRUDLTest(TembaTest):
         Label.get_or_create(self.org, self.user, "Junk", folder=folder)
         Label.get_or_create(self.org, self.user, "Important")
 
-        self.setUpSecondaryOrg()
         Label.get_or_create(self.org2, self.admin2, "Other Org")
 
         # viewers can't edit flows so don't have access to this JSON endpoint as that's only place it's used

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -13,14 +13,12 @@ import stripe.error
 from bs4 import BeautifulSoup
 from dateutil.relativedelta import relativedelta
 from smartmin.csv_imports.models import ImportTask
-from smartmin.tests import SmartminTestMixin
 
 from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
-from django.test import TransactionTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -52,7 +50,7 @@ from temba.middleware import BrandingMiddleware
 from temba.msgs.models import ExportMessagesTask, Label, Msg
 from temba.orgs.models import Debit, UserSettings
 from temba.request_logs.models import HTTPLog
-from temba.tests import ESMockWithScroll, MockResponse, TembaTest, TembaTestMixin, matchers
+from temba.tests import ESMockWithScroll, MockResponse, TembaNonAtomicTest, TembaTest, matchers
 from temba.tests.engine import MockSessionWriter
 from temba.tests.s3 import MockS3Client
 from temba.tests.twilio import MockRequestValidator, MockTwilioClient
@@ -185,9 +183,9 @@ class UserTest(TembaTest):
         self.assertFalse(self.org.is_active)
 
 
-class OrgDeleteTest(TransactionTestCase, TembaTestMixin, SmartminTestMixin):
+class OrgDeleteTest(TembaNonAtomicTest):
     def setUp(self):
-        self.setUpOrg()
+        self.setUpOrgs()
         self.setUpLocations()
 
         # set up a sync event and alert on our channel
@@ -499,7 +497,8 @@ class OrgTest(TembaTest):
         self.assertEqual(tigo, self.org.get_channel_for_role(Channel.ROLE_SEND, "tel", tigo_urn))
 
     def test_get_send_channel_for_tel_short_code(self):
-        self.releaseChannels()
+        self.channel.release()
+
         short_code = Channel.create(self.org, self.admin, "RW", "KN", "MTN", "5050")
         Channel.create(self.org, self.admin, "RW", "WA", name="WhatsApp", address="+250788383000", tps=15)
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1336,8 +1336,6 @@ class OrgTest(TembaTest):
 
         choose_url = reverse("orgs.org_choose")
 
-        # have a second org
-        self.setUpSecondaryOrg()
         self.login(self.admin)
 
         response = self.client.get(reverse("orgs.org_home"))

--- a/temba/public/tests.py
+++ b/temba/public/tests.py
@@ -1,16 +1,12 @@
 from unittest.mock import MagicMock
 
-from smartmin.tests import _CRUDLTest
-
-from django.contrib.auth.models import User
 from django.core.files import File
 from django.urls import reverse
 
 from temba.apks.models import Apk
-from temba.tests import TembaTest, TembaTestMixin
+from temba.tests import TembaTest
 
 from .models import Lead, Video
-from .views import VideoCRUDL
 
 
 class PublicTest(TembaTest):
@@ -191,14 +187,100 @@ class PublicTest(TembaTest):
         self.assertEqual(len(response.context["urlset"]), num_fixed_items + 1)
 
 
-class VideoCRUDLTest(TembaTestMixin, _CRUDLTest):
-    def setUp(self):
-        super().setUp()
-        self.crudl = VideoCRUDL
-        self.user = User.objects.create_superuser("admin", "a@b.com", "admin")
+class VideoCRUDLTest(TembaTest):
+    def test_create_and_update(self):
+        create_url = reverse("public.video_create")
 
-    def getCreatePostData(self):
-        return dict(name="Video One", description="My description", summary="My Summary", vimeo_id="1234", order=0)
+        payload = {
+            "name": "Video One",
+            "description": "My description",
+            "summary": "My Summary",
+            "vimeo_id": "1234",
+            "order": 0,
+        }
 
-    def getUpdatePostData(self):
-        return dict(name="Video Updated", description="My description", summary="My Summary", vimeo_id="1234", order=0)
+        # can't create if not logged in
+        response = self.client.post(create_url, payload)
+        self.assertLoginRedirect(response)
+
+        # can't create as org user
+        self.login(self.admin)
+        response = self.client.post(create_url, payload)
+        self.assertLoginRedirect(response)
+
+        # can create as superuser
+        self.login(self.superuser)
+        response = self.client.post(create_url, payload)
+        self.assertEqual(302, response.status_code)
+
+        video = Video.objects.get()
+        self.assertEqual("Video One", video.name)
+        self.assertEqual("My description", video.description)
+        self.assertEqual("My Summary", video.summary)
+        self.assertEqual("1234", video.vimeo_id)
+        self.assertEqual(0, video.order)
+
+        payload = {
+            "name": "Name 2",
+            "description": "Description 2",
+            "summary": "Summary 2",
+            "vimeo_id": "4567",
+            "order": 2,
+        }
+
+        update_url = reverse("public.video_update", args=[video.id])
+
+        self.client.logout()
+
+        # can't update if not logged in
+        response = self.client.post(update_url, payload)
+        self.assertLoginRedirect(response)
+
+        # can't update as org user
+        self.login(self.admin)
+        response = self.client.post(update_url, payload)
+        self.assertLoginRedirect(response)
+
+        # can update as superuser
+        self.login(self.superuser)
+        response = self.client.post(update_url, payload)
+        self.assertEqual(302, response.status_code)
+
+        video.refresh_from_db()
+        self.assertEqual("Name 2", video.name)
+        self.assertEqual("Description 2", video.description)
+        self.assertEqual("Summary 2", video.summary)
+        self.assertEqual("4567", video.vimeo_id)
+        self.assertEqual(2, video.order)
+
+    def test_read_and_list(self):
+        video1 = Video.objects.create(
+            name="Video One",
+            summary="Unicorn",
+            description="Video of unicorns",
+            vimeo_id="1234",
+            order=0,
+            created_by=self.superuser,
+            modified_by=self.superuser,
+        )
+        video2 = Video.objects.create(
+            name="Video One",
+            summary="Unicorn",
+            description="Video of unicorns",
+            vimeo_id="1234",
+            order=0,
+            created_by=self.superuser,
+            modified_by=self.superuser,
+        )
+
+        list_url = reverse("public.video_list")
+        read_url = reverse("public.video_read", args=[video1.id])
+
+        # don't need to be logged in to list
+        response = self.client.get(list_url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual([video1, video2], list(response.context["object_list"]))
+
+        # don't need to be logged in to read
+        response = self.client.get(read_url)
+        self.assertEqual(200, response.status_code)

--- a/temba/request_logs/tests.py
+++ b/temba/request_logs/tests.py
@@ -14,7 +14,6 @@ from .tasks import trim_http_logs_task
 class HTTPLogTest(TembaTest):
     def setUp(self):
         super().setUp()
-        self.setUpSecondaryOrg()
 
         # create some classifiers
         self.c1 = Classifier.create(self.org, self.admin, WitType.slug, "Booker", {}, sync=False)

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -57,7 +57,6 @@ class TembaTestMixin:
             created_by=self.user,
             modified_by=self.user,
         )
-        self.org.initialize(topup_size=1000)
 
         # add users to the org
         self.user.set_org(self.org)
@@ -81,10 +80,12 @@ class TembaTestMixin:
             created_by=self.admin2,
             modified_by=self.admin2,
         )
-        self.org2.initialize(topup_size=1000)
 
         self.org2.administrators.add(self.admin2)
         self.admin2.set_org(self.org)
+
+        self.org.initialize(topup_size=1000)  # has to after we create users
+        self.org2.initialize(topup_size=1000)
 
         self.superuser.set_org(self.org)
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -57,6 +57,7 @@ class TembaTestMixin:
             created_by=self.user,
             modified_by=self.user,
         )
+        self.org.initialize(topup_size=1000)
 
         # add users to the org
         self.user.set_org(self.org)
@@ -80,12 +81,10 @@ class TembaTestMixin:
             created_by=self.admin2,
             modified_by=self.admin2,
         )
+        self.org2.initialize(topup_size=1000)
 
         self.org2.administrators.add(self.admin2)
         self.admin2.set_org(self.org)
-
-        self.org.initialize(topup_size=1000)  # has to after we create users
-        self.org2.initialize(topup_size=1000)
 
         self.superuser.set_org(self.org)
 
@@ -534,17 +533,8 @@ class TembaTest(TembaTestMixin, SmartminTest):
                 channel.counts.all().delete()
                 channel.delete()
 
-    def releaseIVRCalls(self, delete=False):
-        self.release(IVRCall.objects.all(), delete=delete)
-
-    def releaseMessages(self):
-        self.release(Msg.objects.all())
-
     def releaseContacts(self, delete=False):
         self.release(Contact.objects.all(), delete=delete, user=self.admin)
-
-    def releaseContactFields(self, delete=False):
-        self.release(ContactField.all_fields.all(), delete=delete, user=self.admin)
 
     def releaseRuns(self, delete=False):
         self.release(FlowRun.objects.all(), delete=delete)

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -72,6 +72,20 @@ class TembaTestMixin:
         self.surveyor.set_org(self.org)
         self.org.surveyors.add(self.surveyor)
 
+        # setup a second org with a single admin
+        self.admin2 = self.create_user("Administrator2")
+        self.org2 = Org.objects.create(
+            name="Trileet Inc.",
+            timezone=pytz.timezone("Africa/Kigali"),
+            brand="rapidpro.io",
+            created_by=self.admin2,
+            modified_by=self.admin2,
+        )
+        self.org2.initialize(topup_size=1000)
+
+        self.org2.administrators.add(self.admin2)
+        self.admin2.set_org(self.org)
+
         self.superuser.set_org(self.org)
 
         # a single Android channel
@@ -497,20 +511,6 @@ class TembaTestMixin:
 class TembaTest(TembaTestMixin, SmartminTest):
     def setUp(self):
         self.setUpOrg()
-
-    def setUpSecondaryOrg(self, topup_size=None):
-        self.admin2 = self.create_user("Administrator2")
-        self.org2 = Org.objects.create(
-            name="Trileet Inc.",
-            timezone=pytz.timezone("Africa/Kigali"),
-            brand="rapidpro.io",
-            created_by=self.admin2,
-            modified_by=self.admin2,
-        )
-        self.org2.administrators.add(self.admin2)
-        self.admin2.set_org(self.org)
-
-        self.org2.initialize(topup_size=topup_size)
 
     def tearDown(self):
         clear_flow_users()


### PR DESCRIPTION
* Fix campaign events not being protected by org
* Every test runs with two orgs in the database
* More testing with objects belonging to the other org
* Replace `_CRUDLTest` based tests with regular `TembaTest`