### PR TITLE
🏺 Ensure ivr_retry value is preserved when saving revisions

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2608,6 +2608,10 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         voice_flow.refresh_from_db()
         self.assertEqual(voice_flow.metadata["ivr_retry"], 1440)
 
+        # check we still have that value after saving a new revision
+        voice_flow.save_revision(self.admin, voice_flow.as_json())
+        self.assertEqual(voice_flow.metadata["ivr_retry"], 1440)
+
         # update flow triggers, and test if form has expected fields
         post_data = dict()
         response = self.client.post(reverse("flows.flow_update", args=[flow3.pk]), post_data, follow=True)
@@ -2680,7 +2684,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # check flow listing
         response = self.client.get(reverse("flows.flow_list"))
-        self.assertEqual(list(response.context["object_list"]), [flow3, voice_flow, flow2, flow1, flow])  # by saved_on
+        self.assertEqual(list(response.context["object_list"]), [voice_flow, flow3, flow2, flow1, flow])  # by saved_on
 
         # test getting the json
         response = self.client.get(reverse("flows.flow_json", args=[flow.uuid]))

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -699,7 +699,7 @@ class FlowCRUDL(SmartCRUDL):
                 metadata[Flow.CONTACT_CREATION] = self.form.cleaned_data[Flow.CONTACT_CREATION]
 
             if "ivr_retry" in self.form.cleaned_data:
-                metadata["ivr_retry"] = int(self.form.cleaned_data["ivr_retry"])
+                metadata[Flow.METADATA_IVR_RETRY] = int(self.form.cleaned_data["ivr_retry"])
 
             obj.metadata = metadata
             return obj


### PR DESCRIPTION
Legacy flows use metadata as an ever accumulating bod, new flows have been just setting this to the output of flow inspection. 

Best I can tell the only thing mailroom expects to be able to read from metadata is `ivr_retry`.. so need to make sure we preserve that.

You can observe this problem if you change `ivr_retry` on an IVR flow, then do anything to trigger an editor save, and the previous value will be lost.