### PR TITLE
Raise Validation Error on the form, field could have been not included

### DIFF
--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2089,7 +2089,12 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         # no omnibox...
         self.assertEqual(["text", "step_node", "loc"], list(response.context["form"].fields.keys()))
 
-        response = self.client.post(send_url, {"text": "Hurry up", "step_node": color_split["uuid"]})
+        response = self.client.post(f"{send_url}?step_node={color_split['uuid']}", {"text": "Hurry up"})
+        self.assertFormError(response, "form", None, "At least one recipient is required.")
+
+        response = self.client.post(
+            f"{send_url}?step_node={color_split['uuid']}", {"text": "Hurry up", "step_node": color_split["uuid"]}
+        )
         self.assertRedirect(response, reverse("msgs.msg_inbox"))
 
         broadcast = Broadcast.objects.get()

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -101,7 +101,7 @@ class SendMessageForm(Form):
             step_node = cleaned.get("step_node")
 
             if not step_node and not omnibox:
-                self.add_error("omnibox", _("At least one recipient is required."))
+                self.add_error(None, _("At least one recipient is required."))
 
         return cleaned
 


### PR DESCRIPTION
Addresses https://sentry.io/organizations/nyaruka/issues/2996424029/ from the flow editor the error should now be added to a field we do not have 

somehow similar is https://sentry.io/organizations/nyaruka/issues/2996072964/ which end up not matching any contacts

I will keep investigating on why in both cases the recipients are not matched at all

especially for the flow case there is a badge of counts of contacts 
