### PR TITLE
🧹 Dict to struct cleanup

### DIFF
--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -57,12 +57,13 @@ from temba.tests import (
     mock_mailroom,
 )
 from temba.tests.engine import MockSessionWriter
+from temba.tests.requests import mock_object
 from temba.tests.s3 import MockS3Client, jsonlgz_encode
 from temba.tests.twilio import MockRequestValidator, MockTwilioClient
 from temba.tickets.models import Ticketer
 from temba.tickets.types.mailgun import MailgunType
 from temba.triggers.models import Trigger
-from temba.utils import dict_to_struct, json, languages
+from temba.utils import json, languages
 
 from .context_processors import GroupPermWrapper
 from .models import CreditAlert, Invitation, Org, OrgRole, TopUp, TopUpCredits
@@ -5121,10 +5122,11 @@ class StripeCreditsTest(TembaTest):
     @patch("stripe.Charge.create")
     @override_settings(SEND_EMAILS=True)
     def test_add_credits(self, charge_create, customer_create):
-        customer_create.return_value = dict_to_struct("Customer", dict(id="stripe-cust-1"))
-        charge_create.return_value = dict_to_struct(
+        customer_create.return_value = mock_object("Customer", id="stripe-cust-1")
+        charge_create.return_value = mock_object(
             "Charge",
-            dict(id="stripe-charge-1", card=dict_to_struct("Card", dict(last4="1234", type="Visa", name="Rudolph"))),
+            id="stripe-charge-1",
+            card=mock_object("Card", last4="1234", type="Visa", name="Rudolph"),
         )
 
         settings.BRANDING[settings.DEFAULT_BRAND]["bundles"] = (dict(cents="2000", credits=1000, feature=""),)
@@ -5160,14 +5162,12 @@ class StripeCreditsTest(TembaTest):
     @patch("stripe.Charge.create")
     @override_settings(SEND_EMAILS=True)
     def test_add_btc_credits(self, charge_create, customer_create):
-        customer_create.return_value = dict_to_struct("Customer", dict(id="stripe-cust-1"))
-        charge_create.return_value = dict_to_struct(
+        customer_create.return_value = mock_object("Customer", id="stripe-cust-1")
+        charge_create.return_value = mock_object(
             "Charge",
-            dict(
-                id="stripe-charge-1",
-                card=None,
-                source=dict_to_struct("Source", dict(bitcoin=dict_to_struct("Bitcoin", dict(address="abcde")))),
-            ),
+            id="stripe-charge-1",
+            card=None,
+            source=mock_object("Source", bitcoin=mock_object("Bitcoin", address="abcde")),
         )
 
         settings.BRANDING[settings.DEFAULT_BRAND]["bundles"] = (dict(cents="2000", credits=1000, feature=""),)
@@ -5240,7 +5240,7 @@ class StripeCreditsTest(TembaTest):
                 self.throw = False
 
             def list(self):
-                return dict_to_struct("MockCardData", dict(data=[MockCard(), MockCard()]))
+                return mock_object("MockCardData", data=[MockCard(), MockCard()])
 
             def create(self, card):
                 if self.throw:
@@ -5260,9 +5260,10 @@ class StripeCreditsTest(TembaTest):
         customer_retrieve.return_value = MockCustomer(id="stripe-cust-1", email=self.admin.email)
         customer_create.return_value = MockCustomer(id="stripe-cust-2", email=self.admin2.email)
 
-        charge_create.return_value = dict_to_struct(
+        charge_create.return_value = mock_object(
             "Charge",
-            dict(id="stripe-charge-1", card=dict_to_struct("Card", dict(last4="1234", type="Visa", name="Rudolph"))),
+            id="stripe-charge-1",
+            card=mock_object("Card", last4="1234", type="Visa", name="Rudolph"),
         )
 
         settings.BRANDING[settings.DEFAULT_BRAND]["bundles"] = (dict(cents="2000", credits=1000, feature=""),)

--- a/temba/tests/requests.py
+++ b/temba/tests/requests.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from unittest.mock import patch
 
 from requests import HTTPError
@@ -5,7 +6,11 @@ from requests.structures import CaseInsensitiveDict
 
 from django.utils.encoding import force_bytes, force_text
 
-from temba.utils import dict_to_struct, json
+from temba.utils import json
+
+
+def mock_object(type_name, **attrs):
+    return namedtuple(type_name, attrs.keys())(*attrs.values())
 
 
 class MockResponse:
@@ -33,13 +38,11 @@ class MockResponse:
         self.streaming = False
         self.charset = "utf-8"
         self.connection = dict()
-        self.raw = dict_to_struct("MockRaw", dict(version="1.1", status=status_code, headers=headers))
+        self.raw = mock_object("MockRaw", version="1.1", status=status_code, headers=headers)
         self.reason = ""
 
         # mock up a request object on our response as well
-        self.request = dict_to_struct(
-            "MockRequest", dict(method=method, url=url, body="request body", headers=headers)
-        )
+        self.request = mock_object("MockRequest", method=method, url=url, body="request body", headers=headers)
 
     def add_header(self, key, value):
         self.headers[key] = value

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -2,8 +2,6 @@ import locale
 import resource
 from itertools import islice
 
-import iso8601
-
 from django.conf import settings
 from django.db import transaction
 
@@ -52,62 +50,6 @@ def sizeof_fmt(num, suffix="b"):
             return "%3.1f %s%s" % (num, unit, suffix)
         num /= 1024.0
     return "%.1f %s%s" % (num, "Y", suffix)
-
-
-def get_dict_from_cursor(cursor):
-    """
-    Returns all rows from a cursor as a dict
-    """
-    desc = cursor.description
-    return [dict(zip([col[0] for col in desc], row)) for row in cursor.fetchall()]
-
-
-class DictStruct:
-    """
-    Wraps a dictionary turning it into a structure looking object. This is useful to 'mock' dictionaries
-    coming from Redis to look like normal objects
-    """
-
-    def __init__(self, classname, entries, datetime_fields=()):
-        self._classname = classname
-        self._values = entries
-
-        # for each of our datetime fields, convert back to datetimes
-        for field in datetime_fields:
-            value = self._values.get(field, None)
-            if value:
-                self._values[field] = iso8601.parse_date(value)
-
-        self._initialized = True
-
-    def __getattr__(self, item):
-        if item not in self._values:
-            raise AttributeError("%s does not have a %s field" % (self._classname, item))
-
-        return self._values[item]
-
-    def __setattr__(self, item, value):
-        # needed to prevent infinite loop
-        if "_initialized" not in self.__dict__:
-            return object.__setattr__(self, item, value)
-
-        if item not in self._values:
-            raise AttributeError("%s does not have a %s field" % (self._classname, item))
-
-        self._values[item] = value
-
-    def __str__(self):
-        return "%s [%s]" % (self._classname, self._values)
-
-
-def dict_to_struct(classname, attributes, datetime_fields=()):
-    """
-    Given a classname and a dictionary will return an object that allows for dot access to
-    the passed in attributes.
-
-    ex: dict_to_struct('MsgStruct', attributes)
-    """
-    return DictStruct(classname, attributes, datetime_fields)
 
 
 def prepped_request_to_str(prepped):

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -34,17 +34,7 @@ from temba.tests import ESMockWithScroll, TembaTest, matchers
 from temba.utils import json, uuid
 from temba.utils.templatetags.temba import format_datetime
 
-from . import (
-    chunk_list,
-    countries,
-    dict_to_struct,
-    format_number,
-    languages,
-    percentage,
-    redact,
-    sizeof_fmt,
-    str_to_bool,
-)
+from . import chunk_list, countries, format_number, languages, percentage, redact, sizeof_fmt, str_to_bool
 from .cache import get_cacheable_attr, get_cacheable_result, incrby_existing
 from .celery import nonoverlapping_task
 from .dates import datetime_to_str, datetime_to_timestamp, timestamp_to_datetime
@@ -664,19 +654,11 @@ class JsonTest(TembaTest):
             json.loads(encoded), {"name": "Date Test", "age": Decimal("10"), "now": json.encode_datetime(now)}
         )
 
-        # test the same using our object mocking
-        mock = dict_to_struct("Mock", json.loads(encoded), ["now"])
-        self.assertEqual(mock.now, source["now"])
-
         # try it with a microsecond of 0 instead
         source["now"] = timezone.now().replace(microsecond=0)
 
         # encode it
         encoded = json.dumps(source)
-
-        # test the same using our object mocking
-        mock = dict_to_struct("Mock", json.loads(encoded), ["now"])
-        self.assertEqual(mock.now, source["now"])
 
         # test that we throw with unknown types
         with self.assertRaises(TypeError):


### PR DESCRIPTION
`dict_to_struct` used to be used for msg handling but now it was just being used in some tests so have replaced it with a simpler test utility