### PR TITLE
Update help links for the editor

### DIFF
--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -237,9 +237,9 @@
       brand: '{{brand.name|escapejs}}',
 
       help: {
-        legacy_extra: 'https://help.nyaruka.com/en/articles/3747485-migrating-away-from-legacy_extra',
-        missing_dependency: 'http://help.nyaruka.com/en/articles/3747650-fixing-missing-dependencies',
-        invalid_regex: 'http://help.nyaruka.com/en/articles/3747654-invalid-regular-expressions'
+        legacy_extra: 'https://help.nyaruka.com/',
+        missing_dependency: 'https://help.nyaruka.com/en/article/fixing-missing-dependencies-1toe127/',
+        invalid_regex: 'https://help.nyaruka.com/en/article/invalid-regular-expressions-814k8d/'
       },
 
       endpoints: {


### PR DESCRIPTION
For the record, the legacy_extra link was to a placeholder that was never published was an empty article, making it the help root for now.