### PR TITLE
☎️ URN lookups on the contact API endpoint should be normalized with org country

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1664,7 +1664,7 @@ class APITest(TembaTest):
         self.assertResultsByUUID(response, [contact2])
 
         # filter by URN (which should be normalized)
-        response = self.fetchJSON(url, "urn=%s" % quote_plus("tel:+250-78-8000004"))
+        response = self.fetchJSON(url, "urn=%s" % quote_plus("tel:078-8000004"))
         self.assertResultsByUUID(response, [contact4])
 
         # error if URN can't be parsed

--- a/temba/api/v2/views_base.py
+++ b/temba/api/v2/views_base.py
@@ -86,11 +86,13 @@ class BaseAPIView(NonAtomicMixin, generics.GenericAPIView):
         return context
 
     def normalize_urn(self, value):
-        if self.request.user.get_org().is_anon:
+        org = self.request.user.get_org()
+
+        if org.is_anon:
             raise InvalidQueryError("URN lookups not allowed for anonymous organizations")
 
         try:
-            return URN.identity(URN.normalize(value))
+            return URN.identity(URN.normalize(value, country_code=org.get_country_code()))
         except ValueError:
             raise InvalidQueryError("Invalid URN: %s" % value)
 


### PR DESCRIPTION
If you POST to this endpoint with a URN that doesn't exist we actually let you create a contact with that URN - however to know if that URN doesn't exist, we need to normalize it with the org country. Otherwise if a user POSTS a local tel number, the lookup fails to find that contact, but then mailroom errors trying to create that contact.