### PR TITLE
Remove usage of Contact.get_or_create_by_urns from tests

### DIFF
--- a/temba/airtime/tests.py
+++ b/temba/airtime/tests.py
@@ -11,7 +11,7 @@ class AirtimeCRUDLTest(TembaTest, CRUDLTestMixin):
     def setUp(self):
         super().setUp()
 
-        contact = self.create_contact("Ben Haggerty", "+250700000003")
+        contact = self.create_contact("Ben Haggerty", phone="+250700000003")
 
         self.transfer1 = AirtimeTransfer.objects.create(
             org=self.org,
@@ -37,7 +37,7 @@ class AirtimeCRUDLTest(TembaTest, CRUDLTestMixin):
         self.other_org_transfer = AirtimeTransfer.objects.create(
             org=self.org2,
             status=AirtimeTransfer.STATUS_SUCCESS,
-            contact=self.create_contact("Frank", "+12065552021", org=self.org2),
+            contact=self.create_contact("Frank", phone="+12065552021", org=self.org2),
             recipient="tel:+12065552021",
             currency="USD",
             desired_amount="1",
@@ -150,7 +150,7 @@ class RecipientsToURNsMigrationTest(MigrationTest):
     migrate_to = "0013_recipient_to_urn"
 
     def setUpBeforeMigration(self, apps):
-        contact = self.create_contact("Ben Haggerty", "+250700000003")
+        contact = self.create_contact("Ben Haggerty", phone="+250700000003")
 
         self.transfer1 = AirtimeTransfer.objects.create(
             org=self.org,

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -52,14 +52,14 @@ class APITest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.joe = self.create_contact("Joe Blow", "0788123123")
-        self.frank = self.create_contact("Frank", twitter="franky")
+        self.joe = self.create_contact("Joe Blow", phone="0788123123")
+        self.frank = self.create_contact("Frank", urns=["twitter:franky"])
 
         self.twitter = Channel.create(
             self.org, self.user, None, "TT", name="Twitter Channel", address="billy_bob", role="SR"
         )
 
-        self.hans = self.create_contact("Hans Gruber", "+4921551511", org=self.org2)
+        self.hans = self.create_contact("Hans Gruber", phone="+4921551511", org=self.org2)
 
         self.org2channel = Channel.create(self.org2, self.user, "RW", "A", name="Org2Channel")
 
@@ -1018,7 +1018,7 @@ class APITest(TembaTest):
 
         # create our contact and set a registration date
         contact = self.create_contact(
-            "Joe", "+12065551515", fields={"registration": self.org.format_datetime(timezone.now())}
+            "Joe", phone="+12065551515", fields={"registration": self.org.format_datetime(timezone.now())}
         )
         reporters.contacts.add(contact)
 
@@ -1592,12 +1592,12 @@ class APITest(TembaTest):
 
         # create some more contacts (in addition to Joe and Frank)
         contact1 = self.create_contact(
-            "Ann", "0788000001", language="fra", fields={"nickname": "Annie", "gender": "female"}
+            "Ann", phone="0788000001", language="fra", fields={"nickname": "Annie", "gender": "female"}
         )
-        contact2 = self.create_contact("Bob", "0788000002")
-        contact3 = self.create_contact("Cat", "0788000003")
+        contact2 = self.create_contact("Bob", phone="0788000002")
+        contact3 = self.create_contact("Cat", phone="0788000003")
         contact4 = self.create_contact(
-            "Don", "0788000004", language="fra", fields={"nickname": "Donnie", "gender": "male"}
+            "Don", phone="0788000004", language="fra", fields={"nickname": "Donnie", "gender": "male"}
         )
 
         contact1.stop(self.user)
@@ -1620,7 +1620,7 @@ class APITest(TembaTest):
         self.joe.refresh_from_db()
 
         # create contact for other org
-        hans = self.create_contact("Hans", "0788000004", org=self.org2)
+        hans = self.create_contact("Hans", phone="0788000004", org=self.org2)
 
         # no filtering
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 4):
@@ -2165,11 +2165,11 @@ class APITest(TembaTest):
 
         # create some contacts to act on
         self.bulk_release([self.joe, self.frank], user=self.admin, delete=True)
-        contact1 = self.create_contact("Ann", "+250788000001")
-        contact2 = self.create_contact("Bob", "+250788000002")
-        contact3 = self.create_contact("Cat", "+250788000003")
-        contact4 = self.create_contact("Don", "+250788000004")  # a blocked contact
-        contact5 = self.create_contact("Eve", "+250788000005")  # a deleted contact
+        contact1 = self.create_contact("Ann", phone="+250788000001")
+        contact2 = self.create_contact("Bob", phone="+250788000002")
+        contact3 = self.create_contact("Cat", phone="+250788000003")
+        contact4 = self.create_contact("Don", phone="+250788000004")  # a blocked contact
+        contact5 = self.create_contact("Eve", phone="+250788000005")  # a deleted contact
         contact4.block(self.user)
         contact5.release(self.user)
 

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -24,10 +24,10 @@ class CampaignTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.farmer1 = self.create_contact("Rob Jasper", "+250788111111")
-        self.farmer2 = self.create_contact("Mike Gordon", "+250788222222", language="spa")
+        self.farmer1 = self.create_contact("Rob Jasper", phone="+250788111111")
+        self.farmer2 = self.create_contact("Mike Gordon", phone="+250788222222", language="spa")
 
-        self.nonfarmer = self.create_contact("Trey Anastasio", "+250788333333")
+        self.nonfarmer = self.create_contact("Trey Anastasio", phone="+250788333333")
         self.farmers = self.create_group("Farmers", [self.farmer1, self.farmer2])
 
         self.reminder_flow = self.create_flow(name="Reminder Flow")
@@ -1361,7 +1361,7 @@ class CampaignTest(TembaTest):
         )
 
         # create a contact not in the group, but with a field value
-        anna = self.create_contact("Anna", urn="tel:+250788333333", fields={"planting_date": "09-10-2020 12:30"})
+        anna = self.create_contact("Anna", phone="+250788444444", fields={"planting_date": "09-10-2020 12:30"})
 
         # no contacts in our dynamic group yet, so no event fires
         self.assertEqual(EventFire.objects.filter(event=event).count(), 0)

--- a/temba/channels/types/jiochat/tests.py
+++ b/temba/channels/types/jiochat/tests.py
@@ -48,7 +48,7 @@ class JioChatTypeTest(TembaTest):
         self.assertContains(response, reverse("courier.jc", args=[channel.uuid]))
         self.assertContains(response, channel.config[Channel.CONFIG_SECRET])
 
-        contact = self.create_contact("JioChat User", urn=URN.from_jiochat("1234"))
+        contact = self.create_contact("JioChat User", urns=[URN.from_jiochat("1234")])
 
         # make sure we our jiochat channel satisfies as a send channel
         response = self.client.get(reverse("contacts.contact_read", args=[contact.uuid]))

--- a/temba/channels/types/telegram/tests.py
+++ b/temba/channels/types/telegram/tests.py
@@ -80,7 +80,7 @@ class TelegramTypeTest(TembaTest):
             response.context["form"].errors["auth_token"][0],
         )
 
-        contact = self.create_contact("Telegram User", urn=URN.from_telegram("1234"))
+        contact = self.create_contact("Telegram User", urns=[URN.from_telegram("1234")])
 
         # make sure we our telegram channel satisfies as a send channel
         response = self.client.get(reverse("contacts.contact_read", args=[contact.uuid]))

--- a/temba/channels/types/twitter/tests.py
+++ b/temba/channels/types/twitter/tests.py
@@ -149,7 +149,7 @@ class TwitterTypeTest(TembaTest):
     @patch("twython.Twython.lookup_user")
     @mock_mailroom
     def test_resolve(self, mr_mocks, mock_lookup_user):
-        self.joe = self.create_contact("joe", twitter="therealjoe")
+        self.joe = self.create_contact("joe", urns=["twitter:therealjoe"])
 
         urn = self.joe.get_urns()[0]
 
@@ -179,8 +179,8 @@ class TwitterTypeTest(TembaTest):
         self.assertEqual("therealjoe", new_urn.display)
         self.assertEqual("twitterid:123456#therealjoe", new_urn.urn)
 
-        old_fred = self.create_contact("old fred", urn=URN.from_twitter("fred"))
-        new_fred = self.create_contact("new fred", urn=URN.from_twitterid("12345", screen_name="fred"))
+        old_fred = self.create_contact("old fred", urns=[URN.from_twitter("fred")])
+        new_fred = self.create_contact("new fred", urns=[URN.from_twitterid("12345", screen_name="fred")])
 
         mock_lookup_user.return_value = [dict(screen_name="fred", id="12345")]
         resolve_twitter_ids()
@@ -191,7 +191,7 @@ class TwitterTypeTest(TembaTest):
         # old fred should be unchanged
         self.assertEqual("twitterid:12345", old_fred.urns.all()[0].identity)
 
-        self.jane = self.create_contact("jane", twitter="jane10")
+        self.jane = self.create_contact("jane", urns=["twitter:jane10"])
         mock_lookup_user.side_effect = Exception(
             "Twitter API returned a 404 (Not Found), No user matches for specified terms."
         )
@@ -200,7 +200,7 @@ class TwitterTypeTest(TembaTest):
         self.jane.refresh_from_db()
         self.assertEqual(Contact.STATUS_STOPPED, self.jane.status)
 
-        self.sarah = self.create_contact("sarah", twitter="sarah20")
+        self.sarah = self.create_contact("sarah", urns=["twitter:sarah20"])
         mock_lookup_user.side_effect = Exception("Unable to reach API")
         resolve_twitter_ids()
 

--- a/temba/channels/types/wechat/tests.py
+++ b/temba/channels/types/wechat/tests.py
@@ -54,7 +54,7 @@ class WeChatTypeTest(TembaTest):
         self.assertContains(response, "10.10.10.10")
         self.assertContains(response, "172.16.20.30")
 
-        contact = self.create_contact("WeChat User", urn=URN.from_wechat("1234"))
+        contact = self.create_contact("WeChat User", urns=[URN.from_wechat("1234")])
 
         # make sure we our jiochat channel satisfies as a send channel
         response = self.client.get(reverse("contacts.contact_read", args=[contact.uuid]))

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -144,7 +144,7 @@ class WhatsAppTypeTest(TembaTest):
         with patch("requests.post") as mock_post:
             mock_post.side_effect = [MockResponse(200, '{ "error": false }')]
             self.assertFalse(channel.http_logs.filter(log_type=HTTPLog.WHATSAPP_CONTACTS_REFRESHED, is_error=False))
-            self.create_contact("Joe", urn="whatsapp:250788382382")
+            self.create_contact("Joe", urns=["whatsapp:250788382382"])
             self.client.post(refresh_url)
 
             self.assertEqual(mock_post.call_args_list[0][1]["json"]["contacts"], ["+250788382382"])

--- a/temba/dashboard/tests.py
+++ b/temba/dashboard/tests.py
@@ -17,7 +17,7 @@ class DashboardTest(TembaTest):
     def create_activity(self):
 
         # and some message and call activity
-        joe = self.create_contact("Joe", number="+593979099111")
+        joe = self.create_contact("Joe", phone="+593979099111")
         self.create_outgoing_msg(joe, "Tea of coffee?")
         self.create_incoming_msg(joe, "Coffee")
         self.create_outgoing_msg(joe, "OK")
@@ -79,7 +79,7 @@ class DashboardTest(TembaTest):
         self.create_activity()
 
         types = ["T", "TT", "FB", "NX", "AT", "KN", "CK"]
-        michael = self.create_contact("Michael", twitter="mjackson")
+        michael = self.create_contact("Michael", urns=["twitter:mjackson"])
         for t in types:
             channel = Channel.create(self.org, self.user, None, t, name=f"Test Channel {t}", address=f"{t}:1234")
             self.create_outgoing_msg(michael, f"Message on {t}", channel=channel)

--- a/temba/flows/legacy/definition/tests.py
+++ b/temba/flows/legacy/definition/tests.py
@@ -177,7 +177,7 @@ class ActionTest(TembaTest):
         self.assertEqual([label, "@step.contact"], action.labels)
 
     def test_trigger_flow(self):
-        contact = self.create_contact("Eric", "+250788382382")
+        contact = self.create_contact("Eric", phone="+250788382382")
         group = self.create_group("My Group", [])
         flow = self.get_flow("color")
 
@@ -190,7 +190,7 @@ class ActionTest(TembaTest):
         self.assertEqual(["@contact.supervisor"], action.variables)
 
     def test_send(self):
-        contact = self.create_contact("Eric", "+250788382382")
+        contact = self.create_contact("Eric", phone="+250788382382")
         group = self.create_group("My Group", [])
 
         action = SendAction(

--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -1032,7 +1032,7 @@ class FlowMigrationTest(TembaTest):
             self.assertNotIn("webhook_action", ruleset)
 
     def test_migrate_to_9(self):
-        contact = self.create_contact("Ben Haggerty", number="+12065552020")
+        contact = self.create_contact("Ben Haggerty", phone="+12065552020")
 
         # our group and flow to move to uuids
         group = self.create_group("Phans", [])

--- a/temba/flows/management/commands/tests.py
+++ b/temba/flows/management/commands/tests.py
@@ -28,9 +28,9 @@ class RunAuditTest(TembaTest):
 
 class RecalcNodeCountsTest(TembaTest):
     def test_recalc_node_counts(self):
-        contact1 = self.create_contact("Ben Haggerty", number="+12065552020")
-        contact2 = self.create_contact("Joe", number="+12065550002")
-        contact3 = self.create_contact("Frank", number="+12065550003")
+        contact1 = self.create_contact("Ben Haggerty", phone="+12065552020")
+        contact2 = self.create_contact("Joe", phone="+12065550002")
+        contact3 = self.create_contact("Frank", phone="+12065550003")
 
         def check_node_count_rebuild(flow, assert_count):
             node_counts = FlowNodeCount.get_totals(flow)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -69,10 +69,10 @@ class FlowTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.contact = self.create_contact("Eric", "+250788382382")
-        self.contact2 = self.create_contact("Nic", "+250788383383")
-        self.contact3 = self.create_contact("Norbert", "+250788123456")
-        self.contact4 = self.create_contact("Teeh", "+250788123457", language="por")
+        self.contact = self.create_contact("Eric", phone="+250788382382")
+        self.contact2 = self.create_contact("Nic", phone="+250788383383")
+        self.contact3 = self.create_contact("Norbert", phone="+250788123456")
+        self.contact4 = self.create_contact("Teeh", phone="+250788123457", language="por")
 
         self.other_group = self.create_group("Other", [])
 
@@ -938,7 +938,7 @@ class FlowTest(TembaTest):
         self.assertEqual(recent.visited_on, iso8601.parse_date(run1.path[1]["arrived_on"]))
 
         # a new participant, showing distinct active counts and incremented path
-        ryan = self.create_contact("Ryan Lewis", "+12065550725")
+        ryan = self.create_contact("Ryan Lewis", phone="+12065550725")
         session2 = (
             MockSessionWriter(ryan, flow)
             .visit(color_prompt)
@@ -1138,7 +1138,7 @@ class FlowTest(TembaTest):
         self.assertEqual(0, FlowRun.objects.filter(flow=flow).count())
 
         # test that expirations remove activity when triggered from the cron in the same way
-        tupac = self.create_contact("Tupac Shakur", "+12065550725")
+        tupac = self.create_contact("Tupac Shakur", phone="+12065550725")
         (
             MockSessionWriter(tupac, flow)
             .visit(color_prompt)
@@ -1203,7 +1203,7 @@ class FlowTest(TembaTest):
         )
 
         # check that flow interruption counts properly
-        jimmy = self.create_contact("Jimmy Graham", "+12065558888")
+        jimmy = self.create_contact("Jimmy Graham", phone="+12065558888")
         (
             MockSessionWriter(jimmy, flow)
             .visit(color_prompt)
@@ -1285,7 +1285,7 @@ class FlowTest(TembaTest):
 
         # add in some fake data
         for i in range(0, 10):
-            contact = self.create_contact("Contact %d" % i, "+120655530%d" % i)
+            contact = self.create_contact("Contact %d" % i, phone="+120655530%d" % i)
             (
                 MockSessionWriter(contact, favorites)
                 .visit(color_prompt)
@@ -1311,7 +1311,7 @@ class FlowTest(TembaTest):
             )
 
         for i in range(0, 5):
-            contact = self.create_contact("Contact %d" % i, "+120655531%d" % i)
+            contact = self.create_contact("Contact %d" % i, phone="+120655531%d" % i)
             (
                 MockSessionWriter(contact, favorites)
                 .visit(color_prompt)
@@ -1338,7 +1338,7 @@ class FlowTest(TembaTest):
 
         # test update flow values
         for i in range(0, 5):
-            contact = self.create_contact("Contact %d" % i, "+120655532%d" % i)
+            contact = self.create_contact("Contact %d" % i, phone="+120655532%d" % i)
             (
                 MockSessionWriter(contact, favorites)
                 .visit(color_prompt)
@@ -1395,7 +1395,7 @@ class FlowTest(TembaTest):
 
         # send a few more runs through our updated flow
         for i in range(0, 3):
-            contact = self.create_contact("Contact %d" % i, "+120655533%d" % i)
+            contact = self.create_contact("Contact %d" % i, phone="+120655533%d" % i)
             (
                 MockSessionWriter(contact, favorites)
                 .visit(color_prompt)
@@ -1489,7 +1489,7 @@ class FlowTest(TembaTest):
         # create start for 10 contacts
         start = FlowStart.objects.create(org=self.org, flow=flow, created_by=self.admin)
         for i in range(10):
-            contact = self.create_contact("Bob", twitter=f"bobby{i}")
+            contact = self.create_contact("Bob", urns=[f"twitter:bobby{i}"])
             start.contacts.add(contact)
 
         # create runs for first 5
@@ -1520,7 +1520,7 @@ class FlowTest(TembaTest):
 
         # send 12 invalid color responses from two contacts
         session = None
-        bob = self.create_contact("Bob", number="+260964151234")
+        bob = self.create_contact("Bob", phone="+260964151234")
         for m in range(12):
             contact = self.contact if m % 2 == 0 else bob
             session = (
@@ -2252,7 +2252,7 @@ class FlowTest(TembaTest):
         )
 
         # run it again to completion
-        joe = self.create_contact("Joe", "1234")
+        joe = self.create_contact("Joe", phone="1234")
         (
             MockSessionWriter(joe, flow)
             .visit(color_prompt)
@@ -2427,7 +2427,7 @@ class FlowTest(TembaTest):
 
 class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_views(self):
-        contact = self.create_contact("Eric", "+250788382382")
+        contact = self.create_contact("Eric", phone="+250788382382")
         flow = self.get_flow("color", legacy=True)
 
         # create a flow for another org
@@ -3075,7 +3075,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(["Favorites"], [res["text"] for res in json_payload["results"]])
 
     def test_broadcast(self):
-        contact = self.create_contact("Bob", number="+593979099111")
+        contact = self.create_contact("Bob", phone="+593979099111")
         flow = self.get_flow("color")
 
         self.login(self.admin)
@@ -3247,7 +3247,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertLoginRedirect(response)
 
     def test_recent_messages(self):
-        contact = self.create_contact("Bob", number="+593979099111")
+        contact = self.create_contact("Bob", phone="+593979099111")
         flow = self.get_flow("favorites_v13")
         flow_nodes = flow.as_json()["nodes"]
         color_prompt = flow_nodes[0]
@@ -3347,7 +3347,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         name_split = flow_nodes[7]
         end_prompt = flow_nodes[8]
 
-        pete = self.create_contact("Pete", "+12065553027")
+        pete = self.create_contact("Pete", phone="+12065553027")
         pete_session = (
             MockSessionWriter(pete, flow)
             .visit(color_prompt)
@@ -3363,7 +3363,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             .save()
         )
 
-        jimmy = self.create_contact("Jimmy", "+12065553026")
+        jimmy = self.create_contact("Jimmy", phone="+12065553026")
         (
             MockSessionWriter(jimmy, flow)
             .visit(color_prompt)
@@ -3535,7 +3535,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         beer_prompt = flow_nodes[3]
         beer_split = flow_nodes[5]
 
-        pete = self.create_contact("Pete", "+12065553027")
+        pete = self.create_contact("Pete", phone="+12065553027")
         (
             MockSessionWriter(pete, flow)
             .visit(color_prompt)
@@ -4042,7 +4042,7 @@ class FlowRunTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.contact = self.create_contact("Ben Haggerty", "+250788123123")
+        self.contact = self.create_contact("Ben Haggerty", phone="+250788123123")
 
     def test_as_archive_json(self):
         flow = self.get_flow("color_v13")
@@ -4278,7 +4278,7 @@ class FlowRunTest(TembaTest):
 
 class FlowSessionTest(TembaTest):
     def test_trim(self):
-        contact = self.create_contact("Ben Haggerty", "+250788123123")
+        contact = self.create_contact("Ben Haggerty", phone="+250788123123")
         flow = self.get_flow("color")
 
         # create some runs that have sessions
@@ -4324,7 +4324,7 @@ class FlowSessionTest(TembaTest):
 
 class FlowStartTest(TembaTest):
     def test_trim(self):
-        contact = self.create_contact("Ben Haggerty", "+250788123123")
+        contact = self.create_contact("Ben Haggerty", phone="+250788123123")
         group = self.create_group("Testers", contacts=[contact])
         flow = self.get_flow("color")
 
@@ -4381,9 +4381,9 @@ class ExportFlowResultsTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.contact = self.create_contact("Eric", "+250788382382")
-        self.contact2 = self.create_contact("Nic", "+250788383383")
-        self.contact3 = self.create_contact("Norbert", "+250788123456")
+        self.contact = self.create_contact("Eric", phone="+250788382382")
+        self.contact2 = self.create_contact("Nic", phone="+250788383383")
+        self.contact3 = self.create_contact("Norbert", phone="+250788123456")
 
     def _export(
         self, flow, responded_only=False, include_msgs=True, contact_fields=None, extra_urns=(), group_memberships=None
@@ -6293,7 +6293,7 @@ class SimulationTest(TembaTest):
 
 class FlowSessionCRUDLTest(TembaTest):
     def test_session_json(self):
-        contact = self.create_contact("Bob", number="+1234567890")
+        contact = self.create_contact("Bob", phone="+1234567890")
         flow = self.get_flow("color_v13")
 
         session = MockSessionWriter(contact, flow).wait().save().session
@@ -6322,7 +6322,7 @@ class FlowStartCRUDLTest(TembaTest, CRUDLTestMixin):
         list_url = reverse("flows.flowstart_list")
 
         flow = self.get_flow("color_v13")
-        contact = self.create_contact("Bob", number="+1234567890")
+        contact = self.create_contact("Bob", phone="+1234567890")
         group = self.create_group("Testers", contacts=[contact])
         start1 = FlowStart.create(flow, self.admin, contacts=[contact])
         start2 = FlowStart.create(flow, self.admin, query="name ~ Bob", restart_participants=False, start_type="A")

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -8,7 +8,7 @@ from temba.tests import TembaTest
 class IVRCallTest(TembaTest):
     def test_release(self):
         flow = self.get_flow("ivr")
-        contact = self.create_contact("Jose", "+12065552000")
+        contact = self.create_contact("Jose", phone="+12065552000")
 
         call1 = self.create_incoming_call(flow, contact)
         call2 = self.create_incoming_call(flow, contact)

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -387,8 +387,8 @@ class MailroomQueueTest(TembaTest):
         )
 
     def test_queue_broadcast(self):
-        jim = self.create_contact("Jim", "+12065551212")
-        bobs = self.create_group("Bobs", [self.create_contact("Bob", "+12065551313")])
+        jim = self.create_contact("Jim", phone="+12065551212")
+        bobs = self.create_group("Bobs", [self.create_contact("Bob", phone="+12065551313")])
 
         bcast = Broadcast.create(
             self.org,
@@ -427,8 +427,8 @@ class MailroomQueueTest(TembaTest):
 
     def test_queue_flow_start(self):
         flow = self.get_flow("favorites")
-        jim = self.create_contact("Jim", "+12065551212")
-        bobs = self.create_group("Bobs", [self.create_contact("Bob", "+12065551313")])
+        jim = self.create_contact("Jim", phone="+12065551212")
+        bobs = self.create_group("Bobs", [self.create_contact("Bob", phone="+12065551313")])
 
         start = FlowStart.create(
             flow,
@@ -467,8 +467,8 @@ class MailroomQueueTest(TembaTest):
         )
 
     def test_queue_interrupt_by_contacts(self):
-        jim = self.create_contact("Jim", "+12065551212")
-        bob = self.create_contact("Bob", "+12065551313")
+        jim = self.create_contact("Jim", phone="+12065551212")
+        bob = self.create_contact("Bob", phone="+12065551313")
 
         queue_interrupt(self.org, contacts=[jim, bob])
 
@@ -513,7 +513,7 @@ class MailroomQueueTest(TembaTest):
         )
 
     def test_queue_interrupt_by_session(self):
-        jim = self.create_contact("Jim", "+12065551212")
+        jim = self.create_contact("Jim", phone="+12065551212")
 
         flow = self.get_flow("favorites")
         flow_nodes = flow.as_json()["nodes"]

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -54,11 +54,11 @@ class MsgTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.joe = self.create_contact("Joe Blow", "123")
+        self.joe = self.create_contact("Joe Blow", phone="123")
         ContactURN.create(self.org, self.joe, "tel:789")
 
-        self.frank = self.create_contact("Frank Blow", "321")
-        self.kevin = self.create_contact("Kevin Durant", "987")
+        self.frank = self.create_contact("Frank Blow", phone="321")
+        self.kevin = self.create_contact("Kevin Durant", phone="987")
 
         self.just_joe = self.create_group("Just Joe", [self.joe])
         self.joe_and_frank = self.create_group("Joe and Frank", [self.joe, self.frank])
@@ -315,8 +315,8 @@ class MsgTest(TembaTest):
 
     def test_broadcast_metadata(self):
         Channel.create(self.org, self.admin, None, channel_type="TT")
-        contact1 = self.create_contact("Stephen", "+12078778899", language="fra")
-        contact2 = self.create_contact("Maaaarcos", number="+12078778888", twitter="marky65")
+        contact1 = self.create_contact("Stephen", phone="+12078778899", language="fra")
+        contact2 = self.create_contact("Maaaarcos", urns=["tel:+12078778888", "twitter:marky65"])
 
         # can't create quick replies if you don't include base translation
         with self.assertRaises(ValueError):
@@ -1719,9 +1719,9 @@ class MsgCRUDLTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.joe = self.create_contact("Joe Blow", "+250788000001")
-        self.frank = self.create_contact("Frank Blow", "250788000002")
-        self.billy = self.create_contact("Billy Bob", twitter="billy_bob")
+        self.joe = self.create_contact("Joe Blow", phone="+250788000001")
+        self.frank = self.create_contact("Frank Blow", phone="250788000002")
+        self.billy = self.create_contact("Billy Bob", urns=["twitter:billy_bob"])
 
     def test_filter(self):
         # create some folders and labels
@@ -1792,15 +1792,15 @@ class BroadcastTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.joe = self.create_contact("Joe Blow", "123")
-        self.frank = self.create_contact("Frank Blow", "321")
+        self.joe = self.create_contact("Joe Blow", phone="123")
+        self.frank = self.create_contact("Frank Blow", phone="321")
 
         self.just_joe = self.create_group("Just Joe", [self.joe])
 
         self.joe_and_frank = self.create_group("Joe and Frank", [self.joe, self.frank])
 
-        self.kevin = self.create_contact(name="Kevin Durant", number="987")
-        self.lucy = self.create_contact(name="Lucy M", twitter="lucy")
+        self.kevin = self.create_contact(name="Kevin Durant", phone="987")
+        self.lucy = self.create_contact(name="Lucy M", urns=["twitter:lucy"])
 
         # a Twitter channel
         self.twitter = Channel.create(self.org, self.user, None, "TT")
@@ -2225,7 +2225,7 @@ class BroadcastTest(TembaTest):
         self.assertIn(self.joe, broadcast.contacts.all())
 
     def test_message_parts(self):
-        contact = self.create_contact("Matt", "+12067778811")
+        contact = self.create_contact("Matt", phone="+12067778811")
 
         sms = self.create_outgoing_msg(contact, "Text")
 
@@ -2374,8 +2374,8 @@ class LabelTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.joe = self.create_contact("Joe Blow", number="073835001")
-        self.frank = self.create_contact("Frank", number="073835002")
+        self.joe = self.create_contact("Joe Blow", phone="073835001")
+        self.frank = self.create_contact("Frank", phone="073835002")
 
     def test_get_or_create(self):
         label1 = Label.get_or_create(self.org, self.user, "Spam")
@@ -2750,8 +2750,8 @@ class SystemLabelTest(TembaTest):
             },
         )
 
-        contact1 = self.create_contact("Bob", number="0783835001")
-        contact2 = self.create_contact("Jim", number="0783835002")
+        contact1 = self.create_contact("Bob", phone="0783835001")
+        contact2 = self.create_contact("Jim", phone="0783835002")
         msg1 = self.create_incoming_msg(contact1, "Message 1")
         self.create_incoming_msg(contact1, "Message 2")
         msg3 = self.create_incoming_msg(contact1, "Message 3")
@@ -2915,7 +2915,7 @@ class TagsTest(TembaTest):
     def setUp(self):
         super().setUp()
 
-        self.joe = self.create_contact("Joe Blow", number="+250788382382")
+        self.joe = self.create_contact("Joe Blow", phone="+250788382382")
 
     def render_template(self, string, context=None):
         from django.template import Context, Template
@@ -2984,7 +2984,7 @@ class MsgsFailWithoutTopup(MigrationTest):
     migrate_to = "0140_fail_msgs_missing_topups"
 
     def setUpBeforeMigration(self, apps):
-        contact = self.create_contact("Ben Haggerty", "+250700000003")
+        contact = self.create_contact("Ben Haggerty", phone="+250700000003")
 
         now = timezone.now()
         two_days_ago = now - timedelta(hours=48)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -284,8 +284,8 @@ class OrgDeleteTest(TembaNonAtomicTest):
         # now allocate some credits to our child org
         self.org.allocate_credits(self.admin, self.child_org, 300)
 
-        parent_contact = self.create_contact("Parent Contact", "+2345123", org=self.parent_org)
-        child_contact = self.create_contact("Child Contact", "+3456123", org=self.child_org)
+        parent_contact = self.create_contact("Parent Contact", phone="+2345123", org=self.parent_org)
+        child_contact = self.create_contact("Child Contact", phone="+3456123", org=self.child_org)
 
         # add some fields
         parent_field = self.create_field("age", "Parent Age", org=self.parent_org)
@@ -761,7 +761,7 @@ class OrgTest(TembaTest):
     def test_org_flagging_and_suspending(self, mock_async_start):
         self.login(self.admin)
 
-        mark = self.create_contact("Mark", number="+12065551212")
+        mark = self.create_contact("Mark", phone="+12065551212")
         flow = self.create_flow()
 
         def send_broadcast():
@@ -1588,7 +1588,7 @@ class OrgTest(TembaTest):
 
     def test_topup_expiration(self):
 
-        contact = self.create_contact("Usain Bolt", "+250788123123")
+        contact = self.create_contact("Usain Bolt", phone="+250788123123")
         welcome_topup = self.org.topups.get()
 
         # send some messages with a valid topup
@@ -1615,7 +1615,7 @@ class OrgTest(TembaTest):
         self.assertEqual(15, self.org.get_credits_used())
 
     def test_low_credits_threshold(self):
-        contact = self.create_contact("Usain Bolt", "+250788123123")
+        contact = self.create_contact("Usain Bolt", phone="+250788123123")
 
         # add some more unexpire topup credits
         TopUp.create(self.admin, price=0, credits=1000)
@@ -1628,7 +1628,7 @@ class OrgTest(TembaTest):
         self.assertEqual(300, self.org.get_low_credits_threshold())
 
     def test_topup_decrementing(self):
-        self.contact = self.create_contact("Joe", "+250788123123")
+        self.contact = self.create_contact("Joe", phone="+250788123123")
 
         self.create_incoming_msg(self.contact, "Orange")
 
@@ -1663,7 +1663,7 @@ class OrgTest(TembaTest):
         self.org.is_multi_user = False
         self.org.save(update_fields=["is_multi_user", "is_multi_org"])
 
-        contact = self.create_contact("Michael Shumaucker", "+250788123123")
+        contact = self.create_contact("Michael Shumaucker", phone="+250788123123")
         welcome_topup = self.org.topups.get()
 
         self.create_incoming_msgs(contact, 10)
@@ -1973,7 +1973,7 @@ class OrgTest(TembaTest):
     def test_has_airtime_transfers(self):
         AirtimeTransfer.objects.filter(org=self.org).delete()
         self.assertFalse(self.org.has_airtime_transfers())
-        contact = self.create_contact("Bob", number="+250788123123")
+        contact = self.create_contact("Bob", phone="+250788123123")
 
         AirtimeTransfer.objects.create(
             org=self.org,
@@ -2705,7 +2705,7 @@ class OrgTest(TembaTest):
             secret="12355",
             config={Channel.CONFIG_FCM_ID: "145"},
         )
-        contact = self.create_contact("Joe", "+250788383444", org=sub_org)
+        contact = self.create_contact("Joe", phone="+250788383444", org=sub_org)
         msg = self.create_outgoing_msg(contact, "How is it going?")
 
         # there is no topup on suborg, and this msg won't be credited
@@ -2992,7 +2992,7 @@ class AnonOrgTest(TembaTest):
 
     def test_contacts(self):
         # are there real phone numbers on the contact list page?
-        contact = self.create_contact(None, "+250788123123")
+        contact = self.create_contact(None, phone="+250788123123")
         self.login(self.admin)
 
         masked = "%010d" % contact.pk
@@ -3397,7 +3397,7 @@ class OrgCRUDLTest(TembaTest):
         self.assertEqual(self.org.timezone, pytz.timezone("Africa/Kigali"))
         self.assertEqual(("%d-%m-%Y", "%d-%m-%Y %H:%M"), self.org.get_datetime_formats())
 
-        contact = self.create_contact("Bob", number="+250788382382")
+        contact = self.create_contact("Bob", phone="+250788382382")
         self.create_incoming_msg(contact, "My name is Frank")
 
         self.login(self.admin)
@@ -3842,7 +3842,7 @@ class BulkExportTest(TembaTest):
     def test_get_dependencies(self):
 
         # import a flow that triggers another flow
-        contact1 = self.create_contact("Marshawn", "+14255551212")
+        contact1 = self.create_contact("Marshawn", phone="+14255551212")
         substitutions = dict(contact_id=contact1.id)
         flow = self.get_flow("triggered", substitutions, legacy=True)
 
@@ -4037,7 +4037,7 @@ class BulkExportTest(TembaTest):
         event = campaign.events.filter(is_active=True).last()
 
         # create a contact and place her into our campaign
-        sally = self.create_contact("Sally", urn="tel:+12345", fields={"survey_start": "10-05-2025 12:30:10"})
+        sally = self.create_contact("Sally", phone="+12345", fields={"survey_start": "10-05-2025 12:30:10"})
         campaign.group.contacts.add(sally)
 
         # importing it again shouldn't result in failures
@@ -4634,7 +4634,7 @@ class CreditAlertTest(TembaTest):
             self.assertEqual(len(mail.outbox), 0)
 
     def test_check_org_credits(self):
-        self.joe = self.create_contact("Joe Blow", "123")
+        self.joe = self.create_contact("Joe Blow", phone="123")
         self.create_outgoing_msg(self.joe, "Hello")
         with self.settings(HOSTNAME="rapidpro.io", SEND_EMAILS=True):
             with patch("temba.orgs.models.Org.get_credits_remaining") as mock_get_credits_remaining:
@@ -5001,8 +5001,8 @@ class OrgActivityTest(TembaTest):
         now = timezone.now()
 
         # create a few contacts
-        self.create_contact("Marshawn", "+14255551212")
-        russell = self.create_contact("Marshawn", "+14255551313")
+        self.create_contact("Marshawn", phone="+14255551212")
+        russell = self.create_contact("Marshawn", phone="+14255551313")
 
         # create some messages for russel
         self.create_incoming_msg(russell, "hut")

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -16,7 +16,7 @@ from .models import Schedule
 class ScheduleTest(TembaTest):
     def setUp(self):
         super().setUp()
-        self.joe = self.create_contact(name="Joe Blow", number="123")
+        self.joe = self.create_contact("Joe Blow", phone="123")
 
     def test_get_repeat_days_display(self):
         sched = Schedule.create_schedule(self.org, self.user, timezone.now(), Schedule.REPEAT_WEEKLY, "M")
@@ -220,8 +220,6 @@ class ScheduleTest(TembaTest):
     def test_schedule_ui(self):
         self.login(self.admin)
 
-        joe = self.create_contact("Joe Blow", "123")
-
         # test missing recipients
         omnibox = omnibox_serialize(self.org, [], [], True)
         post_data = dict(text="message content", omnibox=omnibox, sender=self.channel.pk, schedule=True)
@@ -229,7 +227,7 @@ class ScheduleTest(TembaTest):
         self.assertContains(response, "At least one recipient is required")
 
         # missing message
-        omnibox = omnibox_serialize(self.org, [], [joe], True)
+        omnibox = omnibox_serialize(self.org, [], [self.joe], True)
         post_data = dict(text="", omnibox=omnibox, sender=self.channel.pk, schedule=True)
         response = self.client.post(reverse("msgs.broadcast_send"), post_data, follow=True)
         self.assertContains(response, "This field is required")

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -25,7 +25,7 @@ from temba.utils import json
 from temba.utils.uuid import UUID, uuid4
 from temba.values.constants import Value
 
-from .mailroom import update_field_locally, update_fields_locally
+from .mailroom import create_contact_locally, update_field_locally
 
 
 def add_testing_flag_to_context(*args):
@@ -183,33 +183,16 @@ class TembaTestMixin:
         data = self.get_import_json(filename, substitutions=substitutions)
         return data["flows"][0]
 
-    def create_contact(self, name=None, number=None, twitter=None, urn=None, fields=None, **kwargs):
+    def create_contact(self, name=None, *, language=None, phone=None, urns=None, fields=None, org=None, user=None):
         """
-        Create a contact in the master test org
+        Create a new contact
         """
 
-        org = kwargs.pop("org", None) or self.org
-        user = kwargs.pop("user", None) or self.user
+        org = org or self.org
+        user = user or self.user
+        urns = [URN.from_tel(phone)] if phone else urns
 
-        urns = []
-        if number:
-            urns.append(URN.from_tel(number))
-        if twitter:
-            urns.append(URN.from_twitter(twitter))
-        if urn:
-            urns.append(urn)
-
-        assert name or urns, "contact should have a name or a contact"
-
-        kwargs["name"] = name
-        kwargs["urns"] = urns
-
-        contact = Contact.get_or_create_by_urns(org, user, **kwargs)
-
-        if fields:
-            update_fields_locally(user, contact, fields)
-
-        return contact
+        return create_contact_locally(org, user, name, language, urns or [], fields or {}, group_uuids=[])
 
     def create_group(self, name, contacts=(), query=None, org=None):
         assert not (contacts and query), "can't provide contact list for a smart group"

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -16,7 +16,7 @@ class TicketTest(TembaTest):
     def test_model(self):
         ticketer = Ticketer.create(self.org, self.user, MailgunType.slug, "Email (bob@acme.com)", {})
 
-        contact = self.create_contact("Bob", twitter="bobby")
+        contact = self.create_contact("Bob", urns=["twitter:bobby"])
 
         ticket = Ticket.objects.create(
             org=self.org,
@@ -46,7 +46,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.mailgun = Ticketer.create(self.org, self.user, MailgunType.slug, "Email (bob@acme.com)", {})
         self.zendesk = Ticketer.create(self.org, self.user, ZendeskType.slug, "Zendesk (acme)", {})
-        self.contact = self.create_contact("Bob", twitter="bobby")
+        self.contact = self.create_contact("Bob", urns=["twitter:bobby"])
 
     def create_ticket(self, subject, body, status, ticketer=None, org=None):
         return Ticket.objects.create(
@@ -158,7 +158,7 @@ class TicketerTest(TembaTest):
     def test_release(self):
         ticketer = Ticketer.create(self.org, self.user, MailgunType.slug, "Email (bob@acme.com)", {})
 
-        contact = self.create_contact("Bob", twitter="bobby")
+        contact = self.create_contact("Bob", urns=["twitter:bobby"])
 
         ticket = Ticket.objects.create(
             org=self.org,

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -145,8 +145,8 @@ class TriggerTest(TembaTest):
         self.assertEqual(1, Trigger.objects.filter(keyword="startkeyword", is_archived=False).count())
         self.assertNotEqual(other_trigger, Trigger.objects.filter(keyword="startkeyword", is_archived=False)[0])
 
-        self.contact = self.create_contact("Eric", "+250788382382")
-        self.contact2 = self.create_contact("Nic", "+250788383383")
+        self.contact = self.create_contact("Eric", phone="+250788382382")
+        self.contact2 = self.create_contact("Nic", phone="+250788383383")
         group1 = self.create_group("first", [self.contact2])
         group2 = self.create_group("second", [self.contact])
         group3 = self.create_group("third", [self.contact, self.contact2])
@@ -207,7 +207,7 @@ class TriggerTest(TembaTest):
         self.assertIsNotNone(trigger)
 
         # now lets check that group specific call triggers work
-        mike = self.create_contact("Mike", "+17075551213")
+        mike = self.create_contact("Mike", phone="+17075551213")
         bassists = self.create_group("Bassists", [mike])
 
         # flow specific to our group
@@ -299,10 +299,10 @@ class TriggerTest(TembaTest):
         self.login(self.admin)
         flow = self.create_flow()
 
-        chester = self.create_contact("Chester", "+250788987654")
-        shinoda = self.create_contact("Shinoda", "+250234213455")
+        chester = self.create_contact("Chester", phone="+250788987654")
+        shinoda = self.create_contact("Shinoda", phone="+250234213455")
         linkin_park = self.create_group("Linkin Park", [chester, shinoda])
-        stromae = self.create_contact("Stromae", "+250788645323")
+        stromae = self.create_contact("Stromae", phone="+250788645323")
 
         now = timezone.now()
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -640,7 +640,7 @@ class TemplateTagTestSimple(TestCase):
 
 class CacheTest(TembaTest):
     def test_get_cacheable_result(self):
-        self.create_contact("Bob", number="1234")
+        self.create_contact("Bob", phone="1234")
 
         def calculate():
             return Contact.objects.all().count(), 60
@@ -650,7 +650,7 @@ class CacheTest(TembaTest):
         with self.assertNumQueries(0):
             self.assertEqual(get_cacheable_result("test_contact_count", calculate), 1)  # from cache
 
-        self.create_contact("Jim", number="2345")
+        self.create_contact("Jim", phone="2345")
 
         with self.assertNumQueries(0):
             self.assertEqual(get_cacheable_result("test_contact_count", calculate), 1)  # not updated
@@ -939,7 +939,7 @@ class GSM7Test(TembaTest):
 
 class ModelsTest(TembaTest):
     def test_require_update_fields(self):
-        contact = self.create_contact("Bob", twitter="bobby")
+        contact = self.create_contact("Bob", urns=["twitter:bobby"])
         flow = self.get_flow("color")
         run = FlowRun.objects.create(org=self.org, flow=flow, contact=contact)
 
@@ -969,8 +969,8 @@ class ModelsTest(TembaTest):
         self.assertEqual(curr, 100)
 
     def test_patch_queryset_count(self):
-        self.create_contact("Ann", twitter="ann")
-        self.create_contact("Bob", twitter="bob")
+        self.create_contact("Ann", urns=["twitter:ann"])
+        self.create_contact("Bob", urns=["twitter:bob"])
 
         with self.assertNumQueries(0):
             qs = Contact.objects.all()
@@ -1304,7 +1304,7 @@ class TestJSONAsTextField(TestCase):
 
 class TestJSONField(TembaTest):
     def test_jsonfield_decimal_encoding(self):
-        contact = self.create_contact("Xavier", number="+5939790990001")
+        contact = self.create_contact("Xavier", phone="+5939790990001")
 
         with connection.cursor() as cur:
             cur.execute(


### PR DESCRIPTION
Rather than cover it in `#pragma: no cover` I want to drop that method in #2986 but there is a bunch of test code using - so this PR cleans that up to avoid making that other PR's diff any crazier.