### PR TITLE
Smart system groups part 5

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -775,14 +775,16 @@ class ContactGroupWriteSerializer(WriteSerializer):
 
     def validate(self, data):
         org = self.context["org"]
-        org_active_groups_limit = org.get_limit(Org.LIMIT_GROUPS)
+        group_limit = org.get_limit(Org.LIMIT_GROUPS)
+
+        if self.instance and self.instance.is_system:
+            raise serializers.ValidationError("Cannot update a system group.")
 
         group_count = ContactGroup.get_groups(org, user_only=True).count()
-        if group_count >= org_active_groups_limit:
+        if group_count >= group_limit:
             raise serializers.ValidationError(
-                "This org has %s groups and the limit is %s. "
-                "You must delete existing ones before you can "
-                "create new ones." % (group_count, org_active_groups_limit)
+                f"This workspace has {group_count} groups and the limit is {group_limit}. "
+                f"You must delete existing ones before you can create new ones."
             )
         return data
 

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -740,6 +740,7 @@ class ContactFieldWriteSerializer(WriteSerializer):
 
 class ContactGroupReadSerializer(ReadSerializer):
     status = serializers.SerializerMethodField()
+    system = serializers.ReadOnlyField(source="is_system")
     count = serializers.SerializerMethodField()
 
     STATUSES = {
@@ -757,7 +758,7 @@ class ContactGroupReadSerializer(ReadSerializer):
 
     class Meta:
         model = ContactGroup
-        fields = ("uuid", "name", "query", "status", "count")
+        fields = ("uuid", "name", "query", "status", "system", "count")
 
 
 class ContactGroupWriteSerializer(WriteSerializer):

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2935,6 +2935,7 @@ class APITest(TembaTest):
         self.assertEndpointAccess(url)
 
         self.create_field("isdeveloper", "Is developer")
+        open_tickets = self.org.groups.get(name="Open Tickets")
         customers = self.create_group("Customers", [self.frank])
         developers = self.create_group("Developers", query='isdeveloper = "YES"')
         ContactGroup.objects.filter(id=developers.id).update(status=ContactGroup.STATUS_READY)
@@ -2958,6 +2959,13 @@ class APITest(TembaTest):
         self.assertEqual(
             resp_json["results"],
             [
+                {
+                    "uuid": open_tickets.uuid,
+                    "name": "Open Tickets",
+                    "query": "tickets > 0",
+                    "status": "ready",
+                    "count": 0,
+                },
                 {
                     "uuid": dynamic.uuid,
                     "name": "Big Group",

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2963,6 +2963,7 @@ class APITest(TembaTest):
                     "name": "Big Group",
                     "query": 'isdeveloper = "NO"',
                     "status": "evaluating",
+                    "system": False,
                     "count": 0,
                 },
                 {
@@ -2970,9 +2971,17 @@ class APITest(TembaTest):
                     "name": "Developers",
                     "query": 'isdeveloper = "YES"',
                     "status": "ready",
+                    "system": False,
                     "count": 0,
                 },
-                {"uuid": customers.uuid, "name": "Customers", "query": None, "status": "ready", "count": 1},
+                {
+                    "uuid": customers.uuid,
+                    "name": "Customers",
+                    "query": None,
+                    "status": "ready",
+                    "system": False,
+                    "count": 1,
+                },
             ],
         )
 
@@ -2999,7 +3008,14 @@ class APITest(TembaTest):
         reporters = ContactGroup.objects.get(name="Reporters")
         self.assertEqual(
             response.json(),
-            {"uuid": reporters.uuid, "name": "Reporters", "query": None, "status": "ready", "count": 0},
+            {
+                "uuid": reporters.uuid,
+                "name": "Reporters",
+                "query": None,
+                "status": "ready",
+                "system": False,
+                "count": 0,
+            },
         )
 
         # try to create another group with same name

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2216,6 +2216,8 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
             )
 
         instance = self.get_object()
+        if instance.is_system:
+            raise InvalidQueryError("Cannot delete a system group.")
 
         # if there are still dependencies, give up
         triggers = instance.triggers.filter(is_archived=False)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2094,6 +2094,9 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
 
      * **uuid** - the UUID of the group (string), filterable as `uuid`
      * **name** - the name of the group (string), filterable as `name`
+     * **query** - the query if a smart group (string)
+     * **status** - the status (one of "initializing", "evaluating" or "ready")
+     * **system** - whether this is a system group that can't be edited (bool)
      * **count** - the number of contacts in the group (int)
 
     Example:
@@ -2109,8 +2112,10 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
                 {
                     "uuid": "5f05311e-8f81-4a67-a5b5-1501b6d6496a",
                     "name": "Reporters",
-                    "count": 315,
-                    "query": null
+                    "query": null,
+                    "status": "ready",
+                    "system": false,
+                    "count": 315
                 },
                 ...
             ]

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1529,6 +1529,7 @@ class ContactGroup(TembaModel, DependencyMixin):
             name="Active",
             group_type=ContactGroup.TYPE_DB_ACTIVE,
             is_system=True,
+            status=cls.STATUS_READY,
             created_by=org.created_by,
             modified_by=org.modified_by,
         )
@@ -1536,6 +1537,7 @@ class ContactGroup(TembaModel, DependencyMixin):
             name="Blocked",
             group_type=ContactGroup.TYPE_DB_BLOCKED,
             is_system=True,
+            status=cls.STATUS_READY,
             created_by=org.created_by,
             modified_by=org.modified_by,
         )
@@ -1543,6 +1545,7 @@ class ContactGroup(TembaModel, DependencyMixin):
             name="Stopped",
             group_type=ContactGroup.TYPE_DB_STOPPED,
             is_system=True,
+            status=cls.STATUS_READY,
             created_by=org.created_by,
             modified_by=org.modified_by,
         )
@@ -1550,17 +1553,20 @@ class ContactGroup(TembaModel, DependencyMixin):
             name="Archived",
             group_type=ContactGroup.TYPE_DB_ARCHIVED,
             is_system=True,
+            status=cls.STATUS_READY,
             created_by=org.created_by,
             modified_by=org.modified_by,
         )
-        # org.groups.create(
-        #    name="Open Tickets",
-        #    group_type=ContactGroup.TYPE_SMART,
-        #    is_system=True,
-        #    query="tickets > 0",
-        #    created_by=org.created_by,
-        #    modified_by=org.modified_by,
-        # )
+        if settings.TESTING:  # TODO enable for production
+            org.groups.create(
+                name="Open Tickets",
+                group_type=ContactGroup.TYPE_SMART,
+                is_system=True,
+                query="tickets > 0",
+                status=cls.STATUS_READY,  # since this group will always be empty for new orgs
+                created_by=org.created_by,
+                modified_by=org.modified_by,
+            )
 
     @classmethod
     def get_groups(cls, org: Org, *, manual_only=False, user_only=False, ready_only=False):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1553,6 +1553,14 @@ class ContactGroup(TembaModel, DependencyMixin):
             created_by=org.created_by,
             modified_by=org.modified_by,
         )
+        # org.groups.create(
+        #    name="Open Tickets",
+        #    group_type=ContactGroup.TYPE_SMART,
+        #    is_system=True,
+        #    query="tickets > 0",
+        #    created_by=org.created_by,
+        #    modified_by=org.modified_by,
+        # )
 
     @classmethod
     def get_groups(cls, org: Org, *, manual_only=False, user_only=False, ready_only=False):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -340,25 +340,19 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
         context = super().get_context_data(**kwargs)
 
         org = self.request.user.get_org()
-        counts = Contact.get_status_counts(org)
-
-        folders = [
-            dict(count=counts[Contact.STATUS_ACTIVE], label=_("Active"), url=reverse("contacts.contact_list")),
-            dict(count=counts[Contact.STATUS_BLOCKED], label=_("Blocked"), url=reverse("contacts.contact_blocked")),
-            dict(count=counts[Contact.STATUS_STOPPED], label=_("Stopped"), url=reverse("contacts.contact_stopped")),
-            dict(count=counts[Contact.STATUS_ARCHIVED], label=_("Archived"), url=reverse("contacts.contact_archived")),
-        ]
 
         # resolve the paginated object list so we can initialize a cache of URNs
         contacts = context["object_list"]
         Contact.bulk_urn_cache_initialize(contacts)
 
+        system_groups, smart_groups, manual_groups = self.get_groups(org)
+
         context["contacts"] = contacts
-        context["groups"] = self.get_groups(org)
-        context["folders"] = folders
+        context["system_groups"] = system_groups
+        context["smart_groups"] = smart_groups
+        context["manual_groups"] = manual_groups
         context["has_contacts"] = contacts or org.get_contact_count() > 0
         context["search_error"] = self.search_error
-        context["folder_count"] = counts[self.system_group] if self.system_group else None
 
         context["sort_direction"] = self.sort_direction
         context["sort_field"] = self.sort_field
@@ -370,25 +364,42 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
 
         return context
 
-    def get_groups(self, org):
-        groups = ContactGroup.get_groups(org).select_related("org").order_by("-is_system", Upper("name"))
+    def get_groups(self, org) -> tuple:
+        # get all groups including status groups which one day will be regular smart+system groups
+        groups = org.groups.filter(is_active=True).select_related("org").order_by(Upper("name"))
         group_counts = ContactGroupCount.get_totals(groups)
 
-        rendered = []
-        for g in groups:
-            rendered.append(
-                {
-                    "pk": g.id,
-                    "uuid": g.uuid,
-                    "label": g.name,
-                    "count": group_counts[g],
-                    "is_smart": g.is_smart,
-                    "is_system": g.is_system,
-                    "is_ready": g.status == ContactGroup.STATUS_READY,
-                }
-            )
+        system, smart, manual = [], [], []
 
-        return rendered
+        for group in groups:
+            obj = {
+                "id": group.id,
+                "name": group.name,
+                "count": group_counts[group],
+                "url": reverse("contacts.contact_filter", args=[group.uuid]),
+            }
+
+            if group.group_type == ContactGroup.TYPE_DB_ACTIVE:
+                obj.update({"name": _("Active"), "url": reverse("contacts.contact_list")})
+                system.append(obj)
+            elif group.group_type == ContactGroup.TYPE_DB_BLOCKED:
+                obj.update({"name": _("Blocked"), "url": reverse("contacts.contact_blocked")})
+                system.append(obj)
+            elif group.group_type == ContactGroup.TYPE_DB_STOPPED:
+                obj.update({"name": _("Stopped"), "url": reverse("contacts.contact_stopped")})
+                system.append(obj)
+            elif group.group_type == ContactGroup.TYPE_DB_ARCHIVED:
+                obj.update({"name": _("Archived"), "url": reverse("contacts.contact_archived")})
+                system.append(obj)
+            elif group.is_system:
+                system.append(obj)
+            elif group.group_type == ContactGroup.TYPE_SMART:
+                smart.append(obj)
+            else:
+                manual.append(obj)
+
+        # return system groups in the order we create them
+        return sorted(system, key=lambda g: g["id"]), smart, manual
 
 
 class ContactForm(forms.ModelForm):

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -3753,15 +3753,15 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(topup.price, 0)
 
         # check default org content was created correctly
-        system_fields = list(org.contactfields(manager="system_fields").order_by("key").values_list("key", flat=True))
-        system_groups = list(org.groups.filter(is_system=True).order_by("name").values_list("name", flat=True))
-        sample_flows = list(org.flows.order_by("name").values_list("name", flat=True))
+        system_fields = set(org.contactfields(manager="system_fields").values_list("key", flat=True))
+        system_groups = set(org.groups.filter(is_system=True).values_list("name", flat=True))
+        sample_flows = set(org.flows.values_list("name", flat=True))
         internal_ticketer = org.ticketers.get()
 
-        self.assertEqual(["created_on", "id", "language", "last_seen_on", "name"], system_fields)
-        self.assertEqual(["Active", "Archived", "Blocked", "Stopped"], system_groups)
+        self.assertEqual({"created_on", "id", "language", "last_seen_on", "name"}, system_fields)
+        self.assertEqual({"Active", "Archived", "Blocked", "Stopped", "Open Tickets"}, system_groups)
         self.assertEqual(
-            ["Sample Flow - Order Status Checker", "Sample Flow - Satisfaction Survey", "Sample Flow - Simple Poll"],
+            {"Sample Flow - Order Status Checker", "Sample Flow - Satisfaction Survey", "Sample Flow - Simple Poll"},
             sample_flows,
         )
         self.assertEqual("RapidPro Tickets", internal_ticketer.name)

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -483,6 +483,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
     def test_create_keyword(self):
         create_url = reverse("triggers.trigger_create_keyword")
+        open_tickets = self.org.groups.get(name="Open Tickets")
         flow1 = self.create_flow("Flow 1", flow_type=Flow.TYPE_MESSAGE)
         flow2 = self.create_flow("Flow 2", flow_type=Flow.TYPE_VOICE)
 
@@ -504,8 +505,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual([flow1, flow2], list(response.context["form"].fields["flow"].queryset))
 
         # group options are any group
-        self.assertEqual([group1, group2], list(response.context["form"].fields["groups"].queryset))
-        self.assertEqual([group1, group2], list(response.context["form"].fields["exclude_groups"].queryset))
+        self.assertEqual([group1, group2, open_tickets], list(response.context["form"].fields["groups"].queryset))
+        self.assertEqual(
+            [group1, group2, open_tickets], list(response.context["form"].fields["exclude_groups"].queryset)
+        )
 
         # try a keyword with spaces
         self.assertCreateSubmit(
@@ -982,6 +985,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
     def test_create_catchall(self):
         create_url = reverse("triggers.trigger_create_catchall")
+        open_tickets = self.org.groups.get(name="Open Tickets")
         flow1 = self.create_flow("Flow 1", flow_type=Flow.TYPE_MESSAGE)
         flow2 = self.create_flow("Flow 2", flow_type=Flow.TYPE_VOICE)
 
@@ -1003,7 +1007,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual([flow1, flow2], list(response.context["form"].fields["flow"].queryset))
 
         # group options are any group
-        self.assertEqual([group1, group2], list(response.context["form"].fields["groups"].queryset))
+        self.assertEqual([group1, group2, open_tickets], list(response.context["form"].fields["groups"].queryset))
 
         # create a trigger with no groups
         self.assertCreateSubmit(

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -2,6 +2,7 @@ from smartmin.views import SmartCreateView, SmartCRUDL, SmartListView, SmartTemp
 
 from django import forms
 from django.db.models import Min
+from django.db.models.functions import Upper
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _, ngettext_lazy
@@ -70,7 +71,7 @@ class BaseTriggerForm(forms.ModelForm):
 
         self.fields["flow"].queryset = flows.order_by("name")
 
-        groups = ContactGroup.get_groups(self.org)
+        groups = ContactGroup.get_groups(self.org).order_by(Upper("name"))
 
         self.fields["groups"].queryset = groups
         self.fields["exclude_groups"].queryset = groups
@@ -168,8 +169,8 @@ class RegisterTriggerForm(BaseTriggerForm):
         # on this form flow becomes the flow to be triggered from the generated flow and is optional
         self.fields["flow"].required = False
 
-        self.fields["action_join_group"].queryset = (
-            ContactGroup.get_groups(self.org, manual_only=True).filter().order_by("name")
+        self.fields["action_join_group"].queryset = ContactGroup.get_groups(self.org, manual_only=True).order_by(
+            Upper("name")
         )
         self.fields["action_join_group"].user = user
 

--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -111,7 +111,9 @@
                 -if group.is_smart
                   .lp-nav-item(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}' class="{% if current_group.id == group.pk %}font-normal selected{% endif %}")
                     .name.pointer-events-none
-                      {{group.label}}
+                      {{ group.label }}
+                      -if group.is_system
+                        .glyph.icon-two-factor.text-xs.opacity-50
                     .count.pointer-events-none
                       {{ group.count | intcomma }}
 
@@ -123,7 +125,9 @@
                 -if not group.is_smart
                   .lp-nav-item(class="{% if current_group.id == group.pk %}font-normal selected{% endif %}")
                     .name(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}')
-                      {{group.label}}
+                      {{ group.label }}
+                      -if group.is_system
+                        .glyph.icon-two-factor.text-xs.opacity-50
                     .count(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}')
                       {{ group.count | intcomma }}
 

--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -85,12 +85,12 @@
               -trans "Import Contacts"
 
           .lp-nav.upper
-            -for folder in folders
-              .lp-nav-item(class="{% if request.path == folder.url %}font-normal selected{% endif %}")
-                .name(onclick="goto(event)" href='{{folder.url}}')
-                  {{folder.label}}
-                .count(onclick="goto(event)" href='{{folder.url}}')
-                  {{ folder.count | intcomma }}
+            -for group in system_groups
+              .lp-nav-item(onclick="goto(event)" href='{{ group.url }}' class="{% if request.path == group.url %}font-normal selected{% endif %}")
+                .name.pointer-events-none
+                  {{ group.name }}
+                .count.pointer-events-none
+                  {{ group.count | intcomma }}
           
           .secondary-buttons.mb-6
             -if org_perms.contacts.contact_create
@@ -107,29 +107,23 @@
             .font-normal.uppercase.text-xs.pb-1.text-gray-500
               -trans "Smart Groups"
             .inner-scroll
-              -for group in groups
-                -if group.is_smart
-                  .lp-nav-item(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}' class="{% if current_group.id == group.pk %}font-normal selected{% endif %}")
-                    .name.pointer-events-none
-                      {{ group.label }}
-                      -if group.is_system
-                        .glyph.icon-two-factor.text-xs.opacity-25
-                    .count.pointer-events-none
-                      {{ group.count | intcomma }}
+              -for group in smart_groups
+                .lp-nav-item(onclick="goto(event)" href='{{ group.url }}' class="{% if request.path == group.url %}font-normal selected{% endif %}")
+                  .name.pointer-events-none
+                    {{ group.name }}
+                  .count.pointer-events-none
+                    {{ group.count | intcomma }}
 
           .lp-nav.lower
             .font-normal.uppercase.text-xs.text-gray-500.pb-1
               -trans "Groups"
             .inner-scroll
-              -for group in groups
-                -if not group.is_smart
-                  .lp-nav-item(class="{% if current_group.id == group.pk %}font-normal selected{% endif %}")
-                    .name(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}')
-                      {{ group.label }}
-                      -if group.is_system
-                        .glyph.icon-two-factor.text-xs.opacity-25
-                    .count(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}')
-                      {{ group.count | intcomma }}
+              -for group in manual_groups
+                .lp-nav-item(onclick="goto(event)" href='{{ group.url }}' class="{% if request.path == group.url %}font-normal selected{% endif %}")
+                  .name.pointer-events-none
+                    {{ group.name }}
+                  .count.pointer-events-none
+                    {{ group.count | intcomma }}
 
           .flex-grow
         .right.overflow-x-hidden.p-2.-mt-1

--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -113,7 +113,7 @@
                     .name.pointer-events-none
                       {{ group.label }}
                       -if group.is_system
-                        .glyph.icon-two-factor.text-xs.opacity-50
+                        .glyph.icon-two-factor.text-xs.opacity-25
                     .count.pointer-events-none
                       {{ group.count | intcomma }}
 
@@ -127,7 +127,7 @@
                     .name(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}')
                       {{ group.label }}
                       -if group.is_system
-                        .glyph.icon-two-factor.text-xs.opacity-50
+                        .glyph.icon-two-factor.text-xs.opacity-25
                     .count(onclick="goto(event)" href='{% url "contacts.contact_filter" group.uuid %}')
                       {{ group.count | intcomma }}
 


### PR DESCRIPTION
Note that this PR is not adding any such groups, except an _Open Tickets_ group in testing - just getting the UI and API ready for them.

They appear at the top of the list with a padlock icon..

<img width="279" alt="Captura de Pantalla 2022-03-30 a la(s) 12 03 23" src="https://user-images.githubusercontent.com/675558/160891471-1ad278c6-8e0b-48fb-ad34-78cf12952a04.png">

and no menu items to delete them...

<img width="281" alt="Captura de Pantalla 2022-03-30 a la(s) 12 04 15" src="https://user-images.githubusercontent.com/675558/160891573-f43cfb6e-7904-423e-8ed4-9ebdbffaaf61.png">
<img width="268" alt="Captura de Pantalla 2022-03-30 a la(s) 12 04 06" src="https://user-images.githubusercontent.com/675558/160891581-48392c4c-883c-456d-a05a-8dde51c15264.png">

