### PR TITLE
Add `.contact.urn_display` to runs endpoint

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -222,7 +222,7 @@ class ContactField(TembaModelField):
         if self.with_urn:
             urn = obj.get_urn()
             if urn:
-                urn_str = urn.get_for_api(org)
+                urn_str = urn.get_for_api()
                 urn_display = obj.anon_identifier if org.is_anon else obj.get_urn_display()
             else:
                 urn_str, urn_display = None, None

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -211,23 +211,25 @@ class ContactField(TembaModelField):
     model = Contact
     lookup_fields = ("uuid", "urns__urn")
 
-    def __init__(self, with_urn=False, **kwargs):
-        self.with_urn = with_urn
+    def __init__(self, as_summary=False, **kwargs):
+        self.as_summary = as_summary
         super().__init__(**kwargs)
 
     def to_representation(self, obj):
         rep = {"uuid": str(obj.uuid), "name": obj.name}
         org = self.context["org"]
 
-        if self.with_urn:
+        if self.as_summary:
             urn = obj.get_urn()
             if urn:
-                urn_str = urn.get_for_api()
-                urn_display = obj.anon_identifier if org.is_anon else obj.get_urn_display()
+                urn_str, urn_display = urn.get_for_api(), obj.get_urn_display()
             else:
                 urn_str, urn_display = None, None
 
             rep.update({"urn": urn_str, "urn_display": urn_display})
+
+            if org.is_anon:
+                rep["anon_display"] = obj.anon_identifier
 
         return rep
 

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -211,16 +211,25 @@ class ContactField(TembaModelField):
     model = Contact
     lookup_fields = ("uuid", "urns__urn")
 
-    def __init__(self, **kwargs):
-        self.with_urn = kwargs.pop("with_urn", False)
+    def __init__(self, with_urn=False, **kwargs):
+        self.with_urn = with_urn
         super().__init__(**kwargs)
 
     def to_representation(self, obj):
-        if self.with_urn and not self.context["org"].is_anon:
-            urn = obj.urns.first()
-            return {"uuid": obj.uuid, "urn": urn.identity if urn else None, "name": obj.name}
+        rep = {"uuid": str(obj.uuid), "name": obj.name}
+        org = self.context["org"]
 
-        return {"uuid": obj.uuid, "name": obj.name}
+        if self.with_urn:
+            urn = obj.get_urn()
+            if urn:
+                urn_str = urn.get_for_api(org)
+                urn_display = obj.anon_identifier if org.is_anon else obj.get_urn_display()
+            else:
+                urn_str, urn_display = None, None
+
+            rep.update({"urn": urn_str, "urn_display": urn_display})
+
+        return rep
 
     def get_queryset(self):
         return self.model.objects.filter(org=self.context["org"], is_active=True)

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -932,7 +932,7 @@ class FlowRunReadSerializer(ReadSerializer):
     }
 
     flow = fields.FlowField()
-    contact = fields.ContactField(with_urn=True)
+    contact = fields.ContactField(as_summary=True)
     start = serializers.SerializerMethodField()
     path = serializers.SerializerMethodField()
     values = serializers.SerializerMethodField()

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -528,7 +528,7 @@ class ContactReadSerializer(ReadSerializer):
         if not obj.is_active:
             return []
 
-        return [urn.api_urn() for urn in obj.get_urns()]
+        return [urn.get_for_api() for urn in obj.get_urns()]
 
     def get_groups(self, obj):
         if not obj.is_active:

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -86,7 +86,7 @@ class FieldsTest(TembaTest):
         )
 
         self.assert_field(
-            fields.ContactField(source="test", with_urn=True),
+            fields.ContactField(source="test", as_summary=True),
             submissions={
                 joe.uuid: joe,  # by UUID
                 joe.get_urn().urn: joe,  # by URN
@@ -151,7 +151,7 @@ class FieldsTest(TembaTest):
             )
 
             self.assert_field(
-                fields.ContactField(source="test", with_urn=True),
+                fields.ContactField(source="test", as_summary=True),
                 submissions={
                     joe.uuid: joe,  # by UUID
                     joe.get_urn().urn: joe,  # by URN
@@ -163,19 +163,22 @@ class FieldsTest(TembaTest):
                         "uuid": str(joe.uuid),
                         "name": "Joe",
                         "urn": "tel:********",
-                        "urn_display": f"{joe.id:010}",
+                        "urn_display": "********",
+                        "anon_display": f"{joe.id:010}",
                     },
                     frank: {
                         "uuid": str(frank.uuid),
                         "name": "Frank",
                         "urn": "twitterid:********",
-                        "urn_display": f"{frank.id:010}",
+                        "urn_display": "********",
+                        "anon_display": f"{frank.id:010}",
                     },
                     voldemort: {
                         "uuid": str(voldemort.uuid),
                         "name": "",
                         "urn": None,
                         "urn_display": None,
+                        "anon_display": f"{voldemort.id:010}",
                     },
                 },
             )
@@ -3750,7 +3753,8 @@ class EndpointsTest(TembaTest):
                         "uuid": self.frank.uuid,
                         "name": self.frank.name,
                         "urn": "twitter:********",
-                        "urn_display": f"{self.frank.id:010}",
+                        "urn_display": "********",
+                        "anon_display": f"{self.frank.id:010}",
                     },
                     "start": None,
                     "responded": False,

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -48,7 +48,267 @@ from .serializers import format_datetime, normalize_extra
 NUM_BASE_REQUEST_QUERIES = 5  # number of db queries required for any API request
 
 
-class APITest(TembaTest):
+class FieldsTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+
+    def assert_field(self, f, *, submissions: dict, representations: dict):
+        f._context = {"org": self.org}  # noqa
+
+        for submitted, expected in submissions.items():
+            if isinstance(expected, type) and issubclass(expected, Exception):
+                with self.assertRaises(expected, msg=f"expected exception for '{submitted}'"):
+                    f.to_internal_value(submitted)
+            else:
+                self.assertEqual(
+                    f.to_internal_value(submitted), expected, f"to_internal_value mismatch for '{submitted}'"
+                )
+
+        for value, expected in representations.items():
+            self.assertEqual(f.to_representation(value), expected, f"to_representation mismatch for '{value}'")
+
+    def test_contact(self):
+        joe = self.create_contact("Joe", urns=["tel:+593999123456"])
+        frank = self.create_contact("Frank", urns=["twitterid:2352463463#franky"])  # urn has display fragment
+        voldemort = self.create_contact("", urns=[])  # no name or URNs
+
+        self.assert_field(
+            fields.ContactField(source="test"),
+            submissions={
+                joe.uuid: joe,  # by UUID
+                joe.get_urn().urn: joe,  # by URN
+                0: serializers.ValidationError,
+                (joe.uuid, frank.uuid): serializers.ValidationError,
+            },
+            representations={
+                joe: {"uuid": str(joe.uuid), "name": "Joe"},
+            },
+        )
+
+        self.assert_field(
+            fields.ContactField(source="test", with_urn=True),
+            submissions={
+                joe.uuid: joe,  # by UUID
+                joe.get_urn().urn: joe,  # by URN
+                0: serializers.ValidationError,
+                (joe.uuid, frank.uuid): serializers.ValidationError,
+            },
+            representations={
+                joe: {
+                    "uuid": str(joe.uuid),
+                    "name": "Joe",
+                    "urn": "tel:+593999123456",
+                    "urn_display": "099 912 3456",
+                },
+                frank: {
+                    "uuid": str(frank.uuid),
+                    "name": "Frank",
+                    "urn": "twitterid:2352463463#franky",
+                    "urn_display": "franky",
+                },
+                voldemort: {
+                    "uuid": str(voldemort.uuid),
+                    "name": "",
+                    "urn": None,
+                    "urn_display": None,
+                },
+            },
+        )
+
+        self.assert_field(
+            fields.ContactField(source="test", many=True),
+            submissions={
+                (joe.uuid, frank.uuid): [joe, frank],
+                joe.uuid: serializers.ValidationError,
+            },
+            representations={
+                (joe, frank): [
+                    {"uuid": str(joe.uuid), "name": "Joe"},
+                    {"uuid": str(frank.uuid), "name": "Frank"},
+                ]
+            },
+        )
+
+        with AnonymousOrg(self.org):
+            self.assert_field(
+                fields.ContactField(source="test"),
+                submissions={
+                    joe.uuid: joe,  # by UUID
+                    joe.get_urn().urn: joe,  # by URN
+                    0: serializers.ValidationError,
+                    (joe.uuid, frank.uuid): serializers.ValidationError,
+                },
+                representations={
+                    joe: {"uuid": str(joe.uuid), "name": "Joe"},
+                    frank: {"uuid": str(frank.uuid), "name": "Frank"},
+                    voldemort: {"uuid": str(voldemort.uuid), "name": ""},
+                },
+            )
+
+            self.assert_field(
+                fields.ContactField(source="test", with_urn=True),
+                submissions={
+                    joe.uuid: joe,  # by UUID
+                    joe.get_urn().urn: joe,  # by URN
+                    0: serializers.ValidationError,
+                    (joe.uuid, frank.uuid): serializers.ValidationError,
+                },
+                representations={
+                    joe: {
+                        "uuid": str(joe.uuid),
+                        "name": "Joe",
+                        "urn": "tel:********",
+                        "urn_display": f"{joe.id:010}",
+                    },
+                    frank: {
+                        "uuid": str(frank.uuid),
+                        "name": "Frank",
+                        "urn": "twitterid:********",
+                        "urn_display": f"{frank.id:010}",
+                    },
+                    voldemort: {
+                        "uuid": str(voldemort.uuid),
+                        "name": "",
+                        "urn": None,
+                        "urn_display": None,
+                    },
+                },
+            )
+
+    def test_others(self):
+        group = self.create_group("Customers")
+        field_obj = self.create_field("registered", "Registered On", value_type=ContactField.TYPE_DATETIME)
+        flow = self.create_flow("Test")
+        campaign = Campaign.create(self.org, self.admin, "Reminders #1", group)
+        event = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, field_obj, 6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12
+        )
+
+        field = fields.LimitedListField(child=serializers.IntegerField(), source="test")
+
+        self.assertEqual(field.to_internal_value([1, 2, 3]), [1, 2, 3])
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, list(range(101)))  # too long
+
+        field = fields.CampaignField(source="test")
+        field._context = {"org": self.org}
+
+        self.assertEqual(field.to_internal_value(str(campaign.uuid)), campaign)
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, {"id": 3})  # not a string or int
+
+        field = fields.CampaignEventField(source="test")
+        field._context = {"org": self.org}
+
+        self.assertEqual(field.to_internal_value(str(event.uuid)), event)
+
+        field._context = {"org": self.org2}
+
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, event.uuid)
+
+        deleted_channel = self.create_channel("A", "My Android", "123456")
+        deleted_channel.is_active = False
+        deleted_channel.save(update_fields=("is_active",))
+
+        self.assert_field(
+            fields.ChannelField(source="test"),
+            submissions={self.channel.uuid: self.channel, deleted_channel.uuid: serializers.ValidationError},
+            representations={self.channel: {"uuid": str(self.channel.uuid), "name": "Test Channel"}},
+        )
+
+        self.assert_field(
+            fields.ContactGroupField(source="test"),
+            submissions={group.uuid: group},
+            representations={group: {"uuid": str(group.uuid), "name": "Customers"}},
+        )
+
+        field_created_on = self.org.fields.get(key="created_on")
+
+        self.assert_field(
+            fields.ContactFieldField(source="test"),
+            submissions={"registered": field_obj, "created_on": field_created_on, "xyz": serializers.ValidationError},
+            representations={field_obj: {"key": "registered", "label": "Registered On"}},
+        )
+
+        self.assert_field(
+            fields.FlowField(source="test"),
+            submissions={flow.uuid: flow},
+            representations={flow: {"uuid": str(flow.uuid), "name": flow.name}},
+        )
+
+        self.assert_field(
+            fields.TopicField(source="test"),
+            submissions={str(self.org.default_ticket_topic.uuid): self.org.default_ticket_topic},
+            representations={
+                self.org.default_ticket_topic: {"uuid": str(self.org.default_ticket_topic.uuid), "name": "General"}
+            },
+        )
+
+        self.assert_field(
+            fields.URNField(source="test"),
+            submissions={
+                "tel:+1-800-123-4567": "tel:+18001234567",
+                "tel:0788 123 123": "tel:+250788123123",  # using org country
+                "tel:(078) 812-3123": "tel:+250788123123",
+                "12345": serializers.ValidationError,  # un-parseable
+                "tel:800-123-4567": serializers.ValidationError,  # no country code
+                18_001_234_567: serializers.ValidationError,  # non-string
+            },
+            representations={"tel:+18001234567": "tel:+18001234567"},
+        )
+
+        self.editor.is_active = False
+        self.editor.save(update_fields=("is_active",))
+
+        self.assert_field(
+            fields.UserField(source="test"),
+            submissions={
+                "VIEWER@NYARUKA.COM": self.user,
+                "admin@nyaruka.com": self.admin,
+                self.editor.email: serializers.ValidationError,  # deleted
+                self.admin2.email: serializers.ValidationError,  # not in org
+            },
+            representations={
+                self.user: {"email": "viewer@nyaruka.com", "name": ""},
+                self.editor: {"email": "editor@nyaruka.com", "name": "Ed McEdits"},
+            },
+        )
+        self.assert_field(
+            fields.UserField(source="test", assignable_only=True),
+            submissions={
+                self.user.email: serializers.ValidationError,  # not assignable
+                self.admin.email: self.admin,
+                self.agent.email: self.agent,
+            },
+            representations={self.agent: {"email": "agent@nyaruka.com", "name": "Agnes"}},
+        )
+
+        field = fields.TranslatableField(source="test", max_length=10)
+        field._context = {"org": self.org}
+
+        self.assertEqual(field.to_internal_value("Hello"), ({"base": "Hello"}, "base"))
+        self.assertEqual(field.to_internal_value({"base": "Hello"}), ({"base": "Hello"}, "base"))
+
+        self.org.set_flow_languages(self.admin, ["kin"])
+        self.org.save()
+
+        self.assertEqual(field.to_internal_value("Hello"), ({"kin": "Hello"}, "kin"))
+        self.assertEqual(
+            field.to_internal_value({"eng": "Hello", "kin": "Muraho"}), ({"eng": "Hello", "kin": "Muraho"}, "kin")
+        )
+
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, 123)  # not a string or dict
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, {"kin": 123})
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, {})
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, {123: "Hello", "kin": "Muraho"})
+        self.assertRaises(serializers.ValidationError, field.to_internal_value, "HelloHello1")  # too long
+        self.assertRaises(
+            serializers.ValidationError, field.to_internal_value, {"kin": "HelloHello1"}
+        )  # also too long
+        self.assertRaises(
+            serializers.ValidationError, field.to_internal_value, {"eng": "HelloHello1"}
+        )  # base lang not provided
+
+
+class EndpointsTest(TembaTest):
     def setUp(self):
         super().setUp()
 
@@ -174,178 +434,6 @@ class APITest(TembaTest):
             reverse("api.v2.fields") + ".json", content_type="application/json", HTTP_X_FORWARDED_HTTPS="https"
         )
         self.assertContains(response, "Server Error. Site administrators have been notified.", status_code=500)
-
-    def test_serializer_fields(self):
-        def assert_field(f, *, submissions: dict, representations: dict):
-            f._context = {"org": self.org}  # noqa
-
-            for submitted, expected in submissions.items():
-                if isinstance(expected, type) and issubclass(expected, Exception):
-                    with self.assertRaises(expected, msg=f"expected exception for '{submitted}'"):
-                        f.to_internal_value(submitted)
-                else:
-                    self.assertEqual(
-                        f.to_internal_value(submitted), expected, f"to_internal_value mismatch for '{submitted}'"
-                    )
-
-            for value, expected in representations.items():
-                self.assertEqual(f.to_representation(value), expected, f"to_representation mismatch for '{value}'")
-
-        group = self.create_group("Customers")
-        field_obj = self.create_field("registered", "Registered On", value_type=ContactField.TYPE_DATETIME)
-        flow = self.create_flow("Test")
-        campaign = Campaign.create(self.org, self.admin, "Reminders #1", group)
-        event = CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, field_obj, 6, CampaignEvent.UNIT_HOURS, flow, delivery_hour=12
-        )
-
-        field = fields.LimitedListField(child=serializers.IntegerField(), source="test")
-
-        self.assertEqual(field.to_internal_value([1, 2, 3]), [1, 2, 3])
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, list(range(101)))  # too long
-
-        field = fields.CampaignField(source="test")
-        field._context = {"org": self.org}
-
-        self.assertEqual(field.to_internal_value(str(campaign.uuid)), campaign)
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, {"id": 3})  # not a string or int
-
-        field = fields.CampaignEventField(source="test")
-        field._context = {"org": self.org}
-
-        self.assertEqual(field.to_internal_value(str(event.uuid)), event)
-
-        field._context = {"org": self.org2}
-
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, event.uuid)
-
-        deleted_channel = self.create_channel("A", "My Android", "123456")
-        deleted_channel.is_active = False
-        deleted_channel.save(update_fields=("is_active",))
-
-        assert_field(
-            fields.ChannelField(source="test"),
-            submissions={self.channel.uuid: self.channel, deleted_channel.uuid: serializers.ValidationError},
-            representations={self.channel: {"uuid": str(self.channel.uuid), "name": "Test Channel"}},
-        )
-
-        assert_field(
-            fields.ContactField(source="test"),
-            submissions={
-                self.joe.uuid: self.joe,  # by UUID
-                self.joe.get_urn().urn: self.joe,  # by URN
-                0: serializers.ValidationError,
-                (self.joe.uuid, self.frank.uuid): serializers.ValidationError,
-            },
-            representations={self.joe: {"uuid": str(self.joe.uuid), "name": "Joe Blow"}},
-        )
-
-        assert_field(
-            fields.ContactField(source="test", many=True),
-            submissions={
-                (self.joe.uuid, self.frank.uuid): [self.joe, self.frank],
-                self.joe.uuid: serializers.ValidationError,
-            },
-            representations={
-                (self.joe, self.frank): [
-                    {"uuid": str(self.joe.uuid), "name": "Joe Blow"},
-                    {"uuid": str(self.frank.uuid), "name": "Frank"},
-                ]
-            },
-        )
-
-        assert_field(
-            fields.ContactGroupField(source="test"),
-            submissions={group.uuid: group},
-            representations={group: {"uuid": str(group.uuid), "name": "Customers"}},
-        )
-
-        field_created_on = self.org.fields.get(key="created_on")
-
-        assert_field(
-            fields.ContactFieldField(source="test"),
-            submissions={"registered": field_obj, "created_on": field_created_on, "xyz": serializers.ValidationError},
-            representations={field_obj: {"key": "registered", "label": "Registered On"}},
-        )
-
-        assert_field(
-            fields.FlowField(source="test"),
-            submissions={flow.uuid: flow},
-            representations={flow: {"uuid": str(flow.uuid), "name": flow.name}},
-        )
-
-        assert_field(
-            fields.TopicField(source="test"),
-            submissions={str(self.org.default_ticket_topic.uuid): self.org.default_ticket_topic},
-            representations={
-                self.org.default_ticket_topic: {"uuid": str(self.org.default_ticket_topic.uuid), "name": "General"}
-            },
-        )
-
-        assert_field(
-            fields.URNField(source="test"),
-            submissions={
-                "tel:+1-800-123-4567": "tel:+18001234567",
-                "tel:0788 123 123": "tel:+250788123123",  # using org country
-                "tel:(078) 812-3123": "tel:+250788123123",
-                "12345": serializers.ValidationError,  # un-parseable
-                "tel:800-123-4567": serializers.ValidationError,  # no country code
-                18_001_234_567: serializers.ValidationError,  # non-string
-            },
-            representations={"tel:+18001234567": "tel:+18001234567"},
-        )
-
-        self.editor.is_active = False
-        self.editor.save(update_fields=("is_active",))
-
-        assert_field(
-            fields.UserField(source="test"),
-            submissions={
-                "VIEWER@NYARUKA.COM": self.user,
-                "admin@nyaruka.com": self.admin,
-                self.editor.email: serializers.ValidationError,  # deleted
-                self.admin2.email: serializers.ValidationError,  # not in org
-            },
-            representations={
-                self.user: {"email": "viewer@nyaruka.com", "name": ""},
-                self.editor: {"email": "editor@nyaruka.com", "name": "Ed McEdits"},
-            },
-        )
-        assert_field(
-            fields.UserField(source="test", assignable_only=True),
-            submissions={
-                self.user.email: serializers.ValidationError,  # not assignable
-                self.admin.email: self.admin,
-                self.agent.email: self.agent,
-            },
-            representations={self.agent: {"email": "agent@nyaruka.com", "name": "Agnes"}},
-        )
-
-        field = fields.TranslatableField(source="test", max_length=10)
-        field._context = {"org": self.org}
-
-        self.assertEqual(field.to_internal_value("Hello"), ({"base": "Hello"}, "base"))
-        self.assertEqual(field.to_internal_value({"base": "Hello"}), ({"base": "Hello"}, "base"))
-
-        self.org.set_flow_languages(self.admin, ["kin"])
-        self.org.save()
-
-        self.assertEqual(field.to_internal_value("Hello"), ({"kin": "Hello"}, "kin"))
-        self.assertEqual(
-            field.to_internal_value({"eng": "Hello", "kin": "Muraho"}), ({"eng": "Hello", "kin": "Muraho"}, "kin")
-        )
-
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, 123)  # not a string or dict
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, {"kin": 123})
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, {})
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, {123: "Hello", "kin": "Muraho"})
-        self.assertRaises(serializers.ValidationError, field.to_internal_value, "HelloHello1")  # too long
-        self.assertRaises(
-            serializers.ValidationError, field.to_internal_value, {"kin": "HelloHello1"}
-        )  # also too long
-        self.assertRaises(
-            serializers.ValidationError, field.to_internal_value, {"eng": "HelloHello1"}
-        )  # base lang not provided
 
     @override_settings(FLOW_START_PARAMS_SIZE=4)
     def test_normalize_extra(self):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1421,26 +1421,26 @@ class ContactURN(models.Model):
 
         return self
 
-    def get_display(self, org=None, international=False, formatted=True):
+    def get_display(self, org=None, international: bool = False, formatted: bool = True) -> str:
         """
-        Gets a representation of the URN for display
+        Gets a representation of the URN for display, e.g. tel:+12345678901 becomes +1 234 567-8901
         """
-        if not org:
-            org = self.org
-
-        if org.is_anon:
+        if (org or self.org).is_anon:
             return self.ANON_MASK
 
         return URN.format(self.urn, international=international, formatted=formatted)
 
-    def api_urn(self):
-        if self.org.is_anon:
+    def get_for_api(self, org=None) -> str:
+        """
+        Gets a representation for sharing over the API which will have the path redacted if the org is anon
+        """
+        if (org or self.org).is_anon:
             return URN.from_parts(self.scheme, self.ANON_MASK)
 
-        return URN.from_parts(self.scheme, self.path, display=self.display)
+        return self.urn
 
     @property
-    def urn(self):
+    def urn(self) -> str:
         """
         Returns a full representation of this contact URN as a string
         """

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1198,7 +1198,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
                 broadcast.contacts.remove(self)
 
     @classmethod
-    def bulk_urn_cache_initialize(cls, contacts, *, using="default"):
+    def bulk_urn_cache_initialize(cls, org, contacts, *, using="default"):
         """
         Initializes the URN caches on the given contacts.
         """
@@ -1207,6 +1207,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
 
         contact_map = dict()
         for contact in contacts:
+            contact.org = org
             contact_map[contact.id] = contact
             # initialize URN list cache
             setattr(contact, "_urns_cache", list())
@@ -1219,7 +1220,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
         )
         for urn in urns:
             contact = contact_map[urn.contact_id]
-            urn.org = contact.org
+            urn.org = org
             getattr(contact, "_urns_cache").append(urn)
 
     def get_groups(self, *, manual_only=False):
@@ -1430,14 +1431,14 @@ class ContactURN(models.Model):
 
         return URN.format(self.urn, international=international, formatted=formatted)
 
-    def get_for_api(self, org=None) -> str:
+    def get_for_api(self) -> str:
         """
-        Gets a representation for sharing over the API which will have the path redacted if the org is anon
+        Gets a representation for the API which will be scheme:path and will have the path redacted if the org is anon
         """
-        if (org or self.org).is_anon:
+        if self.org.is_anon:
             return URN.from_parts(self.scheme, self.ANON_MASK)
 
-        return self.urn
+        return URN.from_parts(self.scheme, self.path)
 
     @property
     def urn(self) -> str:
@@ -1935,14 +1936,12 @@ class ExportContactsTask(BaseExportTask):
         # write out contacts in batches to limit memory usage
         for batch_ids in chunk_list(contact_ids, 1000):
             # fetch all the contacts for our batch
-            batch_contacts = (
-                Contact.objects.filter(id__in=batch_ids).prefetch_related("org", "groups").using("readonly")
-            )
+            batch_contacts = Contact.objects.filter(id__in=batch_ids).prefetch_related("groups").using("readonly")
 
             # to maintain our sort, we need to lookup by id, create a map of our id->contact to aid in that
             contact_by_id = {c.id: c for c in batch_contacts}
 
-            Contact.bulk_urn_cache_initialize(batch_contacts, using="readonly")
+            Contact.bulk_urn_cache_initialize(self.org, batch_contacts, using="readonly")
 
             for contact_id in batch_ids:
                 contact = contact_by_id[contact_id]

--- a/temba/contacts/search/omnibox.py
+++ b/temba/contacts/search/omnibox.py
@@ -89,10 +89,10 @@ def omnibox_mixed_search(org, query, types):
                 offset=0,
                 total=len(search_results.contact_ids),
                 only=("id", "uuid", "name", "org_id"),
-            ).prefetch_related("org")
+            )
 
             results += list(contacts[:per_type_limit])
-            Contact.bulk_urn_cache_initialize(contacts=results)
+            Contact.bulk_urn_cache_initialize(org, contacts=results)
 
         except SearchException:
             pass

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -331,7 +331,7 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
 
         # resolve the paginated object list so we can initialize a cache of URNs
         contacts = context["object_list"]
-        Contact.bulk_urn_cache_initialize(contacts)
+        Contact.bulk_urn_cache_initialize(org, contacts)
 
         system_groups, smart_groups, manual_groups = self.get_groups(org)
 
@@ -810,7 +810,7 @@ class ContactCRUDL(SmartCRUDL):
             context["has_sendable_urn"] = has_sendable_urn
 
             # load our contacts values
-            Contact.bulk_urn_cache_initialize([contact])
+            Contact.bulk_urn_cache_initialize(contact.org, [contact])
 
             # lookup all of our contact fields
             all_contact_fields = []

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -766,6 +766,8 @@ class TembaTest(TembaTestMixin, SmartminTest):
             role.group  # noqa
             role.permissions  # noqa
 
+        self.maxDiff = None
+
     def tearDown(self):
         clear_flow_users()
 


### PR DESCRIPTION
Will add this in other places but this PR is complicated enough for now

```json
{
  "uuid": "9a00cb2f-b63b-4796-bc17-e1939fd29303",
  "name": "Frank",
  "urn": "twitterid:2352463463#franky",
  "urn_display": "franky"
}
```

if org is anon...

```json
{
  "uuid": "9a00cb2f-b63b-4796-bc17-e1939fd29303",
  "name": "Frank",
  "urn": "twitterid:********",
  "urn_display": "0000023525",
}
```

if contact doesn't have a URN...

```json
{
  "uuid": "9a00cb2f-b63b-4796-bc17-e1939fd29303",
  "name": "Frank",
  "urn": null,
  "urn_display": null,
}
```

but I have a sense that @ericnewcomer is going to want the anon id even when there's no URN so starting to question stuffing it in there