### PR TITLE
add spacing between individual channel log events

### DIFF
--- a/templates/channels/channellog_log.haml
+++ b/templates/channels/channellog_log.haml
@@ -1,6 +1,6 @@
 -load humanize channels i18n
 
-%table.list
+%table.list.mb-4
   %tbody
     %tr.border-b
       %td(style="width: 30px;")


### PR DESCRIPTION
<img width="828" alt="Screen Shot 2021-03-02 at 10 29 23 AM" src="https://user-images.githubusercontent.com/168067/109696775-458f2880-7b42-11eb-8adf-90aa805380ae.png">
