### PR TITLE
Always explicitly provide org when requesting a user API token

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -256,19 +256,15 @@ class APIToken(models.Model):
         return self.key
 
 
-def get_or_create_api_token(user):
+def get_or_create_api_token(org, user):
     """
     Gets or creates an API token for this user. If user doen't have access to the API, this returns None.
     """
-    org = user.get_org()
-    if not org:
-        org = user.get_orgs(roles=[OrgRole.ADMINISTRATOR]).first()
 
-    if org:
-        try:
-            token = APIToken.get_or_create(org, user)
-            return token.key
-        except ValueError:
-            pass
+    try:
+        token = APIToken.get_or_create(org, user)
+        return token.key
+    except ValueError:
+        pass
 
     return None

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -152,6 +152,9 @@ class DocumentationRenderer(BrowsableAPIRenderer):
         response = renderer_context["response"]
         renderer = self.get_default_renderer(view)
 
+        org = request.org
+        user = request.user
+
         return {
             "content": self.get_content(renderer, data, accepted_media_type, renderer_context),
             "view": view,
@@ -160,6 +163,7 @@ class DocumentationRenderer(BrowsableAPIRenderer):
             "description": view.get_view_description(html=True),
             "name": self.get_name(view),
             "breadcrumblist": self.get_breadcrumbs(request),
+            "api_token": user.get_api_token(org) if (org and user) else None,
         }
 
     def render(self, data, accepted_media_type=None, renderer_context=None):

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -601,12 +601,10 @@ class EndpointsTest(TembaTest):
 
         # login as administrator
         self.login(self.admin)
-        token = self.admin.api_token  # generates token for the user
+        token = self.admin.get_api_token(self.org)
         self.assertIsInstance(token, str)
         self.assertEqual(len(token), 40)
-
-        with self.assertNumQueries(0):  # subsequent lookup of token comes from cache
-            self.assertEqual(self.admin.api_token, token)
+        self.assertEqual(token, self.admin.get_api_token(self.org))  # subsequent calls return same token
 
         # browse as HTML
         response = self.fetchHTML(url)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -247,6 +247,11 @@ class ExplorerView(SmartTemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        org = self.request.org
+        user = self.request.user
+
+        context["api_token"] = user.get_api_token(org) if (org and user) else None
         context["endpoints"] = [
             ArchivesEndpoint.get_read_explorer(),
             BoundariesEndpoint.get_read_explorer(),

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -255,11 +255,10 @@ class User(AuthUser):
 
         return UserSettings.objects.get_or_create(user=self)[0]
 
-    @cached_property
-    def api_token(self) -> str:
+    def get_api_token(self, org) -> str:
         from temba.api.models import get_or_create_api_token
 
-        return get_or_create_api_token(self)
+        return get_or_create_api_token(org, self)
 
     def as_engine_ref(self) -> dict:
         return {"email": self.email, "name": self.name}

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -3166,17 +3166,17 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(user.last_name, "Alexander")
         self.assertEqual(user.email, "kellan@example.com")
         self.assertTrue(user.check_password("HeyThere123"))
-        self.assertTrue(user.api_token)  # should be able to generate an API token
 
         # should have a new org
         org = Org.objects.get(name="AlexCom")
         self.assertEqual(org.timezone, pytz.timezone("Africa/Kigali"))
 
-        # of which our user is an administrator
-        self.assertTrue(org.get_admins().filter(pk=user.pk))
+        # of which our user is an administrator and can generate an API token
+        self.assertIn(user, org.get_admins())
+        self.assertIsNotNone(user.get_api_token(org))
 
         # not the logged in user at the signup time
-        self.assertFalse(org.get_admins().filter(pk=self.user.pk))
+        self.assertNotIn(self.user, org.get_admins())
 
     @override_settings(
         AUTH_PASSWORD_VALIDATORS=[
@@ -3250,15 +3250,15 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(user.last_name, "Rwagasore")
         self.assertEqual(user.email, "myal12345678901234567890@relieves.org")
         self.assertTrue(user.check_password("HelloWorld1"))
-        self.assertTrue(user.api_token)  # should be able to generate an API token
 
         # should have a new org
         org = Org.objects.get(name="Relieves World")
         self.assertEqual(org.timezone, pytz.timezone("Africa/Kigali"))
         self.assertEqual(str(org), "Relieves World")
 
-        # of which our user is an administrator
-        self.assertTrue(org.get_admins().filter(pk=user.pk))
+        # of which our user is an administrator, and can generate an API token
+        self.assertIn(user, org.get_admins())
+        self.assertIsNotNone(user.get_api_token(org))
 
         # check default org content was created correctly
         system_fields = set(org.fields.filter(is_system=True).values_list("key", flat=True))

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -3243,6 +3243,11 @@ class OrgCRUDL(SmartCRUDL):
         success_url = "@orgs.org_home"
         success_message = ""
 
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+            context["api_token"] = self.request.user.get_api_token(self.request.org)
+            return context
+
     class Prometheus(InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         class ToggleForm(forms.ModelForm):
             class Meta:

--- a/templates/api/v2/api_explorer.haml
+++ b/templates/api/v2/api_explorer.haml
@@ -22,9 +22,9 @@
           -trans "Explorer"
 
       <li style="flex-grow:1"></li>
-      -if request.user.api_token
+      -if api_token
           %li(style="color: #666")
-          API Token: {{ request.user.api_token }}
+          API Token: {{ api_token }}
       -else
         %li
           -trans "Log in to get your API Token"
@@ -79,7 +79,7 @@
               {{brand.link}}{{ endpoint.url }}.json<span class="query-display"></span><br/>
             <b class="font-bold">Authorization:</b>
             .whitespace-nowrap.text-sm(class="md:text-base md:inline")
-              Token {{ request.user.api_token }}
+              Token {{ api_token }}
           -if endpoint.params
             .form-group.mt-4.items-center(class="md:flex")
               %label.control-label.self-start.pt-4.w-56.pr-6(class="md:text-right")
@@ -101,7 +101,7 @@
             %a{ href: '{{ endpoint.url }}' }
               -trans "View Full Documentation"
 
-          -if user.api_token
+          -if api_token
             .button-primary(onclick='javascript:handleRequest("{{ endpoint.slug }}", "{{ endpoint.method }}", "{{ endpoint.url }}.json")') {{ endpoint.method|upper }}
           -else
             %span

--- a/templates/api/v2/api_root.html
+++ b/templates/api/v2/api_root.html
@@ -139,7 +139,7 @@
         {% endfor %}
 
         <li class="mr-4" style="flex-grow:1"></li>
-        {% if request.user.api_token %}<li class="token" style="color: #666">API Token: {{ request.user.api_token }}</li>{% else %}<li class="pull-right">Log in to get your API Token</li>{% endif %}
+        {% if api_token %}<li class="token" style="color: #666">API Token: {{ api_token }}</li>{% else %}<li class="pull-right">Log in to get your API Token</li>{% endif %}
     </ul>
     {% endblock %}
 

--- a/templates/orgs/org_token.haml
+++ b/templates/orgs/org_token.haml
@@ -7,7 +7,7 @@
 
 -block fields
   .field.api-token(style="padding-bottom: 10px")
-    API Token: <span id="api_token">{{user.api_token}}</span>
+    API Token: <span id="api_token">{{api_token}}</span>
     <a href="javascript:refreshToken()" class='api-token-refresh'><div class="icon-loop"></div></a>
 
 -block form-buttons
@@ -19,7 +19,7 @@
     -trans "API Explorer"
 
 -block summary
-  -blocktrans trimmed with token=user.api_token
+  -blocktrans trimmed with token=api_token
     Your API Token is <b>{{ token }}</b>.
 
 -block extra-script


### PR DESCRIPTION
Replaces `User.api_token` with explicit `User.get_api_token(org)`