### PR TITLE
🧹 Middleware cleanup

### DIFF
--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -31,25 +31,6 @@ class ExceptionMiddleware:
         return None
 
 
-class OrgHeaderMiddleware:
-    """
-    Simple middleware to add a response header with the current org id, which can then be included in logs
-    """
-
-    def __init__(self, get_response=None):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-
-        if hasattr(request, "user") and request.user.is_authenticated:
-            org = request.user.get_org()
-            if org:
-                response["X-Temba-Org"] = org.id
-
-        return response
-
-
 class BrandingMiddleware:
     def __init__(self, get_response=None):
         self.get_response = get_response
@@ -117,57 +98,94 @@ class ConsentMiddleware:  # pragma: no cover
         return response
 
 
-class ActivateLanguageMiddleware:
+class OrgMiddleware:
+    """
+    Determines the current org for this request and sets it on the user object on the request
+    """
+
     def __init__(self, get_response=None):
         self.get_response = get_response
 
     def __call__(self, request):
-        user = request.user
-        language = request.branding.get("language", settings.DEFAULT_LANGUAGE)
-        if user.is_anonymous or user.is_superuser:
-            translation.activate(language)
+        assert hasattr(request, "user"), "must be called after django.contrib.auth.middleware.AuthenticationMiddleware"
 
+        org = self.determine_org(request)
+        request.org = org
+
+        if request.user.is_authenticated:
+            request.user.set_org(org)
+
+        response = self.get_response(request)
+
+        # set a response header to make it easier to find the current org id
+        if org:
+            response["X-Temba-Org"] = org.id
+
+        return response
+
+    def determine_org(self, request):
+        user = request.user
+
+        if not user.is_authenticated:
+            return None
+
+        # check for value in session
+        org_id = request.session.get("org_id", None)
+        if org_id:
+            org = Org.objects.filter(is_active=True, id=org_id).first()
+
+            # only use if user actually belongs to this org
+            if org and (user.is_superuser or user.is_staff or org.has_user(user)):
+                return org
+
+        # otherwise if user only belongs to one org, we can use that
+        user_orgs = user.get_user_orgs()
+        if user_orgs.count() == 1:
+            return user_orgs[0]
+
+        return None
+
+
+class ActivateTimezoneMiddleware:
+    """
+    Activates the timezone for the current org
+    """
+
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        assert hasattr(request, "org"), "must be called after temba.middleware.OrgMiddleware"
+
+        if request.org:
+            timezone.activate(request.org.timezone)
+        else:
+            timezone.activate(settings.USER_TIME_ZONE)
+
+        return self.get_response(request)
+
+
+class ActivateLanguageMiddleware:
+    """
+    Activates the translation language for the current user
+    """
+
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        assert hasattr(request, "user"), "must be called after django.contrib.auth.middleware.AuthenticationMiddleware"
+
+        user = request.user
+
+        if not user.is_authenticated or user.is_superuser:
+            language = request.branding.get("language", settings.DEFAULT_LANGUAGE)
+            translation.activate(language)
         else:
             user_settings = user.get_settings()
             translation.activate(user_settings.language)
 
-        response = self.get_response(request)
-        return response
-
-
-class OrgTimezoneMiddleware:
-    def __init__(self, get_response=None):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        user = request.user
-        org = None
-
-        if not user.is_anonymous:
-
-            org_id = request.session.get("org_id", None)
-            if org_id:
-                org = Org.objects.filter(is_active=True, pk=org_id).first()
-
-            # only set the org if they are still a user or an admin
-            if org and (user.is_superuser or user.is_staff or org.has_user(user)):
-                user.set_org(org)
-
-            # otherwise, show them what orgs are available
-            else:
-                user_orgs = user.get_user_orgs()
-                if user_orgs.count() == 1:
-                    user.set_org(user_orgs[0])
-
-            org = request.user.get_org()
-
-        if org:
-            timezone.activate(org.timezone)
-        else:
-            timezone.activate(settings.USER_TIME_ZONE)
-
-        response = self.get_response(request)
-        return response
+        return self.get_response(request)
 
 
 class ProfilerMiddleware:  # pragma: no cover

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -146,7 +146,7 @@ class OrgMiddleware:
         return None
 
 
-class ActivateTimezoneMiddleware:
+class TimezoneMiddleware:
     """
     Activates the timezone for the current org
     """
@@ -165,7 +165,7 @@ class ActivateTimezoneMiddleware:
         return self.get_response(request)
 
 
-class ActivateLanguageMiddleware:
+class LanguageMiddleware:
     """
     Activates the translation language for the current user
     """

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -222,8 +222,8 @@ MIDDLEWARE = (
     "temba.middleware.ConsentMiddleware",
     "temba.middleware.BrandingMiddleware",
     "temba.middleware.OrgMiddleware",
-    "temba.middleware.ActivateLanguageMiddleware",
-    "temba.middleware.ActivateTimezoneMiddleware",
+    "temba.middleware.LanguageMiddleware",
+    "temba.middleware.TimezoneMiddleware",
 )
 
 # security middleware configuration

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -221,9 +221,9 @@ MIDDLEWARE = (
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "temba.middleware.ConsentMiddleware",
     "temba.middleware.BrandingMiddleware",
-    "temba.middleware.OrgTimezoneMiddleware",
+    "temba.middleware.OrgMiddleware",
     "temba.middleware.ActivateLanguageMiddleware",
-    "temba.middleware.OrgHeaderMiddleware",
+    "temba.middleware.ActivateTimezoneMiddleware",
 )
 
 # security middleware configuration


### PR DESCRIPTION
Was looking at making some optimizations around permission checking but first wanted to simplify the current set of middlewares so that we have...

 * `OrgMiddleware` - responsible for determining the org and setting it on the request/response
 * `TimezoneMiddleware` - responsible for setting the timezone (currently just based on org but might one day be based on user)
 * `LanguageMiddleware` - responsible for setting the language (currently just based on user but might one day look for default on org)