### PR TITLE
👪 Always use mailroom for group changes

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -822,9 +822,9 @@ class ContactBulkActionSerializer(WriteSerializer):
         group = self.validated_data.get("group")
 
         if action == self.ADD:
-            group.update_contacts(user, contacts, add=True)
+            Contact.bulk_change_group(user, contacts, group, add=True)
         elif action == self.REMOVE:
-            group.update_contacts(user, contacts, add=False)
+            Contact.bulk_change_group(user, contacts, group, add=False)
         elif action == self.INTERRUPT:
             mailroom.queue_interrupt(self.context["org"], contacts=contacts)
         elif action == self.ARCHIVE:

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1599,9 +1599,13 @@ class APITest(TembaTest):
         contact3.release(self.user)
 
         # put some contacts in a group
-        group = ContactGroup.get_or_create(self.org, self.admin, "Customers")
-        group.update_contacts(self.user, [self.joe], add=True)  # add contacts separately for predictable modified_on
-        group.update_contacts(self.user, [contact4], add=True)  # ordering
+        group = self.create_group("Customers", contacts=[self.joe, contact4])
+
+        # tweak modified_on so we get the order we want
+        self.joe.modified_on = timezone.now()
+        self.joe.save(update_fields=("modified_on",), handle_update=False)
+        contact4.modified_on = timezone.now()
+        contact4.save(update_fields=("modified_on",), handle_update=False)
 
         contact1.refresh_from_db()
         contact4.refresh_from_db()

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -712,18 +712,6 @@ class CampaignTest(TembaTest):
         self.set_contact_field(self.nonfarmer, "planting_date", "1/7/2025", legacy_handle=True)
         self.assertEqual(2, EventFire.objects.filter(event__is_active=True).count())
 
-        # remove one of the farmers from the group
-        self.farmers.update_contacts(self.admin, [self.farmer1], add=False)
-
-        # should only be one event now (on farmer 2)
-        fire = EventFire.objects.get()
-        self.assertEqual(2, fire.scheduled.day)
-        self.assertEqual(6, fire.scheduled.month)
-        self.assertEqual(2022, fire.scheduled.year)
-
-        # but if we add him back in, should be updated
-        post_data = dict(name=self.farmer1.name, groups=[self.farmers.id], __urn__tel=self.farmer1.get_urn("tel").path)
-
         planting_date_field = ContactField.get_by_key(self.org, "planting_date")
 
         self.client.post(reverse("contacts.contact_update", args=[self.farmer1.id]), post_data)

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -85,7 +85,7 @@ class RemoveFromGroupForm(forms.Form):
         assert not group.is_dynamic, "can't manually add/remove contacts for a dynamic group"
 
         # remove contact from group
-        group.update_contacts(self.user, [contact], add=False)
+        Contact.bulk_change_group(self.user, [contact], group, add=False)
 
         return {"status": "success"}
 
@@ -1603,9 +1603,9 @@ class ContactGroupCRUDL(SmartCRUDL):
 
                 if preselected_contacts:
                     preselected_ids = [int(c_id) for c_id in preselected_contacts.split(",") if c_id.isdigit()]
-                    contacts = Contact.objects.filter(org=org, pk__in=preselected_ids, is_active=True)
+                    contacts = org.contacts.filter(id__in=preselected_ids, is_active=True)
 
-                    self.object.update_contacts(user, contacts, add=True)
+                    on_transaction_commit(lambda: Contact.bulk_change_group(user, contacts, self.object, add=True))
 
         def get_form_kwargs(self):
             kwargs = super().get_form_kwargs()

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -144,10 +144,13 @@ def apply_modifiers(org, user, contacts, modifiers: List):
                 fields = dict(is_blocked=False, is_stopped=False)
 
         elif mod.type == "groups":
-            add = mod.modification == "add"
             groups = ContactGroup.user_groups.filter(query=None, uuid__in=[g.uuid for g in mod.groups])
             for group in groups:
-                group.update_contacts(user, contacts, add=add)
+                assert not group.is_dynamic, "can't add/remove contacts from dynamic groups"
+                if mod.modification == "add":
+                    group.contacts.add(*contacts)
+                else:
+                    group.contacts.remove(*contacts)
 
         elif mod.type == "urns":
             assert len(contacts) == 1, "should never be trying to bulk update contact URNs"

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -628,7 +628,7 @@ class Command(BaseCommand):
                     contact, _ = Contact.get_or_create(org, urn, user=user)
                     contacts.append(contact)
 
-                group.update_contacts(user, contacts, True)
+                Contact.bulk_change_group(user, contacts, group, add=True)
 
         self._log(self.style.SUCCESS("OK") + "\n")
 


### PR DESCRIPTION
Still can't get rid of campaign event re-evaluation in RP (imports), but this gets rid of it in the case of group membership changes.