### PR TITLE
Remove `view.get_gear_links`, put content menus in context

### DIFF
--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -667,12 +667,15 @@ class CampaignTest(TembaTest):
         campaign = Campaign.create(self.org, self.admin, "Perform the rain dance", self.farmers)
 
         response = self.client.get(reverse("campaigns.campaign_read", args=[campaign.uuid]))
-
-        gear_links = response.context["view"].get_gear_links()
-        self.assertListEqual([gl["title"] for gl in gear_links], ["Service"])
         self.assertEqual(
-            gear_links[-1]["href"],
-            f"/org/service/?organization={campaign.org_id}&redirect_url=/campaign/read/{campaign.uuid}/",
+            [
+                {
+                    "type": "url_post",
+                    "label": "Service",
+                    "url": f"/org/service/?organization={campaign.org_id}&redirect_url=/campaign/read/{campaign.uuid}/",
+                }
+            ],
+            response.context["content_menu"],
         )
 
     def test_view_campaign_read_archived(self):
@@ -685,9 +688,9 @@ class CampaignTest(TembaTest):
         # page title and main content title should NOT contain (Archived)
         self.assertContains(response, "Perform the rain dance", count=2)
         self.assertContains(response, "Archived", count=0)
-
-        gear_links = response.context["view"].get_gear_links()
-        self.assertListEqual([gl["title"] for gl in gear_links], ["New Event", "Export", "Edit", "Archive"])
+        self.assertListEqual(
+            ["New Event", "Export", "Edit", "Archive"], [i["label"] for i in response.context["content_menu"]]
+        )
 
         # archive the campaign
         campaign.is_archived = True
@@ -698,9 +701,7 @@ class CampaignTest(TembaTest):
         # page title and main content title should contain (Archived)
         self.assertContains(response, "Perform the rain dance", count=2)
         self.assertContains(response, "Archived", count=2)
-
-        gear_links = response.context["view"].get_gear_links()
-        self.assertListEqual([gl["title"] for gl in gear_links], ["Activate", "Export"])
+        self.assertListEqual(["Activate", "Export"], [i["label"] for i in response.context["content_menu"]])
 
     def test_view_campaign_archive(self):
         self.login(self.admin)
@@ -749,9 +750,7 @@ class CampaignTest(TembaTest):
         # page title and main content title should NOT contain Archived
         self.assertContains(response, "Perform the rain dance", count=1)
         self.assertContains(response, "Archived", count=0)
-
-        gear_links = response.context["view"].get_gear_links()
-        self.assertListEqual([gl["title"] for gl in gear_links], ["Edit", "Delete"])
+        self.assertListEqual(["Edit", "Delete"], [i["label"] for i in response.context["content_menu"]])
 
         # archive the campaign
         campaign.is_archived = True
@@ -763,8 +762,7 @@ class CampaignTest(TembaTest):
         self.assertContains(response, "Perform the rain dance", count=1)
         self.assertContains(response, "Archived", count=1)
 
-        gear_links = response.context["view"].get_gear_links()
-        self.assertListEqual([gl["title"] for gl in gear_links], ["Delete"])
+        self.assertListEqual(["Delete"], [i["label"] for i in response.context["content_menu"]])
 
     def test_view_campaignevent_update_on_archived_campaign(self):
         self.login(self.admin)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -113,12 +113,15 @@ class ChannelTest(TembaTest):
         self.login(self.customer_support)
 
         response = self.client.get(reverse("channels.channel_read", args=[self.tel_channel.uuid]))
-
-        gear_links = response.context["view"].get_gear_links()
-        self.assertListEqual([gl["title"] for gl in gear_links], ["Service"])
         self.assertEqual(
-            gear_links[-1]["href"],
-            f"/org/service/?organization={self.tel_channel.org_id}&redirect_url=/channels/channel/read/{self.tel_channel.uuid}/",
+            [
+                {
+                    "type": "url_post",
+                    "label": "Service",
+                    "url": f"/org/service/?organization={self.tel_channel.org_id}&redirect_url=/channels/channel/read/{self.tel_channel.uuid}/",
+                }
+            ],
+            response.context["content_menu"],
         )
 
     def test_deactivate(self):

--- a/temba/channels/types/dialog360/tests.py
+++ b/temba/channels/types/dialog360/tests.py
@@ -214,11 +214,18 @@ class Dialog360TypeTest(TembaTest):
         self.assertContains(response, "Hello")
         self.assertContains(response, reverse("channels.types.dialog360.sync_logs", args=[channel.uuid]))
 
-        # Check if message templates link are in sync_logs view
+        # check if message templates link are in sync_logs view
         response = self.client.get(reverse("channels.types.dialog360.sync_logs", args=[channel.uuid]))
-        gear_links = response.context["view"].get_gear_links()
-        self.assertEqual(gear_links[-1]["title"], "Message Templates")
-        self.assertEqual(gear_links[-1]["href"], reverse("channels.types.dialog360.templates", args=[channel.uuid]))
+        self.assertEqual(
+            [
+                {
+                    "type": "link",
+                    "label": "Message Templates",
+                    "url": reverse("channels.types.dialog360.templates", args=[channel.uuid]),
+                }
+            ],
+            response.context["content_menu"],
+        )
 
         # sync logs not accessible by user from other org
         self.login(self.admin2)

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -490,11 +490,18 @@ class WhatsAppTypeTest(TembaTest):
         self.assertContains(response, "Hello")
         self.assertNotContains(response, "Hi")
 
-        # Check if message templates link are in sync_logs view
+        # check if message templates link are in sync_logs view
         response = self.client.get(reverse("channels.types.whatsapp.sync_logs", args=[channel.uuid]))
-        gear_links = response.context["view"].get_gear_links()
-        self.assertEqual(gear_links[-1]["title"], "Message Templates")
-        self.assertEqual(gear_links[-1]["href"], reverse("channels.types.whatsapp.templates", args=[channel.uuid]))
+        self.assertEqual(
+            [
+                {
+                    "type": "link",
+                    "label": "Message Templates",
+                    "url": reverse("channels.types.whatsapp.templates", args=[channel.uuid]),
+                }
+            ],
+            response.context["content_menu"],
+        )
 
         # sync logs and message templates not accessible by user from other org
         self.login(self.admin2)

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -2959,12 +2959,15 @@ class ContactTest(TembaTest):
         self.login(self.customer_support)
 
         response = self.client.get(reverse("contacts.contact_read", args=[self.joe.uuid]))
-
-        gear_links = response.context["view"].get_gear_links()
-        self.assertListEqual([gl["title"] for gl in gear_links], ["Service"])
         self.assertEqual(
-            gear_links[-1]["href"],
-            f"/org/service/?organization={self.joe.org_id}&redirect_url=/contact/read/{self.joe.uuid}/",
+            [
+                {
+                    "type": "url_post",
+                    "label": "Service",
+                    "url": f"/org/service/?organization={self.org.id}&redirect_url=/contact/read/{self.joe.uuid}/",
+                }
+            ],
+            response.context["content_menu"],
         )
 
     def test_read_language(self):

--- a/templates/gear_links_include.haml
+++ b/templates/gear_links_include.haml
@@ -13,104 +13,103 @@
     margin-left: 1em;
   }
 
--with gear_links=view.get_gear_links
-  -if gear_links
+-if gear_links
 
-    -for link in gear_links
-      -if link.modax
-        %temba-modax{ header:'{{link.modax}}', endpoint:"{{link.href}}", id:"{{link.id}}"}
+  -for link in gear_links
+    -if link.modax
+      %temba-modax{ header:'{{link.modax}}', endpoint:"{{link.href}}", id:"{{link.id}}"}
 
-    #gear-container.flex.items-center.text-gray-700
-      -if gear_links|length == 1
-        -with link=gear_links|first
-          -if link.modax
-            .button-light{onclick:'showModax("{{link.id}}")', class:'{{ link|gear_link_classes:True }}'}
-              {{link.title}}
+  #gear-container.flex.items-center.text-gray-700
+    -if gear_links|length == 1
+      -with link=gear_links|first
+        -if link.modax
+          .button-light{onclick:'showModax("{{link.id}}")', class:'{{ link|gear_link_classes:True }}'}
+            {{link.title}}
+            %span{class:'gear-flag'}
+              {{link.flag}}
+
+        -else          
+          .button-light{onclick:'{%if link.on_click%}{{link.on_click}}{% else %}goto(event){%endif%}', href:'{{link.href}}', class:'{{ link|gear_link_classes:True }}', data-success-url:'{{ link.success_url }}'}
+            {{link.title}}
+
+    - else
+      -with link=gear_links|first
+        -if link.modax
+          .button-light{onclick:'javascript:showModax("{{link.id}}")', class:'{{ link|gear_link_classes:True }}', data-success-url:'{{ link.success_url }}'}
+            {{link.title}}
               %span{class:'gear-flag'}
                 {{link.flag}}
 
-          -else          
+        -else
+          -if link.js_class
+            .button-light{onclick:'{%if link.on_click%}{{link.on_click}}{% else %}void(0);{%endif%}', href:'{{link.href}}', class:'{{ link|gear_link_classes:True }}', data-success-url:'{{ link.success_url }}'}
+              {{link.title}}
+
+          -else
             .button-light{onclick:'{%if link.on_click%}{{link.on_click}}{% else %}goto(event){%endif%}', href:'{{link.href}}', class:'{{ link|gear_link_classes:True }}', data-success-url:'{{ link.success_url }}'}
               {{link.title}}
 
-      - else
-        -with link=gear_links|first
-          -if link.modax
-            .button-light{onclick:'javascript:showModax("{{link.id}}")', class:'{{ link|gear_link_classes:True }}', data-success-url:'{{ link.success_url }}'}
-              {{link.title}}
-                %span{class:'gear-flag'}
-                  {{link.flag}}
+      .btn-group.gear-menu.ml-3
+        .button-light.p-icon.dropdown-toggle.text-center{ data-toggle:"dropdown" }
+          .icon-menu.text-gray-500(style="margin-left:-2px;margin-top:1px")
+        %ul.dropdown-menu.label-menu.rounded-lg.border-none.px-4.py-3{'role':'menu', 'aria-labelledby':'dlabel'}
+          -for link in gear_links
+            -if not forloop.first
+              -if link.divider
+                %li.separator.-mx-4.border-b.my-3.border-gray-200
+              -else
+                %li.py-1
+                  -if link.ngClick
+                    .hover-linked.font-normal{onclick:"goto(event);", href:'{{link.href}}', ng-click:'{{link.ngClick}}', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}'}
+                      {{link.title}}
+                      .gear-flag
+                        {{link.flag}}
+                  -elif link.modax
+                    .hover-linked.font-normal{onclick:'javascript:showModax("{{link.id}}")', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}'}
+                      {{link.title}}
+                      %span{class:'gear-flag'}
+                        {{link.flag}}
 
-          -else
-            -if link.js_class
-              .button-light{onclick:'{%if link.on_click%}{{link.on_click}}{% else %}void(0);{%endif%}', href:'{{link.href}}', class:'{{ link|gear_link_classes:True }}', data-success-url:'{{ link.success_url }}'}
-                {{link.title}}
-
-            -else
-              .button-light{onclick:'{%if link.on_click%}{{link.on_click}}{% else %}goto(event){%endif%}', href:'{{link.href}}', class:'{{ link|gear_link_classes:True }}', data-success-url:'{{ link.success_url }}'}
-                {{link.title}}
-
-        .btn-group.gear-menu.ml-3
-          .button-light.p-icon.dropdown-toggle.text-center{ data-toggle:"dropdown" }
-            .icon-menu.text-gray-500(style="margin-left:-2px;margin-top:1px")
-          %ul.dropdown-menu.label-menu.rounded-lg.border-none.px-4.py-3{'role':'menu', 'aria-labelledby':'dlabel'}
-            -for link in gear_links
-              -if not forloop.first
-                -if link.divider
-                  %li.separator.-mx-4.border-b.my-3.border-gray-200
-                -else
-                  %li.py-1
-                    -if link.ngClick
-                      .hover-linked.font-normal{onclick:"goto(event);", href:'{{link.href}}', ng-click:'{{link.ngClick}}', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}'}
+                  -else
+                    -if link.js_class
+                      .hover-linked.font-normal{onclick:'{%if link.on_click%}{{link.on_click}}{% else %}void(0);{%endif%}', class:'{{ link|gear_link_classes }}', href:'{{link.href}}', data-success-url:'{{ link.success_url }}'}
                         {{link.title}}
-                        .gear-flag
+                        %span{class:'gear-flag'}
                           {{link.flag}}
-                    -elif link.modax
-                      .hover-linked.font-normal{onclick:'javascript:showModax("{{link.id}}")', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}'}
+                    -else
+                      .hover-linked.font-normal{onclick:"{%if link.on_click%}{{link.on_click}}{% else %}goto(event){%endif%}", href:'{{link.href}}', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}'}
                         {{link.title}}
                         %span{class:'gear-flag'}
                           {{link.flag}}
 
-                    -else
-                      -if link.js_class
-                        .hover-linked.font-normal{onclick:'{%if link.on_click%}{{link.on_click}}{% else %}void(0);{%endif%}', class:'{{ link|gear_link_classes }}', href:'{{link.href}}', data-success-url:'{{ link.success_url }}'}
-                          {{link.title}}
-                          %span{class:'gear-flag'}
-                            {{link.flag}}
-                      -else
-                        .hover-linked.font-normal{onclick:"{%if link.on_click%}{{link.on_click}}{% else %}goto(event){%endif%}", href:'{{link.href}}', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}'}
-                          {{link.title}}
-                          %span{class:'gear-flag'}
-                            {{link.flag}}
 
-
-      :javascript
-        function showModax(endpoint) {
-          const modax = document.querySelector("temba-modax[id='" + endpoint + "']");
-          if(modax) {
-            modax.open = true;
-          }
+    :javascript
+      function showModax(endpoint) {
+        const modax = document.querySelector("temba-modax[id='" + endpoint + "']");
+        if(modax) {
+          modax.open = true;
         }
+      }
 
-        $("#gear-container .gear-delete").on('click', function(e){
-           $("#delete-form").attr('href', $(this).attr('href'));
-           e.stopPropagation();
+      $("#gear-container .gear-delete").on('click', function(e){
+          $("#delete-form").attr('href', $(this).attr('href'));
+          e.stopPropagation();
 
-           var modal = new ConfirmationModal($('.deletion > .title').html(), $('.deletion > .body').html());
-           modal.addClass('alert');
-           modal.setListeners({ onPrimary: function(){
-             $('#delete-form').click();
-           }}, false);
+          var modal = new ConfirmationModal($('.deletion > .title').html(), $('.deletion > .body').html());
+          modal.addClass('alert');
+          modal.setListeners({ onPrimary: function(){
+            $('#delete-form').click();
+          }}, false);
 
-           modal.setPrimaryButton('Remove');
-           modal.show();
+          modal.setPrimaryButton('Remove');
+          modal.show();
 
-           var successUrl = $(this).data('success-url');
-           if (successUrl){
-             modal.addListener('onSuccess', function(){ document.location.href = successUrl; });
-           }
+          var successUrl = $(this).data('success-url');
+          if (successUrl){
+            modal.addListener('onSuccess', function(){ document.location.href = successUrl; });
+          }
 
-           return false;
-        });
+          return false;
+      });
 
 

--- a/templates/spa.haml
+++ b/templates/spa.haml
@@ -27,22 +27,20 @@
 
 
 -block page-header
-  -with gear_links=view.get_gear_links
+  -if title or gear_links
+    .spa-title.no-menu.flex.items-center.mb-4
+      .text-container.text-2xl.text-gray-700
+        .flex.flex-row
+          -block spa-title
+            #title-text
+              {{title}}
+      .line.flex-grow.mr-2.ml-6
+        .h-0.border.border-gray-200
+      
+      -if gear_links
+        -include "spa_page_menu.haml"
 
-    -if title or gear_links
-      .spa-title.no-menu.flex.items-center.mb-4
-        .text-container.text-2xl.text-gray-700
-          .flex.flex-row
-            -block spa-title
-              #title-text
-                {{title}}
-        .line.flex-grow.mr-2.ml-6
-          .h-0.border.border-gray-200
-        
-        -if gear_links
-          -include "spa_page_menu.haml"
-  
-    -block subtitle
+  -block subtitle
 
 -block alert-messages
   -if user_org.is_suspended

--- a/templates/spa_page_menu.haml
+++ b/templates/spa_page_menu.haml
@@ -104,22 +104,20 @@
     }
   }
 
--with gear_links=view.get_gear_links
+-if gear_links
+  .flex.h-full.spa-gear-buttons
+    -with link=gear_links|first
+      %temba-button.ml-4(name="{{link.title|escapejs}}" onclick="handleMenuClicked(event)" class='{{ link|gear_link_classes }}' data-success-url='{{ link.success_url }}' data-href='{{link.href}}' data-modax='{{link.modax|escapejs}}' data-on-submit='{{link.on_submit|escapejs}}')
 
-  -if gear_links
-    .flex.h-full.spa-gear-buttons
-      -with link=gear_links|first
-        %temba-button.ml-4(name="{{link.title|escapejs}}" onclick="handleMenuClicked(event)" class='{{ link|gear_link_classes }}' data-success-url='{{ link.success_url }}' data-href='{{link.href}}' data-modax='{{link.modax|escapejs}}' data-on-submit='{{link.on_submit|escapejs}}')
- 
-      -if gear_links|length > 1
-        %temba-dropdown.items-stretch.flex.flex-column(arrowoffset="-12" offsetx="24" offsety="6" arrowsize="8")
-          .menu-button.items-center.flex.flex-column.py-2.px-2.ml-2(slot="toggle")
-            %temba-icon( name="menu" size="1.5")
-          .dropdown.px-6.py-4.text-gray-800.z-50(slot="dropdown" style="min-width:200px")
-            -for link in gear_links
-              -if not forloop.first
-                .whitespace-nowrap.menu-item.hover-linked.font-normal{onclick:'handleMenuClicked(event)', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}', data-href:'{{link.href}}', data-modax: '{{link.modax|escapejs}}', data-on-submit:'{{link.on_submit|escapejs}}'}
-                  {{link.title}}
-                  %span{class:'gear-flag'}
-                    {{link.flag}}
+    -if gear_links|length > 1
+      %temba-dropdown.items-stretch.flex.flex-column(arrowoffset="-12" offsetx="24" offsety="6" arrowsize="8")
+        .menu-button.items-center.flex.flex-column.py-2.px-2.ml-2(slot="toggle")
+          %temba-icon( name="menu" size="1.5")
+        .dropdown.px-6.py-4.text-gray-800.z-50(slot="dropdown" style="min-width:200px")
+          -for link in gear_links
+            -if not forloop.first
+              .whitespace-nowrap.menu-item.hover-linked.font-normal{onclick:'handleMenuClicked(event)', class:'{{ link|gear_link_classes }}', data-success-url:'{{ link.success_url }}', data-href:'{{link.href}}', data-modax: '{{link.modax|escapejs}}', data-on-submit:'{{link.on_submit|escapejs}}'}
+                {{link.title}}
+                %span{class:'gear-flag'}
+                  {{link.flag}}
 


### PR DESCRIPTION
Reworks `ContentMenuMixin` to put the menu in the context, and include new and legacy formats