### PR TITLE
👮 Fix suspending and unsuspending orgs

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2272,7 +2272,7 @@ class ContactImport(SmartModel):
             batch.import_async()
 
         # flag org if the set of imported URNs looks suspicious
-        if not self.org.is_verified() and self._detect_spamminess(urns):
+        if not self.org.is_verified and self._detect_spamminess(urns):
             self.org.flag()
 
     def _batches_generator(self, row_iter):


### PR DESCRIPTION
Flagging is currently done via the context menu.. or the update form.

This PR adds suspension/unsuspension to the context menu and removes both that and flagging from the update form.

<img width="419" alt="Captura de pantalla 2023-03-23 a la(s) 13 14 29" src="https://user-images.githubusercontent.com/675558/227308173-b16bd9ba-509e-4fb3-b021-8a36a14ab3d0.png">
