### PR TITLE
🌐 Validate language codes as ISO639-3 on API endpoint

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -2,6 +2,7 @@ import numbers
 from collections import OrderedDict
 
 import iso8601
+import pycountry
 import pytz
 import regex
 from rest_framework import serializers
@@ -567,6 +568,11 @@ class ContactWriteSerializer(WriteSerializer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def validate_language(self, value):
+        if value and not pycountry.languages.get(alpha_3=value):
+            raise serializers.ValidationError("Not a valid ISO639-3 language code.")
+        return value
 
     def validate_groups(self, value):
         # only active contacts can be added to groups

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1771,13 +1771,13 @@ class APITest(TembaTest):
             None,
             {
                 "name": "Jim",
-                "language": "english",
+                "language": "xyz",
                 "urns": ["1234556789"],
                 "groups": ["59686b4e-14bc-4160-9376-b649b218c806"],
                 "fields": {"hmmm": "X"},
             },
         )
-        self.assertResponseError(response, "language", "Ensure this field has no more than 3 characters.")
+        self.assertResponseError(response, "language", "Not a valid ISO639-3 language code.")
         self.assertResponseError(response, "groups", "No such object: 59686b4e-14bc-4160-9376-b649b218c806")
         self.assertResponseError(response, "fields", "Invalid contact field key: hmmm")
 

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1771,13 +1771,13 @@ class APITest(TembaTest):
             None,
             {
                 "name": "Jim",
-                "language": "xyz",
+                "language": "english",
                 "urns": ["1234556789"],
                 "groups": ["59686b4e-14bc-4160-9376-b649b218c806"],
                 "fields": {"hmmm": "X"},
             },
         )
-        self.assertResponseError(response, "language", "Not a valid ISO639-3 language code.")
+        self.assertResponseError(response, "language", "Ensure this field has no more than 3 characters.")
         self.assertResponseError(response, "groups", "No such object: 59686b4e-14bc-4160-9376-b649b218c806")
         self.assertResponseError(response, "fields", "Invalid contact field key: hmmm")
 
@@ -1832,6 +1832,13 @@ class APITest(TembaTest):
         self.assertEqual(set(jean.urns.values_list("identity", flat=True)), {"tel:+250784444444"})
         self.assertEqual(set(jean.user_groups.all()), set())
         self.assertEqual(jean.get_field_value(nickname), "Žan")
+
+        # invalid language values are ignored
+        response = self.postJSON(url, "uuid=%s" % jean.uuid, {"language": "xyz"})
+        self.assertEqual(response.status_code, 200)
+        jean.refresh_from_db()
+        self.assertEqual(jean.name, "Jean II")
+        self.assertIsNone(jean.language)
 
         # update by uuid and remove all fields
         response = self.postJSON(


### PR DESCRIPTION
In the engine, these obviously don't have to be an org language, but they are expected to be a valid ISO639-3 language