### PR TITLE
🕵️‍♂️ Fix issues on imported flows

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -568,7 +568,9 @@ class Org(SmartModel):
 
         # with all the flows and dependencies committed, we can now have mailroom do full validation
         for flow in new_flows:
-            mailroom.get_client().flow_inspect(self.id, flow.get_definition())
+            flow_info = mailroom.get_client().flow_inspect(self.id, flow.get_definition())
+            flow.has_issues = len(flow_info[Flow.INSPECT_ISSUES]) > 0
+            flow.save(update_fields=("has_issues",))
 
     def validate_import(self, import_def):
         from temba.triggers.models import Trigger


### PR DESCRIPTION
Re-saves `Flow.has_issues` on final flow inspection at end of import process
