### PR TITLE
🚒 Strip out invalid HTTP header characters from page title response headers

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -550,6 +550,11 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(reverse("contacts.contact_read", args=["invalid-uuid"]))
         self.assertEqual(response.status_code, 404)
 
+        # check that names inserted as page title headers are encoded properly
+        joe_flow = self.create_contact("Joe\t\nFlow", phone="123567")
+        response = self.client.get(reverse("contacts.contact_read", args=[joe_flow.uuid]), HTTP_TEMBA_SPA=True)
+        self.assertEqual("JoeFlow", response["X-Temba-Page-Title"])
+
     def test_read_language(self):
         joe = self.create_contact("Joe", phone="123")
         read_url = reverse("contacts.contact_read", args=[joe.uuid])

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -3,6 +3,7 @@ import logging
 from urllib.parse import quote, urlencode
 
 import requests
+from gunicorn.http.wsgi import HEADER_VALUE_RE
 
 from django import forms
 from django.conf import settings
@@ -123,7 +124,10 @@ class SpaMixin(View):
         if self.is_spa():
             response.headers[TEMBA_MENU_SELECTION] = context[TEMBA_MENU_SELECTION]
             response.headers[TEMBA_CONTENT_ONLY] = 1 if self.is_content_only() else 0
-            response.headers[TEMBA_PAGE_TITLE] = context["title"]
+
+            # TODO find alternative way to pass back page titles and toast errors
+            title = context["title"]
+            response.headers[TEMBA_PAGE_TITLE] = HEADER_VALUE_RE.sub("", str(title)) if title else None
         return response
 
 
@@ -269,7 +273,7 @@ class BulkActionMixin:
 
         response = self.get(request, *args, **kwargs)
         if action_error:
-            response["Temba-Toast"] = action_error
+            response["Temba-Toast"] = HEADER_VALUE_RE.sub("", str(action_error))
 
         return response
 

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -127,7 +127,8 @@ class SpaMixin(View):
 
             # TODO find alternative way to pass back page titles and toast errors
             title = context["title"]
-            response.headers[TEMBA_PAGE_TITLE] = HEADER_VALUE_RE.sub("", str(title)) if title else None
+            if title:
+                response.headers[TEMBA_PAGE_TITLE] = HEADER_VALUE_RE.sub("", str(title))
         return response
 
 


### PR DESCRIPTION
https://textit.sentry.io/issues/4004534394/?alert_rule_id=5195&alert_timestamp=1678802103157&alert_type=email&environment=production&project=20737&referrer=alert_email

Can't use headers to pass back anything that can be non-ASCII... seems we need to rethink passing back of page titles this way