### PR TITLE
⌚ Fix creating of campaign events based on last_seen_on

### DIFF
--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -973,7 +973,8 @@ class CampaignTest(TembaTest):
 
     def test_eventfire_get_relative_to_value(self):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
-        field_created_on = self.org.contactfields.get(key="created_on")
+        created_on = self.org.contactfields.get(key="created_on")
+        last_seen_on = self.org.contactfields.get(key="last_seen_on")
 
         # create a reminder for our first planting event
         event = CampaignEvent.create_flow_event(
@@ -981,25 +982,47 @@ class CampaignTest(TembaTest):
         )
         self.set_contact_field(self.farmer1, "planting_date", self.org.format_datetime(timezone.now()))
 
-        trimDate = timezone.now() - timedelta(days=settings.EVENT_FIRE_TRIM_DAYS + 1)
-        ev = EventFire.objects.create(event=event, contact=self.farmer1, scheduled=trimDate, fired=trimDate)
+        trim_date = timezone.now() - timedelta(days=settings.EVENT_FIRE_TRIM_DAYS + 1)
+        ev = EventFire.objects.create(event=event, contact=self.farmer1, scheduled=trim_date, fired=trim_date)
         self.assertIsNotNone(ev.get_relative_to_value())
 
+        # create event relative to created_on
         event2 = CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, relative_to=field_created_on, offset=3, unit="D", flow=self.reminder_flow
+            self.org, self.admin, campaign, relative_to=created_on, offset=3, unit="D", flow=self.reminder_flow
         )
 
-        trimDate = timezone.now() - timedelta(days=settings.EVENT_FIRE_TRIM_DAYS + 1)
-        ev2 = EventFire.objects.create(event=event2, contact=self.farmer1, scheduled=trimDate, fired=trimDate)
+        trim_date = timezone.now() - timedelta(days=settings.EVENT_FIRE_TRIM_DAYS + 1)
+        ev2 = EventFire.objects.create(event=event2, contact=self.farmer1, scheduled=trim_date, fired=trim_date)
         self.assertIsNotNone(ev2.get_relative_to_value())
 
         # recalculate for created on
         EventFire.update_campaign_events(campaign)
-        self.assertEqual(2, EventFire.objects.filter(event__relative_to=field_created_on, fired=None).count())
+        self.assertEqual(2, EventFire.objects.filter(event__relative_to=created_on, fired=None).count())
+
+        # create event relative to last_seen_on
+        event3 = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, relative_to=last_seen_on, offset=3, unit="D", flow=self.reminder_flow
+        )
+
+        trim_date = timezone.now() - timedelta(days=settings.EVENT_FIRE_TRIM_DAYS + 1)
+        ev3 = EventFire.objects.create(event=event3, contact=self.farmer1, scheduled=trim_date, fired=trim_date)
+        self.assertIsNone(ev3.get_relative_to_value())
+
+        # give contact a last seen on value
+        self.farmer1.last_seen_on = timezone.now()
+        self.farmer1.save(update_fields=("last_seen_on",), handle_update=False)
+
+        ev4 = EventFire.objects.create(event=event3, contact=self.farmer1, scheduled=trim_date, fired=trim_date)
+        self.assertIsNotNone(ev4.get_relative_to_value())
+
+        # recalculate for created on
+        EventFire.update_campaign_events(campaign)
+        self.assertEqual(1, EventFire.objects.filter(event__relative_to=last_seen_on, fired=None).count())
 
     def test_campaignevent_calculate_scheduled_fire(self):
         planting_date = timezone.now()
-        field_created_on = self.org.contactfields.get(key="created_on")
+        created_on = self.org.contactfields.get(key="created_on")
+        last_seen_on = self.org.contactfields.get(key="last_seen_on")
 
         self.set_contact_field(self.farmer1, "planting_date", self.org.format_datetime(planting_date))
 
@@ -1015,9 +1038,9 @@ class CampaignTest(TembaTest):
         )
         self.assertEqual(event.calculate_scheduled_fire(self.farmer1), expected_result)
 
-        # create a reminder for our first planting event
+        # create a reminder for our first planting event based on created_on
         event = CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, relative_to=field_created_on, offset=5, unit="D", flow=self.reminder_flow
+            self.org, self.admin, campaign, relative_to=created_on, offset=5, unit="D", flow=self.reminder_flow
         )
 
         expected_result = (
@@ -1025,6 +1048,20 @@ class CampaignTest(TembaTest):
             .replace(second=0, microsecond=0)
             .astimezone(self.org.timezone)
         )
+        self.assertEqual(event.calculate_scheduled_fire(self.farmer1), expected_result)
+
+        # create a reminder based on last_seen_on
+        event = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, relative_to=last_seen_on, offset=5, unit="D", flow=self.reminder_flow
+        )
+        self.assertIsNone(event.calculate_scheduled_fire(self.farmer1))
+
+        # give contact a last seen on value
+        now = timezone.now()
+        self.farmer1.last_seen_on = now
+        self.farmer1.save(update_fields=("last_seen_on",), handle_update=False)
+
+        expected_result = (now + timedelta(days=5)).replace(second=0, microsecond=0).astimezone(self.org.timezone)
         self.assertEqual(event.calculate_scheduled_fire(self.farmer1), expected_result)
 
     def test_import_created_on_event(self):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -976,6 +976,8 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         elif field.field_type == ContactField.FIELD_TYPE_SYSTEM:
             if field.key == "created_on":
                 return {Value.KEY_DATETIME: self.created_on}
+            elif field.key == "last_seen_on":
+                return {Value.KEY_DATETIME: self.last_seen_on}
             elif field.key == "language":
                 return {Value.KEY_TEXT: self.language}
             elif field.key == "name":
@@ -1032,6 +1034,8 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         elif field.field_type == ContactField.FIELD_TYPE_SYSTEM:
             if field.key == "created_on":
                 return self.created_on
+            if field.key == "last_seen_on":
+                return self.last_seen_on
             elif field.key == "language":
                 return self.language
             elif field.key == "name":

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -970,23 +970,9 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         """
         Returns the JSON (as a dict) value for this field, or None if there is no value
         """
-        if field.field_type == ContactField.FIELD_TYPE_USER:
-            return self.fields.get(str(field.uuid)) if self.fields else None
+        assert field.field_type == ContactField.FIELD_TYPE_USER, f"not supported for system field {field.key}"
 
-        elif field.field_type == ContactField.FIELD_TYPE_SYSTEM:
-            if field.key == "created_on":
-                return {Value.KEY_DATETIME: self.created_on}
-            elif field.key == "last_seen_on":
-                return {Value.KEY_DATETIME: self.last_seen_on}
-            elif field.key == "language":
-                return {Value.KEY_TEXT: self.language}
-            elif field.key == "name":
-                return {Value.KEY_TEXT: self.name}
-            else:
-                raise ValueError(f"System contact field '{field.key}' is not supported")
-
-        else:  # pragma: no cover
-            raise ValueError(f"Unhandled ContactField type '{field.field_type}'.")
+        return self.fields.get(str(field.uuid)) if self.fields else None
 
     def get_field_serialized(self, field):
         """

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -5248,13 +5248,8 @@ class ContactTest(TembaTest):
         field_language = self.org.contactfields.get(key="language")
         field_name = self.org.contactfields.get(key="name")
 
-        self.assertEqual(joe.get_field_serialized(field_created_on), joe.created_on)
         self.assertEqual(joe.get_field_display(field_created_on), self.org.format_datetime(joe.created_on))
-
-        self.assertEqual(joe.get_field_serialized(field_language), joe.language)
         self.assertEqual(joe.get_field_display(field_language), "eng")
-
-        self.assertEqual(joe.get_field_serialized(field_name), joe.name)
         self.assertEqual(joe.get_field_display(field_name), "Joe Blow")
 
         # create a system field that is not supported
@@ -5262,7 +5257,7 @@ class ContactTest(TembaTest):
             org_id=self.org.id, key="iban", label="IBAN", created_by_id=self.admin.id, modified_by_id=self.admin.id
         )
 
-        self.assertRaises(ValueError, joe.get_field_serialized, field_iban)
+        self.assertRaises(AssertionError, joe.get_field_serialized, field_iban)
         self.assertRaises(ValueError, joe.get_field_display, field_iban)
 
     def test_set_location_fields(self):


### PR DESCRIPTION
Doh https://sentry.io/organizations/nyaruka/issues/1839182650/?project=28903&referrer=alert_email

I was thinking last_seen_on can only be modified inside mailroom so didn't have to worry about RP's legacy campaign event scheduling code but of course when you create/update a campaign event, so have to re-evaluate fires for all contacts in the campaign group and that happens in RP.

This is the immediate fix but sooner than later we should move that task to mailroom. It takes a campaign event and re-calculates all fires.