### PR TITLE
Fix handling of attempts to sync old unclaimed channels

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1095,6 +1095,15 @@ class ChannelTest(TembaTest):
         # should be an error response
         self.assertEqual({"error": "Can't sync unclaimed channel", "error_id": 4, "cmds": []}, response.json())
 
+        self.unclaimed_channel.secret = "12345674674"
+        self.unclaimed_channel.save(update_fields=("secret",))
+
+        response = self.sync(self.unclaimed_channel)
+        self.assertEqual(401, response.status_code)
+
+        # should be an error response
+        self.assertEqual({"error": "Can't sync unclaimed channel", "error_id": 4, "cmds": []}, response.json())
+
     @mock_mailroom
     def test_sync_released(self, mr_mocks):
         # register an Android channel

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -732,7 +732,7 @@ def sync(request, channel_id):
     request_time = request.GET.get("ts", "")
     request_signature = force_bytes(request.GET.get("signature", ""))
 
-    if not channel.secret:
+    if not channel.org or not channel.secret:
         return JsonResponse({"error_id": 4, "error": "Can't sync unclaimed channel", "cmds": []}, status=401)
 
     # check that the request isn't too old (15 mins)


### PR DESCRIPTION
Return error instead of https://sentry.io/organizations/nyaruka/issues/2234386424/?project=21956&referrer=alert_email