### PR TITLE
Add simplified dashboard to menu

### DIFF
--- a/static/js/urls.js
+++ b/static/js/urls.js
@@ -39,6 +39,7 @@ window.urls = [
   { old: /\/user\/read\/(.*)/,                           new: /\/staff\/user\/(.*)/ },
   { old: /\/org\/update\/(.*)/,                          new: /\/staff\/workspaces\/(.*)\/update/ },
   { old: /\/org\/home\//,                                new: /\/settings\/workspace\// },
+  { old: /\/dashboard\/home\//,                          new: /\/settings\/dashboard\// },
   { old: /\/org\/manage_accounts_sub_org\/\?org=(.*)/,   new: /\/settings\/(.*)\// },
 
 ];

--- a/temba/dashboard/views.py
+++ b/temba/dashboard/views.py
@@ -6,17 +6,20 @@ from smartmin.views import SmartTemplateView
 from django.db.models import Q, Sum
 from django.http import JsonResponse
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel, ChannelCount
 from temba.orgs.models import Org
 from temba.orgs.views import OrgPermsMixin
+from temba.utils.views import SpaMixin
 
 
-class Home(OrgPermsMixin, SmartTemplateView):
+class Home(SpaMixin, OrgPermsMixin, SmartTemplateView):
     """
     The main dashboard view
     """
 
+    title = _("Dashboard")
     permission = "orgs.org_dashboard"
     template_name = "dashboard/home.haml"
 
@@ -99,14 +102,6 @@ class MessageHistory(OrgPermsMixin, SmartTemplateView):
             [
                 dict(name="Incoming", type="column", data=msgs_in, showInNavigator=False),
                 dict(name="Outgoing", type="column", data=msgs_out, showInNavigator=False),
-                dict(
-                    name="Total",
-                    type="column",
-                    data=msgs_total,
-                    showInNavigator=True,
-                    showInLegend=False,
-                    visible=False,
-                ),
             ],
             safe=False,
         )

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1241,6 +1241,16 @@ class OrgCRUDL(SmartCRUDL):
                     )
                 )
 
+                if self.has_org_perm("orgs.org_dashboard"):
+                    menu.append(
+                        self.create_menu_item(
+                            menu_id="dashboard",
+                            name=_("Dashboard"),
+                            icon="icon.dashboard",
+                            href=reverse("dashboard.dashboard_home"),
+                        )
+                    )
+
                 if self.request.user.settings.two_factor_enabled:
                     menu.append(
                         self.create_menu_item(

--- a/templates/dashboard/home.haml
+++ b/templates/dashboard/home.haml
@@ -1,4 +1,4 @@
-{% extends "frame.html" %}
+-extends "smartmin/base.html"
 
 -load smartmin temba compress i18n humanize tz
 

--- a/templates/dashboard/home_spa.haml
+++ b/templates/dashboard/home_spa.haml
@@ -51,9 +51,6 @@
     var store = document.querySelector("temba-store");
     store.getUrl('/dashboard/message_history').then(function(response){
       var data = response.json;
-
-      console.log(data);
-
       // Create the chart
       Highcharts.stockChart('message-chart', {
         chart: {
@@ -95,9 +92,6 @@
         },
         navigator: {
           series: {
-            // we want to stack the navigator, but can't due to a highcharts bug, for now we
-            // use a third non-visible series with the sum of the first two series
-            // https://github.com/highcharts/highcharts/issues/7033
             stacking: 'normal',
             type: 'column'
           }

--- a/templates/dashboard/home_spa.haml
+++ b/templates/dashboard/home_spa.haml
@@ -1,0 +1,108 @@
+-extends "smartmin/base.html"
+
+-load smartmin temba compress i18n humanize tz
+-block messages
+-block content
+  #range-group.card.scrollable.flex-shrink-0
+    #range-header.flex.bg-gray-100.-mx-6.-mt-6.px-8.py-2.border-b
+      #range-from.flex-grow
+      #range-to
+    #message-chart
+
+-block extra-script
+  {{block.super}}
+
+  :javascript
+    function setChartOptions(begin, end, direction) {
+      var from = Highcharts.dateFormat('%A, %B %e, %Y', begin);
+      var to = Highcharts.dateFormat('%A, %B %e, %Y', end)
+      document.querySelector("#range-from").innerText = from;
+      document.querySelector("#range-to").innerText = to;
+    }
+
+    Highcharts.setOptions({
+	  lang: {
+	    thousandsSep: ','
+	  }
+    });
+
+    function selectionChanged(chart) {
+      var direction = "";
+      if (chart.series[0].visible) {
+        direction += "I";
+      }
+
+      if (chart.series[1].visible) {
+        direction += "O";
+      }
+
+      var axis = chart.xAxis[0];
+      setChartOptions(axis.min, axis.max, direction);
+    }
+
+    var redrawMarker = null;
+    function markDirty(chart) {
+      if (redrawMarker != null) {
+        window.clearTimeout(redrawMarker);
+      }
+      redrawMarker = window.setTimeout(selectionChanged.bind(null, chart), 200);
+    }
+
+    var store = document.querySelector("temba-store");
+    store.getUrl('/dashboard/message_history').then(function(response){
+      var data = response.json;
+
+      console.log(data);
+
+      // Create the chart
+      Highcharts.stockChart('message-chart', {
+        chart: {
+          zoomType: 'x',
+          events: {
+            // mark dirty out the gate
+            load: function(e) {
+              markDirty(this);
+            },
+            redraw: function(e) {
+              markDirty(this);
+            }
+          }
+        },
+        plotOptions: {
+          series: {
+            showInLegend: true,
+            stacking: 'normal'
+          }
+        },
+        legend: {
+          enabled: true
+        },
+        rangeSelector: {
+          buttons: [
+            {type: 'week', count: 1, text: 'W'},
+            {type: 'month', count: 1, text: 'M'},
+            {type: 'year', count: 1, text: 'Y'},
+            {type: 'all', count: 1, text: 'all'}
+          ],
+          inputEnabled: false,
+          selected: 1
+        },
+        xAxis: {
+          minRange: 3600000 * 24
+        },
+        credits: {
+          enabled: false
+        },
+        navigator: {
+          series: {
+            // we want to stack the navigator, but can't due to a highcharts bug, for now we
+            // use a third non-visible series with the sum of the first two series
+            // https://github.com/highcharts/highcharts/issues/7033
+            stacking: 'normal',
+            type: 'column'
+          }
+        },
+        series: data
+      });
+
+    });

--- a/templates/spa_frame.haml
+++ b/templates/spa_frame.haml
@@ -279,7 +279,7 @@
 -block full-page-script
 
   %script(src="{{ STATIC_URL }}js/labels.js")
-  %script(src="{{ STATIC_URL }}highcharts/highcharts.js")
+  %script(src="{{ STATIC_URL }}highcharts/highstock.js?v=3.0")
   %script(src="{{ STATIC_URL }}highcharts/modules/drilldown.js")
   %script(src="{{ STATIC_URL }}qrious/dist/qrious.min.js")
 
@@ -691,7 +691,7 @@
       });
     }
 
-    var toMap = /(msg|contact|flow|ticket|channels|triggers|campaign|org|user|settings|httplog|classifier|workspace).*/;
+    var toMap = /(msg|contact|flow|ticket|channels|triggers|campaign|org|user|settings|httplog|classifier|workspace|dashboard).*/;
 
     function handleNoPath(event) {
       var details = event.detail;


### PR DESCRIPTION
* Exposes dashboard to all users with perm (don't have to be multi org)
* Only shows cumulative message count chart (removed channel / org breakdown below as this was broken before and a bit goofy overall and we should do something better here anyways)

<img width="961" alt="Screenshot 2023-01-11 at 4 17 09 PM" src="https://user-images.githubusercontent.com/211652/211945817-cfad305d-8c9d-4e84-8bde-bc0801bfd388.png">
