### PR TITLE
Fix icon colors on latest chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@nyaruka/flow-editor": "1.13.16",
-        "@nyaruka/temba-components": "0.11.15",
+        "@nyaruka/temba-components": "0.11.16",
         "colorette": "1.2.2",
         "fa-icons": "0.2.0",
         "is-core-module": "2.4.0",
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@nyaruka/temba-components": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.11.15.tgz",
-      "integrity": "sha512-Zoe+I1pSLqJU/5qyFudjhWp/LJHLzIcas1JmPlfP6NnHO0zfc6mximexBumLm8tyGdDU4y1u/Vm2m7yKR0zWug==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.11.16.tgz",
+      "integrity": "sha512-H9XvxFvLQea1rD+UESSj0Nm+u8huUgnWvi7kLRUsPhQgtfG2Oyw036GjzL5U+kpFIx2CH9HOBOQsBtKAVttZuQ==",
       "dependencies": {
         "flru": "^1.0.2",
         "geojson": "^0.5.0",
@@ -2443,9 +2443,9 @@
       }
     },
     "@nyaruka/temba-components": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.11.15.tgz",
-      "integrity": "sha512-Zoe+I1pSLqJU/5qyFudjhWp/LJHLzIcas1JmPlfP6NnHO0zfc6mximexBumLm8tyGdDU4y1u/Vm2m7yKR0zWug==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.11.16.tgz",
+      "integrity": "sha512-H9XvxFvLQea1rD+UESSj0Nm+u8huUgnWvi7kLRUsPhQgtfG2Oyw036GjzL5U+kpFIx2CH9HOBOQsBtKAVttZuQ==",
       "requires": {
         "flru": "^1.0.2",
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.13.16",
-    "@nyaruka/temba-components": "0.11.15",
+    "@nyaruka/temba-components": "0.11.16",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",
     "is-core-module": "2.4.0",

--- a/static/css/temba-components.css
+++ b/static/css/temba-components.css
@@ -90,6 +90,17 @@ html {
   --font-size: 14px;
   --button-font-size: 1.125rem;
 
+  --icon-color: var(--text-color);
+  --icon-color-hover: var(--icon-color);
+  
+  --transition-speed: 200ms;
+  --event-padding: 0.5em 1em;
+  --help-text-margin-left: 4px;
+  --help-text-margin-top: 0px;
+  --temba-select-selected-padding: 9px;
+  --temba-select-selected-line-height: 16px;
+  --temba-select-selected-font-size: 13px;
+
   --header-bg: var(--color-primary-dark);
   --header-text: var(--color-text-light);
   


### PR DESCRIPTION
Looks like latest chrome won't let you override custom css properties defined on `:host`. This moves all host defined defaults to the main config and removes them from the individual components.