### PR TITLE
Make test users more realistic

### DIFF
--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -661,9 +661,6 @@ class CampaignTest(TembaTest):
         self.assertEqual(response.status_code, 404)
 
     def test_view_campaign_read_with_customer_support(self):
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         campaign = Campaign.create(self.org, self.admin, "Perform the rain dance", self.farmers)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -110,9 +110,6 @@ class ChannelTest(TembaTest):
         raise Exception("Did not find '%s' cmd in response: '%s'" % (cmd_name, response.content))
 
     def test_channel_read_with_customer_support(self):
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         response = self.client.get(reverse("channels.channel_read", args=[self.tel_channel.uuid]))
@@ -2099,9 +2096,6 @@ class ChannelLogTest(TembaTest):
             # admin has no access
             self.assertLoginRedirect(response)
 
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         with AnonymousOrg(self.org):
@@ -2161,9 +2155,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=9)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         read_url = reverse("channels.channellog_read", args=[success_log.channel.uuid, success_log.id])
@@ -2216,9 +2207,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=4)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         read_url = reverse("channels.channellog_read", args=[success_log.channel.uuid, success_log.id])
@@ -2268,9 +2256,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=4)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         response = self.client.get(read_url)
@@ -2331,9 +2316,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=14)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         read_url = reverse("channels.channellog_read", args=[success_log.channel.uuid, success_log.id])
@@ -2387,9 +2369,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=4)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         response = self.client.get(read_url)
@@ -2451,9 +2430,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=4)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         read_url = reverse("channels.channellog_read", args=[success_log.channel.uuid, success_log.id])
@@ -2519,9 +2495,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=4)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         response = self.client.get(read_url)
@@ -2589,9 +2562,6 @@ class ChannelLogTest(TembaTest):
             self.assertContains(response, ContactURN.ANON_MASK, count=5)
 
         # login as customer support, must see URNs
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         read_url = reverse("channels.channellog_read", args=[success_log.channel.uuid, success_log.id])

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -2707,9 +2707,6 @@ class ContactTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
     def test_read_with_customer_support(self):
-        self.customer_support.is_staff = True
-        self.customer_support.save()
-
         self.login(self.customer_support)
 
         response = self.client.get(reverse("contacts.contact_read", args=[self.joe.uuid]))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -96,7 +96,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         mr_mocks.contact_search('name != ""', contacts=[])
         smart = self.create_group("No Name", query='name = ""')
 
-        with self.assertNumQueries(56):
+        with self.assertNumQueries(68):
             response = self.client.get(list_url)
 
         self.assertEqual([frank, joe], list(response.context["object_list"]))
@@ -2228,7 +2228,7 @@ class ContactTest(TembaTest):
         assertHistoryEvent(history, 11, "flow_entered", flow__name="Colors")
         assertHistoryEvent(history, 12, "msg_received", msg__text="Message caption")
         assertHistoryEvent(
-            history, 13, "msg_created", msg__text="A beautiful broadcast", msg__created_by__email="User@nyaruka.com"
+            history, 13, "msg_created", msg__text="A beautiful broadcast", msg__created_by__email="viewer@nyaruka.com"
         )
         assertHistoryEvent(history, 14, "campaign_fired", campaign__name="Planting Reminders")
         assertHistoryEvent(history, -1, "msg_received", msg__text="Inbound message 11")

--- a/temba/dashboard/tests.py
+++ b/temba/dashboard/tests.py
@@ -82,7 +82,7 @@ class DashboardTest(TembaTest):
 
         # org message activity
         self.assertEqual(12, response.context["orgs"][0]["count_sum"])
-        self.assertEqual("Temba", response.context["orgs"][0]["channel__org__name"])
+        self.assertEqual("Nyaruka", response.context["orgs"][0]["channel__org__name"])
 
         # our pie chart
         self.assertEqual(5, response.context["channel_types"][0]["count_sum"])

--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -1061,7 +1061,7 @@ class FlowMigrationTest(TembaTest):
         email_node = order_checker.get_definition()["nodes"][10]
         email_action = email_node["actions"][1]
 
-        self.assertEqual(["Administrator"], email_action["addresses"])
+        self.assertEqual(["admin@nyaruka.com"], email_action["addresses"])
 
     def test_migrate_bad_group_names(self):
         # This test makes sure that bad contact groups (< 25, etc) are migrated forward properly.

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2471,14 +2471,14 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(
             [
                 {
-                    "user": {"email": "Administrator@nyaruka.com", "name": ""},
+                    "user": {"email": "admin@nyaruka.com", "name": "Andy"},
                     "created_on": matchers.ISODate(),
                     "id": revisions[0].id,
                     "version": "13.1.0",
                     "revision": 2,
                 },
                 {
-                    "user": {"email": "Administrator@nyaruka.com", "name": ""},
+                    "user": {"email": "admin@nyaruka.com", "name": "Andy"},
                     "created_on": matchers.ISODate(),
                     "id": revisions[1].id,
                     "version": "11.12",
@@ -4969,7 +4969,7 @@ class ExportFlowResultsTest(TembaTest):
             sheet_runs,
             1,
             [
-                "Administrator",
+                "admin@nyaruka.com",
                 run.contact.uuid,
                 "+250788382382",
                 "Eric",
@@ -5161,7 +5161,7 @@ class SimulationTest(TembaTest):
                             "default_country": "RW",
                             "redaction_policy": "none",
                         },
-                        "user": {"email": "Administrator@nyaruka.com", "name": ""},
+                        "user": {"email": "admin@nyaruka.com", "name": "Andy"},
                     },
                     json.loads(mock_post.call_args[1]["data"])["trigger"],
                 )
@@ -5255,7 +5255,7 @@ class FlowSessionCRUDLTest(TembaTest):
         self.assertEqual(200, response.status_code)
 
         response_json = json.loads(response.content)
-        self.assertEqual("Temba", response_json["_metadata"]["org"])
+        self.assertEqual("Nyaruka", response_json["_metadata"]["org"])
         self.assertEqual(session.uuid, response_json["uuid"])
 
         # now try with an s3 session
@@ -5271,7 +5271,7 @@ class FlowSessionCRUDLTest(TembaTest):
         with patch("temba.utils.s3.s3.client", return_value=mock_s3):
             response = self.client.get(url)
             self.assertEqual(200, response.status_code)
-            self.assertEqual("Temba", response_json["_metadata"]["org"])
+            self.assertEqual("Nyaruka", response_json["_metadata"]["org"])
             self.assertEqual(session.uuid, response_json["uuid"])
 
 
@@ -5296,7 +5296,7 @@ class FlowStartCRUDLTest(TembaTest, CRUDLTestMixin):
             list_url, allow_viewers=True, allow_editors=True, context_objects=[start3, start2, start1]
         )
 
-        self.assertContains(response, "was started by Administrator for")
+        self.assertContains(response, "was started by admin@nyaruka.com for")
         self.assertContains(response, "was started by an API call for")
         self.assertContains(response, "was started by Zapier for")
         self.assertContains(response, "all contacts")

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -1035,7 +1035,12 @@ class EventTest(TembaTest):
                     "ticketer": {"uuid": str(ticketer.uuid), "name": "Email (bob@acme.com)"},
                 },
                 "created_on": matchers.ISODate(),
-                "created_by": {"id": self.agent.id, "first_name": "", "last_name": "", "email": "Agent@nyaruka.com"},
+                "created_by": {
+                    "id": self.agent.id,
+                    "first_name": "Agnes",
+                    "last_name": "",
+                    "email": "agent@nyaruka.com",
+                },
             },
             Event.from_ticket_event(self.org, self.user, event1),
         )

--- a/temba/notifications/tests.py
+++ b/temba/notifications/tests.py
@@ -153,8 +153,8 @@ class NotificationTest(TembaTest):
         send_notification_emails()
 
         self.assertEqual(1, len(mail.outbox))
-        self.assertEqual("[Temba] Your contact export is ready", mail.outbox[0].subject)
-        self.assertEqual(["Editor@nyaruka.com"], mail.outbox[0].recipients())
+        self.assertEqual("[Nyaruka] Your contact export is ready", mail.outbox[0].subject)
+        self.assertEqual(["editor@nyaruka.com"], mail.outbox[0].recipients())
 
         # calling task again won't send more emails
         send_notification_emails()
@@ -192,8 +192,8 @@ class NotificationTest(TembaTest):
         send_notification_emails()
 
         self.assertEqual(1, len(mail.outbox))
-        self.assertEqual("[Temba] Your message export is ready", mail.outbox[0].subject)
-        self.assertEqual(["Editor@nyaruka.com"], mail.outbox[0].recipients())
+        self.assertEqual("[Nyaruka] Your message export is ready", mail.outbox[0].subject)
+        self.assertEqual(["editor@nyaruka.com"], mail.outbox[0].recipients())
 
     def test_results_export_finished(self):
         flow1 = self.create_flow("Test Flow 1")
@@ -230,8 +230,8 @@ class NotificationTest(TembaTest):
         send_notification_emails()
 
         self.assertEqual(1, len(mail.outbox))
-        self.assertEqual("[Temba] Your results export is ready", mail.outbox[0].subject)
-        self.assertEqual(["Editor@nyaruka.com"], mail.outbox[0].recipients())
+        self.assertEqual("[Nyaruka] Your results export is ready", mail.outbox[0].subject)
+        self.assertEqual(["editor@nyaruka.com"], mail.outbox[0].recipients())
         self.assertIn("Test Flow 1", mail.outbox[0].body)
         self.assertIn("Test Flow 2", mail.outbox[0].body)
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -164,7 +164,7 @@ class UserTest(TembaTest):
         )
 
         # submit correct username and password
-        response = self.client.post(login_url, {"username": "Administrator", "password": "Administrator"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "Qwerty123"})
         self.assertRedirect(response, reverse("orgs.org_choose"))
 
         del self.admin.settings  # clear cached_property
@@ -180,7 +180,7 @@ class UserTest(TembaTest):
 
         # login via login page again
         response = self.client.post(
-            login_url + "?next=/msg/inbox/", {"username": "Administrator", "password": "Administrator"}
+            login_url + "?next=/msg/inbox/", {"username": "admin@nyaruka.com", "password": "Qwerty123"}
         )
         self.assertRedirect(response, verify_url)
         self.assertTrue(response.url.endswith("?next=/msg/inbox/"))
@@ -203,7 +203,7 @@ class UserTest(TembaTest):
         self.client.logout()
 
         # login via login page again
-        response = self.client.post(login_url, {"username": "Administrator", "password": "Administrator"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "Qwerty123"})
         self.assertRedirect(response, verify_url)
 
         # but this time we've lost our phone so go to the page for backup tokens
@@ -229,9 +229,9 @@ class UserTest(TembaTest):
         failed_url = reverse("users.user_failed")
 
         # submit incorrect username and password 3 times
-        self.client.post(login_url, {"username": "Administrator", "password": "pass123"})
-        self.client.post(login_url, {"username": "Administrator", "password": "pass123"})
-        response = self.client.post(login_url, {"username": "Administrator", "password": "pass123"})
+        self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "pass123"})
+        self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "pass123"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "pass123"})
 
         self.assertRedirect(response, failed_url)
         self.assertRedirect(self.client.get(reverse("msgs.msg_inbox")), login_url)
@@ -240,7 +240,7 @@ class UserTest(TembaTest):
         FailedLogin.objects.all().update(failed_on=timezone.now() - timedelta(minutes=3))
 
         # now we're allowed to make failed logins again
-        response = self.client.post(login_url, {"username": "Administrator", "password": "pass123"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "pass123"})
         self.assertFormError(
             response,
             "form",
@@ -249,7 +249,7 @@ class UserTest(TembaTest):
         )
 
         # and successful logins
-        response = self.client.post(login_url, {"username": "Administrator", "password": "Administrator"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "Qwerty123"})
         self.assertRedirect(response, reverse("orgs.org_choose"))
 
         # try again with 2FA enabled
@@ -257,16 +257,16 @@ class UserTest(TembaTest):
         self.admin.enable_2fa()
 
         # submit incorrect username and password 3 times
-        self.client.post(login_url, {"username": "Administrator", "password": "pass123"})
-        self.client.post(login_url, {"username": "Administrator", "password": "pass123"})
-        response = self.client.post(login_url, {"username": "Administrator", "password": "pass123"})
+        self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "pass123"})
+        self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "pass123"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "pass123"})
 
         self.assertRedirect(response, failed_url)
         self.assertRedirect(self.client.get(reverse("msgs.msg_inbox")), login_url)
 
         # login correctly
         FailedLogin.objects.all().delete()
-        response = self.client.post(login_url, {"username": "Administrator", "password": "Administrator"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "Qwerty123"})
         self.assertRedirect(response, verify_url)
 
         # now enter a backup token 3 times incorrectly
@@ -286,7 +286,7 @@ class UserTest(TembaTest):
         response = self.client.post(backup_url, {"token": "nope"})
         self.assertRedirect(response, login_url)
 
-        response = self.client.post(login_url, {"username": "Administrator", "password": "Administrator"})
+        response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "Qwerty123"})
         self.assertRedirect(response, verify_url)
 
         response = self.client.post(backup_url, {"token": self.admin.backup_tokens.first()})
@@ -338,7 +338,7 @@ class UserTest(TembaTest):
 
         # submit with valid OTP and password
         with patch("pyotp.TOTP.verify", return_value=True):
-            response = self.client.post(enable_url, {"otp": "123456", "password": "Administrator"})
+            response = self.client.post(enable_url, {"otp": "123456", "password": "Qwerty123"})
 
         header = {"HTTP_TEMBA_SPA": 1}
         response = self.client.get(tokens_url, **header)
@@ -373,7 +373,7 @@ class UserTest(TembaTest):
 
         # submit with valid OTP and password
         with patch("pyotp.TOTP.verify", return_value=True):
-            response = self.client.post(enable_url, {"otp": "123456", "password": "Administrator"})
+            response = self.client.post(enable_url, {"otp": "123456", "password": "Qwerty123"})
         self.assertRedirect(response, tokens_url)
         self.assertTrue(self.admin.settings.two_factor_enabled)
 
@@ -406,7 +406,7 @@ class UserTest(TembaTest):
         self.assertFormError(response, "form", "password", "Password incorrect.")
 
         # submit with valid password
-        response = self.client.post(disable_url, {"password": "Administrator"})
+        response = self.client.post(disable_url, {"password": "Qwerty123"})
         self.assertRedirect(response, reverse("orgs.org_home"))
 
         del self.admin.settings  # clear cached_property
@@ -425,7 +425,7 @@ class UserTest(TembaTest):
 
         # simulate a login for a 2FA user 10 minutes ago
         with patch("django.utils.timezone.now", return_value=timezone.now() - timedelta(minutes=10)):
-            response = self.client.post(login_url, {"username": "Administrator", "password": "Administrator"})
+            response = self.client.post(login_url, {"username": "admin@nyaruka.com", "password": "Qwerty123"})
             self.assertRedirect(response, verify_url)
 
             response = self.client.get(verify_url)
@@ -465,7 +465,7 @@ class UserTest(TembaTest):
         self.assertFormError(response, "form", "password", "Password incorrect.")
 
         # submit with real password
-        response = self.client.post(confirm_url, {"password": "Administrator"})
+        response = self.client.post(confirm_url, {"password": "Qwerty123"})
         self.assertRedirect(response, tokens_url)
 
         response = self.client.get(tokens_url)
@@ -495,7 +495,7 @@ class UserTest(TembaTest):
         self.assertRedirect(response, failed_url)
 
         # even correct password now redirects to failed page
-        response = self.client.post(confirm_url, {"password": "Administrator"})
+        response = self.client.post(confirm_url, {"password": "Qwerty123"})
         self.assertRedirect(response, failed_url)
 
         FailedLogin.objects.all().delete()
@@ -505,7 +505,7 @@ class UserTest(TembaTest):
         self.assertFormError(response, "form", "password", "Password incorrect.")
 
         # and also correct ones
-        response = self.client.post(confirm_url, {"password": "Administrator"})
+        response = self.client.post(confirm_url, {"password": "Qwerty123"})
         self.assertRedirect(response, "/msg/inbox/")
 
     def test_ui_permissions(self):
@@ -571,7 +571,7 @@ class UserTest(TembaTest):
         # our admin should still be good
         self.admin.refresh_from_db()
         self.assertTrue(self.admin.is_active)
-        self.assertEqual("Administrator@nyaruka.com", self.admin.email)
+        self.assertEqual("admin@nyaruka.com", self.admin.email)
 
         # but she should be removed from org
         self.assertFalse(self.admin.get_orgs(brands=[settings.DEFAULT_BRAND]).exists())
@@ -581,7 +581,7 @@ class UserTest(TembaTest):
 
         # now she gets deactivated and ambiguated and belongs to no orgs
         self.assertFalse(self.admin.is_active)
-        self.assertNotEqual("Administrator@nyaruka.com", self.admin.email)
+        self.assertNotEqual("admin@nyaruka.com", self.admin.email)
         self.assertFalse(self.admin.get_orgs().exists())
 
     def test_brand_aliases(self):
@@ -1199,7 +1199,7 @@ class OrgTest(TembaTest):
                 "first_name": "Admin",
                 "last_name": "User",
                 "email": "administrator@temba.com",
-                "current_password": "Administrator",
+                "current_password": "Qwerty123",
             },
             HTTP_X_FORMAX=True,
         )
@@ -1592,7 +1592,7 @@ class OrgTest(TembaTest):
         self.assertEqual(self.admin.api_tokens.filter(is_active=True).count(), 0)
 
         # make sure an existing user can not be invited again
-        user = Org.create_user("admin1@temba.com", "admin1@temba.com")
+        user = Org.create_user("admin1@temba.com", "Qwerty123")
         user.set_org(self.org)
         self.org.administrators.add(user)
         self.login(user)
@@ -1671,22 +1671,16 @@ class OrgTest(TembaTest):
 
     @patch("temba.utils.email.send_temba_email")
     def test_join(self, mock_send_temba_email):
-        def create_invite(group, username):
+        def create_invite(group, email):
             return Invitation.objects.create(
                 org=self.org,
                 user_group=group,
-                email=f"{username}@nyaruka.com",
+                email=email,
                 created_by=self.admin,
                 modified_by=self.admin,
             )
 
-        def create_user(username):
-            user = User.objects.create_user(f"{username}@nyaruka.com", f"{username}@nyaruka.com")
-            user.set_password(f"{username}@nyaruka.com")
-            user.save()
-            return user
-
-        editor_invitation = create_invite("E", "invitededitor")
+        editor_invitation = create_invite("E", "invitededitor@nyaruka.com")
         editor_invitation.send()
         email_args = mock_send_temba_email.call_args[0]  # all positional args
 
@@ -1708,7 +1702,7 @@ class OrgTest(TembaTest):
         )
 
         # a user is already logged in
-        self.invited_editor = create_user("invitededitor")
+        self.invited_editor = self.create_user("invitededitor@nyaruka.com")
 
         # different user login
         self.login(self.admin)
@@ -1759,18 +1753,18 @@ class OrgTest(TembaTest):
 
         # test it for each role
         for role in roles:
-            invite = create_invite(role[0], "User%s" % role[0])
-            user = create_user("User%s" % role[0])
+            invite = create_invite(role[0], f"user.{role[0]}@nyaruka.com")
+            user = self.create_user(f"user.{role[0]}@nyaruka.com")
             self.login(user)
             response = self.client.post(reverse("orgs.org_join_accept", args=[invite.secret]), follow=True)
             self.assertEqual(200, response.status_code)
             self.assertIsNotNone(role[1].filter(pk=user.pk).first())
 
         # try an expired invite
-        invite = create_invite("S", "invitedexpired")
+        invite = create_invite("S", "invitedexpired@nyaruka.com")
         invite.is_active = False
         invite.save()
-        expired_user = create_user("invitedexpired")
+        expired_user = self.create_user("invitedexpired@nyaruka.com")
         self.login(expired_user)
         response = self.client.post(reverse("orgs.org_join_accept", args=[invite.secret]), follow=True)
         self.assertEqual(200, response.status_code)
@@ -2398,7 +2392,7 @@ class OrgTest(TembaTest):
                     )
                     # name shouldn't change
                     self.org.refresh_from_db()
-                    self.assertEqual(self.org.name, "Temba")
+                    self.assertEqual(self.org.name, "Nyaruka")
 
                     # now disconnect our twilio connection
                     self.assertTrue(self.org.is_connected_to_twilio())
@@ -2472,7 +2466,7 @@ class OrgTest(TembaTest):
         self.assertTrue(APIToken.objects.filter(org=self.org, role=prometheus_group, is_active=True))
 
         # other admin sees it enabled too
-        self.other_admin = self.create_user("Other Administrator")
+        self.other_admin = self.create_user("other_admin@nyaruka.com")
         self.org.administrators.add(self.other_admin)
         self.login(self.other_admin)
 
@@ -2710,7 +2704,7 @@ class OrgTest(TembaTest):
 
         # name shouldn't change
         self.org.refresh_from_db()
-        self.assertEqual(self.org.name, "Temba")
+        self.assertEqual(self.org.name, "Nyaruka")
         self.assertTrue(self.org.has_smtp_config())
 
         self.client.post(
@@ -2859,7 +2853,7 @@ class OrgTest(TembaTest):
         )
         # name shouldn't change
         self.org.refresh_from_db()
-        self.assertEqual(self.org.name, "Temba")
+        self.assertEqual(self.org.name, "Nyaruka")
 
         # should change vonage config
         self.client.post(account_url, {"api_key": "other_key", "api_secret": "secret-too", "disconnect": "false"})
@@ -3435,7 +3429,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(grant_url)
         self.assertRedirect(response, "/users/login/")
 
-        self.user = self.create_user(username="tito")
+        self.user = self.create_user("tito@nyaruka.com")
 
         self.login(self.user)
         response = self.client.get(grant_url)
@@ -3467,8 +3461,8 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # check user exists and is admin
         User.objects.get(username="john@carmack.com")
-        self.assertTrue(org.administrators.filter(username="john@carmack.com"))
-        self.assertTrue(org.administrators.filter(username="tito"))
+        self.assertTrue(org.administrators.filter(username="john@carmack.com").exists())
+        self.assertTrue(org.administrators.filter(username="tito@nyaruka.com").exists())
 
         # try a new org with a user that already exists instead
         del post_data["password"]
@@ -3482,8 +3476,8 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(100_000, org.get_credits_remaining())
         self.assertEqual(org.date_format, Org.DATE_FORMAT_DAY_FIRST)
 
-        self.assertTrue(org.administrators.filter(username="john@carmack.com"))
-        self.assertTrue(org.administrators.filter(username="tito"))
+        self.assertTrue(org.administrators.filter(username="john@carmack.com").exists())
+        self.assertTrue(org.administrators.filter(username="tito@nyaruka.com").exists())
 
         # try a new org with US timezone
         post_data["name"] = "Bulls"
@@ -3557,17 +3551,14 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         granters = Group.objects.get(name="Granters")
         self.admin.groups.add(granters)
-        self.admin.username = "Administrator@nyaruka.com"
-        self.admin.set_password("Administrator@nyaruka.com")
-        self.admin.save()
 
         self.login(self.admin)
 
-        # user with email Administrator@nyaruka.com already exists and we set a password
+        # user with email admin@nyaruka.com already exists and we set a password
         response = self.client.post(
             grant_url,
             {
-                "email": "Administrator@nyaruka.com",
+                "email": "admin@nyaruka.com",
                 "first_name": "John",
                 "last_name": "Carmack",
                 "name": "Oculus",
@@ -3614,7 +3605,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_new_signup_with_user_logged_in(self, mock_pre_process):
         mock_pre_process.return_value = None
         signup_url = reverse("orgs.org_signup")
-        self.user = self.create_user(username="tito")
+        self.user = self.create_user("tito@nyaruka.com")
 
         self.login(self.user)
 
@@ -5052,7 +5043,7 @@ class CreditAlertTest(TembaTest):
         # email sent
         sent_email = mail.outbox[0]
         self.assertEqual(1, len(sent_email.to))
-        self.assertIn("RapidPro workspace for Temba", sent_email.body)
+        self.assertIn("RapidPro workspace for Nyaruka", sent_email.body)
         self.assertIn("expiring credits in less than one month.", sent_email.body)
 
         # check topup expiration, it should no create a new one, because last one is still active
@@ -5091,11 +5082,11 @@ class CreditAlertTest(TembaTest):
             self.assertEqual(len(mail.outbox), 1)
 
             sent_email = mail.outbox[0]
-            self.assertIn("RapidPro workspace for Temba", sent_email.body)
+            self.assertIn("RapidPro workspace for Nyaruka", sent_email.body)
 
             # this email has been sent to multiple recipients
             self.assertListEqual(
-                sent_email.recipients(), ["Administrator@nyaruka.com", "Surveyor@nyaruka.com", "User@nyaruka.com"]
+                sent_email.recipients(), ["admin@nyaruka.com", "surveyor@nyaruka.com", "viewer@nyaruka.com"]
             )
 
     def test_creditalert_sendemail_no_org_admins(self):
@@ -5134,7 +5125,7 @@ class CreditAlertTest(TembaTest):
                 # alert email is for out of credits type
                 sent_email = mail.outbox[0]
                 self.assertEqual(len(sent_email.to), 1)
-                self.assertIn("RapidPro workspace for Temba", sent_email.body)
+                self.assertIn("RapidPro workspace for Nyaruka", sent_email.body)
                 self.assertIn("is out of credit.", sent_email.body)
 
                 # no new alert if one is sent and no new email
@@ -5178,7 +5169,7 @@ class CreditAlertTest(TembaTest):
                     # email sent
                     sent_email = mail.outbox[2]
                     self.assertEqual(len(sent_email.to), 1)
-                    self.assertIn("RapidPro workspace for Temba", sent_email.body)
+                    self.assertIn("RapidPro workspace for Nyaruka", sent_email.body)
                     self.assertIn("is running low on credits", sent_email.body)
 
                     # no new alert if one is sent and no new email
@@ -5313,7 +5304,7 @@ class StripeCreditsTest(TembaTest):
     @patch("stripe.Charge.create")
     @override_settings(SEND_EMAILS=True)
     def test_add_credits_existing_customer(self, charge_create, customer_retrieve, customer_create):
-        self.admin2 = self.create_user("Administrator 2")
+        self.admin2 = self.create_user("admin2@nyaruka.com")
         self.org.administrators.add(self.admin2)
 
         self.org.stripe_customer = "stripe-cust-1"

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -38,6 +38,7 @@ def add_testing_flag_to_context(*args):
 
 class TembaTestMixin:
     databases = ("default", "readonly")
+    default_password = "Qwerty123"
 
     def setUpOrgs(self):
         # make sure we start off without any service users
@@ -47,19 +48,23 @@ class TembaTestMixin:
 
         self.create_anonymous_user()
 
-        self.superuser = User.objects.create_superuser(username="super", email="super@user.com", password="super")
+        self.superuser = User.objects.create_superuser(
+            username="super", email="super@user.com", password=self.default_password
+        )
 
         # create different user types
-        self.non_org_user = self.create_user("NonOrg")
-        self.admin = self.create_user("Administrator")
-        self.editor = self.create_user("Editor")
-        self.user = self.create_user("User", ("Viewers",))
-        self.agent = self.create_user("Agent")
-        self.surveyor = self.create_user("Surveyor")
-        self.customer_support = self.create_user("support", ("Customer Support",))
+        self.non_org_user = self.create_user("nonorg@nyaruka.com")
+        self.admin = self.create_user("admin@nyaruka.com", first_name="Andy")
+        self.editor = self.create_user("editor@nyaruka.com", first_name="Ed", last_name="McEdits")
+        self.user = self.create_user("viewer@nyaruka.com")
+        self.agent = self.create_user("agent@nyaruka.com", first_name="Agnes")
+        self.surveyor = self.create_user("surveyor@nyaruka.com")
+        self.customer_support = self.create_user(
+            "support@nyaruka.com", group_names=("Customer Support",), is_staff=True
+        )
 
         self.org = Org.objects.create(
-            name="Temba",
+            name="Nyaruka",
             timezone=pytz.timezone("Africa/Kigali"),
             brand=settings.DEFAULT_BRAND,
             created_by=self.user,
@@ -84,10 +89,10 @@ class TembaTestMixin:
         self.org.surveyors.add(self.surveyor)
 
         # setup a second org with a single admin
-        self.admin2 = self.create_user("Administrator2")
+        self.admin2 = self.create_user("administrator@trileet.com")
         self.org2 = Org.objects.create(
             name="Trileet Inc.",
-            timezone=pytz.timezone("Africa/Kigali"),
+            timezone=pytz.timezone("US/Pacific"),
             brand="rapidpro.io",
             created_by=self.admin2,
             modified_by=self.admin2,
@@ -163,8 +168,8 @@ class TembaTestMixin:
 
     def login(self, user, update_last_auth_on: bool = True):
         self.assertTrue(
-            self.client.login(username=user.username, password=user.username),
-            "Couldn't login as %(user)s:%(user)s" % dict(user=user.username),
+            self.client.login(username=user.username, password=self.default_password),
+            f"couldn't login as {user.username}:{self.default_password}",
         )
         if update_last_auth_on:
             user.record_auth()
@@ -202,9 +207,9 @@ class TembaTestMixin:
         data = self.get_import_json(filename, substitutions=substitutions)
         return data["flows"][0]
 
-    def create_user(self, username, group_names=()):
-        user = User.objects.create_user(username, "%s@nyaruka.com" % username)
-        user.set_password(username)
+    def create_user(self, email, group_names=(), **kwargs):
+        user = User.objects.create_user(username=email, email=email, **kwargs)
+        user.set_password(self.default_password)
         user.save()
         for group in group_names:
             user.groups.add(Group.objects.get(name=group))

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -351,7 +351,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
                         "direction": "O",
                         "type": "I",
                         "created_on": matchers.ISODate(),
-                        "sender": {"id": self.admin.id, "email": "Administrator@nyaruka.com"},
+                        "sender": {"id": self.admin.id, "email": "admin@nyaruka.com"},
                         "attachments": [],
                     },
                     "ticket": {
@@ -372,16 +372,16 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
                         "direction": "O",
                         "type": "I",
                         "created_on": matchers.ISODate(),
-                        "sender": {"id": self.admin.id, "email": "Administrator@nyaruka.com"},
+                        "sender": {"id": self.admin.id, "email": "admin@nyaruka.com"},
                         "attachments": [],
                     },
                     "ticket": {
                         "uuid": str(joes_open_tickets[1].uuid),
                         "assignee": {
                             "id": self.admin.id,
-                            "first_name": "",
+                            "first_name": "Andy",
                             "last_name": "",
-                            "email": "Administrator@nyaruka.com",
+                            "email": "admin@nyaruka.com",
                         },
                         "topic": {"uuid": matchers.UUID4String(), "name": "General"},
                         "body": "Question 1",
@@ -452,9 +452,9 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(
             [
                 ("", "Unassigned"),
-                (self.admin.id, "Administrator"),
-                (self.agent.id, "Agent"),
-                (self.editor.id, "Editor"),
+                (self.admin.id, "Andy"),
+                (self.agent.id, "Agnes"),
+                (self.editor.id, "Ed McEdits"),
             ],
             list(response.context["form"].fields["assignee"].choices),
         )


### PR DESCRIPTION
Was working on `orgs.User` stuff and noticed that we are very inefficient about checking permissions in views and it's being hidden in tests because `TembaTest.user` is being added directly to `auth.Group[name=Viewers]` - which is not how we grant permissions in the real world.

Figured I'd fix that in the tests before adding a fix to make the permission checking more efficient - and while I'm messing with test users, make them more realistic.