### PR TITLE
Fix to allow displaying logs that timed out

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1292,12 +1292,12 @@ class ChannelLog(models.Model):
         def redact_http(log: dict) -> dict:
             return {
                 "url": self._get_display_value(user, log["url"], redact_values=redact_values),
-                "status_code": log["status_code"],
+                "status_code": log.get("status_code", 0),
                 "request": self._get_display_value(
                     user, log["request"], redact_keys=redact_request_keys, redact_values=redact_values
                 ),
                 "response": self._get_display_value(
-                    user, log["response"], redact_keys=redact_response_keys, redact_values=redact_values
+                    user, log.get("response", ""), redact_keys=redact_response_keys, redact_values=redact_values
                 ),
                 "elapsed_ms": log["elapsed_ms"],
                 "retries": log["retries"],

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -2113,8 +2113,6 @@ class ChannelLogTest(TembaTest):
             "created_on": matchers.Datetime(),
         }
 
-        self.maxDiff = None
-
         self.assertEqual(expected_unredacted, log.get_display(self.admin))
         self.assertEqual(expected_unredacted, log.get_display(self.customer_support))
 
@@ -2176,8 +2174,6 @@ class ChannelLogTest(TembaTest):
             "errors": [{"message": "response n********", "code": ""}],
             "created_on": matchers.Datetime(),
         }
-
-        self.maxDiff = None
 
         self.assertEqual(expected_unredacted, log.get_display(self.admin))
         self.assertEqual(expected_unredacted, log.get_display(self.customer_support))

--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -674,8 +674,6 @@ class FlowMigrationTest(TembaTest):
                     for text in sorted(action["msg"].values()):
                         replies.append(text)
 
-        self.maxDiff = None
-
         self.assertEqual(
             replies,
             [

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -127,8 +127,6 @@ class MailroomClientTest(TembaTest):
 
         call = mock_post.call_args
 
-        self.maxDiff = None
-
         self.assertEqual(("http://localhost:8090/mr/flow/preview_start",), call[0])
         self.assertEqual({"User-Agent": "Temba", "Content-Type": "application/json"}, call[1]["headers"])
         self.assertEqual(


### PR DESCRIPTION
Fixes https://sentry.io/organizations/nyaruka/issues/3541064485/

```
KeyError: 'status_code'
  File "django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "django/views/generic/base.py", line 84, in view
    return self.dispatch(request, *args, **kwargs)
  File "temba/orgs/views.py", line 169, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "smartmin/views.py", line 117, in dispatch
    return wrapper(request, *args, **kwargs)
  File "smartmin/views.py", line 113, in wrapper
    return super(SmartView, self).dispatch(request, *args, **kwargs)
  File "django/views/generic/base.py", line 119, in dispatch
    return handler(request, *args, **kwargs)
  File "temba/utils/views.py", line 373, in get
    return super().get(request, *args, **kwargs)
  File "django/views/generic/list.py", line 174, in get
    context = self.get_context_data()
  File "temba/channels/views.py", line 1573, in get_context_data
    context["logs"] = [log.get_display(self.request.user) for log in context["object_list"]]
  File "temba/channels/views.py", line 1573, in <listcomp>
    context["logs"] = [log.get_display(self.request.user) for log in context["object_list"]]
  File "temba/channels/models.py", line 1315, in get_display
    "http_logs": [redact_http(h) for h in http_logs],
  File "temba/channels/models.py", line 1315, in <listcomp>
    "http_logs": [redact_http(h) for h in http_logs],
  File "temba/channels/models.py", line 1295, in redact_http
    "status_code": log["status_code"],

