### PR TITLE
Change cookie checking for UI so that we always default to new UI

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -467,7 +467,6 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
 
         # new ui path
         self.login(self.user)
-        self.make_beta(self.user)
         self.new_ui()
         response = self.client.get(tel_channel_read_url)
         self.assertEqual(f"/settings/channels/{self.tel_channel.uuid}", response.headers[TEMBA_MENU_SELECTION])

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -3467,7 +3467,7 @@ class OrgCRUDL(SmartCRUDL):
 
             org = self.get_object()
             context["sub_orgs"] = org.children.filter(is_active=True)
-            context["is_spa"] = self.request.COOKIES.get("nav") == "2"
+            context["is_spa"] = self.request.COOKIES.get("nav", "old" if settings.TESTING else "new") != "old"
             return context
 
     class EditSubOrg(SpaMixin, ModalMixin, Edit):

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -137,9 +137,6 @@ class TembaTestMixin:
     def make_beta(self, user):
         user.groups.add(Group.objects.get(name="Beta"))
 
-    def unbeta(self, user):
-        user.groups.remove(Group.objects.get(name="Beta"))
-
     def clear_cache(self):
         """
         Clears the redis cache. We are extra paranoid here and check that redis host is 'localhost'
@@ -172,12 +169,10 @@ class TembaTestMixin:
             session.save()
 
     def old_ui(self):
-        self.unbeta(self.admin)
-        self.client.cookies.load({"nav": "1"})
+        self.client.cookies.load({"nav": "old"})
 
     def new_ui(self):
-        self.make_beta(self.admin)
-        self.client.cookies.load({"nav": "2"})
+        self.client.cookies.load({"nav": "new"})
 
     def import_file(self, filename, site="http://rapidpro.io", substitutions=None):
         data = self.get_import_json(filename, substitutions=substitutions)

--- a/temba/tests/crudl.py
+++ b/temba/tests/crudl.py
@@ -26,18 +26,13 @@ class CRUDLTestMixin:
             check.pre_check(self, pre_msg_prefix)
 
         if new_ui or "HTTP_TEMBA_SPA" in kwargs:
-            self.client.cookies.load({"nav": "2"})
-            if user:
-                self.make_beta(user)
+            self.client.cookies.load({"nav": "new"})
 
         response = self.client.post(url, post_data, **kwargs) if method == "POST" else self.client.get(url, **kwargs)
 
         # remove our spa cookie if we added it
         if new_ui or "HTTP_TEMBA_SPA" in kwargs:
-            self.client.cookies.load({"nav": "1"})
-
-            if user:
-                self.unbeta(user)
+            self.client.cookies.load({"nav": "old"})
 
         for check in checks:
             check.check(self, response, msg_prefix)

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -286,7 +286,7 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # deep link into a page that doesn't have our ticket
         deep_link = f"{list_url}all/closed/{str(ticket.uuid)}/"
-        self.make_beta(self.admin)
+
         self.login(self.admin)
 
         response = self.client.get(deep_link)

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -38,15 +38,6 @@
         }
       }
 
-      function switchToNewInterface() {
-        document.cookie = "nav=2; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/;";
-        if (document.location.pathname == "/") {
-          document.location.href = "{% url 'orgs.org_start' %}";
-        } else {
-          document.location.reload();
-        }
-      }
-
       window.supportEmail = '{{brand.support_email}}';
       function conditionalLoad(local, remote) {
         if (local != null && (window.location.hostname == "localhost" || remote == null)) {
@@ -338,20 +329,12 @@
       -block nav
         -include 'includes/nav.html'
 
-    -block interface-option
-      -if user.is_authenticated
-        #preview.text-center.px-3.text-sm.py-1(style='background:rgba(0,0,0,.75);z-index:10000;position:fixed;bottom:0px;width:100%;color:#fff')
-          Switch to the
-          %span.linked(onclick="switchToNewInterface()" style="color:#43b1ff")<
-            new interface
-
     -if messages
       -block messages
         -if messages
           -for msg in messages
             %div{class:"alert alert-{{ message.tags }}"}
               {{ msg }}
-
 
     -block post-header
     <!-- Content -->

--- a/templates/no_nav.haml
+++ b/templates/no_nav.haml
@@ -32,5 +32,3 @@
         .bottom
           -block footer
             {{block.super}}
-
--block interface-option

--- a/templates/orgs/login/login.haml
+++ b/templates/orgs/login/login.haml
@@ -8,9 +8,6 @@
 
   {% analytics_hook 'login' %}
 
-  :javascript
-    document.cookie = "nav=2; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/;";
-
   -blocktrans trimmed
     Please sign in with your email address and password.
 

--- a/templates/spa_frame.haml
+++ b/templates/spa_frame.haml
@@ -4,23 +4,6 @@
 -block page-top
 -block header
 
-
-  :javascript
-    function leaveNewInterface() {
-      var confirm = document.querySelector("#legacy-ui");
-      confirm.open = true;
-    }
-
-    function handleUIConfirm(event) {
-      var button = event.detail.button;
-      if (button.primary) {
-        document.cookie = "nav=1; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/;";
-        document.location.reload();
-      }
-    }
-
--block interface-option
-
 -block extra-style
   {{block.super}}
 
@@ -779,13 +762,4 @@
               -->
               Copyright © 2012-2023 TextIt. All rights reserved.
   
-  %temba-dialog#legacy-ui(header='Not ready yet?' primaryButtonName='Use the old interface for now' -temba-button-clicked="handleUIConfirm")
-    .p-4
-      .mb-4
-        The new interface has some great new features, so we encourage you to take some time to get comfortable with it. 
-        Soon all accounts will be switched over, so it's better to switch now if you have a moment.
-
-      We understand that you might not be ready to switch in the moment so we'll continue to support the old interface 
-      for a bit. If the new interface isn't working well for you, we'd love to hear about it.
-
   %temba-lightbox


### PR DESCRIPTION
Only `nav=old` will use old UI. So `nav=1` or `nav=2` gets new UI, and we just use `nav=old` as default temporarily in unit tests until those can be rewritten.