### PR TITLE
📺 Rework channel log rendering to always start from JSON

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1001,6 +1001,11 @@ class ChannelLog(models.Model):
         if anonymize:
             self._anonymize(data, self.channel, urn)
 
+        # out of an abundance of caution, check that we're not returning one of our own credential values
+        for log in data["http_logs"]:
+            for secret in self.channel.type.redact_values:
+                assert secret not in log["url"] and secret not in log["request"] and secret not in log["response"]
+
         return data
 
     def get_json(self):

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -990,7 +990,7 @@ class ChannelLog(models.Model):
         for err in data["errors"]:
             err["message"] = cls._anonymize_value(err["message"], urn)
 
-    def get_display(self, anonymize: bool, urn) -> dict:
+    def get_display(self, *, anonymize: bool, urn) -> dict:
         data = self.get_json()
 
         # add reference URLs to errors

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1582,7 +1582,7 @@ class ChannelLogTest(TembaTest):
         msg_out = self.create_outgoing_msg(contact, "Working", channel=channel, status="S", logs=[log])
 
         expected_unredacted = {
-            "description": "Message Send",
+            "type": "msg_send",
             "http_logs": [
                 {
                     "url": "https://telegram.com/send?to=74747474",
@@ -1595,11 +1595,12 @@ class ChannelLogTest(TembaTest):
                 }
             ],
             "errors": [{"code": "bad_response", "ext_code": "", "message": "response not right", "ref_url": None}],
-            "created_on": matchers.Datetime(),
+            "elapsed_ms": 0,
+            "created_on": matchers.ISODate(),
         }
 
         expected_redacted = {
-            "description": "Message Send",
+            "type": "msg_send",
             "http_logs": [
                 {
                     "url": "https://telegram.com/send?to=********",
@@ -1612,7 +1613,8 @@ class ChannelLogTest(TembaTest):
                 }
             ],
             "errors": [{"code": "bad_response", "ext_code": "", "message": "response n********", "ref_url": None}],
-            "created_on": matchers.Datetime(),
+            "elapsed_ms": 0,
+            "created_on": matchers.ISODate(),
         }
 
         self.assertEqual(expected_unredacted, log.get_display(self.admin, urn=msg_out.contact_urn))
@@ -1643,11 +1645,10 @@ class ChannelLogTest(TembaTest):
         msg_out = self.create_outgoing_msg(contact, "Working", channel=channel, status="S", logs=[log])
 
         expected_unredacted = {
-            "description": "Message Send",
+            "type": "msg_send",
             "http_logs": [
                 {
                     "url": "https://telegram.com/send?to=74747474",
-                    "status_code": 0,
                     "request": 'POST https://telegram.com/send?to=74747474 HTTP/1.1\r\n\r\n{"to":"74747474"}',
                     "response": "",
                     "elapsed_ms": 30001,
@@ -1656,15 +1657,15 @@ class ChannelLogTest(TembaTest):
                 }
             ],
             "errors": [{"code": "bad_response", "ext_code": "", "message": "response not right", "ref_url": None}],
-            "created_on": matchers.Datetime(),
+            "elapsed_ms": 0,
+            "created_on": matchers.ISODate(),
         }
 
         expected_redacted = {
-            "description": "Message Send",
+            "type": "msg_send",
             "http_logs": [
                 {
                     "url": "https://telegram.com/send?to=********",
-                    "status_code": 0,
                     "request": 'POST https://telegram.com/send?to=******** HTTP/1.1\r\n\r\n{"to":"********"}',
                     "response": "********",
                     "elapsed_ms": 30001,
@@ -1673,7 +1674,8 @@ class ChannelLogTest(TembaTest):
                 }
             ],
             "errors": [{"code": "bad_response", "ext_code": "", "message": "response n********", "ref_url": None}],
-            "created_on": matchers.Datetime(),
+            "elapsed_ms": 0,
+            "created_on": matchers.ISODate(),
         }
 
         self.assertEqual(expected_unredacted, log.get_display(self.admin, urn=msg_out.contact_urn))

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1900,6 +1900,16 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(reverse("channels.channellog_list", args=["invalid-uuid"]))
         self.assertEqual(404, response.status_code)
 
+    def assertRedacted(self, response, values: tuple):
+        for value in values:
+            self.assertNotContains(response, value)
+
+        self.assertContains(response, ChannelLog.REDACT_MASK)
+
+    def assertNotRedacted(self, response, values: tuple):
+        for value in values:
+            self.assertContains(response, value)
+
     def test_redaction_for_telegram(self):
         urn = "telegram:3527065"
         contact = self.create_contact("Fred Jones", urns=[urn])
@@ -1928,35 +1938,22 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("3527065", "Nic", "Pottier"))
 
-        self.assertContains(response, "3527065", count=3)
-        self.assertContains(response, "Nic", count=2)
-        self.assertContains(response, "Pottier", count=1)
-
-        # check read page shows redacted content for an anon org
+        # but for anon org we see redaction...
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
+            self.assertRedacted(response, ("3527065", "Nic", "Pottier"))
 
-            self.assertContains(response, "3527065", count=0)
-            self.assertContains(response, "Nic", count=0)
-            self.assertContains(response, "Pottier", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=8)
+            # even as customer support
+            self.login(self.customer_support, choose_org=self.org)
 
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-
-        response = self.client.get(read_url)
-
-        self.assertContains(response, "3527065", count=3)
-
-        with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-            # contact_urn is still masked on the read page, it uses contacts.models.Contact.get_display
-            # Contact.get_display does not check if user is staff
-            self.assertContains(response, "3527065", count=2)
-            self.assertContains(response, "Nic", count=2)
-            self.assertContains(response, "Pottier", count=1)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("3527065", "Nic", "Pottier"))
+
+            # unless we explicitly break out of it
+            response = self.client.get(read_url + "?break=1")
+            self.assertNotRedacted(response, ("3527065", "Nic", "Pottier"))
 
     def test_redaction_for_telegram_with_invalid_json(self):
         urn = "telegram:3527065"
@@ -1983,32 +1980,15 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         self.login(self.admin)
 
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
+
+        # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("3527065", "Nic"))
 
-        self.assertContains(response, "3527065", count=2)
-
+        # but for anon org we see redaction...
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-
-            self.assertContains(response, "3527065", count=0)
-            self.assertContains(response, "Nic", count=0)
-            self.assertContains(response, "Pottier", count=0)
-
-            # everything is masked
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=3)
-
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-
-        response = self.client.get(read_url)
-
-        self.assertContains(response, "3527065", count=2)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(read_url)
-            self.assertContains(response, "Nic", count=1)
-
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("3527065", "Nic"))
 
     def test_redaction_for_telegram_when_no_match(self):
         urn = "telegram:3527065"
@@ -2035,32 +2015,15 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         self.login(self.admin)
 
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
+
+        # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("3527065",))
 
-        self.assertContains(response, "3527065", count=1)
-        self.assertContains(response, "There is no contact identifying information", count=2)
-
+        # but for anon org we see complete redaction
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-
-            # url/request/reponse are masked
-            self.assertContains(response, "There is no contact identifying information", count=0)
-
-            self.assertContains(response, "3527065", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=3)
-
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-
-        response = self.client.get(read_url)
-
-        self.assertContains(response, "3527065", count=1)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(read_url)
-            self.assertContains(response, "There is no contact identifying information", count=2)
-
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("3527065", "api.telegram.org", "/65474/sendMessage"))
 
     def test_redaction_for_twitter(self):
         urn = "twitterid:767659860"
@@ -2088,36 +2051,14 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
 
+        # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("767659860", "Aaron Tumukunde", "tumaaron"))
 
-        self.assertContains(response, "767659860", count=5)
-        self.assertContains(response, "Aaron Tumukunde", count=1)
-        self.assertContains(response, "tumaaron", count=2)
-
+        # but for anon org we see redaction...
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-
-            self.assertContains(response, "767659860", count=0)
-            self.assertContains(response, "Aaron Tumukunde", count=0)
-            self.assertContains(response, "tumaaron", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=13)
-
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-
-        response = self.client.get(read_url)
-
-        self.assertContains(response, "767659860", count=5)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(read_url)
-            # contact_urn is still masked on the read page, it uses contacts.models.Contact.get_display
-            # Contact.get_display does not check if user is staff
-            self.assertContains(response, "767659860", count=4)
-            self.assertContains(response, "Aaron Tumukunde", count=1)
-            self.assertContains(response, "tumaaron", count=2)
-
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("767659860", "Aaron Tumukunde", "tumaaron"))
 
     def test_redaction_for_twitter_when_no_match(self):
         urn = "twitterid:767659860"
@@ -2144,31 +2085,15 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
         self.login(self.admin)
 
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
+
+        # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("767659860",))
 
-        self.assertContains(response, "767659860", count=1)
-        self.assertContains(response, "There is no contact identifying information", count=2)
-
+        # but for anon org we see complete redaction...
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-
-            # url/request/reponse are masked
-            self.assertContains(response, "There is no contact identifying information", count=0)
-
-            self.assertContains(response, "767659860", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=3)
-
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-        response = self.client.get(read_url)
-
-        self.assertContains(response, "767659860", count=1)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(read_url)
-            self.assertContains(response, "There is no contact identifying information", count=2)
-
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("767659860", "twitter.com", "/65474/sendMessage"))
 
     def test_redaction_for_facebook(self):
         urn = "facebook:2150393045080607"
@@ -2198,35 +2123,14 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         response = self.client.get(read_url)
 
-        self.assertContains(response, "2150393045080607", count=3)
-        self.assertContains(response, "facebook:2150393045080607", count=1)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(read_url)
-
-            self.assertContains(response, "2150393045080607", count=0)
-            self.assertContains(response, "facebook:", count=1)
-
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=3)
-
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-
-        read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
-
+        # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("2150393045080607",))
 
-        self.assertContains(response, "2150393045080607", count=3)
-        self.assertContains(response, "facebook:2150393045080607", count=1)
-
+        # but for anon org we see redaction...
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-            # contact_urn is still masked on the read page, it uses contacts.models.Contact.get_display
-            # Contact.get_display does not check if user is staff
-            self.assertContains(response, "2150393045080607", count=2)
-            self.assertContains(response, "facebook:", count=1)
-
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("2150393045080607",))
 
     def test_redaction_for_facebook_when_no_match(self):
         # in this case we are paranoid and mask everything
@@ -2255,33 +2159,14 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         read_url = reverse("channels.channellog_msg", args=[channel.uuid, msg.id])
 
+        # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("2150393045080607",))
 
-        self.assertContains(response, "2150393045080607", count=1)
-
+        # but for anon org we see complete redaction...
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-
-            # url/request/reponse are masked
-            self.assertContains(response, "There is no contact identifying information", count=0)
-
-            self.assertContains(response, "2150393045080607", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=3)
-
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-
-        response = self.client.get(read_url)
-
-        self.assertContains(response, "2150393045080607", count=1)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(read_url)
-            self.assertContains(response, "There is no contact identifying information", count=2)
-
-            # contact_urn is still masked on the read page, it uses contacts.models.Contact.get_display
-            # Contact.get_display does not check if user is staff
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("2150393045080607", "facebook.com", "/65474/sendMessage"))
 
     def test_redaction_for_twilio(self):
         contact = self.create_contact("Fred Jones", phone="+593979099111")
@@ -2310,37 +2195,12 @@ class ChannelLogCRUDLTest(CRUDLTestMixin, TembaTest):
 
         # check read page shows un-redacted content for a regular org
         response = self.client.get(read_url)
+        self.assertNotRedacted(response, ("097 909 9111", "979099111", "Quito"))
 
-        self.assertContains(response, "097 909 9111", count=1)
-        self.assertContains(response, "979099111", count=1)
-        self.assertContains(response, "Quito", count=1)
-
-        # check read page shows redacted content for an anon org
+        # but for anon org we see redaction...
         with AnonymousOrg(self.org):
             response = self.client.get(read_url)
-
-            self.assertContains(response, "097 909 9111", count=0)
-            self.assertContains(response, "979099111", count=0)
-            self.assertContains(response, "Quito", count=0)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=4)
-
-        # login as customer support, must see URNs
-        self.login(self.customer_support, choose_org=self.org)
-
-        response = self.client.get(read_url)
-
-        self.assertContains(response, "097 909 9111", count=1)
-        self.assertContains(response, "979099111", count=1)
-        self.assertContains(response, "Quito", count=1)
-
-        with AnonymousOrg(self.org):
-            response = self.client.get(read_url)
-            # contact_urn is still masked on the read page, it uses contacts.models.Contact.get_display
-            # Contact.get_display does not check if user is staff
-            self.assertContains(response, "097 909 9111", count=0)
-            self.assertContains(response, "979099111", count=1)
-            self.assertContains(response, "Quito", count=1)
-            self.assertContains(response, HTTPLog.REDACT_MASK, count=1)
+            self.assertRedacted(response, ("097 909 9111", "979099111", "Quito"))
 
     def test_channellog_anonymous_org_no_msg(self):
         tw_urn = "15128505839"

--- a/temba/channels/types/facebookapp/type.py
+++ b/temba/channels/types/facebookapp/type.py
@@ -1,5 +1,6 @@
 import requests
 
+from django.conf import settings
 from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
@@ -36,6 +37,8 @@ class FacebookAppType(ChannelType):
     schemes = [URN.FACEBOOK_SCHEME]
     max_length = 2000
     free_sending = True
+
+    redact_values = (settings.FACEBOOK_APPLICATION_SECRET, settings.FACEBOOK_WEBHOOK_SECRET)
 
     def get_urls(self):
         return [

--- a/temba/channels/types/instagram/type.py
+++ b/temba/channels/types/instagram/type.py
@@ -1,5 +1,6 @@
 import requests
 
+from django.conf import settings
 from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
@@ -38,6 +39,8 @@ class InstagramType(ChannelType):
     schemes = [URN.INSTAGRAM_SCHEME]
     max_length = 2000
     free_sending = True
+
+    redact_values = (settings.FACEBOOK_APPLICATION_SECRET, settings.FACEBOOK_WEBHOOK_SECRET)
 
     def get_urls(self):
         return [

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -990,7 +990,7 @@ class ChannelLogCRUDL(SmartCRUDL):
 
             anonymize = self.request.org.is_anon and not (self.request.GET.get("break") and self.request.user.is_staff)
 
-            context["log"] = self.object.get_display(anonymize, urn=None)
+            context["log"] = self.object.get_display(anonymize=anonymize, urn=None)
             return context
 
     class BaseOwned(SpaMixin, OrgObjPermsMixin, SmartListView):
@@ -1026,7 +1026,7 @@ class ChannelLogCRUDL(SmartCRUDL):
             anonymize = self.request.org.is_anon and not (self.request.GET.get("break") and self.request.user.is_staff)
 
             context["msg"] = self.owner
-            context["logs"] = [log.get_display(anonymize, urn=urn) for log in context["object_list"]]
+            context["logs"] = [log.get_display(anonymize=anonymize, urn=urn) for log in context["object_list"]]
             return context
 
     class Call(BaseOwned):
@@ -1045,5 +1045,5 @@ class ChannelLogCRUDL(SmartCRUDL):
             anonymize = self.request.org.is_anon and not (self.request.GET.get("break") and self.request.user.is_staff)
 
             context["call"] = self.owner
-            context["logs"] = [log.get_display(anonymize, urn=urn) for log in context["object_list"]]
+            context["logs"] = [log.get_display(anonymize=anonymize, urn=urn) for log in context["object_list"]]
             return context

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -987,70 +987,63 @@ class ChannelLogCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
-            context["log"] = self.object.get_display(self.request.user, urn=None)
+
+            anonymize = self.request.org.is_anon and not (self.request.GET.get("break") and self.request.user.is_staff)
+
+            context["log"] = self.object.get_display(anonymize, urn=None)
             return context
 
-    class Msg(SpaMixin, OrgObjPermsMixin, SmartListView):
+    class BaseOwned(SpaMixin, OrgObjPermsMixin, SmartListView):
+        permission = "channels.channellog_read"
+
+        @classmethod
+        def derive_url_pattern(cls, path, action):
+            return r"^(?P<channel_uuid>[0-9a-f-]+)/%s/%s/(?P<owner_id>\d+)/$" % (path, action)
+
+        def derive_menu_path(self):
+            return f"/settings/channels/{self.owner.channel.uuid}"
+
+        def get_object_org(self):
+            return self.owner.org
+
+        def derive_queryset(self, **kwargs):
+            uuids = self.owner.log_uuids or []
+            return super().derive_queryset(**kwargs).filter(uuid__in=uuids).order_by("created_on")
+
+    class Msg(BaseOwned):
         """
         All channel logs for a message
         """
 
-        permission = "channels.channellog_read"
-
-        @classmethod
-        def derive_url_pattern(cls, path, action):
-            return r"^(?P<channel_uuid>[0-9a-f-]+)/%s/%s/(?P<msg_id>\d+)/$" % (path, action)
-
         @cached_property
-        def msg(self):
-            return get_object_or_404(Msg, id=self.kwargs["msg_id"])
-
-        def derive_menu_path(self):
-            return f"/settings/channels/{self.msg.channel.uuid}"
-
-        def get_object_org(self):
-            return self.msg.org
-
-        def derive_queryset(self, **kwargs):
-            uuids = self.msg.log_uuids or []
-            return super().derive_queryset(**kwargs).filter(uuid__in=uuids).order_by("created_on")
+        def owner(self):
+            return get_object_or_404(Msg, id=self.kwargs["owner_id"])
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
 
-            urn = self.msg.contact_urn
+            urn = self.owner.contact_urn
+            anonymize = self.request.org.is_anon and not (self.request.GET.get("break") and self.request.user.is_staff)
 
-            context["msg"] = self.msg
-            context["logs"] = [log.get_display(self.request.user, urn=urn) for log in context["object_list"]]
+            context["msg"] = self.owner
+            context["logs"] = [log.get_display(anonymize, urn=urn) for log in context["object_list"]]
             return context
 
-    class Call(SpaMixin, OrgObjPermsMixin, SmartListView):
+    class Call(BaseOwned):
         """
         All channel logs for a call
         """
 
-        permission = "channels.channellog_read"
-
-        @classmethod
-        def derive_url_pattern(cls, path, action):
-            return r"^(?P<channel_uuid>[0-9a-f-]+)/%s/%s/(?P<call_id>\d+)/$" % (path, action)
-
         @cached_property
-        def call(self):
-            return get_object_or_404(Call, id=self.kwargs["call_id"])
-
-        def get_object_org(self):
-            return self.call.org
-
-        def derive_queryset(self, **kwargs):
-            uuids = self.call.log_uuids or []
-            return super().derive_queryset(**kwargs).filter(uuid__in=uuids).order_by("created_on")
+        def owner(self):
+            return get_object_or_404(Call, id=self.kwargs["owner_id"])
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
 
-            urn = self.call.contact_urn
+            urn = self.owner.contact_urn
+            anonymize = self.request.org.is_anon and not (self.request.GET.get("break") and self.request.user.is_staff)
 
-            context["call"] = self.call
-            context["logs"] = [log.get_display(self.request.user, urn=urn) for log in context["object_list"]]
+            context["call"] = self.owner
+            context["logs"] = [log.get_display(anonymize, urn=urn) for log in context["object_list"]]
             return context

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -325,7 +325,6 @@ PERMISSIONS = {
     "classifiers.intent": ("api",),
     "contacts.contact": (
         "api",
-        "break_anon",
         "export",
         "history",
         "interrupt",


### PR DESCRIPTION
Also changes anonymization of logs: staff users will see anonymized by default and have to eplicitly break out of that with a url parameter (that we'll probably turn into something in the UI).

Making it easier to switch to loading channel logs from JSON blobs in S3.