### PR TITLE
🧯 Fix contact exports when orgs only have orphaned URNs in a given scheme

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1887,7 +1887,7 @@ class ExportContactsTask(BaseExportTask):
                 )
 
             for scheme in schemes_in_use:
-                contact_max = scheme_contact_max.get(scheme, 0)
+                contact_max = scheme_contact_max.get(scheme) or 0
                 for i in range(contact_max):
                     fields.append(
                         dict(

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -3785,6 +3785,9 @@ class ContactFieldTest(TembaTest):
         self.assertEqual(302, response.status_code)
         self.assertEqual("/contact/", response.url)
 
+        # create orphaned URN in scheme that no contacts have a URN for
+        ContactURN.create(self.org, None, "line:12345")
+
         def request_export(query=""):
             self.client.post(reverse("contacts.contact_export") + query, dict(group_memberships=(group.pk,)))
             task = ExportContactsTask.objects.all().order_by("-id").first()
@@ -3800,7 +3803,7 @@ class ContactFieldTest(TembaTest):
             self.create_contact_import(path)
 
         # no group specified, so will default to 'Active'
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(40):
             export = request_export()
             self.assertExcelSheet(
                 export[0],
@@ -3853,7 +3856,7 @@ class ContactFieldTest(TembaTest):
         # change the order of the fields
         self.contactfield_2.priority = 15
         self.contactfield_2.save()
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(40):
             export = request_export()
             self.assertExcelSheet(
                 export[0],
@@ -3911,7 +3914,7 @@ class ContactFieldTest(TembaTest):
         ContactURN.create(self.org, contact, "tel:+12062233445")
 
         # but should have additional Twitter and phone columns
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(40):
             export = request_export()
             self.assertExcelSheet(
                 export[0],
@@ -3996,7 +3999,7 @@ class ContactFieldTest(TembaTest):
         assertImportExportedFile()
 
         # export a specified group of contacts (only Ben and Adam are in the group)
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(41):
             self.assertExcelSheet(
                 request_export("?g=%s" % group.uuid)[0],
                 [
@@ -4061,7 +4064,7 @@ class ContactFieldTest(TembaTest):
                 log_info_threshold.return_value = 1
 
                 with ESMockWithScroll(data=mock_es_data):
-                    with self.assertNumQueries(41):
+                    with self.assertNumQueries(42):
                         self.assertExcelSheet(
                             request_export("?s=name+has+adam+or+name+has+deng")[0],
                             [
@@ -4120,7 +4123,7 @@ class ContactFieldTest(TembaTest):
         # export a search within a specified group of contacts
         mock_es_data = [{"_type": "_doc", "_index": "dummy_index", "_source": {"id": contact.id}}]
         with ESMockWithScroll(data=mock_es_data):
-            with self.assertNumQueries(40):
+            with self.assertNumQueries(41):
                 self.assertExcelSheet(
                     request_export("?g=%s&s=Hagg" % group.uuid)[0],
                     [


### PR DESCRIPTION
Fixes https://sentry.io/organizations/nyaruka/issues/2064518360/?project=21956&referrer=alert_email