### PR TITLE
NOOP instead of assert if archiving msg which is already archived etc

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -581,10 +581,11 @@ class Msg(models.Model):
         """
         Archives this message
         """
-        assert self.direction == self.DIRECTION_IN and self.visibility == Msg.VISIBILITY_VISIBLE
+        assert self.direction == self.DIRECTION_IN
 
-        self.visibility = self.VISIBILITY_ARCHIVED
-        self.save(update_fields=("visibility", "modified_on"))
+        if self.visibility == self.VISIBILITY_VISIBLE:
+            self.visibility = self.VISIBILITY_ARCHIVED
+            self.save(update_fields=("visibility", "modified_on"))
 
     @classmethod
     def archive_all_for_contacts(cls, contacts):
@@ -603,10 +604,11 @@ class Msg(models.Model):
         """
         Restores (i.e. un-archives) this message
         """
-        assert self.direction == self.DIRECTION_IN and self.visibility == Msg.VISIBILITY_ARCHIVED
+        assert self.direction == self.DIRECTION_IN
 
-        self.visibility = self.VISIBILITY_VISIBLE
-        self.save(update_fields=("visibility", "modified_on"))
+        if self.visibility == self.VISIBILITY_ARCHIVED:
+            self.visibility = self.VISIBILITY_VISIBLE
+            self.save(update_fields=("visibility", "modified_on"))
 
     def delete(self, soft: bool = False):
         """


### PR DESCRIPTION
Avoids sentry errors like https://textit.sentry.io/issues/4028647796/?alert_rule_id=5195&alert_timestamp=1679530070033&alert_type=email&environment=production&project=20737&ref_fallback=ga&referrer=alert_email