### PR TITLE
🕰️ Remove no longer needed support for parsing millisecond timestamps

### DIFF
--- a/temba/utils/dates.py
+++ b/temba/utils/dates.py
@@ -240,12 +240,7 @@ def timestamp_to_datetime(ms):
     """
     Converts a UTC microsecond timestamp to a datetime
     """
-    try:
-        dt = datetime.datetime.utcfromtimestamp(ms / 1_000)
-    except ValueError:
-        # possible this is actually a microsecond accuracy timestamp
-        dt = datetime.datetime.utcfromtimestamp(ms / 1_000_000)
-
+    dt = datetime.datetime.utcfromtimestamp(ms / 1_000_000)
     return dt.replace(tzinfo=pytz.utc)
 
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -247,10 +247,6 @@ class DatesTest(TembaTest):
         self.assertEqual(datetime_to_timestamp(d2), 1_388_624_645_123_456)
         self.assertEqual(timestamp_to_datetime(1_388_624_645_123_456), d2.astimezone(pytz.utc))
 
-        # can also parse as a millisecond timestamp
-        d3 = datetime.datetime(2014, 1, 2, 3, 4, 5, microsecond=123_000, tzinfo=pytz.utc)
-        self.assertEqual(timestamp_to_datetime(1_388_631_845_123), d3.astimezone(pytz.utc))
-
     def test_datetime_to_str(self):
         tz = pytz.timezone("Africa/Kigali")
         d2 = tz.localize(datetime.datetime(2014, 1, 2, 3, 4, 5, 6))


### PR DESCRIPTION
Now that all prod boxes will make requests with microseconds, this isn't used