### PR TITLE
Stop saving `JSONAsTextField` values as null for empty dicts and lists

### DIFF
--- a/temba/utils/models/fields.py
+++ b/temba/utils/models/fields.py
@@ -102,10 +102,6 @@ class JSONAsTextField(CheckFieldDefaultMixin, models.Field):
             raise ValueError('Unexpected type "%s" for JSONAsTextField' % (type(value),))
 
     def get_db_prep_value(self, value, *args, **kwargs):
-        # if the value is falsy we will save is as null
-        if self.null and value in (None, {}, []) and not kwargs.get("force"):
-            return None
-
         if value is None:
             return None
 

--- a/temba/utils/models/tests.py
+++ b/temba/utils/models/tests.py
@@ -176,8 +176,8 @@ class TestJSONAsTextField(TestCase):
             cur.execute("select * from utils_jsonmodeltestdefaultnull")
 
             data = cur.fetchall()
-        # but in the database the field is saved as null
-        self.assertEqual(data[0][1], None)
+        # and in the database the field saved as default value
+        self.assertEqual(data[0][1], "{}")
 
     def test_default_without_null(self):
         model = JsonModelTestDefault()


### PR DESCRIPTION
Want to get JSON fields like`Org.config` which currently use our `JSONAsTextField` class onto the real `models.JSONField` so that they're real JSONB in the database, with validation, and we can use JSON operators in Django querysets.

Except probably fields like `FlowSession.output` and `FlowRevision.definition` where there would probably be a performance penalty because of their size.

Step one is making the existing fields behave more like real JSON fields so no more automatically converting values like `{}` to NULL.