### PR TITLE
🌐 Use actual PO library to check for msgid differences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ script:
   - set -e
 
   # test that everything is well formatted, no missing migrations etc
-  - ./code_check.py
+  - ./code_check.py --debug
 
   # run our Javascript tests
   - node_modules/karma/bin/karma start karma.conf.coffee --single-run --browsers PhantomJS


### PR DESCRIPTION
Digging into why [this Transifex PR](https://github.com/rapidpro/rapidpro/pull/1201) is failing and it seems they now word wrap generated PO files to 79 (?) chars so..

```
msgid "This URL should be called by ArabiaCell when new messages are received."
```

becomes

```
msgid ""
"This URL should be called by ArabiaCell when new messages are received."
```

and our approach of using grep to find significant differences fails because it's just comparing lines starting with  `msgid`