### PR TITLE
🙉 Pass `force=True` when closing tickets as part of releasing a ticketer

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -4570,7 +4570,7 @@ class APITest(TembaTest):
         self.postJSON(url, f"uuid={ticket1.uuid}", {"status": "closed"})
 
         # check that triggered a call to mailroom
-        mock_ticket_close.assert_called_once_with(self.org.id, self.admin.id, [ticket1.id])
+        mock_ticket_close.assert_called_once_with(self.org.id, self.admin.id, [ticket1.id], force=False)
 
         # reopen a ticket
         self.postJSON(url, f"uuid={ticket2.uuid}", {"status": "open"})

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -203,8 +203,8 @@ class MailroomClient:
 
         return self._request("ticket/change_topic", payload)
 
-    def ticket_close(self, org_id, user_id, ticket_ids):
-        payload = {"org_id": org_id, "user_id": user_id, "ticket_ids": ticket_ids}
+    def ticket_close(self, org_id: int, user_id: int, ticket_ids: list, force: bool):
+        payload = {"org_id": org_id, "user_id": user_id, "ticket_ids": ticket_ids, "force": force}
 
         return self._request("ticket/close", payload)
 

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -361,13 +361,13 @@ class MailroomClientTest(TembaTest):
     def test_ticket_close(self):
         with patch("requests.post") as mock_post:
             mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
-            response = get_client().ticket_close(1, 12, [123, 345])
+            response = get_client().ticket_close(1, 12, [123, 345], force=True)
 
             self.assertEqual({"changed_ids": [123]}, response)
             mock_post.assert_called_once_with(
                 "http://localhost:8090/mr/ticket/close",
                 headers={"User-Agent": "Temba"},
-                json={"org_id": 1, "user_id": 12, "ticket_ids": [123, 345]},
+                json={"org_id": 1, "user_id": 12, "ticket_ids": [123, 345], "force": True},
             )
 
     def test_ticket_reopen(self):

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2932,7 +2932,7 @@ class OrgCRUDL(SmartCRUDL):
                     formax.add_section(
                         "tickets",
                         reverse("tickets.ticketer_read", args=[ticketer.uuid]),
-                        icon=ticketer.get_type().icon,
+                        icon=ticketer.type.icon,
                     )
 
             if self.has_org_perm("orgs.org_profile"):

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -234,7 +234,7 @@ class TestClient(MailroomClient):
         return {"changed_ids": [t.id for t in tickets]}
 
     @_client_method
-    def ticket_close(self, org_id, user_id, ticket_ids):
+    def ticket_close(self, org_id: int, user_id: int, ticket_ids: list, force: bool):
         tickets = Ticket.objects.filter(org_id=org_id, status=Ticket.STATUS_OPEN, id__in=ticket_ids)
 
         for ticket in tickets:

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -60,9 +60,9 @@ class TicketTest(TembaTest):
 
         # test bulk closing
         with patch("temba.mailroom.client.MailroomClient.ticket_close") as mock_close:
-            Ticket.bulk_close(self.org, self.admin, [ticket])
+            Ticket.bulk_close(self.org, self.admin, [ticket], force=True)
 
-        mock_close.assert_called_once_with(self.org.id, self.admin.id, [ticket.id])
+        mock_close.assert_called_once_with(self.org.id, self.admin.id, [ticket.id], force=True)
 
         # test bulk re-opening
         with patch("temba.mailroom.client.MailroomClient.ticket_reopen") as mock_reopen:
@@ -482,7 +482,7 @@ class TicketerTest(TembaTest):
         self.assertEqual(self.user, ticketer.modified_by)
 
         # will have asked mailroom to close the ticket
-        mock_ticket_close.assert_called_once_with(self.org.id, self.user.id, [ticket.id])
+        mock_ticket_close.assert_called_once_with(self.org.id, self.user.id, [ticket.id], force=True)
 
         # reactivate
         ticketer.is_active = True

--- a/templates/tickets/ticketer_read.haml
+++ b/templates/tickets/ticketer_read.haml
@@ -2,7 +2,7 @@
 -load smartmin i18n
 
 -block pjax
-  -blocktrans trimmed with type_name=object.get_type.name name=object.name
+  -blocktrans trimmed with type_name=object.type.name name=object.name
     {{ type_name }} ticketing service over <b>{{ name }}</b>. Contacts who have open tickets with this service will have their
     messages forwarded to the service, and replies made using the service will be sent back to the contact.
 
@@ -17,5 +17,5 @@
 
 
 -block summary
-  -blocktrans trimmed with type_name=object.get_type.name name=object.name
+  -blocktrans trimmed with type_name=object.type.name name=object.name
     {{ type_name }} ticketing service over <b>{{ name }}</b>.

--- a/templates/tickets/types/zendesk/configure.haml
+++ b/templates/tickets/types/zendesk/configure.haml
@@ -2,10 +2,10 @@
 -load smartmin i18n
 
 -block title
-  .medium-help.float-left(class='{{ object.get_type.icon }}')
+  .medium-help.float-left(class='{{ object.type.icon }}')
 
   %h2.font_normalize.header-margin.title
-    {{ ticketer.get_type.name }}
+    {{ ticketer.type.name }}
     -trans "Ticketing Service"
     .ticketer-name
       {{ ticketer.name }}


### PR DESCRIPTION
You should always be able to remove a ticketer even if it's horked