### PR TITLE
🧰 API fixes 

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -173,6 +173,12 @@ class TembaModelField(serializers.RelatedField):
     # throw validation exception if any object not found, otherwise returns none
     require_exists = True
 
+    lookup_validators = {
+        "uuid": is_uuid,
+        "id": lambda v: isinstance(v, int),
+        "name": lambda v: isinstance(v, str) and v,
+    }
+
     @classmethod
     def many_init(cls, *args, **kwargs):
         """
@@ -195,7 +201,8 @@ class TembaModelField(serializers.RelatedField):
         # ignore lookup fields that can't be queryed with the given value
         lookup_fields = []
         for lookup_field in self.lookup_fields:
-            if lookup_field != "uuid" or is_uuid(value):
+            validator = self.lookup_validators.get(lookup_field)
+            if not validator or validator(value):
                 lookup_fields.append(lookup_field)
 
         # if we have no possible lookup fields left, there's no matching object

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3569,6 +3569,9 @@ class EndpointsTest(TembaTest):
         # add a surveyor message (no URN etc)
         joe_msg4 = self.create_outgoing_msg(self.joe, "Surveys!", surveyor=True)
 
+        # add an unhandled message
+        self.create_incoming_msg(self.joe, "Just in!", status="P")
+
         # add a deleted message
         deleted_msg = self.create_incoming_msg(self.frank, "!@$!%", visibility="D")
 

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -984,6 +984,10 @@ class EndpointsTest(TembaTest):
         response = self.postJSON(url, None, {"text": "Hello"})
         self.assertResponseError(response, "non_field_errors", "Must provide either urns, contacts or groups.")
 
+        # try to create new broadcast with invalid group lookup
+        response = self.postJSON(url, None, {"text": "Hello", "groups": [123456]})
+        self.assertResponseError(response, "groups", "No such object: 123456")
+
         # try to create new broadcast with translations that don't include base language
         response = self.postJSON(
             url, None, {"text": {"kin": "Muraho"}, "base_language": "eng", "contacts": [self.joe.uuid]}

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3589,6 +3589,10 @@ class EndpointsTest(TembaTest):
         frank_msg1.refresh_from_db(fields=("modified_on",))
         joe_msg3.refresh_from_db(fields=("modified_on",))
 
+        # make this message sent later than other sent message created before it to check ordering of sent messages
+        frank_msg2.sent_on = timezone.now()
+        frank_msg2.save(update_fields=("sent_on",))
+
         # default response is all messages sorted by created_on
         response = self.fetchJSON(url)
         self.assertResultsById(
@@ -3633,7 +3637,7 @@ class EndpointsTest(TembaTest):
 
         # filter by folder (sent)
         response = self.fetchJSON(url, "folder=sent")
-        self.assertResultsById(response, [joe_msg4, frank_msg2])
+        self.assertResultsById(response, [frank_msg2, joe_msg4])
 
         # filter by folder (failed)
         response = self.fetchJSON(url, "folder=failed")

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2551,9 +2551,9 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             if sys_label:
                 return SystemLabel.get_queryset(org, sys_label)
             elif folder == "incoming":
-                return self.model.objects.filter(org=org, direction="I")
+                return self.model.objects.filter(org=org, direction=Msg.DIRECTION_IN, status=Msg.STATUS_HANDLED)
             else:
-                return self.model.objects.filter(pk=-1)
+                return self.model.objects.none()
         else:
             return self.model.objects.filter(
                 org=org, visibility__in=(Msg.VISIBILITY_VISIBLE, Msg.VISIBILITY_ARCHIVED)

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -25,6 +25,7 @@ from temba.api.v2.views_base import (
     DeleteAPIMixin,
     ListAPIMixin,
     ModifiedOnCursorPagination,
+    SentOnCursorPagination,
     WriteAPIMixin,
 )
 from temba.archives.models import Archive
@@ -2475,11 +2476,10 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
     You can also filter by `folder` where folder is one of `inbox`, `flows`, `archived`, `outbox`, `incoming`, `failed` or `sent`.
     Note that you cannot filter by more than one of `contact`, `folder`, `label` or `broadcast` at the same time.
 
-    Without any parameters this endpoint will return all incoming and outgoing messages ordered by creation date.
+    The sort order for the `incoming` folder is the last modified date, and the sort order for the `sent` folder is the
+    sent date. All other requests are sorted by the message creation date.
 
-    The sort order for all folders save for `incoming` is the message creation date. For the `incoming` folder (which
-    includes all incoming messages, regardless of visibility or type) messages are sorted by last modified date. This
-    allows clients to poll for updates to message labels and visibility changes.
+    Without any parameters this endpoint will return all incoming and outgoing messages ordered by creation date.
 
     Example:
 
@@ -2514,15 +2514,14 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
 
     class Pagination(CreatedOnCursorPagination):
         """
-        Overridden paginator for Msg endpoint that switches from created_on to modified_on when looking
-        at all incoming messages.
+        Overridden paginator that switches depending on folder being requested.
         """
 
+        ordering = {"incoming": ModifiedOnCursorPagination.ordering, "sent": SentOnCursorPagination.ordering}
+
         def get_ordering(self, request, queryset, view=None):
-            if request.query_params.get("folder", "").lower() == "incoming":
-                return "-modified_on", "-id"
-            else:
-                return CreatedOnCursorPagination.ordering
+            folder = request.query_params.get("folder", "").lower()
+            return self.ordering.get(folder, CreatedOnCursorPagination.ordering)
 
     permission = "msgs.msg_api"
     model = Msg

--- a/temba/api/v2/views_base.py
+++ b/temba/api/v2/views_base.py
@@ -274,19 +274,25 @@ class DeleteAPIMixin(mixins.DestroyModelMixin):
 
 class CreatedOnCursorPagination(CursorPagination):
     ordering = ("-created_on", "-id")
-    offset_cutoff = 1000000
+    offset_cutoff = 10000
 
 
 class ModifiedOnCursorPagination(CursorPagination):
+    ordering = ("-modified_on", "-id")
+    offset_cutoff = 10000
+
     def get_ordering(self, request, queryset, view):
         if str_to_bool(request.GET.get("reverse")):
             return "modified_on", "id"
         else:
-            return "-modified_on", "-id"
+            return self.ordering
 
-    offset_cutoff = 1000000
+
+class SentOnCursorPagination(CursorPagination):
+    ordering = ("-sent_on", "-id")
+    offset_cutoff = 10000
 
 
 class DateJoinedCursorPagination(CursorPagination):
     ordering = ("-date_joined", "-id")
-    offset_cutoff = 1000000
+    offset_cutoff = 10000

--- a/temba/api/v2/views_base.py
+++ b/temba/api/v2/views_base.py
@@ -274,12 +274,12 @@ class DeleteAPIMixin(mixins.DestroyModelMixin):
 
 class CreatedOnCursorPagination(CursorPagination):
     ordering = ("-created_on", "-id")
-    offset_cutoff = 10000
+    offset_cutoff = 100000
 
 
 class ModifiedOnCursorPagination(CursorPagination):
     ordering = ("-modified_on", "-id")
-    offset_cutoff = 10000
+    offset_cutoff = 100000
 
     def get_ordering(self, request, queryset, view):
         if str_to_bool(request.GET.get("reverse")):
@@ -290,9 +290,9 @@ class ModifiedOnCursorPagination(CursorPagination):
 
 class SentOnCursorPagination(CursorPagination):
     ordering = ("-sent_on", "-id")
-    offset_cutoff = 10000
+    offset_cutoff = 100000
 
 
 class DateJoinedCursorPagination(CursorPagination):
     ordering = ("-date_joined", "-id")
-    offset_cutoff = 10000
+    offset_cutoff = 100000


### PR DESCRIPTION
 * Exclude unhandled messages when fetching `folder=incoming` - otherwise we end up returning messages with attachments that mailroom hasn't yet had time to resolve https://textit.sentry.io/issues/3948812308/
 * Don't use lookup values with the wrong type - i.e. don't try to match name with an integer value https://textit.sentry.io/issues/3949513511
 * If fetching `folder=sent`, sort by -sent_on same as UI and same as the index we made for that.