### PR TITLE
Policy redirect bug

### DIFF
--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -102,7 +102,7 @@ class BrandingMiddleware:
 
 class ConsentMiddleware:  # pragma: no cover
 
-    REQUIRES_CONSENT = ("/msg", "/contact", "/flow", "/trigger", "/org/home", "/campaign", "/channel")
+    REQUIRES_CONSENT = ("/msg", "/contact", "/flow", "/trigger", "/org/home", "/campaign", "/channel", "/welcome")
 
     def __init__(self, get_response=None):
         self.get_response = get_response
@@ -112,7 +112,7 @@ class ConsentMiddleware:  # pragma: no cover
             for path in ConsentMiddleware.REQUIRES_CONSENT:
                 if request.path.startswith(path):
                     if Policy.get_policies_needing_consent(request.user):
-                        return HttpResponseRedirect(reverse("policies.policy_list"))
+                        return HttpResponseRedirect(reverse("policies.policy_list") + "?next=" + request.path)
         response = self.get_response(request)
         return response
 

--- a/temba/policies/views.py
+++ b/temba/policies/views.py
@@ -94,6 +94,8 @@ class PolicyCRUDL(SmartCRUDL):
                         Max("created_on")
                     )["created_on__max"]
 
+            context["next"] = self.request.GET.get("next", None)
+
             return context
 
     class GiveConsent(OrgPermsMixin, SmartFormView):
@@ -130,4 +132,8 @@ class PolicyCRUDL(SmartCRUDL):
                 # forget we were ever friends
                 analytics.change_consent(self.request.user.email, False)
 
-            return HttpResponseRedirect(reverse("policies.policy_list"))
+            redirect = self.request.POST.get("next")
+            if not redirect:
+                redirect = reverse("policies.policy_list")
+
+            return HttpResponseRedirect(redirect)

--- a/templates/policies/policy_list.haml
+++ b/templates/policies/policy_list.haml
@@ -55,7 +55,7 @@
 
   -if needs_consent
     .give-consent
-      .button-primary.inline-block.posterize.lift{href:'{% url "policies.policy_give_consent" %}?consent=true'}
+      .button-primary.inline-block.posterize.lift{href:'{% url "policies.policy_give_consent" %}?consent=true{% if next %}&next={{next}}{%endif%}'}
         -trans "I agree to the above policies"
 
 -block extra-script


### PR DESCRIPTION
Fixes bug whereby new users landing on the welcome page have not yet accepted policies but can open modals on that page that do not handle policy redirects gracefully.

* Force policy redirect on welcome page
* Add support for "next" for policy redirects to retain user navigation intent

A follow-on to this would be determine why in this case the redirect is not breaking out of the modal.