### PR TITLE
Tweak migration dependency

### DIFF
--- a/temba/locations/migrations/0028_alter_adminboundary_level_alter_adminboundary_name_and_more.py
+++ b/temba/locations/migrations/0028_alter_adminboundary_level_alter_adminboundary_name_and_more.py
@@ -16,6 +16,7 @@ DROP INDEX locations_boundaryalias_name;
 class Migration(migrations.Migration):
     dependencies = [
         ("orgs", "0122_alter_org_config"),
+        ("sql", "0005_squashed"),
         ("locations", "0027_squashed"),
     ]
 


### PR DESCRIPTION
Sometimes you add a migration, and suddenly migrations are running in a different order exposing a dependency issue we hadn't seen before. Can't wait to get indexes out of sql files and into Django models so it's Django's problem to keep things like this in the right order.