### PR TITLE
🧯 Fix creating scheduled triggers not being able to see weekday options

### DIFF
--- a/templates/triggers/trigger_create_schedule.haml
+++ b/templates/triggers/trigger_create_schedule.haml
@@ -3,11 +3,10 @@
 
 -block extra-script
   {{ block.super }}  
-  <script src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
 
   :javascript
     document.addEventListener("DOMContentLoaded", function(){
-      var repeatPeriod = document.querySelector("#id_schedule_repeat_period");
+      var repeatPeriod = document.querySelector("#id_repeat_period");
       if (repeatPeriod) {
         repeatPeriod.addEventListener("change", function(event){
           


### PR DESCRIPTION
Refactoring schedule forms is proving trickier than I thought so here's the quick fix..