### PR TITLE
Add undocumented param to contacts API endpoint which allows URNs to be expanded

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -14,6 +14,18 @@ from temba.utils import languages
 from temba.utils.uuid import find_uuid, is_uuid
 
 
+def serialize_urn(org, urn):
+    if isinstance(urn, ContactURN):
+        return URN.from_parts(urn.scheme, ContactURN.ANON_MASK if org.is_anon else urn.path)
+    elif isinstance(urn, dict):
+        return {
+            "channel": urn["channel"],
+            "scheme": urn["scheme"],
+            "path": ContactURN.ANON_MASK if org.is_anon else urn["path"],
+            "display": urn["display"] or None,
+        }
+
+
 def validate_language(value):
     if not languages.get_name(str(value)):
         raise serializers.ValidationError("Not an allowed ISO 639-3 language code.")
@@ -253,7 +265,7 @@ class ContactField(TembaModelField):
         if self.as_summary:
             urn = obj.get_urn()
             if urn:
-                urn_str, urn_display = urn.get_for_api(), obj.get_urn_display() if not org.is_anon else None
+                urn_str, urn_display = serialize_urn(org, urn), obj.get_urn_display() if not org.is_anon else None
             else:
                 urn_str, urn_display = None, None
 

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -543,7 +543,9 @@ class ContactReadSerializer(ReadSerializer):
         if not obj.is_active:
             return []
 
-        return [urn.get_for_api() for urn in obj.get_urns()]
+        urns = obj.expanded_urns if hasattr(obj, "expanded_urns") else obj.get_urns()
+
+        return [fields.serialize_urn(self.context["org"], urn) for urn in urns]
 
     def get_groups(self, obj):
         if not obj.is_active:

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1456,6 +1456,12 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIView)
     def prepare_for_serialization(self, object_list, using: str):
         Contact.bulk_urn_cache_initialize(object_list, using=using)
 
+        if str_to_bool(self.request.query_params.get("expand_urns")):
+            contact_info = Contact.bulk_inspect(object_list)
+
+            for contact in object_list:
+                contact.expanded_urns = contact_info[contact]["urns"]
+
     def get_serializer_context(self):
         """
         So that we only fetch active contact fields once for all contacts

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -217,7 +217,7 @@ class MailroomClient:
 
         return self._request("contact/create", payload)
 
-    def contact_modify(self, org_id, user_id, contact_ids, modifiers: list[Modifier]):
+    def contact_modify(self, org_id: int, user_id: int, contact_ids: list[int], modifiers: list[Modifier]):
         payload = {
             "org_id": org_id,
             "user_id": user_id,
@@ -231,6 +231,11 @@ class MailroomClient:
         payload = {"org_id": org_id, "channel_id": channel_id, "urn": urn}
 
         return self._request("contact/resolve", payload)
+
+    def contact_inspect(self, org_id: int, contact_ids: list[int]):
+        payload = {"org_id": org_id, "contact_ids": contact_ids}
+
+        return self._request("contact/inspect", payload)
 
     def contact_interrupt(self, org_id: int, user_id: int, contact_id: int):
         payload = {"org_id": org_id, "user_id": user_id, "contact_id": contact_id}

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -351,6 +351,19 @@ class MailroomClientTest(TembaTest):
         )
 
     @patch("requests.post")
+    def test_contact_inspect(self, mock_post):
+        mock_post.return_value = MockResponse(200, '{"101": {}, "102": {}}')
+
+        response = get_client().contact_inspect(self.org.id, [101, 102])
+
+        self.assertEqual({"101": {}, "102": {}}, response)
+        mock_post.assert_called_once_with(
+            "http://localhost:8090/mr/contact/inspect",
+            headers={"User-Agent": "Temba"},
+            json={"org_id": self.org.id, "contact_ids": [101, 102]},
+        )
+
+    @patch("requests.post")
     def test_contact_interrupt(self, mock_post):
         mock_post.return_value = MockResponse(200, '{"sessions": 1}')
 


### PR DESCRIPTION
Without param...

```
"urns": ["tel:+250700009999", "twitterid:357475478548745"]
```

With param...

```
"urns": [
    {
        "channel": {
            "uuid": "c9a5d98a-4c89-4f25-af96-81f06b67e019",
            "name": "Vonage"
        },
        "scheme": "tel",
        "path": "+250700009999",
        "display": null
    },
    {
        "channel": null,
        "scheme": "twitterid",
        "path": "357475478548745",
        "display": "cathy"
    }
]
```

Without param in anon org...

```
"urns": ["tel:********", "twitterid:********"]
```

With param in anon org...

```
"urns": [
    {
        "channel": {
            "uuid": "c9a5d98a-4c89-4f25-af96-81f06b67e019",
            "name": "Vonage"
        },
        "scheme": "tel",
        "path": "********",
        "display": null
    },
    {
        "channel": null,
        "scheme": "twitterid",
        "path": "********",
        "display": "cathy"
    }
]
```

No channel indicates a URN which is not sendable.