### PR TITLE
Fix and simplify rocketchat callback URL generation

### DIFF
--- a/temba/channels/types/rocketchat/client.py
+++ b/temba/channels/types/rocketchat/client.py
@@ -14,7 +14,7 @@ class ClientError(Exception):
 
 
 class Client:
-    def __init__(self, base_url: str, bot_username: str, secret: str):
+    def __init__(self, base_url: str, secret: str):
         self.base_url = base_url.rstrip("/")
         self.secret = secret
 
@@ -37,12 +37,10 @@ class Client:
     def put(self, url, timeout_msg=None, **kwargs):
         return self._request("put", url, timeout_msg, **kwargs)
 
-    def settings(self, domain, channel):
-        from .type import RocketChatType
-
+    def settings(self, webhook_url: str, bot_username: str):
         payload = {
-            "webhook": {"url": RocketChatType.callback_url(channel, domain)},
-            "bot": {"username": channel.config["bot_username"]},
+            "webhook": {"url": webhook_url},
+            "bot": {"username": bot_username},
         }
 
         response = self.put(

--- a/temba/channels/types/rocketchat/type.py
+++ b/temba/channels/types/rocketchat/type.py
@@ -1,14 +1,9 @@
-import re
-
-from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from temba.contacts.models import URN
 
 from ...models import ChannelType
 from .views import ClaimView
-
-RE_HOST = re.compile(r"(?:(?P<scheme>https?)://)?(?P<domain>[^ \"'/]+)")
 
 
 class RocketChatType(ChannelType):
@@ -40,14 +35,3 @@ class RocketChatType(ChannelType):
 
     def is_available_to(self, user):
         return user.is_beta()
-
-    @staticmethod
-    def callback_url(channel, domain=None):
-        if not domain:
-            domain = RE_HOST.search(channel.org.get_brand_domain() or "")
-            domain = domain and domain.group() or ""
-        search = RE_HOST.search(domain)
-        if not search:
-            raise ValueError("Could not identify the hostname.")
-        scheme, domain = search.groups()
-        return f"{scheme or 'https'}://{domain}{reverse('courier.rc', args=[channel.uuid])}"


### PR DESCRIPTION
Should use Channel.callback_domain instead of trying to resolve request URI