### PR TITLE
Update widget focus and borders on legacy editor

### DIFF
--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -12,6 +12,20 @@
   -compress css
     {% lessblock %}
       :plain
+
+        input {
+          padding: 3px 6px;
+        }
+
+        textarea, input {
+          box-shadow: 0 0 0 1px var(--color-widget-border) !important;
+        }
+
+        textarea:focus, input:focus {
+          outline: none;
+          box-shadow: var(--widget-box-shadow-focused), 0 0 0 1px var(--color-focus) !important;
+        }
+
         .empty {
           margin-left: 30px;
 


### PR DESCRIPTION
Focus and borders on the old editor look bad. Even though it's gone in a month, this is worth fixing.