### PR TITLE
🪓 Split task to trim starts and sessions into two separate tasks

### DIFF
--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -87,18 +87,12 @@ def trim_flow_revisions():
     logger.info(f"Trimmed {count} flow revisions since {last_trim} in {elapsed}")
 
 
-@cron_task(name="trim_flow_sessions_and_starts")
-def trim_flow_sessions_and_starts():
-    num_sessions = _trim_flow_sessions()
-    num_starts = _trim_flow_starts()
-
-    return {"sessions": num_sessions, "starts": num_starts}
-
-
-def _trim_flow_sessions() -> int:
+@cron_task(name="trim_flow_sessions")
+def trim_flow_sessions():
     """
     Cleanup old flow sessions
     """
+
     trim_before = timezone.now() - settings.RETENTION_PERIODS["flowsession"]
     num_deleted = 0
 
@@ -113,13 +107,15 @@ def _trim_flow_sessions() -> int:
         FlowSession.objects.filter(id__in=session_ids).delete()
         num_deleted += len(session_ids)
 
-    return num_deleted
+    return {"deleted": num_deleted}
 
 
-def _trim_flow_starts() -> int:
+@cron_task(name="trim_flow_starts")
+def trim_flow_starts() -> int:
     """
     Cleanup completed non-user created flow starts
     """
+
     trim_before = timezone.now() - settings.RETENTION_PERIODS["flowstart"]
     num_deleted = 0
 
@@ -149,4 +145,4 @@ def _trim_flow_starts() -> int:
         FlowStart.objects.filter(id__in=start_ids).delete()
         num_deleted += len(start_ids)
 
-    return num_deleted
+    return {"deleted": num_deleted}

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -54,7 +54,13 @@ from .models import (
     FlowVersionConflictException,
     get_flow_user,
 )
-from .tasks import squash_flowcounts, trim_flow_revisions, trim_flow_sessions_and_starts, update_session_wait_expires
+from .tasks import (
+    squash_flowcounts,
+    trim_flow_revisions,
+    trim_flow_sessions,
+    trim_flow_starts,
+    update_session_wait_expires,
+)
 from .views import FlowCRUDL
 
 
@@ -4005,7 +4011,7 @@ class FlowSessionTest(TembaTest):
         run2.session.ended_on = timezone.now()
         run2.session.save(update_fields=("status", "ended_on"))
 
-        trim_flow_sessions_and_starts()
+        trim_flow_sessions()
 
         run1, run2, run3, run4 = FlowRun.objects.order_by("id")
 
@@ -4067,7 +4073,7 @@ class FlowStartTest(TembaTest):
         create_start(None, FlowStart.TYPE_FLOW_ACTION, FlowStart.STATUS_COMPLETE, date2, contacts=[contact])
         create_start(None, FlowStart.TYPE_TRIGGER, FlowStart.STATUS_FAILED, date2, groups=[group])
 
-        trim_flow_sessions_and_starts()
+        trim_flow_starts()
 
         # check that related objects still exist!
         contact.refresh_from_db()

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -877,8 +877,9 @@ CELERY_BEAT_SCHEDULE = {
     "trim-channel-log": {"task": "trim_channel_log_task", "schedule": crontab(hour=3, minute=0)},
     "trim-event-fires": {"task": "trim_event_fires_task", "schedule": timedelta(seconds=900)},
     "trim-flow-revisions": {"task": "trim_flow_revisions", "schedule": crontab(hour=0, minute=0)},
-    "trim-flow-sessions-and-starts": {"task": "trim_flow_sessions_and_starts", "schedule": crontab(hour=0, minute=0)},
-    "trim-http-logs": {"task": "trim_http_logs_task", "schedule": crontab(hour=3, minute=0)},
+    "trim-flow-sessions": {"task": "trim_flow_sessions", "schedule": crontab(hour=0, minute=0)},
+    "trim-flow-starts": {"task": "trim_flow_starts", "schedule": crontab(hour=1, minute=0)},
+    "trim-http-logs": {"task": "trim_http_logs_task", "schedule": crontab(hour=2, minute=0)},
     "trim-sync-events": {"task": "trim_sync_events_task", "schedule": crontab(hour=3, minute=0)},
     "trim-webhook-event": {"task": "trim_webhook_event_task", "schedule": crontab(hour=3, minute=0)},
 }


### PR DESCRIPTION
One of these is really really slow and I think it's the start one because it updates all the runs