### PR TITLE
Relayer syncing should ignore bad URNs

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1113,10 +1113,7 @@ class ChannelTest(TembaTest):
         self.assertEqual(2, Msg.objects.filter(channel=self.tel_channel, status="F", direction="O").count())
 
         # we should now have two incoming messages
-        self.assertEqual(3, Msg.objects.filter(direction="I").count())
-
-        # one of them should have an empty 'tel'
-        self.assertTrue(Msg.objects.filter(direction="I", contact_urn__path="empty"))
+        self.assertEqual(2, Msg.objects.filter(direction="I").count())
 
         # We should now have one sync
         self.assertEqual(1, SyncEvent.objects.filter(channel=self.tel_channel).count())
@@ -1327,9 +1324,9 @@ class ChannelTest(TembaTest):
         response = self.sync(
             self.tel_channel,
             cmds=[
-                dict(cmd="mo_sms", phone="2505551212", msg="First message", p_id="1", ts=date),
-                dict(cmd="mo_sms", phone="2505551212", msg="First message", p_id="2", ts=date),
-                dict(cmd="mo_sms", phone="2505551212", msg="A second message", p_id="3", ts=date),
+                dict(cmd="mo_sms", phone="0788383383", msg="First message", p_id="1", ts=date),
+                dict(cmd="mo_sms", phone="0788383383", msg="First message", p_id="2", ts=date),
+                dict(cmd="mo_sms", phone="0788383383", msg="A second message", p_id="3", ts=date),
             ],
         )
         self.assertEqual(200, response.status_code)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1076,14 +1076,14 @@ class ChannelTest(TembaTest):
             dict(cmd="mt_fail", msg_id=msg5.pk, ts=date),
             dict(cmd="mt_fail", msg_id=(msg6.pk - 4294967296), ts=date),  # simulate a negative integer from relayer
             # a missed call
-            dict(cmd="call", phone="2505551212", type="miss", ts=date),
+            dict(cmd="call", phone="0788381212", type="miss", ts=date),
             # repeated missed calls should be skipped
-            dict(cmd="call", phone="2505551212", type="miss", ts=date),
-            dict(cmd="call", phone="2505551212", type="miss", ts=date),
+            dict(cmd="call", phone="0788381212", type="miss", ts=date),
+            dict(cmd="call", phone="0788381212", type="miss", ts=date),
             # incoming
-            dict(cmd="call", phone="2505551212", type="mt", dur=10, ts=date),
+            dict(cmd="call", phone="0788381212", type="mt", dur=10, ts=date),
             # repeated calls should be skipped
-            dict(cmd="call", phone="2505551212", type="mt", dur=10, ts=date),
+            dict(cmd="call", phone="0788381212", type="mt", dur=10, ts=date),
             # incoming, invalid URN
             dict(cmd="call", phone="*", type="mt", dur=10, ts=date),
             # outgoing

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -255,11 +255,9 @@ def sync(request, channel_id):
                 if cmd["phone"] and call_tuple not in unique_calls:
                     urn = URN.from_tel(cmd["phone"])
                     try:
-                        urn = URN.normalize(urn, channel.country.code)
-                        if URN.validate(urn):
-                            ChannelEvent.create_relayer_event(
-                                channel, urn, cmd["type"], date, extra=dict(duration=duration)
-                            )
+                        ChannelEvent.create_relayer_event(
+                            channel, urn, cmd["type"], date, extra={"duration": duration}
+                        )
                     except ValueError:
                         # in some cases Android passes us invalid URNs, in those cases just ignore them
                         pass

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -255,12 +255,15 @@ def sync(request, channel_id):
                 if cmd["phone"] and call_tuple not in unique_calls:
                     urn = URN.from_tel(cmd["phone"])
                     try:
-                        ChannelEvent.create_relayer_event(
-                            channel, urn, cmd["type"], date, extra=dict(duration=duration)
-                        )
+                        urn = URN.normalize(urn, channel.country.code)
+                        if URN.validate(urn):
+                            ChannelEvent.create_relayer_event(
+                                channel, urn, cmd["type"], date, extra=dict(duration=duration)
+                            )
                     except ValueError:
                         # in some cases Android passes us invalid URNs, in those cases just ignore them
                         pass
+
                     unique_calls.add(call_tuple)
                 handled = True
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -734,7 +734,11 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
         """
         Resolves a contact and URN from a channel interaction. Only used for relayer endpoints.
         """
-        response = mailroom.get_client().contact_resolve(channel.org_id, channel.id, urn)
+        try:
+            response = mailroom.get_client().contact_resolve(channel.org_id, channel.id, urn)
+        except mailroom.MailroomException as e:
+            raise ValueError(e.response.get("error"))
+
         contact = Contact.objects.get(id=response["contact"]["id"])
         contact_urn = ContactURN.objects.get(id=response["urn"]["id"])
         return contact, contact_urn

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -144,6 +144,13 @@ class TestClient(MailroomClient):
         org = Org.objects.get(id=org_id)
         user = get_anonymous_user()
 
+        try:
+            urn = URN.normalize(urn, org.default_country_code)
+            if not URN.validate(urn, org.default_country_code):
+                raise ValueError()
+        except ValueError:
+            raise MailroomException("contact/resolve", None, {"error": "invalid URN"})
+
         contact_urn = ContactURN.lookup(org, urn)
         if contact_urn:
             contact = contact_urn.contact


### PR DESCRIPTION
rather than wait for mailroom to fail trying to create them which currently leads to sentry errors in both mailroom and rapid e.g.

https://sentry.io/organizations/nyaruka/issues/2323400685/?project=1281372&query=is%3Aunresolved

https://sentry.io/organizations/nyaruka/issues/2750945343/?project=20737&query=is%3Aunresolved

