### PR TITLE
Only show Missed Call trigger as option for workspaces with an Android channel

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1163,12 +1163,6 @@ class Org(SmartModel):
             self._user_role_cache[user] = get_role()
         return self._user_role_cache[user]
 
-    def has_twilio_number(self):  # pragma: needs cover
-        return self.channels.filter(channel_type="T")
-
-    def has_vonage_number(self):  # pragma: needs cover
-        return self.channels.filter(channel_type="NX")
-
     def init_topups(self, topup_size=None):
         if topup_size:
             return TopUp.create(self, self.created_by, price=0, credits=topup_size)

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -481,11 +481,13 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         # but a new conversation trigger can't be created with a suitable channel
         self.assertNotContains(response, create_new_convo_url)
 
-        # create a facebook channel
+        # create a facebook channel and delete our Android channel
         self.create_channel("FB", "Facebook Channel", "1234567")
+        self.channel.release()
 
         response = self.client.get(create_url)
         self.assertContains(response, create_new_convo_url)
+        self.assertNotContains(response, create_missed_call_url)
 
     def test_create_keyword(self):
         create_url = reverse("triggers.trigger_create_keyword")

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -483,7 +483,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # create a facebook channel and delete our Android channel
         self.create_channel("FB", "Facebook Channel", "1234567")
-        self.channel.release()
+        self.channel.release(self.admin)
 
         response = self.client.get(create_url)
         self.assertContains(response, create_new_convo_url)

--- a/temba/triggers/types.py
+++ b/temba/triggers/types.py
@@ -145,7 +145,7 @@ class InboundCallTriggerType(TriggerType):
 
 class MissedCallTriggerType(TriggerType):
     """
-    A trigger for missed inbound IVR calls
+    A trigger for missed calls on Android devices
     """
 
     class Form(BaseTriggerForm):

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _, ngettext_lazy
 
 from temba.channels.models import Channel
+from temba.channels.types.android import AndroidType
 from temba.contacts.models import ContactGroup, ContactURN
 from temba.contacts.search.omnibox import omnibox_serialize
 from temba.flows.models import Flow
@@ -259,12 +260,15 @@ class TriggerCRUDL(SmartCRUDL):
                 formax.add_section(name, reverse(url), icon=icon, action="redirect", button=_("New Trigger"))
 
             org_schemes = self.org.get_schemes(Channel.ROLE_RECEIVE)
+
             add_section("trigger-keyword", "triggers.trigger_create_keyword", "icon-tree")
             add_section("trigger-register", "triggers.trigger_create_register", "icon-users-2")
             add_section("trigger-catchall", "triggers.trigger_create_catchall", "icon-bubble")
             add_section("trigger-schedule", "triggers.trigger_create_schedule", "icon-clock")
             add_section("trigger-inboundcall", "triggers.trigger_create_inbound_call", "icon-phone2")
-            add_section("trigger-missedcall", "triggers.trigger_create_missed_call", "icon-phone")
+
+            if self.org.channels.filter(is_active=True, channel_type=AndroidType.code).exists():
+                add_section("trigger-missedcall", "triggers.trigger_create_missed_call", "icon-phone")
 
             if ContactURN.SCHEMES_SUPPORTING_NEW_CONVERSATION.intersection(org_schemes):
                 add_section("trigger-new-conversation", "triggers.trigger_create_new_conversation", "icon-bubbles-2")

--- a/templates/triggers/trigger_create_missed_call.haml
+++ b/templates/triggers/trigger_create_missed_call.haml
@@ -2,4 +2,4 @@
 -load i18n
 
 -block summary
-  -trans "Start a flow after a missed call."
+  -trans "Start a flow after a missed call on an Android Phone channel."


### PR DESCRIPTION
Users shouldn't be using this except for missed calls on Android devices