### PR TITLE
🚰 Fix reading of S3 event streams

### DIFF
--- a/temba/archives/models.py
+++ b/temba/archives/models.py
@@ -196,11 +196,7 @@ class Archive(models.Model):
                 if not line:
                     break
 
-                yield self._parse_record(line)
-
-    @staticmethod
-    def _parse_record(line):
-        return json.loads(line.decode("utf-8"))
+                yield json.loads(line.decode("utf-8"))
 
     def release(self):
 

--- a/temba/tests/s3.py
+++ b/temba/tests/s3.py
@@ -1,7 +1,30 @@
 import gzip
 import io
+from typing import Dict, List
 
-from temba.utils import json
+from temba.utils import chunk_list, json
+
+
+class MockEventStream:
+    def __init__(self, records: List[Dict], max_payload_size=256):
+        # serialize records as a JSONL payload
+        buffer = io.BytesIO()
+        for record in records:
+            buffer.write(json.dumps(record).encode("utf-8"))
+            buffer.write(b"\n")
+
+        payload = buffer.getvalue()
+        payload_chunks = chunk_list(payload, size=max_payload_size)
+
+        self.events = [{"Records": {"Payload": chunk}} for chunk in payload_chunks]
+        self.events.append(
+            {"Stats": {"Details": {"BytesScanned": 123, "BytesProcessed": 234, "BytesReturned": len(payload)}}},
+        )
+        self.events.append({"End": {}})
+
+    def __iter__(self):
+        for event in self.events:
+            yield event
 
 
 class MockS3Client:
@@ -12,7 +35,7 @@ class MockS3Client:
     def __init__(self):
         self.objects = {}
 
-    def put_jsonl(self, bucket, key, records):
+    def put_jsonl(self, bucket, key, records: List[Dict]):
         stream = io.BytesIO()
         gz = gzip.GzipFile(fileobj=stream, mode="wb")
 
@@ -45,19 +68,13 @@ class MockS3Client:
         stream.seek(0)
         zstream = gzip.GzipFile(fileobj=stream)
 
-        payload = io.BytesIO()
+        records = []
         while True:
             line = zstream.readline()
             if not line:
                 break
-            payload.write(line)
 
-        payload.seek(0)
+            # unlike real S3 we don't actually filter any records by expression
+            records.append(json.loads(line.decode("utf-8")))
 
-        return {
-            "Payload": [
-                {"Records": {"Payload": payload.read()}},
-                {"Stats": {"Details": {"BytesScanned": 123, "BytesProcessed": 234, "BytesReturned": 3456}}},
-                {"End": {}},
-            ]
-        }
+        return {"Payload": MockEventStream(records)}

--- a/temba/tests/s3.py
+++ b/temba/tests/s3.py
@@ -6,7 +6,7 @@ from temba.utils import chunk_list, json
 
 
 class MockEventStream:
-    def __init__(self, records: List[Dict], max_payload_size=256):
+    def __init__(self, records: List[Dict], max_payload_size: int = 256):
         # serialize records as a JSONL payload
         buffer = io.BytesIO()
         for record in records:
@@ -35,7 +35,7 @@ class MockS3Client:
     def __init__(self):
         self.objects = {}
 
-    def put_jsonl(self, bucket, key, records: List[Dict]):
+    def put_jsonl(self, bucket: str, key: str, records: List[Dict]):
         stream = io.BytesIO()
         gz = gzip.GzipFile(fileobj=stream, mode="wb")
 

--- a/temba/utils/s3.py
+++ b/temba/utils/s3.py
@@ -1,9 +1,0 @@
-from django.core.files.storage import DefaultStorage
-
-
-class PublicFileStorage(DefaultStorage):
-    default_acl = "public-read"
-
-
-public_file_storage = PublicFileStorage()
-public_file_storage.default_acl = "public-read"

--- a/temba/utils/s3/__init__.py
+++ b/temba/utils/s3/__init__.py
@@ -1,0 +1,1 @@
+from .s3 import *  # noqa

--- a/temba/utils/s3/s3.py
+++ b/temba/utils/s3/s3.py
@@ -28,8 +28,6 @@ class EventStreamReader:
                 self.buffer.extend(event["Records"]["Payload"])
 
                 lines = self.buffer.splitlines(keepends=True)
-                if not lines:
-                    continue
 
                 # if last line doesn't end with \n then it's incomplete and goes back in the buffer
                 if not lines[-1].endswith(b"\n"):

--- a/temba/utils/s3/s3.py
+++ b/temba/utils/s3/s3.py
@@ -1,0 +1,40 @@
+from typing import Dict, Iterable
+
+from django.core.files.storage import DefaultStorage
+
+from temba.utils import json
+
+
+class PublicFileStorage(DefaultStorage):
+    default_acl = "public-read"
+
+
+public_file_storage = PublicFileStorage()
+public_file_storage.default_acl = "public-read"
+
+
+class EventStreamReader:
+    """
+    Util for reading payloads from an S3 event stream and reconstructing JSONL records as they become available
+    """
+
+    def __init__(self, event_stream):
+        self.event_stream = event_stream
+        self.buffer = bytearray()
+
+    def __iter__(self) -> Iterable[Dict]:
+        for event in self.event_stream:
+            if "Records" in event:
+                self.buffer.extend(event["Records"]["Payload"])
+
+                lines = self.buffer.splitlines(keepends=True)
+                if not lines:
+                    continue
+
+                # if last line doesn't end with \n then it's incomplete and goes back in the buffer
+                if not lines[-1].endswith(b"\n"):
+                    self.buffer = bytearray(lines[-1])
+                    lines = lines[:-1]
+
+                for line in lines:
+                    yield json.loads(line.decode("utf-8"))

--- a/temba/utils/s3/tests.py
+++ b/temba/utils/s3/tests.py
@@ -1,0 +1,19 @@
+from temba.tests import TembaTest
+from temba.tests.s3 import MockEventStream
+
+from .s3 import EventStreamReader
+
+
+class EventStreamReaderTest(TembaTest):
+    def test_buffer(self):
+        stream = MockEventStream(records=[{"id": 1, "text": "Hi"}], max_payload_size=256,)
+
+        buffer = EventStreamReader(stream)
+        self.assertEqual([{"id": 1, "text": "Hi"}], list(buffer))
+
+        stream = MockEventStream(
+            records=[{"id": 1, "text": "Hi"}, {"id": 2, "text": "Hi"}, {"id": 3, "text": "Hi"}], max_payload_size=5,
+        )
+
+        buffer = EventStreamReader(stream)
+        self.assertEqual([{"id": 1, "text": "Hi"}, {"id": 2, "text": "Hi"}, {"id": 3, "text": "Hi"}], list(buffer))

--- a/temba/utils/s3/tests.py
+++ b/temba/utils/s3/tests.py
@@ -6,11 +6,19 @@ from .s3 import EventStreamReader
 
 class EventStreamReaderTest(TembaTest):
     def test_buffer(self):
-        stream = MockEventStream(records=[{"id": 1, "text": "Hi"}], max_payload_size=256,)
+        # empty payload
+        stream = MockEventStream(records=[], max_payload_size=256)
+
+        buffer = EventStreamReader(stream)
+        self.assertEqual([], list(buffer))
+
+        # single record that fits in single payload
+        stream = MockEventStream(records=[{"id": 1, "text": "Hi"}], max_payload_size=256)
 
         buffer = EventStreamReader(stream)
         self.assertEqual([{"id": 1, "text": "Hi"}], list(buffer))
 
+        # multiple records that will be split across several small payloads
         stream = MockEventStream(
             records=[{"id": 1, "text": "Hi"}, {"id": 2, "text": "Hi"}, {"id": 3, "text": "Hi"}], max_payload_size=5,
         )


### PR DESCRIPTION
I naively assumed the payloads returned in the event stream from S3 select calls would contain batches of whole JSONL records, but they're actually just chunks of 65K bytes, so requires some care reconstructing those into the original records.