### PR TITLE
Update components and editor to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@nyaruka/flow-editor": "1.12.8",
-        "@nyaruka/temba-components": "0.8.12",
+        "@nyaruka/flow-editor": "1.12.9",
+        "@nyaruka/temba-components": "0.8.14",
         "@tailwindcss/ui": "0.2.2",
         "fa-icons": "0.2.0",
         "less": "2.7.1",
@@ -60,18 +60,18 @@
       }
     },
     "node_modules/@nyaruka/flow-editor": {
-      "version": "1.12.8",
-      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.8.tgz",
-      "integrity": "sha512-EEpCXP4Aet4K1xQML1UfTsUUM7f2ba+B8+J4vHRbv9pyylXaDLSd8GNuTnqqBWgwGLp6aTjpzWxmts41mPxWuw==",
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.9.tgz",
+      "integrity": "sha512-QlbrZLzWw/8lWV7HvfjClIIM24TZxUakpE25Qkk960DGLXhNkNE6EDq4L4gBHGzduKgfXyWsPpN1zrmSNbtOgg==",
       "dependencies": {
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
       }
     },
     "node_modules/@nyaruka/temba-components": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.8.12.tgz",
-      "integrity": "sha512-9lwtcMb4QTQUu3rfj0kAXHGNSgdJeha1WPAyF72FW27Q9oaIP6ID2HoQAQhEReEy1ToBduSE8DpEBMT9aDO+ww==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.8.14.tgz",
+      "integrity": "sha512-NEmb9L4PST8yOcX/Z6qPSweLUx0BXng79rnqD11tU4ePWgxloZeD6h/RRnR2By0yXP9Z+MH6l7aNItk9uM7qvA==",
       "dependencies": {
         "autosize": "4.0.2",
         "axios": "^0.21.1",
@@ -83,6 +83,7 @@
         "lit-element": "2.3.1",
         "lit-flatpickr": "^0.2.2",
         "lit-html": "1.2.1",
+        "lorem-ipsum": "2.0.3",
         "marked": "0.7.0",
         "node-forge": "0.10.0",
         "serialize-javascript": "^3.0.0",
@@ -475,6 +476,11 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1386,6 +1392,21 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dependencies": {
         "js-tokens": "^3.0.0"
+      }
+    },
+    "node_modules/lorem-ipsum": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.3.tgz",
+      "integrity": "sha512-CX2r84DMWjW/DWiuzicTI9aRaJPAw2cvAGMJYZh/nx12OkTGqloj8y8FU0S8ZkKwOdqhfxEA6Ly8CW2P6Yxjwg==",
+      "dependencies": {
+        "commander": "^2.17.1"
+      },
+      "bin": {
+        "lorem-ipsum": "dist/bin/lorem-ipsum.bin.js"
+      },
+      "engines": {
+        "node": ">= 8.x",
+        "npm": ">= 5.x"
       }
     },
     "node_modules/marked": {
@@ -3048,18 +3069,18 @@
       }
     },
     "@nyaruka/flow-editor": {
-      "version": "1.12.8",
-      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.8.tgz",
-      "integrity": "sha512-EEpCXP4Aet4K1xQML1UfTsUUM7f2ba+B8+J4vHRbv9pyylXaDLSd8GNuTnqqBWgwGLp6aTjpzWxmts41mPxWuw==",
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/@nyaruka/flow-editor/-/flow-editor-1.12.9.tgz",
+      "integrity": "sha512-QlbrZLzWw/8lWV7HvfjClIIM24TZxUakpE25Qkk960DGLXhNkNE6EDq4L4gBHGzduKgfXyWsPpN1zrmSNbtOgg==",
       "requires": {
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
       }
     },
     "@nyaruka/temba-components": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.8.12.tgz",
-      "integrity": "sha512-9lwtcMb4QTQUu3rfj0kAXHGNSgdJeha1WPAyF72FW27Q9oaIP6ID2HoQAQhEReEy1ToBduSE8DpEBMT9aDO+ww==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.8.14.tgz",
+      "integrity": "sha512-NEmb9L4PST8yOcX/Z6qPSweLUx0BXng79rnqD11tU4ePWgxloZeD6h/RRnR2By0yXP9Z+MH6l7aNItk9uM7qvA==",
       "requires": {
         "autosize": "4.0.2",
         "axios": "^0.21.1",
@@ -3071,6 +3092,7 @@
         "lit-element": "2.3.1",
         "lit-flatpickr": "^0.2.2",
         "lit-html": "1.2.1",
+        "lorem-ipsum": "2.0.3",
         "marked": "0.7.0",
         "node-forge": "0.10.0",
         "serialize-javascript": "^3.0.0",
@@ -3466,6 +3488,11 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -4371,6 +4398,14 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
         "js-tokens": "^3.0.0"
+      }
+    },
+    "lorem-ipsum": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.3.tgz",
+      "integrity": "sha512-CX2r84DMWjW/DWiuzicTI9aRaJPAw2cvAGMJYZh/nx12OkTGqloj8y8FU0S8ZkKwOdqhfxEA6Ly8CW2P6Yxjwg==",
+      "requires": {
+        "commander": "^2.17.1"
       }
     },
     "marked": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/flow-editor": "1.12.8",
-    "@nyaruka/temba-components": "0.8.12",
+    "@nyaruka/flow-editor": "1.12.9",
+    "@nyaruka/temba-components": "0.8.14",
     "@tailwindcss/ui": "0.2.2",
     "fa-icons": "0.2.0",
     "less": "2.7.1",


### PR DESCRIPTION
### Editor
* Allow expressions in add labels form
* CurrencyElement fix for airtime router
* Bump axios from 0.19.0 to 0.21.1 (security)

### Components
* Fix prod build include generation
* Bump socket.io from 2.3.0 to 2.4.1 (security)
* Update to newer version of open-wc/testing-karma
* New contact list, temba list, block options, and others for agents
* Modax hide on redirect