### PR TITLE
🆘 Return validation errors from engine as detail field

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -683,7 +683,7 @@ class Flow(TembaModel):
 
         # save a new revision but we can't validate it just yet because we're in a transaction and mailroom
         # won't see any new database objects
-        self.save_revision(user, cloned_definition, validate=False)
+        self.save_revision(user, cloned_definition)
 
     def import_legacy_definition(self, flow_json, uuid_map):
         """
@@ -1196,7 +1196,7 @@ class Flow(TembaModel):
             if self.is_legacy():
                 self.update(flow_def, user=get_flow_user(self.org))
             else:
-                self.save_revision(get_flow_user(self.org), flow_def, validate=False)
+                self.save_revision(get_flow_user(self.org), flow_def)
 
             self.refresh_from_db()
 
@@ -1222,7 +1222,7 @@ class Flow(TembaModel):
         """
         return self.revisions.order_by("revision").last()
 
-    def save_revision(self, user, definition, validate=True):
+    def save_revision(self, user, definition):
         """
         Saves a new revision for this flow, validation will be done on the definition first
         """

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -372,13 +372,15 @@ class FlowCRUDL(SmartCRUDL):
                     }
                 )
 
-            except FlowValidationException:  # pragma: no cover
+            except FlowValidationException as e:
                 error = _("Your flow failed validation. Please refresh your browser.")
+                detail = str(e)
             except FlowVersionConflictException:
                 error = _(
                     "Your flow has been upgraded to the latest version. "
                     "In order to continue editing, please refresh your browser."
                 )
+                detail = None
             except FlowUserConflictException as e:
                 error = (
                     _(
@@ -387,13 +389,15 @@ class FlowCRUDL(SmartCRUDL):
                     )
                     % e.other_user
                 )
+                detail = None
             except Exception as e:  # pragma: no cover
                 import traceback
 
                 traceback.print_stack(e)
                 error = _("Your flow could not be saved. Please refresh your browser.")
+                detail = None
 
-            return JsonResponse({"status": "failure", "description": error}, status=400)
+            return JsonResponse({"status": "failure", "description": error, "detail": detail}, status=400)
 
     class OrgQuerysetMixin(object):
         def derive_queryset(self, *args, **kwargs):


### PR DESCRIPTION
At very least then we can read this in the browser console