### PR TITLE
📅 Prevent saving of campaign events without `start_mode`

### DIFF
--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -412,8 +412,7 @@ class CampaignTest(TembaTest):
             reverse("campaigns.campaignevent_create") + "?campaign=%d" % campaign.pk, post_data
         )
 
-        self.assertTrue(response.context["form"].errors)
-        self.assertIn("Please select a flow", response.context["form"].errors["flow_to_start"])
+        self.assertFormError(response, "form", "flow_to_start", "This field is required.")
 
         post_data = dict(
             relative_to=self.planting_date.pk,
@@ -1432,6 +1431,17 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
                 "delivery_hour": 13,
             },
             form_errors={"message_start_mode": "This field is required."},
+        )
+        self.assertCreateSubmit(
+            create_url,
+            {
+                "event_type": "F",
+                "direction": "A",
+                "offset": 1,
+                "unit": "W",
+                "delivery_hour": 13,
+            },
+            form_errors={"flow_start_mode": "This field is required.", "flow_to_start": "This field is required."},
         )
 
         # can create an event with just a base translation

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -1420,8 +1420,22 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         self.assertEqual(3, len(response.context["form"].fields["message_start_mode"].choices))
 
+        # try to submit with missing fields
+        self.assertCreateSubmit(
+            create_url,
+            {
+                "event_type": "M",
+                "base": "This is my message",
+                "direction": "A",
+                "offset": 1,
+                "unit": "W",
+                "delivery_hour": 13,
+            },
+            form_errors={"message_start_mode": "This field is required."},
+        )
+
         # can create an event with just a base translation
-        response = self.assertCreateSubmit(
+        self.assertCreateSubmit(
             create_url,
             {
                 "relative_to": planting_date.id,
@@ -1573,7 +1587,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(contact_fields, ["created_on", "last_seen_on", "planting_date", "registered"])
 
         # translation in new language is optional
-        response = self.assertUpdateSubmit(
+        self.assertUpdateSubmit(
             update_url,
             {
                 "relative_to": planting_date.id,
@@ -1586,6 +1600,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
                 "unit": "W",
                 "flow_to_start": "",
                 "delivery_hour": 13,
+                "message_start_mode": "I",
             },
         )
 
@@ -1657,6 +1672,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
                 "unit": "D",
                 "flow_to_start": "",
                 "delivery_hour": 11,
+                "message_start_mode": "I",
             },
         )
         self.assertEqual(302, response.status_code)
@@ -1710,6 +1726,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
                 "unit": "W",
                 "flow_to_start": "",
                 "delivery_hour": 13,
+                "message_start_mode": "I",
             },
         )
 

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -300,25 +300,32 @@ class CampaignEventForm(forms.ModelForm):
             (CampaignEvent.MODE_PASSIVE, _("Send the message")),
         ),
         required=False,
-        widget=SelectWidget(attrs={"placeholder": _("Message sending rules"), "widget_only": True}),
+        widget=SelectWidget(attrs={"widget_only": True}),
     )
 
     def clean(self):
         data = super().clean()
-        if self.data["event_type"] == CampaignEvent.TYPE_MESSAGE and self.languages:
-            language = self.languages[0].language
-            iso_code = language["iso_code"]
-            if iso_code not in self.data or not self.data[iso_code].strip():
-                raise ValidationError(_("A message is required for '%s'") % language["name"])
 
-            for lang_data in self.languages:
-                lang = lang_data.language
-                iso_code = lang["iso_code"]
-                if iso_code in self.data and len(self.data[iso_code].strip()) > Msg.MAX_TEXT_LEN:
-                    raise ValidationError(
-                        _("Translation for '%(language)s' exceeds the %(limit)d character limit.")
-                        % dict(language=lang["name"], limit=Msg.MAX_TEXT_LEN)
-                    )
+        if self.data["event_type"] == CampaignEvent.TYPE_MESSAGE:
+            if self.languages:
+                language = self.languages[0].language
+                iso_code = language["iso_code"]
+                if iso_code not in self.data or not self.data[iso_code].strip():
+                    raise ValidationError(_("A message is required for '%s'") % language["name"])
+
+                for lang_data in self.languages:
+                    lang = lang_data.language
+                    iso_code = lang["iso_code"]
+                    if iso_code in self.data and len(self.data[iso_code].strip()) > Msg.MAX_TEXT_LEN:
+                        raise ValidationError(
+                            _("Translation for '%(language)s' exceeds the %(limit)d character limit.")
+                            % dict(language=lang["name"], limit=Msg.MAX_TEXT_LEN)
+                        )
+            if not data.get("message_start_mode"):
+                self.add_error("message_start_mode", _("This field is required."))
+        else:
+            if not data.get("flow_start_mode"):
+                self.add_error("flow_start_mode", _("This field is required."))
 
         return data
 

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -324,16 +324,12 @@ class CampaignEventForm(forms.ModelForm):
             if not data.get("message_start_mode"):
                 self.add_error("message_start_mode", _("This field is required."))
         else:
+            if not data.get("flow_to_start"):
+                self.add_error("flow_to_start", _("This field is required."))
             if not data.get("flow_start_mode"):
                 self.add_error("flow_start_mode", _("This field is required."))
 
         return data
-
-    def clean_flow_to_start(self):
-        if self.data["event_type"] == CampaignEvent.TYPE_FLOW:
-            if "flow_to_start" not in self.data or not self.data["flow_to_start"]:
-                raise ValidationError("Please select a flow")
-            return self.data["flow_to_start"]
 
     def pre_save(self, request, obj):
         org = self.user.get_org()
@@ -371,7 +367,7 @@ class CampaignEventForm(forms.ModelForm):
 
         # otherwise, it's an event that runs an existing flow
         else:
-            obj.flow = Flow.objects.get(org=org, id=self.cleaned_data["flow_to_start"])
+            obj.flow = self.cleaned_data["flow_to_start"]
             obj.start_mode = self.cleaned_data["flow_start_mode"]
 
     def __init__(self, user, *args, **kwargs):


### PR DESCRIPTION
Not entirely sure how because the dropdowns in the UI always show something, but we've let a few events be created with blank start_mode values that then blow up when we fire them https://sentry.io/organizations/nyaruka/issues/2571945045/?project=1281372&referrer=alert_email