### PR TITLE
Make `contact.modify` work with new and old format

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1009,7 +1009,8 @@ class Contact(LegacyUUIDMixin, SmartModel):
             raise e
 
         def modified(contact):
-            return len(response.get(contact.id, {}).get("events", [])) > 0
+            c = response.get("modified", {}).get(contact.id, {}) or response.get(contact.id, {})
+            return len(c.get("events", [])) > 0
 
         return [c.id for c in contacts if modified(c)]
 


### PR DESCRIPTION
https://github.com/nyaruka/mailroom/pull/63 changes response to be..

```
{
  "modified": {
    "10001": {...},
    "10002": {...}
  },
  "skipped": []
}
```

instead of 

```
{
  "10001": {...},
  "10002": {...}
}
```