### PR TITLE
🐕‍🦺 Add error messages for all error codes from mailroom query parsing

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-20 18:24+0000\n"
+"POT-Creation-Date: 2020-07-28 21:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2367,6 +2367,52 @@ msgid "The unique group to export"
 msgstr ""
 
 msgid "The search query"
+msgstr ""
+
+#, python-format
+msgid "Invalid query syntax at '%(token)s'"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a number"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a date"
+msgstr ""
+
+#, python-format
+msgid "'%(value)s' is not a valid language code"
+msgstr ""
+
+#, python-format
+msgid "'%(value)s' is not a valid group name"
+msgstr ""
+
+#, python-format
+msgid "Using ~ with name requires token of at least %(min_token_length)s characters"
+msgstr ""
+
+#, python-format
+msgid "Using ~ with URN requires value of at least %(min_value_length)s characters"
+msgstr ""
+
+msgid "Can only use ~ with name or URN values"
+msgstr ""
+
+#, python-format
+msgid "Can only use %(operator)s with number or date values"
+msgstr ""
+
+#, python-format
+msgid "Can't check whether '%(property)s' is set or not set"
+msgstr ""
+
+#, python-format
+msgid "Can't resolve '%(property)s' to a field or URN scheme"
+msgstr ""
+
+msgid "Can't query on URNs in an anonymous workspace"
 msgstr ""
 
 msgid "day"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: TextIt\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-20 18:24+0000\n"
+"POT-Creation-Date: 2020-07-28 21:40+0000\n"
 "PO-Revision-Date: 2014-09-24 19:56+0000\n"
 "Last-Translator: TextIt <info@textit.in>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/textit/language/es/)\n"
@@ -3669,6 +3669,54 @@ msgid "The unique group to export"
 msgstr "El grupo único para exportar"
 
 msgid "The search query"
+msgstr ""
+
+#, python-format
+msgid "Invalid query syntax at '%(token)s'"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a number"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a date"
+msgstr ""
+
+#, fuzzy, python-format
+#| msgid "Using a Local Number"
+msgid "'%(value)s' is not a valid language code"
+msgstr "Con un número local"
+
+#, fuzzy, python-format
+#| msgid "Using a Local Number"
+msgid "'%(value)s' is not a valid group name"
+msgstr "Con un número local"
+
+#, python-format
+msgid "Using ~ with name requires token of at least %(min_token_length)s characters"
+msgstr ""
+
+#, python-format
+msgid "Using ~ with URN requires value of at least %(min_value_length)s characters"
+msgstr ""
+
+msgid "Can only use ~ with name or URN values"
+msgstr ""
+
+#, python-format
+msgid "Can only use %(operator)s with number or date values"
+msgstr ""
+
+#, python-format
+msgid "Can't check whether '%(property)s' is set or not set"
+msgstr ""
+
+#, python-format
+msgid "Can't resolve '%(property)s' to a field or URN scheme"
+msgstr ""
+
+msgid "Can't query on URNs in an anonymous workspace"
 msgstr ""
 
 #, fuzzy
@@ -12828,11 +12876,6 @@ msgstr ""
 #~| msgid "Your app's server access token"
 #~ msgid "Empty user access token!"
 #~ msgstr "Token de acceso desde su repositorio"
-
-#, fuzzy, python-brace-format
-#~| msgid "Using a Local Number"
-#~ msgid "f'{val}' isn't a valid number"
-#~ msgstr "Con un número local"
 
 #, fuzzy, python-brace-format
 #~| msgid "Invalid group or contact id"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-20 18:24+0000\n"
+"POT-Creation-Date: 2020-07-28 21:40+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Last-Translator: Jesus EKIE <jesus@fehudigital.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/rapidpro/teams/226/fr/)\n"
@@ -2667,6 +2667,54 @@ msgstr "Le groupe unique à exporter"
 
 msgid "The search query"
 msgstr "La requête de recherche"
+
+#, python-format
+msgid "Invalid query syntax at '%(token)s'"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a number"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a date"
+msgstr ""
+
+#, fuzzy, python-format
+#| msgid "%(day)s is not a valid day of the week"
+msgid "'%(value)s' is not a valid language code"
+msgstr "%(day)s n'est pas un jour de la semaine valide"
+
+#, fuzzy, python-format
+#| msgid "f'{val}' isn't a valid number"
+msgid "'%(value)s' is not a valid group name"
+msgstr "f'{val}' n'est pas un numéro valide"
+
+#, python-format
+msgid "Using ~ with name requires token of at least %(min_token_length)s characters"
+msgstr ""
+
+#, python-format
+msgid "Using ~ with URN requires value of at least %(min_value_length)s characters"
+msgstr ""
+
+msgid "Can only use ~ with name or URN values"
+msgstr ""
+
+#, python-format
+msgid "Can only use %(operator)s with number or date values"
+msgstr ""
+
+#, python-format
+msgid "Can't check whether '%(property)s' is set or not set"
+msgstr ""
+
+#, python-format
+msgid "Can't resolve '%(property)s' to a field or URN scheme"
+msgstr ""
+
+msgid "Can't query on URNs in an anonymous workspace"
+msgstr ""
 
 msgid "day"
 msgstr "jour"
@@ -10984,10 +11032,6 @@ msgstr "${count} trouvé pour ${query}"
 #, python-brace-format
 #~ msgid "Unrecognized field: '{prop}'"
 #~ msgstr "Champ non reconnu: '{prop}'"
-
-#, python-brace-format
-#~ msgid "f'{val}' isn't a valid number"
-#~ msgstr "f'{val}' n'est pas un numéro valide"
 
 #, python-brace-format
 #~ msgid "Unknown text comparator: '{self.comparator}'"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: TextIt\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-20 18:24+0000\n"
+"POT-Creation-Date: 2020-07-28 21:40+0000\n"
 "PO-Revision-Date: 2014-04-14 20:37+0000\n"
 "Last-Translator: produtos <produtos.ti@takenet.com.br>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/textit/language/pt_BR/)\n"
@@ -3377,6 +3377,54 @@ msgid "The unique group to export"
 msgstr "Os fluxos para exportar"
 
 msgid "The search query"
+msgstr ""
+
+#, python-format
+msgid "Invalid query syntax at '%(token)s'"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a number"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a date"
+msgstr ""
+
+#, fuzzy, python-format
+#| msgid "Using a Local Number"
+msgid "'%(value)s' is not a valid language code"
+msgstr "Use um número local"
+
+#, fuzzy, python-format
+#| msgid "Using a Local Number"
+msgid "'%(value)s' is not a valid group name"
+msgstr "Use um número local"
+
+#, python-format
+msgid "Using ~ with name requires token of at least %(min_token_length)s characters"
+msgstr ""
+
+#, python-format
+msgid "Using ~ with URN requires value of at least %(min_value_length)s characters"
+msgstr ""
+
+msgid "Can only use ~ with name or URN values"
+msgstr ""
+
+#, python-format
+msgid "Can only use %(operator)s with number or date values"
+msgstr ""
+
+#, python-format
+msgid "Can't check whether '%(property)s' is set or not set"
+msgstr ""
+
+#, python-format
+msgid "Can't resolve '%(property)s' to a field or URN scheme"
+msgstr ""
+
+msgid "Can't query on URNs in an anonymous workspace"
 msgstr ""
 
 #, fuzzy
@@ -11886,11 +11934,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Empty user access token!"
 #~ msgstr "Seu Token API é"
-
-#, fuzzy, python-brace-format
-#~| msgid "Using a Local Number"
-#~ msgid "f'{val}' isn't a valid number"
-#~ msgstr "Use um número local"
 
 #, fuzzy, python-brace-format
 #~| msgid "Invalid group or contact id"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-20 18:24+0000\n"
+"POT-Creation-Date: 2020-07-28 21:40+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Last-Translator: Hudson Brendon <hudson.brendon@ilhasoft.com.br>, 2020\n"
 "Language-Team: Russian (https://www.transifex.com/rapidpro/teams/226/ru/)\n"
@@ -2621,6 +2621,54 @@ msgstr "Уникальная группа для экспорта"
 
 msgid "The search query"
 msgstr "Поисковый запрос"
+
+#, python-format
+msgid "Invalid query syntax at '%(token)s'"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a number"
+msgstr ""
+
+#, python-format
+msgid "Unable to convert '%(value)s' to a date"
+msgstr ""
+
+#, fuzzy, python-format
+#| msgid "%(day)s is not a valid day of the week"
+msgid "'%(value)s' is not a valid language code"
+msgstr "%(day)s не является действительным днем ​​недели"
+
+#, fuzzy, python-format
+#| msgid "f'{val}' isn't a valid number"
+msgid "'%(value)s' is not a valid group name"
+msgstr "f'{val}' не является действительным номером"
+
+#, python-format
+msgid "Using ~ with name requires token of at least %(min_token_length)s characters"
+msgstr ""
+
+#, python-format
+msgid "Using ~ with URN requires value of at least %(min_value_length)s characters"
+msgstr ""
+
+msgid "Can only use ~ with name or URN values"
+msgstr ""
+
+#, python-format
+msgid "Can only use %(operator)s with number or date values"
+msgstr ""
+
+#, python-format
+msgid "Can't check whether '%(property)s' is set or not set"
+msgstr ""
+
+#, python-format
+msgid "Can't resolve '%(property)s' to a field or URN scheme"
+msgstr ""
+
+msgid "Can't query on URNs in an anonymous workspace"
+msgstr ""
 
 msgid "day"
 msgstr "день"
@@ -11148,10 +11196,6 @@ msgstr "Найдено ${count} по ${query}"
 #, python-brace-format
 #~ msgid "Unrecognized field: '{prop}'"
 #~ msgstr "Нераспознанное поле: '{prop}'"
-
-#, python-brace-format
-#~ msgid "f'{val}' isn't a valid number"
-#~ msgstr "f'{val}' не является действительным номером"
 
 #, python-brace-format
 #~ msgid "Unknown text comparator: '{self.comparator}'"

--- a/temba/contacts/search/tests.py
+++ b/temba/contacts/search/tests.py
@@ -1,5 +1,8 @@
 from unittest.mock import patch
 
+from temba.mailroom import MailroomException
+from temba.tests import TembaTest
+
 from . import ParsedQuery, SearchException
 
 
@@ -39,3 +42,100 @@ class MockParseQuery:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         return self.patch.__exit__(exc_type, exc_val, exc_tb)
+
+
+class SearchExceptionTest(TembaTest):
+    def test_str(self):
+        tests = (
+            (
+                {
+                    "error": "mismatched input '$' expecting {'(', TEXT, STRING}",
+                    "code": "unexpected_token",
+                    "extra": {"token": "$"},
+                },
+                "Invalid query syntax at '$'",
+            ),
+            (
+                {"error": "can't convert 'XZ' to a number", "code": "invalid_number", "extra": {"value": "XZ"}},
+                "Unable to convert 'XZ' to a number",
+            ),
+            (
+                {"error": "can't convert 'AB' to a date", "code": "invalid_date", "extra": {"value": "AB"}},
+                "Unable to convert 'AB' to a date",
+            ),
+            (
+                {
+                    "error": "'Cool Kids' is not a valid group name",
+                    "code": "invalid_group",
+                    "extra": {"value": "Cool Kids"},
+                },
+                "'Cool Kids' is not a valid group name",
+            ),
+            (
+                {
+                    "error": "'zzzzzz' is not a valid language code",
+                    "code": "invalid_language",
+                    "extra": {"value": "zzzz"},
+                },
+                "'zzzz' is not a valid language code",
+            ),
+            (
+                {
+                    "error": "contains operator on name requires token of minimum length 2",
+                    "code": "invalid_partial_name",
+                    "extra": {"min_token_length": "2"},
+                },
+                "Using ~ with name requires token of at least 2 characters",
+            ),
+            (
+                {
+                    "error": "contains operator on URN requires value of minimum length 3",
+                    "code": "invalid_partial_urn",
+                    "extra": {"min_value_length": "3"},
+                },
+                "Using ~ with URN requires value of at least 3 characters",
+            ),
+            (
+                {
+                    "error": "contains conditions can only be used with name or URN values",
+                    "code": "unsupported_contains",
+                    "extra": {"property": "uuid"},
+                },
+                "Can only use ~ with name or URN values",
+            ),
+            (
+                {
+                    "error": "comparisons with > can only be used with date and number fields",
+                    "code": "unsupported_comparison",
+                    "extra": {"property": "uuid", "operator": ">"},
+                },
+                "Can only use > with number or date values",
+            ),
+            (
+                {
+                    "error": "can't check whether 'uuid' is set or not set",
+                    "code": "unsupported_setcheck",
+                    "extra": {"property": "uuid", "operator": "!="},
+                },
+                "Can't check whether 'uuid' is set or not set",
+            ),
+            (
+                {
+                    "error": "can't resolve 'beers' to attribute, scheme or field",
+                    "code": "unknown_property",
+                    "extra": {"property": "beers"},
+                },
+                "Can't resolve 'beers' to a field or URN scheme",
+            ),
+            (
+                {"error": "cannot query on redacted URNs", "code": "redacted_urns"},
+                "Can't query on URNs in an anonymous workspace",
+            ),
+            ({"error": "no code here"}, "no code here",),
+        )
+
+        for response, message in tests:
+            e = MailroomException("parse_query", None, response)
+            e = SearchException.from_mailroom_exception(e)
+
+            self.assertEqual(message, str(e))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -885,12 +885,12 @@ class ContactGroupCRUDLTest(TembaTest):
         ContactGroup.user_groups.filter(id=self.dynamic_group.pk).update(status=ContactGroup.STATUS_READY)
 
         # update both name and query, form should fail, because query is not parsable
-        mr_mocks.error("error at !", code="query_unexpected_token", extra={"token": "!"})
+        mr_mocks.error("error at !", code="unexpected_token", extra={"token": "!"})
         response = self.client.post(url, dict(name="Frank", query="(!))!)"))
         self.assertFormError(response, "form", "query", "Invalid query syntax at '!'")
 
         # try to update a group with an invalid query
-        mr_mocks.error("error at >", code="query_unexpected_token", extra={"token": ">"})
+        mr_mocks.error("error at >", code="unexpected_token", extra={"token": ">"})
         response = self.client.post(url, dict(name="Frank", query="name <> some_name"))
         self.assertFormError(response, "form", "query", "Invalid query syntax at '>'")
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -885,14 +885,14 @@ class ContactGroupCRUDLTest(TembaTest):
         ContactGroup.user_groups.filter(id=self.dynamic_group.pk).update(status=ContactGroup.STATUS_READY)
 
         # update both name and query, form should fail, because query is not parsable
-        mr_mocks.parse_query("(!))!)", error="error at !")
+        mr_mocks.error("error at !", code="query_unexpected_token", extra={"token": "!"})
         response = self.client.post(url, dict(name="Frank", query="(!))!)"))
-        self.assertFormError(response, "form", "query", "error at !")
+        self.assertFormError(response, "form", "query", "Invalid query syntax at '!'")
 
         # try to update a group with an invalid query
-        mr_mocks.parse_query("name <> some_name", error="error at >")
+        mr_mocks.error("error at >", code="query_unexpected_token", extra={"token": ">"})
         response = self.client.post(url, dict(name="Frank", query="name <> some_name"))
-        self.assertFormError(response, "form", "query", "error at >")
+        self.assertFormError(response, "form", "query", "Invalid query syntax at '>'")
 
         # dependent on id
         response = self.client.post(url, dict(name="Frank", query="id = 123"))

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -31,7 +31,7 @@ class Mocks:
 
         self._parse_query[query] = mock
 
-    def error(self, msg: str, code: str, extra: Dict):
+    def error(self, msg: str, code: str = None, extra: Dict = None):
         """
         Queues an error which will become a mailroom exception at the next client call
         """

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import Dict, List
 from unittest.mock import patch
 
 from django.conf import settings
@@ -20,13 +20,8 @@ class Mocks:
         self._parse_query = {}
         self._errors = []
 
-    def parse_query(self, query, *, fields=None, allow_as_group=True, elastic_query=None, error: str = None):
-        assert not (fields and error), "can't mock with both fields and error"
-
+    def parse_query(self, query, *, fields=None, allow_as_group=True, elastic_query=None):
         def mock():
-            if error:
-                raise MailroomException("mr/parse_query", None, {"error": error})
-
             return {
                 "query": query,
                 "fields": list(fields),
@@ -36,15 +31,21 @@ class Mocks:
 
         self._parse_query[query] = mock
 
-    def error(self, msg: str):
+    def error(self, msg: str, code: str, extra: Dict):
         """
         Queues an error which will become a mailroom exception at the next client call
         """
-        self._errors.append(msg)
+        err = {"error": msg}
+        if code:
+            err["code"] = code
+        if extra:
+            err["extra"] = extra
+
+        self._errors.append(err)
 
     def _check_error(self, endpoint: str):
         if self._errors:
-            raise MailroomException(endpoint, None, {"error": self._errors.pop(0)})
+            raise MailroomException(endpoint, None, self._errors.pop(0))
 
 
 class TestClient(MailroomClient):


### PR DESCRIPTION
Addresses https://github.com/rapidpro/rapidpro/issues/1289. For example:

<img width="626" alt="Captura de Pantalla 2020-07-28 a la(s) 16 36 56" src="https://user-images.githubusercontent.com/675558/88724736-9ba17680-d0f0-11ea-8b68-399387f82f61.png">

becomes

<img width="623" alt="Captura de Pantalla 2020-07-28 a la(s) 16 37 12" src="https://user-images.githubusercontent.com/675558/88724745-9e03d080-d0f0-11ea-861a-3b99bcd502cd.png">

and can be localized.
