### PR TITLE
📬 Use mailroom endpoints for ticket assignment and notes

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -2046,7 +2046,13 @@ class ContactTest(TembaTest):
         ChannelLog.objects.create(channel=self.channel, description="Its an ivr call", is_error=False, connection=call)
 
         # add a note to our open ticket
-        ticket.add_note(self.user, note="I have a bad feeling about this")
+        ticket.events.create(
+            org=self.org,
+            contact=ticket.contact,
+            event_type="N",
+            note="I have a bad feeling about this",
+            created_by=self.admin,
+        )
 
         # fetch our contact history
         self.login(self.admin)

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -182,6 +182,22 @@ class MailroomClient:
 
         return self._request("contact/parse_query", payload)
 
+    def ticket_assign(self, org_id: int, user_id: int, ticket_ids: list, assignee_id: int, note: str):
+        payload = {
+            "org_id": org_id,
+            "user_id": user_id,
+            "ticket_ids": ticket_ids,
+            "assignee_id": assignee_id,
+            "note": note,
+        }
+
+        return self._request("ticket/assign", payload)
+
+    def ticket_note(self, org_id: int, user_id: int, ticket_ids: list, note: str):
+        payload = {"org_id": org_id, "user_id": user_id, "ticket_ids": ticket_ids, "note": note}
+
+        return self._request("ticket/note", payload)
+
     def ticket_close(self, org_id, user_id, ticket_ids):
         payload = {"org_id": org_id, "user_id": user_id, "ticket_ids": ticket_ids}
 

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -321,6 +321,30 @@ class MailroomClientTest(TembaTest):
         with self.assertRaises(MailroomException):
             get_client().contact_search(1, "2752dbbc-723f-4007-8bc5-b3720835d3a9", "age > 10", "-created_on")
 
+    def test_ticket_assign(self):
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
+            response = get_client().ticket_assign(1, 12, [123, 345], 4, "please handle")
+
+            self.assertEqual({"changed_ids": [123]}, response)
+            mock_post.assert_called_once_with(
+                "http://localhost:8090/mr/ticket/assign",
+                headers={"User-Agent": "Temba"},
+                json={"org_id": 1, "user_id": 12, "ticket_ids": [123, 345], "assignee_id": 4, "note": "please handle"},
+            )
+
+    def test_ticket_note(self):
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
+            response = get_client().ticket_note(1, 12, [123, 345], "please handle")
+
+            self.assertEqual({"changed_ids": [123]}, response)
+            mock_post.assert_called_once_with(
+                "http://localhost:8090/mr/ticket/note",
+                headers={"User-Agent": "Temba"},
+                json={"org_id": 1, "user_id": 12, "ticket_ids": [123, 345], "note": "please handle"},
+            )
+
     def test_ticket_close(self):
         with patch("requests.post") as mock_post:
             mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -821,7 +821,7 @@ class OrgDeleteTest(TembaNonAtomicTest):
         # add a ticketer and ticket
         ticketer = Ticketer.create(self.org, self.admin, MailgunType.slug, "Email (bob)", {})
         ticket = self.create_ticket(ticketer, self.org.contacts.first(), "Need help")
-        ticket.add_note(self.admin, note="This is interesting!")
+        ticket.events.create(org=self.org, contact=ticket.contact, event_type="N", note="spam", created_by=self.admin)
 
     def release_org(self, org, child_org=None, delete=False, expected_files=3):
 

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -176,31 +176,16 @@ class Ticket(models.Model):
 
     assignee = models.ForeignKey(User, on_delete=models.PROTECT, null=True, related_name="assigned_tickets")
 
-    def assign(self, user: User, *, assignee: User, note: str):
-        now = timezone.now()
-        self.assignee = assignee
-        self.modified_on = now
-        self.last_activity_on = now
-        self.save(update_fields=("assignee", "modified_on", "last_activity_on"))
+    @classmethod
+    def bulk_assign(cls, org, user: User, tickets: list, assignee: User, note: str = None):
+        ticket_ids = [t.id for t in tickets if t.ticketer.is_active]
+        assignee_id = assignee.id if assignee else None
+        return mailroom.get_client().ticket_assign(org.id, user.id, ticket_ids, assignee_id, note)
 
-        self.events.create(
-            org=self.org,
-            contact=self.contact,
-            event_type=TicketEvent.TYPE_ASSIGNED,
-            assignee=assignee,
-            note=note,
-            created_by=user,
-        )
-
-    def add_note(self, user: User, *, note: str):
-        now = timezone.now()
-        self.modified_on = timezone.now()
-        self.last_activity_on = now
-        self.save(update_fields=("modified_on", "last_activity_on"))
-
-        self.events.create(
-            org=self.org, contact=self.contact, event_type=TicketEvent.TYPE_NOTE, note=note, created_by=user
-        )
+    @classmethod
+    def bulk_note(cls, org, user: User, tickets: list, note: str):
+        ticket_ids = [t.id for t in tickets if t.ticketer.is_active]
+        return mailroom.get_client().ticket_note(org.id, user.id, ticket_ids, note)
 
     @classmethod
     def bulk_close(cls, org, user, tickets):

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -176,6 +176,12 @@ class Ticket(models.Model):
 
     assignee = models.ForeignKey(User, on_delete=models.PROTECT, null=True, related_name="assigned_tickets")
 
+    def assign(self, user: User, *, assignee: User, note: str):
+        self.bulk_assign(self.org, user, [self], assignee=assignee, note=note)
+
+    def add_note(self, user: User, *, note: str):
+        self.bulk_note(self.org, user, [self], note=note)
+
     @classmethod
     def bulk_assign(cls, org, user: User, tickets: list, assignee: User, note: str = None):
         ticket_ids = [t.id for t in tickets if t.ticketer.is_active]

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -230,7 +230,7 @@ class TicketCRUDL(SmartCRUDL):
             initial = super().derive_initial()
             ticket = self.get_object()
             if ticket.assignee:
-                initial["assignee"] = ticket.assignee.pk
+                initial["assignee"] = ticket.assignee.id
             return initial
 
         def form_valid(self, form):


### PR DESCRIPTION
Better to have everything that changes tickets in one place. When we add notifications for ticket events it will live in mailroom.