### PR TITLE
Expose flow on messages API endpoint

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -1267,6 +1267,7 @@ class MsgReadSerializer(ReadSerializer):
     archived = serializers.SerializerMethodField()
     visibility = serializers.SerializerMethodField()
     labels = serializers.SerializerMethodField()
+    flow = fields.FlowField()
     media = serializers.SerializerMethodField()  # deprecated
     created_on = serializers.DateTimeField(default_timezone=pytz.UTC)
     modified_on = serializers.DateTimeField(default_timezone=pytz.UTC)
@@ -1322,6 +1323,7 @@ class MsgReadSerializer(ReadSerializer):
             "visibility",
             "text",
             "labels",
+            "flow",
             "attachments",
             "created_on",
             "sent_on",

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3578,6 +3578,7 @@ class EndpointsTest(APITest):
                 "visibility": msg_visibility,
                 "text": msg.text,
                 "labels": [{"uuid": str(lb.uuid), "name": lb.name} for lb in msg.labels.all()],
+                "flow": {"uuid": str(msg.flow.uuid), "name": msg.flow.name} if msg.flow else None,
                 "attachments": [{"content_type": a.content_type, "url": a.url} for a in msg.get_attachments()],
                 "created_on": format_datetime(msg.created_on),
                 "sent_on": format_datetime(msg.sent_on),
@@ -3651,7 +3652,7 @@ class EndpointsTest(APITest):
         )
 
         # filter by incoming, should get deleted messages too
-        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 5):
+        with self.assertNumQueries(NUM_BASE_REQUEST_QUERIES + 6):
             response = self.fetchJSON(url, "folder=incoming")
 
         resp_json = response.json()

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2472,6 +2472,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
      * **text** - the text of the message received (string). Note this is the logical view and the message may have been received as multiple physical messages.
      * **attachments** - the attachments on the message (array of objects).
      * **labels** - any labels set on this message (array of objects), filterable as `label` with label name or UUID.
+     * **flow** - the UUID and name of the flow if message was part of a flow (object, optional).
      * **created_on** - when this message was either received by the channel or created (datetime) (filterable as `before` and `after`).
      * **sent_on** - for outgoing messages, when the channel sent the message (null if not yet sent or an incoming message) (datetime).
      * **modified_on** - when the message was last modified (datetime)
@@ -2506,6 +2507,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
                 "text": "How are you?",
                 "attachments": [{"content_type": "audio/wav" "url": "http://domain.com/recording.wav"}],
                 "labels": [{"name": "Important", "uuid": "5a4eb79e-1b1f-4ae3-8700-09384cca385f"}],
+                "flow": {"uuid": "254fd2ff-4990-4621-9536-0a448d313692", "name": "Registration"},
                 "created_on": "2016-01-06T15:33:00.813162Z",
                 "sent_on": "2016-01-06T15:35:03.675716Z",
                 "modified_on": "2016-01-06T15:35:03.675716Z"
@@ -2546,6 +2548,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             "text": "Hi Bob",
             "attachments": [],
             "labels": [],
+            "flow": null,
             "created_on": "2023-01-06T15:33:00.813162Z",
             "sent_on": "2023-01-06T15:35:03.675716Z",
             "modified_on": "2023-01-06T15:35:03.675716Z"
@@ -2640,6 +2643,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
             Prefetch("contact_urn", queryset=ContactURN.objects.only("scheme", "path", "display")),
             Prefetch("channel", queryset=Channel.objects.only("uuid", "name")),
             Prefetch("labels", queryset=Label.objects.only("uuid", "name").order_by("pk")),
+            Prefetch("flow", queryset=Flow.objects.only("uuid", "name")),
         )
 
         # incoming folder gets sorted by 'modified_on'


### PR DESCRIPTION
Flow is already part of the "api" format that we use for archiving