### PR TITLE
Improve validation of flow expires values

### DIFF
--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -220,7 +220,7 @@ class CampaignTest(TembaTest):
                 "revision": 1,
                 "language": "eng",
                 "type": "messaging_background",
-                "expire_after_minutes": 10080,
+                "expire_after_minutes": 0,
                 "localization": {},
                 "nodes": [
                     {
@@ -1537,7 +1537,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
                 "name": f"Single Message ({event.id})",
                 "spec_version": "13.0.0",
                 "revision": 1,
-                "expire_after_minutes": 10080,
+                "expire_after_minutes": 0,
                 "language": "fra",
                 "type": "messaging_background",
                 "localization": {"spa": {action_uuid: {"text": ["hola"]}}},

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1952,7 +1952,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         flow2 = Flow.objects.get(org=self.org, name="Surveyor Flow")
         self.assertEqual(flow2.flow_type, "S")
-        self.assertEqual(flow2.expires_after_minutes, 10080)
+        self.assertEqual(flow2.expires_after_minutes, 0)
 
         # make sure we don't get a start flow button for Android Surveys
         response = self.client.get(reverse("flows.flow_editor", args=[flow2.uuid]))

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -13,16 +13,6 @@ class IVRManager(models.Manager):
 
 
 class IVRCall(ChannelConnection):
-    EXPIRES_CHOICES = (
-        (1, _("After 1 minute")),
-        (2, _("After 2 minutes")),
-        (3, _("After 3 minutes")),
-        (4, _("After 4 minutes")),
-        (5, _("After 5 minutes")),
-        (10, _("After 10 minutes")),
-        (15, _("After 15 minutes")),
-    )
-
     RETRY_CHOICES = ((-1, _("Never")), (30, _("After 30 minutes")), (60, _("After 1 hour")), (1440, _("After 1 day")))
 
     objects = IVRManager()

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -4383,13 +4383,13 @@ class BulkExportTest(TembaTest):
         self.assertIn("Child Flow", group)
 
     def test_import_voice_flows_expiration_time(self):
-        # all imported voice flows should have a max expiration time of 15 min
+        # import file has invalid expires for an IVR flow so it should get the default (5)
         self.get_flow("ivr")
 
         self.assertEqual(Flow.objects.filter(flow_type=Flow.TYPE_VOICE).count(), 1)
         voice_flow = Flow.objects.get(flow_type=Flow.TYPE_VOICE)
         self.assertEqual(voice_flow.name, "IVR Flow")
-        self.assertEqual(voice_flow.expires_after_minutes, 15)
+        self.assertEqual(voice_flow.expires_after_minutes, 5)
 
     def test_import(self):
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -436,7 +436,7 @@ class TembaTestMixin:
             "type": Flow.GOFLOW_TYPES[flow_type],
             "revision": 1,
             "spec_version": "13.1.0",
-            "expire_after_minutes": Flow.DEFAULT_EXPIRES_AFTER,
+            "expire_after_minutes": Flow.EXPIRES_DEFAULTS[flow_type],
             "language": "eng",
             "nodes": nodes,
         }


### PR DESCRIPTION
The engine should enforce this and ignore bad values but we can also do a better job on the RP side