### PR TITLE
👪 Fix manage accounts form blowing up used by multiple users at same time

### DIFF
--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1551,6 +1551,24 @@ class OrgTest(TembaTest):
         invites_on_form = [row["invite"].email for row in response.context["form"].invite_rows]
         self.assertEqual(["code@temba.com", "norbert@temba.com"], invites_on_form)
 
+        # users for whom nothing is submitted for remain unchanged
+        response = self.client.post(
+            url,
+            {
+                f"user_{self.admin.id}_role": "A",
+                "invite_emails": "",
+                "invite_role": "A",
+            },
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.org.refresh_from_db()
+        self.assertEqual(set(self.org.administrators.all()), {self.admin})
+        self.assertEqual(set(self.org.editors.all()), {self.user, self.editor})
+        self.assertFalse(set(self.org.viewers.all()), set())
+        self.assertEqual(set(self.org.surveyors.all()), set())
+        self.assertEqual(set(self.org.agents.all()), {self.agent})
+
         # try to remove ourselves as admin
         response = self.client.post(
             url,

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1775,8 +1775,8 @@ class OrgCRUDL(SmartCRUDL):
                 roles = {}
 
                 for row in self.user_rows:
-                    role = self.cleaned_data[row["role_field"]]
-                    remove = self.cleaned_data[row["remove_field"]]
+                    role = self.cleaned_data.get(row["role_field"])
+                    remove = self.cleaned_data.get(row["remove_field"])
                     roles[row["user"]] = OrgRole.from_code(role) if not remove else None
                 return roles
 


### PR DESCRIPTION
Couple of times have seen errors like https://sentry.io/organizations/nyaruka/issues/2277034731/?project=21956&referrer=alert_email which I think happen when more than one user is editing users at the same time, thus a new user exists at form submission time who didn't exist when form was rendered.