### PR TITLE
fixed create trigger

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 RapidPro - Platform to visually build interactive messaging systems 
 anywhere in the world.
 
-Copyright (C) 2017 Nyaruka, UNICEF, and individual contributors.
+Copyright (C) 2012-2022 TextIt, UNICEF, and individual contributors.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -234,7 +234,7 @@ class TriggerCRUDL(SmartCRUDL):
                 )
             )
 
-            menu.append(self.create_menu_item(name=_("Create Trigger"), icon="plus", href="triggers.trigger_create"))
+            menu.append(self.create_menu_item(name=_("New Trigger"), icon="plus", href="triggers.trigger_create"))
 
             menu.append(self.create_divider())
 
@@ -252,11 +252,11 @@ class TriggerCRUDL(SmartCRUDL):
             return menu
 
     class Create(SpaMixin, FormaxMixin, OrgFilterMixin, OrgPermsMixin, SmartTemplateView):
-        title = _("Create Trigger")
+        title = _("New Trigger")
 
         def derive_formax_sections(self, formax, context):
             def add_section(name, url, icon):
-                formax.add_section(name, reverse(url), icon=icon, action="redirect", button=_("Create Trigger"))
+                formax.add_section(name, reverse(url), icon=icon, action="redirect", button=_("New Trigger"))
 
             org_schemes = self.org.get_schemes(Channel.ROLE_RECEIVE)
             add_section("trigger-keyword", "triggers.trigger_create_keyword", "icon-tree")

--- a/templates/triggers/trigger_list.haml
+++ b/templates/triggers/trigger_list.haml
@@ -23,7 +23,7 @@
             -if org_perms.triggers.trigger_create
               .w-64.mr-5
                 .button-primary.block(onclick="goto(event)" href="{% url 'triggers.trigger_create' %}")
-                  -trans "Create Trigger"
+                  -trans "New Trigger"
 
           .lp-nav.upper
             -for folder in main_folders


### PR DESCRIPTION
i'm assuming it's ok to leave all of the BTS instances of `triggers.trigger_create` as is for now, but let me know if it would be preferred to update those (and/or the translations)  to `trigger_new` and `New Trigger` for consistency, respectively