### PR TITLE
Stop using FlowStart.modified_by so that it can be removed

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -929,7 +929,6 @@ class Flow(TembaModel):
             restart_participants=restart_participants,
             include_active=include_active,
             created_by=user,
-            modified_by=user,
             query=query,
         )
 
@@ -3151,14 +3150,12 @@ class FlowStart(models.Model):
     # when this flow start was created
     created_on = models.DateTimeField(default=timezone.now, editable=False)
 
-    # deprecated fields
-    is_active = models.BooleanField(default=True, null=True)
-
-    modified_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT, null=True)
-
-    modified_on = models.DateTimeField(default=timezone.now, editable=False, null=True)
-
     contact_count = models.IntegerField(default=0, null=True)
+
+    # TODO: remove these deprecated fields
+    is_active = models.BooleanField(default=True, null=True)
+    modified_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT, null=True)
+    modified_on = models.DateTimeField(default=timezone.now, editable=False, null=True)
 
     @classmethod
     def create(

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1489,7 +1489,7 @@ class FlowTest(TembaTest):
         flow = self.get_flow("color", legacy=True)
 
         # create start for 10 contacts
-        start = FlowStart.objects.create(flow=flow, created_by=self.admin, modified_by=self.admin)
+        start = FlowStart.objects.create(flow=flow, created_by=self.admin)
         for i in range(10):
             contact = self.create_contact("Bob", twitter=f"bobby{i}")
             start.contacts.add(contact)


### PR DESCRIPTION
We have a TODO to drop some fields on `FlowStart` that we no longer use but can't do that until we've removed the last usage.