### PR TITLE
Clear keyword triggers when switching to flow type that doesn't support them

### DIFF
--- a/templates/flows/flow_create.haml
+++ b/templates/flows/flow_create.haml
@@ -26,11 +26,13 @@
     var modalBody = document.querySelector("#create-flow-modal").shadowRoot;
     var typeSelect = modalBody.querySelector("temba-select[name='flow_type']");
     var keywords = modalBody.querySelector(".keywords");
+    var keywordsSelect = modalBody.querySelector("temba-select[name='keyword_triggers']");
     
     typeSelect.addEventListener("change", function(evt) {
         var selected = evt.target.values[0];
         if (selected.value === "B" || selected.value === "S") {
           keywords.classList.add("hidden");
+          keywordsSelect.clear();
         } else {
           keywords.classList.remove("hidden");
         }


### PR DESCRIPTION
Currently if you enter keywords then switch to Surveyor type, and submit you get https://sentry.io/organizations/nyaruka/issues/2808019846/?environment=production&project=20737&referrer=alert_email