### PR TITLE
Tweak tickets API endpoint to accept a `uuid` URL param

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -4562,7 +4562,7 @@ class APITest(TembaTest):
         self.assertEqual("Bob", resp_json["results"][0]["contact"]["name"])
 
         # filter further by ticket uuid
-        response = self.fetchJSON(url, f"ticket={ticket3.uuid}")
+        response = self.fetchJSON(url, f"uuid={ticket3.uuid}")
         resp_json = response.json()
         self.assertEqual(1, len(resp_json["results"]))
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -3539,9 +3539,9 @@ class TicketsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             else:
                 queryset = queryset.filter(id=-1)
 
-        ticket_uuid = params.get("ticket")
-        if ticket_uuid:
-            queryset = queryset.filter(uuid=ticket_uuid)
+        uuid = params.get("uuid") or params.get("ticket")
+        if uuid:
+            queryset = queryset.filter(uuid=uuid)
 
         # filter by ticketer type if provided, unpublished support for agents
         ticketer_type = params.get("ticketer_type")


### PR DESCRIPTION
Every other endpoint calls this param just `uuid`