### PR TITLE
Proper skip anonymous user for analytics

### DIFF
--- a/temba/utils/analytics.py
+++ b/temba/utils/analytics.py
@@ -212,7 +212,7 @@ def track(user, event_name, properties=None, context=None):
         return
 
     # no op for anon user
-    if user.is_anonymous:
+    if not user.is_authenticated:
         return
 
     email = user.email

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -1251,7 +1251,7 @@ class AnalyticsTest(SmartminTest):
             id=1000, name="Some Org", brand="Some Brand", created_on=timezone.now(), account_value=lambda: 1000
         )
         self.admin = SimpleNamespace(
-            username="admin@example.com", first_name="", last_name="", email="admin@example.com", is_anonymous=False
+            username="admin@example.com", first_name="", last_name="", email="admin@example.com", is_authenticated=True
         )
 
         self.intercom_mock = MagicMock()


### PR DESCRIPTION
Proper solution is to check is_authenticated instead of is_anonymous as mentioned on  https://docs.djangoproject.com/en/3.2/ref/contrib/auth/#django.contrib.auth.models.User.is_anonymous

And fixes https://sentry.io/organizations/nyaruka/issues/1532503323/