### PR TITLE
🔍 Use newer metadata field from mailroom search endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
 
   # install mailroom
-  - MAILROOM_VERSION=5.5.26
+  - MAILROOM_VERSION=5.7.3
   - wget https://github.com/nyaruka/mailroom/releases/download/v${MAILROOM_VERSION}/mailroom_${MAILROOM_VERSION}_linux_amd64.tar.gz
   - tar -xvf mailroom_${MAILROOM_VERSION}_linux_amd64.tar.gz mailroom
 

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from django.utils import timezone
 
 from temba.contacts.models import Contact, ContactField, ContactGroup, ImportTask
-from temba.contacts.search.tests import MockParseQuery
 from temba.flows.models import Flow, FlowRevision
 from temba.msgs.models import Msg
 from temba.orgs.models import Language, Org
@@ -1448,10 +1447,9 @@ class CampaignTest(TembaTest):
         self.assertEqual(EventFire.objects.filter(event=event, contact=anna).count(), 1)
 
         # change dynamic group query so anna is removed
-        with MockParseQuery('gender = "FEMALE"', ["gender"]):
-            women.update_query(query='gender="FEMALE"')
-            ContactGroup.user_groups.filter(id=women.id).update(status=ContactGroup.STATUS_READY)
-            anna.handle_update(fields=["gender"])
+        women.update_query(query='gender="FEMALE"')
+        ContactGroup.user_groups.filter(id=women.id).update(status=ContactGroup.STATUS_READY)
+        anna.handle_update(fields=["gender"])
 
         self.assertEqual(set(women.contacts.all()), set())
 
@@ -1459,10 +1457,9 @@ class CampaignTest(TembaTest):
         self.assertEqual(EventFire.objects.filter(event=event, contact=anna).count(), 0)
 
         # but if query is reverted, her event fire should be recreated
-        with MockParseQuery('gender = "F"', ["gender"]):
-            women.update_query("gender=F")
-            ContactGroup.user_groups.filter(id=women.id).update(status=ContactGroup.STATUS_READY)
-            anna.handle_update(fields=["gender"])
+        women.update_query("gender=F")
+        ContactGroup.user_groups.filter(id=women.id).update(status=ContactGroup.STATUS_READY)
+        anna.handle_update(fields=["gender"])
 
         self.assertEqual(set(women.contacts.all()), {anna})
 

--- a/temba/contacts/search/parser.py
+++ b/temba/contacts/search/parser.py
@@ -759,11 +759,18 @@ class ContactQLVisitor(ParseTreeVisitor):
         return value.replace(r"\"", '"')  # unescape embedded quotes
 
 
+class Metadata(NamedTuple):
+    attributes: list = []
+    schemes: list = []
+    fields: list = []
+    groups: list = []
+    allow_as_group: bool = False
+
+
 class ParsedQuery(NamedTuple):
     query: str
-    fields: list
     elastic_query: dict
-    allow_as_group: bool
+    metadata: Metadata
 
 
 def parse_query(org_id, query, group_uuid=""):
@@ -773,9 +780,7 @@ def parse_query(org_id, query, group_uuid=""):
     try:
         client = mailroom.get_client()
         response = client.parse_query(org_id, query, group_uuid=str(group_uuid))
-        return ParsedQuery(
-            response["query"], response["fields"], response["elastic_query"], response.get("allow_as_group", False)
-        )
+        return ParsedQuery(response["query"], response["elastic_query"], Metadata(**response["metadata"]),)
 
     except mailroom.MailroomException as e:
         raise SearchException.from_mailroom_exception(e)
@@ -784,9 +789,8 @@ def parse_query(org_id, query, group_uuid=""):
 class SearchResults(NamedTuple):
     total: int
     query: str
-    fields: list
-    allow_as_group: bool
     contact_ids: list
+    metadata: Metadata
 
 
 def search_contacts(org_id, group_uuid, query, sort=None, offset=None):
@@ -794,11 +798,7 @@ def search_contacts(org_id, group_uuid, query, sort=None, offset=None):
         client = mailroom.get_client()
         response = client.contact_search(org_id, str(group_uuid), query, sort, offset=offset)
         return SearchResults(
-            response["total"],
-            response["query"],
-            response["fields"],
-            response.get("allow_as_group", False),
-            response["contact_ids"],
+            response["total"], response["query"], response["contact_ids"], Metadata(**response["metadata"]),
         )
 
     except mailroom.MailroomException as e:

--- a/temba/contacts/search/parser.py
+++ b/temba/contacts/search/parser.py
@@ -770,7 +770,7 @@ class Metadata(NamedTuple):
 class ParsedQuery(NamedTuple):
     query: str
     elastic_query: dict
-    metadata: Metadata
+    metadata: Metadata = Metadata()
 
 
 def parse_query(org_id, query, group_uuid=""):
@@ -790,7 +790,7 @@ class SearchResults(NamedTuple):
     total: int
     query: str
     contact_ids: list
-    metadata: Metadata
+    metadata: Metadata = Metadata()
 
 
 def search_contacts(org_id, group_uuid, query, sort=None, offset=None):

--- a/temba/contacts/search/parser.py
+++ b/temba/contacts/search/parser.py
@@ -780,7 +780,7 @@ def parse_query(org_id, query, group_uuid=""):
     try:
         client = mailroom.get_client()
         response = client.parse_query(org_id, query, group_uuid=str(group_uuid))
-        return ParsedQuery(response["query"], response["elastic_query"], Metadata(**response["metadata"]),)
+        return ParsedQuery(response["query"], response["elastic_query"], Metadata(**response.get("metadata", {})),)
 
     except mailroom.MailroomException as e:
         raise SearchException.from_mailroom_exception(e)
@@ -798,7 +798,7 @@ def search_contacts(org_id, group_uuid, query, sort=None, offset=None):
         client = mailroom.get_client()
         response = client.contact_search(org_id, str(group_uuid), query, sort, offset=offset)
         return SearchResults(
-            response["total"], response["query"], response["contact_ids"], Metadata(**response["metadata"]),
+            response["total"], response["query"], response["contact_ids"], Metadata(**response.get("metadata", {})),
         )
 
     except mailroom.MailroomException as e:

--- a/temba/contacts/search/tests.py
+++ b/temba/contacts/search/tests.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from temba.mailroom import MailroomException
 from temba.tests import TembaTest
 
-from . import ParsedQuery, SearchException
+from . import Metadata, ParsedQuery, SearchException
 
 
 class MockParseQuery:
@@ -33,9 +33,14 @@ class MockParseQuery:
         else:
             mock.return_value = ParsedQuery(
                 query=self.query,
-                fields=self.fields,
                 elastic_query=self.elastic_query,
-                allow_as_group=self.allow_as_group,
+                metadata=Metadata(
+                    attributes=[],
+                    schemes=[],
+                    fields=[{"key": f, "name": ""} for f in self.fields],
+                    groups=[],
+                    allow_as_group=self.allow_as_group,
+                ),
             )
 
         return mock

--- a/temba/contacts/search/tests.py
+++ b/temba/contacts/search/tests.py
@@ -1,52 +1,7 @@
-from unittest.mock import patch
-
 from temba.mailroom import MailroomException
 from temba.tests import TembaTest
 
-from . import Metadata, ParsedQuery, SearchException
-
-
-class MockParseQuery:
-    """
-    Mocks temba.contacts.search.parse_query with the passed in query and fields
-    """
-
-    def __init__(self, query=None, fields=None, elastic_query=None, allow_as_group=True, error=None):
-        assert (query is not None and fields is not None and error is None) or (
-            error is not None and query is None and fields is None
-        )
-
-        if not elastic_query:
-            elastic_query = {"term": {"is_active": True}}
-
-        self.query = query
-        self.fields = fields
-        self.elastic_query = elastic_query
-        self.allow_as_group = allow_as_group
-        self.error = error
-
-    def __enter__(self):
-        self.patch = patch("temba.contacts.search.parse_query")
-        mock = self.patch.__enter__()
-        if self.error:
-            mock.side_effect = SearchException(self.error)
-        else:
-            mock.return_value = ParsedQuery(
-                query=self.query,
-                elastic_query=self.elastic_query,
-                metadata=Metadata(
-                    attributes=[],
-                    schemes=[],
-                    fields=[{"key": f, "name": ""} for f in self.fields],
-                    groups=[],
-                    allow_as_group=self.allow_as_group,
-                ),
-            )
-
-        return mock
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        return self.patch.__exit__(exc_type, exc_val, exc_tb)
+from . import SearchException
 
 
 class SearchExceptionTest(TembaTest):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -128,7 +128,7 @@ class ContactGroupForm(forms.ModelForm):
 
         try:
             parsed = parse_query(self.org.id, self.cleaned_data["query"])
-            if not parsed.allow_as_group:
+            if not parsed.metadata.allow_as_group:
                 raise forms.ValidationError(_('You cannot create a dynamic group based on "id" or "group".'))
 
             if (
@@ -264,7 +264,7 @@ class ContactListView(OrgPermsMixin, BulkActionMixin, SmartListView):
             try:
                 results = search_contacts(org.id, str(group.uuid), search_query, sort_on, offset)
                 self.parsed_query = results.query if len(results.query) > 0 else None
-                self.save_dynamic_search = results.allow_as_group
+                self.save_dynamic_search = results.metadata.allow_as_group
 
                 return IDSliceQuerySet(Contact, results.contact_ids, offset, results.total)
             except SearchException as e:
@@ -1216,7 +1216,7 @@ class ContactCRUDL(SmartCRUDL):
                 summary = {
                     "total": results.total,
                     "query": results.query,
-                    "fields": results.fields,
+                    "fields": results.metadata.fields,
                     "sample": IDSliceQuerySet(Contact, results.contact_ids, 0, results.total)[0:samples],
                 }
             except SearchException as e:
@@ -1243,9 +1243,10 @@ class ContactCRUDL(SmartCRUDL):
             summary["sample"] = json_contacts
 
             # add in our field defs
+            field_keys = [f["key"] for f in summary["fields"]]
             summary["fields"] = {
                 str(f.uuid): {"label": f.label}
-                for f in ContactField.user_fields.filter(org=org, key__in=summary["fields"], is_active=True)
+                for f in ContactField.user_fields.filter(org=org, key__in=field_keys, is_active=True)
             }
             return JsonResponse(summary)
 

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -23,18 +23,19 @@ class Mocks:
 
     @staticmethod
     def _parse_query_response(query: str, elastic: Dict, fields: List, allow_as_group: bool):
+        def field_ref(f):
+            return {"key": f.key, "name": f.label} if isinstance(f, ContactField) else {"key": f}
+
         return {
             "query": query,
             "elastic_query": elastic,
             "metadata": {
                 "attributes": [],
                 "schemes": [],
-                "fields": [{"key": f.key, "name": f.label} for f in fields],
+                "fields": [field_ref(f) for f in fields],
                 "groups": [],
                 "allow_as_group": allow_as_group,
             },
-            "fields": [f.key for f in fields],  # deprecated
-            "allow_as_group": allow_as_group,  # deprecated
         }
 
     def parse_query(self, query, *, cleaned=None, fields=(), allow_as_group=True, elastic_query=None):
@@ -59,8 +60,6 @@ class Mocks:
                     "groups": [],
                     "allow_as_group": allow_as_group,
                 },
-                "fields": [f.key for f in fields],  # deprecated
-                "allow_as_group": allow_as_group,  # deprecated
             }
 
         self._contact_search[query] = mock

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -37,10 +37,10 @@ class Mocks:
             "allow_as_group": allow_as_group,  # deprecated
         }
 
-    def parse_query(self, query, *, fields=(), allow_as_group=True, elastic_query=None):
+    def parse_query(self, query, *, cleaned=None, fields=(), allow_as_group=True, elastic_query=None):
         def mock():
             elastic = elastic_query or {"term": {"is_active": True}}
-            return self._parse_query_response(query, elastic, fields, allow_as_group)
+            return self._parse_query_response(cleaned or query, elastic, fields, allow_as_group)
 
         self._parse_query[query] = mock
 

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -18,18 +18,52 @@ from temba.utils import json
 class Mocks:
     def __init__(self):
         self._parse_query = {}
+        self._contact_search = {}
         self._errors = []
 
-    def parse_query(self, query, *, fields=None, allow_as_group=True, elastic_query=None):
-        def mock():
-            return {
-                "query": query,
-                "fields": list(fields),
+    @staticmethod
+    def _parse_query_response(query: str, elastic: Dict, fields: List, allow_as_group: bool):
+        return {
+            "query": query,
+            "elastic_query": elastic,
+            "metadata": {
+                "attributes": [],
+                "schemes": [],
+                "fields": [{"key": f.key, "name": f.label} for f in fields],
+                "groups": [],
                 "allow_as_group": allow_as_group,
-                "elastic_query": elastic_query or {"term": {"is_active": True}},
-            }
+            },
+            "fields": [f.key for f in fields],  # deprecated
+            "allow_as_group": allow_as_group,  # deprecated
+        }
+
+    def parse_query(self, query, *, fields=(), allow_as_group=True, elastic_query=None):
+        def mock():
+            elastic = elastic_query or {"term": {"is_active": True}}
+            return self._parse_query_response(query, elastic, fields, allow_as_group)
 
         self._parse_query[query] = mock
+
+    def contact_search(self, query, *, cleaned=None, contacts=(), total=0, fields=(), allow_as_group=True):
+        def mock(offset, sort):
+            return {
+                "query": cleaned or query,
+                "contact_ids": [c.id for c in contacts],
+                "total": total or len(contacts),
+                "offset": offset,
+                "sort": sort,
+                "metadata": {
+                    "attributes": [],
+                    "schemes": [],
+                    "fields": [{"key": f.key, "name": f.label} for f in fields],
+                    "groups": [],
+                    "allow_as_group": allow_as_group,
+                },
+                "fields": [f.key for f in fields],  # deprecated
+                "allow_as_group": allow_as_group,  # deprecated
+            }
+
+        self._contact_search[query] = mock
 
     def error(self, msg: str, code: str = None, extra: Dict = None):
         """
@@ -76,13 +110,18 @@ class TestClient(MailroomClient):
         # otherwise just approximate what mailroom would do
         tokens = [t.lower() for t in re.split(r"\W+", query) if t]
         fields = ContactField.all_fields.filter(org_id=org_id, key__in=tokens)
+        allow_as_group = "id" not in tokens and "group" not in tokens
 
-        return {
-            "query": query,
-            "fields": [f.key for f in fields],
-            "allow_as_group": "id" not in tokens and "group" not in tokens,
-            "elastic_query": {"term": {"is_active": True}},
-        }
+        return Mocks._parse_query_response(query, {"term": {"is_active": True}}, fields, allow_as_group)
+
+    def contact_search(self, org_id, group_uuid, query, sort, offset=0):
+        self.mocks._check_error("contact_search")
+
+        mock = self.mocks._contact_search.get(query or "")
+
+        assert mock, f"missing contact_search mock for query '{query}'"
+
+        return mock(offset, sort)
 
     def ticket_close(self, org_id, ticket_ids):
         self.mocks._check_error("ticket_close")


### PR DESCRIPTION
The search/parse mailroom endpoints always returned `fields` which was a mixture of contact fields, attributes and schemes which RP then had to sort out, but a while we ago we added a more detailed metadata blob more like what you get from flow flow inspection. This is switching the RP calling code to use that, tho ended up having to cleanup how we do mocking of searching in general.