### PR TITLE
Display current flow on contact read page

### DIFF
--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -751,6 +751,7 @@ class ContactCRUDL(SmartCRUDL):
     class Read(SpaMixin, OrgObjPermsMixin, SmartReadView):
         slug_url_kwarg = "uuid"
         fields = ("name",)
+        select_related = ("current_flow",)
 
         def derive_title(self):
             return self.object.get_display()

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -37,6 +37,11 @@
         %temba-icon(name="archive")
         -trans "Archived"
 
+    -if user.is_beta and contact.current_flow
+      .lbl-group.linked.inverted.bg-tertiary.mr-2.mb-2(onclick="goto(event)" href="{% url 'flows.flow_editor' contact.current_flow.uuid %}")
+        %temba-icon(name="flow")
+        {{ contact.current_flow.name }}
+
     -for group in contact_groups
       -if group.is_dynamic
         -include "includes/recipients_group.haml" with group=group


### PR DESCRIPTION
<img width="293" alt="Captura de Pantalla 2022-02-11 a la(s) 14 06 29" src="https://user-images.githubusercontent.com/675558/153659860-32406cc4-513a-4f17-aabd-10fa096d9a93.png">

I've limited it to beta users for now. This is going to be mostly for me to debug and test problems with that field being set.