### PR TITLE
Make sure tests can run without making requests to external URLs

### DIFF
--- a/temba/channels/types/jasmin/tests.py
+++ b/temba/channels/types/jasmin/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from temba.tests import TembaTest
@@ -6,7 +8,8 @@ from ...models import Channel
 
 
 class JasminTypeTest(TembaTest):
-    def test_claim(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_claim(self, mock_socket_hostname):
         Channel.objects.all().delete()
 
         url = reverse("channels.types.jasmin.claim")

--- a/temba/channels/types/junebug/tests.py
+++ b/temba/channels/types/junebug/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from temba.tests import TembaTest
@@ -6,7 +8,8 @@ from ...models import Channel
 
 
 class JunebugTypeTest(TembaTest):
-    def test_claim(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_claim(self, mock_socket_hostname):
         Channel.objects.all().delete()
         self.login(self.admin)
 

--- a/temba/channels/types/kannel/tests.py
+++ b/temba/channels/types/kannel/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -7,7 +9,8 @@ from ...models import Channel
 
 
 class KannelTypeTest(TembaTest):
-    def test_claim(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_claim(self, mock_socket_hostname):
         Channel.objects.all().delete()
 
         # update the org brand to check the courier URL is set accordingly

--- a/temba/channels/types/shaqodoon/tests.py
+++ b/temba/channels/types/shaqodoon/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from temba.tests import TembaTest
@@ -6,7 +8,8 @@ from ...models import Channel
 
 
 class ShaqodoonTypeTest(TembaTest):
-    def test_claim(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_claim(self, mock_socket_hostname):
         Channel.objects.all().delete()
 
         self.login(self.admin)

--- a/temba/channels/types/telesom/tests.py
+++ b/temba/channels/types/telesom/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from temba.tests import TembaTest
@@ -6,7 +8,8 @@ from ...models import Channel
 
 
 class TelesomTypeTest(TembaTest):
-    def test_claim(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_claim(self, mock_socket_hostname):
         Channel.objects.all().delete()
 
         self.login(self.admin)

--- a/temba/channels/types/twiml_api/tests.py
+++ b/temba/channels/types/twiml_api/tests.py
@@ -50,7 +50,8 @@ class TwimlAPITypeTest(TembaTest):
 
     @patch("twilio.rest.Client", MockTwilioClient)
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
-    def test_channel_claim_form_valid_data(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_channel_claim_form_valid_data(self, mock_socket_hostname):
         claim_url = reverse("channels.types.twiml_api.claim")
 
         form_data = dict(
@@ -83,7 +84,8 @@ class TwimlAPITypeTest(TembaTest):
 
     @patch("twilio.rest.Client", MockTwilioClient)
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
-    def test_channel_claim_form_valid_data_shortcode(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_channel_claim_form_valid_data_shortcode(self, mock_socket_hostname):
         claim_url = reverse("channels.types.twiml_api.claim")
 
         form_data = dict(
@@ -116,7 +118,8 @@ class TwimlAPITypeTest(TembaTest):
 
     @patch("twilio.rest.Client", MockTwilioClient)
     @patch("twilio.request_validator.RequestValidator", MockRequestValidator)
-    def test_channel_claim_form_without_account_sid(self):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
+    def test_channel_claim_form_without_account_sid(self, mock_socket_hostname):
         claim_url = reverse("channels.types.twiml_api.claim")
 
         form_data = dict(country="US", number="8080", url="https://twilio.com", role="SR", account_token="abcd1234")

--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -14,17 +14,23 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
     def setUp(self):
         super().setUp()
 
-        self.channel = Channel.create(
-            self.org,
-            self.user,
-            None,
-            "VP",
-            name="Viber",
-            address="12345",
-            role="SR",
-            schemes=["viber"],
-            config={"auth_token": "abcd1234"},
-        )
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = (
+                MockResponse(
+                    200, json.dumps({"status": 0, "status_message": "ok", "id": "viberId", "uri": "viberName"})
+                ),
+            )
+            self.channel = Channel.create(
+                self.org,
+                self.user,
+                None,
+                "VP",
+                name="Viber",
+                address="12345",
+                role="SR",
+                schemes=["viber"],
+                config={"auth_token": "abcd1234"},
+            )
 
     @patch("requests.post")
     def test_claim(self, mock_post):

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -25,8 +25,9 @@ from .type import (
 
 
 class WhatsAppTypeTest(CRUDLTestMixin, TembaTest):
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
     @patch("temba.channels.types.whatsapp.WhatsAppType.check_health")
-    def test_claim(self, mock_health):
+    def test_claim(self, mock_health, mock_socket_hostname):
         mock_health.return_value = MockResponse(200, '{"meta": {"api_status": "stable", "version": "v2.35.2"}}')
         TemplateTranslation.objects.all().delete()
         Channel.objects.all().delete()
@@ -171,8 +172,9 @@ class WhatsAppTypeTest(CRUDLTestMixin, TembaTest):
         # deactivate our channel
         channel.release(self.admin)
 
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
     @patch("temba.channels.types.whatsapp.WhatsAppType.check_health")
-    def test_duplicate_number_channels(self, mock_health):
+    def test_duplicate_number_channels(self, mock_health, mock_socket_hostname):
         mock_health.return_value = MockResponse(200, '{"meta": {"api_status": "stable", "version": "v2.35.2"}}')
         TemplateTranslation.objects.all().delete()
         Channel.objects.all().delete()
@@ -305,8 +307,9 @@ class WhatsAppTypeTest(CRUDLTestMixin, TembaTest):
             self.assertEqual("abc345", channel.config[Channel.CONFIG_AUTH_TOKEN])
             self.assertEqual("abc098", channel2.config[Channel.CONFIG_AUTH_TOKEN])
 
+    @patch("socket.gethostbyname", return_value="123.123.123.123")
     @patch("temba.channels.types.whatsapp.WhatsAppType.check_health")
-    def test_claim_self_hosted_templates(self, mock_health):
+    def test_claim_self_hosted_templates(self, mock_health, mock_socket_hostname):
         mock_health.return_value = MockResponse(200, '{"meta": {"api_status": "stable", "version": "v2.35.2"}}')
         Channel.objects.all().delete()
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -954,10 +954,11 @@ class TestValidators(TestCase):
 
                 self.assertEqual(tc[1], cm.exception.message)
             else:
-                try:
-                    validate_external_url(tc[0])
-                except Exception:
-                    self.fail(f"unexpected validation error for '{tc[0]}'")
+                with patch("socket.gethostbyname", return_value="123.123.123.123"):
+                    try:
+                        validate_external_url(tc[0])
+                    except Exception:
+                        self.fail(f"unexpected validation error for '{tc[0]}'")
 
 
 class TestUUIDs(TembaTest):


### PR DESCRIPTION
Run these locally without internet access

I'll keep find if a way to make github actions run them tests in a similar fashion just after installing all the dependencies we need from the internet