### PR TITLE
🚚 Replace `gauge` on analytics backend with `gauges`

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -256,7 +256,7 @@ def sync(request, channel_id):
         sync_event.save()
 
     # keep track of how long a sync takes
-    analytics.gauge("temba.relayer_sync", time.time() - start)
+    analytics.gauges({"temba.relayer_sync": time.time() - start})
 
     return JsonResponse(result)
 

--- a/temba/utils/analytics/base.py
+++ b/temba/utils/analytics/base.py
@@ -12,9 +12,9 @@ class AnalyticsBackend(metaclass=abc.ABCMeta):
     slug: str = None
     hook_templates = {}
 
-    def gauge(self, event: str, value):
+    def gauges(self, values: dict):
         """
-        Records a gauge value
+        Records gauge values
         """
 
     def track(self, user, event: str, properties: dict):
@@ -52,9 +52,10 @@ class ConsoleBackend(AnalyticsBackend):
 
     slug = "console"
 
-    def gauge(self, event: str, value):
+    def gauges(self, values: dict):
         if not settings.TESTING:  # pragma: no cover
-            print(f"[analytics] gauge={event} value={value}")
+            for name, value in values.items():
+                print(f"[analytics] gauge={name} value={value}")
 
     def track(self, user, event: str, properties: dict):
         if not settings.TESTING:  # pragma: no cover
@@ -67,15 +68,15 @@ def get_backends() -> list:
     return list(backends.values())
 
 
-def gauge(event: str, value):
+def gauges(values: dict):
     """
     Reports a gauge value
     """
     for backend in get_backends():
         try:
-            backend.gauge(event, value)
+            backend.gauges(values)
         except Exception:
-            logger.exception(f"error updating gauge on {backend.slug}")
+            logger.exception(f"error reporting gauges on {backend.slug}")
 
 
 def identify(user, brand, org):

--- a/temba/utils/analytics/tests.py
+++ b/temba/utils/analytics/tests.py
@@ -15,13 +15,13 @@ class AnalyticsTest(TembaTest):
         super().setUp()
 
     @patch("temba.utils.analytics.base.get_backends")
-    def test_gauge(self, mock_get_backends):
+    def test_gauges(self, mock_get_backends):
         good = MagicMock()
         mock_get_backends.return_value = [BadBackend(), good]
 
-        analytics.gauge("foo_level", 123)
+        analytics.gauges({"foo_level": 123})
 
-        good.gauge.assert_called_once_with("foo_level", 123)
+        good.gauges.assert_called_once_with({"foo_level": 123})
 
     @patch("temba.utils.analytics.base.get_backends")
     def test_track(self, mock_get_backends):
@@ -92,7 +92,7 @@ class BadBackend(AnalyticsBackend):
     slug = "bad"
     hook_templates = {"frame-top": "bad/frame_top.html"}
 
-    def gauge(self, event: str, value):
+    def gauges(self, values: dict):
         raise ValueError("boom")
 
     def track(self, user, event: str, properties: dict):

--- a/temba/utils/crons.py
+++ b/temba/utils/crons.py
@@ -80,7 +80,7 @@ def _record_cron_execution(r, name: str, start, end, result):
 
     pipe.execute()
 
-    analytics.gauge(f"temba.cron_{name}", (end - start).total_seconds())
+    analytics.gauges({f"temba.cron_{name}": (end - start).total_seconds()})
 
 
 def clear_cron_stats():


### PR DESCRIPTION
Which allows backends to more easily send guage values in bulk