### PR TITLE
fixed zaper page title

### DIFF
--- a/templates/orgs/org_resthooks.haml
+++ b/templates/orgs/org_resthooks.haml
@@ -1,6 +1,9 @@
 -extends 'smartmin/form.html'
 -load smartmin i18n
 
+-block spa-title
+  Zapier
+  
 -block pre-form
 
   .mb-4


### PR DESCRIPTION
add a `-block spa-title` to override the 'Edit Org' title being set in org_resthooks.haml -> smartmin/form.html -> smartmin/base.html -> templates/spa.html