### PR TITLE
Add support to sync ZVW templates

### DIFF
--- a/temba/utils/whatsapp/tasks.py
+++ b/temba/utils/whatsapp/tasks.py
@@ -168,7 +168,7 @@ def refresh_whatsapp_templates():
 
     with r.lock("refresh_whatsapp_templates", 1800):
         # for every whatsapp channel
-        for channel in Channel.objects.filter(is_active=True, channel_type__in=["WA", "D3", "WAC"]):
+        for channel in Channel.objects.filter(is_active=True, channel_type__in=["WA", "D3", "WAC", "ZVW"]):
 
             # update the version only when have it set in the config
             if channel.config.get("version"):


### PR DESCRIPTION
Requires 

1) change to mailroom to make the `external_id` https://github.com/nyaruka/rapidpro/blob/2ffaf8b7b5386193139ed0182402257d2434f414/temba/templates/models.py#L93 available to templates translations https://github.com/nyaruka/mailroom/blob/e02864f75b68d4b0eddb0eccc257d6f2e9754cb8/core/models/templates.go#L41

2) Adjustment to courier to be able to sent Zenvia WhatsApp templates using the `external_id` of the templates translations
https://zenvia.github.io/zenvia-openapi-spec/v2/#tag/WhatsApp/paths/~1channels~1whatsapp~1messages/post
