### PR TITLE
🏑 Fields and globals API fixes

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -1080,6 +1080,18 @@ class GlobalWriteSerializer(WriteSerializer):
             raise serializers.ValidationError("Name creates Key that is invalid")
         return value
 
+    def validate(self, data):
+        if not self.instance and not data.get("name"):
+            raise serializers.ValidationError("Name is required when creating new global.")
+
+        globals_count = Global.objects.filter(org=self.context["org"], is_active=True).count()
+        if globals_count >= Global.MAX_ORG_GLOBALS:
+            raise serializers.ValidationError(
+                "This org has %s globals and the limit is %s. You must delete existing ones before you can "
+                "create new ones." % (globals_count, Global.MAX_ORG_GLOBALS)
+            )
+        return data
+
     def save(self):
         value = self.validated_data["value"]
         if self.instance:

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1774,7 +1774,7 @@ class FieldsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
 
     def get_queryset(self):
         org = self.request.user.get_org()
-        return getattr(self.model, "user_fields").filter(org=org)
+        return self.model.user_fields.filter(org=org, is_active=True)
 
     def filter_queryset(self, queryset):
         params = self.request.query_params

--- a/temba/globals/models.py
+++ b/temba/globals/models.py
@@ -15,6 +15,7 @@ class Global(SmartModel):
     A global is a constant value that can be used in templates in flows and messages.
     """
 
+    MAX_ORG_GLOBALS = 250
     MAX_KEY_LEN = 36
     MAX_NAME_LEN = 36
     MAX_VALUE_LEN = 640


### PR DESCRIPTION
* Filter by is_active when updating fields on API endpoint to fix https://sentry.io/organizations/nyaruka/issues/1939081165/?project=20737
 * Require name when creating globals to fix https://sentry.io/organizations/nyaruka/issues/1913245478/?project=20737