### PR TITLE
Update layout and color for badge buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,12 @@
         "@nyaruka/flow-editor": "1.13.15",
         "@nyaruka/temba-components": "0.11.9",
         "@tailwindcss/ui": "0.2.2",
+        "colorette": "1.2.2",
         "fa-icons": "0.2.0",
+        "is-core-module": "2.4.0",
         "less": "2.7.1",
         "postcss": "7.0.27",
+        "queue-microtask": "1.2.3",
         "react": "16.13.1",
         "react-dom": "16.13.1"
       },
@@ -387,6 +390,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -460,6 +464,11 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -910,8 +919,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/geojson": {
       "version": "0.5.0",
@@ -971,7 +979,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       }
@@ -1125,6 +1132,17 @@
         "rgba-regex": "^1.0.0"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
@@ -1252,7 +1270,13 @@
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.1.tgz",
       "integrity": "sha1-bL/qIrO4MDBOml+zcdVPpIDJ188=",
       "dependencies": {
-        "mkdirp": "^0.5.0"
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.2.11",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "source-map": "^0.5.3"
       },
       "optionalDependencies": {
         "errno": "^0.1.1",
@@ -2299,6 +2323,25 @@
       "dependencies": {
         "inherits": "~2.0.3"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -3370,6 +3413,11 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3831,8 +3879,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "geojson": {
       "version": "0.5.0",
@@ -3889,7 +3936,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -4038,6 +4084,14 @@
         "hsla-regex": "^1.0.0",
         "rgb-regex": "^1.0.1",
         "rgba-regex": "^1.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-date-object": {
@@ -5264,6 +5318,11 @@
       "requires": {
         "inherits": "~2.0.3"
       }
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
     "@nyaruka/flow-editor": "1.13.15",
     "@nyaruka/temba-components": "0.11.9",
     "@tailwindcss/ui": "0.2.2",
+    "colorette": "1.2.2",
     "fa-icons": "0.2.0",
+    "is-core-module": "2.4.0",
     "less": "2.7.1",
     "postcss": "7.0.27",
+    "queue-microtask": "1.2.3",
     "react": "16.13.1",
     "react-dom": "16.13.1"
   },

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -480,19 +480,11 @@ textarea {
   resize: vertical;
 }
 
-input::-webkit-input-placeholder, textarea::-webkit-input-placeholder {
-  color: #a0aec0;
-}
-
 input::-moz-placeholder, textarea::-moz-placeholder {
   color: #a0aec0;
 }
 
 input:-ms-input-placeholder, textarea:-ms-input-placeholder {
-  color: #a0aec0;
-}
-
-input::-ms-input-placeholder, textarea::-ms-input-placeholder {
   color: #a0aec0;
 }
 
@@ -621,22 +613,12 @@ video {
   line-height: 1.5;
 }
 
-.form-input::-webkit-input-placeholder {
-  color: #9fa6b2;
-  opacity: 1;
-}
-
 .form-input::-moz-placeholder {
   color: #9fa6b2;
   opacity: 1;
 }
 
 .form-input:-ms-input-placeholder {
-  color: #9fa6b2;
-  opacity: 1;
-}
-
-.form-input::-ms-input-placeholder {
   color: #9fa6b2;
   opacity: 1;
 }
@@ -668,22 +650,12 @@ video {
   line-height: 1.5;
 }
 
-.form-textarea::-webkit-input-placeholder {
-  color: #9fa6b2;
-  opacity: 1;
-}
-
 .form-textarea::-moz-placeholder {
   color: #9fa6b2;
   opacity: 1;
 }
 
 .form-textarea:-ms-input-placeholder {
-  color: #9fa6b2;
-  opacity: 1;
-}
-
-.form-textarea::-ms-input-placeholder {
   color: #9fa6b2;
   opacity: 1;
 }
@@ -766,6 +738,25 @@ video {
   border-color: #a4cafe;
 }
 
+.form-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+@media not print {
+  .form-checkbox::-ms-check {
+    border-width: 1px;
+    color: transparent;
+    background: inherit;
+    border-color: inherit;
+    border-radius: inherit;
+  }
+}
+
 .form-checkbox {
   -webkit-appearance: none;
      -moz-appearance: none;
@@ -789,25 +780,6 @@ video {
   border-radius: 0.25rem;
 }
 
-.form-checkbox:checked {
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
-  border-color: transparent;
-  background-color: currentColor;
-  background-size: 100% 100%;
-  background-position: center;
-  background-repeat: no-repeat;
-}
-
-@media not print {
-  .form-checkbox::-ms-check {
-    border-width: 1px;
-    color: transparent;
-    background: inherit;
-    border-color: inherit;
-    border-radius: inherit;
-  }
-}
-
 .form-checkbox:focus {
   outline: none;
   box-shadow: 0 0 0 3px rgba(164, 202, 254, 0.45);
@@ -816,6 +788,25 @@ video {
 
 .form-checkbox:checked:focus {
   border-color: transparent;
+}
+
+.form-radio:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+@media not print {
+  .form-radio::-ms-check {
+    border-width: 1px;
+    color: transparent;
+    background: inherit;
+    border-color: inherit;
+    border-radius: inherit;
+  }
 }
 
 .form-radio {
@@ -839,25 +830,6 @@ video {
   background-color: #ffffff;
   border-color: #d2d6dc;
   border-width: 1px;
-}
-
-.form-radio:checked {
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
-  border-color: transparent;
-  background-color: currentColor;
-  background-size: 100% 100%;
-  background-position: center;
-  background-repeat: no-repeat;
-}
-
-@media not print {
-  .form-radio::-ms-check {
-    border-width: 1px;
-    color: transparent;
-    background: inherit;
-    border-color: inherit;
-    border-radius: inherit;
-  }
 }
 
 .form-radio:focus {
@@ -1039,8 +1011,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #717171;
-  background-color: #f7f7f7;
 }
 
 .button-light:active {
@@ -1058,6 +1028,11 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-light {
+  color: #717171;
+  background-color: #f7f7f7;
+}
 
 .button-light:hover {
     cursor: pointer;
@@ -1087,13 +1062,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #717171;
-  background-color: #f7f7f7;
-  padding: 8px 12px;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-  display: flex;
-  align-items: center;
 }
 
 .button-action:active {
@@ -1112,6 +1080,11 @@ a:hover {
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
 
+.button-action {
+  color: #717171;
+  background-color: #f7f7f7;
+}
+
 .button-action:hover {
     cursor: pointer;
     box-shadow:
@@ -1119,6 +1092,14 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .6);
   }
+
+.button-action {
+  padding: 8px 12px;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  display: flex;
+  align-items: center;
+}
 
 .p-icon {
   padding: 8px 12px;
@@ -1144,8 +1125,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #fff;
-  background-color: rgb(var(--tertiary-rgb));
 }
 
 .button-tertiary:active {
@@ -1163,6 +1142,11 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-tertiary {
+  color: #fff;
+  background-color: rgb(var(--tertiary-rgb));
+}
 
 .button-secondary {
   padding-left: 1.5rem;
@@ -1184,8 +1168,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #fff;
-  background-color: rgb(var(--secondary-rgb));
 }
 
 .button-secondary:active {
@@ -1203,6 +1185,11 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-secondary {
+  color: #fff;
+  background-color: rgb(var(--secondary-rgb));
+}
 
 .button-primary {
   padding-left: 1.5rem;
@@ -1224,8 +1211,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #fff;
-  background-color: rgb(var(--primary-rgb));
 }
 
 .button-primary:active {
@@ -1243,6 +1228,11 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-primary {
+  color: #fff;
+  background-color: rgb(var(--primary-rgb));
+}
 
 .button-white {
   padding-left: 1.5rem;
@@ -1264,8 +1254,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: rgb(var(--primary-rgb));
-  background-color: #fff;
 }
 
 .button-white:active {
@@ -1283,6 +1271,11 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-white {
+  color: rgb(var(--primary-rgb));
+  background-color: #fff;
+}
 
 .button-danger {
   padding-left: 1.5rem;
@@ -1304,8 +1297,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #fff;
-  background-color: rgb(var(--error-rgb));
 }
 
 .button-danger:active {
@@ -1323,6 +1314,11 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-danger {
+  color: #fff;
+  background-color: rgb(var(--error-rgb));
+}
 
 .button-dark-alpha {
   padding-left: 1.5rem;
@@ -1344,8 +1340,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #fff;
-  background-color: rgba(0, 0, 0, .2);
 }
 
 .button-dark-alpha:active {
@@ -1363,6 +1357,11 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-dark-alpha {
+  color: #fff;
+  background-color: rgba(0, 0, 0, .2);
+}
 
 .button-sm {
   padding-left: 1.5rem;
@@ -1384,16 +1383,6 @@ a:hover {
   font-weight: 400;
   display: inline-block;
   margin-top: 1px;
-  color: #fff;
-  background-color: rgba(0, 0, 0, .2);
-  font-size: 0.875rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  letter-spacing: 0.05em;
-  box-shadow: none;
-  color: rgba(255, 255, 255, .9);
 }
 
 .button-sm:active {
@@ -1411,6 +1400,19 @@ a:hover {
       0 1px 2px 0 rgba(0, 0, 0, 0.06),
       inset 0 0 20px 20px rgba(255, 255, 255, .1);
   }
+
+.button-sm {
+  color: #fff;
+  background-color: rgba(0, 0, 0, .2);
+  font-size: 0.875rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  letter-spacing: 0.05em;
+  box-shadow: none;
+  color: rgba(255, 255, 255, .9);
+}
 
 .button-sm:hover {
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
@@ -1477,7 +1479,6 @@ a:hover {
   letter-spacing: 0.025em;
   white-space: nowrap;
   text-align: center;
-  background-color: rgb(var(--primary-rgb));
 }
 
 .lbl-primary.linked:hover {
@@ -1490,6 +1491,10 @@ a:hover {
 .lbl-primary.linked:active {
     box-shadow: none;
   }
+
+.lbl-primary {
+  background-color: rgb(var(--primary-rgb));
+}
 
 .lbl-primary.linked:hover {
     text-decoration: none;
@@ -1547,8 +1552,14 @@ a:hover {
     box-shadow: none;
   }
 
+.lbl-group {
+  display: flex;
+  align-items: center;
+}
+
 .lbl-group temba-icon {
-    display: inline-block;
+    --icon-color: rgba(0,0,0,.5);
+    margin-right: 3px;
   }
 
 .lbl.inverted {
@@ -1609,8 +1620,14 @@ a:hover {
     box-shadow: none;
   }
 
+.lbl-group-dynamic {
+  display: flex;
+  align-items: center;
+}
+
 .lbl-group-dynamic temba-icon {
-    display: inline-block;
+    --icon-color: rgba(0,0,0,.5);
+    margin-right: 3px;
   }
 
 .lbl-group-dynamic::before {
@@ -1635,9 +1652,6 @@ a:hover {
   letter-spacing: 0.025em;
   white-space: nowrap;
   text-align: center;
-  color: #fff;
-  background-color: #fff;
-  color: rgb(var(--secondary-rgb));
 }
 
 .lbl-secondary.linked:hover {
@@ -1650,6 +1664,12 @@ a:hover {
 .lbl-secondary.linked:active {
     box-shadow: none;
   }
+
+.lbl-secondary {
+  color: #fff;
+  background-color: #fff;
+  color: rgb(var(--secondary-rgb));
+}
 
 .lbl-secondary.linked:hover {
     text-decoration: none;
@@ -1998,12 +2018,6 @@ table.list.selectable tbody tr.checked td {
         display: flex;
         cursor: pointer;
         color: inherit;
-        align-items: center;
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
-        padding-top: 0.25rem;
-        padding-bottom: 0.25rem;
-        border-color: #f7f7f7;
       }
 
 .lp-frame .left .lp-nav .lp-nav-item.active {
@@ -2014,6 +2028,15 @@ table.list.selectable tbody tr.checked td {
           color: rgb(var(--primary-rgb));
           text-decoration: none;
         }
+
+.lp-frame .left .lp-nav .lp-nav-item {
+        align-items: center;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+        border-color: #f7f7f7;
+}
 
 .lp-frame .left .lp-nav .lp-nav-item .name {
           line-height: 1;
@@ -2227,9 +2250,6 @@ code {
         font-size: 80px;
         flex-basis: 160px;
         padding-top: 10px;
-        background-color: rgb(var(--primary-rgb));
-        color: #fff;
-        padding: 3rem;
       }
 
 .formax .formax-section.open .formax-icon .margin-wrapper {
@@ -2239,6 +2259,12 @@ code {
 .formax .formax-section.open .formax-icon .i-container {
           width: 80px;
         }
+
+.formax .formax-section.open .formax-icon {
+        background-color: rgb(var(--primary-rgb));
+        color: #fff;
+        padding: 3rem;
+}
 
 .formax .formax-section.open .formax-icon:before {
           vertical-align: inherit;
@@ -11554,10 +11580,6 @@ code {
   padding-left: 1px;
 }
 
-.placeholder-transparent::-webkit-input-placeholder {
-  color: transparent;
-}
-
 .placeholder-transparent::-moz-placeholder {
   color: transparent;
 }
@@ -11566,16 +11588,8 @@ code {
   color: transparent;
 }
 
-.placeholder-transparent::-ms-input-placeholder {
-  color: transparent;
-}
-
 .placeholder-transparent::placeholder {
   color: transparent;
-}
-
-.placeholder-black::-webkit-input-placeholder {
-  color: #37383c;
 }
 
 .placeholder-black::-moz-placeholder {
@@ -11586,16 +11600,8 @@ code {
   color: #37383c;
 }
 
-.placeholder-black::-ms-input-placeholder {
-  color: #37383c;
-}
-
 .placeholder-black::placeholder {
   color: #37383c;
-}
-
-.placeholder-white::-webkit-input-placeholder {
-  color: #fff;
 }
 
 .placeholder-white::-moz-placeholder {
@@ -11606,16 +11612,8 @@ code {
   color: #fff;
 }
 
-.placeholder-white::-ms-input-placeholder {
-  color: #fff;
-}
-
 .placeholder-white::placeholder {
   color: #fff;
-}
-
-.placeholder-error::-webkit-input-placeholder {
-  color: rgb(var(--error-rgb));
 }
 
 .placeholder-error::-moz-placeholder {
@@ -11626,16 +11624,8 @@ code {
   color: rgb(var(--error-rgb));
 }
 
-.placeholder-error::-ms-input-placeholder {
-  color: rgb(var(--error-rgb));
-}
-
 .placeholder-error::placeholder {
   color: rgb(var(--error-rgb));
-}
-
-.placeholder-success::-webkit-input-placeholder {
-  color: rgb(var(--success-rgb));
 }
 
 .placeholder-success::-moz-placeholder {
@@ -11646,16 +11636,8 @@ code {
   color: rgb(var(--success-rgb));
 }
 
-.placeholder-success::-ms-input-placeholder {
-  color: rgb(var(--success-rgb));
-}
-
 .placeholder-success::placeholder {
   color: rgb(var(--success-rgb));
-}
-
-.placeholder-primary::-webkit-input-placeholder {
-  color: rgb(var(--primary-rgb));
 }
 
 .placeholder-primary::-moz-placeholder {
@@ -11666,16 +11648,8 @@ code {
   color: rgb(var(--primary-rgb));
 }
 
-.placeholder-primary::-ms-input-placeholder {
-  color: rgb(var(--primary-rgb));
-}
-
 .placeholder-primary::placeholder {
   color: rgb(var(--primary-rgb));
-}
-
-.placeholder-secondary::-webkit-input-placeholder {
-  color: rgb(var(--secondary-rgb));
 }
 
 .placeholder-secondary::-moz-placeholder {
@@ -11686,16 +11660,8 @@ code {
   color: rgb(var(--secondary-rgb));
 }
 
-.placeholder-secondary::-ms-input-placeholder {
-  color: rgb(var(--secondary-rgb));
-}
-
 .placeholder-secondary::placeholder {
   color: rgb(var(--secondary-rgb));
-}
-
-.placeholder-tertiary::-webkit-input-placeholder {
-  color: rgb(var(--tertiary-rgb));
 }
 
 .placeholder-tertiary::-moz-placeholder {
@@ -11706,16 +11672,8 @@ code {
   color: rgb(var(--tertiary-rgb));
 }
 
-.placeholder-tertiary::-ms-input-placeholder {
-  color: rgb(var(--tertiary-rgb));
-}
-
 .placeholder-tertiary::placeholder {
   color: rgb(var(--tertiary-rgb));
-}
-
-.placeholder-dark-alpha-20::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .02);
 }
 
 .placeholder-dark-alpha-20::-moz-placeholder {
@@ -11726,16 +11684,8 @@ code {
   color: rgba(0, 0, 0, .02);
 }
 
-.placeholder-dark-alpha-20::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .02);
-}
-
 .placeholder-dark-alpha-20::placeholder {
   color: rgba(0, 0, 0, .02);
-}
-
-.placeholder-dark-alpha-30::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .03);
 }
 
 .placeholder-dark-alpha-30::-moz-placeholder {
@@ -11746,16 +11696,8 @@ code {
   color: rgba(0, 0, 0, .03);
 }
 
-.placeholder-dark-alpha-30::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .03);
-}
-
 .placeholder-dark-alpha-30::placeholder {
   color: rgba(0, 0, 0, .03);
-}
-
-.placeholder-dark-alpha-50::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .05);
 }
 
 .placeholder-dark-alpha-50::-moz-placeholder {
@@ -11766,16 +11708,8 @@ code {
   color: rgba(0, 0, 0, .05);
 }
 
-.placeholder-dark-alpha-50::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .05);
-}
-
 .placeholder-dark-alpha-50::placeholder {
   color: rgba(0, 0, 0, .05);
-}
-
-.placeholder-dark-alpha-70::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .07);
 }
 
 .placeholder-dark-alpha-70::-moz-placeholder {
@@ -11786,16 +11720,8 @@ code {
   color: rgba(0, 0, 0, .07);
 }
 
-.placeholder-dark-alpha-70::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .07);
-}
-
 .placeholder-dark-alpha-70::placeholder {
   color: rgba(0, 0, 0, .07);
-}
-
-.placeholder-dark-alpha-100::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .1);
 }
 
 .placeholder-dark-alpha-100::-moz-placeholder {
@@ -11806,16 +11732,8 @@ code {
   color: rgba(0, 0, 0, .1);
 }
 
-.placeholder-dark-alpha-100::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .1);
-}
-
 .placeholder-dark-alpha-100::placeholder {
   color: rgba(0, 0, 0, .1);
-}
-
-.placeholder-dark-alpha-200::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .2);
 }
 
 .placeholder-dark-alpha-200::-moz-placeholder {
@@ -11826,16 +11744,8 @@ code {
   color: rgba(0, 0, 0, .2);
 }
 
-.placeholder-dark-alpha-200::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .2);
-}
-
 .placeholder-dark-alpha-200::placeholder {
   color: rgba(0, 0, 0, .2);
-}
-
-.placeholder-dark-alpha-300::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .3);
 }
 
 .placeholder-dark-alpha-300::-moz-placeholder {
@@ -11846,16 +11756,8 @@ code {
   color: rgba(0, 0, 0, .3);
 }
 
-.placeholder-dark-alpha-300::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .3);
-}
-
 .placeholder-dark-alpha-300::placeholder {
   color: rgba(0, 0, 0, .3);
-}
-
-.placeholder-dark-alpha-400::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .4);
 }
 
 .placeholder-dark-alpha-400::-moz-placeholder {
@@ -11866,16 +11768,8 @@ code {
   color: rgba(0, 0, 0, .4);
 }
 
-.placeholder-dark-alpha-400::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .4);
-}
-
 .placeholder-dark-alpha-400::placeholder {
   color: rgba(0, 0, 0, .4);
-}
-
-.placeholder-dark-alpha-500::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .5);
 }
 
 .placeholder-dark-alpha-500::-moz-placeholder {
@@ -11886,16 +11780,8 @@ code {
   color: rgba(0, 0, 0, .5);
 }
 
-.placeholder-dark-alpha-500::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .5);
-}
-
 .placeholder-dark-alpha-500::placeholder {
   color: rgba(0, 0, 0, .5);
-}
-
-.placeholder-dark-alpha-600::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .6);
 }
 
 .placeholder-dark-alpha-600::-moz-placeholder {
@@ -11906,16 +11792,8 @@ code {
   color: rgba(0, 0, 0, .6);
 }
 
-.placeholder-dark-alpha-600::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .6);
-}
-
 .placeholder-dark-alpha-600::placeholder {
   color: rgba(0, 0, 0, .6);
-}
-
-.placeholder-dark-alpha-700::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .7);
 }
 
 .placeholder-dark-alpha-700::-moz-placeholder {
@@ -11926,16 +11804,8 @@ code {
   color: rgba(0, 0, 0, .7);
 }
 
-.placeholder-dark-alpha-700::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .7);
-}
-
 .placeholder-dark-alpha-700::placeholder {
   color: rgba(0, 0, 0, .7);
-}
-
-.placeholder-dark-alpha-800::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .8);
 }
 
 .placeholder-dark-alpha-800::-moz-placeholder {
@@ -11946,16 +11816,8 @@ code {
   color: rgba(0, 0, 0, .8);
 }
 
-.placeholder-dark-alpha-800::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .8);
-}
-
 .placeholder-dark-alpha-800::placeholder {
   color: rgba(0, 0, 0, .8);
-}
-
-.placeholder-dark-alpha-900::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .9);
 }
 
 .placeholder-dark-alpha-900::-moz-placeholder {
@@ -11966,16 +11828,8 @@ code {
   color: rgba(0, 0, 0, .9);
 }
 
-.placeholder-dark-alpha-900::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .9);
-}
-
 .placeholder-dark-alpha-900::placeholder {
   color: rgba(0, 0, 0, .9);
-}
-
-.placeholder-light-alpha-20::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .02);
 }
 
 .placeholder-light-alpha-20::-moz-placeholder {
@@ -11986,16 +11840,8 @@ code {
   color: rgba(255, 255, 255, .02);
 }
 
-.placeholder-light-alpha-20::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .02);
-}
-
 .placeholder-light-alpha-20::placeholder {
   color: rgba(255, 255, 255, .02);
-}
-
-.placeholder-light-alpha-30::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .03);
 }
 
 .placeholder-light-alpha-30::-moz-placeholder {
@@ -12006,16 +11852,8 @@ code {
   color: rgba(255, 255, 255, .03);
 }
 
-.placeholder-light-alpha-30::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .03);
-}
-
 .placeholder-light-alpha-30::placeholder {
   color: rgba(255, 255, 255, .03);
-}
-
-.placeholder-light-alpha-50::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .05);
 }
 
 .placeholder-light-alpha-50::-moz-placeholder {
@@ -12026,16 +11864,8 @@ code {
   color: rgba(255, 255, 255, .05);
 }
 
-.placeholder-light-alpha-50::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .05);
-}
-
 .placeholder-light-alpha-50::placeholder {
   color: rgba(255, 255, 255, .05);
-}
-
-.placeholder-light-alpha-70::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .07);
 }
 
 .placeholder-light-alpha-70::-moz-placeholder {
@@ -12046,16 +11876,8 @@ code {
   color: rgba(255, 255, 255, .07);
 }
 
-.placeholder-light-alpha-70::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .07);
-}
-
 .placeholder-light-alpha-70::placeholder {
   color: rgba(255, 255, 255, .07);
-}
-
-.placeholder-light-alpha-100::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .1);
 }
 
 .placeholder-light-alpha-100::-moz-placeholder {
@@ -12066,16 +11888,8 @@ code {
   color: rgba(255, 255, 255, .1);
 }
 
-.placeholder-light-alpha-100::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .1);
-}
-
 .placeholder-light-alpha-100::placeholder {
   color: rgba(255, 255, 255, .1);
-}
-
-.placeholder-light-alpha-200::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .2);
 }
 
 .placeholder-light-alpha-200::-moz-placeholder {
@@ -12086,16 +11900,8 @@ code {
   color: rgba(255, 255, 255, .2);
 }
 
-.placeholder-light-alpha-200::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .2);
-}
-
 .placeholder-light-alpha-200::placeholder {
   color: rgba(255, 255, 255, .2);
-}
-
-.placeholder-light-alpha-300::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .3);
 }
 
 .placeholder-light-alpha-300::-moz-placeholder {
@@ -12106,16 +11912,8 @@ code {
   color: rgba(255, 255, 255, .3);
 }
 
-.placeholder-light-alpha-300::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .3);
-}
-
 .placeholder-light-alpha-300::placeholder {
   color: rgba(255, 255, 255, .3);
-}
-
-.placeholder-light-alpha-400::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .4);
 }
 
 .placeholder-light-alpha-400::-moz-placeholder {
@@ -12126,16 +11924,8 @@ code {
   color: rgba(255, 255, 255, .4);
 }
 
-.placeholder-light-alpha-400::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .4);
-}
-
 .placeholder-light-alpha-400::placeholder {
   color: rgba(255, 255, 255, .4);
-}
-
-.placeholder-light-alpha-500::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .5);
 }
 
 .placeholder-light-alpha-500::-moz-placeholder {
@@ -12146,16 +11936,8 @@ code {
   color: rgba(255, 255, 255, .5);
 }
 
-.placeholder-light-alpha-500::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .5);
-}
-
 .placeholder-light-alpha-500::placeholder {
   color: rgba(255, 255, 255, .5);
-}
-
-.placeholder-light-alpha-600::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .6);
 }
 
 .placeholder-light-alpha-600::-moz-placeholder {
@@ -12166,16 +11948,8 @@ code {
   color: rgba(255, 255, 255, .6);
 }
 
-.placeholder-light-alpha-600::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .6);
-}
-
 .placeholder-light-alpha-600::placeholder {
   color: rgba(255, 255, 255, .6);
-}
-
-.placeholder-light-alpha-700::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .7);
 }
 
 .placeholder-light-alpha-700::-moz-placeholder {
@@ -12186,16 +11960,8 @@ code {
   color: rgba(255, 255, 255, .7);
 }
 
-.placeholder-light-alpha-700::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .7);
-}
-
 .placeholder-light-alpha-700::placeholder {
   color: rgba(255, 255, 255, .7);
-}
-
-.placeholder-light-alpha-800::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .8);
 }
 
 .placeholder-light-alpha-800::-moz-placeholder {
@@ -12206,16 +11972,8 @@ code {
   color: rgba(255, 255, 255, .8);
 }
 
-.placeholder-light-alpha-800::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .8);
-}
-
 .placeholder-light-alpha-800::placeholder {
   color: rgba(255, 255, 255, .8);
-}
-
-.placeholder-light-alpha-900::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .9);
 }
 
 .placeholder-light-alpha-900::-moz-placeholder {
@@ -12226,16 +11984,8 @@ code {
   color: rgba(255, 255, 255, .9);
 }
 
-.placeholder-light-alpha-900::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .9);
-}
-
 .placeholder-light-alpha-900::placeholder {
   color: rgba(255, 255, 255, .9);
-}
-
-.placeholder-gray-100::-webkit-input-placeholder {
-  color: #f7f7f7;
 }
 
 .placeholder-gray-100::-moz-placeholder {
@@ -12246,16 +11996,8 @@ code {
   color: #f7f7f7;
 }
 
-.placeholder-gray-100::-ms-input-placeholder {
-  color: #f7f7f7;
-}
-
 .placeholder-gray-100::placeholder {
   color: #f7f7f7;
-}
-
-.placeholder-gray-200::-webkit-input-placeholder {
-  color: #ededed;
 }
 
 .placeholder-gray-200::-moz-placeholder {
@@ -12266,16 +12008,8 @@ code {
   color: #ededed;
 }
 
-.placeholder-gray-200::-ms-input-placeholder {
-  color: #ededed;
-}
-
 .placeholder-gray-200::placeholder {
   color: #ededed;
-}
-
-.placeholder-gray-300::-webkit-input-placeholder {
-  color: #e2e2e2;
 }
 
 .placeholder-gray-300::-moz-placeholder {
@@ -12286,16 +12020,8 @@ code {
   color: #e2e2e2;
 }
 
-.placeholder-gray-300::-ms-input-placeholder {
-  color: #e2e2e2;
-}
-
 .placeholder-gray-300::placeholder {
   color: #e2e2e2;
-}
-
-.placeholder-gray-400::-webkit-input-placeholder {
-  color: #cbcbcb;
 }
 
 .placeholder-gray-400::-moz-placeholder {
@@ -12306,16 +12032,8 @@ code {
   color: #cbcbcb;
 }
 
-.placeholder-gray-400::-ms-input-placeholder {
-  color: #cbcbcb;
-}
-
 .placeholder-gray-400::placeholder {
   color: #cbcbcb;
-}
-
-.placeholder-gray-500::-webkit-input-placeholder {
-  color: #a0a0a0;
 }
 
 .placeholder-gray-500::-moz-placeholder {
@@ -12326,16 +12044,8 @@ code {
   color: #a0a0a0;
 }
 
-.placeholder-gray-500::-ms-input-placeholder {
-  color: #a0a0a0;
-}
-
 .placeholder-gray-500::placeholder {
   color: #a0a0a0;
-}
-
-.placeholder-gray-600::-webkit-input-placeholder {
-  color: #717171;
 }
 
 .placeholder-gray-600::-moz-placeholder {
@@ -12346,16 +12056,8 @@ code {
   color: #717171;
 }
 
-.placeholder-gray-600::-ms-input-placeholder {
-  color: #717171;
-}
-
 .placeholder-gray-600::placeholder {
   color: #717171;
-}
-
-.placeholder-gray-700::-webkit-input-placeholder {
-  color: #4a4a4a;
 }
 
 .placeholder-gray-700::-moz-placeholder {
@@ -12366,16 +12068,8 @@ code {
   color: #4a4a4a;
 }
 
-.placeholder-gray-700::-ms-input-placeholder {
-  color: #4a4a4a;
-}
-
 .placeholder-gray-700::placeholder {
   color: #4a4a4a;
-}
-
-.placeholder-gray-750::-webkit-input-placeholder {
-  color: #333;
 }
 
 .placeholder-gray-750::-moz-placeholder {
@@ -12386,16 +12080,8 @@ code {
   color: #333;
 }
 
-.placeholder-gray-750::-ms-input-placeholder {
-  color: #333;
-}
-
 .placeholder-gray-750::placeholder {
   color: #333;
-}
-
-.placeholder-gray-800::-webkit-input-placeholder {
-  color: #2d2d2d;
 }
 
 .placeholder-gray-800::-moz-placeholder {
@@ -12406,16 +12092,8 @@ code {
   color: #2d2d2d;
 }
 
-.placeholder-gray-800::-ms-input-placeholder {
-  color: #2d2d2d;
-}
-
 .placeholder-gray-800::placeholder {
   color: #2d2d2d;
-}
-
-.placeholder-gray-900::-webkit-input-placeholder {
-  color: #1a1a1a;
 }
 
 .placeholder-gray-900::-moz-placeholder {
@@ -12426,16 +12104,8 @@ code {
   color: #1a1a1a;
 }
 
-.placeholder-gray-900::-ms-input-placeholder {
-  color: #1a1a1a;
-}
-
 .placeholder-gray-900::placeholder {
   color: #1a1a1a;
-}
-
-.focus\:placeholder-transparent:focus::-webkit-input-placeholder {
-  color: transparent;
 }
 
 .focus\:placeholder-transparent:focus::-moz-placeholder {
@@ -12446,16 +12116,8 @@ code {
   color: transparent;
 }
 
-.focus\:placeholder-transparent:focus::-ms-input-placeholder {
-  color: transparent;
-}
-
 .focus\:placeholder-transparent:focus::placeholder {
   color: transparent;
-}
-
-.focus\:placeholder-black:focus::-webkit-input-placeholder {
-  color: #37383c;
 }
 
 .focus\:placeholder-black:focus::-moz-placeholder {
@@ -12466,16 +12128,8 @@ code {
   color: #37383c;
 }
 
-.focus\:placeholder-black:focus::-ms-input-placeholder {
-  color: #37383c;
-}
-
 .focus\:placeholder-black:focus::placeholder {
   color: #37383c;
-}
-
-.focus\:placeholder-white:focus::-webkit-input-placeholder {
-  color: #fff;
 }
 
 .focus\:placeholder-white:focus::-moz-placeholder {
@@ -12486,16 +12140,8 @@ code {
   color: #fff;
 }
 
-.focus\:placeholder-white:focus::-ms-input-placeholder {
-  color: #fff;
-}
-
 .focus\:placeholder-white:focus::placeholder {
   color: #fff;
-}
-
-.focus\:placeholder-error:focus::-webkit-input-placeholder {
-  color: rgb(var(--error-rgb));
 }
 
 .focus\:placeholder-error:focus::-moz-placeholder {
@@ -12506,16 +12152,8 @@ code {
   color: rgb(var(--error-rgb));
 }
 
-.focus\:placeholder-error:focus::-ms-input-placeholder {
-  color: rgb(var(--error-rgb));
-}
-
 .focus\:placeholder-error:focus::placeholder {
   color: rgb(var(--error-rgb));
-}
-
-.focus\:placeholder-success:focus::-webkit-input-placeholder {
-  color: rgb(var(--success-rgb));
 }
 
 .focus\:placeholder-success:focus::-moz-placeholder {
@@ -12526,16 +12164,8 @@ code {
   color: rgb(var(--success-rgb));
 }
 
-.focus\:placeholder-success:focus::-ms-input-placeholder {
-  color: rgb(var(--success-rgb));
-}
-
 .focus\:placeholder-success:focus::placeholder {
   color: rgb(var(--success-rgb));
-}
-
-.focus\:placeholder-primary:focus::-webkit-input-placeholder {
-  color: rgb(var(--primary-rgb));
 }
 
 .focus\:placeholder-primary:focus::-moz-placeholder {
@@ -12546,16 +12176,8 @@ code {
   color: rgb(var(--primary-rgb));
 }
 
-.focus\:placeholder-primary:focus::-ms-input-placeholder {
-  color: rgb(var(--primary-rgb));
-}
-
 .focus\:placeholder-primary:focus::placeholder {
   color: rgb(var(--primary-rgb));
-}
-
-.focus\:placeholder-secondary:focus::-webkit-input-placeholder {
-  color: rgb(var(--secondary-rgb));
 }
 
 .focus\:placeholder-secondary:focus::-moz-placeholder {
@@ -12566,16 +12188,8 @@ code {
   color: rgb(var(--secondary-rgb));
 }
 
-.focus\:placeholder-secondary:focus::-ms-input-placeholder {
-  color: rgb(var(--secondary-rgb));
-}
-
 .focus\:placeholder-secondary:focus::placeholder {
   color: rgb(var(--secondary-rgb));
-}
-
-.focus\:placeholder-tertiary:focus::-webkit-input-placeholder {
-  color: rgb(var(--tertiary-rgb));
 }
 
 .focus\:placeholder-tertiary:focus::-moz-placeholder {
@@ -12586,16 +12200,8 @@ code {
   color: rgb(var(--tertiary-rgb));
 }
 
-.focus\:placeholder-tertiary:focus::-ms-input-placeholder {
-  color: rgb(var(--tertiary-rgb));
-}
-
 .focus\:placeholder-tertiary:focus::placeholder {
   color: rgb(var(--tertiary-rgb));
-}
-
-.focus\:placeholder-dark-alpha-20:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .02);
 }
 
 .focus\:placeholder-dark-alpha-20:focus::-moz-placeholder {
@@ -12606,16 +12212,8 @@ code {
   color: rgba(0, 0, 0, .02);
 }
 
-.focus\:placeholder-dark-alpha-20:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .02);
-}
-
 .focus\:placeholder-dark-alpha-20:focus::placeholder {
   color: rgba(0, 0, 0, .02);
-}
-
-.focus\:placeholder-dark-alpha-30:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .03);
 }
 
 .focus\:placeholder-dark-alpha-30:focus::-moz-placeholder {
@@ -12626,16 +12224,8 @@ code {
   color: rgba(0, 0, 0, .03);
 }
 
-.focus\:placeholder-dark-alpha-30:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .03);
-}
-
 .focus\:placeholder-dark-alpha-30:focus::placeholder {
   color: rgba(0, 0, 0, .03);
-}
-
-.focus\:placeholder-dark-alpha-50:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .05);
 }
 
 .focus\:placeholder-dark-alpha-50:focus::-moz-placeholder {
@@ -12646,16 +12236,8 @@ code {
   color: rgba(0, 0, 0, .05);
 }
 
-.focus\:placeholder-dark-alpha-50:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .05);
-}
-
 .focus\:placeholder-dark-alpha-50:focus::placeholder {
   color: rgba(0, 0, 0, .05);
-}
-
-.focus\:placeholder-dark-alpha-70:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .07);
 }
 
 .focus\:placeholder-dark-alpha-70:focus::-moz-placeholder {
@@ -12666,16 +12248,8 @@ code {
   color: rgba(0, 0, 0, .07);
 }
 
-.focus\:placeholder-dark-alpha-70:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .07);
-}
-
 .focus\:placeholder-dark-alpha-70:focus::placeholder {
   color: rgba(0, 0, 0, .07);
-}
-
-.focus\:placeholder-dark-alpha-100:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .1);
 }
 
 .focus\:placeholder-dark-alpha-100:focus::-moz-placeholder {
@@ -12686,16 +12260,8 @@ code {
   color: rgba(0, 0, 0, .1);
 }
 
-.focus\:placeholder-dark-alpha-100:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .1);
-}
-
 .focus\:placeholder-dark-alpha-100:focus::placeholder {
   color: rgba(0, 0, 0, .1);
-}
-
-.focus\:placeholder-dark-alpha-200:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .2);
 }
 
 .focus\:placeholder-dark-alpha-200:focus::-moz-placeholder {
@@ -12706,16 +12272,8 @@ code {
   color: rgba(0, 0, 0, .2);
 }
 
-.focus\:placeholder-dark-alpha-200:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .2);
-}
-
 .focus\:placeholder-dark-alpha-200:focus::placeholder {
   color: rgba(0, 0, 0, .2);
-}
-
-.focus\:placeholder-dark-alpha-300:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .3);
 }
 
 .focus\:placeholder-dark-alpha-300:focus::-moz-placeholder {
@@ -12726,16 +12284,8 @@ code {
   color: rgba(0, 0, 0, .3);
 }
 
-.focus\:placeholder-dark-alpha-300:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .3);
-}
-
 .focus\:placeholder-dark-alpha-300:focus::placeholder {
   color: rgba(0, 0, 0, .3);
-}
-
-.focus\:placeholder-dark-alpha-400:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .4);
 }
 
 .focus\:placeholder-dark-alpha-400:focus::-moz-placeholder {
@@ -12746,16 +12296,8 @@ code {
   color: rgba(0, 0, 0, .4);
 }
 
-.focus\:placeholder-dark-alpha-400:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .4);
-}
-
 .focus\:placeholder-dark-alpha-400:focus::placeholder {
   color: rgba(0, 0, 0, .4);
-}
-
-.focus\:placeholder-dark-alpha-500:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .5);
 }
 
 .focus\:placeholder-dark-alpha-500:focus::-moz-placeholder {
@@ -12766,16 +12308,8 @@ code {
   color: rgba(0, 0, 0, .5);
 }
 
-.focus\:placeholder-dark-alpha-500:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .5);
-}
-
 .focus\:placeholder-dark-alpha-500:focus::placeholder {
   color: rgba(0, 0, 0, .5);
-}
-
-.focus\:placeholder-dark-alpha-600:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .6);
 }
 
 .focus\:placeholder-dark-alpha-600:focus::-moz-placeholder {
@@ -12786,16 +12320,8 @@ code {
   color: rgba(0, 0, 0, .6);
 }
 
-.focus\:placeholder-dark-alpha-600:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .6);
-}
-
 .focus\:placeholder-dark-alpha-600:focus::placeholder {
   color: rgba(0, 0, 0, .6);
-}
-
-.focus\:placeholder-dark-alpha-700:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .7);
 }
 
 .focus\:placeholder-dark-alpha-700:focus::-moz-placeholder {
@@ -12806,16 +12332,8 @@ code {
   color: rgba(0, 0, 0, .7);
 }
 
-.focus\:placeholder-dark-alpha-700:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .7);
-}
-
 .focus\:placeholder-dark-alpha-700:focus::placeholder {
   color: rgba(0, 0, 0, .7);
-}
-
-.focus\:placeholder-dark-alpha-800:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .8);
 }
 
 .focus\:placeholder-dark-alpha-800:focus::-moz-placeholder {
@@ -12826,16 +12344,8 @@ code {
   color: rgba(0, 0, 0, .8);
 }
 
-.focus\:placeholder-dark-alpha-800:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .8);
-}
-
 .focus\:placeholder-dark-alpha-800:focus::placeholder {
   color: rgba(0, 0, 0, .8);
-}
-
-.focus\:placeholder-dark-alpha-900:focus::-webkit-input-placeholder {
-  color: rgba(0, 0, 0, .9);
 }
 
 .focus\:placeholder-dark-alpha-900:focus::-moz-placeholder {
@@ -12846,16 +12356,8 @@ code {
   color: rgba(0, 0, 0, .9);
 }
 
-.focus\:placeholder-dark-alpha-900:focus::-ms-input-placeholder {
-  color: rgba(0, 0, 0, .9);
-}
-
 .focus\:placeholder-dark-alpha-900:focus::placeholder {
   color: rgba(0, 0, 0, .9);
-}
-
-.focus\:placeholder-light-alpha-20:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .02);
 }
 
 .focus\:placeholder-light-alpha-20:focus::-moz-placeholder {
@@ -12866,16 +12368,8 @@ code {
   color: rgba(255, 255, 255, .02);
 }
 
-.focus\:placeholder-light-alpha-20:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .02);
-}
-
 .focus\:placeholder-light-alpha-20:focus::placeholder {
   color: rgba(255, 255, 255, .02);
-}
-
-.focus\:placeholder-light-alpha-30:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .03);
 }
 
 .focus\:placeholder-light-alpha-30:focus::-moz-placeholder {
@@ -12886,16 +12380,8 @@ code {
   color: rgba(255, 255, 255, .03);
 }
 
-.focus\:placeholder-light-alpha-30:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .03);
-}
-
 .focus\:placeholder-light-alpha-30:focus::placeholder {
   color: rgba(255, 255, 255, .03);
-}
-
-.focus\:placeholder-light-alpha-50:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .05);
 }
 
 .focus\:placeholder-light-alpha-50:focus::-moz-placeholder {
@@ -12906,16 +12392,8 @@ code {
   color: rgba(255, 255, 255, .05);
 }
 
-.focus\:placeholder-light-alpha-50:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .05);
-}
-
 .focus\:placeholder-light-alpha-50:focus::placeholder {
   color: rgba(255, 255, 255, .05);
-}
-
-.focus\:placeholder-light-alpha-70:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .07);
 }
 
 .focus\:placeholder-light-alpha-70:focus::-moz-placeholder {
@@ -12926,16 +12404,8 @@ code {
   color: rgba(255, 255, 255, .07);
 }
 
-.focus\:placeholder-light-alpha-70:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .07);
-}
-
 .focus\:placeholder-light-alpha-70:focus::placeholder {
   color: rgba(255, 255, 255, .07);
-}
-
-.focus\:placeholder-light-alpha-100:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .1);
 }
 
 .focus\:placeholder-light-alpha-100:focus::-moz-placeholder {
@@ -12946,16 +12416,8 @@ code {
   color: rgba(255, 255, 255, .1);
 }
 
-.focus\:placeholder-light-alpha-100:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .1);
-}
-
 .focus\:placeholder-light-alpha-100:focus::placeholder {
   color: rgba(255, 255, 255, .1);
-}
-
-.focus\:placeholder-light-alpha-200:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .2);
 }
 
 .focus\:placeholder-light-alpha-200:focus::-moz-placeholder {
@@ -12966,16 +12428,8 @@ code {
   color: rgba(255, 255, 255, .2);
 }
 
-.focus\:placeholder-light-alpha-200:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .2);
-}
-
 .focus\:placeholder-light-alpha-200:focus::placeholder {
   color: rgba(255, 255, 255, .2);
-}
-
-.focus\:placeholder-light-alpha-300:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .3);
 }
 
 .focus\:placeholder-light-alpha-300:focus::-moz-placeholder {
@@ -12986,16 +12440,8 @@ code {
   color: rgba(255, 255, 255, .3);
 }
 
-.focus\:placeholder-light-alpha-300:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .3);
-}
-
 .focus\:placeholder-light-alpha-300:focus::placeholder {
   color: rgba(255, 255, 255, .3);
-}
-
-.focus\:placeholder-light-alpha-400:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .4);
 }
 
 .focus\:placeholder-light-alpha-400:focus::-moz-placeholder {
@@ -13006,16 +12452,8 @@ code {
   color: rgba(255, 255, 255, .4);
 }
 
-.focus\:placeholder-light-alpha-400:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .4);
-}
-
 .focus\:placeholder-light-alpha-400:focus::placeholder {
   color: rgba(255, 255, 255, .4);
-}
-
-.focus\:placeholder-light-alpha-500:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .5);
 }
 
 .focus\:placeholder-light-alpha-500:focus::-moz-placeholder {
@@ -13026,16 +12464,8 @@ code {
   color: rgba(255, 255, 255, .5);
 }
 
-.focus\:placeholder-light-alpha-500:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .5);
-}
-
 .focus\:placeholder-light-alpha-500:focus::placeholder {
   color: rgba(255, 255, 255, .5);
-}
-
-.focus\:placeholder-light-alpha-600:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .6);
 }
 
 .focus\:placeholder-light-alpha-600:focus::-moz-placeholder {
@@ -13046,16 +12476,8 @@ code {
   color: rgba(255, 255, 255, .6);
 }
 
-.focus\:placeholder-light-alpha-600:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .6);
-}
-
 .focus\:placeholder-light-alpha-600:focus::placeholder {
   color: rgba(255, 255, 255, .6);
-}
-
-.focus\:placeholder-light-alpha-700:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .7);
 }
 
 .focus\:placeholder-light-alpha-700:focus::-moz-placeholder {
@@ -13066,16 +12488,8 @@ code {
   color: rgba(255, 255, 255, .7);
 }
 
-.focus\:placeholder-light-alpha-700:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .7);
-}
-
 .focus\:placeholder-light-alpha-700:focus::placeholder {
   color: rgba(255, 255, 255, .7);
-}
-
-.focus\:placeholder-light-alpha-800:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .8);
 }
 
 .focus\:placeholder-light-alpha-800:focus::-moz-placeholder {
@@ -13086,16 +12500,8 @@ code {
   color: rgba(255, 255, 255, .8);
 }
 
-.focus\:placeholder-light-alpha-800:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .8);
-}
-
 .focus\:placeholder-light-alpha-800:focus::placeholder {
   color: rgba(255, 255, 255, .8);
-}
-
-.focus\:placeholder-light-alpha-900:focus::-webkit-input-placeholder {
-  color: rgba(255, 255, 255, .9);
 }
 
 .focus\:placeholder-light-alpha-900:focus::-moz-placeholder {
@@ -13106,16 +12512,8 @@ code {
   color: rgba(255, 255, 255, .9);
 }
 
-.focus\:placeholder-light-alpha-900:focus::-ms-input-placeholder {
-  color: rgba(255, 255, 255, .9);
-}
-
 .focus\:placeholder-light-alpha-900:focus::placeholder {
   color: rgba(255, 255, 255, .9);
-}
-
-.focus\:placeholder-gray-100:focus::-webkit-input-placeholder {
-  color: #f7f7f7;
 }
 
 .focus\:placeholder-gray-100:focus::-moz-placeholder {
@@ -13126,16 +12524,8 @@ code {
   color: #f7f7f7;
 }
 
-.focus\:placeholder-gray-100:focus::-ms-input-placeholder {
-  color: #f7f7f7;
-}
-
 .focus\:placeholder-gray-100:focus::placeholder {
   color: #f7f7f7;
-}
-
-.focus\:placeholder-gray-200:focus::-webkit-input-placeholder {
-  color: #ededed;
 }
 
 .focus\:placeholder-gray-200:focus::-moz-placeholder {
@@ -13146,16 +12536,8 @@ code {
   color: #ededed;
 }
 
-.focus\:placeholder-gray-200:focus::-ms-input-placeholder {
-  color: #ededed;
-}
-
 .focus\:placeholder-gray-200:focus::placeholder {
   color: #ededed;
-}
-
-.focus\:placeholder-gray-300:focus::-webkit-input-placeholder {
-  color: #e2e2e2;
 }
 
 .focus\:placeholder-gray-300:focus::-moz-placeholder {
@@ -13166,16 +12548,8 @@ code {
   color: #e2e2e2;
 }
 
-.focus\:placeholder-gray-300:focus::-ms-input-placeholder {
-  color: #e2e2e2;
-}
-
 .focus\:placeholder-gray-300:focus::placeholder {
   color: #e2e2e2;
-}
-
-.focus\:placeholder-gray-400:focus::-webkit-input-placeholder {
-  color: #cbcbcb;
 }
 
 .focus\:placeholder-gray-400:focus::-moz-placeholder {
@@ -13186,16 +12560,8 @@ code {
   color: #cbcbcb;
 }
 
-.focus\:placeholder-gray-400:focus::-ms-input-placeholder {
-  color: #cbcbcb;
-}
-
 .focus\:placeholder-gray-400:focus::placeholder {
   color: #cbcbcb;
-}
-
-.focus\:placeholder-gray-500:focus::-webkit-input-placeholder {
-  color: #a0a0a0;
 }
 
 .focus\:placeholder-gray-500:focus::-moz-placeholder {
@@ -13206,16 +12572,8 @@ code {
   color: #a0a0a0;
 }
 
-.focus\:placeholder-gray-500:focus::-ms-input-placeholder {
-  color: #a0a0a0;
-}
-
 .focus\:placeholder-gray-500:focus::placeholder {
   color: #a0a0a0;
-}
-
-.focus\:placeholder-gray-600:focus::-webkit-input-placeholder {
-  color: #717171;
 }
 
 .focus\:placeholder-gray-600:focus::-moz-placeholder {
@@ -13226,16 +12584,8 @@ code {
   color: #717171;
 }
 
-.focus\:placeholder-gray-600:focus::-ms-input-placeholder {
-  color: #717171;
-}
-
 .focus\:placeholder-gray-600:focus::placeholder {
   color: #717171;
-}
-
-.focus\:placeholder-gray-700:focus::-webkit-input-placeholder {
-  color: #4a4a4a;
 }
 
 .focus\:placeholder-gray-700:focus::-moz-placeholder {
@@ -13246,16 +12596,8 @@ code {
   color: #4a4a4a;
 }
 
-.focus\:placeholder-gray-700:focus::-ms-input-placeholder {
-  color: #4a4a4a;
-}
-
 .focus\:placeholder-gray-700:focus::placeholder {
   color: #4a4a4a;
-}
-
-.focus\:placeholder-gray-750:focus::-webkit-input-placeholder {
-  color: #333;
 }
 
 .focus\:placeholder-gray-750:focus::-moz-placeholder {
@@ -13266,16 +12608,8 @@ code {
   color: #333;
 }
 
-.focus\:placeholder-gray-750:focus::-ms-input-placeholder {
-  color: #333;
-}
-
 .focus\:placeholder-gray-750:focus::placeholder {
   color: #333;
-}
-
-.focus\:placeholder-gray-800:focus::-webkit-input-placeholder {
-  color: #2d2d2d;
 }
 
 .focus\:placeholder-gray-800:focus::-moz-placeholder {
@@ -13286,16 +12620,8 @@ code {
   color: #2d2d2d;
 }
 
-.focus\:placeholder-gray-800:focus::-ms-input-placeholder {
-  color: #2d2d2d;
-}
-
 .focus\:placeholder-gray-800:focus::placeholder {
   color: #2d2d2d;
-}
-
-.focus\:placeholder-gray-900:focus::-webkit-input-placeholder {
-  color: #1a1a1a;
 }
 
 .focus\:placeholder-gray-900:focus::-moz-placeholder {
@@ -13303,10 +12629,6 @@ code {
 }
 
 .focus\:placeholder-gray-900:focus:-ms-input-placeholder {
-  color: #1a1a1a;
-}
-
-.focus\:placeholder-gray-900:focus::-ms-input-placeholder {
   color: #1a1a1a;
 }
 
@@ -13339,7 +12661,6 @@ code {
 }
 
 .sticky {
-  position: -webkit-sticky;
   position: sticky;
 }
 
@@ -25846,10 +25167,6 @@ code {
     padding-left: 1px;
   }
 
-  .md\:placeholder-transparent::-webkit-input-placeholder {
-    color: transparent;
-  }
-
   .md\:placeholder-transparent::-moz-placeholder {
     color: transparent;
   }
@@ -25858,16 +25175,8 @@ code {
     color: transparent;
   }
 
-  .md\:placeholder-transparent::-ms-input-placeholder {
-    color: transparent;
-  }
-
   .md\:placeholder-transparent::placeholder {
     color: transparent;
-  }
-
-  .md\:placeholder-black::-webkit-input-placeholder {
-    color: #37383c;
   }
 
   .md\:placeholder-black::-moz-placeholder {
@@ -25878,16 +25187,8 @@ code {
     color: #37383c;
   }
 
-  .md\:placeholder-black::-ms-input-placeholder {
-    color: #37383c;
-  }
-
   .md\:placeholder-black::placeholder {
     color: #37383c;
-  }
-
-  .md\:placeholder-white::-webkit-input-placeholder {
-    color: #fff;
   }
 
   .md\:placeholder-white::-moz-placeholder {
@@ -25898,16 +25199,8 @@ code {
     color: #fff;
   }
 
-  .md\:placeholder-white::-ms-input-placeholder {
-    color: #fff;
-  }
-
   .md\:placeholder-white::placeholder {
     color: #fff;
-  }
-
-  .md\:placeholder-error::-webkit-input-placeholder {
-    color: rgb(var(--error-rgb));
   }
 
   .md\:placeholder-error::-moz-placeholder {
@@ -25918,16 +25211,8 @@ code {
     color: rgb(var(--error-rgb));
   }
 
-  .md\:placeholder-error::-ms-input-placeholder {
-    color: rgb(var(--error-rgb));
-  }
-
   .md\:placeholder-error::placeholder {
     color: rgb(var(--error-rgb));
-  }
-
-  .md\:placeholder-success::-webkit-input-placeholder {
-    color: rgb(var(--success-rgb));
   }
 
   .md\:placeholder-success::-moz-placeholder {
@@ -25938,16 +25223,8 @@ code {
     color: rgb(var(--success-rgb));
   }
 
-  .md\:placeholder-success::-ms-input-placeholder {
-    color: rgb(var(--success-rgb));
-  }
-
   .md\:placeholder-success::placeholder {
     color: rgb(var(--success-rgb));
-  }
-
-  .md\:placeholder-primary::-webkit-input-placeholder {
-    color: rgb(var(--primary-rgb));
   }
 
   .md\:placeholder-primary::-moz-placeholder {
@@ -25958,16 +25235,8 @@ code {
     color: rgb(var(--primary-rgb));
   }
 
-  .md\:placeholder-primary::-ms-input-placeholder {
-    color: rgb(var(--primary-rgb));
-  }
-
   .md\:placeholder-primary::placeholder {
     color: rgb(var(--primary-rgb));
-  }
-
-  .md\:placeholder-secondary::-webkit-input-placeholder {
-    color: rgb(var(--secondary-rgb));
   }
 
   .md\:placeholder-secondary::-moz-placeholder {
@@ -25978,16 +25247,8 @@ code {
     color: rgb(var(--secondary-rgb));
   }
 
-  .md\:placeholder-secondary::-ms-input-placeholder {
-    color: rgb(var(--secondary-rgb));
-  }
-
   .md\:placeholder-secondary::placeholder {
     color: rgb(var(--secondary-rgb));
-  }
-
-  .md\:placeholder-tertiary::-webkit-input-placeholder {
-    color: rgb(var(--tertiary-rgb));
   }
 
   .md\:placeholder-tertiary::-moz-placeholder {
@@ -25998,16 +25259,8 @@ code {
     color: rgb(var(--tertiary-rgb));
   }
 
-  .md\:placeholder-tertiary::-ms-input-placeholder {
-    color: rgb(var(--tertiary-rgb));
-  }
-
   .md\:placeholder-tertiary::placeholder {
     color: rgb(var(--tertiary-rgb));
-  }
-
-  .md\:placeholder-dark-alpha-20::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .02);
   }
 
   .md\:placeholder-dark-alpha-20::-moz-placeholder {
@@ -26018,16 +25271,8 @@ code {
     color: rgba(0, 0, 0, .02);
   }
 
-  .md\:placeholder-dark-alpha-20::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .02);
-  }
-
   .md\:placeholder-dark-alpha-20::placeholder {
     color: rgba(0, 0, 0, .02);
-  }
-
-  .md\:placeholder-dark-alpha-30::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .03);
   }
 
   .md\:placeholder-dark-alpha-30::-moz-placeholder {
@@ -26038,16 +25283,8 @@ code {
     color: rgba(0, 0, 0, .03);
   }
 
-  .md\:placeholder-dark-alpha-30::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .03);
-  }
-
   .md\:placeholder-dark-alpha-30::placeholder {
     color: rgba(0, 0, 0, .03);
-  }
-
-  .md\:placeholder-dark-alpha-50::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .05);
   }
 
   .md\:placeholder-dark-alpha-50::-moz-placeholder {
@@ -26058,16 +25295,8 @@ code {
     color: rgba(0, 0, 0, .05);
   }
 
-  .md\:placeholder-dark-alpha-50::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .05);
-  }
-
   .md\:placeholder-dark-alpha-50::placeholder {
     color: rgba(0, 0, 0, .05);
-  }
-
-  .md\:placeholder-dark-alpha-70::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .07);
   }
 
   .md\:placeholder-dark-alpha-70::-moz-placeholder {
@@ -26078,16 +25307,8 @@ code {
     color: rgba(0, 0, 0, .07);
   }
 
-  .md\:placeholder-dark-alpha-70::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .07);
-  }
-
   .md\:placeholder-dark-alpha-70::placeholder {
     color: rgba(0, 0, 0, .07);
-  }
-
-  .md\:placeholder-dark-alpha-100::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .1);
   }
 
   .md\:placeholder-dark-alpha-100::-moz-placeholder {
@@ -26098,16 +25319,8 @@ code {
     color: rgba(0, 0, 0, .1);
   }
 
-  .md\:placeholder-dark-alpha-100::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .1);
-  }
-
   .md\:placeholder-dark-alpha-100::placeholder {
     color: rgba(0, 0, 0, .1);
-  }
-
-  .md\:placeholder-dark-alpha-200::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .2);
   }
 
   .md\:placeholder-dark-alpha-200::-moz-placeholder {
@@ -26118,16 +25331,8 @@ code {
     color: rgba(0, 0, 0, .2);
   }
 
-  .md\:placeholder-dark-alpha-200::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .2);
-  }
-
   .md\:placeholder-dark-alpha-200::placeholder {
     color: rgba(0, 0, 0, .2);
-  }
-
-  .md\:placeholder-dark-alpha-300::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .3);
   }
 
   .md\:placeholder-dark-alpha-300::-moz-placeholder {
@@ -26138,16 +25343,8 @@ code {
     color: rgba(0, 0, 0, .3);
   }
 
-  .md\:placeholder-dark-alpha-300::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .3);
-  }
-
   .md\:placeholder-dark-alpha-300::placeholder {
     color: rgba(0, 0, 0, .3);
-  }
-
-  .md\:placeholder-dark-alpha-400::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .4);
   }
 
   .md\:placeholder-dark-alpha-400::-moz-placeholder {
@@ -26158,16 +25355,8 @@ code {
     color: rgba(0, 0, 0, .4);
   }
 
-  .md\:placeholder-dark-alpha-400::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .4);
-  }
-
   .md\:placeholder-dark-alpha-400::placeholder {
     color: rgba(0, 0, 0, .4);
-  }
-
-  .md\:placeholder-dark-alpha-500::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .5);
   }
 
   .md\:placeholder-dark-alpha-500::-moz-placeholder {
@@ -26178,16 +25367,8 @@ code {
     color: rgba(0, 0, 0, .5);
   }
 
-  .md\:placeholder-dark-alpha-500::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .5);
-  }
-
   .md\:placeholder-dark-alpha-500::placeholder {
     color: rgba(0, 0, 0, .5);
-  }
-
-  .md\:placeholder-dark-alpha-600::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .6);
   }
 
   .md\:placeholder-dark-alpha-600::-moz-placeholder {
@@ -26198,16 +25379,8 @@ code {
     color: rgba(0, 0, 0, .6);
   }
 
-  .md\:placeholder-dark-alpha-600::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .6);
-  }
-
   .md\:placeholder-dark-alpha-600::placeholder {
     color: rgba(0, 0, 0, .6);
-  }
-
-  .md\:placeholder-dark-alpha-700::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .7);
   }
 
   .md\:placeholder-dark-alpha-700::-moz-placeholder {
@@ -26218,16 +25391,8 @@ code {
     color: rgba(0, 0, 0, .7);
   }
 
-  .md\:placeholder-dark-alpha-700::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .7);
-  }
-
   .md\:placeholder-dark-alpha-700::placeholder {
     color: rgba(0, 0, 0, .7);
-  }
-
-  .md\:placeholder-dark-alpha-800::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .8);
   }
 
   .md\:placeholder-dark-alpha-800::-moz-placeholder {
@@ -26238,16 +25403,8 @@ code {
     color: rgba(0, 0, 0, .8);
   }
 
-  .md\:placeholder-dark-alpha-800::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .8);
-  }
-
   .md\:placeholder-dark-alpha-800::placeholder {
     color: rgba(0, 0, 0, .8);
-  }
-
-  .md\:placeholder-dark-alpha-900::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .9);
   }
 
   .md\:placeholder-dark-alpha-900::-moz-placeholder {
@@ -26258,16 +25415,8 @@ code {
     color: rgba(0, 0, 0, .9);
   }
 
-  .md\:placeholder-dark-alpha-900::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .9);
-  }
-
   .md\:placeholder-dark-alpha-900::placeholder {
     color: rgba(0, 0, 0, .9);
-  }
-
-  .md\:placeholder-light-alpha-20::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .02);
   }
 
   .md\:placeholder-light-alpha-20::-moz-placeholder {
@@ -26278,16 +25427,8 @@ code {
     color: rgba(255, 255, 255, .02);
   }
 
-  .md\:placeholder-light-alpha-20::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .02);
-  }
-
   .md\:placeholder-light-alpha-20::placeholder {
     color: rgba(255, 255, 255, .02);
-  }
-
-  .md\:placeholder-light-alpha-30::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .03);
   }
 
   .md\:placeholder-light-alpha-30::-moz-placeholder {
@@ -26298,16 +25439,8 @@ code {
     color: rgba(255, 255, 255, .03);
   }
 
-  .md\:placeholder-light-alpha-30::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .03);
-  }
-
   .md\:placeholder-light-alpha-30::placeholder {
     color: rgba(255, 255, 255, .03);
-  }
-
-  .md\:placeholder-light-alpha-50::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .05);
   }
 
   .md\:placeholder-light-alpha-50::-moz-placeholder {
@@ -26318,16 +25451,8 @@ code {
     color: rgba(255, 255, 255, .05);
   }
 
-  .md\:placeholder-light-alpha-50::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .05);
-  }
-
   .md\:placeholder-light-alpha-50::placeholder {
     color: rgba(255, 255, 255, .05);
-  }
-
-  .md\:placeholder-light-alpha-70::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .07);
   }
 
   .md\:placeholder-light-alpha-70::-moz-placeholder {
@@ -26338,16 +25463,8 @@ code {
     color: rgba(255, 255, 255, .07);
   }
 
-  .md\:placeholder-light-alpha-70::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .07);
-  }
-
   .md\:placeholder-light-alpha-70::placeholder {
     color: rgba(255, 255, 255, .07);
-  }
-
-  .md\:placeholder-light-alpha-100::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .1);
   }
 
   .md\:placeholder-light-alpha-100::-moz-placeholder {
@@ -26358,16 +25475,8 @@ code {
     color: rgba(255, 255, 255, .1);
   }
 
-  .md\:placeholder-light-alpha-100::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .1);
-  }
-
   .md\:placeholder-light-alpha-100::placeholder {
     color: rgba(255, 255, 255, .1);
-  }
-
-  .md\:placeholder-light-alpha-200::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .2);
   }
 
   .md\:placeholder-light-alpha-200::-moz-placeholder {
@@ -26378,16 +25487,8 @@ code {
     color: rgba(255, 255, 255, .2);
   }
 
-  .md\:placeholder-light-alpha-200::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .2);
-  }
-
   .md\:placeholder-light-alpha-200::placeholder {
     color: rgba(255, 255, 255, .2);
-  }
-
-  .md\:placeholder-light-alpha-300::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .3);
   }
 
   .md\:placeholder-light-alpha-300::-moz-placeholder {
@@ -26398,16 +25499,8 @@ code {
     color: rgba(255, 255, 255, .3);
   }
 
-  .md\:placeholder-light-alpha-300::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .3);
-  }
-
   .md\:placeholder-light-alpha-300::placeholder {
     color: rgba(255, 255, 255, .3);
-  }
-
-  .md\:placeholder-light-alpha-400::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .4);
   }
 
   .md\:placeholder-light-alpha-400::-moz-placeholder {
@@ -26418,16 +25511,8 @@ code {
     color: rgba(255, 255, 255, .4);
   }
 
-  .md\:placeholder-light-alpha-400::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .4);
-  }
-
   .md\:placeholder-light-alpha-400::placeholder {
     color: rgba(255, 255, 255, .4);
-  }
-
-  .md\:placeholder-light-alpha-500::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .5);
   }
 
   .md\:placeholder-light-alpha-500::-moz-placeholder {
@@ -26438,16 +25523,8 @@ code {
     color: rgba(255, 255, 255, .5);
   }
 
-  .md\:placeholder-light-alpha-500::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .5);
-  }
-
   .md\:placeholder-light-alpha-500::placeholder {
     color: rgba(255, 255, 255, .5);
-  }
-
-  .md\:placeholder-light-alpha-600::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .6);
   }
 
   .md\:placeholder-light-alpha-600::-moz-placeholder {
@@ -26458,16 +25535,8 @@ code {
     color: rgba(255, 255, 255, .6);
   }
 
-  .md\:placeholder-light-alpha-600::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .6);
-  }
-
   .md\:placeholder-light-alpha-600::placeholder {
     color: rgba(255, 255, 255, .6);
-  }
-
-  .md\:placeholder-light-alpha-700::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .7);
   }
 
   .md\:placeholder-light-alpha-700::-moz-placeholder {
@@ -26478,16 +25547,8 @@ code {
     color: rgba(255, 255, 255, .7);
   }
 
-  .md\:placeholder-light-alpha-700::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .7);
-  }
-
   .md\:placeholder-light-alpha-700::placeholder {
     color: rgba(255, 255, 255, .7);
-  }
-
-  .md\:placeholder-light-alpha-800::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .8);
   }
 
   .md\:placeholder-light-alpha-800::-moz-placeholder {
@@ -26498,16 +25559,8 @@ code {
     color: rgba(255, 255, 255, .8);
   }
 
-  .md\:placeholder-light-alpha-800::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .8);
-  }
-
   .md\:placeholder-light-alpha-800::placeholder {
     color: rgba(255, 255, 255, .8);
-  }
-
-  .md\:placeholder-light-alpha-900::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .9);
   }
 
   .md\:placeholder-light-alpha-900::-moz-placeholder {
@@ -26518,16 +25571,8 @@ code {
     color: rgba(255, 255, 255, .9);
   }
 
-  .md\:placeholder-light-alpha-900::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .9);
-  }
-
   .md\:placeholder-light-alpha-900::placeholder {
     color: rgba(255, 255, 255, .9);
-  }
-
-  .md\:placeholder-gray-100::-webkit-input-placeholder {
-    color: #f7f7f7;
   }
 
   .md\:placeholder-gray-100::-moz-placeholder {
@@ -26538,16 +25583,8 @@ code {
     color: #f7f7f7;
   }
 
-  .md\:placeholder-gray-100::-ms-input-placeholder {
-    color: #f7f7f7;
-  }
-
   .md\:placeholder-gray-100::placeholder {
     color: #f7f7f7;
-  }
-
-  .md\:placeholder-gray-200::-webkit-input-placeholder {
-    color: #ededed;
   }
 
   .md\:placeholder-gray-200::-moz-placeholder {
@@ -26558,16 +25595,8 @@ code {
     color: #ededed;
   }
 
-  .md\:placeholder-gray-200::-ms-input-placeholder {
-    color: #ededed;
-  }
-
   .md\:placeholder-gray-200::placeholder {
     color: #ededed;
-  }
-
-  .md\:placeholder-gray-300::-webkit-input-placeholder {
-    color: #e2e2e2;
   }
 
   .md\:placeholder-gray-300::-moz-placeholder {
@@ -26578,16 +25607,8 @@ code {
     color: #e2e2e2;
   }
 
-  .md\:placeholder-gray-300::-ms-input-placeholder {
-    color: #e2e2e2;
-  }
-
   .md\:placeholder-gray-300::placeholder {
     color: #e2e2e2;
-  }
-
-  .md\:placeholder-gray-400::-webkit-input-placeholder {
-    color: #cbcbcb;
   }
 
   .md\:placeholder-gray-400::-moz-placeholder {
@@ -26598,16 +25619,8 @@ code {
     color: #cbcbcb;
   }
 
-  .md\:placeholder-gray-400::-ms-input-placeholder {
-    color: #cbcbcb;
-  }
-
   .md\:placeholder-gray-400::placeholder {
     color: #cbcbcb;
-  }
-
-  .md\:placeholder-gray-500::-webkit-input-placeholder {
-    color: #a0a0a0;
   }
 
   .md\:placeholder-gray-500::-moz-placeholder {
@@ -26618,16 +25631,8 @@ code {
     color: #a0a0a0;
   }
 
-  .md\:placeholder-gray-500::-ms-input-placeholder {
-    color: #a0a0a0;
-  }
-
   .md\:placeholder-gray-500::placeholder {
     color: #a0a0a0;
-  }
-
-  .md\:placeholder-gray-600::-webkit-input-placeholder {
-    color: #717171;
   }
 
   .md\:placeholder-gray-600::-moz-placeholder {
@@ -26638,16 +25643,8 @@ code {
     color: #717171;
   }
 
-  .md\:placeholder-gray-600::-ms-input-placeholder {
-    color: #717171;
-  }
-
   .md\:placeholder-gray-600::placeholder {
     color: #717171;
-  }
-
-  .md\:placeholder-gray-700::-webkit-input-placeholder {
-    color: #4a4a4a;
   }
 
   .md\:placeholder-gray-700::-moz-placeholder {
@@ -26658,16 +25655,8 @@ code {
     color: #4a4a4a;
   }
 
-  .md\:placeholder-gray-700::-ms-input-placeholder {
-    color: #4a4a4a;
-  }
-
   .md\:placeholder-gray-700::placeholder {
     color: #4a4a4a;
-  }
-
-  .md\:placeholder-gray-750::-webkit-input-placeholder {
-    color: #333;
   }
 
   .md\:placeholder-gray-750::-moz-placeholder {
@@ -26678,16 +25667,8 @@ code {
     color: #333;
   }
 
-  .md\:placeholder-gray-750::-ms-input-placeholder {
-    color: #333;
-  }
-
   .md\:placeholder-gray-750::placeholder {
     color: #333;
-  }
-
-  .md\:placeholder-gray-800::-webkit-input-placeholder {
-    color: #2d2d2d;
   }
 
   .md\:placeholder-gray-800::-moz-placeholder {
@@ -26698,16 +25679,8 @@ code {
     color: #2d2d2d;
   }
 
-  .md\:placeholder-gray-800::-ms-input-placeholder {
-    color: #2d2d2d;
-  }
-
   .md\:placeholder-gray-800::placeholder {
     color: #2d2d2d;
-  }
-
-  .md\:placeholder-gray-900::-webkit-input-placeholder {
-    color: #1a1a1a;
   }
 
   .md\:placeholder-gray-900::-moz-placeholder {
@@ -26718,16 +25691,8 @@ code {
     color: #1a1a1a;
   }
 
-  .md\:placeholder-gray-900::-ms-input-placeholder {
-    color: #1a1a1a;
-  }
-
   .md\:placeholder-gray-900::placeholder {
     color: #1a1a1a;
-  }
-
-  .md\:focus\:placeholder-transparent:focus::-webkit-input-placeholder {
-    color: transparent;
   }
 
   .md\:focus\:placeholder-transparent:focus::-moz-placeholder {
@@ -26738,16 +25703,8 @@ code {
     color: transparent;
   }
 
-  .md\:focus\:placeholder-transparent:focus::-ms-input-placeholder {
-    color: transparent;
-  }
-
   .md\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
-  }
-
-  .md\:focus\:placeholder-black:focus::-webkit-input-placeholder {
-    color: #37383c;
   }
 
   .md\:focus\:placeholder-black:focus::-moz-placeholder {
@@ -26758,16 +25715,8 @@ code {
     color: #37383c;
   }
 
-  .md\:focus\:placeholder-black:focus::-ms-input-placeholder {
-    color: #37383c;
-  }
-
   .md\:focus\:placeholder-black:focus::placeholder {
     color: #37383c;
-  }
-
-  .md\:focus\:placeholder-white:focus::-webkit-input-placeholder {
-    color: #fff;
   }
 
   .md\:focus\:placeholder-white:focus::-moz-placeholder {
@@ -26778,16 +25727,8 @@ code {
     color: #fff;
   }
 
-  .md\:focus\:placeholder-white:focus::-ms-input-placeholder {
-    color: #fff;
-  }
-
   .md\:focus\:placeholder-white:focus::placeholder {
     color: #fff;
-  }
-
-  .md\:focus\:placeholder-error:focus::-webkit-input-placeholder {
-    color: rgb(var(--error-rgb));
   }
 
   .md\:focus\:placeholder-error:focus::-moz-placeholder {
@@ -26798,16 +25739,8 @@ code {
     color: rgb(var(--error-rgb));
   }
 
-  .md\:focus\:placeholder-error:focus::-ms-input-placeholder {
-    color: rgb(var(--error-rgb));
-  }
-
   .md\:focus\:placeholder-error:focus::placeholder {
     color: rgb(var(--error-rgb));
-  }
-
-  .md\:focus\:placeholder-success:focus::-webkit-input-placeholder {
-    color: rgb(var(--success-rgb));
   }
 
   .md\:focus\:placeholder-success:focus::-moz-placeholder {
@@ -26818,16 +25751,8 @@ code {
     color: rgb(var(--success-rgb));
   }
 
-  .md\:focus\:placeholder-success:focus::-ms-input-placeholder {
-    color: rgb(var(--success-rgb));
-  }
-
   .md\:focus\:placeholder-success:focus::placeholder {
     color: rgb(var(--success-rgb));
-  }
-
-  .md\:focus\:placeholder-primary:focus::-webkit-input-placeholder {
-    color: rgb(var(--primary-rgb));
   }
 
   .md\:focus\:placeholder-primary:focus::-moz-placeholder {
@@ -26838,16 +25763,8 @@ code {
     color: rgb(var(--primary-rgb));
   }
 
-  .md\:focus\:placeholder-primary:focus::-ms-input-placeholder {
-    color: rgb(var(--primary-rgb));
-  }
-
   .md\:focus\:placeholder-primary:focus::placeholder {
     color: rgb(var(--primary-rgb));
-  }
-
-  .md\:focus\:placeholder-secondary:focus::-webkit-input-placeholder {
-    color: rgb(var(--secondary-rgb));
   }
 
   .md\:focus\:placeholder-secondary:focus::-moz-placeholder {
@@ -26858,16 +25775,8 @@ code {
     color: rgb(var(--secondary-rgb));
   }
 
-  .md\:focus\:placeholder-secondary:focus::-ms-input-placeholder {
-    color: rgb(var(--secondary-rgb));
-  }
-
   .md\:focus\:placeholder-secondary:focus::placeholder {
     color: rgb(var(--secondary-rgb));
-  }
-
-  .md\:focus\:placeholder-tertiary:focus::-webkit-input-placeholder {
-    color: rgb(var(--tertiary-rgb));
   }
 
   .md\:focus\:placeholder-tertiary:focus::-moz-placeholder {
@@ -26878,16 +25787,8 @@ code {
     color: rgb(var(--tertiary-rgb));
   }
 
-  .md\:focus\:placeholder-tertiary:focus::-ms-input-placeholder {
-    color: rgb(var(--tertiary-rgb));
-  }
-
   .md\:focus\:placeholder-tertiary:focus::placeholder {
     color: rgb(var(--tertiary-rgb));
-  }
-
-  .md\:focus\:placeholder-dark-alpha-20:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .02);
   }
 
   .md\:focus\:placeholder-dark-alpha-20:focus::-moz-placeholder {
@@ -26898,16 +25799,8 @@ code {
     color: rgba(0, 0, 0, .02);
   }
 
-  .md\:focus\:placeholder-dark-alpha-20:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .02);
-  }
-
   .md\:focus\:placeholder-dark-alpha-20:focus::placeholder {
     color: rgba(0, 0, 0, .02);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-30:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .03);
   }
 
   .md\:focus\:placeholder-dark-alpha-30:focus::-moz-placeholder {
@@ -26918,16 +25811,8 @@ code {
     color: rgba(0, 0, 0, .03);
   }
 
-  .md\:focus\:placeholder-dark-alpha-30:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .03);
-  }
-
   .md\:focus\:placeholder-dark-alpha-30:focus::placeholder {
     color: rgba(0, 0, 0, .03);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-50:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .05);
   }
 
   .md\:focus\:placeholder-dark-alpha-50:focus::-moz-placeholder {
@@ -26938,16 +25823,8 @@ code {
     color: rgba(0, 0, 0, .05);
   }
 
-  .md\:focus\:placeholder-dark-alpha-50:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .05);
-  }
-
   .md\:focus\:placeholder-dark-alpha-50:focus::placeholder {
     color: rgba(0, 0, 0, .05);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-70:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .07);
   }
 
   .md\:focus\:placeholder-dark-alpha-70:focus::-moz-placeholder {
@@ -26958,16 +25835,8 @@ code {
     color: rgba(0, 0, 0, .07);
   }
 
-  .md\:focus\:placeholder-dark-alpha-70:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .07);
-  }
-
   .md\:focus\:placeholder-dark-alpha-70:focus::placeholder {
     color: rgba(0, 0, 0, .07);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-100:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .1);
   }
 
   .md\:focus\:placeholder-dark-alpha-100:focus::-moz-placeholder {
@@ -26978,16 +25847,8 @@ code {
     color: rgba(0, 0, 0, .1);
   }
 
-  .md\:focus\:placeholder-dark-alpha-100:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .1);
-  }
-
   .md\:focus\:placeholder-dark-alpha-100:focus::placeholder {
     color: rgba(0, 0, 0, .1);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-200:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .2);
   }
 
   .md\:focus\:placeholder-dark-alpha-200:focus::-moz-placeholder {
@@ -26998,16 +25859,8 @@ code {
     color: rgba(0, 0, 0, .2);
   }
 
-  .md\:focus\:placeholder-dark-alpha-200:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .2);
-  }
-
   .md\:focus\:placeholder-dark-alpha-200:focus::placeholder {
     color: rgba(0, 0, 0, .2);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-300:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .3);
   }
 
   .md\:focus\:placeholder-dark-alpha-300:focus::-moz-placeholder {
@@ -27018,16 +25871,8 @@ code {
     color: rgba(0, 0, 0, .3);
   }
 
-  .md\:focus\:placeholder-dark-alpha-300:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .3);
-  }
-
   .md\:focus\:placeholder-dark-alpha-300:focus::placeholder {
     color: rgba(0, 0, 0, .3);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-400:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .4);
   }
 
   .md\:focus\:placeholder-dark-alpha-400:focus::-moz-placeholder {
@@ -27038,16 +25883,8 @@ code {
     color: rgba(0, 0, 0, .4);
   }
 
-  .md\:focus\:placeholder-dark-alpha-400:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .4);
-  }
-
   .md\:focus\:placeholder-dark-alpha-400:focus::placeholder {
     color: rgba(0, 0, 0, .4);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-500:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .5);
   }
 
   .md\:focus\:placeholder-dark-alpha-500:focus::-moz-placeholder {
@@ -27058,16 +25895,8 @@ code {
     color: rgba(0, 0, 0, .5);
   }
 
-  .md\:focus\:placeholder-dark-alpha-500:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .5);
-  }
-
   .md\:focus\:placeholder-dark-alpha-500:focus::placeholder {
     color: rgba(0, 0, 0, .5);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-600:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .6);
   }
 
   .md\:focus\:placeholder-dark-alpha-600:focus::-moz-placeholder {
@@ -27078,16 +25907,8 @@ code {
     color: rgba(0, 0, 0, .6);
   }
 
-  .md\:focus\:placeholder-dark-alpha-600:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .6);
-  }
-
   .md\:focus\:placeholder-dark-alpha-600:focus::placeholder {
     color: rgba(0, 0, 0, .6);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-700:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .7);
   }
 
   .md\:focus\:placeholder-dark-alpha-700:focus::-moz-placeholder {
@@ -27098,16 +25919,8 @@ code {
     color: rgba(0, 0, 0, .7);
   }
 
-  .md\:focus\:placeholder-dark-alpha-700:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .7);
-  }
-
   .md\:focus\:placeholder-dark-alpha-700:focus::placeholder {
     color: rgba(0, 0, 0, .7);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-800:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .8);
   }
 
   .md\:focus\:placeholder-dark-alpha-800:focus::-moz-placeholder {
@@ -27118,16 +25931,8 @@ code {
     color: rgba(0, 0, 0, .8);
   }
 
-  .md\:focus\:placeholder-dark-alpha-800:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .8);
-  }
-
   .md\:focus\:placeholder-dark-alpha-800:focus::placeholder {
     color: rgba(0, 0, 0, .8);
-  }
-
-  .md\:focus\:placeholder-dark-alpha-900:focus::-webkit-input-placeholder {
-    color: rgba(0, 0, 0, .9);
   }
 
   .md\:focus\:placeholder-dark-alpha-900:focus::-moz-placeholder {
@@ -27138,16 +25943,8 @@ code {
     color: rgba(0, 0, 0, .9);
   }
 
-  .md\:focus\:placeholder-dark-alpha-900:focus::-ms-input-placeholder {
-    color: rgba(0, 0, 0, .9);
-  }
-
   .md\:focus\:placeholder-dark-alpha-900:focus::placeholder {
     color: rgba(0, 0, 0, .9);
-  }
-
-  .md\:focus\:placeholder-light-alpha-20:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .02);
   }
 
   .md\:focus\:placeholder-light-alpha-20:focus::-moz-placeholder {
@@ -27158,16 +25955,8 @@ code {
     color: rgba(255, 255, 255, .02);
   }
 
-  .md\:focus\:placeholder-light-alpha-20:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .02);
-  }
-
   .md\:focus\:placeholder-light-alpha-20:focus::placeholder {
     color: rgba(255, 255, 255, .02);
-  }
-
-  .md\:focus\:placeholder-light-alpha-30:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .03);
   }
 
   .md\:focus\:placeholder-light-alpha-30:focus::-moz-placeholder {
@@ -27178,16 +25967,8 @@ code {
     color: rgba(255, 255, 255, .03);
   }
 
-  .md\:focus\:placeholder-light-alpha-30:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .03);
-  }
-
   .md\:focus\:placeholder-light-alpha-30:focus::placeholder {
     color: rgba(255, 255, 255, .03);
-  }
-
-  .md\:focus\:placeholder-light-alpha-50:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .05);
   }
 
   .md\:focus\:placeholder-light-alpha-50:focus::-moz-placeholder {
@@ -27198,16 +25979,8 @@ code {
     color: rgba(255, 255, 255, .05);
   }
 
-  .md\:focus\:placeholder-light-alpha-50:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .05);
-  }
-
   .md\:focus\:placeholder-light-alpha-50:focus::placeholder {
     color: rgba(255, 255, 255, .05);
-  }
-
-  .md\:focus\:placeholder-light-alpha-70:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .07);
   }
 
   .md\:focus\:placeholder-light-alpha-70:focus::-moz-placeholder {
@@ -27218,16 +25991,8 @@ code {
     color: rgba(255, 255, 255, .07);
   }
 
-  .md\:focus\:placeholder-light-alpha-70:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .07);
-  }
-
   .md\:focus\:placeholder-light-alpha-70:focus::placeholder {
     color: rgba(255, 255, 255, .07);
-  }
-
-  .md\:focus\:placeholder-light-alpha-100:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .1);
   }
 
   .md\:focus\:placeholder-light-alpha-100:focus::-moz-placeholder {
@@ -27238,16 +26003,8 @@ code {
     color: rgba(255, 255, 255, .1);
   }
 
-  .md\:focus\:placeholder-light-alpha-100:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .1);
-  }
-
   .md\:focus\:placeholder-light-alpha-100:focus::placeholder {
     color: rgba(255, 255, 255, .1);
-  }
-
-  .md\:focus\:placeholder-light-alpha-200:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .2);
   }
 
   .md\:focus\:placeholder-light-alpha-200:focus::-moz-placeholder {
@@ -27258,16 +26015,8 @@ code {
     color: rgba(255, 255, 255, .2);
   }
 
-  .md\:focus\:placeholder-light-alpha-200:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .2);
-  }
-
   .md\:focus\:placeholder-light-alpha-200:focus::placeholder {
     color: rgba(255, 255, 255, .2);
-  }
-
-  .md\:focus\:placeholder-light-alpha-300:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .3);
   }
 
   .md\:focus\:placeholder-light-alpha-300:focus::-moz-placeholder {
@@ -27278,16 +26027,8 @@ code {
     color: rgba(255, 255, 255, .3);
   }
 
-  .md\:focus\:placeholder-light-alpha-300:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .3);
-  }
-
   .md\:focus\:placeholder-light-alpha-300:focus::placeholder {
     color: rgba(255, 255, 255, .3);
-  }
-
-  .md\:focus\:placeholder-light-alpha-400:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .4);
   }
 
   .md\:focus\:placeholder-light-alpha-400:focus::-moz-placeholder {
@@ -27298,16 +26039,8 @@ code {
     color: rgba(255, 255, 255, .4);
   }
 
-  .md\:focus\:placeholder-light-alpha-400:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .4);
-  }
-
   .md\:focus\:placeholder-light-alpha-400:focus::placeholder {
     color: rgba(255, 255, 255, .4);
-  }
-
-  .md\:focus\:placeholder-light-alpha-500:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .5);
   }
 
   .md\:focus\:placeholder-light-alpha-500:focus::-moz-placeholder {
@@ -27318,16 +26051,8 @@ code {
     color: rgba(255, 255, 255, .5);
   }
 
-  .md\:focus\:placeholder-light-alpha-500:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .5);
-  }
-
   .md\:focus\:placeholder-light-alpha-500:focus::placeholder {
     color: rgba(255, 255, 255, .5);
-  }
-
-  .md\:focus\:placeholder-light-alpha-600:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .6);
   }
 
   .md\:focus\:placeholder-light-alpha-600:focus::-moz-placeholder {
@@ -27338,16 +26063,8 @@ code {
     color: rgba(255, 255, 255, .6);
   }
 
-  .md\:focus\:placeholder-light-alpha-600:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .6);
-  }
-
   .md\:focus\:placeholder-light-alpha-600:focus::placeholder {
     color: rgba(255, 255, 255, .6);
-  }
-
-  .md\:focus\:placeholder-light-alpha-700:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .7);
   }
 
   .md\:focus\:placeholder-light-alpha-700:focus::-moz-placeholder {
@@ -27358,16 +26075,8 @@ code {
     color: rgba(255, 255, 255, .7);
   }
 
-  .md\:focus\:placeholder-light-alpha-700:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .7);
-  }
-
   .md\:focus\:placeholder-light-alpha-700:focus::placeholder {
     color: rgba(255, 255, 255, .7);
-  }
-
-  .md\:focus\:placeholder-light-alpha-800:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .8);
   }
 
   .md\:focus\:placeholder-light-alpha-800:focus::-moz-placeholder {
@@ -27378,16 +26087,8 @@ code {
     color: rgba(255, 255, 255, .8);
   }
 
-  .md\:focus\:placeholder-light-alpha-800:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .8);
-  }
-
   .md\:focus\:placeholder-light-alpha-800:focus::placeholder {
     color: rgba(255, 255, 255, .8);
-  }
-
-  .md\:focus\:placeholder-light-alpha-900:focus::-webkit-input-placeholder {
-    color: rgba(255, 255, 255, .9);
   }
 
   .md\:focus\:placeholder-light-alpha-900:focus::-moz-placeholder {
@@ -27398,16 +26099,8 @@ code {
     color: rgba(255, 255, 255, .9);
   }
 
-  .md\:focus\:placeholder-light-alpha-900:focus::-ms-input-placeholder {
-    color: rgba(255, 255, 255, .9);
-  }
-
   .md\:focus\:placeholder-light-alpha-900:focus::placeholder {
     color: rgba(255, 255, 255, .9);
-  }
-
-  .md\:focus\:placeholder-gray-100:focus::-webkit-input-placeholder {
-    color: #f7f7f7;
   }
 
   .md\:focus\:placeholder-gray-100:focus::-moz-placeholder {
@@ -27418,16 +26111,8 @@ code {
     color: #f7f7f7;
   }
 
-  .md\:focus\:placeholder-gray-100:focus::-ms-input-placeholder {
-    color: #f7f7f7;
-  }
-
   .md\:focus\:placeholder-gray-100:focus::placeholder {
     color: #f7f7f7;
-  }
-
-  .md\:focus\:placeholder-gray-200:focus::-webkit-input-placeholder {
-    color: #ededed;
   }
 
   .md\:focus\:placeholder-gray-200:focus::-moz-placeholder {
@@ -27438,16 +26123,8 @@ code {
     color: #ededed;
   }
 
-  .md\:focus\:placeholder-gray-200:focus::-ms-input-placeholder {
-    color: #ededed;
-  }
-
   .md\:focus\:placeholder-gray-200:focus::placeholder {
     color: #ededed;
-  }
-
-  .md\:focus\:placeholder-gray-300:focus::-webkit-input-placeholder {
-    color: #e2e2e2;
   }
 
   .md\:focus\:placeholder-gray-300:focus::-moz-placeholder {
@@ -27458,16 +26135,8 @@ code {
     color: #e2e2e2;
   }
 
-  .md\:focus\:placeholder-gray-300:focus::-ms-input-placeholder {
-    color: #e2e2e2;
-  }
-
   .md\:focus\:placeholder-gray-300:focus::placeholder {
     color: #e2e2e2;
-  }
-
-  .md\:focus\:placeholder-gray-400:focus::-webkit-input-placeholder {
-    color: #cbcbcb;
   }
 
   .md\:focus\:placeholder-gray-400:focus::-moz-placeholder {
@@ -27478,16 +26147,8 @@ code {
     color: #cbcbcb;
   }
 
-  .md\:focus\:placeholder-gray-400:focus::-ms-input-placeholder {
-    color: #cbcbcb;
-  }
-
   .md\:focus\:placeholder-gray-400:focus::placeholder {
     color: #cbcbcb;
-  }
-
-  .md\:focus\:placeholder-gray-500:focus::-webkit-input-placeholder {
-    color: #a0a0a0;
   }
 
   .md\:focus\:placeholder-gray-500:focus::-moz-placeholder {
@@ -27498,16 +26159,8 @@ code {
     color: #a0a0a0;
   }
 
-  .md\:focus\:placeholder-gray-500:focus::-ms-input-placeholder {
-    color: #a0a0a0;
-  }
-
   .md\:focus\:placeholder-gray-500:focus::placeholder {
     color: #a0a0a0;
-  }
-
-  .md\:focus\:placeholder-gray-600:focus::-webkit-input-placeholder {
-    color: #717171;
   }
 
   .md\:focus\:placeholder-gray-600:focus::-moz-placeholder {
@@ -27518,16 +26171,8 @@ code {
     color: #717171;
   }
 
-  .md\:focus\:placeholder-gray-600:focus::-ms-input-placeholder {
-    color: #717171;
-  }
-
   .md\:focus\:placeholder-gray-600:focus::placeholder {
     color: #717171;
-  }
-
-  .md\:focus\:placeholder-gray-700:focus::-webkit-input-placeholder {
-    color: #4a4a4a;
   }
 
   .md\:focus\:placeholder-gray-700:focus::-moz-placeholder {
@@ -27538,16 +26183,8 @@ code {
     color: #4a4a4a;
   }
 
-  .md\:focus\:placeholder-gray-700:focus::-ms-input-placeholder {
-    color: #4a4a4a;
-  }
-
   .md\:focus\:placeholder-gray-700:focus::placeholder {
     color: #4a4a4a;
-  }
-
-  .md\:focus\:placeholder-gray-750:focus::-webkit-input-placeholder {
-    color: #333;
   }
 
   .md\:focus\:placeholder-gray-750:focus::-moz-placeholder {
@@ -27558,16 +26195,8 @@ code {
     color: #333;
   }
 
-  .md\:focus\:placeholder-gray-750:focus::-ms-input-placeholder {
-    color: #333;
-  }
-
   .md\:focus\:placeholder-gray-750:focus::placeholder {
     color: #333;
-  }
-
-  .md\:focus\:placeholder-gray-800:focus::-webkit-input-placeholder {
-    color: #2d2d2d;
   }
 
   .md\:focus\:placeholder-gray-800:focus::-moz-placeholder {
@@ -27578,16 +26207,8 @@ code {
     color: #2d2d2d;
   }
 
-  .md\:focus\:placeholder-gray-800:focus::-ms-input-placeholder {
-    color: #2d2d2d;
-  }
-
   .md\:focus\:placeholder-gray-800:focus::placeholder {
     color: #2d2d2d;
-  }
-
-  .md\:focus\:placeholder-gray-900:focus::-webkit-input-placeholder {
-    color: #1a1a1a;
   }
 
   .md\:focus\:placeholder-gray-900:focus::-moz-placeholder {
@@ -27595,10 +26216,6 @@ code {
   }
 
   .md\:focus\:placeholder-gray-900:focus:-ms-input-placeholder {
-    color: #1a1a1a;
-  }
-
-  .md\:focus\:placeholder-gray-900:focus::-ms-input-placeholder {
     color: #1a1a1a;
   }
 
@@ -27631,7 +26248,6 @@ code {
   }
 
   .md\:sticky {
-    position: -webkit-sticky;
     position: sticky;
   }
 

--- a/static/scss/tailwind.scss
+++ b/static/scss/tailwind.scss
@@ -222,9 +222,11 @@ a {
 
 .lbl-group {
   @apply lbl;
-
+  display: flex;
+  align-items: center;
   temba-icon {
-    display: inline-block;
+    --icon-color: rgba(0,0,0,.5);
+    margin-right: 3px;
   }
 }
 
@@ -239,6 +241,8 @@ a {
 
 .lbl-group.inverted {
   @apply text-light-alpha-900;
+
+  
 
   &::before {
     @apply text-light-alpha-900;

--- a/templates/includes/recipients_contact.haml
+++ b/templates/includes/recipients_contact.haml
@@ -1,5 +1,5 @@
 -load contacts
 
-.item.contact.lbl.linked.mr-2.mb-2(onclick="goto(event)" href="{% url 'contacts.contact_read' contact.uuid %}")
-  .icon.icon-user.text-dark-alpha-300.-mb-1
+.lbl-group.linked.mr-2.mb-2(onclick="goto(event)" href="{% url 'contacts.contact_read' contact.uuid %}")
+  %temba-icon(name="user")
   {{ contact|name_or_urn:user_org }}


### PR DESCRIPTION
* Switch badge buttons to use flexbox to ensure icon centering. 
* Update icon color to match text.
* Have single recipient use `temba-icon` instead of `.icon`
* Add missing deps for `npm tw-build`

Fixes: https://github.com/rapidpro/rapidpro/issues/1490

<img width="246" alt="Screen Shot 2021-05-25 at 9 38 21 AM" src="https://user-images.githubusercontent.com/211652/119535815-47314c80-bd3d-11eb-9aa9-58333a78db1d.png">
<img width="703" alt="Screen Shot 2021-05-25 at 9 39 37 AM" src="https://user-images.githubusercontent.com/211652/119535827-48fb1000-bd3d-11eb-8ebb-27356d3d1fa9.png">
