### PR TITLE
Tweaks for newer Python

### DIFF
--- a/temba/assets/models.py
+++ b/temba/assets/models.py
@@ -47,7 +47,7 @@ class AssetFileNotFound(AssetException):
     pass
 
 
-class BaseAssetStore(object):
+class BaseAssetStore:
     """
     Base class for asset handlers. Assumes that pk is primary key of a db object with an associated asset.
     """

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.db import models
 from django.db.models import Model
 from django.utils import timezone
@@ -69,7 +67,7 @@ class Campaign(TembaModel):
             event.schedule_async()
 
     @classmethod
-    def import_campaigns(cls, org, user, campaign_defs, same_site=False) -> List:
+    def import_campaigns(cls, org, user, campaign_defs, same_site=False) -> list:
         """
         Import campaigns from a list of exported campaigns
         """

--- a/temba/classifiers/types/wit/client.py
+++ b/temba/classifiers/types/wit/client.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 import requests
 
 
@@ -14,7 +12,7 @@ class Client:
     def __init__(self, access_token: str):
         self.access_token = access_token
 
-    def get_intents(self) -> Tuple[List, requests.Response]:
+    def get_intents(self) -> tuple[list, requests.Response]:
         return self._request("intents")
 
     def _request(self, endpoint: str):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2217,8 +2217,7 @@ class ContactImport(SmartModel):
 
             if header_prefix == "":
                 attribute = header_name.lower()
-                if attribute.startswith("contact "):  # header "Contact UUID" -> uuid etc
-                    attribute = attribute[8:]
+                attribute = attribute.removeprefix("contact ")  # header "Contact UUID" -> uuid etc
 
                 if attribute in ("uuid", "name", "language"):
                     mapping = {"type": "attribute", "name": attribute}

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import iso8601
 import phonenumbers
@@ -713,7 +713,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
     @classmethod
     def create(
-        cls, org, user, name: str, language: str, urns: List[str], fields: Dict[ContactField, str], groups: List
+        cls, org, user, name: str, language: str, urns: list[str], fields: dict[ContactField, str], groups: list
     ):
         fields_by_key = {f.key: v for f, v in fields.items()}
         group_uuids = [g.uuid for g in groups]
@@ -950,7 +950,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         else:
             return str(value)
 
-    def update(self, name: str, language: str) -> List[modifiers.Modifier]:
+    def update(self, name: str, language: str) -> list[modifiers.Modifier]:
         """
         Updates attributes of this contact
         """
@@ -963,7 +963,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
         return mods
 
-    def update_fields(self, values: Dict[ContactField, str]) -> List[modifiers.Modifier]:
+    def update_fields(self, values: dict[ContactField, str]) -> list[modifiers.Modifier]:
         """
         Updates custom field values of this contact
         """
@@ -975,7 +975,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
         return mods
 
-    def update_static_groups(self, groups) -> List[modifiers.Modifier]:
+    def update_static_groups(self, groups) -> list[modifiers.Modifier]:
         """
         Updates the static groups for this contact to match the provided list
         """
@@ -999,16 +999,16 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
         return mods
 
-    def update_urns(self, urns: List[str]) -> List[modifiers.Modifier]:
+    def update_urns(self, urns: list[str]) -> list[modifiers.Modifier]:
         return [modifiers.URNs(urns=urns, modification="set")]
 
-    def modify(self, user, mods: List[modifiers.Modifier], refresh=True):
+    def modify(self, user, mods: list[modifiers.Modifier], refresh=True):
         self.bulk_modify(user, [self], mods)
         if refresh:
             self.refresh_from_db()
 
     @classmethod
-    def bulk_modify(cls, user, contacts, mods: List[modifiers.Modifier]):
+    def bulk_modify(cls, user, contacts, mods: list[modifiers.Modifier]):
         if not contacts:
             return
 
@@ -2119,7 +2119,7 @@ class ContactImport(SmartModel):
     finished_on = models.DateTimeField(null=True)
 
     @classmethod
-    def try_to_parse(cls, org: Org, file, filename: str) -> Tuple[List, int]:
+    def try_to_parse(cls, org: Org, file, filename: str) -> tuple[list, int]:
         """
         Tries to parse the given file stream as an import. If successful it returns the automatic column mappings and
         total number of records. Otherwise raises a ValidationError.
@@ -2178,7 +2178,7 @@ class ContactImport(SmartModel):
         return mappings, num_records
 
     @staticmethod
-    def _extract_uuid_and_urns(row, mappings) -> Tuple[str, List[str]]:
+    def _extract_uuid_and_urns(row, mappings) -> tuple[str, list[str]]:
         """
         Extracts any UUIDs and URNs from the given row so they can be checked for uniqueness
         """
@@ -2198,7 +2198,7 @@ class ContactImport(SmartModel):
         return uuid, urns
 
     @classmethod
-    def _auto_mappings(cls, org: Org, headers: List[str]) -> List:
+    def _auto_mappings(cls, org: Org, headers: list[str]) -> list:
         """
         Automatic mappings for the given list of headers - users can customize these later
         """
@@ -2244,7 +2244,7 @@ class ContactImport(SmartModel):
         return mappings
 
     @staticmethod
-    def _validate_mappings(mappings: List):
+    def _validate_mappings(mappings: list):
         non_ignored_mappings = []
 
         has_uuid, has_urn = False, False
@@ -2394,7 +2394,7 @@ class ContactImport(SmartModel):
         return Path(self.file.name).suffix[1:].lower()
 
     @staticmethod
-    def _parse_header(header: str) -> Tuple[str, str]:
+    def _parse_header(header: str) -> tuple[str, str]:
         """
         Parses a header like "Field: Foo" into ("field", "Foo")
         """
@@ -2403,7 +2403,7 @@ class ContactImport(SmartModel):
         prefix, name = (parts[0], parts[1]) if len(parts) >= 2 else ("", parts[0])
         return prefix.lower(), name
 
-    def _row_to_spec(self, row: List[str]) -> Dict:
+    def _row_to_spec(self, row: list[str]) -> dict:
         """
         Convert a record (dict of headers to values) to a contact spec
         """
@@ -2446,7 +2446,7 @@ class ContactImport(SmartModel):
         return spec
 
     @classmethod
-    def _parse_row(cls, row: List[str], size: int, tz=None) -> List[str]:
+    def _parse_row(cls, row: list[str], size: int, tz=None) -> list[str]:
         """
         Parses the raw values in the given row, returning a new list with the given size
         """
@@ -2473,7 +2473,7 @@ class ContactImport(SmartModel):
             return str(value).strip()
 
     @classmethod
-    def _detect_spamminess(cls, urns: List[str]) -> bool:
+    def _detect_spamminess(cls, urns: list[str]) -> bool:
         """
         Takes the list of URNs that have been imported and tries to detect spamming
         """

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1,7 +1,6 @@
 import logging
 from collections import OrderedDict
 from datetime import timedelta
-from typing import Dict, List
 
 import iso8601
 from smartmin.views import (
@@ -2093,7 +2092,7 @@ class ContactImportCRUDL(SmartCRUDL):
                         "name"
                     )
 
-            def get_form_values(self) -> List[Dict]:
+            def get_form_values(self) -> list[dict]:
                 """
                 Gather form data into a list the same size as the mappings
                 """

--- a/temba/flows/legacy/__init__.py
+++ b/temba/flows/legacy/__init__.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from packaging.version import Version
 
 VERSIONS = [
@@ -39,7 +37,7 @@ def get_versions_after(version_number):
     return [v for v in VERSIONS if Version(v) > version_number]
 
 
-def migrate_definition(json_flow: Dict, flow=None):
+def migrate_definition(json_flow: dict, flow=None):
     from . import migrations
 
     versions = get_versions_after(json_flow["version"])

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -3,7 +3,6 @@ import time
 from array import array
 from collections import defaultdict
 from datetime import timedelta
-from typing import Dict
 
 import iso8601
 import regex
@@ -709,11 +708,11 @@ class Flow(TembaModel):
         """
         return Version(self.version_number) < Version(Flow.INITIAL_GOFLOW_VERSION)
 
-    def as_export_ref(self) -> Dict:
+    def as_export_ref(self) -> dict:
         return {Flow.DEFINITION_UUID: str(self.uuid), Flow.DEFINITION_NAME: self.name}
 
     @classmethod
-    def get_metadata(cls, flow_info) -> Dict:
+    def get_metadata(cls, flow_info) -> dict:
         return {
             Flow.METADATA_RESULTS: flow_info[Flow.INSPECT_RESULTS],
             Flow.METADATA_DEPENDENCIES: flow_info[Flow.INSPECT_DEPENDENCIES],
@@ -737,7 +736,7 @@ class Flow(TembaModel):
             self.save_revision(user=None, definition=flow_def)
             self.refresh_from_db()
 
-    def get_definition(self) -> Dict:
+    def get_definition(self) -> dict:
         """
         Returns the current definition of this flow
         """
@@ -1404,7 +1403,7 @@ class FlowRevision(SmartModel):
             for rule in ruleset["rules"]:
                 validate_localization(rule["category"])
 
-    def get_migrated_definition(self, to_version: str = Flow.CURRENT_SPEC_VERSION) -> Dict:
+    def get_migrated_definition(self, to_version: str = Flow.CURRENT_SPEC_VERSION) -> dict:
         definition = self.definition
 
         # if it's previous to version 6, wrap the definition to

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -215,7 +215,7 @@ class FlowCRUDL(SmartCRUDL):
 
     model = Flow
 
-    class AllowOnlyActiveFlowMixin(object):
+    class AllowOnlyActiveFlowMixin:
         def get_queryset(self):
             initial_queryset = super().get_queryset()
             return initial_queryset.filter(is_active=True)

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, NamedTuple
+from typing import NamedTuple
 
 import requests
 
@@ -47,9 +47,9 @@ class ContactSpec(NamedTuple):
 
     name: str
     language: str
-    urns: List[str]
-    fields: Dict[str, str]
-    groups: List[str]
+    urns: list[str]
+    fields: dict[str, str]
+    groups: list[str]
 
 
 class MailroomClient:
@@ -147,7 +147,7 @@ class MailroomClient:
 
         return self._request("contact/create", payload)
 
-    def contact_modify(self, org_id, user_id, contact_ids, modifiers: List[Modifier]):
+    def contact_modify(self, org_id, user_id, contact_ids, modifiers: list[Modifier]):
         payload = {
             "org_id": org_id,
             "user_id": user_id,

--- a/temba/mailroom/modifiers.py
+++ b/temba/mailroom/modifiers.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NamedTuple
+from typing import NamedTuple
 
 
 class FieldRef(NamedTuple):
@@ -14,7 +14,7 @@ class GroupRef(NamedTuple):
 class Modifier:
     type: str
 
-    def as_def(self) -> Dict:
+    def as_def(self) -> dict:
         return {"type": self.type, **self.__dict__}
 
     def __eq__(self, other):
@@ -42,7 +42,7 @@ class Field(Modifier):
         self.field = field
         self.value = value
 
-    def as_def(self) -> Dict:
+    def as_def(self) -> dict:
         return {"type": self.type, "field": self.field._asdict(), "value": self.value}
 
 
@@ -61,17 +61,17 @@ class Status(Modifier):
 class Groups(Modifier):
     type = "groups"
 
-    def __init__(self, groups: List[GroupRef], modification: str):
+    def __init__(self, groups: list[GroupRef], modification: str):
         self.groups = groups
         self.modification = modification
 
-    def as_def(self) -> Dict:
+    def as_def(self) -> dict:
         return {"type": self.type, "groups": [g._asdict() for g in self.groups], "modification": self.modification}
 
 
 class URNs(Modifier):
     type = "urns"
 
-    def __init__(self, urns: List[str], modification: str):
+    def __init__(self, urns: list[str], modification: str):
         self.urns = urns
         self.modification = modification

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -2,7 +2,6 @@ import logging
 import time
 from array import array
 from datetime import datetime, timedelta
-from typing import Dict, List
 
 import iso8601
 import pytz
@@ -115,14 +114,14 @@ class Broadcast(models.Model):
         *,
         groups=None,
         contacts=None,
-        urns: List[str] = None,
-        contact_ids: List[int] = None,
+        urns: list[str] = None,
+        contact_ids: list[int] = None,
         base_language: str = None,
         channel: Channel = None,
         ticket=None,
-        media: Dict = None,
+        media: dict = None,
         send_all: bool = False,
-        quick_replies: List[Dict] = None,
+        quick_replies: list[dict] = None,
         template_state: str = TEMPLATE_STATE_LEGACY,
         status: str = STATUS_INITIALIZING,
         **kwargs,
@@ -212,7 +211,7 @@ class Broadcast(models.Model):
         if self.schedule:
             self.schedule.delete()
 
-    def update_recipients(self, *, groups=None, contacts=None, urns: List[str] = None):
+    def update_recipients(self, *, groups=None, contacts=None, urns: list[str] = None):
         """
         Only used to update recipients for scheduled / repeating broadcasts
         """
@@ -222,7 +221,7 @@ class Broadcast(models.Model):
 
         self._set_recipients(groups=groups, contacts=contacts, urns=urns)
 
-    def _set_recipients(self, *, groups=None, contacts=None, urns: List[str] = None, contact_ids=None):
+    def _set_recipients(self, *, groups=None, contacts=None, urns: list[str] = None, contact_ids=None):
         """
         Sets the recipients which may be contact groups, contacts or contact URNs.
         """

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -5228,14 +5228,14 @@ class StripeCreditsTest(TembaTest):
         self.org.stripe_customer = "stripe-cust-1"
         self.org.save()
 
-        class MockCard(object):
+        class MockCard:
             def __init__(self):
                 self.id = "stripe-card-1"
 
             def delete(self):
                 pass
 
-        class MockCards(object):
+        class MockCards:
             def __init__(self):
                 self.throw = False
 
@@ -5248,7 +5248,7 @@ class StripeCreditsTest(TembaTest):
                 else:
                     return MockCard()
 
-        class MockCustomer(object):
+        class MockCustomer:
             def __init__(self, id, email):
                 self.id = id
                 self.email = email

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from datetime import timedelta
 from decimal import Decimal
 from functools import wraps
-from typing import Dict, List
 from unittest.mock import call, patch
 
 from django_redis import get_redis_connection
@@ -43,7 +42,7 @@ class Mocks:
         self.queued_batch_tasks = []
 
     @staticmethod
-    def _parse_query_response(query: str, elastic: Dict, fields: List, allow_as_group: bool):
+    def _parse_query_response(query: str, elastic: dict, fields: list, allow_as_group: bool):
         def field_ref(f):
             return {"key": f.key, "name": f.label} if isinstance(f, ContactField) else {"key": f}
 
@@ -85,7 +84,7 @@ class Mocks:
 
         self._contact_search[query] = mock
 
-    def error(self, msg: str, code: str = None, extra: Dict = None):
+    def error(self, msg: str, code: str = None, extra: dict = None):
         """
         Queues an error which will become a mailroom exception at the next client call
         """
@@ -131,7 +130,7 @@ class TestClient(MailroomClient):
         return {"contact": {"id": obj.id, "uuid": str(obj.uuid), "name": obj.name}}
 
     @_client_method
-    def contact_modify(self, org_id, user_id, contact_ids, modifiers: List[Modifier]):
+    def contact_modify(self, org_id, user_id, contact_ids, modifiers: list[Modifier]):
         org = Org.objects.get(id=org_id)
         user = User.objects.get(id=user_id)
         contacts = org.contacts.filter(id__in=contact_ids)
@@ -306,7 +305,7 @@ def _wrap_test_method(f, mock_client: bool, mock_queue: bool, instance, *args, *
             patch_queue_batch_task.stop()
 
 
-def apply_modifiers(org, user, contacts, modifiers: List):
+def apply_modifiers(org, user, contacts, modifiers: list):
     """
     Approximates mailroom applying modifiers but doesn't do dynamic group re-evaluation.
     """
@@ -429,7 +428,7 @@ def update_field_locally(user, contact, key, value, label=None):
                 EventFire.objects.create(contact=contact, event=event, scheduled=scheduled)
 
 
-def update_urns_locally(contact, urns: List[str]):
+def update_urns_locally(contact, urns: list[str]):
     country = contact.org.default_country_code
     priority = ContactURN.PRIORITY_HIGHEST
 

--- a/temba/tests/matchers.py
+++ b/temba/tests/matchers.py
@@ -10,7 +10,7 @@ UUID4_REGEX = regex.compile(
 )
 
 
-class MatcherMixin(object):
+class MatcherMixin:
     def __ne__(self, other):
         return not self.__eq__(other)
 

--- a/temba/tests/s3.py
+++ b/temba/tests/s3.py
@@ -2,7 +2,6 @@ import gzip
 import io
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List
 from unittest.mock import call
 
 import iso8601
@@ -13,7 +12,7 @@ from temba.utils import chunk_list, json
 
 
 class MockEventStream:
-    def __init__(self, records: List[Dict], max_payload_size: int = 256):
+    def __init__(self, records: list[dict], max_payload_size: int = 256):
         # serialize records as a JSONL payload
         buffer = io.BytesIO()
         for record in records:

--- a/temba/tests/twilio.py
+++ b/temba/tests/twilio.py
@@ -24,7 +24,7 @@ class MockTwilioClient(Client):
     def validate(self, request):
         return True
 
-    class MockInstanceResource(object):
+    class MockInstanceResource:
         def __init__(self, *args, **kwargs):
             pass
 
@@ -42,7 +42,7 @@ class MockTwilioClient(Client):
             if len(objs) > 0:
                 return objs[0]
 
-    class MockAPI(object):
+    class MockAPI:
         def __init__(self, *args, **kwargs):
             self.base_url = "base_url"
             pass

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -62,7 +62,7 @@ def get_dict_from_cursor(cursor):
     return [dict(zip([col[0] for col in desc], row)) for row in cursor.fetchall()]
 
 
-class DictStruct(object):
+class DictStruct:
     """
     Wraps a dictionary turning it into a structure looking object. This is useful to 'mock' dictionaries
     coming from Redis to look like normal objects

--- a/temba/utils/export.py
+++ b/temba/utils/export.py
@@ -158,7 +158,7 @@ class BaseExportTask(TembaModel):
         abstract = True
 
 
-class TableExporter(object):
+class TableExporter:
     """
     Class that abstracts out writing a table of data to a CSV or Excel file. This only works for exports that
     have a single sheet (as CSV's don't have sheets) but takes care of writing to a CSV in the case

--- a/temba/utils/http.py
+++ b/temba/utils/http.py
@@ -11,7 +11,7 @@ def http_headers(extra=None):
     return headers
 
 
-class HttpEvent(object):
+class HttpEvent:
     def __init__(self, method, url, request_body=None, status_code=None, response_body=None):
         self.method = method
         self.url = url

--- a/temba/utils/management/commands/perf_test.py
+++ b/temba/utils/management/commands/perf_test.py
@@ -84,7 +84,7 @@ TEST_URLS = (
 )
 
 
-class URLResult(object):
+class URLResult:
     def __init__(self, url, times, allowed_max, prev_times):
         self.url = url
         self.times = times

--- a/temba/utils/management/commands/test_db.py
+++ b/temba/utils/management/commands/test_db.py
@@ -705,7 +705,7 @@ class Command(BaseCommand):
         self.stdout.flush()
 
 
-class DisableTriggersOn(object):
+class DisableTriggersOn:
     """
     Helper context manager for temporarily disabling database triggers for a given model
     """

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -143,7 +143,7 @@ class TranslatableField(HStoreField):
     Model field which is a set of language code and translation pairs stored as HSTORE
     """
 
-    class Validator(object):
+    class Validator:
         def __init__(self, max_length):
             self.max_length = max_length
 
@@ -166,7 +166,7 @@ class TranslatableField(HStoreField):
         return super().validators + [TranslatableField.Validator(self.max_length)]
 
 
-class CheckFieldDefaultMixin(object):
+class CheckFieldDefaultMixin:
     """
     This was copied from https://github.com/django/django/commit/f6e1789654e82bac08cead5a2d2a9132f6403f52
 
@@ -284,7 +284,7 @@ class TembaModel(SmartModel):
         abstract = True
 
 
-class RequireUpdateFieldsMixin(object):
+class RequireUpdateFieldsMixin:
     def save(self, *args, **kwargs):
         if self.id and "update_fields" not in kwargs and "force_insert" not in kwargs:
             raise ValueError("Updating without specifying update_fields is disabled for this model")

--- a/temba/utils/s3/s3.py
+++ b/temba/utils/s3/s3.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable
+from typing import Iterable
 from urllib.parse import urlparse
 
 import boto3
@@ -65,7 +65,7 @@ class EventStreamReader:
         self.event_stream = event_stream
         self.buffer = bytearray()
 
-    def __iter__(self) -> Iterable[Dict]:
+    def __iter__(self) -> Iterable[dict]:
         for event in self.event_stream:
             if "Records" in event:
                 self.buffer.extend(event["Records"]["Payload"])

--- a/temba/utils/urns/urns.py
+++ b/temba/utils/urns/urns.py
@@ -12,7 +12,7 @@ ESCAPES = {
 }
 
 
-class ParsedURN(object):
+class ParsedURN:
     def __init__(self, scheme, path, query="", fragment=""):
         self.scheme = scheme
         self.path = path


### PR DESCRIPTION
Just a little cleanup..

 * Classes don't need to inherit from `object` (Python 3+)
 * Can use `list`, `dict` etc instead of `Dict`, `List` (Python 3.9+)
 * `str.removeprefix` (Python 3.9+)