### PR TITLE
Replace django deprecations part 1

### DIFF
--- a/temba/airtime/views.py
+++ b/temba/airtime/views.py
@@ -2,7 +2,7 @@ from smartmin.views import SmartCRUDL, SmartListView, SmartReadView
 
 from django.db.models import Prefetch
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.airtime.models import AirtimeTransfer
 from temba.contacts.models import URN, ContactURN

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import Group, User
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.models import Org, OrgRole
 from temba.utils.cache import get_cacheable_attr

--- a/temba/api/urls.py
+++ b/temba/api/urls.py
@@ -1,10 +1,11 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 from django.views.generic import RedirectView
 
 from .views import RefreshAPITokenView
 
 urlpatterns = [
-    url(r"^api/$", RedirectView.as_view(pattern_name="api.v2", permanent=False), name="api"),
-    url(r"^api/v2/", include("temba.api.v2.urls")),
-    url(r"^api/apitoken/refresh/$", RefreshAPITokenView.as_view(), name="api.apitoken_refresh"),
+    re_path(r"^api/$", RedirectView.as_view(pattern_name="api.v2", permanent=False), name="api"),
+    re_path(r"^api/v2/", include("temba.api.v2.urls")),
+    re_path(r"^api/apitoken/refresh/$", RefreshAPITokenView.as_view(), name="api.apitoken_refresh"),
 ]

--- a/temba/api/v2/urls.py
+++ b/temba/api/v2/urls.py
@@ -1,6 +1,6 @@
 from rest_framework.urlpatterns import format_suffix_patterns
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import (
     ArchivesEndpoint,
@@ -40,42 +40,42 @@ from .views import (
 )
 
 urlpatterns = [
-    url(r"^$", RootView.as_view(), name="api.v2"),
-    url(r"^explorer/$", ExplorerView.as_view(), name="api.v2.explorer"),
-    url(r"^authenticate$", AuthenticateView.as_view(), name="api.v2.authenticate"),
+    re_path(r"^$", RootView.as_view(), name="api.v2"),
+    re_path(r"^explorer/$", ExplorerView.as_view(), name="api.v2.explorer"),
+    re_path(r"^authenticate$", AuthenticateView.as_view(), name="api.v2.authenticate"),
     # ========== endpoints A-Z ===========
-    url(r"^archives$", ArchivesEndpoint.as_view(), name="api.v2.archives"),
-    url(r"^boundaries$", BoundariesEndpoint.as_view(), name="api.v2.boundaries"),
-    url(r"^broadcasts$", BroadcastsEndpoint.as_view(), name="api.v2.broadcasts"),
-    url(r"^campaigns$", CampaignsEndpoint.as_view(), name="api.v2.campaigns"),
-    url(r"^campaign_events$", CampaignEventsEndpoint.as_view(), name="api.v2.campaign_events"),
-    url(r"^channels$", ChannelsEndpoint.as_view(), name="api.v2.channels"),
-    url(r"^channel_events$", ChannelEventsEndpoint.as_view(), name="api.v2.channel_events"),
-    url(r"^classifiers$", ClassifiersEndpoint.as_view(), name="api.v2.classifiers"),
-    url(r"^contacts$", ContactsEndpoint.as_view(), name="api.v2.contacts"),
-    url(r"^contact_actions$", ContactActionsEndpoint.as_view(), name="api.v2.contact_actions"),
-    url(r"^definitions$", DefinitionsEndpoint.as_view(), name="api.v2.definitions"),
-    url(r"^fields$", FieldsEndpoint.as_view(), name="api.v2.fields"),
-    url(r"^flow_starts$", FlowStartsEndpoint.as_view(), name="api.v2.flow_starts"),
-    url(r"^flows$", FlowsEndpoint.as_view(), name="api.v2.flows"),
-    url(r"^globals$", GlobalsEndpoint.as_view(), name="api.v2.globals"),
-    url(r"^groups$", GroupsEndpoint.as_view(), name="api.v2.groups"),
-    url(r"^labels$", LabelsEndpoint.as_view(), name="api.v2.labels"),
-    url(r"^media$", MediaEndpoint.as_view(), name="api.v2.media"),
-    url(r"^messages$", MessagesEndpoint.as_view(), name="api.v2.messages"),
-    url(r"^message_actions$", MessageActionsEndpoint.as_view(), name="api.v2.message_actions"),
-    url(r"^org$", WorkspaceEndpoint.as_view(), name="api.v2.org"),  # deprecated
-    url(r"^resthooks$", ResthooksEndpoint.as_view(), name="api.v2.resthooks"),
-    url(r"^resthook_events$", ResthookEventsEndpoint.as_view(), name="api.v2.resthook_events"),
-    url(r"^resthook_subscribers$", ResthookSubscribersEndpoint.as_view(), name="api.v2.resthook_subscribers"),
-    url(r"^runs$", RunsEndpoint.as_view(), name="api.v2.runs"),
-    url(r"^templates$", TemplatesEndpoint.as_view(), name="api.v2.templates"),
-    url(r"^ticketers$", TicketersEndpoint.as_view(), name="api.v2.ticketers"),
-    url(r"^tickets$", TicketsEndpoint.as_view(), name="api.v2.tickets"),
-    url(r"^ticket_actions$", TicketActionsEndpoint.as_view(), name="api.v2.ticket_actions"),
-    url(r"^topics$", TopicsEndpoint.as_view(), name="api.v2.topics"),
-    url(r"^users$", UsersEndpoint.as_view(), name="api.v2.users"),
-    url(r"^workspace$", WorkspaceEndpoint.as_view(), name="api.v2.workspace"),
+    re_path(r"^archives$", ArchivesEndpoint.as_view(), name="api.v2.archives"),
+    re_path(r"^boundaries$", BoundariesEndpoint.as_view(), name="api.v2.boundaries"),
+    re_path(r"^broadcasts$", BroadcastsEndpoint.as_view(), name="api.v2.broadcasts"),
+    re_path(r"^campaigns$", CampaignsEndpoint.as_view(), name="api.v2.campaigns"),
+    re_path(r"^campaign_events$", CampaignEventsEndpoint.as_view(), name="api.v2.campaign_events"),
+    re_path(r"^channels$", ChannelsEndpoint.as_view(), name="api.v2.channels"),
+    re_path(r"^channel_events$", ChannelEventsEndpoint.as_view(), name="api.v2.channel_events"),
+    re_path(r"^classifiers$", ClassifiersEndpoint.as_view(), name="api.v2.classifiers"),
+    re_path(r"^contacts$", ContactsEndpoint.as_view(), name="api.v2.contacts"),
+    re_path(r"^contact_actions$", ContactActionsEndpoint.as_view(), name="api.v2.contact_actions"),
+    re_path(r"^definitions$", DefinitionsEndpoint.as_view(), name="api.v2.definitions"),
+    re_path(r"^fields$", FieldsEndpoint.as_view(), name="api.v2.fields"),
+    re_path(r"^flow_starts$", FlowStartsEndpoint.as_view(), name="api.v2.flow_starts"),
+    re_path(r"^flows$", FlowsEndpoint.as_view(), name="api.v2.flows"),
+    re_path(r"^globals$", GlobalsEndpoint.as_view(), name="api.v2.globals"),
+    re_path(r"^groups$", GroupsEndpoint.as_view(), name="api.v2.groups"),
+    re_path(r"^labels$", LabelsEndpoint.as_view(), name="api.v2.labels"),
+    re_path(r"^media$", MediaEndpoint.as_view(), name="api.v2.media"),
+    re_path(r"^messages$", MessagesEndpoint.as_view(), name="api.v2.messages"),
+    re_path(r"^message_actions$", MessageActionsEndpoint.as_view(), name="api.v2.message_actions"),
+    re_path(r"^org$", WorkspaceEndpoint.as_view(), name="api.v2.org"),  # deprecated
+    re_path(r"^resthooks$", ResthooksEndpoint.as_view(), name="api.v2.resthooks"),
+    re_path(r"^resthook_events$", ResthookEventsEndpoint.as_view(), name="api.v2.resthook_events"),
+    re_path(r"^resthook_subscribers$", ResthookSubscribersEndpoint.as_view(), name="api.v2.resthook_subscribers"),
+    re_path(r"^runs$", RunsEndpoint.as_view(), name="api.v2.runs"),
+    re_path(r"^templates$", TemplatesEndpoint.as_view(), name="api.v2.templates"),
+    re_path(r"^ticketers$", TicketersEndpoint.as_view(), name="api.v2.ticketers"),
+    re_path(r"^tickets$", TicketsEndpoint.as_view(), name="api.v2.tickets"),
+    re_path(r"^ticket_actions$", TicketActionsEndpoint.as_view(), name="api.v2.ticket_actions"),
+    re_path(r"^topics$", TopicsEndpoint.as_view(), name="api.v2.topics"),
+    re_path(r"^users$", UsersEndpoint.as_view(), name="api.v2.users"),
+    re_path(r"^workspace$", WorkspaceEndpoint.as_view(), name="api.v2.workspace"),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns, allowed=["json", "api"])

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -14,7 +14,7 @@ from django.contrib.auth import authenticate, login
 from django.contrib.auth.models import User
 from django.db.models import Prefetch, Q
 from django.http import HttpResponse, JsonResponse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from temba.api.models import APIToken, Resthook, ResthookSubscriber, WebHookEvent

--- a/temba/assets/urls.py
+++ b/temba/assets/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import AssetDownloadView, AssetStreamView
 
 urlpatterns = [
-    url(r"download/(?P<type>\w+)/(?P<pk>\d+)/$", AssetDownloadView.as_view(), name="assets.download"),
-    url(r"stream/(?P<type>\w+)/(?P<pk>\d+)/$", AssetStreamView.as_view(), name="assets.stream"),
+    re_path(r"download/(?P<type>\w+)/(?P<pk>\d+)/$", AssetDownloadView.as_view(), name="assets.download"),
+    re_path(r"stream/(?P<type>\w+)/(?P<pk>\d+)/$", AssetStreamView.as_view(), name="assets.stream"),
 ]

--- a/temba/assets/views.py
+++ b/temba/assets/views.py
@@ -3,7 +3,7 @@ import mimetypes
 from smartmin.views import SmartTemplateView, SmartView
 
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseNotFound, HttpResponseRedirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 
 from temba.notifications.views import NotificationTargetMixin

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.db.models import Model
 from django.utils import timezone
-from django.utils.translation import ngettext, ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from temba import mailroom
 from temba.contacts.models import Contact, ContactField, ContactGroup

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import ContactField, ContactGroup
 from temba.flows.models import Flow

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -3,6 +3,7 @@ import time
 from abc import ABCMeta
 from datetime import timedelta
 from enum import Enum
+from urllib.parse import quote_plus
 from xml.sax.saxutils import escape
 
 import phonenumbers
@@ -23,7 +24,6 @@ from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.template import Context, Engine, TemplateDoesNotExist
 from django.utils import timezone
-from django.utils.http import urlquote_plus
 from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
@@ -973,7 +973,7 @@ class Channel(TembaModel, DependencyMixin):
 
             # encode based on our content type
             if content_type == Channel.CONTENT_TYPE_URLENCODED:
-                replacement = urlquote_plus(replacement)
+                replacement = quote_plus(replacement)
 
             # if this is JSON, need to wrap in quotes (and escape them)
             elif content_type == Channel.CONTENT_TYPE_JSON:

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -24,7 +24,7 @@ from django.dispatch import receiver
 from django.template import Context, Engine, TemplateDoesNotExist
 from django.utils import timezone
 from django.utils.http import urlquote_plus
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
 from temba.orgs.models import DependencyMixin, Org

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -14,7 +14,6 @@ from smartmin.models import SmartModel
 from twilio.base.exceptions import TwilioRestException
 
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib.auth.models import Group, User
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ObjectDoesNotExist
@@ -23,6 +22,7 @@ from django.db.models import Max, Q, Sum
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.template import Context, Engine, TemplateDoesNotExist
+from django.urls import re_path
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -137,7 +137,7 @@ class ChannelType(metaclass=ABCMeta):
         """
         claim_view_kwargs = self.claim_view_kwargs if self.claim_view_kwargs else {}
         claim_view_kwargs["channel_type"] = self
-        return url(r"^claim$", self.claim_view.as_view(**claim_view_kwargs), name="claim")
+        return re_path(r"^claim$", self.claim_view.as_view(**claim_view_kwargs), name="claim")
 
     def get_update_form(self):
         if self.update_form is None:

--- a/temba/channels/types/africastalking/type.py
+++ b/temba/channels/types/africastalking/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/africastalking/views.py
+++ b/temba/channels/types/africastalking/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import SelectWidget
 

--- a/temba/channels/types/android/views.py
+++ b/temba/channels/types/android/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartFormView
 
 from django import forms
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.apks.models import Apk
 from temba.orgs.models import Org

--- a/temba/channels/types/arabiacell/type.py
+++ b/temba/channels/types/arabiacell/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/arabiacell/views.py
+++ b/temba/channels/types/arabiacell/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin

--- a/temba/channels/types/blackmyna/type.py
+++ b/temba/channels/types/blackmyna/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/bongolive/type.py
+++ b/temba/channels/types/bongolive/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/bongolive/views.py
+++ b/temba/channels/types/bongolive/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin

--- a/temba/channels/types/burstsms/type.py
+++ b/temba/channels/types/burstsms/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/chikka/type.py
+++ b/temba/channels/types/chikka/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.chikka.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/chikka/views.py
+++ b/temba/channels/types/chikka/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import ALL_COUNTRIES, AuthenticatedExternalClaimView, ClaimViewMixin
 from temba.utils.fields import SelectWidget

--- a/temba/channels/types/clickatell/type.py
+++ b/temba/channels/types/clickatell/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.clickatell.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/clickatell/views.py
+++ b/temba/channels/types/clickatell/views.py
@@ -1,7 +1,7 @@
 import phonenumbers
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, AuthenticatedExternalClaimView, ClaimViewMixin

--- a/temba/channels/types/clickmobile/type.py
+++ b/temba/channels/types/clickmobile/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.clickmobile.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/clickmobile/views.py
+++ b/temba/channels/types/clickmobile/views.py
@@ -2,7 +2,7 @@ import phonenumbers
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/clicksend/type.py
+++ b/temba/channels/types/clicksend/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/dartmedia/type.py
+++ b/temba/channels/types/dartmedia/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.dartmedia.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/dialog360/type.py
+++ b/temba/channels/types/dialog360/type.py
@@ -4,7 +4,7 @@ from django.conf.urls import url
 from django.forms import ValidationError
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.types.dialog360.views import ClaimView

--- a/temba/channels/types/dialog360/type.py
+++ b/temba/channels/types/dialog360/type.py
@@ -1,8 +1,7 @@
 import requests
 
-from django.conf.urls import url
 from django.forms import ValidationError
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -43,8 +42,8 @@ class Dialog360Type(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            url(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(), name="templates"),
-            url(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(), name="sync_logs"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(), name="templates"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(), name="sync_logs"),
         ]
 
     def get_headers(self, channel):

--- a/temba/channels/types/dialog360/views.py
+++ b/temba/channels/types/dialog360/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 from temba.utils.fields import ExternalURLField

--- a/temba/channels/types/discord/type.py
+++ b/temba/channels/types/discord/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/discord/views.py
+++ b/temba/channels/types/discord/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartFormView
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/dmark/type.py
+++ b/temba/channels/types/dmark/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.dmark.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/dmark/views.py
+++ b/temba/channels/types/dmark/views.py
@@ -2,7 +2,7 @@ import requests
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/external/type.py
+++ b/temba/channels/types/external/type.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel, ChannelType
 from .views import ClaimView, UpdateForm

--- a/temba/channels/types/external/views.py
+++ b/temba/channels/types/external/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartFormView
 from django import forms
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.forms import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 from temba.utils.fields import ExternalURLField, SelectMultipleWidget, SelectWidget

--- a/temba/channels/types/facebook/type.py
+++ b/temba/channels/types/facebook/type.py
@@ -1,6 +1,6 @@
 import requests
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 from temba.triggers.models import Trigger

--- a/temba/channels/types/facebook/views.py
+++ b/temba/channels/types/facebook/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/facebookapp/type.py
+++ b/temba/channels/types/facebookapp/type.py
@@ -1,6 +1,6 @@
 import requests
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
@@ -41,7 +41,7 @@ class FacebookAppType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            url(r"^(?P<uuid>[a-z0-9\-]+)/refresh_token$", RefreshToken.as_view(), name="refresh_token"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/refresh_token$", RefreshToken.as_view(), name="refresh_token"),
         ]
 
     def deactivate(self, channel):

--- a/temba/channels/types/facebookapp/type.py
+++ b/temba/channels/types/facebookapp/type.py
@@ -1,7 +1,7 @@
 import requests
 
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/facebookapp/views.py
+++ b/temba/channels/types/facebookapp/views.py
@@ -4,7 +4,7 @@ from smartmin.views import SmartFormView, SmartModelActionView
 from django import forms
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views import ModalMixin, OrgObjPermsMixin
 

--- a/temba/channels/types/firebase/type.py
+++ b/temba/channels/types/firebase/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/firebase/views.py
+++ b/temba/channels/types/firebase/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/freshchat/type.py
+++ b/temba/channels/types/freshchat/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/freshchat/views.py
+++ b/temba/channels/types/freshchat/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/globe/type.py
+++ b/temba/channels/types/globe/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.globe.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/globe/views.py
+++ b/temba/channels/types/globe/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import AuthenticatedExternalClaimView, ClaimViewMixin

--- a/temba/channels/types/highconnection/type.py
+++ b/temba/channels/types/highconnection/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalCallbackClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/hormuud/type.py
+++ b/temba/channels/types/hormuud/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalCallbackClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/hub9/type.py
+++ b/temba/channels/types/hub9/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.dartmedia.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/i2sms/type.py
+++ b/temba/channels/types/i2sms/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.i2sms.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/i2sms/views.py
+++ b/temba/channels/types/i2sms/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...views import AuthenticatedExternalClaimView
 

--- a/temba/channels/types/infobip/type.py
+++ b/temba/channels/types/infobip/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalCallbackClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/jasmin/type.py
+++ b/temba/channels/types/jasmin/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.jasmin.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/jasmin/views.py
+++ b/temba/channels/types/jasmin/views.py
@@ -1,7 +1,7 @@
 import phonenumbers
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import ALL_COUNTRIES, AuthenticatedExternalCallbackClaimView, ClaimViewMixin
 from temba.utils.fields import ExternalURLField, SelectWidget

--- a/temba/channels/types/jiochat/type.py
+++ b/temba/channels/types/jiochat/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/jiochat/views.py
+++ b/temba/channels/types/jiochat/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/junebug/type.py
+++ b/temba/channels/types/junebug/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelType
 from temba.channels.types.junebug.views import ClaimView

--- a/temba/channels/types/junebug/views.py
+++ b/temba/channels/types/junebug/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, AuthenticatedExternalClaimView, ClaimViewMixin

--- a/temba/channels/types/kaleyra/type.py
+++ b/temba/channels/types/kaleyra/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelType
 from temba.channels.types.kaleyra.views import ClaimView

--- a/temba/channels/types/kaleyra/views.py
+++ b/temba/channels/types/kaleyra/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/kannel/type.py
+++ b/temba/channels/types/kannel/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.kannel.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/kannel/views.py
+++ b/temba/channels/types/kannel/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import ExternalURLField, SelectWidget
 from temba.utils.uuid import uuid4

--- a/temba/channels/types/line/type.py
+++ b/temba/channels/types/line/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/line/views.py
+++ b/temba/channels/types/line/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartFormView
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models.query import Q
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/m3tech/type.py
+++ b/temba/channels/types/m3tech/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/macrokiosk/type.py
+++ b/temba/channels/types/macrokiosk/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.macrokiosk.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/macrokiosk/views.py
+++ b/temba/channels/types/macrokiosk/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import SelectWidget
 

--- a/temba/channels/types/mblox/type.py
+++ b/temba/channels/types/mblox/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/messangi/type.py
+++ b/temba/channels/types/messangi/type.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelType
 from temba.channels.types.messangi.views import ClaimView

--- a/temba/channels/types/messangi/views.py
+++ b/temba/channels/types/messangi/views.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/mtarget/type.py
+++ b/temba/channels/types/mtarget/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/mtarget/views.py
+++ b/temba/channels/types/mtarget/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin

--- a/temba/channels/types/novo/type.py
+++ b/temba/channels/types/novo/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelType
 from temba.channels.types.novo.views import ClaimView

--- a/temba/channels/types/novo/views.py
+++ b/temba/channels/types/novo/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/playmobile/type.py
+++ b/temba/channels/types/playmobile/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelType
 from temba.channels.types.playmobile.views import ClaimView

--- a/temba/channels/types/playmobile/views.py
+++ b/temba/channels/types/playmobile/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import ExternalURLField
 

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -1,7 +1,7 @@
 import requests
 
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel, ChannelType
 from temba.contacts.models import URN

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -1,6 +1,6 @@
 import requests
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel, ChannelType
@@ -43,4 +43,4 @@ class PlivoType(ChannelType):
         )
 
     def get_urls(self):
-        return [self.get_claim_url(), url(r"^search$", SearchView.as_view(), name="search")]
+        return [self.get_claim_url(), re_path(r"^search$", SearchView.as_view(), name="search")]

--- a/temba/channels/types/plivo/views.py
+++ b/temba/channels/types/plivo/views.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.utils.http import urlencode
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import BaseClaimNumberMixin, ClaimViewMixin

--- a/temba/channels/types/redrabbit/type.py
+++ b/temba/channels/types/redrabbit/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/rocketchat/type.py
+++ b/temba/channels/types/rocketchat/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/rocketchat/views.py
+++ b/temba/channels/types/rocketchat/views.py
@@ -6,7 +6,7 @@ from smartmin.views import SmartFormView
 from django import forms
 from django.contrib import messages
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import ExternalURLField
 from temba.utils.text import random_string, truncate

--- a/temba/channels/types/shaqodoon/type.py
+++ b/temba/channels/types/shaqodoon/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.shaqodoon.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/shaqodoon/views.py
+++ b/temba/channels/types/shaqodoon/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, AuthenticatedExternalClaimView, ClaimViewMixin

--- a/temba/channels/types/signalwire/type.py
+++ b/temba/channels/types/signalwire/type.py
@@ -3,7 +3,7 @@ import requests
 from django.conf import settings
 from django.forms import ValidationError
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.contacts.models import URN

--- a/temba/channels/types/signalwire/views.py
+++ b/temba/channels/types/signalwire/views.py
@@ -4,7 +4,7 @@ from smartmin.views import SmartFormView
 
 from django import forms
 from django.forms import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import SelectWidget
 

--- a/temba/channels/types/smscentral/type.py
+++ b/temba/channels/types/smscentral/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/start/type.py
+++ b/temba/channels/types/start/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/telegram/type.py
+++ b/temba/channels/types/telegram/type.py
@@ -1,7 +1,7 @@
 import telegram
 
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/telegram/views.py
+++ b/temba/channels/types/telegram/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartFormView
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/telesom/type.py
+++ b/temba/channels/types/telesom/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.telesom.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/telesom/views.py
+++ b/temba/channels/types/telesom/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, AuthenticatedExternalClaimView, ClaimViewMixin

--- a/temba/channels/types/thinq/type.py
+++ b/temba/channels/types/thinq/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.thinq.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/thinq/views.py
+++ b/temba/channels/types/thinq/views.py
@@ -2,7 +2,7 @@ import phonenumbers
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -1,6 +1,6 @@
 from twilio.base.exceptions import TwilioRestException
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
@@ -84,4 +84,4 @@ class TwilioType(ChannelType):
                 raise e
 
     def get_urls(self):
-        return [self.get_claim_url(), url(r"^search$", SearchView.as_view(), name="search")]
+        return [self.get_claim_url(), re_path(r"^search$", SearchView.as_view(), name="search")]

--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -1,7 +1,7 @@
 from twilio.base.exceptions import TwilioRestException
 
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 from temba.utils.timezones import timezone_to_country_code

--- a/temba/channels/types/twilio/views.py
+++ b/temba/channels/types/twilio/views.py
@@ -7,7 +7,7 @@ from django import forms
 from django.conf import settings
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.models import Org
 from temba.orgs.views import OrgPermsMixin

--- a/temba/channels/types/twilio_messaging_service/type.py
+++ b/temba/channels/types/twilio_messaging_service/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.twilio.views import SUPPORTED_COUNTRIES
 from temba.contacts.models import URN

--- a/temba/channels/types/twilio_messaging_service/views.py
+++ b/temba/channels/types/twilio_messaging_service/views.py
@@ -4,7 +4,7 @@ from twilio.base.exceptions import TwilioRestException
 from django import forms
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.twilio.views import COUNTRY_CHOICES
 from temba.orgs.models import Org

--- a/temba/channels/types/twilio_whatsapp/type.py
+++ b/temba/channels/types/twilio_whatsapp/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/twilio_whatsapp/views.py
+++ b/temba/channels/types/twilio_whatsapp/views.py
@@ -6,7 +6,7 @@ from twilio.base.exceptions import TwilioRestException
 from django import forms
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.twilio.views import SUPPORTED_COUNTRIES
 from temba.contacts.models import URN

--- a/temba/channels/types/twiml_api/type.py
+++ b/temba/channels/types/twiml_api/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.twiml_api.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/twiml_api/views.py
+++ b/temba/channels/types/twiml_api/views.py
@@ -2,7 +2,7 @@ import phonenumbers
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import ExternalURLField, SelectWidget
 from temba.utils.uuid import uuid4

--- a/temba/channels/types/twitter/type.py
+++ b/temba/channels/types/twitter/type.py
@@ -2,7 +2,7 @@ import logging
 
 from django.forms import ValidationError
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/twitter/views.py
+++ b/temba/channels/types/twitter/views.py
@@ -4,7 +4,7 @@ from twython import TwythonError
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.views import NonAtomicMixin
 

--- a/temba/channels/types/verboice/type.py
+++ b/temba/channels/types/verboice/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelType
 from temba.channels.types.verboice.views import ClaimView

--- a/temba/channels/types/verboice/views.py
+++ b/temba/channels/types/verboice/views.py
@@ -2,7 +2,7 @@ import phonenumbers
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin
 from temba.utils.fields import SelectWidget

--- a/temba/channels/types/viber_public/type.py
+++ b/temba/channels/types/viber_public/type.py
@@ -1,7 +1,7 @@
 import requests
 
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/viber_public/views.py
+++ b/temba/channels/types/viber_public/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartFormView
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin, UpdateChannelForm

--- a/temba/channels/types/vk/type.py
+++ b/temba/channels/types/vk/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/vk/views.py
+++ b/temba/channels/types/vk/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/vonage/type.py
+++ b/temba/channels/types/vonage/type.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel, ChannelType
@@ -105,4 +105,4 @@ class VonageType(ChannelType):
             client.delete_application(app_id)
 
     def get_urls(self):
-        return [self.get_claim_url(), url(r"^search$", SearchView.as_view(), name="search")]
+        return [self.get_claim_url(), re_path(r"^search$", SearchView.as_view(), name="search")]

--- a/temba/channels/types/vonage/type.py
+++ b/temba/channels/types/vonage/type.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel, ChannelType
 from temba.contacts.models import URN

--- a/temba/channels/types/vonage/views.py
+++ b/temba/channels/types/vonage/views.py
@@ -5,7 +5,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.models import Org
 from temba.orgs.views import OrgPermsMixin

--- a/temba/channels/types/wavy/type.py
+++ b/temba/channels/types/wavy/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/wavy/views.py
+++ b/temba/channels/types/wavy/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin

--- a/temba/channels/types/wechat/type.py
+++ b/temba/channels/types/wechat/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/wechat/views.py
+++ b/temba/channels/types/wechat/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -1,8 +1,7 @@
 import requests
 
-from django.conf.urls import url
 from django.forms import ValidationError
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -50,9 +49,9 @@ class WhatsAppType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            url(r"^(?P<uuid>[a-z0-9\-]+)/refresh$", RefreshView.as_view(), name="refresh"),
-            url(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(), name="templates"),
-            url(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(), name="sync_logs"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/refresh$", RefreshView.as_view(), name="refresh"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(), name="templates"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(), name="sync_logs"),
         ]
 
     def deactivate(self, channel):

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -4,7 +4,7 @@ from django.conf.urls import url
 from django.forms import ValidationError
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.channels.types.whatsapp.views import ClaimView

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -2,7 +2,7 @@ import requests
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 from temba.utils.fields import ExternalURLField, SelectWidget

--- a/temba/channels/types/yo/type.py
+++ b/temba/channels/types/yo/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.yo.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/yo/views.py
+++ b/temba/channels/types/yo/views.py
@@ -1,7 +1,7 @@
 import phonenumbers
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.views import ALL_COUNTRIES, AuthenticatedExternalClaimView, ClaimViewMixin
 from temba.utils.fields import SelectWidget

--- a/temba/channels/types/zenvia/type.py
+++ b/temba/channels/types/zenvia/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelType
 from temba.channels.types.zenvia.views import ClaimView

--- a/temba/channels/types/zenvia/views.py
+++ b/temba/channels/types/zenvia/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import Channel
 from ...views import ClaimViewMixin

--- a/temba/channels/types/zenvia_sms/type.py
+++ b/temba/channels/types/zenvia_sms/type.py
@@ -2,7 +2,7 @@ import requests
 
 from django.forms import ValidationError
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.types.zenvia_whatsapp.views import ClaimView
 from temba.contacts.models import URN

--- a/temba/channels/types/zenvia_whatsapp/type.py
+++ b/temba/channels/types/zenvia_whatsapp/type.py
@@ -2,7 +2,7 @@ import requests
 
 from django.forms import ValidationError
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 

--- a/temba/channels/types/zenvia_whatsapp/views.py
+++ b/temba/channels/types/zenvia_whatsapp/views.py
@@ -3,7 +3,7 @@ import requests
 from smartmin.views import SmartFormView
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import SelectWidget
 

--- a/temba/channels/urls.py
+++ b/temba/channels/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 
 from temba.utils.views import CourierURLHandler
 
@@ -15,17 +16,17 @@ for ch_type in Channel.get_types():
         u.name = "channels.types.%s.%s" % (ch_type.slug, u.name)
 
     if channel_urls:
-        type_urls.append(url("^%s/" % ch_type.slug, include(channel_urls)))
+        type_urls.append(re_path("^%s/" % ch_type.slug, include(channel_urls)))
 
     # register a Courier placeholder URL which will error if ever accessed directly
     courier_urls.append(
-        url(ch_type.courier_url, CourierURLHandler.as_view(), name="courier.%s" % ch_type.code.lower())
+        re_path(ch_type.courier_url, CourierURLHandler.as_view(), name="courier.%s" % ch_type.code.lower())
     )
 
 
 urlpatterns = [
-    url(r"^", include(ChannelEventCRUDL().as_urlpatterns())),
-    url(r"^channels/", include(ChannelCRUDL().as_urlpatterns() + ChannelLogCRUDL().as_urlpatterns())),
-    url(r"^c/", include(courier_urls)),
-    url(r"^channels/types/", include(type_urls)),
+    re_path(r"^", include(ChannelEventCRUDL().as_urlpatterns())),
+    re_path(r"^channels/", include(ChannelCRUDL().as_urlpatterns() + ChannelLogCRUDL().as_urlpatterns())),
+    re_path(r"^c/", include(courier_urls)),
+    re_path(r"^channels/types/", include(type_urls)),
 ]

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -31,7 +31,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonRespons
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -324,7 +324,7 @@ def register(request):
     if request.method != "POST":
         return HttpResponse(status=500, content=_("POST Required"))
 
-    client_payload = json.loads(force_text(request.body))
+    client_payload = json.loads(force_str(request.body))
     cmds = client_payload["cmds"]
 
     try:

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -33,7 +33,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from temba.contacts.models import URN

--- a/temba/classifiers/models.py
+++ b/temba/classifiers/models.py
@@ -3,9 +3,9 @@ from abc import ABCMeta
 
 from smartmin.models import SmartModel
 
-from django.conf.urls import url
 from django.db import models
 from django.template import Engine
+from django.urls import re_path
 from django.utils import timezone
 
 from temba.orgs.models import DependencyMixin, Org
@@ -64,7 +64,7 @@ class ClassifierType(metaclass=ABCMeta):
         """
         Gets the URL/view configuration for this classifier's connect page
         """
-        return url(r"^connect", self.connect_view.as_view(classifier_type=self), name="connect")
+        return re_path(r"^connect", self.connect_view.as_view(classifier_type=self), name="connect")
 
     def get_active_intents_from_api(self, classifier):
         """

--- a/temba/classifiers/types/bothub/views.py
+++ b/temba/classifiers/types/bothub/views.py
@@ -1,7 +1,7 @@
 import requests
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.classifiers.models import Classifier
 from temba.classifiers.views import BaseConnectView

--- a/temba/classifiers/types/luis/views.py
+++ b/temba/classifiers/types/luis/views.py
@@ -1,7 +1,7 @@
 import requests
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.classifiers.models import Classifier
 from temba.classifiers.views import BaseConnectView

--- a/temba/classifiers/types/wit/views.py
+++ b/temba/classifiers/types/wit/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.classifiers.models import Classifier
 from temba.classifiers.views import BaseConnectView

--- a/temba/classifiers/urls.py
+++ b/temba/classifiers/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 
 from .models import Classifier
 from .views import ClassifierCRUDL
@@ -11,6 +12,9 @@ for cl_type in Classifier.get_types():
         u.name = "classifiers.types.%s.%s" % (cl_type.slug, u.name)
 
     if cl_urls:
-        type_urls.append(url("^%s/" % cl_type.slug, include(cl_urls)))
+        type_urls.append(re_path("^%s/" % cl_type.slug, include(cl_urls)))
 
-urlpatterns = [url(r"^", include(ClassifierCRUDL().as_urlpatterns())), url(r"^classifiers/types/", include(type_urls))]
+urlpatterns = [
+    re_path(r"^", include(ClassifierCRUDL().as_urlpatterns())),
+    re_path(r"^classifiers/types/", include(type_urls)),
+]

--- a/temba/classifiers/views.py
+++ b/temba/classifiers/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartCRUDL, SmartFormView, SmartReadView, SmartTempla
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views import DependencyDeleteModal, MenuMixin, OrgObjPermsMixin, OrgPermsMixin
 from temba.utils.views import ComponentFormMixin, SpaMixin

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -22,7 +22,7 @@ from django.db.models import Count, F, Max, Q, Sum, Value
 from django.db.models.functions import Concat
 from django.db.models.functions.text import Upper
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
 from temba.assets.models import register_asset_store

--- a/temba/contacts/search/mailroom.py
+++ b/temba/contacts/search/mailroom.py
@@ -1,7 +1,7 @@
 from typing import NamedTuple
 
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
 

--- a/temba/contacts/search/mailroom.py
+++ b/temba/contacts/search/mailroom.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
@@ -39,7 +39,7 @@ class SearchException(Exception):
         if self.code and self.code in self.messages:
             return self.messages[self.code] % self.extra
 
-        return force_text(self.message)
+        return force_str(self.message)
 
 
 class Metadata(NamedTuple):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1,6 +1,7 @@
 import logging
 from collections import OrderedDict
 from datetime import timedelta
+from urllib.parse import quote_plus
 
 import iso8601
 from smartmin.views import (
@@ -29,7 +30,7 @@ from django.http import Http404, HttpResponse, HttpResponseNotFound, HttpRespons
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.http import is_safe_url, urlquote_plus
+from django.utils.http import is_safe_url
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 
@@ -214,8 +215,8 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
         return ContactGroup.all_groups.get(org=self.request.user.get_org(), group_type=self.system_group)
 
     def derive_export_url(self):
-        search = urlquote_plus(self.request.GET.get("search", ""))
-        redirect = urlquote_plus(self.request.get_full_path())
+        search = quote_plus(self.request.GET.get("search", ""))
+        redirect = quote_plus(self.request.get_full_path())
         return "%s?g=%s&s=%s&redirect=%s" % (
             reverse("contacts.contact_export"),
             self.group.uuid,
@@ -1109,7 +1110,7 @@ class ContactCRUDL(SmartCRUDL):
                                 id="create-smartgroup",
                                 title=_("Create Smart Group"),
                                 modax=_("Create Smart Group"),
-                                href=f"{reverse('contacts.contactgroup_create')}?search={urlquote_plus(search)}",
+                                href=f"{reverse('contacts.contactgroup_create')}?search={quote_plus(search)}",
                             )
                         )
                 except SearchException:  # pragma: no cover

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -30,7 +30,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.http import is_safe_url, urlquote_plus
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 
 from temba.archives.models import Archive

--- a/temba/dashboard/urls.py
+++ b/temba/dashboard/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import Home, MessageHistory, RangeDetails
 
 urlpatterns = [
-    url(r"^dashboard/home/$", Home.as_view(), {}, "dashboard.dashboard_home"),
-    url(r"^dashboard/message_history/$", MessageHistory.as_view(), {}, "dashboard.dashboard_message_history"),
-    url(r"^dashboard/range_details/$", RangeDetails.as_view(), {}, "dashboard.dashboard_range_details"),
+    re_path(r"^dashboard/home/$", Home.as_view(), {}, "dashboard.dashboard_home"),
+    re_path(r"^dashboard/message_history/$", MessageHistory.as_view(), {}, "dashboard.dashboard_message_history"),
+    re_path(r"^dashboard/range_details/$", RangeDetails.as_view(), {}, "dashboard.dashboard_range_details"),
 ]

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -20,7 +20,7 @@ from django.db import models, transaction
 from django.db.models import Max, Q, Sum
 from django.db.models.functions import TruncDate
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
 from temba.assets.models import register_asset_store

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -16,7 +16,7 @@ from django.db.models.functions import TruncDate
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from temba.api.models import Resthook
 from temba.archives.models import Archive
@@ -2769,7 +2769,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertEqual(1, len(response.context["runs"]))
             # self.assertNotContains(response, "ic-append-from")
 
-            next_link = re.search('ic-append-from="(.*)" ic-trigger-on', force_text(response.content)).group(1)
+            next_link = re.search('ic-append-from="(.*)" ic-trigger-on', force_str(response.content)).group(1)
             response = self.client.get(next_link)
             self.assertEqual(200, response.status_code)
 
@@ -2810,7 +2810,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             # one more row to add
             self.assertEqual(1, len(response.context["runs"]))
 
-            next_link = re.search('ic-append-from="(.*)" ic-trigger-on', force_text(response.content)).group(1)
+            next_link = re.search('ic-append-from="(.*)" ic-trigger-on', force_str(response.content)).group(1)
             response = self.client.get(next_link)
             self.assertEqual(200, response.status_code)
             self.assertEqual(1, len(response.context["runs"]))

--- a/temba/flows/urls.py
+++ b/temba/flows/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import FlowCRUDL, FlowLabelCRUDL, FlowRunCRUDL, FlowSessionCRUDL, FlowStartCRUDL, PartialTemplate
 
@@ -8,5 +8,5 @@ urlpatterns += FlowRunCRUDL().as_urlpatterns()
 urlpatterns += FlowSessionCRUDL().as_urlpatterns()
 urlpatterns += FlowStartCRUDL().as_urlpatterns()
 urlpatterns += [
-    url(r"^partials/(?P<template>[a-z0-9\-_]+)$", PartialTemplate.as_view(), name="flows.partial_template")
+    re_path(r"^partials/(?P<template>[a-z0-9\-_]+)$", PartialTemplate.as_view(), name="flows.partial_template")
 ]

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -28,7 +28,7 @@ from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import FormView
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -26,7 +26,7 @@ from django.db.models import Count, Max, Min, Sum
 from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -313,7 +313,7 @@ class FlowCRUDL(SmartCRUDL):
                 )
 
             # try to parse our body
-            definition = json.loads(force_text(request.body))
+            definition = json.loads(force_str(request.body))
             try:
                 flow = self.get_object(self.get_queryset())
                 revision, issues = flow.save_revision(self.request.user, definition)

--- a/temba/globals/models.py
+++ b/temba/globals/models.py
@@ -4,7 +4,7 @@ from smartmin.models import SmartModel
 from django.conf import settings
 from django.db import models
 from django.db.models import Count
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.models import DependencyMixin, Org
 from temba.utils.text import unsnakify

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import ChannelConnection
 

--- a/temba/ivr/urls.py
+++ b/temba/ivr/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from temba.utils.views import MailroomURLHandler
 
 urlpatterns = [
     # register a Mailroom placeholder URL which will error if ever accessed directly
-    url(
+    re_path(
         r"^mr/ivr/c/(?P<uuid>[0-9a-f-]+)/(?P<action>handle|status|incoming)$",
         MailroomURLHandler.as_view(),
         name="mailroom.ivr_handler",

--- a/temba/locations/views.py
+++ b/temba/locations/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.db.models import Prefetch
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from temba.locations.models import AdminBoundary, BoundaryAlias

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -16,7 +16,7 @@ from django.db import models
 from django.db.models import Prefetch, Q, Sum
 from django.db.models.functions import Upper
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
 from temba.assets.models import register_asset_store

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+from urllib.parse import quote_plus
 
 from smartmin.views import (
     SmartCreateView,
@@ -19,7 +20,7 @@ from django.forms import Form
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.http import is_safe_url, urlquote_plus
+from django.utils.http import is_safe_url
 from django.utils.translation import gettext_lazy as _
 
 from temba.archives.models import Archive
@@ -126,7 +127,7 @@ class InboxView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
         return self.system_label
 
     def derive_export_url(self):
-        redirect = urlquote_plus(self.request.get_full_path())
+        redirect = quote_plus(self.request.get_full_path())
         label = self.derive_label()
         label_id = label.uuid if isinstance(label, Label) else label
         return "%s?l=%s&redirect=%s" % (reverse("msgs.msg_export"), label_id, redirect)

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -20,7 +20,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import is_safe_url, urlquote_plus
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.archives.models import Archive
 from temba.channels.models import Channel

--- a/temba/notifications/views.py
+++ b/temba/notifications/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartCRUDL, SmartListView
 
 from django.http import JsonResponse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views import OrgPermsMixin
 

--- a/temba/orgs/integrations/dtone/type.py
+++ b/temba/orgs/integrations/dtone/type.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import IntegrationType
 from .views import AccountView

--- a/temba/orgs/integrations/dtone/type.py
+++ b/temba/orgs/integrations/dtone/type.py
@@ -1,5 +1,4 @@
-from django.conf.urls import url
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils.translation import gettext_lazy as _
 
 from ...models import IntegrationType
@@ -41,4 +40,4 @@ class DTOneType(IntegrationType):
             formax.add_section(self.slug, account_url, icon=self.icon, action="redirect", nobutton=True)
 
     def get_urls(self):
-        return [url(r"^account$", AccountView.as_view(integration_type=self), name="account")]
+        return [re_path(r"^account$", AccountView.as_view(integration_type=self), name="account")]

--- a/temba/orgs/integrations/dtone/views.py
+++ b/temba/orgs/integrations/dtone/views.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...views import IntegrationFormaxView
 from .client import DTOneClient

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -33,7 +33,7 @@ from django.db.models import Count, F, Prefetch, Q, Sum
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
 from temba.archives.models import Archive

--- a/temba/orgs/urls.py
+++ b/temba/orgs/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 
 from .models import IntegrationType
 from .views import (
@@ -27,34 +28,34 @@ for integration in IntegrationType.get_all():
         u.name = f"integrations.{integration.slug}.{u.name}"
 
     if integration_urls:
-        integration_type_urls.append(url("^%s/" % integration.slug, include(integration_urls)))
+        integration_type_urls.append(re_path("^%s/" % integration.slug, include(integration_urls)))
 
 
 spa = SpaView.as_view()
 
 urlpatterns += [
-    url(r"^login/$", check_login, name="users.user_check_login"),
-    url(r"^users/login/$", LoginView.as_view(), name="users.login"),
-    url(r"^users/two-factor/verify/$", TwoFactorVerifyView.as_view(), name="users.two_factor_verify"),
-    url(r"^users/two-factor/backup/$", TwoFactorBackupView.as_view(), name="users.two_factor_backup"),
-    url(r"^users/confirm-access/$", ConfirmAccessView.as_view(), name="users.confirm_access"),
-    url(r"^handlers/stripe/$", StripeHandler.as_view(), name="handlers.stripe_handler"),
-    url(r"^integrations/", include(integration_type_urls)),
+    re_path(r"^login/$", check_login, name="users.user_check_login"),
+    re_path(r"^users/login/$", LoginView.as_view(), name="users.login"),
+    re_path(r"^users/two-factor/verify/$", TwoFactorVerifyView.as_view(), name="users.two_factor_verify"),
+    re_path(r"^users/two-factor/backup/$", TwoFactorBackupView.as_view(), name="users.two_factor_backup"),
+    re_path(r"^users/confirm-access/$", ConfirmAccessView.as_view(), name="users.confirm_access"),
+    re_path(r"^handlers/stripe/$", StripeHandler.as_view(), name="handlers.stripe_handler"),
+    re_path(r"^integrations/", include(integration_type_urls)),
     # for backwards compatibility
-    url(r"^api/v1/stripe/$", StripeHandler.as_view()),
+    re_path(r"^api/v1/stripe/$", StripeHandler.as_view()),
     # for spa
-    url(r"^(?P<level_0>contacts|tickets|messages|channels|flows|plugins|settings)/$", spa, name="spa"),
-    url(
+    re_path(r"^(?P<level_0>contacts|tickets|messages|channels|flows|plugins|settings)/$", spa, name="spa"),
+    re_path(
         r"^(?P<level_0>contacts|tickets|messages|channels|flows|plugins|settings)/(?P<level_1>.+)/$",
         spa,
         name="spa.level_1",
     ),
-    url(
+    re_path(
         r"^(?P<level_0>contacts|tickets|messages|channels|flows|plugins|settings)/(?P<level_1>\w+)/(?P<level_2>.+)/$",
         spa,
         name="spa.level_2",
     ),
-    url(
+    re_path(
         r"^(?P<level_0>contacts|tickets|messages|channels|flows|plugins|settings)/(?P<level_1>\w+)/(?P<level_2>.+)/.*$",
         spa,
         name="spa.level_max",

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -47,7 +47,7 @@ from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import resolve_url
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
-from django.utils.encoding import DjangoUnicodeDecodeError, force_text
+from django.utils.encoding import DjangoUnicodeDecodeError, force_str
 from django.utils.html import escape
 from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
@@ -1282,7 +1282,7 @@ class OrgCRUDL(SmartCRUDL):
                 # check that it isn't too old
                 data = self.cleaned_data["import_file"].read()
                 try:
-                    json_data = json.loads(force_text(data))
+                    json_data = json.loads(force_str(data))
                 except (DjangoUnicodeDecodeError, ValueError):
                     raise ValidationError(_("This file is not a valid flow definition file."))
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -52,7 +52,7 @@ from django.utils.html import escape
 from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from email.utils import parseaddr
 from functools import cmp_to_key
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 import iso8601
 import pyotp
@@ -49,7 +49,6 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.encoding import DjangoUnicodeDecodeError, force_str
 from django.utils.html import escape
-from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -221,7 +220,7 @@ class ModalMixin(SmartFormView):
         if "success_url" in kwargs:  # pragma: no cover
             context["success_url"] = kwargs["success_url"]
 
-        pairs = [urlquote(k) + "=" + urlquote(v) for k, v in self.request.GET.items() if k != "_"]
+        pairs = [quote(k) + "=" + quote(v) for k, v in self.request.GET.items() if k != "_"]
         context["action_url"] = self.request.path + "?" + ("&".join(pairs))
 
         return context
@@ -498,7 +497,7 @@ class LoginView(Login):
             verify_url = reverse("users.two_factor_verify")
             redirect_url = self.get_redirect_url()
             if redirect_url:
-                verify_url += f"?{self.redirect_field_name}={urlquote(redirect_url)}"
+                verify_url += f"?{self.redirect_field_name}={quote(redirect_url)}"
 
             return HttpResponseRedirect(verify_url)
 
@@ -2833,7 +2832,7 @@ class OrgCRUDL(SmartCRUDL):
                 surveyors_group = Group.objects.get(name="Surveyors")
                 token = APIToken.get_or_create(org, user, role=surveyors_group)
 
-                org_name = urlquote(org.name)
+                org_name = quote(org.name)
 
                 return HttpResponseRedirect(
                     f"{self.get_success_url()}?org={org_name}&uuid={str(org.uuid)}&token={token}&user={username}"

--- a/temba/public/models.py
+++ b/temba/public/models.py
@@ -1,7 +1,7 @@
 from smartmin.models import SmartModel
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Lead(SmartModel):

--- a/temba/public/urls.py
+++ b/temba/public/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url
 from django.contrib.sitemaps.views import sitemap
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
 
 from temba.settings import DEBUG
@@ -22,18 +22,18 @@ from .views import (
 sitemaps = {"public": PublicViewSitemap, "video": VideoSitemap}
 
 urlpatterns = [
-    url(r"^$", IndexView.as_view(), {}, "public.public_index"),
-    url(r"^sitemap\.xml$", sitemap, {"sitemaps": sitemaps}, name="public.sitemaps"),
-    url(r"^blog/$", Blog.as_view(), {}, "public.public_blog"),
-    url(r"^welcome/$", Welcome.as_view(), {}, "public.public_welcome"),
-    url(r"^android/$", Android.as_view(), {}, "public.public_android"),
-    url(r"^public/welcome/$", WelcomeRedirect.as_view(), {}, "public.public_welcome_redirect"),
-    url(r"^demo/status/$", csrf_exempt(OrderStatus.as_view()), {}, "demo.order_status"),
-    url(r"^demo/coupon/$", csrf_exempt(GenerateCoupon.as_view()), {}, "demo.generate_coupon"),
+    re_path(r"^$", IndexView.as_view(), {}, "public.public_index"),
+    re_path(r"^sitemap\.xml$", sitemap, {"sitemaps": sitemaps}, name="public.sitemaps"),
+    re_path(r"^blog/$", Blog.as_view(), {}, "public.public_blog"),
+    re_path(r"^welcome/$", Welcome.as_view(), {}, "public.public_welcome"),
+    re_path(r"^android/$", Android.as_view(), {}, "public.public_android"),
+    re_path(r"^public/welcome/$", WelcomeRedirect.as_view(), {}, "public.public_welcome_redirect"),
+    re_path(r"^demo/status/$", csrf_exempt(OrderStatus.as_view()), {}, "demo.order_status"),
+    re_path(r"^demo/coupon/$", csrf_exempt(GenerateCoupon.as_view()), {}, "demo.generate_coupon"),
 ]
 
 if DEBUG:  # pragma: needs cover
-    urlpatterns.append(url(r"^style/$", Style.as_view(), {}, "public.public_style")),
+    urlpatterns.append(re_path(r"^style/$", Style.as_view(), {}, "public.public_style")),
 
 
 urlpatterns += LeadCRUDL().as_urlpatterns()

--- a/temba/public/views.py
+++ b/temba/public/views.py
@@ -5,7 +5,7 @@ from smartmin.views import SmartCreateView, SmartCRUDL, SmartFormView, SmartList
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import RedirectView, View
 

--- a/temba/request_logs/models.py
+++ b/temba/request_logs/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models import Index, Q
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.airtime.models import AirtimeTransfer
 from temba.channels.models import Channel

--- a/temba/request_logs/urls.py
+++ b/temba/request_logs/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 
 from .views import HTTPLogCRUDL
 
-urlpatterns = [url(r"^", include(HTTPLogCRUDL().as_urlpatterns()))]
+urlpatterns = [re_path(r"^", include(HTTPLogCRUDL().as_urlpatterns()))]

--- a/temba/request_logs/views.py
+++ b/temba/request_logs/views.py
@@ -3,7 +3,7 @@ from smartmin.views import SmartCRUDL, SmartListView, SmartReadView, smart_url
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.classifiers.models import Classifier
 from temba.orgs.views import OrgObjPermsMixin, OrgPermsMixin

--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.db.models import Index, Q
 from django.utils import timezone
 from django.utils.timesince import timeuntil
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
 

--- a/temba/schedules/views.py
+++ b/temba/schedules/views.py
@@ -2,7 +2,7 @@ from smartmin.views import SmartCRUDL, SmartUpdateView
 
 from django import forms
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views import OrgObjPermsMixin
 from temba.utils.fields import InputWidget, SelectMultipleWidget, SelectWidget

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -9,7 +9,7 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from celery.schedules import crontab
 

--- a/temba/tests/requests.py
+++ b/temba/tests/requests.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from requests import HTTPError
 from requests.structures import CaseInsensitiveDict
 
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 from temba.utils import json
 
@@ -27,7 +27,7 @@ class MockResponse:
         if isinstance(body, dict):
             body = json.dumps(body)
 
-        self.body = force_text(body)
+        self.body = force_str(body)
         self.text = self.body
         self.content = force_bytes(self.body)
         self.status_code = status_code

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.db.models import Q, Sum
 from django.template import Engine
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba import mailroom
 from temba.contacts.models import Contact

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -4,11 +4,11 @@ import regex
 from smartmin.models import SmartModel
 
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models import Q, Sum
 from django.template import Engine
+from django.urls import re_path
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -61,7 +61,7 @@ class TicketerType(metaclass=ABCMeta):
         """
         Gets the URL/view configuration for this ticketer's connect page
         """
-        return url(r"^connect", self.connect_view.as_view(ticketer_type=self), name="connect")
+        return re_path(r"^connect", self.connect_view.as_view(ticketer_type=self), name="connect")
 
 
 class Ticketer(SmartModel, DependencyMixin):

--- a/temba/tickets/types/mailgun/type.py
+++ b/temba/tickets/types/mailgun/type.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import TicketerType
 from .views import ConnectView

--- a/temba/tickets/types/mailgun/views.py
+++ b/temba/tickets/types/mailgun/views.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import escape
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils.email import send_template_email
 from temba.utils.text import random_string

--- a/temba/tickets/types/rocketchat/type.py
+++ b/temba/tickets/types/rocketchat/type.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.tickets.models import TicketerType
 from temba.tickets.types.rocketchat.views import ConnectView

--- a/temba/tickets/types/rocketchat/views.py
+++ b/temba/tickets/types/rocketchat/views.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 
 from django import forms
 from django.contrib import messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.tickets.models import Ticketer
 from temba.tickets.views import BaseConnectView

--- a/temba/tickets/types/zendesk/type.py
+++ b/temba/tickets/types/zendesk/type.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...models import TicketerType
 from .views import AdminUIView, ConfigureView, ConnectView, FileCallbackView, ManifestView

--- a/temba/tickets/types/zendesk/type.py
+++ b/temba/tickets/types/zendesk/type.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
 from ...models import TicketerType
@@ -36,8 +36,8 @@ class ZendeskType(TicketerType):
         """
         return [
             self.get_connect_url(),
-            url(r"^manifest\.json", ManifestView.as_view(), name="manifest"),
-            url(r"^admin_ui", AdminUIView.as_view(), name="admin_ui"),
-            url(r"^configure/(?P<uuid>[a-z0-9\-]+)/$", ConfigureView.as_view(), name="configure"),
-            url(r"^file/(?P<path>[\w\-./]+)$", FileCallbackView.as_view(), name="file_callback"),
+            re_path(r"^manifest\.json", ManifestView.as_view(), name="manifest"),
+            re_path(r"^admin_ui", AdminUIView.as_view(), name="admin_ui"),
+            re_path(r"^configure/(?P<uuid>[a-z0-9\-]+)/$", ConfigureView.as_view(), name="configure"),
+            re_path(r"^file/(?P<path>[\w\-./]+)$", FileCallbackView.as_view(), name="file_callback"),
         ]

--- a/temba/tickets/types/zendesk/views.py
+++ b/temba/tickets/types/zendesk/views.py
@@ -11,7 +11,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.utils.http import urlencode
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View

--- a/temba/tickets/urls.py
+++ b/temba/tickets/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 
 from .models import Ticketer
 from .views import TicketCRUDL, TicketerCRUDL
@@ -11,10 +12,10 @@ for ticketer_type in Ticketer.get_types():
         u.name = "tickets.types.%s.%s" % (ticketer_type.slug, u.name)
 
     if urls:
-        service_urls.append(url("^%s/" % ticketer_type.slug, include(urls)))
+        service_urls.append(re_path("^%s/" % ticketer_type.slug, include(urls)))
 
 urlpatterns = [
-    url(r"^", include(TicketCRUDL().as_urlpatterns())),
-    url(r"^", include(TicketerCRUDL().as_urlpatterns())),
-    url(r"^tickets/types/", include(service_urls)),
+    re_path(r"^", include(TicketCRUDL().as_urlpatterns())),
+    re_path(r"^", include(TicketerCRUDL().as_urlpatterns())),
+    re_path(r"^tickets/types/", include(service_urls)),
 ]

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -7,7 +7,7 @@ from django.http import JsonResponse
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.html import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.msgs.models import Msg
 from temba.notifications.views import NotificationTargetMixin

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -3,7 +3,7 @@ from smartmin.models import SmartModel
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.contacts.models import Contact, ContactGroup

--- a/temba/triggers/types.py
+++ b/temba/triggers/types.py
@@ -1,7 +1,7 @@
 import regex
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.contacts.models import ContactURN

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -4,7 +4,7 @@ from django import forms
 from django.db.models import Min
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ngettext_lazy, ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_lazy
 
 from temba.channels.models import Channel
 from temba.contacts.models import ContactGroup, ContactURN

--- a/temba/urls.py
+++ b/temba/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.conf.urls.static import static
+from django.urls import re_path
 from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 
@@ -10,35 +11,35 @@ from temba.channels.views import register, sync
 js_info_dict = {"packages": ()}  # this is empty due to the fact that all translation are in one folder
 
 urlpatterns = [
-    url(r"^", include("temba.airtime.urls")),
-    url(r"^", include("temba.api.urls")),
-    url(r"^", include("temba.apks.urls")),
-    url(r"^", include("temba.archives.urls")),
-    url(r"^", include("temba.campaigns.urls")),
-    url(r"^", include("temba.channels.urls")),
-    url(r"^", include("temba.classifiers.urls")),
-    url(r"^", include("temba.contacts.urls")),
-    url(r"^", include("temba.dashboard.urls")),
-    url(r"^", include("temba.flows.urls")),
-    url(r"^", include("temba.globals.urls")),
-    url(r"^", include("temba.ivr.urls")),
-    url(r"^", include("temba.locations.urls")),
-    url(r"^", include("temba.msgs.urls")),
-    url(r"^", include("temba.notifications.urls")),
-    url(r"^", include("temba.policies.urls")),
-    url(r"^", include("temba.public.urls")),
-    url(r"^", include("temba.request_logs.urls")),
-    url(r"^", include("temba.schedules.urls")),
-    url(r"^", include("temba.tickets.urls")),
-    url(r"^", include("temba.triggers.urls")),
-    url(r"^", include("temba.orgs.urls")),
-    url(r"^relayers/relayer/sync/(\d+)/$", sync, {}, "sync"),
-    url(r"^relayers/relayer/register/$", register, {}, "register"),
-    url(r"users/user/forget/", RedirectView.as_view(pattern_name="orgs.user_forget", permanent=True)),
-    url(r"^users/", include("smartmin.users.urls")),
-    url(r"^imports/", include("smartmin.csv_imports.urls")),
-    url(r"^assets/", include("temba.assets.urls")),
-    url(r"^jsi18n/$", JavaScriptCatalog.as_view(), js_info_dict, name="django.views.i18n.javascript_catalog"),
+    re_path(r"^", include("temba.airtime.urls")),
+    re_path(r"^", include("temba.api.urls")),
+    re_path(r"^", include("temba.apks.urls")),
+    re_path(r"^", include("temba.archives.urls")),
+    re_path(r"^", include("temba.campaigns.urls")),
+    re_path(r"^", include("temba.channels.urls")),
+    re_path(r"^", include("temba.classifiers.urls")),
+    re_path(r"^", include("temba.contacts.urls")),
+    re_path(r"^", include("temba.dashboard.urls")),
+    re_path(r"^", include("temba.flows.urls")),
+    re_path(r"^", include("temba.globals.urls")),
+    re_path(r"^", include("temba.ivr.urls")),
+    re_path(r"^", include("temba.locations.urls")),
+    re_path(r"^", include("temba.msgs.urls")),
+    re_path(r"^", include("temba.notifications.urls")),
+    re_path(r"^", include("temba.policies.urls")),
+    re_path(r"^", include("temba.public.urls")),
+    re_path(r"^", include("temba.request_logs.urls")),
+    re_path(r"^", include("temba.schedules.urls")),
+    re_path(r"^", include("temba.tickets.urls")),
+    re_path(r"^", include("temba.triggers.urls")),
+    re_path(r"^", include("temba.orgs.urls")),
+    re_path(r"^relayers/relayer/sync/(\d+)/$", sync, {}, "sync"),
+    re_path(r"^relayers/relayer/register/$", register, {}, "register"),
+    re_path(r"users/user/forget/", RedirectView.as_view(pattern_name="orgs.user_forget", permanent=True)),
+    re_path(r"^users/", include("smartmin.users.urls")),
+    re_path(r"^imports/", include("smartmin.csv_imports.urls")),
+    re_path(r"^assets/", include("temba.assets.urls")),
+    re_path(r"^jsi18n/$", JavaScriptCatalog.as_view(), js_info_dict, name="django.views.i18n.javascript_catalog"),
 ]
 
 if settings.DEBUG:
@@ -47,7 +48,7 @@ if settings.DEBUG:
 
 # import any additional urls
 for app in settings.APP_URLS:  # pragma: needs cover
-    urlpatterns.append(url(r"^", include(app)))
+    urlpatterns.append(re_path(r"^", include(app)))
 
 
 def handler500(request):

--- a/temba/utils/cache.py
+++ b/temba/utils/cache.py
@@ -1,6 +1,6 @@
 from django_redis import get_redis_connection
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from temba.utils import json
 
@@ -15,7 +15,7 @@ def get_cacheable(cache_key, callable, r=None, force_dirty=False):
     if not force_dirty:
         cached = r.get(cache_key)
         if cached is not None:
-            return json.loads(force_text(cached))
+            return json.loads(force_str(cached))
 
     (calculated, cache_ttl) = callable()
     r.set(cache_key, json.dumps(calculated), ex=cache_ttl or None)

--- a/temba/utils/countries.py
+++ b/temba/utils/countries.py
@@ -3,7 +3,7 @@ from typing import Optional
 import phonenumbers
 from django_countries.data import COUNTRIES
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 NAMES = COUNTRIES.copy()
 NAMES["GB"] = _("United Kingdom")

--- a/temba/utils/export.py
+++ b/temba/utils/export.py
@@ -10,7 +10,7 @@ from django.core.files import File
 from django.core.files.temp import NamedTemporaryFile
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.assets.models import BaseAssetStore, get_asset_store
 

--- a/temba/utils/fields.py
+++ b/temba/utils/fields.py
@@ -6,7 +6,7 @@ from urllib import parse
 from django import forms
 from django.core.validators import URLValidator
 from django.forms import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class JSONField(forms.Field):

--- a/temba/utils/management/commands/perf_test.py
+++ b/temba/utils/management/commands/perf_test.py
@@ -2,12 +2,12 @@ import fnmatch
 import sys
 import time
 from datetime import datetime, timedelta
+from urllib.parse import quote_plus
 
 import pytz
 
 from django.core.management.base import BaseCommand, CommandError
 from django.test import Client
-from django.utils.http import urlquote_plus
 from django.utils.timezone import now
 
 from temba.contacts.models import ContactGroup
@@ -55,28 +55,28 @@ TEST_URLS = (
     "/api/v2/org.json",
     "/contact/",
     "/contact/?search=2507001",
-    "/contact/?search=" + urlquote_plus("name is Dave or tel has 2507001"),
-    "/contact/?search=" + urlquote_plus("gender=F"),
-    "/contact/?search=" + urlquote_plus('joined=""'),
-    "/contact/?search=" + urlquote_plus('joined!=""'),
+    "/contact/?search=" + quote_plus("name is Dave or tel has 2507001"),
+    "/contact/?search=" + quote_plus("gender=F"),
+    "/contact/?search=" + quote_plus('joined=""'),
+    "/contact/?search=" + quote_plus('joined!=""'),
     "/contact/?search="
-    + urlquote_plus(
+    + quote_plus(
         "district=Wudil or district=Anka or district=Zuru or district=Kaura or "
         "district=Giwa or district=Kalgo or district=Shanga or district=Bunza"
     ),
-    "/contact/?search=" + urlquote_plus("gender=M and state=Katsina and age<40 and joined>") + "{1-year-ago}",
-    "/contact/?search=" + urlquote_plus("(gender=M and district=Faskari) or (gender=F and district=Zuru)"),
+    "/contact/?search=" + quote_plus("gender=M and state=Katsina and age<40 and joined>") + "{1-year-ago}",
+    "/contact/?search=" + quote_plus("(gender=M and district=Faskari) or (gender=F and district=Zuru)"),
     "/contact/blocked/",
     "/contact/stopped/",
     "/contact/filter/{first-group}/",
-    "/contact/filter/{first-group}/?search=" + urlquote_plus("gender=F"),
+    "/contact/filter/{first-group}/?search=" + quote_plus("gender=F"),
     "/contact/filter/{last-group}/",
     "/contact/omnibox/?search=",
     "/contact/omnibox/?search=George",
     "/contact/omnibox/?search=07009",
     "/msg/inbox/",
     "/msg/flow/",
-    "/msg/flow/?search=" + urlquote_plus("poots seattle"),
+    "/msg/flow/?search=" + quote_plus("poots seattle"),
     "/msg/archived/",
     "/msg/outbox/",
     "/msg/sent/",

--- a/temba/utils/models.py
+++ b/temba/utils/models.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from django.db import connection, models
 from django.db.models import JSONField as DjangoJSONField, Sum
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.utils import json, uuid
 

--- a/temba/utils/templatetags/temba.py
+++ b/temba/utils/templatetags/temba.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import escapejs
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext, ugettext_lazy as _, ungettext_lazy
+from django.utils.translation import gettext, gettext_lazy as _, ngettext_lazy
 
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import ContactGroup
@@ -22,13 +22,13 @@ from temba.utils import analytics
 from temba.utils.dates import datetime_to_str
 
 TIME_SINCE_CHUNKS = (
-    (60 * 60 * 24 * 365, ungettext_lazy("%d year", "%d years")),
-    (60 * 60 * 24 * 30, ungettext_lazy("%d month", "%d months")),
-    (60 * 60 * 24 * 7, ungettext_lazy("%d week", "%d weeks")),
-    (60 * 60 * 24, ungettext_lazy("%d day", "%d days")),
-    (60 * 60, ungettext_lazy("%d hour", "%d hours")),
-    (60, ungettext_lazy("%d minute", "%d minutes")),
-    (1, ungettext_lazy("%d second", "%d seconds")),
+    (60 * 60 * 24 * 365, ngettext_lazy("%d year", "%d years")),
+    (60 * 60 * 24 * 30, ngettext_lazy("%d month", "%d months")),
+    (60 * 60 * 24 * 7, ngettext_lazy("%d week", "%d weeks")),
+    (60 * 60 * 24, ngettext_lazy("%d day", "%d days")),
+    (60 * 60, ngettext_lazy("%d hour", "%d hours")),
+    (60, ngettext_lazy("%d minute", "%d minutes")),
+    (1, ngettext_lazy("%d second", "%d seconds")),
 )
 
 
@@ -148,7 +148,7 @@ def delta_filter(delta):
         since = delta.days * 24 * 60 * 60 + delta.seconds
         if since <= 0:
             # d is in the future compared to now, stop processing.
-            return ugettext("0 seconds")
+            return gettext("0 seconds")
         for i, (seconds, name) in enumerate(TIME_SINCE_CHUNKS):
             count = since // seconds
             if count != 0:

--- a/temba/utils/text.py
+++ b/temba/utils/text.py
@@ -10,7 +10,7 @@ from os import urandom
 import chardet
 import regex
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import slugify
 
 CONTROL_CHARACTERES_REGEX = r"[\000-\010]|[\013-\014]|[\016-\037]"
@@ -111,7 +111,7 @@ def decode_base64(original):
 
     decoded = original
     try:
-        decoded = force_text(base64.standard_b64decode(stripped), errors="ignore")
+        decoded = force_str(base64.standard_b64decode(stripped), errors="ignore")
         count = Counter(decoded)
         letters = sum(count[letter] for letter in string.ascii_letters)
         if float(letters) / len(decoded) < 0.5:

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import quote
 
 from django import forms
 from django.db import transaction
@@ -6,7 +7,6 @@ from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirec
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.http import urlquote
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
@@ -246,7 +246,7 @@ class RequireRecentAuthMixin:
         if not is_formax or self.recent_auth_includes_formax:
             last_auth_on = request.user.get_settings().last_auth_on
             if not last_auth_on or (timezone.now() - last_auth_on).total_seconds() > self.recent_auth_seconds:
-                return HttpResponseRedirect(reverse("users.confirm_access") + f"?next={urlquote(request.path)}")
+                return HttpResponseRedirect(reverse("users.confirm_access") + f"?next={quote(request.path)}")
 
         return super().pre_process(request, *args, **kwargs)
 

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.http import urlquote
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 

--- a/temba/utils/whatsapp/views.py
+++ b/temba/utils/whatsapp/views.py
@@ -1,7 +1,7 @@
 from smartmin.views import SmartReadView, SmartUpdateView
 
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
 from temba.orgs.views import OrgPermsMixin


### PR DESCRIPTION
* `django.utils.translation.ugettext` → `gettext`
* `django.utils.translation.ugettext_lazy` → `gettext_lazy`
* `django.utils.encoding.force_text` → `force_str`
* `django.http.urlquote` → `urllib.parse.quote`
* `django.http.urlquote_plus` → `urllib.parse.quote_plus`
* `django.conf.urls.url` → `django.urls.re_path`