### PR TITLE
Display channel logs with earliest at top

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1928,7 +1928,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         msg1_url = reverse("channels.channellog_msg", args=[self.channel.uuid, msg1.id])
 
         self.assertListFetch(
-            msg1_url, allow_viewers=False, allow_editors=False, allow_org2=False, context_objects=[log2, log1]
+            msg1_url, allow_viewers=False, allow_editors=False, allow_org2=False, context_objects=[log1, log2]
         )
 
     def test_call(self):
@@ -1962,7 +1962,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         call1_url = reverse("channels.channellog_call", args=[self.channel.uuid, call1.id])
 
         self.assertListFetch(
-            call1_url, allow_viewers=False, allow_editors=False, allow_org2=False, context_objects=[log2, log1]
+            call1_url, allow_viewers=False, allow_editors=False, allow_org2=False, context_objects=[log1, log2]
         )
 
     def test_read_and_list(self):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1481,7 +1481,7 @@ class ChannelLogCRUDL(SmartCRUDL):
             return self.msg.org
 
         def derive_queryset(self, **kwargs):
-            return super().derive_queryset(**kwargs).filter(msg=self.msg).order_by("-created_on")
+            return super().derive_queryset(**kwargs).filter(msg=self.msg).order_by("created_on")
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
@@ -1514,7 +1514,7 @@ class ChannelLogCRUDL(SmartCRUDL):
             return self.call.org
 
         def derive_queryset(self, **kwargs):
-            return super().derive_queryset(**kwargs).filter(call=self.call).order_by("-created_on")
+            return super().derive_queryset(**kwargs).filter(call=self.call).order_by("created_on")
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Currently the `ChannelLog` instances are listed with newest at top but the individual `HTTPLog` records within them are oldest first... chronological, oldest first, feels most natural for this view even tho our msg list views are the other way.