### PR TITLE
🤫 Background flow fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
       redis_version: '5'
       node_version: '10'
       elastic_version: '6.8.5'
-      rpindexer_version: '5.7.2'
-      mailroom_version: '5.7.40'
+      rpindexer_version: '6.0.0'
+      mailroom_version: '6.1.12'
       DJANGO_SETTINGS_MODULE: temba.settings_ci
     strategy:
       matrix:

--- a/media/test_flows/background.json
+++ b/media/test_flows/background.json
@@ -1,0 +1,59 @@
+{
+  "version": "13",
+  "site": "https://app.rapidpro.io",
+  "flows": [
+    {
+      "name": "Background",
+      "uuid": "1ff89517-5735-466b-be31-682b49521cbf",
+      "spec_version": "13.1.0",
+      "language": "eng",
+      "type": "messaging_background",
+      "nodes": [
+        {
+          "uuid": "cf80a41e-c7b2-46ea-994d-b2301589276b",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "Nothing to see here",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "16c21cf7-8987-430d-bb5a-243f3b5ce2ad"
+            },
+            {
+              "uuid": "6e9c9b9e-9de5-49ee-a74f-4c7fbfdda9d0",
+              "type": "set_contact_name",
+              "name": "Bob"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "b52df965-88c1-4933-b48a-8b96a8baacda",
+              "destination_uuid": null
+            }
+          ]
+        }
+      ],
+      "_ui": {
+        "nodes": {
+          "cf80a41e-c7b2-46ea-994d-b2301589276b": {
+            "position": {
+              "left": 0,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        }
+      },
+      "revision": 6,
+      "expire_after_minutes": 10080,
+      "metadata": {
+        "expires": 10080
+      },
+      "localization": {}
+    }
+  ],
+  "campaigns": [],
+  "triggers": [],
+  "fields": [],
+  "groups": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@nyaruka/flow-editor": "1.12.7",
+        "@nyaruka/flow-editor": "1.12.8",
         "@nyaruka/temba-components": "0.8.12",
         "@tailwindcss/ui": "0.2.2",
         "fa-icons": "0.2.0",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@nyaruka/flow-editor": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.7.tgz",
-      "integrity": "sha512-PeBsjI1Jb1Nhq6C76s+GyYZWzKRPYXs01D3Tbb+DoNevRy88ezkLkgUMthfhGX4Y3BtD1Wfhf/FOOi1I5sUCCQ==",
+      "version": "1.12.8",
+      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.8.tgz",
+      "integrity": "sha512-EEpCXP4Aet4K1xQML1UfTsUUM7f2ba+B8+J4vHRbv9pyylXaDLSd8GNuTnqqBWgwGLp6aTjpzWxmts41mPxWuw==",
       "dependencies": {
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
@@ -3048,9 +3048,9 @@
       }
     },
     "@nyaruka/flow-editor": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.7.tgz",
-      "integrity": "sha512-PeBsjI1Jb1Nhq6C76s+GyYZWzKRPYXs01D3Tbb+DoNevRy88ezkLkgUMthfhGX4Y3BtD1Wfhf/FOOi1I5sUCCQ==",
+      "version": "1.12.8",
+      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.8.tgz",
+      "integrity": "sha512-EEpCXP4Aet4K1xQML1UfTsUUM7f2ba+B8+J4vHRbv9pyylXaDLSd8GNuTnqqBWgwGLp6aTjpzWxmts41mPxWuw==",
       "requires": {
         "react": "^16.8.6",
         "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/flow-editor": "1.12.7",
+    "@nyaruka/flow-editor": "1.12.8",
     "@nyaruka/temba-components": "0.8.12",
     "@tailwindcss/ui": "0.2.2",
     "fa-icons": "0.2.0",

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -847,7 +847,12 @@ class ContactBulkActionSerializer(WriteSerializer):
 
 
 class FlowReadSerializer(ReadSerializer):
-    FLOW_TYPES = {Flow.TYPE_MESSAGE: "message", Flow.TYPE_VOICE: "voice", Flow.TYPE_SURVEY: "survey"}
+    FLOW_TYPES = {
+        Flow.TYPE_MESSAGE: "message",
+        Flow.TYPE_VOICE: "voice",
+        Flow.TYPE_BACKGROUND: "background",
+        Flow.TYPE_SURVEY: "survey",
+    }
 
     type = serializers.SerializerMethodField()
     archived = serializers.ReadOnlyField(source="is_archived")

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -333,14 +333,12 @@ class Flow(TembaModel):
         return flow
 
     @classmethod
-    def get_triggerable_flows(cls, org):
-        return Flow.objects.filter(
-            org=org,
-            is_active=True,
-            is_archived=False,
-            flow_type__in=(Flow.TYPE_MESSAGE, Flow.TYPE_VOICE),
-            is_system=False,
-        )
+    def get_triggerable_flows(cls, org, *, by_schedule: bool):
+        flow_types = [Flow.TYPE_MESSAGE, Flow.TYPE_VOICE]
+        if by_schedule:
+            flow_types.append(Flow.TYPE_BACKGROUND)
+
+        return org.flows.filter(flow_type__in=flow_types, is_active=True, is_archived=False, is_system=False)
 
     @classmethod
     def import_flows(cls, org, user, export_json, dependency_mapping, same_site=False):

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -36,12 +36,14 @@ class TriggerTest(TembaTest):
 
         flow = self.create_flow()
         voice_flow = self.get_flow("ivr")
+        background_flow = self.get_flow("background")
 
         # flow options should show sms and voice flows
         response = self.client.get(reverse("triggers.trigger_keyword"))
 
         self.assertContains(response, flow.name)
         self.assertContains(response, voice_flow.name)
+        self.assertNotContains(response, background_flow.name)
 
         # try a keyword with spaces
         response = self.client.post(

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -299,22 +299,30 @@ class TriggerTest(TembaTest):
     @patch("temba.flows.models.FlowStart.async_start")
     def test_trigger_schedule(self, mock_async_start):
         self.login(self.admin)
+
+        create_url = reverse("triggers.trigger_schedule")
+
         flow = self.create_flow()
+        background_flow = self.get_flow("background")
+        self.get_flow("media_survey")
 
         chester = self.create_contact("Chester", phone="+250788987654")
         shinoda = self.create_contact("Shinoda", phone="+250234213455")
         linkin_park = self.create_group("Linkin Park", [chester, shinoda])
         stromae = self.create_contact("Stromae", phone="+250788645323")
 
+        response = self.client.get(create_url)
+
+        # the normal flow and background flow should be options but not the surveyor flow
+        self.assertEqual(list(response.context["form"].fields["flow"].queryset), [background_flow, flow])
+
         now = timezone.now()
-
         tommorrow = now + timedelta(days=1)
-
         omnibox_selection = omnibox_serialize(flow.org, [linkin_park], [stromae], True)
 
         # try to create trigger without a flow or omnibox
         response = self.client.post(
-            reverse("triggers.trigger_schedule"),
+            create_url,
             {
                 "omnibox": omnibox_selection,
                 "repeat_period": "D",
@@ -327,24 +335,9 @@ class TriggerTest(TembaTest):
         self.assertFalse(Trigger.objects.all())
         self.assertFalse(Schedule.objects.all())
 
-        # survey flows should not be an option
-        flow.flow_type = Flow.TYPE_SURVEY
-        flow.save(update_fields=("flow_type",))
-
-        response = self.client.get(reverse("triggers.trigger_schedule"))
-
-        # check no flows listed
-        self.assertEqual(response.context["form"].fields["flow"].queryset.all().count(), 0)
-
-        # revert flow to messaging flow type
-        flow.flow_type = Flow.TYPE_MESSAGE
-        flow.save(update_fields=("flow_type",))
-
-        self.assertEqual(response.context["form"].fields["flow"].queryset.all().count(), 1)
-
         # this time provide a flow but leave out omnibox..
         response = self.client.post(
-            reverse("triggers.trigger_schedule"),
+            create_url,
             {
                 "flow": flow.id,
                 "repeat_period": "D",
@@ -358,7 +351,7 @@ class TriggerTest(TembaTest):
 
         # ok, really create it
         self.client.post(
-            reverse("triggers.trigger_schedule"),
+            create_url,
             {
                 "flow": flow.id,
                 "omnibox": omnibox_selection,
@@ -371,7 +364,7 @@ class TriggerTest(TembaTest):
         self.assertEqual(Trigger.objects.count(), 1)
 
         self.client.post(
-            reverse("triggers.trigger_schedule"),
+            create_url,
             {
                 "flow": flow.id,
                 "omnibox": omnibox_selection,

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -36,7 +36,7 @@ class BaseTriggerForm(forms.ModelForm):
     """
 
     flow = forms.ModelChoiceField(
-        Flow.objects.filter(pk__lt=0),
+        Flow.objects.none(),
         label=_("Flow"),
         required=True,
         widget=SelectWidget(attrs={"placeholder": _("Select a flow"), "searchable": True}),
@@ -95,7 +95,7 @@ class DefaultTriggerForm(BaseTriggerForm):
     """
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.get_triggerable_flows(user.get_org())
+        flows = Flow.get_triggerable_flows(user.get_org(), by_schedule=False)
         super().__init__(user, flows, *args, **kwargs)
 
 
@@ -138,7 +138,7 @@ class CatchAllTriggerForm(GroupBasedTriggerForm):
     """
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.get_triggerable_flows(user.get_org())
+        flows = Flow.get_triggerable_flows(user.get_org(), by_schedule=False)
         super().__init__(user, flows, *args, **kwargs)
 
     def get_existing_triggers(self, cleaned_data):
@@ -156,7 +156,7 @@ class KeywordTriggerForm(GroupBasedTriggerForm):
     """
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.get_triggerable_flows(user.get_org())
+        flows = Flow.get_triggerable_flows(user.get_org(), by_schedule=False)
         super().__init__(user, flows, *args, **kwargs)
 
     def get_existing_triggers(self, cleaned_data):
@@ -215,7 +215,7 @@ class RegisterTriggerForm(BaseTriggerForm):
     )
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.get_triggerable_flows(user.get_org())
+        flows = Flow.get_triggerable_flows(user.get_org(), by_schedule=False)
 
         super().__init__(user, flows, *args, **kwargs)
 
@@ -249,7 +249,7 @@ class ScheduleTriggerForm(BaseScheduleForm, forms.ModelForm):
     )
 
     flow = forms.ModelChoiceField(
-        Flow.objects.filter(pk__lt=0),
+        Flow.objects.none(),
         label=_("Flow"),
         required=True,
         widget=SelectWidget(attrs={"placeholder": _("Select a flow"), "searchable": True}),
@@ -269,7 +269,7 @@ class ScheduleTriggerForm(BaseScheduleForm, forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.user = user
         org = user.get_org()
-        flows = Flow.get_triggerable_flows(org)
+        flows = Flow.get_triggerable_flows(org, by_schedule=True)
 
         self.fields["start_datetime"].help_text = _("%s Time Zone" % org.timezone)
         self.fields["flow"].queryset = flows
@@ -304,7 +304,7 @@ class NewConversationTriggerForm(BaseTriggerForm):
     channel = forms.ModelChoiceField(Channel.objects.filter(pk__lt=0), label=_("Channel"), required=True)
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.get_triggerable_flows(user.get_org())
+        flows = Flow.get_triggerable_flows(user.get_org(), by_schedule=False)
         super().__init__(user, flows, *args, **kwargs)
 
         self.fields["channel"].queryset = Channel.objects.filter(
@@ -350,7 +350,7 @@ class ReferralTriggerForm(BaseTriggerForm):
     )
 
     def __init__(self, user, *args, **kwargs):
-        flows = Flow.get_triggerable_flows(user.get_org())
+        flows = Flow.get_triggerable_flows(user.get_org(), by_schedule=False)
         super().__init__(user, flows, *args, **kwargs)
 
         self.fields["channel"].queryset = Channel.objects.filter(


### PR DESCRIPTION
- [x] Allow background flows to be used in scheduled triggers
- [x] Fix API not returning type for background flows
- [x] Fix editor parsing of type for Enter Flow actions

I think it's correct to say the only trigger type than use a background flow is a scheduled trigger. Anything else involves input from the the contact, which then get's weird if there's an waiting session because it's not interrupted but it also doesn't see the input which would have been used to resume it.

I think we also want to allow background flows for campaign events but that requires a little more thought: https://github.com/rapidpro/rapidpro/issues/1423