### PR TITLE
🧯 Fix choose org page

### DIFF
--- a/templates/orgs/org_choose.haml
+++ b/templates/orgs/org_choose.haml
@@ -6,7 +6,7 @@
     -trans "Choose Workspace"
 
 -block content
-  -if True or not orgs
+  -if not orgs
     .my-6
       -trans "Your login is not associated with any workspace. Please contact your administrator to receive an invitation to a workspace."
 


### PR DESCRIPTION
No org warning is always shown

<img width="708" alt="Captura de Pantalla 2020-11-23 a la(s) 15 35 31" src="https://user-images.githubusercontent.com/675558/100012608-8f2ce200-2da1-11eb-8e50-cf81d99be38b.png">
