### PR TITLE
Clear primary language

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1920,6 +1920,7 @@ class Org(SmartModel):
         self.released_on = timezone.now()
         self.config = {}
         self.surveyor_password = None
+        self.primary_language = None
         self.save()
 
     @classmethod


### PR DESCRIPTION
We delete the language foreign keys so have to clear it when we save the org.