### PR TITLE
Add common base class for exports that have a date range

### DIFF
--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -19,7 +19,7 @@ from temba.contacts.models import Contact
 from temba.orgs.models import DependencyMixin, Org, User, UserSettings
 from temba.utils import chunk_list
 from temba.utils.dates import date_range
-from temba.utils.export import BaseExportAssetStore, BaseExportTask, TableExporter, export_date_range
+from temba.utils.export import BaseDateRangeExport, BaseExportAssetStore, TableExporter
 from temba.utils.models import DailyCountModel, DailyTimingModel, SquashableModel, TembaModel
 from temba.utils.uuid import uuid4
 
@@ -633,12 +633,9 @@ def export_ticket_stats(org: Org, since: date, until: date) -> openpyxl.Workbook
     return workbook
 
 
-class ExportTicketsTask(BaseExportTask):
+class ExportTicketsTask(BaseDateRangeExport):
     analytics_key = "ticket_export"
     notification_export_type = "ticket"
-
-    start_date = models.DateField()
-    end_date = models.DateField()
 
     @classmethod
     def create(cls, org, user, start_date, end_date):
@@ -646,7 +643,7 @@ class ExportTicketsTask(BaseExportTask):
 
     def write_export(self):
         fields = self.get_fields()
-        start_date, end_date = export_date_range(self.org, self.start_date, self.end_date)
+        start_date, end_date = self._get_date_range()
 
         # get the ticket ids, filtered and ordered by opened on
         ticket_ids = (


### PR DESCRIPTION
Next step is adding a common export base for things that have an associated contact, so then we can have a uniform set of contact columns across the different export types (excluding actual contact exports)