### PR TITLE
📇 Channel logs in S3 part 2: stop filtering by `.msg` and `.call`

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -780,18 +780,6 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
     def get_log_count(self):
         return self.get_count([ChannelCount.SUCCESS_LOG_TYPE, ChannelCount.ERROR_LOG_TYPE])
 
-    def get_error_log_count(self):
-        return self.get_count([ChannelCount.ERROR_LOG_TYPE]) + self.get_ivr_log_count()
-
-    def get_success_log_count(self):
-        return self.get_count([ChannelCount.SUCCESS_LOG_TYPE])
-
-    def get_ivr_log_count(self):
-        return ChannelLog.objects.filter(channel=self).exclude(call=None).order_by("call").distinct("call").count()
-
-    def get_non_ivr_log_count(self):
-        return self.get_log_count() - self.get_ivr_log_count()
-
     def __str__(self):  # pragma: no cover
         if self.name:
             return self.name

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -960,8 +960,6 @@ class ChannelLog(models.Model):
     id = models.BigAutoField(primary_key=True)
     uuid = models.UUIDField(default=uuid4, db_index=True)
     channel = models.ForeignKey(Channel, on_delete=models.PROTECT, related_name="logs")
-    msg = models.ForeignKey("msgs.Msg", on_delete=models.PROTECT, related_name="channel_logs", null=True)
-    call = models.ForeignKey("ivr.Call", on_delete=models.PROTECT, related_name="channel_logs", null=True)
 
     log_type = models.CharField(max_length=16, choices=LOG_TYPE_CHOICES)
     http_logs = models.JSONField(null=True)
@@ -969,6 +967,10 @@ class ChannelLog(models.Model):
     is_error = models.BooleanField(default=False)
     elapsed_ms = models.IntegerField(default=0)
     created_on = models.DateTimeField(default=timezone.now)
+
+    # deprecated
+    msg = models.ForeignKey("msgs.Msg", on_delete=models.PROTECT, related_name="channel_logs", null=True)
+    call = models.ForeignKey("ivr.Call", on_delete=models.PROTECT, related_name="channel_logs", null=True)
 
     def _get_display_value(self, user, original, redact_keys=(), redact_values=()):
         """

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1717,10 +1717,12 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
             ],
             errors=[],
         )
+        msg1.log_uuids = [log1.uuid, log2.uuid]
+        msg1.save(update_fields=("log_uuids",))
 
         # create another msg and log that shouldn't be included
         msg2 = self.create_outgoing_msg(contact, "success message", status="D")
-        ChannelLog.objects.create(
+        log3 = ChannelLog.objects.create(
             channel=self.channel,
             msg=msg2,
             is_error=False,
@@ -1737,6 +1739,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
             ],
             errors=[],
         )
+        msg2.log_uuids = [log3.uuid]
+        msg2.save(update_fields=("log_uuids",))
 
         msg1_url = reverse("channels.channellog_msg", args=[self.channel.uuid, msg1.id])
 
@@ -1773,6 +1777,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
             ],
             errors=[],
         )
+        call1.log_uuids = [log1.uuid, log2.uuid]
+        call1.save(update_fields=("log_uuids",))
 
         # create another call and log that shouldn't be included
         self.create_incoming_call(flow, contact)
@@ -1982,7 +1988,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("TG", "Test TG Channel", "234567")
         msg = self.create_incoming_msg(contact, "incoming msg", channel=channel)
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_SEND,
@@ -1999,6 +2005,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2055,7 +2063,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("TG", "Test TG Channel", "234567")
         msg = self.create_incoming_msg(contact, "incoming msg", channel=channel)
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_SEND,
@@ -2072,6 +2080,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2109,7 +2119,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("TG", "Test TG Channel", "234567")
         msg = self.create_incoming_msg(contact, "incoming msg", channel=channel)
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_SEND,
@@ -2126,6 +2136,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2163,7 +2175,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("TWT", "Test TWT Channel", "nyaruka")
         msg = self.create_incoming_msg(contact, "incoming msg", channel=channel)
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_RECEIVE,
@@ -2180,6 +2192,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2233,7 +2247,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("TWT", "Test TWT Channel", "nyaruka")
         msg = self.create_incoming_msg(contact, "incoming msg", channel=channel)
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_SEND,
@@ -2250,6 +2264,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2286,7 +2302,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("FB", "Test FB Channel", "54764868534")
         msg = self.create_incoming_msg(contact, "incoming msg", channel=channel)
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_RECEIVE,
@@ -2303,6 +2319,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2360,7 +2378,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("FB", "Test FB Channel", "54764868534")
         msg = self.create_incoming_msg(contact, "incoming msg", channel=channel)
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_SEND,
@@ -2377,6 +2395,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2425,7 +2445,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         channel = self.create_channel("T", "Test Twilio Channel", "+12345")
         msg = self.create_outgoing_msg(contact, "Hi")
 
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=channel,
             msg=msg,
             log_type=ChannelLog.LOG_TYPE_MSG_STATUS,
@@ -2442,6 +2462,8 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
                 }
             ],
         )
+        msg.log_uuids = [log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 
@@ -2529,6 +2551,8 @@ MessageSid=e1d12194-a643-4007-834a-5900db47e262&SmsSid=e1d12194-a643-4007-834a-5
                 }
             ],
         )
+        msg.log_uuids = [success_log.uuid]
+        msg.save(update_fields=("log_uuids",))
 
         self.login(self.admin)
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -2475,7 +2475,7 @@ class FacebookWhitelistTest(TembaTest, CRUDLTestMixin):
         self.login(self.admin)
         response = self.client.get(read_url)
         self.assertContains(response, self.channel.name)
-        self.assertContentMenu(read_url, self.admin, ["Settings", "Edit", "Delete", "Whitelist Domain"])
+        self.assertContentMenu(read_url, self.admin, ["Settings", "Logs", "Edit", "Delete", "Whitelist Domain"])
 
         with patch("requests.post") as mock:
             mock.return_value = MockResponse(400, '{"error": { "message": "FB Error" } }')

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -19,7 +19,6 @@ from django.utils.encoding import force_bytes
 
 from temba.channels.types.vonage import VonageType
 from temba.contacts.models import URN, Contact, ContactGroup, ContactURN
-from temba.ivr.models import Call
 from temba.msgs.models import Msg
 from temba.orgs.models import Org
 from temba.request_logs.models import HTTPLog
@@ -1793,19 +1792,6 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         self.channel.role = "CASR"
         self.channel.save(update_fields=("role",))
 
-        other_org_channel = Channel.create(
-            self.org2,
-            self.admin2,
-            "RW",
-            "EX",
-            name="Other Channel",
-            address="+250785551414",
-            role="SR",
-            secret="45473",
-            schemes=("tel",),
-            config={"send_url": "http://send.com"},
-        )
-
         contact = self.create_contact("Fred Jones", phone="+12067799191")
 
         # create unrelated incoming message
@@ -1852,13 +1838,6 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
             errors=[{"message": "invalid credentials", "code": ""}],
         )
 
-        # create call with an interaction log
-        ivr_flow = self.get_flow("ivr")
-        call = self.create_incoming_call(ivr_flow, contact)
-
-        # create failed call with an interaction log
-        self.create_incoming_call(ivr_flow, contact, status=Call.STATUS_FAILED)
-
         # create a non-message, non-call other log
         other_log = ChannelLog.objects.create(
             channel=self.channel,
@@ -1877,110 +1856,25 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
             ],
         )
 
-        # create log for other org
-        other_org_contact = self.create_contact("Hans", phone="+593979123456")
-        other_org_msg = self.create_outgoing_msg(other_org_contact, "hi", status="D")
-        other_org_log = ChannelLog.objects.create(
-            channel=other_org_channel,
-            msg=other_org_msg,
-            log_type=ChannelLog.LOG_TYPE_MSG_SEND,
-            is_error=False,
-            http_logs=[
-                {
-                    "url": "https://foo.bar/send?msg=message",
-                    "status_code": 200,
-                    "request": "POST /send?msg=message\r\n\r\n{}",
-                    "response": 'HTTP/1.0 200 OK\r\r\r\n{"ok":true}',
-                    "elapsed_ms": 12,
-                    "retries": 0,
-                    "created_on": "2022-01-01T00:00:00Z",
-                }
-            ],
-        )
-
         list_url = reverse("channels.channellog_list", args=[self.channel.uuid])
 
-        # can't see the view without logging in
-        response = self.client.get(list_url)
-        self.assertLoginRedirect(response)
-
-        read_url = reverse("channels.channellog_read", args=[failed_log.id])
-        response = self.client.get(read_url)
-        self.assertLoginRedirect(response)
-
-        # same if logged in as other admin
-        self.login(self.admin2)
-
-        response = self.client.get(list_url)
-        self.assertLoginRedirect(response)
-
-        read_url = reverse("channels.channellog_read", args=[failed_log.id])
-        response = self.client.get(read_url)
-        self.assertLoginRedirect(response)
-
-        # login as real admin
-        self.login(self.admin)
-
-        response = self.client.get(reverse("channels.channellog_list", args=["invalid-uuid"]))
-        self.assertEqual(404, response.status_code)
-
-        # check our list page has both our channel logs
-        response = self.client.get(list_url)
-        self.assertEqual([failed_log, success_log], list(response.context["object_list"]))
-
-        response = self.client.get(list_url)
+        response = self.assertListFetch(
+            list_url,
+            allow_viewers=False,
+            allow_editors=False,
+            allow_org2=False,
+            context_objects=[other_log, failed_log, success_log],
+        )
         self.assertEqual(f"/settings/channels/{self.channel.uuid}", response.headers[TEMBA_MENU_SELECTION])
 
-        # check error logs only
-        response = self.client.get(list_url + "?errors=1")
-        self.assertEqual([failed_log], list(response.context["object_list"]))
+        # try viewing the failed message log
+        read_url = reverse("channels.channellog_read", args=[failed_log.id])
 
-        # view failed alone
-        response = self.client.get(read_url)
-        self.assertContains(response, "failed+message")
-        self.assertContains(response, "invalid credentials")
+        self.assertReadFetch(read_url, allow_viewers=False, allow_editors=False, context_object=failed_log)
 
-        # check other logs only
-        response = self.client.get(list_url + "?others=1")
-        self.assertEqual([other_log], list(response.context["object_list"]))
-
-        # can't view log from other org
-        response = self.client.get(reverse("channels.channellog_read", args=[other_org_log.id]))
-        self.assertLoginRedirect(response)
-
-        # disconnect our msg
-        failed_log.msg = None
-        failed_log.save(update_fields=["msg"])
-        response = self.client.get(read_url)
-        self.assertContains(response, "failed+message")
-        self.assertContains(response, "invalid credentials")
-
-        # view success alone
-        channel_log_read_url = reverse("channels.channellog_read", args=[success_log.id])
-        response = self.client.get(channel_log_read_url)
-        self.assertContains(response, "POST /send?msg=message")
-
-        self.assertEqual(self.channel.get_success_log_count(), 3)
-        self.assertEqual(self.channel.get_error_log_count(), 4)  # error log count always includes IVR logs
-
-        # check that IVR logs are displayed correctly
-        response = self.client.get(reverse("channels.channellog_list", args=[self.channel.uuid]) + "?calls=1")
-        self.assertContains(response, "15 seconds")
-        self.assertContains(response, "2 results")
-
-        # make sure we can see the details of the IVR log
-        response = self.client.get(reverse("channels.channellog_call", args=[self.channel.uuid, call.id]))
-        self.assertContains(response, "{&quot;say&quot;: &quot;Hello&quot;}")
-
-        # if duration isn't set explicitly, it can be calculated
-        call.started_on = datetime(2019, 8, 12, 11, 4, 0, 0, timezone.utc)
-        call.status = Call.STATUS_IN_PROGRESS
-        call.duration = None
-        call.save(update_fields=("started_on", "status", "duration"))
-
-        with patch("django.utils.timezone.now", return_value=datetime(2019, 8, 12, 11, 4, 30, 0, timezone.utc)):
-            response = self.client.get(reverse("channels.channellog_list", args=[self.channel.uuid]) + "?calls=1")
-            self.assertContains(response, "30 seconds")
+        # invalid channel UUID returns 404
+        response = self.client.get(reverse("channels.channellog_list", args=["invalid-uuid"]))
+        self.assertEqual(404, response.status_code)
 
     def test_redaction_for_telegram(self):
         urn = "telegram:3527065"
@@ -2010,20 +1904,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.login(self.admin)
 
-        list_url = reverse("channels.channellog_list", args=[channel.uuid])
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
-
-        # check list page shows un-redacted content for a regular org
-        response = self.client.get(list_url)
-
-        self.assertContains(response, "3527065", count=1)
-
-        # check list page shows redacted content for an anon org
-        with AnonymousOrg(self.org):
-            response = self.client.get(list_url)
-
-            self.assertContains(response, "3527065", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
 
         # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
@@ -2197,18 +2078,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.login(self.admin)
 
-        list_url = reverse("channels.channellog_list", args=[channel.uuid])
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
-
-        response = self.client.get(list_url)
-
-        self.assertContains(response, "767659860", count=1)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(list_url)
-
-            self.assertContains(response, "767659860", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
 
         response = self.client.get(read_url)
 
@@ -2324,19 +2194,6 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.login(self.admin)
 
-        list_url = reverse("channels.channellog_list", args=[channel.uuid])
-        response = self.client.get(list_url)
-
-        self.assertContains(response, "2150393045080607", count=1)
-        self.assertContains(response, "facebook:2150393045080607", count=0)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(list_url)
-
-            self.assertContains(response, "2150393045080607", count=0)
-            self.assertContains(response, "facebook:2150393045080607", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
-
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
 
         response = self.client.get(read_url)
@@ -2400,16 +2257,6 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.login(self.admin)
 
-        list_url = reverse("channels.channellog_list", args=[channel.uuid])
-        response = self.client.get(list_url)
-
-        self.assertContains(response, "2150393045080607", count=1)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(list_url)
-
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
-
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
 
         response = self.client.get(read_url)
@@ -2467,22 +2314,7 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.login(self.admin)
 
-        list_url = reverse("channels.channellog_list", args=[channel.uuid])
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
-
-        # check list page shows un-redacted content for a regular org
-        response = self.client.get(list_url)
-
-        self.assertContains(response, "097 909 9111", count=1)
-
-        # check list page shows redacted content for an anon org
-        with AnonymousOrg(self.org):
-            response = self.client.get(list_url)
-
-            self.assertContains(response, "097 909 9111", count=0)
-            self.assertContains(response, "979099111", count=0)
-            self.assertContains(response, "Quito", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
 
         # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
@@ -2556,12 +2388,7 @@ MessageSid=e1d12194-a643-4007-834a-5900db47e262&SmsSid=e1d12194-a643-4007-834a-5
 
         self.login(self.admin)
 
-        list_url = reverse("channels.channellog_list", args=[channel.uuid])
         read_url = reverse("channels.channellog_read", args=[success_log.id])
-
-        # check list page shows un-redacted content for a regular org
-        response = self.client.get(list_url)
-        self.assertNotContains(response, settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN)
 
         response = self.client.get(read_url)
         self.assertNotContains(response, settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN)

--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -104,7 +104,7 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
         )
 
         # read page has link to update page
-        self.assertContentMenu(read_url, self.admin, ["Settings", "Edit", "Delete"])
+        self.assertContentMenu(read_url, self.admin, ["Settings", "Logs", "Edit", "Delete"])
 
     def test_get_error_ref_url(self):
         self.assertEqual(

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -513,6 +513,8 @@ class ChannelCRUDL(SmartCRUDL):
             if obj.type.show_config_page:
                 menu.add_link(_("Settings"), reverse("channels.channel_configuration", args=[obj.uuid]))
 
+            menu.add_link(_("Logs"), reverse("channels.channellog_list", args=[obj.uuid]))
+
             if self.has_org_perm("channels.channel_update"):
                 menu.add_modax(
                     _("Edit"),

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1051,7 +1051,8 @@ class ChannelLogCRUDL(SmartCRUDL):
             return self.msg.org
 
         def derive_queryset(self, **kwargs):
-            return super().derive_queryset(**kwargs).filter(msg=self.msg).order_by("created_on")
+            uuids = self.msg.log_uuids or []
+            return super().derive_queryset(**kwargs).filter(uuid__in=uuids).order_by("created_on")
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
@@ -1084,7 +1085,8 @@ class ChannelLogCRUDL(SmartCRUDL):
             return self.call.org
 
         def derive_queryset(self, **kwargs):
-            return super().derive_queryset(**kwargs).filter(call=self.call).order_by("created_on")
+            uuids = self.call.log_uuids or []
+            return super().derive_queryset(**kwargs).filter(uuid__in=uuids).order_by("created_on")
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1060,7 +1060,7 @@ class ChannelLogCRUDL(SmartCRUDL):
             context["logs"] = [log.get_display(self.request.user) for log in context["object_list"]]
             return context
 
-    class Call(SpaMixin, OrgObjPermsMixin, ContentMenuMixin, SmartListView):
+    class Call(SpaMixin, OrgObjPermsMixin, SmartListView):
         """
         All channel logs for a call
         """
@@ -1074,12 +1074,6 @@ class ChannelLogCRUDL(SmartCRUDL):
         @cached_property
         def call(self):
             return get_object_or_404(Call, id=self.kwargs["call_id"])
-
-        def build_content_menu(self, menu):
-            menu.add_link(
-                _("More Calls"),
-                reverse("channels.channellog_list", args=[self.call.channel.uuid]) + "?calls=1",
-            )
 
         def get_object_org(self):
             return self.call.org

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -547,7 +547,7 @@ class TembaTestMixin:
             sent_on=timezone.now(),
             created_on=timezone.now(),
         )
-        ChannelLog.objects.create(
+        log = ChannelLog.objects.create(
             channel=self.channel,
             call=call,
             log_type=ChannelLog.LOG_TYPE_IVR_START,
@@ -564,6 +564,10 @@ class TembaTestMixin:
                 }
             ],
         )
+
+        call.log_uuids = [log.uuid]
+        call.save(update_fields=("log_uuids",))
+
         return call
 
     def create_archive(

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -132,41 +132,6 @@
                 -if last_sync.power_status == 'FUL'
                   -trans "FULLY CHARGED"
 
-      -else
-
-        -if msg_count or ivr_count or channel.get_error_log_count
-          %table.list.lined
-            %thead
-              %tr
-                %th
-                  -trans "Messages"
-                
-                -if ivr_count
-                  %th
-                    -trans "IVR Messages"
-                %th
-                  -trans "Recent Errors"
-                %th
-                  -trans "Other"
-            %tbody
-              
-              %tr
-                %td
-                  %temba-anchor(href='{% url "channels.channellog_list" channel.uuid %}')
-                    {{ msg_count|intcomma }}
-
-                -if ivr_count
-                  %td
-                    %temba-anchor(href='{% url "channels.channellog_list" channel.uuid %}?calls=1')
-                      {{ ivr_count|intcomma }}
-                %td
-                  %temba-anchor(href='{% url "channels.channellog_list" channel.uuid %}?errors=1')
-                    {{ channel.get_error_log_count|intcomma }}
-                %td.w-0.text-right
-                  .inline-block
-                    %temba-icon(onclick="goto(event, this)" clickable="true" name="log" href='{% url "channels.channellog_list" channel.uuid %}?others=1')
-
-
       .card.pt-8.flex-shrink-0
         %div#channel-chart
 

--- a/templates/channels/channellog_list.haml
+++ b/templates/channels/channellog_list.haml
@@ -1,55 +1,32 @@
 -extends "smartmin/list.html"
--load i18n contacts smartmin humanize temba
+-load i18n smartmin humanize temba
 
 -block spa-title
-  -if request.GET.others
-    -trans "Non-Message Logs"
-  -else
-    {{folder|title}}
+  -trans "Channel Logs"
+
+-block subtitle
+  -trans "Logs are kept for 7 days."
 
 -block extra-style
-  {{block.super}}
+  {{ block.super }}
   :css
     .log-error {
       color: rgb(var(--error-rgb));
     }
--block page-title
-  -trans "Channel Logs"
-
--block title
-  %a{ href:"{% url 'channels.channel_read' channel.uuid %}" }
-    {{ channel }}
-
--block subtitle
-  -trans "Logs are kept for 3 days."
 
 -block content
-
   .mt-4.shadow.rounded-lg.rounded-bl-none.rounded-br-none.bg-white
     -include "includes/short_pagination.haml"
-          
-  .flex-grow.overflow-y-auto.shadow.bg-white.shadow
-        -for obj in object_list
-          .flex.mx-4.my-2(class="{% if obj.is_error %}log-error{% endif %}")
-            .contact.mr-4(style="width:8em")
-              -if obj.msg and obj.msg.contact
-                .hover-linked.truncate(onclick="goto(event)" href='{% url "contacts.contact_read" obj.msg.contact.uuid %}')
-                  {{obj.msg.contact_urn.get_display}}
-              -else
-                -trans "Channel interaction"
-            .description
-              -if obj.msg
-                .hover-linked.truncate.w-64(onclick="goto(event)" href='{% url "channels.channellog_msg" obj.channel.uuid obj.msg.id %}')
-                  {{obj.get_log_type_display}}
-              -elif obj.call
-                .hover-linked.truncate.w-64(onclick="goto(event)" href='{% url "channels.channellog_call" obj.channel.uuid obj.call.id %}')
-                  {{obj.get_log_type_display}}
-              -else
-                .hover-linked.truncate.w-64(onclick="goto(event)" href='{% url "channels.channellog_read" obj.id %}')
-                  {{obj.get_log_type_display}}
-            .elapsed.mx-2.text-right.mr-4.flex-grow
-              %span
-                {{ obj.elapsed_ms|intcomma }}ms
 
-            .created_on.whitespace-nowrap(style='text-align: right' nowrap='true')
-              {% format_datetime obj.created_on seconds=True %}
+  .flex-grow.overflow-y-auto.shadow.bg-white.shadow
+    -for obj in object_list
+      .flex.mx-4.my-2(class="{% if obj.is_error %}log-error{% endif %}")
+        .description
+          .hover-linked.truncate.w-64(onclick="goto(event)" href='{% url "channels.channellog_read" obj.id %}')
+            {{ obj.get_log_type_display }}
+        .elapsed.mx-2.text-right.mr-4.flex-grow
+          %span
+            {{ obj.elapsed_ms|intcomma }}ms
+
+        .created_on.whitespace-nowrap(style='text-align: right' nowrap='true')
+          {{ obj.created_on|datetime }}


### PR DESCRIPTION
We want users to get to logs from msgs and calls... not listing logs themselves which won't be possible when they're just files in S3. But we still need a story for logs that don't have a message or a call.. so for now we still keep a simplified list view of logs.

<img width="833" alt="Captura de pantalla 2023-05-31 a la(s) 15 36 33" src="https://github.com/nyaruka/rapidpro/assets/675558/dff4d39f-8993-45b9-840c-3aa40ab882ce">
