### PR TITLE
🐘 Cache lookups of auth.Group instances

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -44,7 +44,7 @@ from temba.utils import json
 from . import fields
 from .serializers import format_datetime, normalize_extra
 
-NUM_BASE_REQUEST_QUERIES = 7  # number of db queries required for any API request
+NUM_BASE_REQUEST_QUERIES = 6  # number of db queries required for any API request
 
 
 class APITest(TembaTest):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1733,7 +1733,7 @@ class ContactTest(TembaTest):
                 SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]),
                 SearchResults(query="", total=0, contact_ids=[]),
             ]
-            with self.assertNumQueries(17):
+            with self.assertNumQueries(16):
                 actual_result = omnibox_request(query="")
                 expected_result = [
                     # all 3 groups A-Z
@@ -2011,7 +2011,7 @@ class ContactTest(TembaTest):
             )
 
             # fetch our contact history
-            with self.assertNumQueries(67):
+            with self.assertNumQueries(64):
                 response = self.fetch_protected(url, self.admin)
 
             # activity should include all messages in the last 90 days, the channel event, the call, and the flow run
@@ -3803,7 +3803,7 @@ class ContactFieldTest(TembaTest):
             self.create_contact_import(path)
 
         # no group specified, so will default to 'Active'
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(39):
             export = request_export()
             self.assertExcelSheet(
                 export[0],
@@ -3856,7 +3856,7 @@ class ContactFieldTest(TembaTest):
         # change the order of the fields
         self.contactfield_2.priority = 15
         self.contactfield_2.save()
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(39):
             export = request_export()
             self.assertExcelSheet(
                 export[0],
@@ -3914,7 +3914,7 @@ class ContactFieldTest(TembaTest):
         ContactURN.create(self.org, contact, "tel:+12062233445")
 
         # but should have additional Twitter and phone columns
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(39):
             export = request_export()
             self.assertExcelSheet(
                 export[0],
@@ -3999,7 +3999,7 @@ class ContactFieldTest(TembaTest):
         assertImportExportedFile()
 
         # export a specified group of contacts (only Ben and Adam are in the group)
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(40):
             self.assertExcelSheet(
                 request_export("?g=%s" % group.uuid)[0],
                 [
@@ -4064,7 +4064,7 @@ class ContactFieldTest(TembaTest):
                 log_info_threshold.return_value = 1
 
                 with ESMockWithScroll(data=mock_es_data):
-                    with self.assertNumQueries(42):
+                    with self.assertNumQueries(41):
                         self.assertExcelSheet(
                             request_export("?s=name+has+adam+or+name+has+deng")[0],
                             [
@@ -4123,7 +4123,7 @@ class ContactFieldTest(TembaTest):
         # export a search within a specified group of contacts
         mock_es_data = [{"_type": "_doc", "_index": "dummy_index", "_source": {"id": contact.id}}]
         with ESMockWithScroll(data=mock_es_data):
-            with self.assertNumQueries(41):
+            with self.assertNumQueries(40):
                 self.assertExcelSheet(
                     request_export("?g=%s&s=Hagg" % group.uuid)[0],
                     [

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3682,7 +3682,7 @@ class ExportFlowResultsTest(TembaTest):
                 # make sure that we trigger logger
                 log_info_threshold.return_value = 1
 
-                with self.assertNumQueries(43):
+                with self.assertNumQueries(42):
                     workbook = self._export(flow, group_memberships=[devs])
 
                 self.assertEqual(len(captured_logger.output), 3)
@@ -3922,7 +3922,7 @@ class ExportFlowResultsTest(TembaTest):
         )
 
         # test without msgs or unresponded
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(40):
             workbook = self._export(flow, include_msgs=False, responded_only=True, group_memberships=(devs,))
 
         tz = self.org.timezone
@@ -3988,7 +3988,7 @@ class ExportFlowResultsTest(TembaTest):
         )
 
         # test export with a contact field
-        with self.assertNumQueries(43):
+        with self.assertNumQueries(42):
             workbook = self._export(
                 flow,
                 include_msgs=False,
@@ -4218,7 +4218,7 @@ class ExportFlowResultsTest(TembaTest):
 
         contact1_run1, contact2_run1, contact3_run1, contact1_run2, contact2_run2 = FlowRun.objects.order_by("id")
 
-        with self.assertNumQueries(51):
+        with self.assertNumQueries(50):
             workbook = self._export(flow)
 
         tz = self.org.timezone
@@ -4488,7 +4488,7 @@ class ExportFlowResultsTest(TembaTest):
         )
 
         # test without msgs or unresponded
-        with self.assertNumQueries(34):
+        with self.assertNumQueries(33):
             workbook = self._export(flow, include_msgs=False, responded_only=True)
 
         tz = self.org.timezone

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -107,7 +107,7 @@ class LocationTest(TembaTest):
         )
 
         # update our alias for kigali
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(16):
             response = self.client.post(
                 reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]),
                 json.dumps(dict(osm_id=self.state1.osm_id, aliases="kigs\nkig")),
@@ -117,7 +117,7 @@ class LocationTest(TembaTest):
         self.assertEqual(200, response.status_code)
 
         # fetch our aliases again
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(20):
             response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
         response_json = response.json()
 
@@ -133,7 +133,7 @@ class LocationTest(TembaTest):
         self.assertEqual("Kigali City", search_result.json()[0]["name"])
 
         # update our alias for kigali with duplicates
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(16):
             response = self.client.post(
                 reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]),
                 json.dumps(dict(osm_id=self.state1.osm_id, aliases="kigs\nkig\nkig\nkigs\nkig")),
@@ -147,7 +147,7 @@ class LocationTest(TembaTest):
         )
 
         # fetch our aliases again
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(20):
             response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
         response_json = response.json()
 
@@ -187,7 +187,7 @@ class LocationTest(TembaTest):
         )
 
         # fetch our aliases again
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(20):
             response = self.client.get(reverse("locations.adminboundary_boundaries", args=[self.country.osm_id]))
         response_json = response.json()
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -308,7 +308,7 @@ class MsgTest(TembaTest):
 
         (msg1,) = tuple(Msg.objects.filter(broadcast=broadcast1))
 
-        with self.assertNumQueries(44):
+        with self.assertNumQueries(40):
             response = self.client.get(reverse("msgs.msg_outbox"))
 
         self.assertEqual(1, response.context_data["folders"][3]["count"])  # Outbox
@@ -332,7 +332,7 @@ class MsgTest(TembaTest):
         broadcast4.schedule = Schedule.create_schedule(self.org, self.admin, timezone.now(), Schedule.REPEAT_DAILY)
         broadcast4.save(update_fields=["schedule"])
 
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(37):
             response = self.client.get(reverse("msgs.msg_outbox"))
 
         self.assertEqual(5, response.context_data["folders"][3]["count"])  # Outbox
@@ -382,7 +382,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit inbox page as a manager of the organization
-        with self.assertNumQueries(61):
+        with self.assertNumQueries(57):
             response = self.fetch_protected(inbox_url + "?refresh=10000", self.admin)
 
         # make sure that we embed refresh script if View.refresh is set
@@ -466,7 +466,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit archived page as a manager of the organization
-        with self.assertNumQueries(53):
+        with self.assertNumQueries(49):
             response = self.fetch_protected(archive_url, self.admin)
 
         self.assertEqual(response.context["object_list"].count(), 1)
@@ -548,7 +548,7 @@ class MsgTest(TembaTest):
         # org viewer can
         self.login(self.admin)
 
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(37):
             response = self.client.get(url)
 
         self.assertEqual(set(response.context["object_list"]), {msg3, msg2, msg1})
@@ -613,7 +613,7 @@ class MsgTest(TembaTest):
         self.assertEqual(302, response.status_code)
 
         # visit failed page as an administrator
-        with self.assertNumQueries(64):
+        with self.assertNumQueries(60):
             response = self.fetch_protected(failed_url, self.admin)
 
         self.assertEqual(response.context["object_list"].count(), 3)
@@ -754,7 +754,7 @@ class MsgTest(TembaTest):
             return load_workbook(filename=filename)
 
         # export all visible messages (i.e. not msg3) using export_all param
-        with self.assertNumQueries(31):
+        with self.assertNumQueries(30):
             with patch("temba.archives.models.Archive.s3_client", return_value=mock_s3):
                 workbook = request_export("?l=I", {"export_all": 1})
 
@@ -1214,7 +1214,7 @@ class MsgTest(TembaTest):
                 # make sure that we trigger logger
                 log_info_threshold.return_value = 5
 
-                with self.assertNumQueries(30):
+                with self.assertNumQueries(29):
                     self.assertExcelSheet(
                         request_export("?l=I", {"export_all": 1}),
                         [

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -85,7 +85,7 @@ class OrgRole(Enum):
                 return role
         return None
 
-    @property
+    @cached_property
     def group(self):
         """
         Gets the auth group which defines the permissions for this role

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -21,7 +21,7 @@ from temba.flows.models import Flow, FlowRun, FlowSession, clear_flow_users
 from temba.ivr.models import IVRCall
 from temba.locations.models import AdminBoundary, BoundaryAlias
 from temba.msgs.models import HANDLED, INBOX, INCOMING, OUTGOING, PENDING, SENT, Broadcast, Label, Msg
-from temba.orgs.models import Org
+from temba.orgs.models import Org, OrgRole
 from temba.utils import json
 from temba.utils.uuid import UUID, uuid4
 
@@ -569,6 +569,11 @@ class TembaTest(TembaTestMixin, SmartminTest):
 
     def setUp(self):
         self.setUpOrgs()
+
+        # OrgRole.group is a cached property so get that cached before test starts to avoid query count differences
+        # when a test is first to request it and when it's not.
+        for role in OrgRole:
+            role.group  # noqa
 
     def tearDown(self):
         clear_flow_users()


### PR DESCRIPTION
Where this really makes difference to query counts is pages like the org home page where it shaves off ~70 queries but we don't have any tests for that.