### PR TITLE
🧬 Replace trigger folders with type specific filtered list pages

### DIFF
--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -1312,19 +1312,21 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         trigger5 = Trigger.create(self.org, self.admin, Trigger.TYPE_CATCH_ALL, flow1)
         Trigger.create(self.org2, self.admin, Trigger.TYPE_KEYWORD, self.create_flow(org=self.org2), keyword="other")
 
-        keywords_url = reverse("triggers.trigger_type", kwargs={"folder": "keywords"})
-        socials_url = reverse("triggers.trigger_type", kwargs={"folder": "social"})
-        catchall_url = reverse("triggers.trigger_type", kwargs={"folder": "catchall"})
+        keyword_url = reverse("triggers.trigger_type", kwargs={"type": "keyword"})
+        referral_url = reverse("triggers.trigger_type", kwargs={"type": "referral"})
+        catchall_url = reverse("triggers.trigger_type", kwargs={"type": "catch_all"})
 
         response = self.assertListFetch(
-            keywords_url, allow_viewers=True, allow_editors=True, context_objects=[trigger2, trigger1]
+            keyword_url, allow_viewers=True, allow_editors=True, context_objects=[trigger2, trigger1]
         )
         self.assertEqual(("archive",), response.context["actions"])
 
         # can search by keyword
         self.assertListFetch(
-            keywords_url + "?search=TES", allow_viewers=True, allow_editors=True, context_objects=[trigger1]
+            keyword_url + "?search=TES", allow_viewers=True, allow_editors=True, context_objects=[trigger1]
         )
 
-        self.assertListFetch(socials_url, allow_viewers=True, allow_editors=True, context_objects=[trigger3, trigger4])
+        self.assertListFetch(
+            referral_url, allow_viewers=True, allow_editors=True, context_objects=[trigger3, trigger4]
+        )
         self.assertListFetch(catchall_url, allow_viewers=True, allow_editors=True, context_objects=[trigger5])

--- a/temba/triggers/types.py
+++ b/temba/triggers/types.py
@@ -35,6 +35,9 @@ class KeywordTriggerType(TriggerType):
             widgets = {"keyword": InputWidget(), "match_type": SelectWidget()}
 
     code = Trigger.TYPE_KEYWORD
+    slug = "keyword"
+    name = _("Keyword")
+    title = _("Keyword Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE)
     export_fields = TriggerType.export_fields + ("keyword",)
     required_fields = TriggerType.required_fields + ("keyword",)
@@ -66,6 +69,9 @@ class CatchallTriggerType(TriggerType):
             super().__init__(user, Trigger.TYPE_CATCH_ALL, *args, **kwargs)
 
     code = Trigger.TYPE_CATCH_ALL
+    slug = "catch_all"
+    name = _("Catch All")
+    title = _("Catch All Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE)
     form = Form
 
@@ -110,6 +116,9 @@ class ScheduledTriggerType(TriggerType):
             }
 
     code = Trigger.TYPE_SCHEDULE
+    slug = "schedule"
+    name = _("Schedule")
+    title = _("Schedule Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE, Flow.TYPE_BACKGROUND)
     exportable = False
     form = Form
@@ -125,6 +134,9 @@ class InboundCallTriggerType(TriggerType):
             super().__init__(user, Trigger.TYPE_INBOUND_CALL, *args, **kwargs)
 
     code = Trigger.TYPE_INBOUND_CALL
+    slug = "inbound_call"
+    name = _("Inbound Call")
+    title = _("Inbound Call Triggers")
     allowed_flow_types = (Flow.TYPE_VOICE,)
     form = Form
 
@@ -139,6 +151,9 @@ class MissedCallTriggerType(TriggerType):
             super().__init__(user, Trigger.TYPE_MISSED_CALL, *args, **kwargs)
 
     code = Trigger.TYPE_MISSED_CALL
+    slug = "missed_call"
+    name = _("Missed Call")
+    title = _("Missed Call Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE)
     form = Form
 
@@ -165,6 +180,9 @@ class NewConversationTriggerType(TriggerType):
             fields = ("channel",) + BaseTriggerForm.Meta.fields
 
     code = Trigger.TYPE_NEW_CONVERSATION
+    slug = "new_conversation"
+    name = _("New Conversation")
+    title = _("New Conversation Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE,)
     export_fields = TriggerType.export_fields + ("channel",)
     required_fields = TriggerType.required_fields + ("channel",)
@@ -202,6 +220,9 @@ class ReferralTriggerType(TriggerType):
             fields = ("channel", "referrer_id") + BaseTriggerForm.Meta.fields
 
     code = Trigger.TYPE_REFERRAL
+    slug = "referral"
+    name = _("Referral")
+    title = _("Referral Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE,)
     export_fields = TriggerType.export_fields + ("channel",)
     form = Form
@@ -217,8 +238,12 @@ class ClosedTicketTriggerType(TriggerType):
             super().__init__(user, Trigger.TYPE_CLOSED_TICKET, *args, **kwargs)
 
     code = Trigger.TYPE_CLOSED_TICKET
+    slug = "closed_ticket"
+    name = _("Closed Ticket")
+    title = _("Closed Ticket Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE, Flow.TYPE_BACKGROUND)
     form = Form
 
 
-TYPES = {tc.code: tc() for tc in TriggerType.__subclasses__()}
+TYPES_BY_CODE = {tc.code: tc() for tc in TriggerType.__subclasses__()}
+TYPES_BY_SLUG = {tc.slug: tc() for tc in TriggerType.__subclasses__()}

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -59,7 +59,7 @@ class BaseTriggerForm(forms.ModelForm):
 
         self.user = user
         self.org = user.get_org()
-        self.trigger_type = Trigger.get_type(trigger_type)
+        self.trigger_type = Trigger.get_type(code=trigger_type)
 
         flow_types = self.trigger_type.allowed_flow_types
         flows = self.org.flows.filter(flow_type__in=flow_types, is_active=True, is_archived=False, is_system=False)
@@ -225,7 +225,7 @@ class TriggerCRUDL(SmartCRUDL):
         success_message = ""
 
         def get_form_class(self):
-            return self.form_class or Trigger.get_type(self.trigger_type).form
+            return self.form_class or Trigger.get_type(code=self.trigger_type).form
 
         def get_form_kwargs(self):
             kwargs = super().get_form_kwargs()
@@ -409,11 +409,18 @@ class TriggerCRUDL(SmartCRUDL):
             ]
 
         def get_type_folders(self, org):
+            from .types import TYPES_BY_SLUG
+
+            org_triggers = org.triggers.filter(is_active=True, is_archived=False)
             folders = []
-            for key, folder in Trigger.FOLDERS.items():
-                folder_url = reverse("triggers.trigger_type", kwargs={"folder": key})
-                folder_count = Trigger.get_folder(org, key).count()
-                folders.append(dict(label=folder.label, url=folder_url, count=folder_count))
+            for slug, trigger_type in TYPES_BY_SLUG.items():
+                folders.append(
+                    dict(
+                        label=trigger_type.name,
+                        url=reverse("triggers.trigger_type", kwargs={"type": slug}),
+                        count=org_triggers.filter(trigger_type=trigger_type.code).count(),
+                    )
+                )
             return folders
 
     class List(BaseList):
@@ -447,18 +454,23 @@ class TriggerCRUDL(SmartCRUDL):
 
     class Type(BaseList):
         """
-        Folders of related trigger types
+        Type filtered list view
         """
 
         bulk_actions = ("archive",)
 
         @classmethod
         def derive_url_pattern(cls, path, action):
-            return rf"^%s/%s/(?P<folder>{'|'.join(Trigger.FOLDERS.keys())}+)/$" % (path, action)
+            from .types import TYPES_BY_SLUG
+
+            return rf"^%s/%s/(?P<type>{'|'.join(TYPES_BY_SLUG.keys())}+)/$" % (path, action)
+
+        @property
+        def trigger_type(self):
+            return Trigger.get_type(slug=self.kwargs["type"])
 
         def derive_title(self):
-            return Trigger.FOLDERS[self.kwargs["folder"]].title
+            return self.trigger_type.title
 
         def get_queryset(self, *args, **kwargs):
-            qs = super().get_queryset(*args, **kwargs)
-            return Trigger.filter_folder(qs, self.kwargs["folder"]).filter(is_archived=False)
+            return super().get_queryset(*args, **kwargs).filter(is_archived=False, trigger_type=self.trigger_type.code)


### PR DESCRIPTION
Initially it seemed nice to group some trigger types together into folders but we need type specific list pages if we're to make triggers manually sortable.

<img width="587" alt="Captura de Pantalla 2021-07-14 a la(s) 12 23 09" src="https://user-images.githubusercontent.com/675558/125665558-9b53a5d7-7713-4614-a268-6009d9c9483c.png">