### PR TITLE
Fix rendering of dates on upcoming events list

### DIFF
--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -214,15 +214,13 @@
                   {{ evt.flow.name }}
           %td.whitespace-nowrap.text-right
             .pr-6
-              {{ evt.scheduled|naturaltime }}
-
-              .repeats
-                -if evt.repeat_period == 'D'
-                  -trans 'repeats daily'
-                -elif evt.repeat_period == 'W'
-                  -trans 'repeats weekly'
-                -elif evt.repeat_period == 'M'
-                  -trans 'repeats monthly'
+              {{ evt.scheduled|parse_isodate|naturaltime }}{% if evt.repeat_period %}, {% endif %}
+              -if evt.repeat_period == 'D'
+                -trans 'repeats daily'
+              -elif evt.repeat_period == 'W'
+                -trans 'repeats weekly'
+              -elif evt.repeat_period == 'M'
+                -trans 'repeats monthly'
 
     -if upcoming_events|length > 3
       %a.pull-right.show-all.upcoming


### PR DESCRIPTION
<img width="964" alt="Captura de Pantalla 2022-06-15 a la(s) 17 24 31" src="https://user-images.githubusercontent.com/675558/173942906-42f3c7df-3783-451a-9888-bc301bed2e20.png">

<img width="968" alt="Captura de Pantalla 2022-06-15 a la(s) 17 28 36" src="https://user-images.githubusercontent.com/675558/173942917-00359f7f-0b46-4c19-8f28-5c964263c49b.png">

