### PR TITLE
🧯 Fix migrating flows who's definitions contain decimal values

### DIFF
--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -105,7 +105,7 @@ class MailroomClient:
     def flow_change_language(self, flow, language):
         payload = {"flow": flow, "language": language}
 
-        return self._request("flow/change_language", payload)
+        return self._request("flow/change_language", payload, encode_json=True)
 
     def flow_clone(self, flow, dependency_mapping):
         payload = {"flow": flow, "dependency_mapping": dependency_mapping}

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -91,7 +91,7 @@ class MailroomClient:
         if not to_version:
             to_version = Flow.CURRENT_SPEC_VERSION
 
-        return self._request("flow/migrate", {"flow": definition, "to_version": to_version})
+        return self._request("flow/migrate", {"flow": definition, "to_version": to_version}, encode_json=True)
 
     def flow_inspect(self, org_id, flow):
         payload = {"flow": flow}


### PR DESCRIPTION
I think this is another one from when we removed simplejson.. fixes https://sentry.io/organizations/nyaruka/issues/2420898690/?environment=production&project=21956

Also fixes for calls to flow/change_language endpoint