### PR TITLE
Remove update handling from contact.save

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1610,10 +1610,10 @@ class APITest(TembaTest):
 
         # tweak modified_on so we get the order we want
         self.joe.modified_on = timezone.now()
-        self.joe.save(update_fields=("modified_on",), handle_update=False)
+        self.joe.save(update_fields=("modified_on",))
         contact4.modified_on = timezone.now()
         contact4.last_seen_on = datetime(2020, 8, 12, 13, 30, 45, 123456, pytz.UTC)
-        contact4.save(update_fields=("modified_on", "last_seen_on"), handle_update=False)
+        contact4.save(update_fields=("modified_on", "last_seen_on"))
 
         contact1.refresh_from_db()
         contact4.refresh_from_db()

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -979,7 +979,7 @@ class CampaignTest(TembaTest):
 
         # give contact a last seen on value
         self.farmer1.last_seen_on = timezone.now()
-        self.farmer1.save(update_fields=("last_seen_on",), handle_update=False)
+        self.farmer1.save(update_fields=("last_seen_on",))
 
         ev4 = EventFire.objects.create(event=event3, contact=self.farmer1, scheduled=trim_date, fired=trim_date)
         self.assertIsNotNone(ev4.get_relative_to_value())
@@ -1024,7 +1024,7 @@ class CampaignTest(TembaTest):
         # give contact a last seen on value
         now = timezone.now()
         self.farmer1.last_seen_on = now
-        self.farmer1.save(update_fields=("last_seen_on",), handle_update=False)
+        self.farmer1.save(update_fields=("last_seen_on",))
 
         expected_result = (now + timedelta(days=5)).replace(second=0, microsecond=0).astimezone(self.org.timezone)
         self.assertEqual(event.calculate_scheduled_fire(self.farmer1), expected_result)

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -802,17 +802,6 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         """
         return self.all_groups.filter(group_type=ContactGroup.TYPE_USER_DEFINED)
 
-    def save(self, *args, handle_update=None, **kwargs):
-        super().save(*args, **kwargs)
-
-        # `handle_update` must be explicity set to execute handle_update when saving contact
-        if self.id and "update_fields" in kwargs:
-            if handle_update is None:
-                raise ValueError("When saving contacts we need to specify value for `handle_update`.")
-
-            if handle_update is True:
-                self.handle_update(fields=kwargs["update_fields"])
-
     def as_json(self):
         obj = dict(id=self.pk, name=str(self), uuid=self.uuid)
 
@@ -1316,7 +1305,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
             self.is_active = False
             self.name = None
             self.fields = None
-            self.save(update_fields=("name", "is_active", "fields", "modified_on"), handle_update=False)
+            self.save(update_fields=("name", "is_active", "fields", "modified_on"))
 
         # if we are removing everything do so
         if full:

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1239,11 +1239,6 @@ class ContactTest(TembaTest):
             message="Sent 7 days after planting date",
         )
 
-    def test_contact_save_raises_ValueError_if_handle_update_is_not_specified(self):
-        joe = self.create_contact("Joe Blow", phone="0788123123")
-
-        self.assertRaises(ValueError, joe.save, update_fields=("name",))
-
     def test_get_or_create(self):
 
         # can't create without org
@@ -1348,7 +1343,7 @@ class ContactTest(TembaTest):
         group = self.create_group("Test Group", contacts=[contact])
 
         contact.fields = {"gender": "Male", "age": 40}
-        contact.save(update_fields=("fields",), handle_update=False)
+        contact.save(update_fields=("fields",))
 
         self.create_broadcast(self.admin, "Test Broadcast", contacts=[contact])
 
@@ -1592,7 +1587,7 @@ class ContactTest(TembaTest):
 
         # we don't let users undo releasing a contact... but if we have to do it for some reason
         self.joe.is_active = True
-        self.joe.save(update_fields=("is_active",), handle_update=False)
+        self.joe.save(update_fields=("is_active",))
 
         # check joe goes into the appropriate groups
         self.assertEqual(
@@ -1691,7 +1686,7 @@ class ContactTest(TembaTest):
     def test_contact_search_evaluation_created_on_utc_rollover(self):
         # org is in Africa/Kigali timezone: +02:00
         self.joe.created_on = datetime(2019, 6, 8, 23, 14, 0, tzinfo=pytz.UTC)
-        self.joe.save(update_fields=("created_on",), handle_update=False)
+        self.joe.save(update_fields=("created_on",))
 
         query_created_on = self.joe.created_on.astimezone(self.org.timezone).date().isoformat()
 
@@ -1766,7 +1761,7 @@ class ContactTest(TembaTest):
 
         # test 'language' attribute
         self.joe.language = "eng"
-        self.joe.save(update_fields=("language",), handle_update=False)
+        self.joe.save(update_fields=("language",))
         self.assertTrue(evaluate_query(self.org, 'language = "eng"', contact_json=self.joe.as_search_json()))
 
         self.assertFalse(evaluate_query(self.org, 'language != "eng"', contact_json=self.joe.as_search_json()))
@@ -1783,7 +1778,7 @@ class ContactTest(TembaTest):
         )
 
         self.joe.language = None
-        self.joe.save(update_fields=("language",), handle_update=False)
+        self.joe.save(update_fields=("language",))
 
         self.assertFalse(evaluate_query(self.org, 'language = "eng"', contact_json=self.joe.as_search_json()))
 
@@ -1826,7 +1821,7 @@ class ContactTest(TembaTest):
 
         # test 'last_seen_on' attribute
         self.joe.last_seen_on = datetime(2020, 3, 17, 13, 0, 0, 0, pytz.UTC)
-        self.joe.save(update_fields=("last_seen_on",), handle_update=False)
+        self.joe.save(update_fields=("last_seen_on",))
 
         self.assertRaises(
             SearchException,
@@ -1868,7 +1863,7 @@ class ContactTest(TembaTest):
         self.assertFalse(evaluate_query(self.org, f'last_seen_on = ""', contact_json=self.joe.as_search_json()))
 
         self.joe.last_seen_on = None
-        self.joe.save(update_fields=("last_seen_on",), handle_update=False)
+        self.joe.save(update_fields=("last_seen_on",))
 
         self.assertFalse(
             evaluate_query(self.org, f"last_seen_on = 2016-01-01", contact_json=self.joe.as_search_json())
@@ -2629,7 +2624,7 @@ class ContactTest(TembaTest):
 
             kurt = self.create_contact("Kurt", phone="123123")
             self.joe.created_on = timezone.now() - timedelta(days=1000)
-            self.joe.save(update_fields=("created_on",), handle_update=False)
+            self.joe.save(update_fields=("created_on",))
 
             self.create_campaign()
 
@@ -3332,14 +3327,14 @@ class ContactTest(TembaTest):
 
         # this is a bogus
         self.joe.language = "zzz"
-        self.joe.save(update_fields=("language",), handle_update=False)
+        self.joe.save(update_fields=("language",))
         response = self.fetch_protected(reverse("contacts.contact_read", args=[self.joe.uuid]), self.admin)
 
         # should just show the language code instead of the language name
         self.assertContains(response, "zzz")
 
         self.joe.language = "fra"
-        self.joe.save(update_fields=("language",), handle_update=False)
+        self.joe.save(update_fields=("language",))
         response = self.fetch_protected(reverse("contacts.contact_read", args=[self.joe.uuid]), self.admin)
 
         # with a proper code, we should see the language
@@ -3728,7 +3723,7 @@ class ContactTest(TembaTest):
         # update our language to something not on the org
         self.joe.refresh_from_db()
         self.joe.language = "fra"
-        self.joe.save(update_fields=("language",), handle_update=False)
+        self.joe.save(update_fields=("language",))
 
         # add some languages to our org, but not french
         self.client.post(
@@ -3896,7 +3891,7 @@ class ContactTest(TembaTest):
         self.assertEqual([modifiers.Language(language="eng")], self.joe.update(name="Joe Blow", language="eng"))
 
         self.joe.language = "eng"
-        self.joe.save(update_fields=("language",), handle_update=False)
+        self.joe.save(update_fields=("language",))
 
         # change name
         self.assertEqual([modifiers.Name(name="Joseph Blow")], self.joe.update(name="Joseph Blow", language="eng"))
@@ -4149,7 +4144,7 @@ class ContactTest(TembaTest):
 
         joe = Contact.objects.get(pk=self.joe.pk)
         joe.language = "eng"
-        joe.save(update_fields=("language",), handle_update=False)
+        joe.save(update_fields=("language",))
 
         # none value instances
         self.assertEqual(joe.get_field_serialized(weight_field), None)
@@ -4258,7 +4253,7 @@ class ContactTest(TembaTest):
     def test_update_handling(self, mr_mocks):
         bob = self.create_contact("Bob", phone="111222")
         bob.name = "Bob Marley"
-        bob.save(update_fields=("name",), handle_update=False)
+        bob.save(update_fields=("name",))
 
         group = self.create_group("Customers", [])
         nickname = self.create_field("nickname", "Nickname")

--- a/temba/flows/legacy/definition/actions.py
+++ b/temba/flows/legacy/definition/actions.py
@@ -379,12 +379,7 @@ class VariableContactAction(Action):
             contact = Contact.objects.filter(uuid=contact_uuid, org=org).first()
 
             if not contact:
-                contact = Contact.create(org, org.created_by, name="", language="", urns=urns, fields={}, groups=[])
-
-                # if they don't have a name use the one in our action
-                if name and not contact.name:  # pragma: needs cover
-                    contact.name = name
-                    contact.save(update_fields=["name"], handle_update=True)
+                contact = Contact.create(org, org.created_by, name=name, language="", urns=urns, fields={}, groups=[])
 
             if contact:
                 contacts.append(contact)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4442,7 +4442,7 @@ class ExportFlowResultsTest(TembaTest):
 
         # contact name with an illegal character
         self.contact3.name = "Nor\02bert"
-        self.contact3.save(update_fields=("name",), handle_update=False)
+        self.contact3.save(update_fields=("name",))
 
         contact3_run1 = (
             MockSessionWriter(self.contact3, flow)

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -699,7 +699,7 @@ class MsgTest(TembaTest):
         self.login(self.admin)
 
         self.joe.name = "Jo\02e Blow"
-        self.joe.save(update_fields=("name",), handle_update=False)
+        self.joe.save(update_fields=("name",))
 
         self.org.created_on = datetime(2017, 1, 1, 9, tzinfo=pytz.UTC)
         self.org.save()
@@ -1189,7 +1189,7 @@ class MsgTest(TembaTest):
         self.login(self.admin)
 
         self.joe.name = "Jo\02e Blow"
-        self.joe.save(update_fields=("name",), handle_update=False)
+        self.joe.save(update_fields=("name",))
 
         msg1 = self.create_incoming_msg(self.joe, "hello 1", created_on=datetime(2017, 1, 1, 10, tzinfo=pytz.UTC))
         msg2 = self.create_incoming_msg(self.joe, "hello 2", created_on=datetime(2017, 1, 2, 10, tzinfo=pytz.UTC))
@@ -2047,7 +2047,7 @@ class BroadcastTest(TembaTest):
         self.assertEqual("Hola a todos", broadcast1.get_translated_text(self.joe))  # uses org primary language
 
         self.joe.language = "fra"
-        self.joe.save(update_fields=("language",), handle_update=False)
+        self.joe.save(update_fields=("language",))
 
         self.assertEqual("Salut à tous", broadcast1.get_translated_text(self.joe))  # uses contact language
 

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -603,7 +603,7 @@ class Command(BaseCommand):
 
             contact = Contact.create(org, user, c["name"], language="", urns=c["urns"], fields=values, groups=groups)
             contact.uuid = c["uuid"]
-            contact.save(update_fields=["uuid"], handle_update=False)
+            contact.save(update_fields=("uuid",))
 
         self._log(self.style.SUCCESS("OK") + "\n")
 


### PR DESCRIPTION
Removes triggering of `Contact.handle_update` from `Contact.save` since there are no longer any places where modifying a contact should trigger group/campaign evaluation in RP (still same places using `Contact.get_or_create` but it does it explicitly)