### PR TITLE
🤦 Add support for last_seen_on in legacy search code

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -837,6 +837,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
             "urns": [urn_as_json(u) for u in self.urns.all()],
             "fields": self.fields if self.fields else {},
             "created_on": self.created_on.isoformat(),
+            "last_seen_on": self.last_seen_on.isoformat() if self.last_seen_on else None,
         }
 
     @classmethod

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1858,6 +1858,49 @@ class ContactTest(TembaTest):
             evaluate_query(self.org, f'created_on <= "{query_created_on}"', contact_json=self.joe.as_search_json())
         )
 
+        # test 'last_seen_on' attribute
+        self.joe.last_seen_on = datetime(2020, 3, 17, 13, 0, 0, 0, pytz.UTC)
+        self.joe.save(update_fields=("last_seen_on",), handle_update=False)
+
+        self.assertRaises(
+            SearchException,
+            evaluate_query,
+            self.org,
+            'last_seen_on = "this-is-not-a-date"',
+            contact_json=self.joe.as_search_json(),
+        )
+        self.assertRaises(
+            SearchException,
+            evaluate_query,
+            self.org,
+            'last_seen_on ~ "2016-01-01"',
+            contact_json=self.joe.as_search_json(),
+        )
+        query_last_seen_on = self.joe.last_seen_on.astimezone(self.org.timezone).date().isoformat()
+        self.assertTrue(
+            evaluate_query(self.org, f'last_seen_on = "{query_last_seen_on}"', contact_json=self.joe.as_search_json())
+        )
+        query_last_seen_on = (
+            (self.joe.last_seen_on - timedelta(days=6)).astimezone(self.org.timezone).date().isoformat()
+        )
+        self.assertTrue(
+            evaluate_query(self.org, f'last_seen_on > "{query_last_seen_on}"', contact_json=self.joe.as_search_json())
+        )
+        self.assertTrue(
+            evaluate_query(self.org, f'last_seen_on >= "{query_last_seen_on}"', contact_json=self.joe.as_search_json())
+        )
+        query_last_seen_on = (
+            (self.joe.last_seen_on + timedelta(days=6)).astimezone(self.org.timezone).date().isoformat()
+        )
+        self.assertTrue(
+            evaluate_query(self.org, f'last_seen_on < "{query_last_seen_on}"', contact_json=self.joe.as_search_json())
+        )
+        self.assertTrue(
+            evaluate_query(self.org, f'last_seen_on <= "{query_last_seen_on}"', contact_json=self.joe.as_search_json())
+        )
+        self.assertTrue(evaluate_query(self.org, f'last_seen_on != ""', contact_json=self.joe.as_search_json()))
+        self.assertFalse(evaluate_query(self.org, f'last_seen_on = ""', contact_json=self.joe.as_search_json()))
+
         # test TEXT field type
         self.assertFalse(evaluate_query(self.org, 'gender != ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'gender = ""', contact_json=self.joe.as_search_json()))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1901,6 +1901,13 @@ class ContactTest(TembaTest):
         self.assertTrue(evaluate_query(self.org, f'last_seen_on != ""', contact_json=self.joe.as_search_json()))
         self.assertFalse(evaluate_query(self.org, f'last_seen_on = ""', contact_json=self.joe.as_search_json()))
 
+        self.joe.last_seen_on = None
+        self.joe.save(update_fields=("last_seen_on",), handle_update=False)
+
+        self.assertFalse(
+            evaluate_query(self.org, f"last_seen_on = 2016-01-01", contact_json=self.joe.as_search_json())
+        )
+
         # test TEXT field type
         self.assertFalse(evaluate_query(self.org, 'gender != ""', contact_json=self.joe.as_search_json()))
         self.assertTrue(evaluate_query(self.org, 'gender = ""', contact_json=self.joe.as_search_json()))


### PR DESCRIPTION
Turns out yes you can end up evaluating a dynamic group with last_seen_on because the contact create code is still using legacy searching for dynamic groups: https://sentry.io/organizations/nyaruka/issues/1867955474/?project=20737&referrer=alert_email