### PR TITLE
Handle refresh_whatsapp_tokens task exceptions

### DIFF
--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -102,8 +102,8 @@ def refresh_whatsapp_tokens():
 
                 channel.config["auth_token"] = resp.json()["users"][0]["token"]
                 channel.save(update_fields=["config"])
-            except RequestException:
-                pass
+            except Exception as e:
+                logger.error(f"Error refreshing whatsapp token: {str(e)}", exc_info=True)
 
 
 VARIABLE_RE = re.compile(r"{{(\d+)}}")

--- a/temba/channels/types/whatsapp/tasks.py
+++ b/temba/channels/types/whatsapp/tasks.py
@@ -84,23 +84,26 @@ def refresh_whatsapp_tokens():
     with r.lock("refresh_whatsapp_tokens", 1800):
         # iterate across each of our whatsapp channels and get a new token
         for channel in Channel.objects.filter(is_active=True, channel_type="WA"):
-            url = channel.config["base_url"] + "/v1/users/login"
+            try:
+                url = channel.config["base_url"] + "/v1/users/login"
 
-            start = timezone.now()
-            resp = requests.post(
-                url, auth=(channel.config[Channel.CONFIG_USERNAME], channel.config[Channel.CONFIG_PASSWORD])
-            )
-            elapsed = (timezone.now() - start).total_seconds() * 1000
+                start = timezone.now()
+                resp = requests.post(
+                    url, auth=(channel.config[Channel.CONFIG_USERNAME], channel.config[Channel.CONFIG_PASSWORD])
+                )
+                elapsed = (timezone.now() - start).total_seconds() * 1000
 
-            HTTPLog.create_from_response(
-                HTTPLog.WHATSAPP_TOKENS_SYNCED, url, resp, channel=channel, request_time=elapsed
-            )
+                HTTPLog.create_from_response(
+                    HTTPLog.WHATSAPP_TOKENS_SYNCED, url, resp, channel=channel, request_time=elapsed
+                )
 
-            if resp.status_code != 200:
-                continue
+                if resp.status_code != 200:
+                    continue
 
-            channel.config["auth_token"] = resp.json()["users"][0]["token"]
-            channel.save(update_fields=["config"])
+                channel.config["auth_token"] = resp.json()["users"][0]["token"]
+                channel.save(update_fields=["config"])
+            except RequestException:
+                pass
 
 
 VARIABLE_RE = re.compile(r"{{(\d+)}}")


### PR DESCRIPTION
If some request error occurs in a WhatsApp channel during the `refresh_whatsapp_tokens` task, the remaining channels are not refreshed, so future messages to be sent will fail due to an invalid token. 