### PR TITLE
Allow only deleting msg folders without active children labels

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1233,6 +1233,9 @@ class Label(TembaModel):
 
         return changed
 
+    def has_active_children_labels(self):
+        return self.children.filter(is_active=True).exists()
+
     def is_folder(self):
         return self.label_type == Label.TYPE_FOLDER
 
@@ -1244,8 +1247,9 @@ class Label(TembaModel):
 
         # release our children if we are a folder
         if self.is_folder():
-            for label in self.children.all():
-                label.release(user)
+            if self.has_active_children_labels():
+                raise ValueError(f"Cannot delete Folder: {self.name}, since it is a parent to other labels")
+
         else:
             Msg.labels.through.objects.filter(label=self).delete()
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1233,7 +1233,7 @@ class Label(TembaModel):
 
         return changed
 
-    def has_active_children_labels(self):
+    def has_child_labels(self):
         return self.children.filter(is_active=True).exists()
 
     def is_folder(self):
@@ -1247,7 +1247,7 @@ class Label(TembaModel):
 
         # release our children if we are a folder
         if self.is_folder():
-            if self.has_active_children_labels():
+            if self.has_child_labels():
                 raise ValueError(f"Cannot delete Folder: {self.name}, since it is a parent to other labels")
 
         else:

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2524,7 +2524,12 @@ class LabelTest(TembaTest):
         label3.toggle_label([msg3], add=True)
 
         ExportMessagesTask.create(self.org, self.admin, label=label1)
+        with self.assertRaises(ValueError):
+            folder1.release(self.admin)
 
+        # can only release a folder once all its children are released
+        label1.release(self.admin)
+        label2.release(self.admin)
         folder1.release(self.admin)
         folder1.refresh_from_db()
 

--- a/templates/msgs/label_delete.haml
+++ b/templates/msgs/label_delete.haml
@@ -10,7 +10,7 @@
       .message
         {{error}}
 
-  -if object.children.all
+  -if object.has_active_children_labels
     -blocktrans trimmed with name=object.name
       <b>{{name}}</b> cannot be deleted since it is a parent to other labels.
 

--- a/templates/msgs/label_delete.haml
+++ b/templates/msgs/label_delete.haml
@@ -10,7 +10,7 @@
       .message
         {{error}}
 
-  -if object.has_active_children_labels
+  -if object.has_child_labels
     -blocktrans trimmed with name=object.name
       <b>{{name}}</b> cannot be deleted since it is a parent to other labels.
 


### PR DESCRIPTION
Replace https://github.com/nyaruka/rapidpro/pull/3106 
We only delete a folder when it has no msg labels 