### PR TITLE
🎬 Rework flow start modal to show options as exclusions

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2562,11 +2562,19 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             object_unchanged=flow,
         )
 
-        # create flow start with an empty query
+        # try to create a query based flow start with an empty query
         self.assertUpdateSubmit(
             broadcast_url,
             {"mode": "query", "query": "", "exclude_in_other": False, "exclude_reruns": False},
             form_errors={"__all__": "Contact query is required."},
+            object_unchanged=flow,
+        )
+
+        # try to create selection based flow start with an empty selection
+        self.assertUpdateSubmit(
+            broadcast_url,
+            {"mode": "select", "omnibox": [], "exclude_in_other": False, "exclude_reruns": False},
+            form_errors={"omnibox": "This field is required."},
             object_unchanged=flow,
         )
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2529,7 +2529,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             broadcast_url,
             allow_viewers=False,
             allow_editors=True,
-            form_fields=["omnibox", "restart_participants", "include_active", "recipients_mode", "contact_query"],
+            form_fields=["mode", "omnibox", "query", "exclude_in_other", "exclude_reruns"],
         )
 
         # create flow start with a query
@@ -2537,12 +2537,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertUpdateSubmit(
             broadcast_url,
-            {
-                "contact_query": "frank",
-                "recipients_mode": "query",
-                "restart_participants": "on",
-                "include_active": "on",
-            },
+            {"mode": "query", "query": "frank", "exclude_in_other": False, "exclude_reruns": False},
         )
 
         start = FlowStart.objects.get()
@@ -2562,30 +2557,25 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertUpdateSubmit(
             broadcast_url,
-            {
-                "contact_query": 'name = "frank',
-                "recipients_mode": "query",
-                "restart_participants": "on",
-                "include_active": "on",
-            },
-            form_errors={"contact_query": "query contains an error"},
+            {"mode": "query", "query": 'name = "frank', "exclude_in_other": False, "exclude_reruns": False},
+            form_errors={"query": "query contains an error"},
             object_unchanged=flow,
         )
 
         # create flow start with an empty query
         self.assertUpdateSubmit(
             broadcast_url,
-            {"contact_query": "", "recipients_mode": "query", "restart_participants": "on", "include_active": "on"},
-            form_errors={"contact_query": "Contact query is required"},
+            {"mode": "query", "query": "", "exclude_in_other": False, "exclude_reruns": False},
+            form_errors={"__all__": "Contact query is required."},
             object_unchanged=flow,
         )
 
-        # create flow start with restart_participants and include_active both enabled
+        # create selection based flow start with exclude_in_other and exclude_reruns both left unchecked
         selection = json.dumps({"id": contact.uuid, "name": contact.name, "type": "contact"})
 
         self.assertUpdateSubmit(
             broadcast_url,
-            {"omnibox": selection, "recipients_mode": "select", "restart_participants": "on", "include_active": "on"},
+            {"mode": "select", "omnibox": selection, "exclude_in_other": False, "exclude_reruns": False},
         )
 
         start = FlowStart.objects.get()
@@ -2601,8 +2591,10 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         FlowStart.objects.all().delete()
 
-        # create flow start with restart_participants and include_active both enabled
-        self.assertUpdateSubmit(broadcast_url, {"omnibox": selection, "recipients_mode": "select"})
+        # create selection based flow start with exclude_in_other and exclude_reruns both checked
+        self.assertUpdateSubmit(
+            broadcast_url, {"mode": "select", "omnibox": selection, "exclude_in_other": True, "exclude_reruns": True}
+        )
 
         start = FlowStart.objects.get()
         self.assertEqual({contact}, set(start.contacts.all()))
@@ -2616,7 +2608,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # trying to start again should fail because there is already a pending start for this flow
         self.assertUpdateSubmit(
             broadcast_url,
-            {"omnibox": selection, "recipients_mode": "select"},
+            {"mode": "select", "omnibox": selection},
             form_errors={
                 "__all__": "This flow is already being started, please wait until that "
                 "process is complete before starting more contacts."
@@ -2640,18 +2632,16 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             broadcast_url,
             allow_viewers=False,
             allow_editors=True,
-            form_fields=["omnibox", "restart_participants", "include_active", "recipients_mode", "contact_query"],
+            form_fields=["mode", "omnibox", "query", "exclude_in_other", "exclude_reruns"],
         )
 
-        # include active is hidden
-        self.assertNotContains(response, "Include Active")
+        # option to exclude contact in other flows is hidden
+        self.assertNotContains(response, "Exclude contacts currently in a flow")
 
         # create flow start with a query
         mr_mocks.parse_query("frank", cleaned='name ~ "frank"', fields=[])
 
-        self.assertUpdateSubmit(
-            broadcast_url, {"contact_query": "frank", "recipients_mode": "query", "restart_participants": "on"}
-        )
+        self.assertUpdateSubmit(broadcast_url, {"mode": "query", "query": "frank", "exclude_reruns": False})
 
         start = FlowStart.objects.get()
         self.assertEqual(flow, start.flow)

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1838,10 +1838,7 @@ class FlowCRUDL(SmartCRUDL):
                 label=_("Exclude contacts currently in a flow"),
                 required=False,
                 initial=False,
-                help_text=_(
-                    "If unselected, contacts who are currently in a flow "
-                    "will be interrupted before being started in this flow."
-                ),
+                help_text=_("Any contacts currently in a flow will not be interrupted and started in this flow."),
                 widget=CheckboxWidget(),
             )
 
@@ -1850,7 +1847,7 @@ class FlowCRUDL(SmartCRUDL):
                 required=False,
                 initial=False,
                 help_text=_(
-                    "Any contacts who have gone through this flow in the last " "90 days will not be started again."
+                    "Any contacts who have gone through this flow in the last 90 days will not be started again."
                 ),
                 widget=CheckboxWidget(),
             )

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1174,7 +1174,7 @@ class OrgTest(TembaTest):
             omni_mark = json.dumps({"id": mark.uuid, "name": mark.name, "type": "contact"})
             return self.client.post(
                 reverse("flows.flow_broadcast", args=[flow.id]),
-                {"recipients_mode": "select", "omnibox": omni_mark, "restart_participants": "on"},
+                {"mode": "select", "omnibox": omni_mark, "exclude_in_other": True},
                 follow=True,
             )
 

--- a/templates/flows/flow_broadcast.haml
+++ b/templates/flows/flow_broadcast.haml
@@ -29,18 +29,18 @@
         %div= warning
 
     .field.recipients-mode
-      -render_field 'recipients_mode'
+      -render_field 'mode'
 
-    .field.omnibox(class='{% if not form.recipients_mode.value == "select" %}hidden{%endif%}')
+    .field.omnibox(class='{% if not form.mode.value == "select" %}hidden{%endif%}')
       -render_field 'omnibox'
 
-    .field.query(class='{% if form.recipients_mode.value == "select" %}hidden{%endif%}')
-      -render_field 'contact_query'
+    .field.query(class='{% if form.mode.value == "select" %}hidden{%endif%}')
+      -render_field 'query'
 
     .start-options.mt-6.ml-2
-      -render_field 'restart_participants'
       -if object.flow_type != 'B'
-        -render_field 'include_active'
+        -render_field 'exclude_in_other'
+      -render_field 'exclude_reruns'
 
 -block form-buttons
   -if send_channel
@@ -60,24 +60,21 @@
       ele.classList.remove(className);
     }
 
-    var modalBody = document.querySelector("#start-flow").shadowRoot
-
+    var modalBody = document.querySelector("#start-flow").shadowRoot;
     var queryField = modalBody.querySelector('.query');
-    var recipientsField = modalBody.querySelector('.omnibox');
-    var modeSelect = modalBody.querySelector("temba-select[name='recipients_mode']");
+    var omniboxField = modalBody.querySelector('.omnibox');
+    var modeSelect = modalBody.querySelector("temba-select[name='mode']");
 
-    if (modeSelect) {
-      modeSelect.addEventListener("change", function(evt) {
-        var selected = evt.target.values[0];
-        if (selected.value === "query") {
-          removeClass(queryField, "hidden");
-          addClass(recipientsField, "hidden");
-        } else {
-          addClass(queryField, "hidden");
-          removeClass(recipientsField, "hidden");
-        }
-      });
-    }
+    modeSelect.addEventListener("change", function(evt) {
+      var selected = evt.target.values[0];
+      if (selected.value === "query") {
+        removeClass(queryField, "hidden");
+        addClass(omniboxField, "hidden");
+      } else {
+        addClass(queryField, "hidden");
+        removeClass(omniboxField, "hidden");
+      }
+    });
 
 
 


### PR DESCRIPTION
I think these are sufficiently different (even the order is different) that we can get away with changing them and trust users to read the labels/help text. Intentionally avoiding the word "active" as that has a different meaning now.

<img width="617" alt="Captura de Pantalla 2021-07-20 a la(s) 11 51 33" src="https://user-images.githubusercontent.com/675558/126364186-eabb5f11-08ba-41d4-847b-c8fd0038a93e.png">

<img width="614" alt="Captura de Pantalla 2021-07-20 a la(s) 11 55 32" src="https://user-images.githubusercontent.com/675558/126364663-05241656-feea-4bad-b516-437f65b2786e.png">

Also has workaround for bug where we don't show errors for the query box (see https://github.com/nyaruka/temba-components/issues/103) by making that a non-field error. Tho still affected by this bug https://github.com/nyaruka/temba-components/issues/102 which renders error messages for omnibox field twice.
