### PR TITLE
Simplify what we display for Android channels

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -476,10 +476,10 @@ class ChannelReadSerializer(ReadSerializer):
 
         return {
             "name": obj.device,
-            "power_level": obj.get_last_power(),
-            "power_status": obj.get_last_power_status(),
-            "power_source": obj.get_last_power_source(),
-            "network_type": obj.get_last_network_type(),
+            "power_level": self.last_sync.power_level if self.last_sync else -1,
+            "power_status": self.last_sync.power_status if self.last_sync else None,
+            "power_source": self.last_sync.power_source if self.last_sync else None,
+            "network_type": self.last_sync.network_type if self.last_sync else None,
         }
 
     class Meta:

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -476,10 +476,10 @@ class ChannelReadSerializer(ReadSerializer):
 
         return {
             "name": obj.device,
-            "power_level": self.last_sync.power_level if self.last_sync else -1,
-            "power_status": self.last_sync.power_status if self.last_sync else None,
-            "power_source": self.last_sync.power_source if self.last_sync else None,
-            "network_type": self.last_sync.network_type if self.last_sync else None,
+            "power_level": obj.last_sync.power_level if obj.last_sync else -1,
+            "power_status": obj.last_sync.power_status if obj.last_sync else None,
+            "power_source": obj.last_sync.power_source if obj.last_sync else None,
+            "network_type": obj.last_sync.network_type if obj.last_sync else None,
         }
 
     class Meta:

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -478,24 +478,6 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         # org users can
         response = self.fetch_protected(tel_channel_read_url, self.user)
 
-        self.assertEqual(
-            len(response.context["source_stats"]),
-            len(SyncEvent.objects.values_list("power_source", flat=True).distinct()),
-        )
-        self.assertEqual("AC", response.context["source_stats"][0][0])
-        self.assertEqual(1, response.context["source_stats"][0][1])
-        self.assertEqual("BAT", response.context["source_stats"][1][0])
-        self.assertEqual(1, response.context["source_stats"][0][1])
-
-        self.assertEqual(
-            len(response.context["network_stats"]),
-            len(SyncEvent.objects.values_list("network_type", flat=True).distinct()),
-        )
-        self.assertEqual("UMTS", response.context["network_stats"][0][0])
-        self.assertEqual(1, response.context["network_stats"][0][1])
-        self.assertEqual("WIFI", response.context["network_stats"][1][0])
-        self.assertEqual(1, response.context["network_stats"][1][1])
-
         self.assertTrue(len(response.context["latest_sync_events"]) <= 5)
 
         response = self.fetch_protected(tel_channel_read_url, self.admin)

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -77,7 +77,7 @@
                 {% endblocktrans %}
 
       -else
-        -if object.channel_type == 'A'
+        -if object.is_android
           -if last_sync
             -trans "Last synced"
             -blocktrans trimmed with last_sync.created_on|timesince as last_sync
@@ -269,7 +269,7 @@
                 %td
                   = month_data.outgoing_ivr_count|intcomma
 
-  -if object.channel_type == 'A'
+  -if object.is_android
     %table.list.lined.mt-4
       %thead
         %tr

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -101,7 +101,7 @@
 
   -with object.get_sender as sender and object.get_caller as caller
 
-    -if object.channel_type == 'A'      
+    -if object.is_android
       .device
         -if channel.name
           {{ channel.name }}
@@ -148,7 +148,7 @@
       -if channel.is_delegate_caller
         -trans "Voice calls"
   
-    -if object.channel_type == 'A'      
+    -if object.is_android
       -if unsent_msgs_count
         .text-error
           {{unsent_msgs_count|intcomma}}
@@ -161,8 +161,7 @@
 -block content
   -block charts-zone
     -if start_date
-      -if object.channel_type == 'A'
-
+      -if object.is_android
         -if last_sync
           .sync-summary.mb-4
             .flex.text-gray-600
@@ -172,15 +171,9 @@
                 -else
                   .icon-radio{style:"font-size: 16px"}
 
-              .perc
-                -for net in network_share
-                  -if net.0 == last_sync.network_type
-                    {{ net.1 }}%
-              
               .t-status.px-2
                 -trans "ON"
-                = last_sync.network_type
-
+                {{ last_sync.network_type }}
 
             .flex.text-gray-600
               .i-status.w-12.px-3
@@ -203,8 +196,6 @@
                   -trans "CHARGING"
                 -if last_sync.power_status == 'FUL'
                   -trans "FULLY CHARGED"
-
-
 
       -else
 
@@ -246,7 +237,8 @@
 
       -if ivr_count
         .minutes-disclaimer
-          In many cases operators round up to the nearest minute for billing. Minutes shown here are only a usage guideline.
+          -blocktrans trimmed
+            In many cases operators round up to the nearest minute for billing. Minutes shown here are only a usage guideline.
 
       %table.list.lined
         %thead

--- a/templates/channels/channel_read_spa.haml
+++ b/templates/channels/channel_read_spa.haml
@@ -65,7 +65,7 @@
                 {% endblocktrans %}
 
       -else
-        -if object.channel_type == 'A'
+        -if object.is_android
           -if last_sync
             -trans "Last synced"
             -blocktrans trimmed with last_sync.created_on|timesince as last_sync

--- a/templates/channels/email/sms_alert.html
+++ b/templates/channels/email/sms_alert.html
@@ -3,63 +3,68 @@
 
 {% block body %}
 
-  {% if channel.channel_type == 'A' %}
-    <p>
-      {% blocktrans trimmed with org_name=org.name %}
-        We've noticed that the Android phone for {{ org_name }} is having trouble sending text messages.  This might be
-        a temporary problem due to your cellular network, or could be an indication that your phone is out of credit.
-      {% endblocktrans %}
-    </p>
+{% if channel.is_android %}
+<p>
+  {% blocktrans trimmed with org_name=org.name %}
+  We've noticed that the Android phone for {{ org_name }} is having trouble sending text messages. This might be
+  a temporary problem due to your cellular network, or could be an indication that your phone is out of credit.
+  {% endblocktrans %}
+</p>
 
-    <p>
-      {% blocktrans trimmed %}
-        Please check on your phone to make sure it has sufficient credit and can send text messages.  If problems persist
-        you may want to try turning the phone off then back on.  Currently your Android phone has <strong>{{ unsent_count }}</strong>
-        messages which haven't sent in over an hour.
-      {% endblocktrans %}
-    </p>
+<p>
+  {% blocktrans trimmed %}
+  Please check on your phone to make sure it has sufficient credit and can send text messages. If problems persist
+  you may want to try turning the phone off then back on. Currently your Android phone has <strong>{{ unsent_count
+    }}</strong>
+  messages which haven't sent in over an hour.
+  {% endblocktrans %}
+</p>
 
-  {% elif channel.type.free_sending %}
-    <p>
-      {% blocktrans trimmed with org_name=org.name channel_type=channel.get_channel_type_name %}
-        We've noticed that the {{ channel_type }} for {{ org_name }} is having trouble sending text messages.  This might be
-        a temporary problem due to network communication to {{ channel_type }} or may indicate a change in configuration which required your action.
-      {% endblocktrans %}
-    </p>
+{% elif channel.type.free_sending %}
+<p>
+  {% blocktrans trimmed with org_name=org.name channel_type=channel.get_channel_type_name %}
+  We've noticed that the {{ channel_type }} for {{ org_name }} is having trouble sending text messages. This might be
+  a temporary problem due to network communication to {{ channel_type }} or may indicate a change in configuration which
+  required your action.
+  {% endblocktrans %}
+</p>
 
-    <p>
-      {% blocktrans trimmed with channel_type=channel.get_channel_type_name %}
-        Please check on your {{ channel_type }} to make sure it can send text messages.  Currently your {{ channel_type }} has <strong>{{ unsent_count }}</strong>
-        messages which haven't sent in over an hour.
-      {% endblocktrans %}
-    </p>
-  {% else %}
-    <p>
-      {% blocktrans trimmed with org_name=org.name channel_type=channel.get_channel_type_name %}
-        We've noticed that the {{ channel_type }} for {{ org_name }} is having trouble sending text messages.  This might be
-        a temporary problem due to network communication to {{ channel_type }}, or could be an indication that your {{ channel_type }} is out of credit.
-      {% endblocktrans %}
-    </p>
+<p>
+  {% blocktrans trimmed with channel_type=channel.get_channel_type_name %}
+  Please check on your {{ channel_type }} to make sure it can send text messages. Currently your {{ channel_type }} has
+  <strong>{{ unsent_count }}</strong>
+  messages which haven't sent in over an hour.
+  {% endblocktrans %}
+</p>
+{% else %}
+<p>
+  {% blocktrans trimmed with org_name=org.name channel_type=channel.get_channel_type_name %}
+  We've noticed that the {{ channel_type }} for {{ org_name }} is having trouble sending text messages. This might be
+  a temporary problem due to network communication to {{ channel_type }}, or could be an indication that your {{
+  channel_type }} is out of credit.
+  {% endblocktrans %}
+</p>
 
-    <p>
-      {% blocktrans trimmed with channel_type=channel.get_channel_type_name %}
-        Please check on your {{ channel_type }} to make sure it has sufficient credit and can send text messages.  Currently your {{ channel_type }} has <strong>{{ unsent_count }}</strong>
-        messages which haven't sent in over an hour.
-      {% endblocktrans %}
-    </p>
+<p>
+  {% blocktrans trimmed with channel_type=channel.get_channel_type_name %}
+  Please check on your {{ channel_type }} to make sure it has sufficient credit and can send text messages. Currently
+  your {{ channel_type }} has <strong>{{ unsent_count }}</strong>
+  messages which haven't sent in over an hour.
+  {% endblocktrans %}
+</p>
 
 
-  {% endif  %}
-    <p>
-      {% blocktrans trimmed with channel_name=channel.get_name %}
-        You can check the current status of your {{ channel_name }} by visiting its
-      {% endblocktrans %}
-      <a href="{{ branding.link }}/channels/channel/read/{{ channel.uuid }}/">
-        {% trans "status page." %}
-      </a>
-    </p>
+{% endif %}
+<p>
+  {% blocktrans trimmed with channel_name=channel.get_name %}
+  You can check the current status of your {{ channel_name }} by visiting its
+  {% endblocktrans %}
+  <a href="{{ branding.link }}/channels/channel/read/{{ channel.uuid }}/">
+    {% trans "status page." %}
+  </a>
+</p>
 
-    <p>{% trans "Thanks!" %}</p>
+<p>{% trans "Thanks!" %}</p>
 
-    <p>{% blocktrans with brand=branding.name %}The {{ brand }} Team{% endblocktrans %}</p>
+<p>{% blocktrans with brand=branding.name %}The {{ brand }} Team{% endblocktrans %}</p>
 {% endblock %}


### PR DESCRIPTION
Started trying to cleanup Android channel alerts which need to become incidents/notifications (currently channel checking cron is not performant at all).. but first need to cleanup what we display on the read page.