### PR TITLE
Small styling tweaks for api docs

### DIFF
--- a/templates/api/v2/api_explorer.haml
+++ b/templates/api/v2/api_explorer.haml
@@ -164,6 +164,10 @@
 -block extra-style
   {{ block.super }}
   :css
+    .content-card {
+      width: 80%;
+    }
+
     .breadcrumb {
       display: flex;
       flex-wrap: wrap;

--- a/templates/api/v2/api_root.html
+++ b/templates/api/v2/api_root.html
@@ -12,6 +12,25 @@
     <link rel="stylesheet" type="text/css" href='{% static "css/codemirror.css" %}'/>
 
  <style>
+
+    .content-card {
+      width: 80%;
+    }
+
+    .content-main li {
+        margin: 0.4em 0em;
+    }
+
+    .content-main ul {
+        margin-top: 1em;
+        margin-bottom: 1em;
+    }
+
+    code {
+        padding:0.2em 0.5em;
+        font-size: 0.9em;
+    }
+
     .card {
       padding: 0;
       margin: 1em 2em;


### PR DESCRIPTION
* Add some margins to li and adjust code blocks so they don't overlap
* Nicer margins around ul
* Consistent widths for docs and explorer at 80%

<img width="995" alt="Screen Shot 2022-10-17 at 10 55 30 AM" src="https://user-images.githubusercontent.com/211652/196248511-8e433ef6-3715-48b3-9e94-05cb79dfda2f.png">
<img width="996" alt="Screen Shot 2022-10-17 at 10 55 34 AM" src="https://user-images.githubusercontent.com/211652/196248516-b2994f35-79ac-4fd3-8776-516fd3f02732.png">
