### PR TITLE
Don't show location field types as options on deploys where locations aren't enabled

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -355,14 +355,17 @@ class ContactField(TembaModel, DependencyMixin):
     TYPE_DISTRICT = "I"
     TYPE_WARD = "W"
 
-    TYPE_CHOICES = (
+    TYPE_CHOICES_BASIC = (
         (TYPE_TEXT, _("Text")),
         (TYPE_NUMBER, _("Number")),
         (TYPE_DATETIME, _("Date & Time")),
+    )
+    TYPE_CHOICES_LOCATIONS = (
         (TYPE_STATE, _("State")),
         (TYPE_DISTRICT, _("District")),
         (TYPE_WARD, _("Ward")),
     )
+    TYPE_CHOICES = TYPE_CHOICES_BASIC + TYPE_CHOICES_LOCATIONS
 
     ENGINE_TYPES = {
         TYPE_TEXT: "text",

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -4835,8 +4835,25 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_create(self):
         create_url = reverse("contacts.contactfield_create")
 
-        self.assertCreateFetch(
+        # for a deploy that doesn't have locations feature, don't show location field types
+        with override_settings(FEATURES={}):
+            response = self.assertCreateFetch(
+                create_url,
+                allow_viewers=False,
+                allow_editors=True,
+                form_fields=["name", "value_type", "show_in_table"],
+            )
+            self.assertEqual(
+                [("T", "Text"), ("N", "Number"), ("D", "Date & Time")],
+                response.context["form"].fields["value_type"].choices,
+            )
+
+        response = self.assertCreateFetch(
             create_url, allow_viewers=False, allow_editors=True, form_fields=["name", "value_type", "show_in_table"]
+        )
+        self.assertEqual(
+            [("T", "Text"), ("N", "Number"), ("D", "Date & Time"), ("S", "State"), ("I", "District"), ("W", "Ward")],
+            response.context["form"].fields["value_type"].choices,
         )
 
         # try to submit with empty name
@@ -4902,12 +4919,23 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_update(self):
         update_url = reverse("contacts.contactfield_update", args=[self.age.id])
 
-        self.assertUpdateFetch(
+        # for a deploy that doesn't have locations feature, don't show location field types
+        with override_settings(FEATURES={}):
+            response = self.assertUpdateFetch(
+                update_url,
+                allow_viewers=False,
+                allow_editors=True,
+                form_fields={"name": "Age", "value_type": "N", "show_in_table": True},
+            )
+            self.assertEqual(3, len(response.context["form"].fields["value_type"].choices))
+
+        response = self.assertUpdateFetch(
             update_url,
             allow_viewers=False,
             allow_editors=True,
             form_fields={"name": "Age", "value_type": "N", "show_in_table": True},
         )
+        self.assertEqual(6, len(response.context["form"].fields["value_type"].choices))
 
         # try submit without change
         self.assertUpdateSubmit(

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1605,6 +1605,16 @@ class ContactFieldForm(forms.ModelForm):
 
         self.org = org
 
+        is_already_location_type = self.instance and self.instance.value_type in (
+            ContactField.TYPE_STATE,
+            ContactField.TYPE_DISTRICT,
+            ContactField.TYPE_WARD,
+        )
+        allow_location_types = "locations" in settings.FEATURES or is_already_location_type
+        self.fields["value_type"].choices = (
+            ContactField.TYPE_CHOICES if allow_location_types else ContactField.TYPE_CHOICES_BASIC
+        )
+
     def clean_name(self):
         name = self.cleaned_data["name"]
 


### PR DESCRIPTION
<img width="632" alt="Captura de pantalla 2022-11-30 a la(s) 14 07 31" src="https://user-images.githubusercontent.com/675558/204886987-c7f805f7-f75b-4814-a5a4-f3aabd6efd70.png">

<img width="622" alt="Captura de pantalla 2022-11-30 a la(s) 14 07 56" src="https://user-images.githubusercontent.com/675558/204886996-a7324e5b-21b6-4450-a86a-56d4d46c78bf.png">
