### PR TITLE
Remove csrf exemption for views that don't need it

### DIFF
--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -6,7 +6,6 @@ from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
-from django.views.decorators.csrf import csrf_exempt
 
 from temba.contacts.models import ContactField, ContactGroup
 from temba.flows.models import Flow
@@ -30,7 +29,6 @@ class CampaignActionForm(BaseActionForm):
 
 
 class CampaignActionMixin(SmartListView):
-    @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -32,7 +32,6 @@ from django.utils import timezone
 from django.utils.http import is_safe_url, urlquote_plus
 from django.utils.translation import ugettext_lazy as _
 from django.views import View
-from django.views.decorators.csrf import csrf_exempt
 
 from temba.archives.models import Archive
 from temba.channels.models import Channel
@@ -355,7 +354,6 @@ class ContactActionForm(BaseActionForm):
 
 
 class ContactActionMixin(SmartListView):
-    @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -164,7 +164,6 @@ class FlowActionForm(BaseActionForm):
 
 
 class FlowActionMixin(SmartListView):
-    @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -20,7 +20,6 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import is_safe_url, urlquote_plus
 from django.utils.translation import ugettext_lazy as _
-from django.views.decorators.csrf import csrf_exempt
 
 from temba.archives.models import Archive
 from temba.channels.models import Channel
@@ -464,7 +463,6 @@ class MsgActionForm(BaseActionForm):
 
 
 class MsgActionMixin(SmartListView):
-    @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import ugettext_lazy as _
-from django.views.decorators.csrf import csrf_exempt
 
 from temba.channels.models import Channel
 from temba.contacts.models import ContactGroup, ContactURN
@@ -359,7 +358,6 @@ class TriggerActionForm(BaseActionForm):
 
 
 class TriggerActionMixin(SmartListView):
-    @csrf_exempt
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 


### PR DESCRIPTION
I think early on we hadn't figured out how to pass CSRF tokens globally through our JS HTTP calls. We now do that so all of these action views being exempt is not needed. (and a theoretical security risk). 

Tested locally, will test on staging too before we go out live but tokens are definitely being sent.