### PR TITLE
🖼️ Rework branding 

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1590,7 +1590,7 @@ class Alert(SmartModel):
         context["unsent_count"] = Msg.objects.filter(channel=self.channel, status__in=["Q", "P"]).count()
         context["subject"] = subject
 
-        send_template_email(self.channel.alert_email, subject, template, context, self.channel.org.get_branding())
+        send_template_email(self.channel.alert_email, subject, template, context, self.channel.org.branding)
 
 
 def get_alert_user():

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1501,9 +1501,9 @@ class ChannelClaimTest(TembaTest):
         self.channel.last_seen = timezone.now() - timedelta(minutes=40)
         self.channel.save()
 
-        branding = copy.deepcopy(settings.BRANDING)
-        branding["rapidpro.io"]["from_email"] = "support@mybrand.com"
-        with self.settings(BRANDING=branding):
+        brands = copy.deepcopy(settings.BRANDS)
+        brands[0]["from_email"] = "support@mybrand.com"
+        with self.settings(BRANDS=brands):
             check_channels_task()
 
             # should have created one alert
@@ -1518,7 +1518,7 @@ class ChannelClaimTest(TembaTest):
                 org=self.channel.org,
                 channel=self.channel,
                 now=timezone.now(),
-                branding=self.channel.org.get_branding(),
+                branding=self.channel.org.branding,
                 last_seen=self.channel.last_seen,
                 sync=alert.sync_event,
             )
@@ -1551,7 +1551,7 @@ class ChannelClaimTest(TembaTest):
             org=self.channel.org,
             channel=self.channel,
             now=timezone.now(),
-            branding=self.channel.org.get_branding(),
+            branding=self.channel.org.branding,
             last_seen=self.channel.last_seen,
             sync=alert.sync_event,
         )

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1181,7 +1181,7 @@ class ChannelCRUDL(SmartCRUDL):
             org = self.request.org
 
             context["org_timezone"] = str(org.timezone)
-            context["brand"] = org.get_branding()
+            context["brand"] = org.branding
 
             channel_count, org_limit = Channel.get_org_limit_progress(org)
             context["total_count"] = channel_count

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -2186,13 +2186,12 @@ def get_flow_user(org):
     if not __flow_users:
         __flow_users = {}
 
-    branding = org.get_branding()
-    username = "%s_flow" % branding["slug"]
+    username = "%s_flow" % org.branding["slug"]
     flow_user = __flow_users.get(username)
 
     # not cached, let's look it up
     if not flow_user:
-        email = branding["support_email"]
+        email = org.branding["support_email"]
         flow_user = User.objects.filter(username=username).first()
         if flow_user:  # pragma: needs cover
             __flow_users[username] = flow_user

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2506,10 +2506,10 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         mock_flow_is_starting.return_value = False
 
         # now set our brand to redirect
-        branding = copy.deepcopy(settings.BRANDING)
-        branding["rapidpro.io"]["inactive_threshold"] = 1000
+        brands = copy.deepcopy(settings.BRANDS)
+        brands[0]["inactive_threshold"] = 1000
 
-        with self.settings(BRANDING=branding):
+        with self.settings(BRANDS=brands):
             flow = self.create_flow("Test")
             self.create_field("age", "Age")
             contact1 = self.create_contact("Ann", phone="+16302222222", fields={"age": 40})

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.utils import timezone, translation
 
 from temba.orgs.models import Org
+from temba.utils.brands import get_branding
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class BrandingMiddleware:
 
     def __call__(self, request):
         """
-        Check for any branding options based on the current host
+        Set branding for this request based on the current host
         """
 
         host = "localhost"
@@ -43,39 +44,21 @@ class BrandingMiddleware:
         except Exception as e:  # pragma: needs cover
             logger.error(f"Could not get host: {host}, {str(e)}", exc_info=True)
 
-        request.branding = BrandingMiddleware.get_branding_for_host(host)
+        request.branding = self.get_branding_for_host(host)
 
-        response = self.get_response(request)
-        return response
+        return self.get_response(request)
 
     @classmethod
-    def get_branding_for_host(cls, host):
-        brand_key = host
-
+    def get_branding_for_host(cls, host: str) -> dict:
         # ignore subdomains
-        if len(brand_key.split(".")) > 2:  # pragma: needs cover
-            brand_key = ".".join(brand_key.split(".")[-2:])
+        if len(host.split(".")) > 2:  # pragma: needs cover
+            host = ".".join(host.split(".")[-2:])
 
         # prune off the port
-        if ":" in brand_key:
-            brand_key = brand_key[0 : brand_key.rindex(":")]
+        if ":" in host:
+            host = host[0 : host.rindex(":")]
 
-        # override with site specific branding if we have that
-        branding = settings.BRANDING.get(brand_key, None)
-
-        if branding:
-            branding["brand"] = brand_key
-
-            # derive the keys for our brand based on our aliases
-            if "aliases" in branding:
-                branding["keys"] = [brand_key] + branding["aliases"]
-            else:
-                branding["keys"] = [brand_key]
-        else:
-            # if that brand isn't configured, use the default
-            branding = settings.BRANDING.get(settings.DEFAULT_BRAND)
-
-        return branding
+        return get_branding(host)
 
 
 class OrgMiddleware:

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.utils import timezone, translation
 
 from temba.orgs.models import Org
-from temba.utils.brands import get_branding
+from temba.utils.brands import get_branding_by_host
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ class BrandingMiddleware:
         if ":" in host:
             host = host[0 : host.rindex(":")]
 
-        return get_branding(host)
+        return get_branding_by_host(host)
 
 
 class OrgMiddleware:

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -318,7 +318,7 @@ class Notification(models.Model):
                 f"[{self.org.name}] {subject}",
                 template,
                 context,
-                self.org.get_branding(),
+                self.org.branding,
             )
         else:  # pragma: no cover
             logger.warning(f"skipping email send for notification type {self.type.slug} not configured for email")

--- a/temba/orgs/context_processors.py
+++ b/temba/orgs/context_processors.py
@@ -24,7 +24,7 @@ class RolePermsWrapper:
 
 def user_orgs_for_brand(request):
     if request.user.is_authenticated:
-        user_orgs = request.user.get_orgs(brands=request.branding.get("keys", []))
+        user_orgs = request.user.get_orgs(brand=request.branding)
         return {"user_orgs": user_orgs}
     return {}
 

--- a/temba/orgs/context_processors.py
+++ b/temba/orgs/context_processors.py
@@ -24,7 +24,7 @@ class RolePermsWrapper:
 
 def user_orgs_for_brand(request):
     if request.user.is_authenticated:
-        user_orgs = request.user.get_orgs(brand=request.branding)
+        user_orgs = request.user.get_orgs(brand=request.branding["slug"])
         return {"user_orgs": user_orgs}
     return {}
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -688,7 +688,7 @@ class UserTest(TembaTest):
 
         # check our choose page
         response = self.client.get(reverse("orgs.org_choose"), SERVER_NAME="custom-brand.org")
-        self.assertEqual("custom-brand.io", response.context["request"].branding["host"])
+        self.assertEqual("custom", response.context["request"].branding["slug"])
 
         # should contain both orgs
         self.assertContains(response, "Other Brand Org")

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2112,9 +2112,8 @@ class OrgCRUDL(SmartCRUDL):
         def derive_queryset(self, **kwargs):
             qs = super().derive_queryset(**kwargs).filter(is_active=True)
 
-            brands = self.request.branding.get("keys")
-            if brands:
-                qs = qs.filter(brand__in=brands)
+            # TODO update orgs to use only brand slugs
+            qs = qs.filter(brand__in=[self.request.branding["slug"]] + self.request.branding["hosts"])
 
             obj_filter = self.request.GET.get("filter")
             if obj_filter == "anon":
@@ -2712,7 +2711,7 @@ class OrgCRUDL(SmartCRUDL):
         }
 
         def get_user_orgs(self):
-            return self.request.user.get_orgs(brand=self.request.branding["host"])
+            return self.request.user.get_orgs(brand=self.request.branding["slug"])
 
         def get_success_url(self):
             role = self.request.org.get_user_role(self.request.user)

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1921,7 +1921,7 @@ class OrgCRUDL(SmartCRUDL):
 
                         admin_emails = [admin.email for admin in self.instance.get_admins().order_by("email")]
 
-                        branding = self.instance.get_branding()
+                        branding = self.instance.branding
                         subject = _("%(name)s SMTP configuration test") % branding
                         body = (
                             _(
@@ -2712,7 +2712,7 @@ class OrgCRUDL(SmartCRUDL):
         }
 
         def get_user_orgs(self):
-            return self.request.user.get_orgs(brands=self.request.branding.get("keys"))
+            return self.request.user.get_orgs(brand=self.request.branding["host"])
 
         def get_success_url(self):
             role = self.request.org.get_user_role(self.request.user)
@@ -3154,7 +3154,7 @@ class OrgCRUDL(SmartCRUDL):
             ):  # pragma: needs cover
                 obj.add_user(self.request.user, OrgRole.ADMINISTRATOR)
 
-            obj.initialize(branding=obj.get_branding(), topup_size=self.get_welcome_size())
+            obj.initialize(branding=obj.branding, topup_size=self.get_welcome_size())
 
             return obj
 
@@ -3299,7 +3299,7 @@ class OrgCRUDL(SmartCRUDL):
             token = self.get_token(org)
             if token:
                 context["prometheus_token"] = token.key
-                context["prometheus_url"] = f"https://{org.get_branding()['domain']}/mr/org/{org.uuid}/metrics"
+                context["prometheus_url"] = f"https://{org.branding['domain']}/mr/org/{org.uuid}/metrics"
 
             return context
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2112,7 +2112,7 @@ class OrgCRUDL(SmartCRUDL):
         def derive_queryset(self, **kwargs):
             qs = super().derive_queryset(**kwargs).filter(is_active=True)
 
-            # TODO update orgs to use only brand slugs
+            # TODO update orgs to use brand slugs rather than hosts
             qs = qs.filter(brand__in=[self.request.branding["slug"]] + self.request.branding["hosts"])
 
             obj_filter = self.request.GET.get("filter")

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -20,7 +20,8 @@ STORAGE_URL = "http://localhost:8000/media"
 # Add a custom brand for development
 # -----------------------------------------------------------------------------------
 
-custom = copy.deepcopy(BRANDING["rapidpro.io"])
+custom = copy.deepcopy(BRANDS[0])
+custom["host"] = "custom-brand.io"
 custom["aliases"] = ["custom-brand.org"]
 custom["name"] = "Custom Brand"
 custom["slug"] = "custom"
@@ -29,33 +30,25 @@ custom["domain"] = "custom-brand.io"
 custom["email"] = "join@custom-brand.io"
 custom["support_email"] = "support@custom-brand.io"
 custom["allow_signups"] = True
-BRANDING["custom-brand.io"] = custom
+BRANDS.append(custom)
 
-# make another copy as an alternate domain for custom-domain
-custom2 = copy.deepcopy(custom)
-custom2["aliases"] = ["custom-brand.io"]
-custom2["domain"] = "custom-brand.org"
-custom2["email"] = "join@custom-brand.org"
-custom2["support_email"] = "support@custom-brand.org"
-BRANDING["custom-brand.org"] = custom2
-
-custom3 = copy.deepcopy(BRANDING["rapidpro.io"])
-custom3["aliases"] = ["no-topups.org"]
-custom3["name"] = "No Topups"
-custom3["slug"] = "notopups"
-custom3["org"] = "NoTopups"
-custom3["domain"] = "no-topups.org"
-custom3["email"] = "join@no-topups.org"
-custom3["support_email"] = "support@no-topups.org"
-custom3["allow_signups"] = True
-custom3["welcome_topup"] = 0
-custom3["default_plan"] = "trial"
-BRANDING["no-topups.org"] = custom3
+no_topups = copy.deepcopy(BRANDS[0])
+no_topups["host"] = "no-topups.org"
+no_topups["name"] = "No Topups"
+no_topups["slug"] = "notopups"
+no_topups["org"] = "NoTopups"
+no_topups["domain"] = "no-topups.org"
+no_topups["email"] = "join@no-topups.org"
+no_topups["support_email"] = "support@no-topups.org"
+no_topups["allow_signups"] = True
+no_topups["welcome_topup"] = 0
+no_topups["default_plan"] = "trial"
+BRANDS.append(no_topups)
 
 # set our domain on our brands to our tunnel domain if set
 localhost_domain = os.environ.get("LOCALHOST_TUNNEL_DOMAIN")
 if localhost_domain is not None:
-    for b in BRANDING.values():
+    for b in BRANDS:
         b["domain"] = localhost_domain
 
 # allow all hosts in dev

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -1,4 +1,3 @@
-
 # -----------------------------------------------------------------------------------
 # Sample RapidPro settings file, this should allow you to deploy RapidPro locally on
 # a PostgreSQL database.
@@ -21,10 +20,9 @@ STORAGE_URL = "http://localhost:8000/media"
 # -----------------------------------------------------------------------------------
 
 custom = copy.deepcopy(BRANDS[0])
-custom["host"] = "custom-brand.io"
-custom["aliases"] = ["custom-brand.org"]
-custom["name"] = "Custom Brand"
 custom["slug"] = "custom"
+custom["name"] = "Custom Brand"
+custom["hosts"] = ["custom-brand.io", "custom-brand.org"]
 custom["org"] = "Custom"
 custom["domain"] = "custom-brand.io"
 custom["email"] = "join@custom-brand.io"
@@ -33,9 +31,9 @@ custom["allow_signups"] = True
 BRANDS.append(custom)
 
 no_topups = copy.deepcopy(BRANDS[0])
-no_topups["host"] = "no-topups.org"
-no_topups["name"] = "No Topups"
 no_topups["slug"] = "notopups"
+no_topups["name"] = "No Topups"
+no_topups["hosts"] = ["no-topups.org"]
 no_topups["org"] = "NoTopups"
 no_topups["domain"] = "no-topups.org"
 no_topups["email"] = "join@no-topups.org"
@@ -70,7 +68,7 @@ INTERNAL_IPS = ("127.0.0.1",)
 # -----------------------------------------------------------------------------------
 # Mailroom - localhost for dev, no auth token
 # -----------------------------------------------------------------------------------
-MAILROOM_URL = os.environ.get('MAILROOM_URL', 'http://localhost:8090')
+MAILROOM_URL = os.environ.get("MAILROOM_URL", "http://localhost:8090")
 MAILROOM_AUTH_TOKEN = None
 
 # -----------------------------------------------------------------------------------

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -313,11 +313,14 @@ DEFAULT_PLAN = TOPUP_PLAN
 # -----------------------------------------------------------------------------------
 # Branding Configuration
 # -----------------------------------------------------------------------------------
-BRANDING = {
-    "rapidpro.io": {
+BRANDS = [
+    {
+        "host": "rapidpro.io",
+        "aliases": [],
         "slug": "rapidpro",
         "name": "RapidPro",
         "org": "UNICEF",
+        "domain": "app.rapidpro.io",
         "colors": dict(primary="#0c6596"),
         "styles": ["brands/rapidpro/font/style.css"],
         "default_plan": TOPUP_PLAN,
@@ -326,7 +329,6 @@ BRANDING = {
         "support_email": "support@rapidpro.io",
         "link": "https://app.rapidpro.io",
         "docs_link": "http://docs.rapidpro.io",
-        "domain": "app.rapidpro.io",
         "ticket_domain": "tickets.rapidpro.io",
         "favico": "brands/rapidpro/rapidpro.ico",
         "splash": "brands/rapidpro/splash.jpg",
@@ -338,7 +340,7 @@ BRANDING = {
         "description": _("Visually build nationally scalable mobile applications from anywhere in the world."),
         "credits": "Copyright &copy; 2012-2022 UNICEF, Nyaruka. All Rights Reserved.",
     }
-}
+]
 DEFAULT_BRAND = os.environ.get("DEFAULT_BRAND", "rapidpro.io")
 
 FEATURES = {"locations", "ticketers"}
@@ -978,7 +980,7 @@ COMPRESS_OFFLINE = False
 
 # build up our offline compression context based on available brands
 COMPRESS_OFFLINE_CONTEXT = []
-for brand in BRANDING.values():
+for brand in BRANDS:
     context = dict(STATIC_URL=STATIC_URL, base_template="frame.html", debug=False, testing=False)
     context["brand"] = dict(slug=brand["slug"], styles=brand["styles"])
     COMPRESS_OFFLINE_CONTEXT.append(context)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -340,7 +340,7 @@ BRANDS = [
         "credits": "Copyright &copy; 2012-2022 UNICEF, Nyaruka. All Rights Reserved.",
     }
 ]
-DEFAULT_BRAND = os.environ.get("DEFAULT_BRAND", "rapidpro.io")
+DEFAULT_BRAND = os.environ.get("DEFAULT_BRAND", "rapidpro")
 
 FEATURES = {"locations", "ticketers"}
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -315,10 +315,9 @@ DEFAULT_PLAN = TOPUP_PLAN
 # -----------------------------------------------------------------------------------
 BRANDS = [
     {
-        "host": "rapidpro.io",
-        "aliases": [],
         "slug": "rapidpro",
         "name": "RapidPro",
+        "hosts": ["rapidpro.io"],
         "org": "UNICEF",
         "domain": "app.rapidpro.io",
         "colors": dict(primary="#0c6596"),

--- a/temba/settings_compress.py
+++ b/temba/settings_compress.py
@@ -5,5 +5,5 @@ COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_CSS_HASHING_METHOD = "content"
 COMPRESS_OFFLINE_CONTEXT = dict(
-    STATIC_URL=STATIC_URL, base_template="frame.html", brand=BRANDING[DEFAULT_BRAND], debug=False, testing=False
+    STATIC_URL=STATIC_URL, base_template="frame.html", brand=BRANDS[0], debug=False, testing=False
 )

--- a/temba/tickets/types/mailgun/views.py
+++ b/temba/tickets/types/mailgun/views.py
@@ -64,8 +64,8 @@ class ConnectView(BaseConnectView):
     def form_valid(self, form):
         from .type import MailgunType
 
-        branding = self.org.get_branding()
-        domain = self.org.get_branding()["ticket_domain"]
+        branding = self.org.branding
+        domain = branding["ticket_domain"]
         api_key = settings.MAILGUN_API_KEY
         verification_code = self.request.session["verification_code"]
 
@@ -75,7 +75,7 @@ class ConnectView(BaseConnectView):
             subject = _("Verify your email address for tickets")
             template = "tickets/types/mailgun/verify_email"
             context = {"verification_code": verification_code}
-            send_template_email(to_address, subject, template, context, self.request.branding)
+            send_template_email(to_address, subject, template, context, branding)
 
             self.request.session["to_address"] = to_address
             return HttpResponseRedirect(reverse("tickets.types.mailgun.connect") + "?verify=true")

--- a/temba/tickets/types/zendesk/views.py
+++ b/temba/tickets/types/zendesk/views.py
@@ -65,8 +65,7 @@ class ConnectView(BaseConnectView):
         return super(ConnectView, self).get(request, *args, **kwargs)
 
     def get_absolute_url(self):
-        brand = self.org.get_branding()
-        return f"https://{brand['domain']}{reverse('tickets.types.zendesk.connect')}"
+        return f"https://{self.org.branding['domain']}{reverse('tickets.types.zendesk.connect')}"
 
     def get_success_url(self):
         return reverse("tickets.types.zendesk.configure", args=[self.object.uuid])

--- a/temba/utils/brands.py
+++ b/temba/utils/brands.py
@@ -1,15 +1,24 @@
 from django.conf import settings
 
 
-def get_branding(host_or_alias: str) -> dict:
+def get_branding_by_host(host: str) -> dict:
+    """
+    Returns the branding for the given host
+    """
+    for brand in settings.BRANDS:
+        if host in brand["hosts"]:
+            return brand
+
+    return get_branding_by_slug(settings.DEFAULT_BRAND)
+
+
+def get_branding_by_slug(slug: str) -> dict:
     """
     Returns the branding for the given host or alias
     """
     for brand in settings.BRANDS:
-        if host_or_alias == brand["host"]:
+        if slug == brand["slug"]:
             return brand
-        for alias in brand.get("aliases", []):
-            if host_or_alias == alias:
-                return brand
 
-    return get_branding(settings.DEFAULT_BRAND)
+    # TODO update orgs and DEFAULT_BRAND to use brand slugs rather than hosts
+    return get_branding_by_host(slug)

--- a/temba/utils/brands.py
+++ b/temba/utils/brands.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+
+
+def get_branding(host_or_alias: str) -> dict:
+    """
+    Returns the branding for the given host or alias
+    """
+    for brand in settings.BRANDS:
+        if host_or_alias == brand["host"]:
+            return brand
+        for alias in brand.get("aliases", []):
+            if host_or_alias == alias:
+                return brand
+
+    return get_branding(settings.DEFAULT_BRAND)

--- a/temba/utils/brands.py
+++ b/temba/utils/brands.py
@@ -20,5 +20,5 @@ def get_branding_by_slug(slug: str) -> dict:
         if slug == brand["slug"]:
             return brand
 
-    # TODO update orgs and DEFAULT_BRAND to use brand slugs rather than hosts
+    # TODO update orgs to use brand slugs rather than hosts
     return get_branding_by_host(slug)

--- a/temba/utils/brands.py
+++ b/temba/utils/brands.py
@@ -14,7 +14,7 @@ def get_branding_by_host(host: str) -> dict:
 
 def get_branding_by_slug(slug: str) -> dict:
     """
-    Returns the branding for the given host or alias
+    Returns the branding for the given slug
     """
     for brand in settings.BRANDS:
         if slug == brand["slug"]:

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -660,20 +660,20 @@ class MiddlewareTest(TembaTest):
         self.assertEqual(response["X-Temba-Org"], str(self.org.id))
 
     def test_branding(self):
-        def assert_branding(request_host, brand_host):
+        def assert_branding(request_host, brand: str):
             response = self.client.get(reverse("public.public_index"), HTTP_HOST=request_host)
             self.assertEqual(
-                brand_host, response.context["request"].branding["host"], f"brand mismatch for host {request_host}"
+                brand, response.context["request"].branding["slug"], f"brand mismatch for host {request_host}"
             )
 
-        assert_branding("localhost", "rapidpro.io")  # uses default
-        assert_branding("localhost:8888", "rapidpro.io")  # port stripped
-        assert_branding("rapidpro.io", "rapidpro.io")
-        assert_branding("app.rapidpro.io", "rapidpro.io")  # subdomains ignored
-        assert_branding("custom-brand.io", "custom-brand.io")
-        assert_branding("subdomain.custom-brand.io", "custom-brand.io")
-        assert_branding("custom-brand.org", "custom-brand.io")  # by alias
-        assert_branding("api.custom-brand.org", "custom-brand.io")  # by alias
+        assert_branding("localhost", "rapidpro")  # uses default
+        assert_branding("localhost:8888", "rapidpro")  # port stripped
+        assert_branding("rapidpro.io", "rapidpro")
+        assert_branding("app.rapidpro.io", "rapidpro")  # subdomains ignored
+        assert_branding("custom-brand.io", "custom")
+        assert_branding("subdomain.custom-brand.io", "custom")
+        assert_branding("custom-brand.org", "custom")  # by alias
+        assert_branding("api.custom-brand.org", "custom")  # by alias
 
     def test_redirect(self):
         self.assertNotRedirect(self.client.get(reverse("public.public_index")), None)


### PR DESCRIPTION
Problems with current approach:

  * We have to modify settings.BRANDING in the middleware, adding the key/host as "brand" so we can get that from request.branding, e.g. when we need to save an org with the brand key/host.
  * We also modify keys.. which mean the same as aliases

This PR makes it so that we use slug to associated orgs and brands, and then brands have a host list which is what we match against requests.