### PR TITLE
Use elapsed_ms rather than request_time on channel log templates

### DIFF
--- a/templates/channels/channellog_list.haml
+++ b/templates/channels/channellog_list.haml
@@ -55,7 +55,7 @@
                         {{obj.get_description}}
                   %td
                     %span
-                      {{ obj.request_time|default:"0"|intcomma }}ms
+                      {{ obj.elapsed_ms|default:"0"|intcomma }}ms
 
                   %td(style='text-align: right' nowrap='true')
                     {% format_datetime obj.created_on seconds=True %}

--- a/templates/channels/channellog_list_spa.haml
+++ b/templates/channels/channellog_list_spa.haml
@@ -46,16 +46,16 @@
             %td
               -if obj.msg
                 .hover-linked(onclick="goto(event)" href='{% url "channels.channellog_msg" obj.msg.id %}')
-                  {{obj.description}}
+                  {{obj.get_description}}
               -elif obj.connection
                 .hover-linked(onclick="goto(event)" href='{% url "channels.channellog_call" obj.connection.id %}')
-                  {{obj.description}}
+                  {{obj.get_description}}
               -else
                 .hover-linked(onclick="goto(event)" href='{% url "channels.channellog_read" obj.id %}')
-                  {{obj.description}}
+                  {{obj.get_description}}
             %td
               %span
-                {{ obj.request_time|default:"0"|intcomma }}ms
+                {{ obj.elapsed_ms|default:"0"|intcomma }}ms
 
             %td(style='text-align: right' nowrap='true')
               {% format_datetime obj.created_on seconds=True %}


### PR DESCRIPTION
<img width="438" alt="Captura de Pantalla 2022-08-26 a la(s) 09 12 24" src="https://user-images.githubusercontent.com/675558/186923261-2e59775f-80dd-4dcb-bd37-190f772b4bd5.png">
