### PR TITLE
Require passing a name to `TembaTest.create_flow`

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2536,7 +2536,7 @@ class APITest(TembaTest):
         # add our date field to a campaign event
         campaign = Campaign.create(self.org, self.admin, "Reminders", self.create_group("Farmers"))
         CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, registered, offset=1, unit="W", flow=self.create_flow()
+            self.org, self.admin, campaign, registered, offset=1, unit="W", flow=self.create_flow("Flow")
         )
 
         deleted = self.create_field("deleted", "Deleted")

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -193,7 +193,7 @@ class APITest(TembaTest):
 
         group = self.create_group("Customers")
         field_obj = self.create_field("registered", "Registered On", value_type=ContactField.TYPE_DATETIME)
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         campaign = Campaign.create(self.org, self.admin, "Reminders #1", group)
         event = CampaignEvent.create_flow_event(
             self.org, self.admin, campaign, field_obj, 6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12
@@ -548,7 +548,7 @@ class APITest(TembaTest):
         self.login(self.admin)
 
         # create 1255 test runs (5 full pages of 250 items + 1 partial with 5 items)
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         FlowRun.objects.bulk_create([FlowRun(org=self.org, flow=flow, contact=self.joe) for r in range(1255)])
         actual_ids = list(FlowRun.objects.order_by("-pk").values_list("pk", flat=True))
 
@@ -668,7 +668,7 @@ class APITest(TembaTest):
         """
         mock_flowstart_create.side_effect = ValueError("DOH!")
 
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         self.login(self.admin)
         try:
             self.postJSON(reverse("api.v2.flow_starts"), None, dict(flow=flow.uuid, urns=["tel:+12067791212"]))
@@ -1100,7 +1100,7 @@ class APITest(TembaTest):
 
         self.assertEndpointAccess(url)
 
-        flow = self.create_flow()
+        flow = self.create_flow("Test Flow")
         reporters = self.create_group("Reporters", [self.joe, self.frank])
         registration = self.create_field("registration", "Registration", value_type=ContactField.TYPE_DATETIME)
         field_created_on = self.org.fields.get(key="created_on")
@@ -2635,7 +2635,7 @@ class APITest(TembaTest):
         run.save(update_fields=("status", "exited_on", "modified_on"))
 
         # flow belong to other org
-        self.create_flow(org=self.org2, name="Other")
+        self.create_flow("Other", org=self.org2)
 
         # no filtering
         with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 5):
@@ -3561,7 +3561,7 @@ class APITest(TembaTest):
         joe_run3 = MockSessionWriter(self.joe, flow2).wait().save().session.runs.get()
 
         # add a run for another org
-        flow3 = self.create_flow(org=self.org2)
+        flow3 = self.create_flow("Test", org=self.org2)
         MockSessionWriter(self.hans, flow3).wait().save()
 
         # refresh runs which will have been modified by being interrupted

--- a/temba/assets/tests.py
+++ b/temba/assets/tests.py
@@ -60,7 +60,7 @@ class AssetTest(TembaTest):
         self.assertContains(response, "Your download should start automatically", status_code=200)
 
         # create flow results export and check that we can access it
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         results_export_task = ExportFlowResultsTask.objects.create(
             org=self.org, created_by=self.admin, modified_by=self.admin
         )

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -41,10 +41,8 @@ class CampaignTest(TembaTest):
 
     @mock_mailroom
     def test_model(self, mr_mocks):
-
         campaign = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
-
-        flow = self.create_flow()
+        flow = self.create_flow("Test Flow")
 
         event1 = CampaignEvent.create_flow_event(
             self.org, self.admin, campaign, self.planting_date, offset=1, unit="W", flow=flow, delivery_hour=13
@@ -101,7 +99,7 @@ class CampaignTest(TembaTest):
 
     def test_get_offset_display(self):
         campaign = Campaign.create(self.org, self.admin, Campaign.get_unique_name(self.org, "Reminders"), self.farmers)
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         event = CampaignEvent.create_flow_event(
             self.org, self.admin, campaign, self.planting_date, offset=0, unit="W", flow=flow
         )
@@ -155,7 +153,7 @@ class CampaignTest(TembaTest):
         # create a campaign
         campaign = Campaign.create(self.org, self.user, "Planting Reminders", self.farmers)
 
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
 
         event1 = CampaignEvent.create_flow_event(
             self.org, self.admin, campaign, self.planting_date, offset=1, unit="W", flow=flow, delivery_hour="13"
@@ -972,7 +970,7 @@ class CampaignTest(TembaTest):
         # create a campaign
         campaign = Campaign.create(self.org, self.user, "Planting Reminders", self.farmers)
 
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
 
         CampaignEvent.create_flow_event(
             self.org, self.admin, campaign, self.planting_date, offset=1, unit="W", flow=flow, delivery_hour="13"
@@ -1246,7 +1244,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
     def create_campaign(self, org, name, group):
         user = org.get_admins().first()
         registered = org.fields.get(key="registered")
-        flow = self.create_flow(org=org)
+        flow = self.create_flow(f"{name} Flow", org=org)
         campaign = Campaign.create(org, user, name, group)
         CampaignEvent.create_flow_event(
             org, user, campaign, registered, offset=1, unit="W", flow=flow, delivery_hour="13"
@@ -1401,15 +1399,15 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.create_field("registered", "Registered", value_type="D")
 
-        self.campaign1 = self.create_campaign(self.org)
-        self.other_org_campaign = self.create_campaign(self.org2)
+        self.campaign1 = self.create_campaign(self.org, "Welcomes")
+        self.other_org_campaign = self.create_campaign(self.org2, "Welcomes")
 
-    def create_campaign(self, org):
+    def create_campaign(self, org, name):
         user = org.get_admins().first()
         group = self.create_group("Reporters", contacts=[], org=org)
         registered = self.org.fields.get(key="registered")
-        flow = self.create_flow(org=org)
-        campaign = Campaign.create(org, user, "Welcomes", group)
+        campaign = Campaign.create(org, user, name, group)
+        flow = self.create_flow(f"{name} Flow", org=org)
         CampaignEvent.create_flow_event(
             org, user, campaign, registered, offset=1, unit="W", flow=flow, delivery_hour="13"
         )

--- a/temba/channels/types/facebook/tests.py
+++ b/temba/channels/types/facebook/tests.py
@@ -67,7 +67,7 @@ class FacebookTypeTest(TembaTest):
         )
 
     def test_new_conversation_triggers(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
 
         with patch("requests.post") as mock_post:
             mock_post.return_value = MockResponse(200, json.dumps({"success": True}))

--- a/temba/channels/types/facebookapp/tests.py
+++ b/temba/channels/types/facebookapp/tests.py
@@ -187,7 +187,7 @@ class FacebookTypeTest(TembaTest):
         )
 
     def test_new_conversation_triggers(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
 
         with patch("requests.post") as mock_post:
             mock_post.return_value = MockResponse(200, json.dumps({"success": True}))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -4735,7 +4735,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         registered = self.create_field("registered", "Registered", value_type="D")
         campaign = Campaign.create(self.org, self.admin, "Reminders", self.create_group("Farmers"))
         CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, registered, offset=1, unit="W", flow=self.create_flow()
+            self.org, self.admin, campaign, registered, offset=1, unit="W", flow=self.create_flow("Test")
         )
 
         update_url = reverse("contacts.contactfield_update", args=[registered.id])

--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -527,7 +527,7 @@ class FlowMigrationTest(TembaTest):
         }
 
         flow1 = Flow.objects.create(
-            name="base lang test",
+            name="base lang test 1",
             org=self.org,
             created_by=self.admin,
             modified_by=self.admin,
@@ -535,7 +535,7 @@ class FlowMigrationTest(TembaTest):
             version_number=1,
         )
         flow2 = Flow.objects.create(
-            name="Base lang test",
+            name="base lang test 2",
             org=self.org,
             created_by=self.admin,
             modified_by=self.admin,
@@ -802,8 +802,8 @@ class FlowMigrationTest(TembaTest):
 
         # our group and flow to move to uuids
         group = self.create_group("Phans", [])
-        previous_flow = self.create_flow()
-        start_flow = self.create_flow()
+        previous_flow = self.create_flow("Flow 1")
+        start_flow = self.create_flow("Flow 2")
         label = Label.get_or_create(self.org, self.admin, "My label")
 
         substitutions = dict(
@@ -896,7 +896,7 @@ class FlowMigrationTest(TembaTest):
         del flow_json["metadata"]
         flow_json = migrate_to_version_9(flow_json, start_flow)
         self.assertEqual(1, flow_json["metadata"]["revision"])
-        self.assertEqual("Test Flow", flow_json["metadata"]["name"])
+        self.assertEqual("Flow 2", flow_json["metadata"]["name"])
         self.assertEqual(10080, flow_json["metadata"]["expires"])
         self.assertIn("uuid", flow_json["metadata"])
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -375,7 +375,7 @@ class FlowTest(TembaTest):
         self.assertNotContains(response, reverse("flows.flow_simulate", args=[flow.id]))
 
     def test_editor_feature_filters(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
 
         self.login(self.admin)
 
@@ -1561,7 +1561,7 @@ class FlowTest(TembaTest):
 
     @mock_mailroom
     def test_preview_start(self, mr_mocks):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         contact1 = self.create_contact("Ann", phone="+1234567111")
         contact2 = self.create_contact("Bob", phone="+1234567222")
         doctors = self.create_group("Doctors", contacts=[contact1, contact2])
@@ -1752,8 +1752,8 @@ class FlowTest(TembaTest):
         self.assertEqual(0, parent.group_dependencies.all().count())
 
     def test_update_expiration_task(self):
-        flow1 = self.create_flow()
-        flow2 = self.create_flow()
+        flow1 = self.create_flow("Test 1")
+        flow2 = self.create_flow("Test 2")
 
         # create waiting session and run for flow 1
         session1 = FlowSession.objects.create(
@@ -2549,7 +2549,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
     @mock_mailroom
     def test_preview_start(self, mr_mocks):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         self.create_field("age", "Age")
         contact1 = self.create_contact("Ann", phone="+16302222222", fields={"age": 40})
         contact2 = self.create_contact("Bob", phone="+16303333333", fields={"age": 33})
@@ -2616,8 +2616,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
     @mock_mailroom
     def test_broadcast(self, mr_mocks):
         contact = self.create_contact("Bob", phone="+593979099111")
-        flow = self.create_flow()
-        ivr_flow = self.create_flow(flow_type=Flow.TYPE_VOICE)
+        flow = self.create_flow("Test")
+        ivr_flow = self.create_flow("IVR Test", flow_type=Flow.TYPE_VOICE)
 
         broadcast_url = reverse("flows.flow_broadcast", args=[flow.id])
 
@@ -2735,7 +2735,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
     @mock_mailroom
     def test_broadcast_background_flow(self, mr_mocks):
-        flow = self.create_flow(flow_type=Flow.TYPE_BACKGROUND)
+        flow = self.create_flow("Background", flow_type=Flow.TYPE_BACKGROUND)
 
         broadcast_url = reverse("flows.flow_broadcast", args=[flow.id])
 
@@ -2763,8 +2763,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
     @patch("temba.flows.views.uuid4")
     def test_upload_media_action(self, mock_uuid):
-        flow = self.create_flow()
-        other_org_flow = self.create_flow(org=self.org2)
+        flow = self.create_flow("Test")
+        other_org_flow = self.create_flow("Test", org=self.org2)
 
         action_url = reverse("flows.flow_upload_media_action", args=[flow.uuid])
 
@@ -2818,7 +2818,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRedirect(response, reverse("flows.flow_editor", args=[flow_copy.uuid]))
 
     def test_recent_contacts(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         contact1 = self.create_contact("Bob", phone="0979111111")
         contact2 = self.create_contact("", phone="0979222222")
         node1_exit1_uuid = "805f5073-ce96-4b6a-ab9f-e77dd412f83b"
@@ -3605,7 +3605,7 @@ class FlowRunTest(TembaTest):
             uuid=uuid4(),
             org=self.org,
             session=session,
-            flow=self.create_flow(),
+            flow=self.create_flow("Test"),
             contact=self.contact,
             status=FlowRun.STATUS_WAITING,
             created_on=timezone.now(),
@@ -5279,7 +5279,7 @@ class FlowStartCRUDLTest(TembaTest, CRUDLTestMixin):
         FlowStartCount.objects.create(start=start3, count=1000)
         FlowStartCount.objects.create(start=start3, count=234)
 
-        other_org_flow = self.create_flow(org=self.org2)
+        other_org_flow = self.create_flow("Test", org=self.org2)
         FlowStart.create(other_org_flow, self.admin2)
 
         response = self.assertListFetch(

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1211,7 +1211,7 @@ class OrgTest(TembaTest):
         self.login(self.admin)
 
         mark = self.create_contact("Mark", phone="+12065551212")
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
 
         def send_broadcast_via_api():
             url = reverse("api.v2.broadcasts")
@@ -4713,8 +4713,8 @@ class BulkExportTest(TembaTest):
         self.assertEqual(set(cat_blasts.query_fields.all()), {facts_per_day})
 
     def test_import_flow_with_triggers(self):
-        flow1 = self.create_flow()
-        flow2 = self.create_flow()
+        flow1 = self.create_flow("Test 1")
+        flow2 = self.create_flow("Test 2")
 
         trigger1 = Trigger.create(
             self.org, self.admin, Trigger.TYPE_KEYWORD, flow1, keyword="rating", is_archived=True

--- a/temba/request_logs/tests.py
+++ b/temba/request_logs/tests.py
@@ -50,7 +50,7 @@ class HTTPLogTest(TembaTest):
 
 class HTTPLogCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_webhooks(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         l1 = HTTPLog.objects.create(
             org=self.org,
             log_type="webhook_called",

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -448,7 +448,7 @@ class TembaTestMixin:
 
         return bcast
 
-    def create_flow(self, name="Test Flow", *, flow_type=Flow.TYPE_MESSAGE, nodes=None, is_system=False, org=None):
+    def create_flow(self, name: str, *, flow_type=Flow.TYPE_MESSAGE, nodes=None, is_system=False, org=None):
         org = org or self.org
         flow = Flow.create(org, self.admin, name, flow_type=flow_type, is_system=is_system)
         if not nodes:

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -507,7 +507,7 @@ class TicketerTest(TembaTest):
         ticketer.save()
 
         # add a dependency and try again
-        flow = self.create_flow()
+        flow = self.create_flow("Deps")
         flow.ticketer_dependencies.add(ticketer)
 
         self.assertFalse(flow.has_issues)

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -19,7 +19,7 @@ from .types import KeywordTriggerType
 
 class TriggerTest(TembaTest):
     def test_model(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test Flow")
         keyword = Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow, keyword="join")
         catchall = Trigger.create(self.org, self.admin, Trigger.TYPE_CATCH_ALL, flow)
 
@@ -30,7 +30,7 @@ class TriggerTest(TembaTest):
         self.assertEqual('Trigger[type=C, flow="Test Flow"]', str(catchall))
 
     def test_archive_conflicts(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         group1 = self.create_group("Group 1", contacts=[])
         group2 = self.create_group("Group 1", contacts=[])
         channel1 = self.create_channel("FB", "FB Channel 1", "12345")
@@ -147,7 +147,7 @@ class TriggerTest(TembaTest):
     def test_export_import(self):
         # tweak our current channel to be twitter so we can create a channel-based trigger
         Channel.objects.filter(id=self.channel.id).update(channel_type="TT")
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
 
         doctors = self.create_group("Doctors", contacts=[])
         farmers = self.create_group("Farmers", contacts=[])
@@ -235,7 +235,7 @@ class TriggerTest(TembaTest):
         self.assertEqual(3, Trigger.objects.count())  # no new triggers imported
 
     def test_import_invalid(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         flow_ref = {"uuid": str(flow.uuid), "name": "Test Flow"}
 
         # invalid type
@@ -280,7 +280,7 @@ class TriggerTest(TembaTest):
         self.assertIsNone(trigger.keyword)
 
     def test_export_import_keyword(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         doctors = self.create_group("Doctors", contacts=[])
         farmers = self.create_group("Farmers", contacts=[])
         testers = self.create_group("Testers", contacts=[])
@@ -298,7 +298,7 @@ class TriggerTest(TembaTest):
             trigger,
             {
                 "trigger_type": "K",
-                "flow": {"uuid": str(flow.uuid), "name": "Test Flow"},
+                "flow": {"uuid": str(flow.uuid), "name": "Test"},
                 "groups": [
                     {"uuid": str(doctors.uuid), "name": "Doctors"},
                     {"uuid": str(farmers.uuid), "name": "Farmers"},
@@ -309,14 +309,14 @@ class TriggerTest(TembaTest):
         )
 
     def test_export_import_inbound_call(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         trigger = Trigger.create(self.org, self.admin, Trigger.TYPE_INBOUND_CALL, flow)
 
         self.assert_export_import(
             trigger,
             {
                 "trigger_type": "V",
-                "flow": {"uuid": str(flow.uuid), "name": "Test Flow"},
+                "flow": {"uuid": str(flow.uuid), "name": "Test"},
                 "groups": [],
                 "exclude_groups": [],
                 "keyword": None,
@@ -324,14 +324,14 @@ class TriggerTest(TembaTest):
         )
 
     def test_export_import_missed_call(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         trigger = Trigger.create(self.org, self.admin, Trigger.TYPE_MISSED_CALL, flow)
 
         self.assert_export_import(
             trigger,
             {
                 "trigger_type": "M",
-                "flow": {"uuid": str(flow.uuid), "name": "Test Flow"},
+                "flow": {"uuid": str(flow.uuid), "name": "Test"},
                 "groups": [],
                 "exclude_groups": [],
                 "keyword": None,
@@ -340,7 +340,7 @@ class TriggerTest(TembaTest):
 
     @patch("temba.channels.types.facebook.FacebookType.activate_trigger")
     def test_export_import_new_conversation(self, mock_activate_trigger):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         channel = self.create_channel("FB", "Facebook", "1234")
         trigger = Trigger.create(self.org, self.admin, Trigger.TYPE_NEW_CONVERSATION, flow, channel=channel)
 
@@ -348,7 +348,7 @@ class TriggerTest(TembaTest):
             trigger,
             {
                 "trigger_type": "N",
-                "flow": {"uuid": str(flow.uuid), "name": "Test Flow"},
+                "flow": {"uuid": str(flow.uuid), "name": "Test"},
                 "groups": [],
                 "exclude_groups": [],
                 "keyword": None,
@@ -357,7 +357,7 @@ class TriggerTest(TembaTest):
         )
 
     def test_export_import_referral(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         channel = self.create_channel("FB", "Facebook", "1234")
         trigger = Trigger.create(self.org, self.admin, Trigger.TYPE_REFERRAL, flow, channel=channel)
 
@@ -365,7 +365,7 @@ class TriggerTest(TembaTest):
             trigger,
             {
                 "trigger_type": "R",
-                "flow": {"uuid": str(flow.uuid), "name": "Test Flow"},
+                "flow": {"uuid": str(flow.uuid), "name": "Test"},
                 "groups": [],
                 "exclude_groups": [],
                 "keyword": None,
@@ -392,7 +392,7 @@ class TriggerTest(TembaTest):
     @patch("temba.channels.types.facebook.FacebookType.deactivate_trigger")
     def test_release(self, mock_deactivate_trigger):
         channel = self.create_channel("FB", "Facebook", "234567")
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         group = self.create_group("Trigger Group", [])
         trigger = Trigger.objects.create(
             org=self.org,
@@ -493,8 +493,8 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         flow2 = self.create_flow("Flow 2", flow_type=Flow.TYPE_VOICE)
 
         # flows that shouldn't appear as options
-        self.create_flow(flow_type=Flow.TYPE_BACKGROUND)
-        self.create_flow(is_system=True)
+        self.create_flow("Background", flow_type=Flow.TYPE_BACKGROUND)
+        self.create_flow("System", is_system=True)
 
         group1 = self.create_group("Group 1", contacts=[])
         group2 = self.create_group("Group 2", contacts=[])
@@ -995,8 +995,8 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         flow2 = self.create_flow("Flow 2", flow_type=Flow.TYPE_VOICE)
 
         # flows that shouldn't appear as options
-        self.create_flow(flow_type=Flow.TYPE_BACKGROUND)
-        self.create_flow(is_system=True)
+        self.create_flow("Background", flow_type=Flow.TYPE_BACKGROUND)
+        self.create_flow("System", is_system=True)
 
         group1 = self.create_group("Group 1", contacts=[])
         group2 = self.create_group("Group 2", contacts=[])
@@ -1077,7 +1077,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
     def test_update_keyword(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         group1 = self.create_group("Chat", contacts=[])
         group2 = self.create_group("Testers", contacts=[])
         group3 = self.create_group("Doctors", contacts=[])
@@ -1122,7 +1122,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
     def test_update_schedule(self):
-        flow1 = self.create_flow()
+        flow1 = self.create_flow("Test")
         group1 = self.create_group("Chat", contacts=[])
         group2 = self.create_group("Testers", contacts=[])
         contact1 = self.create_contact("Jim", phone="+250788987651")
@@ -1225,6 +1225,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_list(self, mock_activate_trigger, mock_deactivate_trigger):
         flow1 = self.create_flow("Report")
         flow2 = self.create_flow("Survey")
+        flow3 = self.create_flow("Test", org=self.org2)
         channel = self.create_channel("FB", "Facebook", "1234567")
         trigger1 = Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow1, keyword="test")
         trigger2 = Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow2, keyword="abc")
@@ -1233,7 +1234,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow1, keyword="archived", is_archived=True)
         Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow1, keyword="inactive", is_active=False)
-        Trigger.create(self.org2, self.admin, Trigger.TYPE_KEYWORD, self.create_flow(org=self.org2), keyword="other")
+        Trigger.create(self.org2, self.admin, Trigger.TYPE_KEYWORD, flow3, keyword="other")
 
         list_url = reverse("triggers.trigger_list")
 
@@ -1278,14 +1279,16 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRedirect(response, reverse("triggers.trigger_create"))
 
     def test_archived(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
+        other_org_flow = self.create_flow("Test", org=self.org2)
+
         trigger1 = Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow, keyword="start", is_archived=True)
         trigger2 = Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow, keyword="join", is_archived=True)
 
         # triggers that shouldn't appear
         Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow, keyword="active", is_archived=False)
         Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow, keyword="inactive", is_active=False)
-        Trigger.create(self.org2, self.admin, Trigger.TYPE_KEYWORD, self.create_flow(org=self.org2), keyword="other")
+        Trigger.create(self.org2, self.admin, Trigger.TYPE_KEYWORD, other_org_flow, keyword="other")
 
         archived_url = reverse("triggers.trigger_archived")
 
@@ -1363,12 +1366,14 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_type_lists(self):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
+        flow3 = self.create_flow("Flow 3", org=self.org2)
+
         trigger1 = Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow1, keyword="test")
         trigger2 = Trigger.create(self.org, self.admin, Trigger.TYPE_KEYWORD, flow2, keyword="abc")
         trigger3 = Trigger.create(self.org, self.admin, Trigger.TYPE_REFERRAL, flow1, referrer_id="234")
         trigger4 = Trigger.create(self.org, self.admin, Trigger.TYPE_REFERRAL, flow2, referrer_id="456")
         trigger5 = Trigger.create(self.org, self.admin, Trigger.TYPE_CATCH_ALL, flow1)
-        Trigger.create(self.org2, self.admin, Trigger.TYPE_KEYWORD, self.create_flow(org=self.org2), keyword="other")
+        Trigger.create(self.org2, self.admin, Trigger.TYPE_KEYWORD, flow3, keyword="other")
 
         keyword_url = reverse("triggers.trigger_type", kwargs={"type": "keyword"})
         referral_url = reverse("triggers.trigger_type", kwargs={"type": "referral"})

--- a/temba/utils/templatetags/tests.py
+++ b/temba/utils/templatetags/tests.py
@@ -8,7 +8,7 @@ from .temba import object_class_name, object_url, verbose_name_plural
 
 class TembaTagLibraryTest(TembaTest):
     def test_verbose_name_plural(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         group = self.create_group("Testers", contacts=[])
 
         self.assertEqual("Flows", verbose_name_plural(flow))
@@ -17,7 +17,7 @@ class TembaTagLibraryTest(TembaTest):
         self.assertEqual("Campaign Events", verbose_name_plural(CampaignEvent()))
 
     def test_object_url(self):
-        flow = self.create_flow()
+        flow = self.create_flow("Test")
         group = self.create_group("Testers", contacts=[])
 
         self.assertEqual(f"/flow/editor/{flow.uuid}/", object_url(flow))

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -1268,8 +1268,8 @@ class IDSliceQuerySetTest(TembaTest):
         self.assertEqual(0, empty.total)
 
     def test_prefetch_related(self):
-        flow1 = self.create_flow()
-        flow2 = self.create_flow()
+        flow1 = self.create_flow("Test 1")
+        flow2 = self.create_flow("Test 2")
         with self.assertNumQueries(2):
             flows = list(IDSliceQuerySet(Flow, [flow1.id, flow2.id], offset=0, total=2).prefetch_related("org"))
             self.assertEqual(self.org, flows[0].org)


### PR DESCRIPTION
Need to avoid name collisions in tests as well