### PR TITLE
Disable old zenvia

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -918,8 +918,8 @@ class ChannelTest(TembaTest):
         self.assertEqual(response.context["channel_types"]["PHONE"][0].code, "AC")
         self.assertEqual(response.context["channel_types"]["PHONE"][1].code, "T")
         self.assertEqual(response.context["channel_types"]["PHONE"][2].code, "TMS")
-        self.assertEqual(response.context["channel_types"]["PHONE"][-2].code, "YO")
-        self.assertEqual(response.context["channel_types"]["PHONE"][-1].code, "ZV")
+        self.assertEqual(response.context["channel_types"]["PHONE"][-2].code, "WV")
+        self.assertEqual(response.context["channel_types"]["PHONE"][-1].code, "YO")
 
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][0].code, "D3")
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][1].code, "TWA")
@@ -936,8 +936,8 @@ class ChannelTest(TembaTest):
         self.assertEqual(response.context["channel_types"]["PHONE"][0].code, "AC")
         self.assertEqual(response.context["channel_types"]["PHONE"][1].code, "T")
         self.assertEqual(response.context["channel_types"]["PHONE"][2].code, "TMS")
-        self.assertEqual(response.context["channel_types"]["PHONE"][-2].code, "YO")
-        self.assertEqual(response.context["channel_types"]["PHONE"][-1].code, "ZV")
+        self.assertEqual(response.context["channel_types"]["PHONE"][-2].code, "WV")
+        self.assertEqual(response.context["channel_types"]["PHONE"][-1].code, "YO")
 
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][0].code, "WA")
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][1].code, "D3")

--- a/temba/channels/types/zenvia/tests.py
+++ b/temba/channels/types/zenvia/tests.py
@@ -23,8 +23,7 @@ class ZenviaTypeTest(TembaTest):
         self.org.save()
 
         response = self.client.get(reverse("channels.channel_claim"))
-        self.assertContains(response, "Zenvia")
-        self.assertContains(response, url)
+        self.assertNotContains(response, url)
 
         # try to claim a channel
         response = self.client.get(url)

--- a/temba/channels/types/zenvia/type.py
+++ b/temba/channels/types/zenvia/type.py
@@ -49,3 +49,6 @@ class ZenviaType(ChannelType):
             description=_("To receive incoming messages, you need to set the receive URL for your Zenvia account."),
         ),
     )
+
+    def is_available_to(self, user):
+        return False, False


### PR DESCRIPTION
The current integration is broken as the API has changed.

So hide that until we add support on the new API