### PR TITLE
Update temba-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -323,9 +323,9 @@
       }
     },
     "@nyaruka/temba-components": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.1.7.tgz",
-      "integrity": "sha512-p1JhdcLtpXklBfwGSVdKapAZn8UlV4kt0RtStyhqhEVeIHbjaPmHm4nWBep6unDlvfILRIPVFCWEOIA1Wn8ylw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.3.1.tgz",
+      "integrity": "sha512-nFJoDTzMsdT2qCfbZL1q69CWWg2FRA0lzGq45r8SZG1wzMixMn3oE6rERS8VJj3UrsCyE6J+JP1l7RtiiIMGtg==",
       "requires": {
         "autosize": "4.0.2",
         "axios": "0.18.1",
@@ -333,11 +333,27 @@
         "fa-icons": "^0.2.0",
         "flru": "1.0.2",
         "leaflet": "1.5.1",
-        "lit-element": "^2.0.1",
-        "lit-html": "^1.0.0",
+        "lit-element": "2.3.1",
+        "lit-flatpickr": "^0.2.2",
+        "lit-html": "1.2.1",
         "marked": "0.7.0",
         "serialize-javascript": "^3.0.0",
         "textarea-caret": "3.1.0"
+      },
+      "dependencies": {
+        "lit-element": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
+          "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+          "requires": {
+            "lit-html": "^1.1.1"
+          }
+        },
+        "lit-html": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
+          "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+        }
       }
     },
     "accepts": {
@@ -1311,6 +1327,11 @@
         "unpipe": "~1.0.0"
       }
     },
+    "flatpickr": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.3.tgz",
+      "integrity": "sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ=="
+    },
     "flatted": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
@@ -2113,9 +2134,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
           "dev": true
         }
       }
@@ -2197,15 +2218,26 @@
         "lit-html": "^1.0.0"
       }
     },
+    "lit-flatpickr": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/lit-flatpickr/-/lit-flatpickr-0.2.4.tgz",
+      "integrity": "sha512-EKEYJ2QxyS9QfFKoUcOTO/ETgzMUTZ2K1KbDkmcnemStqDWCsUrIZBe5TxNMXsC0LPfSqbQUkCjz0zfFxDhzug==",
+      "requires": {
+        "flatpickr": "^4.6.3",
+        "lit-element": "^2.2.1",
+        "lit-html": "^1.1.2",
+        "tslib": "^1.11.0"
+      }
+    },
     "lit-html": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
       "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA=="
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "log-driver": {
@@ -3338,6 +3370,11 @@
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
       }
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.9.9",
-    "@nyaruka/temba-components": "0.1.7",
+    "@nyaruka/temba-components": "0.3.1",
     "coffeescript": "1.12.7",
     "fa-icons": "0.2.0",
     "less": "2.7.1",

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -125,7 +125,7 @@
           --color-widget-border: rgb(204,204,204);
          
           /* primary colors, should be dark */
-          --color-selection: rgb(var(--primary-rgb));
+          --color-selection: #f0f6ff;
 
           --widget-box-shadow-focused: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(var(--focus-rgb), 0.6);
           --widget-box-shadow-focused-error: inset 0 1px 1px rgba(var(--error-rgb), 0.075), 0 0 8px rgba(var(--error-rgb), 0.6);


### PR DESCRIPTION
In fixing this:
https://github.com/nyaruka/floweditor/issues/890

I needed to update temba-components which hasn't updated on rapid in a while. Since the flow editor and rapid share components (two avoid double loading them), it's time to bring rapid forward.

Summary for between 0.1.5 and 0.3.1
 * Add more event hooks
 * Better support for destructive modax
 * Various styling changes
 * Support for datepicker
 * Support for embedded json option on temba-select