### PR TITLE
🗑️ Archiving a campaign should only recreate events

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -384,7 +384,7 @@ class CampaignEventWriteSerializer(WriteSerializer):
         if self.instance:
 
             # we dont update, we only create
-            self.instance = self.instance.deactivate_and_copy()
+            self.instance = self.instance.recreate()
 
             # we are being set to a flow
             if flow:

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -62,15 +62,20 @@ class Campaign(TembaModel):
 
         return name
 
+    def recreate_events(self):
+        """
+        Recreates all the events in this campaign - called when something like the group changes.
+        """
+
+        for event in self.get_events():
+            event.recreate()
+
     def schedule_events_async(self):
         """
-        Updates all the scheduled events for each contact for this campaign.
-        Should be called anytime a campaign changes.
+        Schedules all the events in this campaign - called when something like the group changes.
         """
-        for event in self.get_events():
-            if EventFire.objects.filter(event=event).exists():
-                event = event.deactivate_and_copy()
 
+        for event in self.get_events():
             event.schedule_async()
 
     @classmethod
@@ -184,34 +189,31 @@ class Campaign(TembaModel):
         return imported
 
     @classmethod
-    def restore_flows(cls, campaign):
-        events = (
-            campaign.events.filter(is_active=True, event_type=CampaignEvent.TYPE_FLOW)
-            .exclude(flow=None)
-            .select_related("flow")
-        )
-        for event in events:
-            event.flow.restore()
-
-    @classmethod
     def apply_action_archive(cls, user, campaigns):
         campaigns.update(is_archived=True, modified_by=user, modified_on=timezone.now())
 
-        # update the events for each campaign
+        # recreate events so existing event fires will be ignored
         for campaign in campaigns:
-            campaign.schedule_events_async()
+            campaign.recreate_events()
 
     @classmethod
     def apply_action_restore(cls, user, campaigns):
         campaigns.update(is_archived=False, modified_by=user, modified_on=timezone.now())
 
-        # update the events for each campaign
         for campaign in campaigns:
-            Campaign.restore_flows(campaign)
+            # for any flow events, ensure flows are restored as well
+            events = (
+                campaign.events.filter(is_active=True, event_type=CampaignEvent.TYPE_FLOW)
+                .exclude(flow=None)
+                .select_related("flow")
+            )
+            for event in events:
+                event.flow.restore()
+
             campaign.schedule_events_async()
 
     def get_events(self):
-        return self.events.filter(is_active=True).order_by("relative_to", "offset")
+        return self.events.filter(is_active=True).order_by("id")
 
     def as_export_def(self):
         """
@@ -514,8 +516,12 @@ class CampaignEvent(TembaModel):
 
         return None  # pragma: no cover
 
-    def deactivate_and_copy(self):
-
+    def recreate(self):
+        """
+        Cleaning up millions of event fires would be expensive so instead we treat campaign events as immutable objects
+        and when a change is made that would invalidate existing event fires, we deactivate the event and recreate it.
+        The event fire handling code knows to ignore event fires for deactivated event.
+        """
         self.release()
 
         # clone our event into a new event

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -40,6 +40,65 @@ class CampaignTest(TembaTest):
             self.org, self.admin, "planting_date", "Planting Date", value_type=Value.TYPE_DATETIME
         )
 
+    @mock_mailroom
+    def test_model(self, mr_mocks):
+        campaign = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
+
+        flow = self.create_flow()
+
+        event1 = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, self.planting_date, offset=1, unit="W", flow=flow, delivery_hour=13
+        )
+        event2 = CampaignEvent.create_message_event(
+            self.org, self.admin, campaign, self.planting_date, offset=3, unit="D", message="Hello", delivery_hour=9
+        )
+
+        self.assertEqual("Reminders", campaign.name)
+        self.assertEqual(f'Campaign[uuid={campaign.uuid}, name="Reminders"]', str(campaign))
+        self.assertEqual(f'Event[relative_to=planting_date, offset=1, flow="Color Flow"]', str(event1))
+        self.assertEqual([event1, event2], list(campaign.get_events()))
+
+        campaign.schedule_events_async()
+
+        # should have queued a scheduling task to mailroom for each event
+        self.assertEqual(
+            [
+                {
+                    "org_id": self.org.id,
+                    "type": "schedule_campaign_event",
+                    "queued_on": matchers.Datetime(),
+                    "task": {"campaign_event_id": event1.id, "org_id": self.org.id},
+                },
+                {
+                    "org_id": self.org.id,
+                    "type": "schedule_campaign_event",
+                    "queued_on": matchers.Datetime(),
+                    "task": {"campaign_event_id": event2.id, "org_id": self.org.id},
+                },
+            ],
+            mr_mocks.queued_batch_tasks,
+        )
+
+        campaign.recreate_events()
+
+        # existing events should be deactivated
+        event1.refresh_from_db()
+        event2.refresh_from_db()
+        self.assertFalse(event1.is_active)
+        self.assertFalse(event2.is_active)
+
+        # and clones created
+        new_event1, new_event2 = campaign.events.filter(is_active=True).order_by("id")
+
+        self.assertEqual(self.planting_date, new_event1.relative_to)
+        self.assertEqual("W", new_event1.unit)
+        self.assertEqual(1, new_event1.offset)
+        self.assertEqual(flow, new_event1.flow)
+        self.assertEqual(13, new_event1.delivery_hour)
+        self.assertEqual("D", new_event2.unit)
+        self.assertEqual(3, new_event2.offset)
+        self.assertEqual({"base": "Hello"}, new_event2.message)
+
     def test_get_unique_name(self):
         campaign1 = Campaign.create(
             self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers
@@ -655,8 +714,8 @@ class CampaignTest(TembaTest):
         response = self.client.get(reverse("campaigns.campaign_list"))
         self.assertNotContains(response, "Planting Reminders")
 
-        # should have queued another scheduling task to mailroom
-        self.assertEqual(5, len(mr_mocks.queued_batch_tasks))
+        # should not have queued another scheduling task to mailroom since campaign is now archived
+        self.assertEqual(4, len(mr_mocks.queued_batch_tasks))
 
         # shouldn't have any active event fires
         self.assertFalse(EventFire.objects.filter(event__is_active=True).exists())
@@ -666,7 +725,7 @@ class CampaignTest(TembaTest):
         self.client.post(reverse("campaigns.campaign_archived"), post_data)
 
         # should have queued another scheduling task to mailroom
-        self.assertEqual(6, len(mr_mocks.queued_batch_tasks))
+        self.assertEqual(5, len(mr_mocks.queued_batch_tasks))
 
         # set a planting date on our other farmer
         self.set_contact_field(self.farmer2, "planting_date", "1/6/2022", legacy_handle=True)
@@ -1102,6 +1161,7 @@ class CampaignTest(TembaTest):
         # if any event fires already exist, scheduling will trigger cloning the event
         EventFire.objects.create(event=planting_reminder, contact=self.farmer1, scheduled=timezone.now(), fired=None)
 
+        campaign.recreate_events()
         campaign.schedule_events_async()
 
         planting_reminder.refresh_from_db()

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -83,6 +83,7 @@ class CampaignCRUDL(SmartCRUDL):
 
             # if our group changed, create our new fires
             if new_group != previous_group:
+                self.object.recreate_events()
                 self.object.schedule_events_async()
 
             response = self.render_to_response(
@@ -678,7 +679,7 @@ class CampaignEventCRUDL(SmartCRUDL):
                 or prev.flow != obj.flow
                 or prev.start_mode != obj.start_mode
             ):
-                obj = obj.deactivate_and_copy()
+                obj = obj.recreate()
                 obj.schedule_async()
 
             return obj


### PR DESCRIPTION
Not queue them to mailroom for scheduling - which is the source of all the "campaign event not found" sentry errors