### PR TITLE
Add decorator to mock UUID generation in tests

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -28,13 +28,22 @@ from temba.globals.models import Global
 from temba.mailroom import FlowValidationException
 from temba.orgs.integrations.dtone import DTOneType
 from temba.templates.models import Template, TemplateTranslation
-from temba.tests import AnonymousOrg, CRUDLTestMixin, MigrationTest, MockResponse, TembaTest, matchers, mock_mailroom
+from temba.tests import (
+    AnonymousOrg,
+    CRUDLTestMixin,
+    MigrationTest,
+    MockResponse,
+    TembaTest,
+    matchers,
+    mock_mailroom,
+    mock_uuids,
+)
 from temba.tests.engine import MockSessionWriter
 from temba.tests.s3 import MockS3Client, jsonlgz_encode
 from temba.tickets.models import Ticketer
 from temba.triggers.models import Trigger
 from temba.utils import json
-from temba.utils.uuid import UUID, uuid4
+from temba.utils.uuid import uuid4
 
 from .checks import mailroom_url
 from .models import (
@@ -2973,8 +2982,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertTrue(start.include_active)
         self.assertEqual('name ~ "frank"', start.query)
 
-    @patch("temba.msgs.models.uuid4")
-    def test_upload_media(self, mock_uuid):
+    @mock_uuids
+    def test_upload_media(self):
         flow = self.create_flow("Test")
         other_org_flow = self.create_flow("Test", org=self.org2)
 
@@ -2989,19 +2998,12 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(expected_json, response.json())
 
-        mock_uuid.side_effect = [
-            UUID("6a65f14f-b762-4485-b860-96a322292775"),
-            UUID("2f42e913-6a19-44c5-90ee-cdf7b14ad5c0"),
-            UUID("f661c405-524e-4bd7-83e2-c93ffe35aa60"),
-            UUID("67ec31c7-a85f-4834-9da2-dee2c7b56576"),
-        ]
-
         assert_upload(
             self.admin,
             f"{settings.MEDIA_ROOT}/test_media/steve marten.jpg",
             {
                 "type": "image/jpeg",
-                "url": f"/media/test_orgs/{self.org.id}/media/6a65/6a65f14f-b762-4485-b860-96a322292775/steve%20marten.jpg",
+                "url": f"/media/test_orgs/{self.org.id}/media/3618/361838c4-2866-495a-8990-9f3c222a7604/steve%20marten.jpg",
             },
         )
         assert_upload(
@@ -3009,7 +3011,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             f"{settings.MEDIA_ROOT}/test_media/snow.mp4",
             {
                 "type": "video/mp4",
-                "url": f"/media/test_orgs/{self.org.id}/media/2f42/2f42e913-6a19-44c5-90ee-cdf7b14ad5c0/snow.mp4",
+                "url": f"/media/test_orgs/{self.org.id}/media/606d/606de307-a799-47fc-8802-edc9301e0e04/snow.mp4",
             },
         )
         assert_upload(
@@ -3017,7 +3019,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             f"{settings.MEDIA_ROOT}/test_media/snow.m4a",
             {
                 "type": "audio/mp4",
-                "url": f"/media/test_orgs/{self.org.id}/media/f661/f661c405-524e-4bd7-83e2-c93ffe35aa60/snow.m4a",
+                "url": f"/media/test_orgs/{self.org.id}/media/5349/53499958-0a0a-48a5-bb5f-8f9f4d8af77b/snow.m4a",
             },
         )
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -25,35 +25,33 @@ from temba.msgs.models import (
     SystemLabelCount,
 )
 from temba.schedules.models import Schedule
-from temba.tests import AnonymousOrg, CRUDLTestMixin, TembaTest
+from temba.tests import AnonymousOrg, CRUDLTestMixin, TembaTest, mock_uuids
 from temba.tests.engine import MockSessionWriter
 from temba.tests.s3 import MockS3Client, jsonlgz_encode
-from temba.utils.uuid import UUID
 
 from .tasks import squash_msgcounts
 from .templatetags.sms import as_icon
 
 
 class MediaTest(TembaTest):
-    @patch("temba.msgs.models.uuid4")
-    def test_model(self, mock_uuid):
-        mock_uuid.side_effect = [UUID("6a65f14f-b762-4485-b860-96a322292775")]
+    @mock_uuids
+    def test_model(self):
         media = Media.from_upload(
             self.org,
             self.admin,
             self.upload(f"{settings.MEDIA_ROOT}/test_media/steve marten.jpg", "image/jpeg"),
         )
 
-        self.assertEqual("6a65f14f-b762-4485-b860-96a322292775", str(media.uuid))
+        self.assertEqual("b97f69f7-5edf-45c7-9fda-d37066eae91d", str(media.uuid))
         self.assertEqual(self.org, media.org)
         self.assertEqual(
-            f"/media/test_orgs/{self.org.id}/media/6a65/6a65f14f-b762-4485-b860-96a322292775/steve%20marten.jpg",
+            f"/media/test_orgs/{self.org.id}/media/b97f/b97f69f7-5edf-45c7-9fda-d37066eae91d/steve%20marten.jpg",
             media.url,
         )
         self.assertEqual("steve marten.jpg", media.name)
         self.assertEqual("image/jpeg", media.content_type)
         self.assertEqual(
-            f"test_orgs/{self.org.id}/media/6a65/6a65f14f-b762-4485-b860-96a322292775/steve marten.jpg", media.path
+            f"test_orgs/{self.org.id}/media/b97f/b97f69f7-5edf-45c7-9fda-d37066eae91d/steve marten.jpg", media.path
         )
         self.assertEqual(self.admin, media.created_by)
         self.assertFalse(media.is_ready)


### PR DESCRIPTION
So I can use it in https://github.com/nyaruka/rapidpro/pull/3917