### PR TITLE
🔥 Fix for API explorer endpoints that have a body editor but not a query string editor

### DIFF
--- a/templates/api/v2/api_explorer.haml
+++ b/templates/api/v2/api_explorer.haml
@@ -123,8 +123,8 @@
       var queryEditor = $("#request-query-" + slug);
       var bodyEditor = $("#request-body-" + slug);
 
-      var query = queryEditor ? ensureQueryPrefix(queryEditor.val()) : '';
-      var body = bodyEditor ? bodyEditor.val() : null;
+      var query = queryEditor.length ? ensureQueryPrefix(queryEditor.val()) : '';
+      var body = bodyEditor.length ? bodyEditor.val() : null;
 
       $("#result-" + slug).text("Requesting...");
 


### PR DESCRIPTION
E.g. flow_starts because you can create but you can't update: https://app.intercom.com/a/apps/l6e7tr01/inbox/inbox/155936/conversations/26086593136