### PR TITLE
Make forgot password email look a little nicer and be easier to localize

### DIFF
--- a/templates/orgs/email/user_forget.html
+++ b/templates/orgs/email/user_forget.html
@@ -1,32 +1,26 @@
 {% extends "email_base.html" %}
-
-{% load tz %}
 {% load i18n %}
+
 {% block body %}
-
-
-{% blocktrans with account_name=user.username brand_link=branding.link  %}
-
-<br/>
-Hi from {{ hostname }},
-<br/>
-<br/>
-Someone has requested that the password for this email address be reset.
-<br/>
-<br/>
-Clicking on the following link will allow you to reset the password for the account {{account_name}}:
-<br/>
-<a href='{{ brand_link }}{{path}}'>Reset password</a>.
-<br/>
-<br/>
-If you did not request this, don't worry, this email has only been sent to you and your account remains secure.
-<br/>
-Thank you.
-<br/>
-<br/>
-Please do not reply to this email.
-<br/>
-<br/>
-{% endblocktrans %}
+<p>
+    {% trans "Hi there" %}
+</p>
+<p>
+    {% trans "Someone has requested that the password for this email address be reset." %}
+</p>
+<p>
+    {% blocktrans trimmed with email=user.username  %}
+    Clicking on the following link will allow you to reset the password for the account {{ email }}:
+    {% endblocktrans %}
+</p>
+<p align="center">
+    <a href='{{ branding.link }}{{ path }}'>Reset password</a>
+</p>
+<p>
+    {% trans "If you did not request this, don't worry, this email has only been sent to you and your account remains secure." %}
+</p>
+<p>
+    {% trans "Thank you. Please do not reply to this email." %}
+</p>
 
 {% endblock body %}

--- a/templates/orgs/email/user_forget.txt
+++ b/templates/orgs/email/user_forget.txt
@@ -1,20 +1,17 @@
 {% load i18n %}
 
+{% block body %}
+{% trans "Hi there" %}
 
-{% blocktrans with account_name=user.username brand_link=branding.link %}
+{% trans "Someone has requested that the password for this email address be reset." %}
 
-Hi from {{ hostname }},
-
-Someone has requested that the password for this email address be reset.
-
-Clicking on the following link will allow you to reset the password for the account {{account_name}}:
-
-{{ brand_link }}{{path}}
-
-If you did not request this, don't worry, this email has only been sent to you and your account remains secure.
-
-Thank you.
-
-Please do not reply to this email.
-
+{% blocktrans trimmed with email=user.username  %}
+Clicking on the following link will allow you to reset the password for the account {{ email }}:
 {% endblocktrans %}
+
+{{ branding.link }}{{ path }}
+
+{% trans "If you did not request this, don't worry, this email has only been sent to you and your account remains secure." %}
+
+{% trans "Thank you. Please do not reply to this email." %}
+{% endblock body %}


### PR DESCRIPTION
Before 

<img width="588" alt="Captura de Pantalla 2021-11-23 a la(s) 09 15 44" src="https://user-images.githubusercontent.com/675558/143042781-465808d6-d379-488a-92da-8ab854e0eec5.png">

After

<img width="588" alt="Captura de Pantalla 2021-11-23 a la(s) 09 27 11" src="https://user-images.githubusercontent.com/675558/143042790-f5992a96-f7c3-4742-b96a-7d628728666c.png">
