### PR TITLE
🍪 Editors should have API tokens

### DIFF
--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1072,6 +1072,12 @@ class OrgTest(TembaTest):
         response = self.client.post(reverse("api.apitoken_refresh"))
         self.assertRedirect(response, reverse("orgs.org_choose"))
 
+        # but can see it as an editor
+        self.login(self.editor)
+        response = self.client.get(url)
+        token = APIToken.objects.get(user=self.editor)
+        self.assertContains(response, token.key)
+
     @override_settings(SEND_EMAILS=True)
     def test_manage_accounts(self):
         url = reverse("orgs.org_manage_accounts")

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -744,6 +744,7 @@ GROUP_PERMISSIONS = {
         "orgs.org_import",
         "orgs.org_profile",
         "orgs.org_resthooks",
+        "orgs.org_token",
         "orgs.topup_list",
         "orgs.topup_read",
         "orgs.usersettings_phone",


### PR DESCRIPTION
They have all the other permissions, just can't get a token from the workspace settings page.