### PR TITLE
Slew of title and label fixes

### DIFF
--- a/static/js/labels.js
+++ b/static/js/labels.js
@@ -137,10 +137,27 @@ function labelObjectRows(labelId, forceRemove, onSuccess) {
     postLabelChanges(objectRowsIds, labelId, addLabel, null, null, onSuccess);
 }
 
+function showPageTitle() {
+    var pageTitle = document.querySelector(".page-title");
+    if (pageTitle) {
+        pageTitle.classList.add('hidden');
+    }
+
+}
+
+function hidePageTitle() {
+    var pageTitle = document.querySelector(".page-title");
+    if (pageTitle) {
+        pageTitle.classList.remove('hidden');
+    }
+
+}
+
 /**
  * When we refresh the object list via pjax, we need to re-select the object rows that were previously selected
  */
 function recheckIds() {
+    
     if (window.lastChecked && window.lastChecked.length > 0) {
         for (var i = 0; i < window.lastChecked.length; i++) {
             var row = $(".object-row[data-object-id='" + window.lastChecked[i] + "']");
@@ -149,12 +166,12 @@ function recheckIds() {
         }
         $('.search-details').hide();
         $('.list-buttons-container').addClass('visible');
-        $('.page-title').hide();
+        hidePageTitle();
         updateLabelMenu();
     } else {
         $('.search-details').show();
         $('.list-buttons-container').removeClass('visible');
-        $('.page-title').show();
+        showPageTitle();
     }
 }
 
@@ -229,7 +246,6 @@ function handleRowSelection(checkbox) {
     var listButtons = document.querySelector(
         '.list-buttons-container'
     ).classList;
-    var pageTitle = document.querySelector('.page-title').classList;
 
     if (checkbox.checked) {
         row.add('checked');
@@ -239,10 +255,10 @@ function handleRowSelection(checkbox) {
 
     if (document.querySelector('tr.checked')) {
         listButtons.add('visible');
-        pageTitle.add('hidden');
+        hidePageTitle();
     } else {
         listButtons.remove('visible');
-        pageTitle.remove('hidden');
+        showPageTitle();
     }
 
     updateLabelMenu();
@@ -263,14 +279,14 @@ function handleRowSelections(row) {
         var checks = $('.object-row.checked');
         if (checks.length == 0) {
             $('.list-buttons-container').removeClass('visible');
-            $('.page-title').show();
+            showPageTitle();
         } else {
             $('.list-buttons-container').addClass('visible');
         }
     } else {
         $('.list-buttons-container').addClass('visible');
         row.addClass('checked');
-        $('.page-title').hide();
+        hidePageTitle();
     }
     updateLabelMenu();
 }

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -199,6 +199,7 @@ class ModalMixin(SmartFormView):
 
         if "HTTP_X_PJAX" in self.request.META and "HTTP_X_FORMAX" not in self.request.META:  # pragma: no cover
             context["base_template"] = "smartmin/modal.html"
+            context["is_modal"] = True
         if "success_url" in kwargs:  # pragma: no cover
             context["success_url"] = kwargs["success_url"]
 
@@ -657,6 +658,7 @@ class UserCRUDL(SmartCRUDL):
 
     class Read(StaffOnlyMixin, ContentMenuMixin, SpaMixin, SmartReadView):
         fields = ("email", "date_joined")
+        menu_path = "/staff/users/all"
 
         def build_content_menu(self, menu):
             obj = self.get_object()

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -154,6 +154,7 @@ class TicketCRUDL(SmartCRUDL):
             context["folder"] = folder
             context["status"] = status
             context["has_tickets"] = self.request.org.tickets.exists()
+            context["title"] = TicketFolder.from_slug(folder).name
             if uuid:
                 context["nextUUID" if in_page else "uuid"] = uuid
 

--- a/templates/includes/short_pagination.haml
+++ b/templates/includes/short_pagination.haml
@@ -68,7 +68,7 @@
               %temba-icon(name="icon.delete" clickable="true")
 
         -if 'unlabel' in actions
-          .linked.ml-4(onclick="unlabelObjectRows({{current_group.pk}}, false, refreshMenu);")
+          .linked.ml-4(onclick="unlabelObjectRows({{current_group.pk}}, refreshMenu);")
             %temba-tip(position="top" text='{{_("Remove from group")|escapejs}}')
               %temba-icon.show-loading(name="icon.delete_small" clickable="true")
 

--- a/templates/msgs/message_box_spa.haml
+++ b/templates/msgs/message_box_spa.haml
@@ -1,9 +1,6 @@
 -extends "msgs/message_box.haml"
 -load smartmin sms temba compress contacts i18n humanize channels
 
--block spa-title
-  #title-text
-
 -block content
 
   // legacy requirement for bulk actions

--- a/templates/orgs/user_read.haml
+++ b/templates/orgs/user_read.haml
@@ -12,5 +12,5 @@
       .p-4
         -for org in object.get_orgs
           .member
-            %a(href="{% url 'orgs.org_read' org.id %}")
+            .linked(onclick="goto(event, this)" href="{% url 'orgs.org_read' org.id %}")
               {{org.name}}

--- a/templates/smartmin/list.haml
+++ b/templates/smartmin/list.haml
@@ -34,7 +34,7 @@
                 -for field in fields
                   %td{ class:'value-{{field}} {% get_class field obj %}{% if field in link_fields %} clickable{% endif %}'}
                     - if field in link_fields
-                      <a {% if pjax %}data-pjax='{{ pjax }}'{% endif %} href="{% get_field_link field obj %}">{% get_value obj field %}</a>
+                      <div class="linked" onclick="goto(event, this)" {% if pjax %}data-pjax='{{ pjax }}'{% endif %} href="{% get_field_link field obj %}">{% get_value obj field %}</div>
                     - else
                       {% get_value obj field %}
 

--- a/templates/spa.haml
+++ b/templates/spa.haml
@@ -28,20 +28,20 @@
 
 -block page-header
 
-  -if title or has_content_menu
-    .spa-title.no-menu.flex.items-center.mb-4
-      .text-container.text-2xl.text-gray-700
-        .flex.flex-row
-          -block spa-title
+  -if not is_modal
+    -if title or has_content_menu
+      .spa-title.no-menu.flex.items-center.mb-4
+        .text-container.text-2xl.text-gray-700
+          .flex.flex-row
             #title-text
               {{title}}
-      .line.flex-grow.mr-2.ml-6
-        .h-0.border.border-gray-200
-      
-      -if has_content_menu
-        -include "spa_page_menu.haml"
+        .line.flex-grow.mr-2.ml-6
+          .h-0.border.border-gray-200
+        
+        -if has_content_menu
+          -include "spa_page_menu.haml"
 
-    -block subtitle
+      -block subtitle
 
 -block alert-messages
   -if user_org.is_suspended

--- a/templates/spa_frame.haml
+++ b/templates/spa_frame.haml
@@ -279,7 +279,9 @@
      
 -block full-page-script
 
-  %script(src="{{ STATIC_URL }}js/labels.js")
+  -compress js
+    %script(src="{{ STATIC_URL }}js/labels.js")
+
   %script(src="{{ STATIC_URL }}highcharts/highstock.js?v=3.0")
   %script(src="{{ STATIC_URL }}highcharts/modules/drilldown.js")
   %script(src="{{ STATIC_URL }}qrious/dist/qrious.min.js")
@@ -369,11 +371,6 @@
         {% if temba_menu_selection %}
         menu.setFocusedItem("{{temba_menu_selection}}");
         
-        // give our focus a chance, then update
-        window.setTimeout(function(){
-          updatePageTitle();
-        }, 100);
-        
         {% endif %}
         // window.addEventListener('resize', function() {
         // menu.collapsed = !!window.matchMedia("(max-width: 800px)").matches
@@ -434,32 +431,6 @@
       }
     }
 
-    function updatePageTitle(force) {
-
-      var spaTitle = "";
-      var titleDiv = document.querySelector(".spa-title #title-text");
-      if (titleDiv && titleDiv.innerText) {
-        spaTitle = titleDiv.innerText.trim();
-      }
-
-      if (!spaTitle || force) {
-        var menu = document.querySelector("temba-menu");
-        if (menu) {
-          var item = menu.getMenuItem();
-          if (item) {
-            spaTitle = item.verbose_name || item.name;
-          }
-        }
-
-        if (spaTitle && titleDiv) {
-          titleDiv.innerText = spaTitle;
-        }
-      }
-
-      // try and set our window title
-      document.title = spaTitle || "";
-    }
-
     function refreshMenu() {
       var menu = document.querySelector("temba-menu");
       if (menu) {
@@ -477,7 +448,6 @@
       var content = document.querySelector(".spa-content");
       content.scrollTo(0, 0);
       
-      updatePageTitle();
       var menu = document.querySelector("temba-menu");
       if (menu && response) {
         var menuSelection = response.headers.get("temba_menu_selection");
@@ -641,7 +611,7 @@
         var eventContainer = document.querySelector(".spa-content");
         eventContainer.addEventListener("temba-spa-ready", fn, {once: true});
       } else {
-        document.addEventListener("DOMContentLoaded", fn);
+        document.addEventListener("DOMContentLoaded", fn, {once: true});
       }      
     }
 
@@ -741,7 +711,8 @@
       groups="/api/v2/groups.json"
       workspace="/api/v2/workspace.json"
     )
-   
+  -else
+    %temba-store
 
 -block page-container
   %temba-mask

--- a/templates/spa_page_header.haml
+++ b/templates/spa_page_header.haml
@@ -2,9 +2,7 @@
     .spa-title.no-menu.flex.items-center.mb-4
       .text-container.text-2xl.text-gray-700
         .flex.flex-row
-          -block spa-title
-            #title-text
-              {{title}}
+            {{title}}
       .line.flex-grow.mr-2.ml-6
         .h-0.border.border-gray-200
       
@@ -12,3 +10,5 @@
         -include "spa_page_menu.haml"
 
   -block subtitle
+
+-block spa-title

--- a/templates/tickets/ticket_list.haml
+++ b/templates/tickets/ticket_list.haml
@@ -104,10 +104,6 @@
           updateTicketList();
         }
       }                    
-
-      if (window.updatePageTitle) {
-        updatePageTitle(true);
-      }
     }
 
     function updateTicketList() {   

--- a/templates/tickets/ticket_list_spa.haml
+++ b/templates/tickets/ticket_list_spa.haml
@@ -96,6 +96,10 @@
     var focusNext;
 
     function handleTicketsMenuChanged(menuItem) {
+
+      var pageTitle = document.querySelector("#title-text");
+      pageTitle.innerHTML = menuItem.name;
+
       var statusSelect = document.querySelector('temba-select[name="ticket-status"]');
       ticketUUID = null;
       focusNext = null;
@@ -108,13 +112,10 @@
           updateTicketList();
         }
       }                    
-
-      if (window.updatePageTitle) {
-        updatePageTitle(true);
-      }
     }
 
     function updateTicketList() {   
+
       var tickets = document.querySelector("temba-ticket-list");
       var chat = document.querySelector("temba-contact-chat");
 
@@ -271,6 +272,7 @@
 
 -block spa-title
   #title-text
+    {{title}}
 
 -block content
   .flex.flex-col.overflow-y-auto.overflow-x-hidden.rounded-b-lg.p-8.-m-8.pb-4.flex-grow

--- a/templates/triggers/trigger_list_spa.haml
+++ b/templates/triggers/trigger_list_spa.haml
@@ -1,14 +1,7 @@
 -extends "smartmin/list.html"
 -load smartmin sms temba compress humanize i18n
 
-        
--block spa-title
-  #title-text
-
 -block content
-
-  // legacy requirement for bulk actions
-  .page-title
 
   %form#search-form.mb-4(method="get")
     %temba-textinput(type='text' placeholder='{% trans "Search" %}' name="search" value="{{search}}")


### PR DESCRIPTION
* Remove global client side title updates (defers to view as before)
* Add client side `page-title` updates for ticket list as this is the only place its currently required
* Make old `labels.js` tolerant to spa page titles
* Put `labels.js` for spa inside a compress for cache busting
* Remove erroneous titles from spa modals
* Add empty `temba-store` when there is no org set
* Make sure `onSpload` event registrations on DOM are only ever fired once
* A few more `goto()` links to avoid page reloads and menu_path

Fixes: #4357
Fixes: #4358 
