### PR TITLE
account page two factor authentication link fixed

### DIFF
--- a/templates/orgs/user_account.haml
+++ b/templates/orgs/user_account.haml
@@ -37,7 +37,7 @@
     %temba-alert.mb-4(level="info")
       {% url "orgs.user_two_factor_enable" as otp_url %}
       -blocktrans with brand=brand.name
-        {{brand}} recommends that you enable <temba-anchor href="{{otp_url}}">two factor</temba-anchor> authentication.
+        {{brand}} recommends that you enable <temba-anchor href="{{otp_url}}">two factor authentication.</temba-anchor>
 
   -include "formax.haml"
 


### PR DESCRIPTION
added 'authentication' to the temba anchor URL text