### PR TITLE
increase max length on external channels to be configurable up to 6400

### DIFF
--- a/temba/channels/types/external/views.py
+++ b/temba/channels/types/external/views.py
@@ -66,7 +66,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         max_length = forms.IntegerField(
             initial=160,
-            validators=[MaxValueValidator(640), MinValueValidator(60)],
+            validators=[MaxValueValidator(6400), MinValueValidator(60)],
             help_text=_(
                 "The maximum length of any single message on this channel. " "(longer messages will be split)"
             ),
@@ -125,7 +125,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         max_length = forms.IntegerField(
             initial=160,
-            validators=[MaxValueValidator(640), MinValueValidator(60)],
+            validators=[MaxValueValidator(6400), MinValueValidator(60)],
             help_text=_(
                 "The maximum length of any single message on this channel. " "(longer messages will be split)"
             ),


### PR DESCRIPTION
By customers request, they have an external channel that wants to take messages longer than 640.

WhatsApp already is way up there (4096) so I think this is safe.