### PR TITLE
Fix generating cloned flow names so they can't end with trailing spaces

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -401,7 +401,7 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
         """
         Returns a clone of this flow
         """
-        name = self.get_unique_name(self.org, f"Copy of {self.name}"[: self.MAX_NAME_LEN])
+        name = self.get_unique_name(self.org, f"Copy of {self.name}"[: self.MAX_NAME_LEN].strip())
         copy = Flow.create(
             self.org,
             user,

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -96,6 +96,7 @@ class FlowTest(TembaTest):
         self.assertEqual("Hello/n", Flow.clean_name("Hello\\n"))
         self.assertEqual("Say 'Hi'", Flow.clean_name('Say "Hi"'))
         self.assertEqual("x" * 64, Flow.clean_name("x" * 100))
+        self.assertEqual("a                                b", Flow.clean_name(f"a{' ' * 32}b{' ' * 32}c"))
 
     @patch("temba.mailroom.queue_interrupt")
     def test_archive(self, mock_queue_interrupt):
@@ -456,6 +457,11 @@ class FlowTest(TembaTest):
         self.assertEqual("Copy of 123456789012345678901234567890123456789012345678901234 2", copy2.name)
         copy3 = flow.clone(self.admin)
         self.assertEqual("Copy of 123456789012345678901234567890123456789012345678901234 3", copy3.name)
+
+        # ensure that truncating doesn't leave trailing spaces
+        flow2 = self.create_flow("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc efghijkl")
+        copy2 = flow2.clone(self.admin)
+        self.assertEqual("Copy of abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc", copy2.name)
 
     def test_copy_group_split_no_name(self):
         flow = self.get_flow("group_split_no_name")

--- a/temba/utils/models/base.py
+++ b/temba/utils/models/base.py
@@ -93,7 +93,7 @@ class TembaNameMixin(models.Model):
         """
         Cleans a name from an import to try to make it valid
         """
-        return original.strip()[: cls.MAX_NAME_LEN].replace('"', "'").replace("\\", "/").replace("\0", "")
+        return original.strip()[: cls.MAX_NAME_LEN].strip().replace('"', "'").replace("\\", "/").replace("\0", "")
 
     def _deleted_name(self) -> str:
         return f"deleted-{uuid4()}-{self.name}"[: self.MAX_NAME_LEN]


### PR DESCRIPTION
Fixes https://sentry.io/organizations/nyaruka/issues/3273003316/?referrer=alert_email&alert_type=email&alert_timestamp=1652521597059&alert_rule_id=34991&environment=production