### PR TITLE
Update to zapier app directory, wide formax option and fixes

### DIFF
--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -2042,6 +2042,9 @@ code {
   }
 
 .formax .formax-section {
+    transition: all 200ms ease-in-out;
+    margin-left: 0px;
+    margin-right: 0px;
     --tw-bg-opacity: 1;
     background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
     border-radius: 0.5rem;
@@ -2114,7 +2117,26 @@ code {
           display: none;
         }
 
+.formax .formax-section.wide.open {
+      margin-left: -115px;
+      margin-right: -115px;
+    }
+
+.formax .formax-section.wide.open .formax-icon {
+        font-size: 50px;
+        padding-top: 0px;
+        flex-basis: 0px;
+      }
+
+.formax .formax-section.wide.open .formax-icon .i-container {
+          width: 0px;
+          margin-top: 20px;
+          margin-left:-25px;
+        }
+
 .formax .formax-section.open {
+      margin-left: -30px;
+      margin-right: -30px;
       --tw-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
       box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
     }

--- a/static/js/formax.js
+++ b/static/js/formax.js
@@ -127,6 +127,12 @@
           } else {
             if (section.data("action") !== 'fixed') {
               hideSection(section);
+
+              // refetch our primary form, but wait until our animation is done
+              window.setTimeout(function(){
+                fetchData(section);
+              }, 1000);
+              
             }
           }
           dependents = section.data("dependents");

--- a/static/scss/tailwind.scss
+++ b/static/scss/tailwind.scss
@@ -691,6 +691,10 @@ code {
 
 .formax {
   .formax-section {
+    transition: all 200ms ease-in-out;
+    margin-left: 0px;
+    margin-right: 0px;
+
     @apply border-0 rounded-lg shadow bg-white mb-4 p-0 overflow-hidden flex items-stretch;
 
     &:hover {
@@ -748,7 +752,27 @@ code {
       }
     }
 
+
+    &.wide.open {
+      margin-left: -115px;
+      margin-right: -115px;
+
+      .formax-icon {
+        font-size: 50px;
+        padding-top: 0px;
+        flex-basis: 0px;
+
+        .i-container {
+          width: 0px;
+          margin-top: 20px;
+          margin-left:-25px;
+        }
+      }
+    }
+
     &.open {
+      margin-left: -30px;
+      margin-right: -30px;
       @apply shadow-lg;
 
       &:hover {

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -116,9 +116,6 @@ class Resthook(SmartModel):
         self.modified_by = user
         self.save(update_fields=["is_active", "modified_on", "modified_by"])
 
-    def as_select2(self):
-        return dict(text=self.slug, id=self.slug)
-
     def __str__(self):  # pragma: needs cover
         return str(self.slug)
 

--- a/temba/api/urls.py
+++ b/temba/api/urls.py
@@ -1,13 +1,12 @@
 from django.conf.urls import include, url
 from django.views.generic import RedirectView
 
-from .views import RefreshAPITokenView, ResthookList, WebHookResultCRUDL
+from .views import RefreshAPITokenView, WebHookResultCRUDL
 
 urlpatterns = [
     url(r"^api/$", RedirectView.as_view(pattern_name="api.v2", permanent=False), name="api"),
     url(r"^api/v2/", include("temba.api.v2.urls")),
     url(r"^api/apitoken/refresh/$", RefreshAPITokenView.as_view(), name="api.apitoken_refresh"),
-    url(r"^api/resthooks/", include([url(r"^$", ResthookList.as_view(), name="api.resthook_list")])),
 ]
 
 urlpatterns += WebHookResultCRUDL().as_urlpatterns()

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -7,7 +7,7 @@ from django.views.generic import View
 
 from temba.orgs.views import OrgObjPermsMixin, OrgPermsMixin
 
-from .models import APIToken, Resthook, WebHookResult
+from .models import APIToken, WebHookResult
 
 
 class RefreshAPITokenView(OrgPermsMixin, SmartView, View):
@@ -40,11 +40,3 @@ class WebHookResultCRUDL(SmartCRUDL):
 
         def get_queryset(self):
             return WebHookResult.objects.filter(org=self.request.user.get_org()).order_by("-created_on")
-
-
-class ResthookList(OrgPermsMixin, SmartListView):
-    model = Resthook
-    permission = "api.resthook_list"
-
-    def derive_queryset(self):
-        return Resthook.objects.filter(is_active=True, org=self.request.user.get_org()).order_by("slug")

--- a/temba/formax.py
+++ b/temba/formax.py
@@ -31,7 +31,9 @@ class Formax:
         context = user_group_perms_processor(self.request)
         self.org = context["user_org"]
 
-    def add_section(self, name, url, icon, action="formax", button="Save", nobutton=False, dependents=None):
+    def add_section(
+        self, name, url, icon, action="formax", button="Save", nobutton=False, dependents=None, wide=False
+    ):
         resolver = resolve(url)
         self.request.META["HTTP_X_FORMAX"] = 1
         self.request.META["HTTP_X_PJAX"] = 1
@@ -57,6 +59,7 @@ class Formax:
                     button=button,
                     nobutton=nobutton,
                     dependents=dependents,
+                    wide=wide,
                 )
             )
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2518,12 +2518,6 @@ class OrgTest(TembaTest):
         response = self.client.post(resthook_url, {"new_slug": "Mother-Registration"})
         self.assertFormError(response, "form", "new_slug", "This event name has already been used.")
 
-        # hit our list page used by select2, checking it lists our resthook
-        response = self.client.get(reverse("api.resthook_list") + "?_format=select2")
-        results = response.json()["results"]
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0], dict(text="mother-registration", id="mother-registration"))
-
         # add a subscriber
         subscriber = mother_reg.add_subscriber("http://foo", self.admin)
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2702,7 +2702,7 @@ class OrgCRUDL(SmartCRUDL):
 
             return obj
 
-    class Resthooks(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
+    class Resthooks(ComponentFormMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class ResthookForm(forms.ModelForm):
             new_slug = forms.SlugField(
                 required=False,
@@ -2717,7 +2717,7 @@ class OrgCRUDL(SmartCRUDL):
                 field_mapping = []
 
                 for resthook in self.instance.get_resthooks():
-                    check_field = forms.BooleanField(required=False)
+                    check_field = forms.BooleanField(required=False, widget=CheckboxWidget())
                     field_name = "resthook_%d" % resthook.id
 
                     field_mapping.append((field_name, check_field))
@@ -2977,7 +2977,10 @@ class OrgCRUDL(SmartCRUDL):
 
             if self.has_org_perm("orgs.org_resthooks"):
                 formax.add_section(
-                    "resthooks", reverse("orgs.org_resthooks"), icon="icon-cloud-lightning", dependents="resthooks"
+                    "resthooks",
+                    reverse("orgs.org_resthooks"),
+                    icon="icon-cloud-lightning",
+                    wide="true",
                 )
 
             # show globals and archives

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -561,7 +561,6 @@ GROUP_PERMISSIONS = {
         "airtime.airtimetransfer_read",
         "api.apitoken_refresh",
         "api.resthook_api",
-        "api.resthook_list",
         "api.resthooksubscriber_api",
         "api.webhookevent_api",
         "api.webhookresult_list",
@@ -688,7 +687,6 @@ GROUP_PERMISSIONS = {
     "Editors": (
         "api.apitoken_refresh",
         "api.resthook_api",
-        "api.resthook_list",
         "api.resthooksubscriber_api",
         "api.webhookevent_api",
         "api.webhookevent_list",
@@ -786,7 +784,6 @@ GROUP_PERMISSIONS = {
         "triggers.trigger.*",
     ),
     "Viewers": (
-        "api.resthook_list",
         "campaigns.campaign_archived",
         "campaigns.campaign_list",
         "campaigns.campaign_read",

--- a/templates/formax.haml
+++ b/templates/formax.haml
@@ -1,6 +1,6 @@
 .formax
   -for section in formax.sections
-    .formax-section{id:'id-{{section.name}}', data-dependents:'{{section.dependents}}', data-button:'{{section.button}}', data-nobutton:'{% if section.nobutton %}true{% else %}false{% endif %}', data-fetched:'true', data-href:'{{section.url}}', data-action:'{{section.action}}', class:'action-{{section.action}}'}
+    .formax-section{id:'id-{{section.name}}', data-dependents:'{{section.dependents}}', data-button:'{{section.button}}', data-nobutton:'{% if section.nobutton %}true{% else %}false{% endif %}', data-fetched:'true', data-href:'{{section.url}}', data-action:'{{section.action}}', class:'action-{{section.action}} {% if section.wide %}wide{%endif%}'}
       .formax-icon.bg-gray-100.flex.flex-row.items-stretch
         .margin-wrapper
           .i-container{class:'{{section.icon}}'}

--- a/templates/orgs/org_resthooks.haml
+++ b/templates/orgs/org_resthooks.haml
@@ -9,8 +9,8 @@
       to flow events you create and trigger any number of Zapier integrations when they occur in your flows.
 
   -if brand.guided_zaps|length > 0
-    .mb-4
-      <script type="text/javascript" src="https://zapier.com/zapbook/embed/widget.js?container=true&inlinecss=true&guided_zaps={{ brand.guided_zaps|join:"," }}"></script>
+    <script type="module" src="https://zapier.com/partner/embed/app-directory/wrapper.js?id=zapier-app-directory&app=textit&theme=light&hide=salesforce-legacy%2Czendesk&zapstyle=row&introcopy=hide"></script>
+
 
 -block fields
     -if current_resthooks
@@ -26,12 +26,15 @@
               %tr
                 %td= resthook.resthook.slug
                 %td.resthook-check.permission
-                  .hidden-input.hide
-                    {{form|field:resthook.field}}
-                  .glyph.level-checkbox
+                  {{form|field:resthook.field}}
 
     .my-4
       {% render_field 'new_slug' %}
+
+-block post-form
+  {{block.super}}
+  .mt-8
+    #zapier-app-directory
 
 -block summary
   -with org.get_resthooks as resthooks
@@ -44,24 +47,6 @@
       -plural
         You have <b>{{ counter }} flow events</b> configured.
 
--block extra-script
-  {{block.super}}
-  :javascript
-    $(function() {
-      $("td.resthook-check .glyph").on('click', function(){
-        var cell = $(this).parent("td.resthook-check");
-        var ipt = cell.find("input[type='checkbox']");
-
-        if (!cell.hasClass("checked")) {
-          cell.addClass('checked');
-          ipt.prop('checked', true);
-        } else {
-          cell.removeClass('checked');
-          ipt.prop('checked', false);
-        }
-      })
-    });
-
 -block extra-style
   :css
 
@@ -71,6 +56,13 @@
 
     td.resthook-check.checked .glyph.level-checkbox:before {
       content: "\e05a";
+    }
+
+    table.list tr td temba-checkbox {
+      --icon-color: #333;
+      width: inherit;
+      height: inherit;
+      margin-right: 0px;
     }
 
     .zap-services {

--- a/templates/smartmin/modal.haml
+++ b/templates/smartmin/modal.haml
@@ -13,10 +13,6 @@
   -block modal-script
 
   -block modal-extra-style
-    :css
-      .select2-container {
-        width: 300px;
-      }
 
   -if form
     {{ form.media }}


### PR DESCRIPTION

All formax open sections now a tad wider:
<img width="823" alt="Screen Shot 2021-08-06 at 11 54 43 AM" src="https://user-images.githubusercontent.com/211652/128580549-da427295-ed41-4fcf-b631-013dcff7f739.png">

But now there's a wider option to accommodate the zapier widgets (also now using the new zapier app directory with popular textit zaps):
<img width="944" alt="Screen Shot 2021-08-06 at 11 55 43 AM" src="https://user-images.githubusercontent.com/211652/128580567-34bc0637-a256-4a94-9833-fafa8bf8b901.png">


