### PR TITLE
Move list refresh registration out of content block

### DIFF
--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -42,6 +42,7 @@
       :javascript
         var static_url = '{{STATIC_URL}}';
 
+      %script{src:"{{ STATIC_URL }}js/libs/jquery.url.js"}
       %script{src:"{{ STATIC_URL }}bower/toastr/toastr.js"}
       %script{src:"{{ STATIC_URL }}bower/bootstrap/js/bootstrap-modal.js"}
       %script{src:"{{ STATIC_URL }}bower/bootstrap/js/bootstrap-dropdown.js"}
@@ -325,6 +326,14 @@
     </form>
 
     :javascript
+
+      var params = '{{url_params|safe}}';
+      $(document).ready(function(){
+        if (window.scheduleRefresh) {
+          scheduleRefresh();
+        }
+      });
+
       $(document).ready(function() {
         if (navigator.appVersion.indexOf("Win")!=-1) {
           $("html").addClass("windows");

--- a/templates/smartmin/base.html
+++ b/templates/smartmin/base.html
@@ -8,7 +8,7 @@
 
 {% block extra-script %}
 
-<script type="text/javascript" src="{{ STATIC_URL }}js/libs/jquery.url.js"></script>
+
 
 <script>
 
@@ -136,7 +136,7 @@
 var refreshTimeout = 10000;
 function refresh(onSuccess, forceReload){
 
-  var url = "{{url_params|safe}}"
+  var url = params;
   {% if page_obj %}
     url += "page={{page_obj.number}}";
   {% endif %}
@@ -165,7 +165,6 @@ function refresh(onSuccess, forceReload){
         if (pjax) {
           return eval(document.querySelector("#pjax").dataset.noPjax);
         }
-        console.log("forcing ignore refresh");
         return true;
       },
       onIgnore: function() {
@@ -179,12 +178,9 @@ function refresh(onSuccess, forceReload){
 
 refreshTimeout = {{ refresh }};
 function scheduleRefresh() {
-    // window.setTimeout(refresh, refreshTimeout);
+  window.setTimeout(refresh, refreshTimeout);
 }
 
-$(document).ready(function(){
-  scheduleRefresh();
-});
 </script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Still need to determine what changed to cause this, but definitely found where we had cascade registration for triggering refreshes. Moved a couple things from the extra-script which is loaded on every pjax completion up the chain so they only ever load once.