### PR TITLE
Add mixin for channel type specific views that gives access to the type class

### DIFF
--- a/temba/channels/types/dialog360/type.py
+++ b/temba/channels/types/dialog360/type.py
@@ -40,8 +40,8 @@ class Dialog360Type(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(), name="templates"),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(), name="sync_logs"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(channel_type=self), name="templates"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(channel_type=self), name="sync_logs"),
         ]
 
     def get_headers(self, channel):

--- a/temba/channels/types/facebookapp/type.py
+++ b/temba/channels/types/facebookapp/type.py
@@ -40,7 +40,9 @@ class FacebookAppType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/refresh_token$", RefreshToken.as_view(), name="refresh_token"),
+            re_path(
+                r"^(?P<uuid>[a-z0-9\-]+)/refresh_token$", RefreshToken.as_view(channel_type=self), name="refresh_token"
+            ),
         ]
 
     def deactivate(self, channel):

--- a/temba/channels/types/facebookapp/views.py
+++ b/temba/channels/types/facebookapp/views.py
@@ -8,10 +8,9 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views import ModalMixin, OrgObjPermsMixin
 from temba.utils.text import truncate
-from temba.utils.views import SpaMixin
 
 from ...models import Channel
-from ...views import ClaimViewMixin
+from ...views import ChannelTypeMixin, ClaimViewMixin
 
 
 class ClaimView(ClaimViewMixin, SmartFormView):
@@ -133,7 +132,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         return super().form_valid(form)
 
 
-class RefreshToken(SpaMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView):
+class RefreshToken(ChannelTypeMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView):
     class Form(forms.Form):
         user_access_token = forms.CharField(min_length=32, required=True, help_text=_("The User Access Token"))
         fb_user_id = forms.CharField(
@@ -178,7 +177,7 @@ class RefreshToken(SpaMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView)
         return context
 
     def get_queryset(self):
-        return self.request.org.channels.filter(is_active=True, channel_type="FBA")
+        return self.request.org.channels.filter(is_active=True, channel_type=self.channel_type.code)
 
     def execute_action(self):
         form = self.form

--- a/temba/channels/types/instagram/type.py
+++ b/temba/channels/types/instagram/type.py
@@ -44,7 +44,7 @@ class InstagramType(ChannelType):
             self.get_claim_url(),
             re_path(
                 r"^(?P<uuid>[a-z0-9\-]+)/refresh_token$",
-                RefreshToken.as_view(),
+                RefreshToken.as_view(channel_type=self),
                 name="refresh_token",
             ),
         ]

--- a/temba/channels/types/instagram/views.py
+++ b/temba/channels/types/instagram/views.py
@@ -10,10 +10,9 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views import ModalMixin, OrgObjPermsMixin
 from temba.utils.text import truncate
-from temba.utils.views import SpaMixin
 
 from ...models import Channel
-from ...views import ClaimViewMixin
+from ...views import ChannelTypeMixin, ClaimViewMixin
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +165,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         return super().form_valid(form)
 
 
-class RefreshToken(SpaMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView):
+class RefreshToken(ChannelTypeMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView):
     class Form(forms.Form):
         user_access_token = forms.CharField(min_length=32, required=True, help_text=_("The User Access Token"))
         fb_user_id = forms.CharField(
@@ -211,7 +210,7 @@ class RefreshToken(SpaMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView)
         return context
 
     def get_queryset(self):
-        return self.request.org.channels.filter(is_active=True, channel_type="IG")
+        return self.request.org.channels.filter(is_active=True, channel_type=self.channel_type.code)
 
     def execute_action(self):
         form = self.form

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -42,4 +42,4 @@ class PlivoType(ChannelType):
         )
 
     def get_urls(self):
-        return [self.get_claim_url(), re_path(r"^search$", SearchView.as_view(), name="search")]
+        return [self.get_claim_url(), re_path(r"^search$", SearchView.as_view(channel_type=self), name="search")]

--- a/temba/channels/types/plivo/views.py
+++ b/temba/channels/types/plivo/views.py
@@ -12,7 +12,7 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
-from temba.channels.views import BaseClaimNumberMixin, ClaimViewMixin
+from temba.channels.views import BaseClaimNumberMixin, ChannelTypeMixin, ClaimViewMixin
 from temba.orgs.views import OrgPermsMixin
 from temba.utils import countries
 from temba.utils.fields import SelectWidget
@@ -208,7 +208,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             del self.request.session[Channel.CONFIG_PLIVO_AUTH_TOKEN]
 
 
-class SearchView(OrgPermsMixin, SmartFormView):
+class SearchView(ChannelTypeMixin, OrgPermsMixin, SmartFormView):
     class Form(forms.Form):
         country = forms.ChoiceField(choices=COUNTRY_CHOICES)
         pattern = forms.CharField(max_length=7, required=False)

--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -84,8 +84,8 @@ class TwilioType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            re_path(r"^search$", SearchView.as_view(), name="search"),
-            re_path(r"^connect$", Connect.as_view(), name="connect"),
+            re_path(r"^search$", SearchView.as_view(channel_type=self), name="search"),
+            re_path(r"^connect$", Connect.as_view(channel_type=self), name="connect"),
         ]
 
     def get_error_ref_url(self, channel, code: str) -> str:

--- a/temba/channels/types/twilio/views.py
+++ b/temba/channels/types/twilio/views.py
@@ -18,10 +18,9 @@ from temba.utils import countries
 from temba.utils.fields import InputWidget, SelectWidget
 from temba.utils.timezones import timezone_to_country_code
 from temba.utils.uuid import uuid4
-from temba.utils.views import SpaMixin
 
 from ...models import Channel
-from ...views import ALL_COUNTRIES, BaseClaimNumberMixin, ClaimViewMixin, UpdateChannelForm
+from ...views import ALL_COUNTRIES, BaseClaimNumberMixin, ChannelTypeMixin, ClaimViewMixin, UpdateChannelForm
 
 SUPPORTED_COUNTRIES = {
     "AU",  # Australia
@@ -278,7 +277,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             del self.request.session[SESSION_TWILIO_AUTH_TOKEN]
 
 
-class SearchView(OrgPermsMixin, SmartFormView):
+class SearchView(ChannelTypeMixin, OrgPermsMixin, SmartFormView):
     class Form(forms.Form):
         country = forms.ChoiceField(choices=SEARCH_COUNTRY_CHOICES)
         pattern = forms.CharField(max_length=3, min_length=3, required=False)
@@ -399,7 +398,7 @@ class UpdateForm(UpdateChannelForm):
         fields = ("name",)
 
 
-class Connect(SpaMixin, OrgPermsMixin, SmartFormView):
+class Connect(ChannelTypeMixin, OrgPermsMixin, SmartFormView):
     class TwilioConnectForm(forms.Form):
         account_sid = forms.CharField(help_text=_("Your Twilio Account SID"), widget=InputWidget(), required=True)
         account_token = forms.CharField(help_text=_("Your Twilio Account Token"), widget=InputWidget(), required=True)

--- a/temba/channels/types/vonage/type.py
+++ b/temba/channels/types/vonage/type.py
@@ -113,8 +113,8 @@ class VonageType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            re_path(r"^search$", SearchView.as_view(), name="search"),
-            re_path(r"^connect$", Connect.as_view(), name="connect"),
+            re_path(r"^search$", SearchView.as_view(channel_type=self), name="search"),
+            re_path(r"^connect$", Connect.as_view(channel_type=self), name="connect"),
         ]
 
     def get_error_ref_url(self, channel, code: str) -> str:

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -48,9 +48,9 @@ class WhatsAppType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/refresh$", RefreshView.as_view(), name="refresh"),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(), name="templates"),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(), name="sync_logs"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/refresh$", RefreshView.as_view(channel_type=self), name="refresh"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(channel_type=self), name="templates"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(channel_type=self), name="sync_logs"),
         ]
 
     def deactivate(self, channel):

--- a/temba/channels/types/whatsapp_cloud/type.py
+++ b/temba/channels/types/whatsapp_cloud/type.py
@@ -6,12 +6,12 @@ from django.urls import re_path
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.types.whatsapp_cloud.views import ClaimView, ClearSessionToken, RequestCode, VerifyCode
 from temba.contacts.models import URN
 from temba.request_logs.models import HTTPLog
 from temba.utils.whatsapp.views import SyncLogsView, TemplatesView
 
 from ...models import ChannelType
+from .views import ClaimView, ClearSessionToken, RequestCode, VerifyCode
 
 
 class WhatsAppCloudType(ChannelType):
@@ -45,11 +45,15 @@ class WhatsAppCloudType(ChannelType):
     def get_urls(self):
         return [
             self.get_claim_url(),
-            re_path(r"^clear_session_token$", ClearSessionToken.as_view(), name="clear_session_token"),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(), name="templates"),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(), name="sync_logs"),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/request_code$", RequestCode.as_view(), name="request_code"),
-            re_path(r"^(?P<uuid>[a-z0-9\-]+)/verify_code$", VerifyCode.as_view(), name="verify_code"),
+            re_path(
+                r"^clear_session_token$", ClearSessionToken.as_view(channel_type=self), name="clear_session_token"
+            ),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/templates$", TemplatesView.as_view(channel_type=self), name="templates"),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/sync_logs$", SyncLogsView.as_view(channel_type=self), name="sync_logs"),
+            re_path(
+                r"^(?P<uuid>[a-z0-9\-]+)/request_code$", RequestCode.as_view(channel_type=self), name="request_code"
+            ),
+            re_path(r"^(?P<uuid>[a-z0-9\-]+)/verify_code$", VerifyCode.as_view(channel_type=self), name="verify_code"),
         ]
 
     def activate(self, channel):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -50,9 +50,21 @@ def get_channel_read_url(channel):
     return reverse("channels.channel_read", args=[channel.uuid])
 
 
-class ClaimViewMixin(SpaMixin, OrgPermsMixin, ComponentFormMixin):
-    permission = "channels.channel_claim"
+class ChannelTypeMixin(SpaMixin):
+    """
+    Mixin for views owned by a specific channel type
+    """
+
     channel_type = None
+
+    def __init__(self, channel_type):
+        self.channel_type = channel_type
+
+        super().__init__()
+
+
+class ClaimViewMixin(ChannelTypeMixin, OrgPermsMixin, ComponentFormMixin):
+    permission = "channels.channel_claim"
     menu_path = "/settings/workspace"
 
     class Form(forms.Form):
@@ -72,10 +84,6 @@ class ClaimViewMixin(SpaMixin, OrgPermsMixin, ComponentFormMixin):
                     params={"limit": limit},
                 )
             return super().clean()
-
-    def __init__(self, channel_type):
-        self.channel_type = channel_type
-        super().__init__()
 
     def get_template_names(self):
         return (

--- a/temba/utils/whatsapp/views.py
+++ b/temba/utils/whatsapp/views.py
@@ -4,15 +4,16 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
+from temba.channels.views import ChannelTypeMixin
 from temba.orgs.views import OrgPermsMixin
 from temba.request_logs.models import HTTPLog
 from temba.templates.models import TemplateTranslation
-from temba.utils.views import ContentMenuMixin, PostOnlyMixin, SpaMixin
+from temba.utils.views import ContentMenuMixin, PostOnlyMixin
 
 from .tasks import refresh_whatsapp_contacts
 
 
-class RefreshView(SpaMixin, PostOnlyMixin, OrgPermsMixin, SmartUpdateView):
+class RefreshView(ChannelTypeMixin, PostOnlyMixin, OrgPermsMixin, SmartUpdateView):
     """
     Responsible for firing off our contact refresh task
     """
@@ -32,7 +33,7 @@ class RefreshView(SpaMixin, PostOnlyMixin, OrgPermsMixin, SmartUpdateView):
         return obj
 
 
-class TemplatesView(SpaMixin, ContentMenuMixin, OrgPermsMixin, SmartReadView):
+class TemplatesView(ChannelTypeMixin, ContentMenuMixin, OrgPermsMixin, SmartReadView):
     """
     Displays a simple table of all the templates synced on this whatsapp channel
     """
@@ -64,7 +65,7 @@ class TemplatesView(SpaMixin, ContentMenuMixin, OrgPermsMixin, SmartReadView):
         return f"/settings/channels/{self.get_object().uuid}"
 
 
-class SyncLogsView(SpaMixin, ContentMenuMixin, OrgPermsMixin, SmartReadView):
+class SyncLogsView(ChannelTypeMixin, ContentMenuMixin, OrgPermsMixin, SmartReadView):
     """
     Displays a simple table of the WhatsApp Templates Synced requests for this channel
     """


### PR DESCRIPTION
Currently channel type classes import their view classes... so view classes can't import type classes easily.. so things like config constants end up in the views module, when ideally they'd live in the channel type. The claim view already solves this by having a `.channel_type` attribute but additional views don't have this. This PR adds a mixin which makes that attribute available to other channel type specific views.