### PR TITLE
Update API auth classes to set `request.org` and use that to set `X-Temba-Org` header

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -511,7 +511,8 @@ class EndpointsTest(TembaTest):
 
         # can fetch campaigns endpoint with valid admin token
         response = request_by_token(campaigns_url, token1.key)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(str(self.org.id), response["X-Temba-Org"])
 
         # but not with surveyor token
         response = request_by_token(campaigns_url, token2.key)
@@ -522,10 +523,11 @@ class EndpointsTest(TembaTest):
 
         # but it can be used to access the contacts endpoint
         response = request_by_token(contacts_url, token2.key)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
 
         response = request_by_basic_auth(contacts_url, self.admin.username, token2.key)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(str(self.org.id), response["X-Temba-Org"])
 
         # simulate the admin user exceeding the rate limit for the v2 scope
         cache.set(f"throttle_v2_{self.org.id}", [time.time() for r in range(10000)])

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -72,17 +72,18 @@ class OrgMiddleware:
     def __call__(self, request):
         assert hasattr(request, "user"), "must be called after django.contrib.auth.middleware.AuthenticationMiddleware"
 
-        org = self.determine_org(request)
-        request.org = org
+        request.org = self.determine_org(request)
 
         if request.user.is_authenticated:
-            request.user.set_org(org)
+            # TODO replace code still using .get_org() and remove
+            request.user.set_org(request.org)
 
+        # continue the chain, which in the case of the API will set request.org
         response = self.get_response(request)
 
         # set a response header to make it easier to find the current org id
-        if org:
-            response["X-Temba-Org"] = org.id
+        if request.org:
+            response["X-Temba-Org"] = request.org.id
 
         return response
 


### PR DESCRIPTION
DRF auth happens after middleware in the view level