### PR TITLE
Override `kir` language name

### DIFF
--- a/temba/utils/languages.py
+++ b/temba/utils/languages.py
@@ -20,6 +20,7 @@ NAME_OVERRIDES = {
     "swh": "Swahili (Indiv. lang., ISO-639-3)",
     "zho": "Chinese",  # zh in ISO-639-1
     "cmn": "Chinese (Mandarin, ISO-639-3)",
+    "kir": "Kyrgyz",  # https://github.com/rapidpro/rapidpro/issues/1551
 }
 
 NAMES = {}

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -1184,11 +1184,12 @@ class TestJSONField(TembaTest):
 
 class LanguagesTest(TembaTest):
     def test_get_name(self):
-        with override_settings(NON_ISO6391_LANGUAGES={"acx", "frc"}):
+        with override_settings(NON_ISO6391_LANGUAGES={"acx", "frc", "kir"}):
             languages.reload()
             self.assertEqual("French", languages.get_name("fra"))
             self.assertEqual("Arabic (Omani, ISO-639-3)", languages.get_name("acx"))  # name is overridden
             self.assertEqual("Cajun French", languages.get_name("frc"))  # non ISO-639-1 lang explicitly included
+            self.assertEqual("Kyrgyz", languages.get_name("kir"))
 
             self.assertEqual("", languages.get_name("cpi"))  # not in our allowed languages
             self.assertEqual("", languages.get_name("xyz"))


### PR DESCRIPTION
Fixes https://github.com/rapidpro/rapidpro/issues/1551