### PR TITLE
Fix modals on spa pages

### DIFF
--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -568,7 +568,7 @@
     $('.contact-field-value.editable').live('click', function(evt) {
       var endpoint = '{% url "contacts.contact_update_fields" object.pk %}';
       var field_id = $(this).parent().data('id');
-      var modax = document.querySelector("#update-custom-fields");
+      var modax = document.querySelector("#update-custom-fields, #shared-modax");
       modax.endpoint = endpoint + '?field=' + field_id;
       modax.open = true;
 

--- a/templates/contacts/contact_update.haml
+++ b/templates/contacts/contact_update.haml
@@ -44,11 +44,9 @@
     });
 
     function createMoveLinks() {
-      var body = document.querySelector("#edit-contact, #gear-modax").shadowRoot.querySelector(".modax-body");
-
+      var body = document.querySelector("#edit-contact, #gear-modax, #shared-modax").shadowRoot.querySelector(".modax-body");
       $(body).find('.order-helper').remove();
 
-      // :not(:first)
       var idx = 0;
       var first = true;
       $(body).find(".control-group temba-textinput[id^=id_urn__]").each(function() {
@@ -65,22 +63,18 @@
           $(this).parents('.control-group').prepend(link);
         }
 
-
         idx++;
         first = false;
-
-
       });
     }
 
     function moveUp(link) {
-      var body = document.querySelector("#edit-contact, #gear-modax").shadowRoot.querySelector(".modax-body");
+      var body = document.querySelector("#edit-contact, #gear-modax, #shared-modax").shadowRoot.querySelector(".modax-body");
       var group = $(body).find('#' + link).parents('.control-group');
       var previous = group.prev();
       previous.before(group);
       createMoveLinks();
     }
-
 
 
 -block fields

--- a/templates/contacts/contact_update_fields.haml
+++ b/templates/contacts/contact_update_fields.haml
@@ -19,7 +19,7 @@
   {{block.super}}
   :javascript
     var input_url = '/contact/update_fields_input/{{contact.id}}/?field=';
-    var body = document.querySelector("#update-custom-fields, #gear-modax").shadowRoot.querySelector(".modax-body");
+    var body = document.querySelector("#update-custom-fields, #gear-modax, #shared-modax").shadowRoot.querySelector(".modax-body");
     var fieldSelect = body.querySelector("temba-select[name='contact_field']");
     fieldSelect.addEventListener('change', function(event) {
       var selectedField = event.target.values[0].value;

--- a/templates/contacts/contact_update_fields_input.haml
+++ b/templates/contacts/contact_update_fields_input.haml
@@ -16,7 +16,7 @@
 
 :javascript
 
-  var modaxBody = document.querySelector("#update-custom-fields, #gear-modax").shadowRoot.querySelector(".modax-body");
+  var modaxBody = document.querySelector("#update-custom-fields, #gear-modax, #shared-modax").shadowRoot.querySelector(".modax-body");
   
   // aggressively grab focus when we load
   var ele = $(modaxBody).find('temba-textinput[name="field_value"]');

--- a/templates/flows/flow_broadcast.haml
+++ b/templates/flows/flow_broadcast.haml
@@ -195,7 +195,7 @@
       return operands.join(" OR ");
     }
 
-    var modax = document.querySelector("#start-flow");
+    var modax = document.querySelector("#start-flow, #shared-modax");
     var modalBody = modax.shadowRoot;
     var queryField = modalBody.querySelector('.query');
     var queryWidget = queryField.querySelector("temba-contact-search");

--- a/templates/spa_frame.haml
+++ b/templates/spa_frame.haml
@@ -25,7 +25,7 @@
 
     html {
       --color-text-dark: #555;
-      --temba-textinput-font-size: 1.125rem;
+      --temba-textinput-font-size: 1;
       --temba-textinput-padding: 0.6em .8em;
       --widget-box-shadow: rgba(0, 0, 0, 0.05) 0px 3px 7px 0px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
       --widget-box-shadow-focused: 0 0 0 3px rgba(164, 202, 254, .45), rgba(0, 0, 0, 0.05) 0px 3px 7px 0px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
@@ -486,7 +486,9 @@
 
       var a = target.closest("a");
       if (!a) {
-        a = evt.path.find(function(ele){ return  ele.tagName == "A" });
+        if (evt.path) {
+          a = evt.path.find(function(ele){ return  ele.tagName == "A" });
+        }
       }
 
       if (a && a.href) {


### PR DESCRIPTION
Add the id for the shared modal used on the spa pages on query selectors. Shrink temba-component text input size to match descaled ui.