### PR TITLE
🔎 Fix bulk actions against querysets from ES searches

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -190,6 +190,10 @@ class ContactCRUDLTest(TembaTest):
         self.client.post(list_url, {"action": "label", "objects": frank.id, "label": survey_audience.id})
         self.assertIn(frank, survey_audience.contacts.all())
 
+        # try label bulk action against search results
+        self.client.post(list_url + "?search=Joe", {"action": "label", "objects": joe.id, "label": survey_audience.id})
+        self.assertIn(joe, survey_audience.contacts.all())
+
         # try archive bulk action
         self.client.post(list_url, {"action": "archive", "objects": frank.id})
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -1672,14 +1672,19 @@ class AnalyticsTest(TestCase):
         )
 
 
-class IDSliceQuerySetTest(TestCase):
-    def test_query_set(self):
-        users = IDSliceQuerySet(User, [1], 0, 1)
-        self.assertEqual(1, users[0].id)
-        self.assertEqual(1, users[0:1][0].id)
+class IDSliceQuerySetTest(TembaTest):
+    def test_slicing(self):
+        empty = IDSliceQuerySet(User, [], 0, 0)
+        self.assertEqual(0, len(empty))
+
+        users = IDSliceQuerySet(User, [self.user.id, self.editor.id, self.admin.id], 0, 3)
+        self.assertEqual(self.user.id, users[0].id)
+        self.assertEqual(self.editor.id, users[0:3][1].id)
+        self.assertEqual(0, users.offset)
+        self.assertEqual(3, users.total)
 
         with self.assertRaises(IndexError):
-            users[2]
+            users[4]
 
         with self.assertRaises(IndexError):
             users[-1]
@@ -1690,9 +1695,9 @@ class IDSliceQuerySetTest(TestCase):
         with self.assertRaises(TypeError):
             users["foo"]
 
-        users = IDSliceQuerySet(User, [1], 10, 100)
-        self.assertEqual(1, users[10].id)
-        self.assertEqual(1, users[10:11][0].id)
+        users = IDSliceQuerySet(User, [self.user.id, self.editor.id, self.admin.id], 10, 100)
+        self.assertEqual(self.user.id, users[10].id)
+        self.assertEqual(self.user.id, users[10:11][0].id)
 
         with self.assertRaises(IndexError):
             users[0]
@@ -1700,8 +1705,34 @@ class IDSliceQuerySetTest(TestCase):
         with self.assertRaises(IndexError):
             users[11:15]
 
-        users = IDSliceQuerySet(User, [], 0, 0)
-        self.assertEqual(0, len(users))
+    def test_filter(self):
+        users = IDSliceQuerySet(User, [self.user.id, self.editor.id, self.admin.id], 10, 100)
+
+        filtered = users.filter(pk=self.user.id)
+        self.assertEqual(User, filtered.model)
+        self.assertEqual([self.user.id], filtered.ids)
+        self.assertEqual(0, filtered.offset)
+        self.assertEqual(1, filtered.total)
+
+        filtered = users.filter(pk__in=[self.user.id, self.admin.id])
+        self.assertEqual(User, filtered.model)
+        self.assertEqual([self.user.id, self.admin.id], filtered.ids)
+        self.assertEqual(0, filtered.offset)
+        self.assertEqual(2, filtered.total)
+
+        # pks can be strings
+        filtered = users.filter(pk=str(self.user.id))
+        self.assertEqual([self.user.id], filtered.ids)
+
+        # only filtering by pk is supported
+        with self.assertRaises(ValueError):
+            users.filter(name="Bob")
+
+    def test_none(self):
+        users = IDSliceQuerySet(User, [self.user.id, self.editor.id], 0, 2)
+        empty = users.none()
+        self.assertEqual([], empty.ids)
+        self.assertEqual(0, empty.total)
 
 
 class RedactTest(TestCase):


### PR DESCRIPTION
Fixes https://github.com/rapidpro/rapidpro/issues/1323 tho please note doesn't fix other problem of ES search results not reflecting changes just made.

This however fixes bulk actions that don't effect whether a contact should be in the current search - e.g. adding and removing from groups as long as the search query doesn't mention those groups