### PR TITLE
Update Media to use similiar storage path as media API endpoint

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3001,7 +3001,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             f"{settings.MEDIA_ROOT}/test_media/steve marten.jpg",
             {
                 "type": "image/jpeg",
-                "url": f"/media/attachments/{self.org.id}/{flow.id}/steps/6a65f14f-b762-4485-b860-96a322292775/steve%20marten.jpg",
+                "url": f"/media/test_orgs/{self.org.id}/media/6a65/6a65f14f-b762-4485-b860-96a322292775/steve%20marten.jpg",
             },
         )
         assert_upload(
@@ -3009,7 +3009,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             f"{settings.MEDIA_ROOT}/test_media/snow.mp4",
             {
                 "type": "video/mp4",
-                "url": f"/media/attachments/{self.org.id}/{flow.id}/steps/2f42e913-6a19-44c5-90ee-cdf7b14ad5c0/snow.mp4",
+                "url": f"/media/test_orgs/{self.org.id}/media/2f42/2f42e913-6a19-44c5-90ee-cdf7b14ad5c0/snow.mp4",
             },
         )
         assert_upload(
@@ -3017,7 +3017,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             f"{settings.MEDIA_ROOT}/test_media/snow.m4a",
             {
                 "type": "audio/mp4",
-                "url": f"/media/attachments/{self.org.id}/{flow.id}/steps/f661c405-524e-4bd7-83e2-c93ffe35aa60/snow.m4a",
+                "url": f"/media/test_orgs/{self.org.id}/media/f661/f661c405-524e-4bd7-83e2-c93ffe35aa60/snow.m4a",
             },
         )
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -705,9 +705,7 @@ class FlowCRUDL(SmartCRUDL):
         slug_url_kwarg = "uuid"
 
         def post(self, request, *args, **kwargs):
-            media = Media.from_upload(
-                self.request.org, self.request.user, self.request.FILES["file"], flow=self.get_object()
-            )
+            media = Media.from_upload(self.request.org, self.request.user, self.request.FILES["file"])
             return JsonResponse({"type": media.content_type, "url": media.url})
 
     class BaseList(SpaMixin, OrgFilterMixin, OrgPermsMixin, BulkActionMixin, SmartListView):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -37,24 +37,24 @@ from .templatetags.sms import as_icon
 class MediaTest(TembaTest):
     @patch("temba.msgs.models.uuid4")
     def test_model(self, mock_uuid):
-        flow = self.create_flow("Color")
         mock_uuid.side_effect = [UUID("6a65f14f-b762-4485-b860-96a322292775")]
         media = Media.from_upload(
             self.org,
             self.admin,
             self.upload(f"{settings.MEDIA_ROOT}/test_media/steve marten.jpg", "image/jpeg"),
-            flow=flow,
         )
 
         self.assertEqual("6a65f14f-b762-4485-b860-96a322292775", str(media.uuid))
         self.assertEqual(self.org, media.org)
         self.assertEqual(
-            f"/media/attachments/{self.org.id}/{flow.id}/steps/{media.uuid}/steve%20marten.jpg",
+            f"/media/test_orgs/{self.org.id}/media/6a65/6a65f14f-b762-4485-b860-96a322292775/steve%20marten.jpg",
             media.url,
         )
         self.assertEqual("steve marten.jpg", media.name)
         self.assertEqual("image/jpeg", media.content_type)
-        self.assertEqual(f"attachments/{self.org.id}/{flow.id}/steps/{media.uuid}/steve marten.jpg", media.path)
+        self.assertEqual(
+            f"test_orgs/{self.org.id}/media/6a65/6a65f14f-b762-4485-b860-96a322292775/steve marten.jpg", media.path
+        )
         self.assertEqual(self.admin, media.created_by)
         self.assertFalse(media.is_ready)
 


### PR DESCRIPTION
```
http://s3.com/attachments/<orgid>/<flowid>/steps/6a65f14f-b762-4485-b860-96a322292775/steve%20marten.jpg
```

becomes

```
http://s3.com/test_orgs/<orgid>/media/6a65/6a65f14f-b762-4485-b860-96a322292775/steve%20marten.jpg
```

which almost matches what the media API endpoint uses except it preserves the file name which courier still needs