### PR TITLE
Fix S3 select query generation for date fields

### DIFF
--- a/temba/tests/s3.py
+++ b/temba/tests/s3.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 from unittest.mock import call
 
 import iso8601
+import regex
 
 from temba.utils import chunk_list, json
 
@@ -133,7 +134,12 @@ def _parse_expression(exp: str) -> list:
     conditions = exp[33:].split(" AND ")
     parsed = []
     for con in conditions:
-        col, op, val = con.split(" ", maxsplit=2)
+        match = regex.match(r"(.*)\s(=|!=|>|>=|<|<=|IN)\s(.+)", con)
+        col, op, val = match.group(1), match.group(2), match.group(3)
+
+        if col.startswith("CAST("):
+            col = regex.match(r"CAST\((.+) AS .+\)", col).group(1)
+
         col = col[2:]  # remove alias prefix
         parsed.append((col, op, _parse_value(val)))
 

--- a/temba/utils/s3/select.py
+++ b/temba/utils/s3/select.py
@@ -28,14 +28,19 @@ def _compile_condition(alias: str, field: str, val) -> str:
         op = LOOKUPS[field_parts[-1]]
         field = "__".join(field_parts[:-1])
 
-    column = _compile_column(alias, field)
+    column = _compile_column(alias, field, cast="TIMESTAMP" if isinstance(val, datetime) else None)
     value = _compile_value(val)
 
     return f"{column} {op} {value}"
 
 
-def _compile_column(alias, field) -> str:
-    return f"{alias}.{field.replace('__', '.')}"
+def _compile_column(alias: str, field: str, cast: str = None) -> str:
+    col = f"{alias}.{field.replace('__', '.')}"
+
+    if cast:
+        col = f"CAST({col} AS {cast})"
+
+    return col
 
 
 def _compile_value(val) -> str:

--- a/temba/utils/s3/tests.py
+++ b/temba/utils/s3/tests.py
@@ -64,11 +64,11 @@ class SelectTest(TembaTest):
             compile_select(where={"uuid": "12345", "id": 123, "active": True}),
         )
         self.assertEqual(
-            "SELECT s.* FROM s3object s WHERE s.created_on > CAST('2021-09-28T18:27:30.123456+00:00' AS TIMESTAMP)",
+            "SELECT s.* FROM s3object s WHERE CAST(s.created_on AS TIMESTAMP) > CAST('2021-09-28T18:27:30.123456+00:00' AS TIMESTAMP)",
             compile_select(where={"created_on__gt": datetime(2021, 9, 28, 18, 27, 30, 123456, pytz.UTC)}),
         )
         self.assertEqual(
-            "SELECT s.* FROM s3object s WHERE s.modified_on <= CAST('2021-09-28T18:27:30.123456+00:00' AS TIMESTAMP)",
+            "SELECT s.* FROM s3object s WHERE CAST(s.modified_on AS TIMESTAMP) <= CAST('2021-09-28T18:27:30.123456+00:00' AS TIMESTAMP)",
             compile_select(where={"modified_on__lte": datetime(2021, 9, 28, 18, 27, 30, 123456, pytz.UTC)}),
         )
         self.assertEqual(


### PR DESCRIPTION
```sql
SELECT s.* FROM s3object s WHERE s.created_on > CAST('2021-09-28T18:27:30.123456+00:00' AS TIMESTAMP)
```

becomes

```sql
SELECT s.* FROM s3object s WHERE CAST(s.created_on AS TIMESTAMP) > CAST('2021-09-28T18:27:30.123456+00:00' AS TIMESTAMP)
```