### PR TITLE
Fix scripts on contact page start modal

### DIFF
--- a/static/js/temba.js
+++ b/static/js/temba.js
@@ -3,6 +3,14 @@ if (typeof console == 'undefined') {
     this.console = { log: function (msg) {} };
 }
 
+function getModax(id) {
+    var modax = document.querySelector(id);
+    if (!modax) {
+        modax = document.querySelector("#shared-modax")
+    }
+    return modax
+}
+
 function checkInner(event) {
     if (event.target) {
         var checkbox = event.target.querySelector("temba-checkbox");

--- a/templates/flows/flow_broadcast.haml
+++ b/templates/flows/flow_broadcast.haml
@@ -80,7 +80,7 @@
   :javascript
 
     function resetWarnings() {
-      var modax = document.querySelector("#start-flow, #shared-modax");
+      var modax = getModax("#start-flow");
       var modalBody = modax.shadowRoot;
   
       var warnings = modalBody.querySelector(".warnings");
@@ -111,7 +111,7 @@
       return operands.join(" OR ");
     }
 
-    var modax = document.querySelector("#start-flow, #shared-modax");
+    var modax = getModax("#start-flow");
     var modalBody = modax.shadowRoot;
     var queryField = modalBody.querySelector('.query');
     var flowSelect = modalBody.querySelector("temba-select[name='flow']");
@@ -177,7 +177,7 @@
 
     var handleDialogButton = function(event){
 
-      var modax = document.querySelector("#start-flow, #shared-modax");
+      var modax = getModax("#start-flow");
       var modalBody = modax.shadowRoot;
 
       if (modax.suspendSubmit) {


### PR DESCRIPTION
Adds helper function to fallback to the shared modax but only if the requested one doesn't exist. Issue here was it was launching with one id, but attaching events to a different one.