### PR TITLE
Show results in flow order

### DIFF
--- a/templates/flows/flow_results.haml
+++ b/templates/flows/flow_results.haml
@@ -339,13 +339,6 @@
       {% endfor %}
     ];
 
-    // alpha sort our result names
-    columns.sort(function(a, b){
-      a = a.text.toLowerCase();
-      b = b.text.toLowerCase();
-      return (a < b) ? -1 : a > b ? 1 : 0;
-    });
-
     $(document).ready(function() {
       Highcharts.setOptions({
         global: {


### PR DESCRIPTION
In page sort was causing issues when results in the first 3 were re-ordered. This sort should really be flow order anyways so I just removed the alpha sort that was causing this issue. If we want to do alpha instead of flow order, it's easy to sort this in the view context instead.