### PR TITLE
use original filename to upload file

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2643,17 +2643,17 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         assert_media_upload(
             f"{settings.MEDIA_ROOT}/test_media/steve.marten.jpg",
             "image/jpeg",
-            "%s/attachments/%d/%d/steps/%s%s" % (settings.STORAGE_URL, self.org.id, flow.id, "11111-111-11", ".jpg"),
+            "%s/attachments/%d/%d/steps/%s/%s" % (settings.STORAGE_URL, self.org.id, flow.id, "11111-111-11", "steve.marten.jpg"),
         )
         assert_media_upload(
             f"{settings.MEDIA_ROOT}/test_media/snow.mp4",
             "video/mp4",
-            "%s/attachments/%d/%d/steps/%s%s" % (settings.STORAGE_URL, self.org.id, flow.id, "22222-222-22", ".mp4"),
+            "%s/attachments/%d/%d/steps/%s/%s" % (settings.STORAGE_URL, self.org.id, flow.id, "22222-222-22", "snow.mp4"),
         )
         assert_media_upload(
             f"{settings.MEDIA_ROOT}/test_media/snow.m4a",
             "audio/mp4",
-            "%s/attachments/%d/%d/steps/%s%s" % (settings.STORAGE_URL, self.org.id, flow.id, "33333-333-33", ".m4a"),
+            "%s/attachments/%d/%d/steps/%s/%s" % (settings.STORAGE_URL, self.org.id, flow.id, "33333-333-33", "snow.m4a"),
         )
 
         # can't upload for flow in other org

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2643,17 +2643,20 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         assert_media_upload(
             f"{settings.MEDIA_ROOT}/test_media/steve.marten.jpg",
             "image/jpeg",
-            "%s/attachments/%d/%d/steps/%s/%s" % (settings.STORAGE_URL, self.org.id, flow.id, "11111-111-11", "steve.marten.jpg"),
+            "%s/attachments/%d/%d/steps/%s/%s"
+            % (settings.STORAGE_URL, self.org.id, flow.id, "11111-111-11", "steve.marten.jpg"),
         )
         assert_media_upload(
             f"{settings.MEDIA_ROOT}/test_media/snow.mp4",
             "video/mp4",
-            "%s/attachments/%d/%d/steps/%s/%s" % (settings.STORAGE_URL, self.org.id, flow.id, "22222-222-22", "snow.mp4"),
+            "%s/attachments/%d/%d/steps/%s/%s"
+            % (settings.STORAGE_URL, self.org.id, flow.id, "22222-222-22", "snow.mp4"),
         )
         assert_media_upload(
             f"{settings.MEDIA_ROOT}/test_media/snow.m4a",
             "audio/mp4",
-            "%s/attachments/%d/%d/steps/%s/%s" % (settings.STORAGE_URL, self.org.id, flow.id, "33333-333-33", "snow.m4a"),
+            "%s/attachments/%d/%d/steps/%s/%s"
+            % (settings.STORAGE_URL, self.org.id, flow.id, "33333-333-33", "snow.m4a"),
         )
 
         # can't upload for flow in other org

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -706,7 +706,7 @@ class FlowCRUDL(SmartCRUDL):
 
         def save_media_upload(self, file):
             flow = self.get_object()
-            name_uuid = str(uuid4())
+            uuid = str(uuid4())
             extension = file.name.split(".")[-1]
 
             # browsers might send m4a files but correct MIME type is audio/mp4
@@ -714,7 +714,7 @@ class FlowCRUDL(SmartCRUDL):
                 file.content_type = "audio/mp4"
 
             url = public_file_storage.save(
-                "attachments/%d/%d/steps/%s.%s" % (flow.org.pk, flow.id, name_uuid, extension), file
+                "attachments/%d/%d/steps/%s/%s" % (flow.org.pk, flow.id, uuid, file.name), file
             )
             return {"type": file.content_type, "url": f"{settings.STORAGE_URL}/{url}"}
 
@@ -1945,7 +1945,7 @@ class FlowCRUDL(SmartCRUDL):
                 query=query,
                 restart_participants=restart_participants,
                 include_active=include_contacts_with_runs,
-            )
+                ,)
             return self.object
 
     class Assets(OrgPermsMixin, SmartTemplateView):

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -706,7 +706,7 @@ class FlowCRUDL(SmartCRUDL):
 
         def save_media_upload(self, file):
             flow = self.get_object()
-            uuid = str(uuid4())
+            random_uuid_folder_name = str(uuid4())
             extension = file.name.split(".")[-1]
 
             # browsers might send m4a files but correct MIME type is audio/mp4
@@ -714,7 +714,7 @@ class FlowCRUDL(SmartCRUDL):
                 file.content_type = "audio/mp4"
 
             url = public_file_storage.save(
-                "attachments/%d/%d/steps/%s/%s" % (flow.org.pk, flow.id, uuid, file.name), file
+                "attachments/%d/%d/steps/%s/%s" % (flow.org.pk, flow.id, random_uuid_folder_name, file.name), file
             )
             return {"type": file.content_type, "url": f"{settings.STORAGE_URL}/{url}"}
 
@@ -1945,7 +1945,7 @@ class FlowCRUDL(SmartCRUDL):
                 query=query,
                 restart_participants=restart_participants,
                 include_active=include_contacts_with_runs,
-                ,)
+            )
             return self.object
 
     class Assets(OrgPermsMixin, SmartTemplateView):


### PR DESCRIPTION
changing file path to use original filename at the end instead UUID. 
As discussed here: https://github.com/nyaruka/courier/issues/383