### PR TITLE
Use channel type to determine redact values in HTTP logs

### DIFF
--- a/temba/channels/templatetags/channels.py
+++ b/temba/channels/templatetags/channels.py
@@ -7,7 +7,7 @@ register = template.Library()
 
 @register.filter
 def channel_icon(channel):
-    return channel.get_type().icon
+    return channel.type.icon
 
 
 @register.simple_tag(takes_context=True)

--- a/temba/channels/types/dialog360/tests.py
+++ b/temba/channels/types/dialog360/tests.py
@@ -60,7 +60,7 @@ class Dialog360TypeTest(TembaTest):
         self.assertEqual("RW", channel.country)
         self.assertEqual("D3", channel.channel_type)
         self.assertEqual(45, channel.tps)
-        self.assertTrue(channel.get_type().has_attachment_support(channel))
+        self.assertTrue(channel.type.has_attachment_support(channel))
 
         # test activating the channel
         with patch("requests.post") as mock_post:
@@ -244,10 +244,10 @@ class Dialog360TypeTest(TembaTest):
                 MockResponse(200, '{"meta": {"api_status": "stable", "version": "2.35.4"}}'),
                 MockResponse(401, '{"meta": {"api_status": "stable", "version": "2.35.4"}}'),
             ]
-            channel.get_type().check_health(channel)
+            channel.type.check_health(channel)
             mock_get.assert_called_with(
                 "https://example.com/whatsapp/v1/health",
                 headers={"D360-API-KEY": "123456789", "Content-Type": "application/json"},
             )
             with self.assertRaises(Exception):
-                channel.get_type().check_health(channel)
+                channel.type.check_health(channel)

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -165,7 +165,7 @@ class PlivoTypeTest(TembaTest):
                 )
 
         with patch("requests.delete") as mock_delete:
-            channel.get_type().deactivate(channel)
+            channel.type.deactivate(channel)
             mock_delete.assert_called_once()
 
     @patch("requests.get")

--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -33,7 +33,7 @@ class TwilioType(ChannelType):
 
     ivr_protocol = ChannelType.IVRProtocol.IVR_PROTOCOL_TWIML
 
-    redact_request_keys = {
+    redact_request_keys = (
         "FromCity",
         "FromState",
         "FromZip",
@@ -43,7 +43,7 @@ class TwilioType(ChannelType):
         "CalledCity",
         "CalledState",
         "CalledZip",
-    }
+    )
 
     def is_recommended_to(self, user):
         org = user.get_org()

--- a/temba/channels/types/twilio_whatsapp/type.py
+++ b/temba/channels/types/twilio_whatsapp/type.py
@@ -44,7 +44,7 @@ class TwilioWhatsappType(ChannelType):
         ),
     )
 
-    redact_request_keys = {
+    redact_request_keys = (
         "FromCity",
         "FromState",
         "FromZip",
@@ -54,4 +54,4 @@ class TwilioWhatsappType(ChannelType):
         "CalledCity",
         "CalledState",
         "CalledZip",
-    }
+    )

--- a/temba/channels/types/twitter/tests.py
+++ b/temba/channels/types/twitter/tests.py
@@ -130,7 +130,7 @@ class TwitterTypeTest(TembaTest):
                 "callback_domain": channel.callback_domain,
             },
         )
-        self.assertTrue(channel.get_type().has_attachment_support(channel))
+        self.assertTrue(channel.type.has_attachment_support(channel))
 
         mock_register_webhook.assert_called_with(
             "beta", "https://%s/c/twt/%s/receive" % (channel.callback_domain, channel.uuid)

--- a/temba/channels/types/twitter/type.py
+++ b/temba/channels/types/twitter/type.py
@@ -41,8 +41,8 @@ class TwitterType(ChannelType):
     async_activation = False
     attachment_support = True
 
-    redact_response_keys = {"urn"}
-    redact_request_keys = {"sender_id", "name", "screen_name", "profile_image_url", "profile_image_url_https"}
+    redact_response_keys = ("urn",)
+    redact_request_keys = ("sender_id", "name", "screen_name", "profile_image_url", "profile_image_url_https")
 
     beta_only = True
 

--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -55,7 +55,7 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
         channel = Channel.objects.get(address="viberId")
         self.assertEqual(channel.config["auth_token"], "123456")
         self.assertEqual(channel.name, "viberName")
-        self.assertTrue(channel.get_type().has_attachment_support(channel))
+        self.assertTrue(channel.type.has_attachment_support(channel))
 
         # should have been called with our webhook URL
         self.assertEqual(mock_post.call_args[0][0], "https://chatapi.viber.com/pa/set_webhook")

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -104,7 +104,7 @@ class WhatsAppTypeTest(TembaTest):
         self.assertEqual("RW", channel.country)
         self.assertEqual("WA", channel.channel_type)
         self.assertEqual(45, channel.tps)
-        self.assertTrue(channel.get_type().has_attachment_support(channel))
+        self.assertTrue(channel.type.has_attachment_support(channel))
 
         # test activating the channel
         with patch("requests.patch") as mock_patch:
@@ -294,7 +294,7 @@ class WhatsAppTypeTest(TembaTest):
         self.assertEqual("RW", channel.country)
         self.assertEqual("WA", channel.channel_type)
         self.assertEqual(45, channel.tps)
-        self.assertTrue(channel.get_type().has_attachment_support(channel))
+        self.assertTrue(channel.type.has_attachment_support(channel))
 
     @patch("requests.get")
     def test_get_api_templates(self, mock_get):
@@ -502,11 +502,11 @@ class WhatsAppTypeTest(TembaTest):
             ]
 
             with self.assertRaises(Exception):
-                channel.get_type().check_health(channel)
+                channel.type.check_health(channel)
 
-            channel.get_type().check_health(channel)
+            channel.type.check_health(channel)
             mock_get.assert_called_with(
                 "https://nyaruka.com/whatsapp/v1/health", headers={"Authorization": "Bearer authtoken123"}
             )
             with self.assertRaises(Exception):
-                channel.get_type().check_health(channel)
+                channel.type.check_health(channel)

--- a/temba/channels/types/whatsapp_cloud/tests.py
+++ b/temba/channels/types/whatsapp_cloud/tests.py
@@ -286,7 +286,7 @@ class WhatsAppCloudTypeTest(TembaTest):
                 self.assertEqual("WABA name", channel.name)
                 self.assertEqual("123123123", channel.address)
                 self.assertEqual("WAC", channel.channel_type)
-                self.assertTrue(channel.get_type().has_attachment_support(channel))
+                self.assertTrue(channel.type.has_attachment_support(channel))
 
                 self.assertEqual("1234", channel.config["wa_number"])
                 self.assertEqual("WABA name", channel.config["wa_verified_name"])

--- a/temba/channels/types/whatsapp_cloud/type.py
+++ b/temba/channels/types/whatsapp_cloud/type.py
@@ -39,7 +39,7 @@ class WhatsAppCloudType(ChannelType):
     max_length = 4096
     attachment_support = True
 
-    redact_values = {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}
+    redact_values = (settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN,)
 
     def get_urls(self):
         return [

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -753,7 +753,7 @@ class ChannelCRUDL(SmartCRUDL):
 
                 channels = Channel.objects.filter(org=org, is_active=True, parent=None).order_by("-role")
                 for channel in channels:
-                    icon = channel.get_type().icon.replace("icon-", "")
+                    icon = channel.type.icon.replace("icon-", "")
                     icon = icon.replace("power-cord", "box")
 
                     menu.append(
@@ -779,7 +779,7 @@ class ChannelCRUDL(SmartCRUDL):
         def get_gear_links(self):
             links = []
 
-            extra_links = self.object.get_type().extra_links
+            extra_links = self.object.type.extra_links
             if extra_links:
                 for extra in extra_links:
                     links.append(dict(title=extra["name"], href=reverse(extra["link"], args=[self.object.uuid])))
@@ -793,7 +793,7 @@ class ChannelCRUDL(SmartCRUDL):
                     )
                 )
 
-            if self.object.get_type().show_config_page:
+            if self.object.type.show_config_page:
                 links.append(
                     dict(title=_("Settings"), href=reverse("channels.channel_configuration", args=[self.object.uuid]))
                 )

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1231,7 +1231,7 @@ class OrgCRUDL(SmartCRUDL):
                     items = []
                     channels = Channel.objects.filter(org=org, is_active=True, parent=None).order_by("-role")
                     for channel in channels:
-                        icon = channel.get_type().icon.replace("icon-", "")
+                        icon = channel.type.icon.replace("icon-", "")
                         icon = icon.replace("power-cord", "box")
                         items.append(
                             self.create_menu_item(
@@ -3274,9 +3274,7 @@ class OrgCRUDL(SmartCRUDL):
             if self.has_org_perm("channels.channel_read"):
                 from temba.channels.views import get_channel_read_url
 
-                formax.add_section(
-                    "channel", get_channel_read_url(channel), icon=channel.get_type().icon, action="link"
-                )
+                formax.add_section("channel", get_channel_read_url(channel), icon=channel.type.icon, action="link")
 
         def add_classifier_section(self, formax, classifier):
 

--- a/temba/request_logs/tests.py
+++ b/temba/request_logs/tests.py
@@ -2,14 +2,11 @@ from datetime import timedelta
 
 from requests import RequestException
 
-from django.conf import settings
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from temba.classifiers.models import Classifier
 from temba.classifiers.types.wit import WitType
-from temba.contacts.models import ContactURN
 from temba.tests import CRUDLTestMixin, MockResponse, TembaTest
 from temba.tickets.models import Ticketer
 from temba.tickets.types.mailgun import MailgunType
@@ -184,9 +181,8 @@ class HTTPLogCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.requestView(reverse("request_logs.httplog_ticketer", args=[t2.uuid]), self.admin)
         self.assertEqual(404, response.status_code)
 
-    @override_settings(WHATSAPP_ADMIN_SYSTEM_USER_TOKEN="WA_ADMIN_TOKEN")
     def test_http_log(self):
-        channel = self.create_channel("WA", "WhatsApp: 1234", "1234")
+        channel = self.create_channel("WAC", "WhatsApp: 1234", "1234")
 
         exception = RequestException("Network is unreachable", response=MockResponse(100, ""))
         start = timezone.now()
@@ -208,7 +204,7 @@ class HTTPLogCRUDLTest(TembaTest, CRUDLTestMixin):
 
         log2 = HTTPLog.create_from_exception(
             HTTPLog.WHATSAPP_TEMPLATES_SYNCED,
-            f"https://graph.facebook.com/v3.3/1234/message_templates?access_token={settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}",
+            "https://graph.facebook.com/v3.3/1234/message_templates?access_token=MISSING_WHATSAPP_ADMIN_SYSTEM_USER_TOKEN",
             exception,
             start,
             channel=channel,
@@ -217,9 +213,7 @@ class HTTPLogCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(log2_url)
         self.assertContains(response, "200")
         self.assertContains(response, "Connection Error")
-        self.assertContains(
-            response, f"https://graph.facebook.com/v3.3/1234/message_templates?access_token={ContactURN.ANON_MASK}"
-        )
+        self.assertContains(response, "https://graph.facebook.com/v3.3/1234/message_templates?access_token=********")
 
         # and can't be from other org
         self.login(self.admin2)

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -177,7 +177,7 @@ class Trigger(SmartModel):
         trigger.archive_conflicts(user)
 
         if trigger.channel:
-            trigger.channel.get_type().activate_trigger(trigger)
+            trigger.channel.type.activate_trigger(trigger)
 
         return trigger
 
@@ -196,7 +196,7 @@ class Trigger(SmartModel):
         self.save(update_fields=("modified_by", "modified_on", "is_archived"))
 
         if self.channel:
-            self.channel.get_type().deactivate_trigger(self)
+            self.channel.type.deactivate_trigger(self)
 
     def restore(self, user):
         self.modified_by = user
@@ -207,7 +207,7 @@ class Trigger(SmartModel):
         self.archive_conflicts(user)
 
         if self.channel:
-            self.channel.get_type().activate_trigger(self)
+            self.channel.type.activate_trigger(self)
 
     def archive_conflicts(self, user):
         """

--- a/temba/utils/whatsapp/__init__.py
+++ b/temba/utils/whatsapp/__init__.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def update_api_version(channel):
     start = timezone.now()
     try:
-        response = channel.get_type().check_health(channel)
+        response = channel.type.check_health(channel)
         api_status = response.json()
         version = api_status["meta"]["version"]
         if not version.startswith("v"):

--- a/temba/utils/whatsapp/tasks.py
+++ b/temba/utils/whatsapp/tasks.py
@@ -177,7 +177,7 @@ def refresh_whatsapp_templates():
             # fetch all our templates
             try:
 
-                templates_data, valid = channel.get_type().get_api_templates(channel)
+                templates_data, valid = channel.type.get_api_templates(channel)
                 if not valid:
                     continue
 

--- a/temba/utils/whatsapp/views.py
+++ b/temba/utils/whatsapp/views.py
@@ -48,7 +48,7 @@ class TemplatesView(OrgPermsMixin, SmartReadView):
         return [
             dict(
                 title=_("Sync Logs"),
-                href=reverse(f"channels.types.{self.object.get_type().slug}.sync_logs", args=[self.object.uuid]),
+                href=reverse(f"channels.types.{self.object.type.slug}.sync_logs", args=[self.object.uuid]),
             )
         ]
 
@@ -79,7 +79,7 @@ class SyncLogsView(OrgPermsMixin, SmartReadView):
         return [
             dict(
                 title=_("Message Templates"),
-                href=reverse(f"channels.types.{self.object.get_type().slug}.templates", args=[self.object.uuid]),
+                href=reverse(f"channels.types.{self.object.type.slug}.templates", args=[self.object.uuid]),
             )
         ]
 

--- a/templates/channels/email/sms_alert.html
+++ b/templates/channels/email/sms_alert.html
@@ -19,7 +19,7 @@
       {% endblocktrans %}
     </p>
 
-  {% elif channel.get_type.free_sending %}
+  {% elif channel.type.free_sending %}
     <p>
       {% blocktrans trimmed with org_name=org.name channel_type=channel.get_channel_type_name %}
         We've noticed that the {{ channel_type }} for {{ org_name }} is having trouble sending text messages.  This might be

--- a/templates/channels/email/sms_alert.txt
+++ b/templates/channels/email/sms_alert.txt
@@ -12,7 +12,7 @@ We've noticed that the Android phone for {{ org_name }} is having trouble sendin
 Please check on your phone to make sure it has sufficient credit and can send text messages.  If problems persist you may want to try turning the phone off then back on.  Currently your Android phone has {{ unsent_count }} messages which haven't sent in over an hour.
 {% endblocktrans %}
 
-{% elif channel.get_type.free_sending %}
+{% elif channel.type.free_sending %}
 {% blocktrans with org_name=org.name channel_type=channel.get_channel_type_name %}
 Hi {{ org_name }},
 


### PR DESCRIPTION
Should be same logic as in `ChannelLog`. And make channel type a property for good measure.