### PR TITLE
Fix campaign group buttons

### DIFF
--- a/templates/campaigns/campaign_list.haml
+++ b/templates/campaigns/campaign_list.haml
@@ -77,7 +77,8 @@
                       {{obj.name}}
 
                     %td.whitespace-nowrap
-                      -include "includes/recipients_group.haml" with group=obj.group
+                      .recipients.inline-block
+                        -include "includes/recipients_group.haml" with group=obj.group
 
                     %td.whitespace-nowrap
                       {{ obj.get_events|length }} event{{ obj.get_events|length|pluralize }}


### PR DESCRIPTION
Nest group buttons on campaign list so they don't grow to largest cell