### PR TITLE
😀 Allow keyword triggers to be single emojis

### DIFF
--- a/temba/triggers/types.py
+++ b/temba/triggers/types.py
@@ -19,7 +19,11 @@ class KeywordTriggerType(TriggerType):
     A trigger for incoming messages that match given keywords
     """
 
-    KEYWORD_REGEX = regex.compile(r"^\w+$", flags=regex.UNICODE | regex.V0)
+    # keywords must a single sequence of word chars, or a single emoji (since engine treats each emoji as a word)
+    KEYWORD_REGEX = regex.compile(
+        r"^(\w+|[\U0001F600-\U0001F64F\U0001F300-\U0001F5FF\U0001F680-\U0001F6FF\U0001F1E0-\U0001F1FF])$",
+        flags=regex.UNICODE,
+    )
 
     class Form(BaseTriggerForm):
         def __init__(self, user, *args, **kwargs):
@@ -49,14 +53,9 @@ class KeywordTriggerType(TriggerType):
         if not self.is_valid_keyword(trigger_def["keyword"]):
             raise ValueError(f"{trigger_def['keyword']} is not a valid keyword")
 
-    def is_valid_keyword(self, keyword):
-        return (
-            keyword
-            and len(keyword) <= Trigger.KEYWORD_MAX_LEN
-            and self.KEYWORD_REGEX.match(
-                keyword.strip(),
-            )
-        )
+    @classmethod
+    def is_valid_keyword(cls, keyword: str) -> bool:
+        return 0 < len(keyword) <= Trigger.KEYWORD_MAX_LEN and cls.KEYWORD_REGEX.match(keyword) is not None
 
 
 class CatchallTriggerType(TriggerType):

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -95,7 +95,9 @@ class BaseTriggerForm(forms.ModelForm):
         keyword = keyword.strip()
 
         if not self.trigger_type.is_valid_keyword(keyword):
-            raise forms.ValidationError(_("Must be a single word containing only letters and numbers."))
+            raise forms.ValidationError(
+                _("Must be a single word containing only letters and numbers, or a single emoji character.")
+            )
 
         return keyword.lower()
 


### PR DESCRIPTION
Adds https://github.com/rapidpro/rapidpro/issues/1554. The engine treats each emoji as a word so they can only be a single emoji.

Added tests on mailroom side to check this works https://github.com/nyaruka/mailroom/commit/27c42a81a61bef9e3d8174adcc82c8a15552e91d