### PR TITLE
💵 Suspend topup orgs that have no active credits

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1432,6 +1432,11 @@ class Org(SmartModel):
         # any time we've reapplied topups, lets invalidate our credit cache too
         self.clear_credit_cache()
 
+        # if we our suspended and have credits now, unsuspend ourselves
+        if self.is_suspended and self.get_credits_remaining() > 0:
+            self.is_suspended = False
+            self.save(update_fields=["is_suspended"])
+
         # update our capabilities based on topups
         self.update_capabilities()
 

--- a/temba/orgs/tasks.py
+++ b/temba/orgs/tasks.py
@@ -108,4 +108,5 @@ def suspend_topup_orgs_task():
     for org in Org.objects.filter(plan=settings.TOPUP_PLAN, is_active=True, is_suspended=False):
         if org.get_credits_remaining() <= 0:
             org.is_suspended = True
-            org.save(update_fields=["is_suspended"])
+            org.plan_end = timezone.now()
+            org.save(update_fields=["is_suspended", "plan_end"])

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1729,6 +1729,7 @@ class OrgTest(TembaTest):
         suspend_topup_orgs_task()
         self.org.refresh_from_db()
         self.assertTrue(self.org.is_suspended)
+        self.assertTrue(timezone.now() - self.org.plan_end < timedelta(seconds=10))
 
         # raise our topup to take 20 and create another for 5
         TopUp.objects.filter(pk=welcome_topup.pk).update(credits=20)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -937,6 +937,7 @@ CELERYBEAT_SCHEDULE = {
     "squash-flowcounts": {"task": "squash_flowcounts", "schedule": timedelta(seconds=60)},
     "squash-msgcounts": {"task": "squash_msgcounts", "schedule": timedelta(seconds=60)},
     "squash-topupcredits": {"task": "squash_topupcredits", "schedule": timedelta(seconds=60)},
+    "suspend-topup-orgs": {"task": "suspend_topup_orgs_task", "schedule": timedelta(hours=1)},
     "sync-classifier-intents": {"task": "sync_classifier_intents", "schedule": timedelta(seconds=300)},
     "sync-old-seen-channels": {"task": "sync_old_seen_channels_task", "schedule": timedelta(seconds=600)},
     "track-org-channel-counts": {"task": "track_org_channel_counts", "schedule": crontab(hour=4, minute=0)},


### PR DESCRIPTION
Takes care of checking orgs with topups every hour to see if they should be suspended. Also flips them back from being suspended when topups are added.