### PR TITLE
🔨 Org deletion whack a mole

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -905,7 +905,7 @@ class Flow(TembaModel):
             m2m.clear()
             m2m.add(*objects)
 
-    def release(self):
+    def release(self, interrupt_sessions=True):
         """
         Releases this flow, marking it inactive. We interrupt all flow runs in a background process.
         We keep FlowRevisions and FlowStarts however.
@@ -938,7 +938,8 @@ class Flow(TembaModel):
         self.global_dependencies.clear()
 
         # queue mailroom to interrupt sessions where contact is currently in this flow
-        mailroom.queue_interrupt(self.org, flow=self)
+        if interrupt_sessions:
+            mailroom.queue_interrupt(self.org, flow=self)
 
     def release_runs(self):
         """

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -242,6 +242,9 @@ class Broadcast(models.Model):
         return Language.get_localized_text(self.text, preferred_languages)
 
     def release(self):
+        for child in self.children.all():
+            child.release()
+
         for msg in self.msgs.all():
             msg.release()
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1698,7 +1698,7 @@ class Org(SmartModel):
         # delete everything associated with our flows
         for flow in self.flows.all():
             # we want to manually release runs so we don't fire a task to do it
-            flow.release()
+            flow.release(interrupt_sessions=False)
             flow.release_runs()
 
             for rev in flow.revisions.all():

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1716,6 +1716,9 @@ class Org(SmartModel):
         self.tickets.all().delete()
         self.airtime_transfers.all().delete()
 
+        for result in self.webhook_results.all():
+            result.release()
+
         # delete our contacts
         for contact in self.contacts.all():
             contact.release(contact.modified_by, full=True, immediately=True)
@@ -1769,9 +1772,6 @@ class Org(SmartModel):
         for topup in self.topups.all():
             topup.release()
 
-        for result in self.webhook_results.all():
-            result.release()
-
         for event in self.webhookevent_set.all():
             event.release()
 
@@ -1786,7 +1786,7 @@ class Org(SmartModel):
         self.languages.all().delete()
 
         # release our broadcasts
-        for bcast in self.broadcast_set.all():
+        for bcast in self.broadcast_set.filter(parent=None):
             bcast.release()
 
         # delete other related objects

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -762,7 +762,8 @@ class OrgDeleteTest(TembaNonAtomicTest):
         self.create_outgoing_msg(child_contact, "Hola mama!", channel=self.child_channel)
 
         # create a broadcast and some counts
-        self.create_broadcast(self.user, "Broadcast with messages", contacts=[parent_contact])
+        bcast1 = self.create_broadcast(self.user, "Broadcast with messages", contacts=[parent_contact])
+        self.create_broadcast(self.user, "Broadcast with messages", contacts=[parent_contact], parent=bcast1)
 
         # create some archives
         self.mock_s3 = MockS3Client()
@@ -827,7 +828,12 @@ class OrgDeleteTest(TembaNonAtomicTest):
             resthook.subscribers.create(target_url="http://foo.bar", created_by=self.admin, modified_by=self.admin)
             WebHookEvent.objects.create(org=org, resthook=resthook, data={})
             WebHookResult.objects.create(
-                org=self.org, url="http://foo.bar", request="GET http://foo.bar", status_code=200, response="zap!"
+                org=self.org,
+                url="http://foo.bar",
+                request="GET http://foo.bar",
+                status_code=200,
+                response="zap!",
+                contact=self.org.contacts.first(),
             )
 
             # release our primary org
@@ -891,7 +897,7 @@ class OrgDeleteTest(TembaNonAtomicTest):
 
     def test_release_child_and_delete(self):
         # 300 credits were given to our child org and each used one
-        self.assertEqual(697, self.parent_org.get_credits_remaining())
+        self.assertEqual(696, self.parent_org.get_credits_remaining())
         self.assertEqual(299, self.child_org.get_credits_remaining())
 
         # release our child org
@@ -899,7 +905,7 @@ class OrgDeleteTest(TembaNonAtomicTest):
 
         # our unused credits are returned to the parent
         self.parent_org.clear_credit_cache()
-        self.assertEqual(995, self.parent_org.get_credits_remaining())
+        self.assertEqual(994, self.parent_org.get_credits_remaining())
 
     def test_delete_task(self):
         # can't delete an unreleased org

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -369,8 +369,8 @@ class TembaTestMixin:
             metadata=metadata,
         )
 
-    def create_broadcast(self, user, text, contacts=(), groups=(), response_to=None, msg_status=SENT):
-        bcast = Broadcast.create(self.org, user, text, contacts=contacts, groups=groups, status=SENT)
+    def create_broadcast(self, user, text, contacts=(), groups=(), response_to=None, msg_status=SENT, parent=None):
+        bcast = Broadcast.create(self.org, user, text, contacts=contacts, groups=groups, status=SENT, parent=parent)
 
         contacts = set(bcast.contacts.all())
         for group in bcast.groups.all():


### PR DESCRIPTION
* handle broadcasts with parents (https://sentry.io/organizations/nyaruka/issues/2398445632/?environment=production&project=20737)
* handle webhook results with contacts (https://sentry.io/organizations/nyaruka/issues/2398213753/?environment=production&project=20737)
* don't trigger mailroom session interruption during org deletion (https://sentry.io/organizations/nyaruka/issues/2398318703/?environment=production&project=20737)

There's also a problem with msg labels used by flows but I want to fix that separately as part of work on flow dependencies.