### PR TITLE
More aggressive menu refreshing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.19.2",
-    "@nyaruka/temba-components": "0.41.1",
+    "@nyaruka/temba-components": "0.41.2",
     "codemirror": "5.18.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -509,6 +509,9 @@ class CampaignEventCRUDL(SmartCRUDL):
         def derive_title(self):
             return _("Event History")
 
+        def derive_menu_path(self):
+            return f"/campaign/{'archived' if self.get_object().campaign.is_archived else 'active'}/"
+
         def pre_process(self, request, *args, **kwargs):
 
             event = self.get_object()

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -875,9 +875,6 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
         """
         Releases this channel making it inactive
         """
-        self.is_active = False
-        self.save(update_fields=["is_active"])
-
         from temba.channels.tasks import interrupt_channel_task
 
         super().release(user)
@@ -886,14 +883,10 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
         try:
             self.type.deactivate(self)
         except TwilioRestException as e:
-            self.is_active = True
-            self.save(update_fields=["is_active"])
             raise e
         except Exception as e:
             # proceed with removing this channel but log the problem
             logger.error(f"Unable to deactivate a channel: {str(e)}", exc_info=True)
-            self.is_active = True
-            self.save(update_fields=["is_active"])
 
         # release any channels working on our behalf
         for delegate_channel in self.org.channels.filter(parent=self):

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -1204,7 +1204,7 @@ class OrgCRUDL(SmartCRUDL):
                 menu = []
                 menu.append(
                     self.create_menu_item(
-                        menu_id="workspace", name=self.org.name, icon="icon.workspace", href="orgs.org_workspace"
+                        menu_id="workspace", name=self.org.name, icon="icon.settings", href="orgs.org_workspace"
                     )
                 )
 
@@ -1415,7 +1415,7 @@ class OrgCRUDL(SmartCRUDL):
                     {
                         "id": "settings",
                         "name": _("Settings"),
-                        "icon": "icon.settings",
+                        "icon": "icon.home",
                         "endpoint": f"{reverse('orgs.org_menu')}settings/",
                         "bottom": True,
                         "show_header": True,

--- a/templates/flows/flow_list_spa.haml
+++ b/templates/flows/flow_list_spa.haml
@@ -108,10 +108,7 @@
 
       function handleCreateLabelModalSubmitted(event) {
         refresh(function() { recheckIds(); }, true);
-        var menu = document.querySelector("temba-menu");
-        if (menu) {
-          menu.refresh();
-        }
+        refreshMenu();
       }
 
       function handleDownloadFlowResults(evt){

--- a/templates/spa_frame.haml
+++ b/templates/spa_frame.haml
@@ -479,6 +479,8 @@
 
       var eventContainer = document.querySelector(".spa-content > div");
       eventContainer.dispatchEvent(new CustomEvent("temba-spa-ready"));
+
+      refreshMenu();
     }
 
     function handleUpdateComplete() {

--- a/templates/tickets/ticket_list_spa.haml
+++ b/templates/tickets/ticket_list_spa.haml
@@ -216,7 +216,7 @@
         empty.style.opacity = '1';
       }
 
-      // menu.refresh();
+      refreshMenu();
     }
 
     function removeTicket(uuid) {
@@ -265,7 +265,7 @@
       } else {
         tickets.refresh();
       }
-      menu.refresh();
+      refreshMenu();
     }
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     react "^16.8.6"
     react-dom "^16.8.6"
 
-"@nyaruka/temba-components@0.41.1":
-  version "0.41.1"
-  resolved "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.41.1.tgz#b1aeea92350d707039c36237686024311011bfbe"
-  integrity sha512-v9kaIBsXASejE9TMdFOylKNl9cshszmQ4scS2OLx9TjADSO0HuRKDTciAopdsn1Z1C2qzCBOfVQ43ja1Iku6pg==
+"@nyaruka/temba-components@0.41.2":
+  version "0.41.2"
+  resolved "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.41.2.tgz#6be0d961d676ae6a62a621e39283d3115c522919"
+  integrity sha512-c8/uT7yPctbnmBpYHW9tVE1niwwFyVp50ilMguY9rVBTnt6h8e3J8LuC38gP31kTbqu4+TLPLNCh40I1x/z5yA==
   dependencies:
     color-hash "^2.0.2"
     geojson "^0.5.0"


### PR DESCRIPTION
 * Call `menu.refresh` once per page load
 * Debounce calls to `menu.refresh` with quiet period of 200ms, now can make calls more freely without fear of over running
 * Switch home icon to home and workspace to settings cog