### PR TITLE
Rework API auth to set org on the request 

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -30,7 +30,7 @@ class APIPermission(BasePermission):
             if request.user.is_anonymous:
                 return False
 
-            org = request.user.get_org()
+            org = request.org
 
             if request.auth:
                 # check that user is still allowed to use the token's role
@@ -256,19 +256,15 @@ class APIToken(models.Model):
         return self.key
 
 
-def get_or_create_api_token(user):
+def get_or_create_api_token(org, user):
     """
     Gets or creates an API token for this user. If user doen't have access to the API, this returns None.
     """
-    org = user.get_org()
-    if not org:
-        org = user.get_orgs(roles=[OrgRole.ADMINISTRATOR]).first()
 
-    if org:
-        try:
-            token = APIToken.get_or_create(org, user)
-            return token.key
-        except ValueError:
-            pass
+    try:
+        token = APIToken.get_or_create(org, user)
+        return token.key
+    except ValueError:
+        pass
 
     return None

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -599,12 +599,10 @@ class EndpointsTest(TembaTest):
 
         # login as administrator
         self.login(self.admin)
-        token = self.admin.api_token  # generates token for the user
+        token = self.admin.get_api_token(self.org)  # generates token for the user
         self.assertIsInstance(token, str)
         self.assertEqual(len(token), 40)
-
-        with self.assertNumQueries(0):  # subsequent lookup of token comes from cache
-            self.assertEqual(self.admin.api_token, token)
+        self.assertEqual(token, self.admi.get_api_token(self.org))  # same value again
 
         # browse as HTML
         response = self.fetchHTML(url)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -494,7 +494,7 @@ class BoundariesEndpoint(ListAPIMixin, BaseAPIView):
     pagination_class = Pagination
 
     def derive_queryset(self):
-        org = self.request.user.get_org()
+        org = self.request.org
         if not org.country:
             return AdminBoundary.objects.none()
 
@@ -596,7 +596,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
     throttle_scope = "v2.broadcasts"
 
     def filter_queryset(self, queryset):
-        org = self.request.user.get_org()
+        org = self.request.org
         queryset = queryset.filter(schedule=None)
 
         # filter by id (optional)
@@ -895,12 +895,12 @@ class CampaignEventsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAP
     pagination_class = CreatedOnCursorPagination
 
     def derive_queryset(self):
-        return self.model.objects.filter(campaign__org=self.request.user.get_org(), is_active=True)
+        return self.model.objects.filter(campaign__org=self.request.org, is_active=True)
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
         queryset = queryset.filter(is_active=True)
-        org = self.request.user.get_org()
+        org = self.request.org
 
         # filter by UUID (optional)
         uuid = params.get("uuid")
@@ -1131,7 +1131,7 @@ class ChannelEventsEndpoint(ListAPIMixin, BaseAPIView):
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        org = self.request.user.get_org()
+        org = self.request.org
 
         # filter by id (optional)
         call_id = self.get_int_param("id")
@@ -1224,7 +1224,7 @@ class ClassifiersEndpoint(ListAPIMixin, BaseAPIView):
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        org = self.request.user.get_org()
+        org = self.request.org
 
         queryset = queryset.filter(org=org, is_active=True)
 
@@ -1403,7 +1403,7 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        org = self.request.user.get_org()
+        org = self.request.org
 
         deleted_only = str_to_bool(params.get("deleted"))
         queryset = queryset.filter(is_active=(not deleted_only))
@@ -1448,7 +1448,7 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
         So that we only fetch active contact fields once for all contacts
         """
         context = super().get_serializer_context()
-        context["contact_fields"] = ContactField.user_fields.active_for_org(org=self.request.user.get_org())
+        context["contact_fields"] = ContactField.user_fields.active_for_org(org=self.request.org)
         return context
 
     def get_object(self):
@@ -1643,7 +1643,7 @@ class DefinitionsEndpoint(BaseAPIView):
         all = 2
 
     def get(self, request, *args, **kwargs):
-        org = request.user.get_org()
+        org = request.org
         params = request.query_params
 
         if "flow_uuid" in params or "campaign_uuid" in params:  # deprecated
@@ -1792,8 +1792,7 @@ class FieldsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
     lookup_params = {"key": "key"}
 
     def derive_queryset(self):
-        org = self.request.user.get_org()
-        return self.model.user_fields.filter(org=org, is_active=True)
+        return self.model.user_fields.filter(org=self.request.org, is_active=True)
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
@@ -2189,7 +2188,7 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
     exclusive_params = ("uuid", "name")
 
     def derive_queryset(self):
-        return ContactGroup.get_groups(self.request.user.get_org())
+        return ContactGroup.get_groups(self.request.org)
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
@@ -2348,8 +2347,7 @@ class LabelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView):
     exclusive_params = ("uuid", "name")
 
     def derive_queryset(self):
-        org = self.request.user.get_org()
-        return self.model.objects.filter(org=org, is_active=True).exclude(label_type=Label.TYPE_FOLDER)
+        return self.model.objects.filter(org=self.request.org, is_active=True).exclude(label_type=Label.TYPE_FOLDER)
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
@@ -2500,7 +2498,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
     }
 
     def derive_queryset(self):
-        org = self.request.user.get_org()
+        org = self.request.org
         folder = self.request.query_params.get("folder")
 
         if folder:
@@ -2518,7 +2516,7 @@ class MessagesEndpoint(ListAPIMixin, BaseAPIView):
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        org = self.request.user.get_org()
+        org = self.request.org
 
         # filter by id (optional)
         msg_id = self.get_int_param("id")
@@ -2797,7 +2795,7 @@ class ResthookSubscribersEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, B
     lookup_params = {"id": "id"}
 
     def get_queryset(self):
-        org = self.request.user.get_org()
+        org = self.request.org
         return self.model.objects.filter(resthook__org=org, is_active=True)
 
     def filter_queryset(self, queryset):
@@ -3032,7 +3030,7 @@ class RunsEndpoint(ListAPIMixin, BaseAPIView):
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        org = self.request.user.get_org()
+        org = self.request.org
 
         # filter by flow (optional)
         flow_uuid = params.get("flow")
@@ -3357,7 +3355,7 @@ class TemplatesEndpoint(ListAPIMixin, BaseAPIView):
     pagination_class = ModifiedOnCursorPagination
 
     def filter_queryset(self, queryset):
-        org = self.request.user.get_org()
+        org = self.request.org
         queryset = org.templates.exclude(translations=None).prefetch_related(
             Prefetch("translations", TemplateTranslation.objects.filter(is_active=True))
         )
@@ -3414,7 +3412,7 @@ class TicketersEndpoint(ListAPIMixin, BaseAPIView):
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        org = self.request.user.get_org()
+        org = self.request.org
 
         queryset = queryset.filter(org=org, is_active=True)
 
@@ -3507,7 +3505,7 @@ class TicketsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
 
     def filter_queryset(self, queryset):
         params = self.request.query_params
-        org = self.request.user.get_org()
+        org = self.request.org
 
         queryset = queryset.filter(org=org)
 
@@ -3693,7 +3691,7 @@ class UsersEndpoint(ListAPIMixin, BaseAPIView):
     pagination_class = DateJoinedCursorPagination
 
     def derive_queryset(self):
-        org = self.request.user.get_org()
+        org = self.request.org
 
         # limit to roles if specified
         roles = self.request.query_params.getlist("role")
@@ -3710,7 +3708,7 @@ class UsersEndpoint(ListAPIMixin, BaseAPIView):
 
         # build a map of users to roles
         user_roles = {}
-        for m in OrgMembership.objects.filter(org=self.request.user.get_org()).select_related("user"):
+        for m in OrgMembership.objects.filter(org=self.request.org).select_related("user"):
             user_roles[m.user] = m.role
 
         context["user_roles"] = user_roles
@@ -3756,8 +3754,7 @@ class WorkspaceEndpoint(BaseAPIView):
     permission = "orgs.org_api"
 
     def get(self, request, *args, **kwargs):
-        org = request.user.get_org()
-        serializer = WorkspaceReadSerializer(org)
+        serializer = WorkspaceReadSerializer(request.org)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @classmethod
@@ -3779,7 +3776,7 @@ class SurveyorAttachmentsEndpoint(BaseAPIView):
     permission = "msgs.msg_api"
 
     def post(self, request, format=None, *args, **kwargs):
-        org = self.request.user.get_org()
+        org = self.request.org
         file = request.data.get("media_file", None)
         extension = request.data.get("extension", None)
 

--- a/temba/assets/views.py
+++ b/temba/assets/views.py
@@ -76,7 +76,6 @@ class AssetDownloadView(NotificationTargetMixin, SmartTemplateView):
         else:
             file_error = None
             self.request.org = asset.org
-            self.request.user.set_org(asset.org)
 
         context["file_error"] = file_error
         context["download_url"] = download_url

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1986,7 +1986,6 @@ class ContactTest(TembaTest):
             path=Substr("path", 2), identity=Concat(DbValue("tel:"), Substr("path", 2))
         )
 
-        self.admin.set_org(self.org)
         self.login(self.admin)
 
         def omnibox_request(query, version="1"):

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -75,9 +75,6 @@ class OrgMiddleware:
         org = self.determine_org(request)
         request.org = org
 
-        if request.user.is_authenticated:
-            request.user.set_org(org)
-
         response = self.get_response(request)
 
         # set a response header to make it easier to find the current org id

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -236,15 +236,6 @@ class User(AuthUser):
     def is_beta(self) -> bool:
         return self.groups.filter(name="Beta").exists()
 
-    def get_org(self):
-        """
-        Gets the request org cached on the user. This should only be used where request.org can't be.
-        """
-        return getattr(self, "_org", None)
-
-    def set_org(self, org):
-        self._org = org
-
     def has_org_perm(self, org, permission: str) -> bool:
         """
         Determines if a user has the given permission in the given org.
@@ -271,11 +262,10 @@ class User(AuthUser):
 
         return UserSettings.objects.get_or_create(user=self)[0]
 
-    @cached_property
-    def api_token(self) -> str:
+    def get_api_token(self, org) -> str:
         from temba.api.models import get_or_create_api_token
 
-        return get_or_create_api_token(self)
+        return get_or_create_api_token(org, self)
 
     def as_engine_ref(self) -> dict:
         return {"email": self.email, "name": self.name}

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2288,7 +2288,6 @@ class OrgTest(TembaTest):
             connect_url = reverse("orgs.org_twilio_connect")
 
             self.login(self.admin)
-            self.admin.set_org(self.org)
 
             response = self.client.get(connect_url)
             self.assertEqual(200, response.status_code)
@@ -3477,7 +3476,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(user.last_name, "Alexander")
         self.assertEqual(user.email, "kellan@example.com")
         self.assertTrue(user.check_password("HeyThere123"))
-        self.assertTrue(user.api_token)  # should be able to generate an API token
+        self.assertIsNotNone(user.get_api_token(self.org))  # should be able to generate an API token
 
         # should have a new org
         org = Org.objects.get(name="AlexCom")
@@ -3581,7 +3580,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(user.last_name, "Rwagasore")
         self.assertEqual(user.email, "myal12345678901234567890@relieves.org")
         self.assertTrue(user.check_password("HelloWorld1"))
-        self.assertTrue(user.api_token)  # should be able to generate an API token
+        self.assertIsNotNone(user.get_api_token(self.org))  # should be able to generate an API token
 
         # should have a new org
         org = Org.objects.get(name="Relieves World")
@@ -3613,9 +3612,6 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
             sample_flows,
         )
         self.assertEqual("RapidPro Tickets", internal_ticketer.name)
-
-        # fake session set_org to make the test work
-        user.set_org(org)
 
         # should now be able to go to channels page
         response = self.client.get(reverse("channels.channel_claim"))

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2941,8 +2941,7 @@ class OrgCRUDL(SmartCRUDL):
                 self.invitation.save()
 
                 # set the active org on this user
-                self.request.user.set_org(org)
-                self.request.session["org_id"] = org.pk
+                self.request.session["org_id"] = org.id
 
         def get_success_url(self):  # pragma: needs cover
             if self.invitation.user_group == "S":

--- a/temba/utils/management/commands/test_db.py
+++ b/temba/utils/management/commands/test_db.py
@@ -291,7 +291,6 @@ class Command(BaseCommand):
                     email, email, password, first_name=u["first_name"], last_name=u["last_name"]
                 )
                 org.add_user(user, u["role"])
-                user.set_org(org)
                 org.cache["users"].append(user)
 
         self._log(self.style.SUCCESS("OK") + "\n")


### PR DESCRIPTION
So we can get rid of User.get_org()  / set_org() and set the X-Temba-Org response header