### PR TITLE
Make ticketer HTTP logs accessible to org admins

### DIFF
--- a/temba/request_logs/tests.py
+++ b/temba/request_logs/tests.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from temba.classifiers.models import Classifier
 from temba.classifiers.types.wit import WitType
-from temba.tests import MockResponse, TembaTest
+from temba.tests import CRUDLTestMixin, MockResponse, TembaTest
 from temba.tickets.models import Ticketer
 from temba.tickets.types.mailgun import MailgunType
 
@@ -16,24 +16,45 @@ from .tasks import trim_http_logs_task
 
 
 class HTTPLogTest(TembaTest):
-    def test_classifier(self):
-        # create some classifiers
+    def test_trim_logs_task(self):
         c1 = Classifier.create(self.org, self.admin, WitType.slug, "Booker", {}, sync=False)
-        c1.intents.create(name="book_flight", external_id="book_flight", created_on=timezone.now(), is_active=True)
-        c1.intents.create(name="book_hotel", external_id="book_hotel", created_on=timezone.now(), is_active=False)
-        c1.intents.create(name="book_car", external_id="book_car", created_on=timezone.now(), is_active=True)
 
+        HTTPLog.objects.create(
+            classifier=c1,
+            url="http://org1.bar/zap/?text=" + ("0123456789" * 30),
+            request="GET /zap",
+            response=" OK 200",
+            is_error=False,
+            log_type=HTTPLog.INTENTS_SYNCED,
+            request_time=10,
+            org=self.org,
+            created_on=timezone.now() - timedelta(days=7),
+        )
+        l2 = HTTPLog.objects.create(
+            classifier=c1,
+            url="http://org2.bar/zap",
+            request="GET /zap",
+            response=" OK 200",
+            is_error=False,
+            log_type=HTTPLog.CLASSIFIER_CALLED,
+            request_time=10,
+            org=self.org,
+        )
+
+        trim_http_logs_task()
+
+        # should only have one log remaining and should be l2
+        self.assertEqual(1, HTTPLog.objects.all().count())
+        self.assertTrue(HTTPLog.objects.filter(id=l2.id))
+
+
+class HTTPLogCRUDLTest(TembaTest, CRUDLTestMixin):
+    def test_classifier(self):
+        c1 = Classifier.create(self.org, self.admin, WitType.slug, "Booker", {}, sync=False)
         c2 = Classifier.create(self.org, self.admin, WitType.slug, "Old Booker", {}, sync=False)
         c2.is_active = False
         c2.save()
 
-        log_url = reverse("request_logs.httplog_classifier", args=[c1.uuid])
-        response = self.client.get(log_url)
-        self.assertLoginRedirect(response)
-
-        self.login(self.admin)
-
-        # create some logs
         l1 = HTTPLog.objects.create(
             classifier=c1,
             url="http://org1.bar/zap/?text=" + ("0123456789" * 30),
@@ -44,7 +65,7 @@ class HTTPLogTest(TembaTest):
             request_time=10,
             org=self.org,
         )
-        l2 = HTTPLog.objects.create(
+        HTTPLog.objects.create(
             classifier=c2,
             url="http://org2.bar/zap",
             request="GET /zap",
@@ -55,60 +76,29 @@ class HTTPLogTest(TembaTest):
             org=self.org,
         )
 
-        response = self.client.get(log_url)
-        self.assertEqual(1, len(response.context["object_list"]))
+        list_url = reverse("request_logs.httplog_classifier", args=[c1.uuid])
+        log_url = reverse("request_logs.httplog_read", args=[l1.id])
+
+        response = self.assertListFetch(list_url, allow_viewers=False, allow_editors=False, context_objects=[l1])
         self.assertContains(response, "Intents Synced")
+        self.assertContains(response, log_url)
         self.assertNotContains(response, "Classifier Called")
 
-        log_url = reverse("request_logs.httplog_read", args=[l1.id])
-        self.assertContains(response, log_url)
-
-        response = self.client.get(log_url)
+        # view the individual log item
+        response = self.assertReadFetch(log_url, allow_viewers=False, allow_editors=False, context_object=l1)
         self.assertContains(response, "200")
         self.assertContains(response, "http://org1.bar/zap")
         self.assertNotContains(response, "http://org2.bar/zap")
 
-        self.login(self.admin2)
-        response = self.client.get(log_url)
-        self.assertLoginRedirect(response)
-
-        # move l1 to be from a week ago
-        l1.created_on = timezone.now() - timedelta(days=7)
-        l1.save(update_fields=["created_on"])
-
-        trim_http_logs_task()
-
-        # should only have one log remaining and should be l2
-        self.assertEqual(1, HTTPLog.objects.all().count())
-        self.assertTrue(HTTPLog.objects.filter(id=l2.id))
-
-        # release l2
-        l2.release()
-        self.assertFalse(HTTPLog.objects.filter(id=l2.id))
+        # can't list logs for deleted classifier
+        response = self.requestView(reverse("request_logs.httplog_classifier", args=[c2.uuid]), self.admin)
+        self.assertEqual(404, response.status_code)
 
     def test_ticketer(self):
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
-        # create some ticketers
         t1 = Ticketer.create(self.org, self.admin, MailgunType.slug, "Email (bob@acme.com)", {})
         t2 = Ticketer.create(self.org, self.admin, MailgunType.slug, "Old Email", {})
         t2.is_active = False
         t2.save()
-
-        list_url = reverse("request_logs.httplog_ticketer", args=[t1.uuid])
-        response = self.client.get(list_url)
-        self.assertLoginRedirect(response)
-
-        # even admins can't view ticketer logs
-        self.login(self.admin)
-        response = self.client.get(list_url)
-        self.assertLoginRedirect(response)
-
-        # customer support can
-        self.login(self.customer_support)
-        response = self.client.get(list_url)
-        self.assertEqual(200, response.status_code)
 
         # create some logs
         l1 = HTTPLog.objects.create(
@@ -122,34 +112,21 @@ class HTTPLogTest(TembaTest):
             org=self.org,
         )
 
-        response = self.client.get(list_url)
-        self.assertEqual(1, len(response.context["object_list"]))
-        self.assertContains(response, "Ticketing Service Called")
-
+        list_url = reverse("request_logs.httplog_ticketer", args=[t1.uuid])
         log_url = reverse("request_logs.httplog_read", args=[l1.id])
+
+        response = self.assertListFetch(list_url, allow_viewers=False, allow_editors=False, context_objects=[l1])
+        self.assertContains(response, "Ticketing Service Called")
         self.assertContains(response, log_url)
 
         # view the individual log item
-        response = self.client.get(log_url)
+        response = self.assertReadFetch(log_url, allow_viewers=False, allow_editors=False, context_object=l1)
         self.assertContains(response, "200")
         self.assertContains(response, "http://org1.bar/zap")
         self.assertNotContains(response, "http://org2.bar/zap")
 
-        # still need to be customer support to do that
-        self.login(self.admin)
-        response = self.client.get(log_url)
-        self.assertLoginRedirect(response)
-
-        # and can't be from other org
-        self.login(self.admin2)
-        response = self.client.get(log_url)
-        self.assertLoginRedirect(response)
-
-        self.login(self.customer_support)
-
         # can't list logs for deleted ticketer
-        list_url = reverse("request_logs.httplog_ticketer", args=[t2.uuid])
-        response = self.client.get(list_url)
+        response = self.requestView(reverse("request_logs.httplog_ticketer", args=[t2.uuid]), self.admin)
         self.assertEqual(404, response.status_code)
 
     def test_channel_log(self):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -559,9 +559,6 @@ GROUP_PERMISSIONS = {
         "policies.policy_update",
         "policies.policy_admin",
         "policies.policy_history",
-        "request_logs.httplog_read",
-        "request_logs.httplog_classifier",
-        "request_logs.httplog_ticketer",
     ),
     "Administrators": (
         "airtime.airtimetransfer_list",
@@ -688,7 +685,7 @@ GROUP_PERMISSIONS = {
         "policies.policy_read",
         "policies.policy_list",
         "policies.policy_give_consent",
-        "request_logs.httplog_classifier",
+        "request_logs.httplog_list",
         "request_logs.httplog_read",
         "templates.template_api",
         "tickets.ticket.*",

--- a/temba/tests/crudl.py
+++ b/temba/tests/crudl.py
@@ -65,6 +65,7 @@ class CRUDLTestMixin:
         allow_agents=False,
         context_objects=None,
         context_object_count=None,
+        object_url=True,
         status=200,
     ):
         viewer, editor, agent, admin, org2_admin = self.get_test_users()
@@ -86,7 +87,10 @@ class CRUDLTestMixin:
         as_user(viewer, allowed=allow_viewers)
         as_user(editor, allowed=allow_editors)
         as_user(agent, allowed=allow_agents)
-        as_user(org2_admin, allowed=True)
+
+        # if the URL references a specific object, need to check users from other orgs can't access it
+        as_user(org2_admin, allowed=not object_url)
+
         return as_user(admin, allowed=True)
 
     def assertCreateFetch(self, url, *, allow_viewers, allow_editors, allow_agents=False, form_fields=(), status=200):
@@ -151,8 +155,7 @@ class CRUDLTestMixin:
         as_user(agent, allowed=allow_agents)
 
         # if the URL references a specific object, need to check users from other orgs can't access it
-        if object_url:
-            as_user(org2_admin, allowed=False)
+        as_user(org2_admin, allowed=not object_url)
 
         return as_user(admin, allowed=True)
 

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -517,13 +517,15 @@ class TicketerTest(TembaTest):
 
 class TicketerCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_org_home(self):
-        Ticketer.create(self.org, self.user, MailgunType.slug, "Email (bob@acme.com)", {})
+        ticketer = Ticketer.create(self.org, self.user, MailgunType.slug, "Email (bob@acme.com)", {})
 
         self.login(self.admin)
         response = self.client.get(reverse("orgs.org_home"))
 
         self.assertContains(response, "Email (bob@acme.com)")
         self.assertContains(response, "ticketer/delete/")
+        self.assertContains(response, "HTTP Log")
+        self.assertContains(response, reverse("request_logs.httplog_ticketer", args=[ticketer.uuid]))
 
     def test_connect(self):
         connect_url = reverse("tickets.ticketer_connect")

--- a/templates/tickets/ticketer_read.haml
+++ b/templates/tickets/ticketer_read.haml
@@ -7,7 +7,7 @@
     messages forwarded to the service, and replies made using the service will be sent back to the contact.
 
   .buttons.mt-5
-    -if org_perms.request_logs.httplog_ticketer
+    -if org_perms.request_logs.httplog_list
       .button-light.mr-3(onclick='goto(event)' href='{% url "request_logs.httplog_ticketer" object.uuid %}')
         -trans "HTTP Log"
     -if org_perms.tickets.ticketer_delete


### PR DESCRIPTION
Not sure why we don't let admins view these since we're going to the trouble of redacting them on the engine side...