### PR TITLE
📺 Fix rendering of nameless channels

### DIFF
--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -7,7 +7,7 @@
       -if object.parent
         {{ object.parent.name }}
       -else
-        {{ object.name }}
+        {{ object.name|default:object.get_address_display }}
 
 -block subtitle
   -if object.get_channel_type_display != object.name
@@ -20,7 +20,7 @@
             {{ object.get_channel_type_display }}
             -trans "Channel"
 
-  -if object.name != object.get_address_display
+  -if object.name
     .text-gray-500.text-base
       {{ object.get_address_display }}
 
@@ -95,8 +95,8 @@
       .device
         -if channel.name
           {{ channel.name }}
-        -if channel.device != channel.name
-          \- {{ channel.device }}
+          \-
+        {{ channel.device }}
         -if channel.os
           .inline-block
             (v{{channel.os}})


### PR DESCRIPTION
Fixes https://github.com/rapidpro/rapidpro/issues/1439. New Android channel currently looks like...

<img width="719" alt="Captura de Pantalla 2021-02-23 a la(s) 14 06 28" src="https://user-images.githubusercontent.com/675558/108897937-9c49af00-75e4-11eb-8d2d-7f0cea4eabab.png">
<img width="347" alt="Captura de Pantalla 2021-02-23 a la(s) 14 06 38" src="https://user-images.githubusercontent.com/675558/108897940-9d7adc00-75e4-11eb-9df4-2991f9bac694.png">

Now like..

<img width="708" alt="Captura de Pantalla 2021-02-23 a la(s) 14 38 44" src="https://user-images.githubusercontent.com/675558/108898345-1aa65100-75e5-11eb-982c-8f29a36b498d.png">
<img width="350" alt="Captura de Pantalla 2021-02-23 a la(s) 14 30 54" src="https://user-images.githubusercontent.com/675558/108898021-b08dac00-75e4-11eb-9ed2-6ce204e1b3b4.png">

Or if you add a name, like...

<img width="703" alt="Captura de Pantalla 2021-02-23 a la(s) 14 31 30" src="https://user-images.githubusercontent.com/675558/108898047-b8e5e700-75e4-11eb-947a-9984f91d426a.png">
<img width="380" alt="Captura de Pantalla 2021-02-23 a la(s) 14 31 15" src="https://user-images.githubusercontent.com/675558/108898204-ecc10c80-75e4-11eb-83ab-a88e68d7e6c8.png">

