### PR TITLE
🔧 code_check.py doesn't need to check for changes in djangojs.po

### DIFF
--- a/code_check.py
+++ b/code_check.py
@@ -39,11 +39,10 @@ def update_po_files():
     saved_msgids = get_current_msgids()
 
     # re-extract locale files from source code
-    ignore_paths = ("env/*", "static/bower/*", "static/components/*", "node_modules/*")
+    ignore_paths = ("env/*", "fabric/*", "media/*", "sitestatic/*", "static/*", "node_modules/*")
     ignore_args = " ".join([f'--ignore="{p}"' for p in ignore_paths])
 
     cmd(f"python manage.py makemessages -a -e haml,html,txt,py --no-location --no-wrap {ignore_args}")
-    cmd(f"python manage.py makemessages -d djangojs -a --no-location --no-wrap {ignore_args}")
 
     # get the new set of msgids
     actual_msgids = get_current_msgids()


### PR DESCRIPTION
We don't use this it for any of the new frontend stuff so there's no point in creating new versions of djangojs.po files that just have date header changes