### PR TITLE
Add `Topic.get_or_create` to handle topics in flow imports

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -576,7 +576,7 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
         # ensure any topic dependencies exist
         for ref in deps_of_type("topic"):
-            topic = Topic.create(self.org, user, ref["name"])
+            topic = Topic.get_or_create(self.org, user, ref["name"])
             dependency_mapping[ref["uuid"]] = str(topic.uuid)
 
         # for dependencies we can't create, look for them by UUID (this is a clone in same workspace)

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -163,6 +163,14 @@ class Topic(TembaModel, DependencyMixin):
 
         return org.topics.create(name=name, created_by=user, modified_by=user)
 
+    @classmethod
+    def get_or_create(cls, org, user, name):
+        existing = org.topics.filter(name__iexact=name).first()
+        if existing:
+            return existing
+
+        return cls.create(org, user, name)
+
     class Meta:
         constraints = [models.UniqueConstraint("org", Lower("name"), name="unique_topic_names")]
 

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -608,6 +608,9 @@ class TopicTest(TembaTest):
         with self.assertRaises(AssertionError):
             Topic.create(self.org, self.admin, "Sales")
 
+        topic2 = Topic.get_or_create(self.org, self.admin, "Sales")
+        self.assertEqual(topic1, topic2)
+
 
 class TeamTest(TembaTest):
     def test_create(self):


### PR DESCRIPTION
I still want to overhaul imports and introduce more consistency across models but for now need this to fix imports of flows with ticketing.