### PR TITLE
Fix group name validation to include system groups

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -760,7 +760,7 @@ class ContactGroupWriteSerializer(WriteSerializer):
     name = serializers.CharField(
         required=True,
         max_length=ContactGroup.MAX_NAME_LEN,
-        validators=[UniqueForOrgValidator(queryset=ContactGroup.user_groups.filter(is_active=True), ignore_case=True)],
+        validators=[UniqueForOrgValidator(queryset=ContactGroup.all_groups.filter(is_active=True), ignore_case=True)],
     )
 
     def validate_name(self, value):

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3008,6 +3008,10 @@ class APITest(TembaTest):
         response = self.postJSON(url, None, {"name": "reporters"})
         self.assertResponseError(response, "name", "This field must be unique.")
 
+        # try to create another group with same name as a system group..
+        response = self.postJSON(url, "uuid=%s" % reporters.uuid, {"name": "blocked"})
+        self.assertResponseError(response, "name", "This field must be unique.")
+
         # it's fine if a group in another org has that name
         response = self.postJSON(url, None, {"name": "Spammers"})
         self.assertEqual(response.status_code, 201)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1126,35 +1126,39 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # can't create group as viewer
         self.login(self.user)
-        response = self.client.post(url, dict(name="Spammers"))
+        response = self.client.post(url, {"name": "Spammers"})
         self.assertLoginRedirect(response)
 
         self.login(self.admin)
 
         # try to create a contact group whose name is only whitespace
-        response = self.client.post(url, dict(name="  "))
+        response = self.client.post(url, {"name": "  "})
         self.assertFormError(response, "form", "name", "This field is required.")
 
         # try to create a contact group whose name begins with reserved character
-        response = self.client.post(url, dict(name="+People"))
+        response = self.client.post(url, {"name": "+People"})
         self.assertFormError(response, "form", "name", "Group name must not be blank or begin with + or -")
 
         # try to create with name that's already taken
-        response = self.client.post(url, dict(name="Customers"))
+        response = self.client.post(url, {"name": "Customers"})
+        self.assertFormError(response, "form", "name", "Name is used by another group")
+
+        # try to create with name that's already taken by a system group
+        response = self.client.post(url, {"name": "blocked"})
         self.assertFormError(response, "form", "name", "Name is used by another group")
 
         # create with valid name (that will be trimmed)
-        response = self.client.post(url, dict(name="first  "))
+        response = self.client.post(url, {"name": "first  "})
         self.assertNoFormErrors(response)
         ContactGroup.user_groups.get(org=self.org, name="first")
 
         # create a group with preselected contacts
-        self.client.post(url, dict(name="Everybody", preselected_contacts="%d,%d" % (self.joe.pk, self.frank.pk)))
+        self.client.post(url, {"name": "Everybody", "preselected_contacts": f"{self.joe.id},{self.frank.id}"})
         group = ContactGroup.user_groups.get(org=self.org, name="Everybody")
         self.assertEqual(set(group.contacts.all()), {self.joe, self.frank})
 
         # create a dynamic group using a query
-        self.client.post(url, dict(name="Frank", group_query="tel = 1234"))
+        self.client.post(url, {"name": "Frank", "group_query": "tel = 1234"})
 
         ContactGroup.user_groups.get(org=self.org, name="Frank", query="tel = 1234")
 
@@ -1164,7 +1168,7 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
         for i in range(10):
             ContactGroup.create_static(self.org2, self.admin2, "group%d" % i)
 
-        response = self.client.post(url, dict(name="People"))
+        response = self.client.post(url, {"name": "People"})
         self.assertNoFormErrors(response)
         ContactGroup.user_groups.get(org=self.org, name="People")
 
@@ -1175,7 +1179,7 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
             ContactGroup.create_static(self.org, self.admin, "group%d" % i)
 
         self.assertEqual(10, ContactGroup.user_groups.all().count())
-        response = self.client.post(url, dict(name="People"))
+        response = self.client.post(url, {"name": "People"})
         self.assertFormError(
             response,
             "form",

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -134,7 +134,7 @@ class ContactGroupForm(forms.ModelForm):
         name = self.cleaned_data["name"].strip()
 
         # make sure the name isn't already taken
-        existing = ContactGroup.all_groups.filter(org=self.org, name__iexact=name)
+        existing = ContactGroup.all_groups.filter(org=self.org, is_active=True, name__iexact=name).first()
         if existing and self.instance != existing:
             raise forms.ValidationError(_("Name is used by another group"))
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -134,7 +134,7 @@ class ContactGroupForm(forms.ModelForm):
         name = self.cleaned_data["name"].strip()
 
         # make sure the name isn't already taken
-        existing = ContactGroup.get_user_group_by_name(self.org, name)
+        existing = ContactGroup.all_groups.filter(org=self.org, name__iexact=name)
         if existing and self.instance != existing:
             raise forms.ValidationError(_("Name is used by another group"))
 


### PR DESCRIPTION
You can't create groups called "Active", "Blocked" etc. That might be a little confusing for users right now especially those who are seeing those system group names translated, but I think in future we want to move toward those being more like groups in other ways. For now we just want to give users a validation error instead of [blowing up with a db constraint error](https://sentry.io/organizations/nyaruka/issues/3052343027/?environment=production&project=20737&referrer=alert_email).