### PR TITLE
Flow fixes and type icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.20.1",
-    "@nyaruka/temba-components": "0.53.2",
+    "@nyaruka/temba-components": "0.53.3",
     "codemirror": "5.18.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.20.1",
-    "@nyaruka/temba-components": "0.53.1",
+    "@nyaruka/temba-components": "0.53.2",
     "codemirror": "5.18.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -9,6 +9,7 @@ function onSpload(fn) {
     var isLoading = container.classList.contains('loading');
     if (isInitial) {
       document.addEventListener('DOMContentLoaded', fn, { once: true });
+      container.classList.remove('initial-load');
     } else {
       if (isLoading) {
         var eventContainer = document.querySelector('.spa-content');
@@ -237,9 +238,8 @@ function hideLoading(response) {
   var containers = document.querySelectorAll(
     '.spa-container, .widget-container'
   );
-  for (container of containers) {
-    container.classList.remove('loading');
-    container.classList.remove('initial-load');
+  for (cont of containers) {
+    cont.classList.remove('loading');
   }
 
   // scroll our content to the top if needed

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -429,7 +429,14 @@ class FlowCRUDL(SmartCRUDL):
                     label=_("Type"),
                     help_text=_("Choose the method for your flow"),
                     choices=Flow.TYPE_CHOICES if "surveyor" in settings.FEATURES else Flow.TYPE_CHOICES[:3],
-                    widget=SelectWidget(attrs={"widget_only": False}),
+                    widget=SelectWidget(
+                        attrs={"widget_only": False},
+                        option_attrs={
+                            Flow.TYPE_BACKGROUND: {"icon": "flow_background"},
+                            Flow.TYPE_SURVEY: {"icon": "flow_surveyor"},
+                            Flow.TYPE_VOICE: {"icon": "flow_ivr"},
+                        },
+                    ),
                 )
 
                 self.fields["base_language"] = forms.ChoiceField(

--- a/temba/utils/fields.py
+++ b/temba/utils/fields.py
@@ -141,10 +141,17 @@ class SelectWidget(forms.Select):
     is_annotated = True
     option_inherits_attrs = True
 
+    def __init__(self, attrs=None, choices=(), *, option_attrs={}):
+        super().__init__(attrs, choices)
+        self.option_attrs = option_attrs
+
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
         if hasattr(self.choices, "option_attrs_by_value"):
             attrs = self.choices.option_attrs_by_value.get(value)
+
+        extra = self.option_attrs.get(value, {})
         attrs = attrs if attrs else {}
+        attrs.update(extra)
         option = super().create_option(name, value, label, selected, index, subindex, attrs)
         return option
 
@@ -248,7 +255,6 @@ class TembaChoiceIterator(forms.models.ModelChoiceIterator):
     def choice(self, obj):
         value = self.field.prepare_value(obj)
         option = (value, self.field.label_from_instance(obj))
-
         if hasattr(obj, "get_attrs"):
             self.option_attrs_by_value[value] = obj.get_attrs()
 

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -83,10 +83,13 @@ class SpaMixin(View):
             dev_mode = getattr(settings, "EDITOR_DEV_MODE", False)
             prefix = "/dev" if dev_mode else settings.STATIC_URL
 
+            print("full page")
+
             # get our list of assets to incude
             scripts = []
             styles = []
 
+            print("dev_mode", dev_mode)
             if dev_mode:  # pragma: no cover
                 response = requests.get("http://localhost:3000/asset-manifest.json")
                 data = response.json()
@@ -109,6 +112,7 @@ class SpaMixin(View):
                 # javascript
                 if key.endswith(".js") and filename.endswith(".js"):
                     scripts.append(filename)
+                    print("filename", filename)
 
             context["flow_editor_scripts"] = scripts
             context["flow_editor_styles"] = styles

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -83,13 +83,10 @@ class SpaMixin(View):
             dev_mode = getattr(settings, "EDITOR_DEV_MODE", False)
             prefix = "/dev" if dev_mode else settings.STATIC_URL
 
-            print("full page")
-
             # get our list of assets to incude
             scripts = []
             styles = []
 
-            print("dev_mode", dev_mode)
             if dev_mode:  # pragma: no cover
                 response = requests.get("http://localhost:3000/asset-manifest.json")
                 data = response.json()
@@ -112,7 +109,6 @@ class SpaMixin(View):
                 # javascript
                 if key.endswith(".js") and filename.endswith(".js"):
                     scripts.append(filename)
-                    print("filename", filename)
 
             context["flow_editor_scripts"] = scripts
             context["flow_editor_styles"] = styles

--- a/templates/flows/flow_editor.haml
+++ b/templates/flows/flow_editor.haml
@@ -97,9 +97,6 @@
 -block extra-script
   {{ block.super }}
 
-  -for script in scripts
-    %script(type="text/javascript" src="{{script}}")
-
   :javascript
     var base = '/flow/assets/{{object.org.id}}/' + new Date().getTime() + '/';
     var api = '/api/v2/';
@@ -190,7 +187,7 @@
       }
     };
 
-    onSpload(function(){
+    onSpload(function(){ 
       // wait for our component to load, then show the editor
       if (window.showFlowEditor) {
         window.showFlowEditor(document.getElementById("rp-flow-editor"), config);
@@ -210,6 +207,18 @@
         %temba-alert.mb-3
           -blocktrans trimmed
             This flow is in the process of being sent, this message will disappear once all contacts have been added to the flow.
+
+-block spa-title
+  .title-text.flex
+    .inline-block.flex.items-center.text-gray-600
+      -if object.flow_type == 'V'
+        %temba-icon.mr-3(name="flow_ivr")
+      -elif object.flow_type == 'S'
+        %temba-icon.mr-3(name="flow_surveyor")
+      -elif object.flow_type == 'B'
+        %temba-icon.mr-3(name="flow_background") 
+    {{ title }}
+          
 
 -block content
   %temba-modax#send-message-modal{ header:"Send Message" }

--- a/templates/flows/flow_list.haml
+++ b/templates/flows/flow_list.haml
@@ -2,8 +2,6 @@
 -load smartmin sms temba compress i18n humanize
 
 -block content
-  // legacy requirement for bulk actions
-  .page-title
   -if org_perms.flows.flow_update
     %temba-modax#export-results{ header:'{% trans "Download Results" %}' }
     %temba-modax#create-label-modal{ header:'{% trans "Create Label" %}', endpoint:"{% url 'flows.flowlabel_create' %}", "-temba-loaded": "handleCreateLabelModalLoaded", "-temba-submitted": "handleCreateLabelModalSubmitted"}
@@ -27,7 +25,7 @@
               -if org_perms.flows.flow_update
                 %th
               %th
-              %th.whitespace-nowrap
+              %th.whitespace-nowrap(style="text-align:right")
                 Runs / Completion
 
         %tbody
@@ -41,11 +39,14 @@
                 .flex.items-center
                   .flex-grow
                     .flex.inline.whitespace-nowrap.flex-grow.items-center(style="max-width:80%")
-                      -if object.flow_type == 'V'
-                        .icon-phone.mr-2.leading-snug
-                      -elif object.flow_type == 'S'
-                        .icon-mobile.mr-2.leading-snug
-                      .name.truncate
+                      .inline-block.flex.items-center.text-gray-600
+                        -if object.flow_type == 'V'
+                          %temba-icon.mr-2(name="flow_ivr")
+                        -elif object.flow_type == 'S'
+                          %temba-icon.mr-2(name="flow_surveyor")
+                        -elif object.flow_type == 'B'
+                          %temba-icon.mr-2(name="flow_background") 
+                      .name.truncate.flex-grow
                         {{ object.name }}
 
                   .whitespace-no-break.flex.items-center.ml-2.justify-end.flex-wrap
@@ -83,7 +84,6 @@
   :javascript
 
     function handleRowClicked(event) {
-
       if (event.target.tagName == "TEMBA-CHECKBOX") {
         return;
       }

--- a/templates/includes/short_pagination.haml
+++ b/templates/includes/short_pagination.haml
@@ -25,10 +25,10 @@
 
               -if org_perms.msgs.label_create
                 -if labels
-                  %li.separator.-mx-4.border-b.my-3
-                %li
-                  .lbl-menu.add-label.linked{onclick:"handleAddLabelClicked()"}
-                    -trans "New Label..."                      
+                  .separator.-mx-4.border-b.my-3
+                
+                .lbl-menu.add-label.linked{onclick:"handleAddLabelClicked()"}
+                  -trans "New Label..."                      
 
         -if 'resend' in actions
           .linked.ml-4(onclick='runActionOnObjectRows("resend", refreshMenu)')

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
     react "^16.8.6"
     react-dom "^16.8.6"
 
-"@nyaruka/temba-components@0.53.2":
-  version "0.53.2"
-  resolved "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.53.2.tgz#98a4211540a4b014be00f137e5b5ab81dbb99ae3"
-  integrity sha512-bitqnC4BrZOmj36+HR7cIMwJrLQaILjP/1yjmWksNnXBsqFro0t945u56PCX/yRi+xwawh9+zk7Tl6ozwPK1TQ==
+"@nyaruka/temba-components@0.53.3":
+  version "0.53.3"
+  resolved "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.53.3.tgz#69299b358222ddec3912847ee504ac5354ec2ea4"
+  integrity sha512-SJrmcriX794HjUcPBvukmm34vfm5OzBA2vHSP974PKFUdzyi+AIKm2o21PkLKwEcLMhx1h1dcdMFZz6khGAa7A==
   dependencies:
     color-hash "^2.0.2"
     geojson "^0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
     react "^16.8.6"
     react-dom "^16.8.6"
 
-"@nyaruka/temba-components@0.53.1":
-  version "0.53.1"
-  resolved "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.53.1.tgz#4016c15455b2ac0c37474294fa090f27e0b1c0ff"
-  integrity sha512-ZdOOdYPNS/ty+HKYcvRETWQ0JwxFQUdkbDo5xUUUyVVui7YNhy4BvCurcyv9hgUYogV+46NKk5WlWDBIEw80qA==
+"@nyaruka/temba-components@0.53.2":
+  version "0.53.2"
+  resolved "https://registry.npmjs.org/@nyaruka/temba-components/-/temba-components-0.53.2.tgz#98a4211540a4b014be00f137e5b5ab81dbb99ae3"
+  integrity sha512-bitqnC4BrZOmj36+HR7cIMwJrLQaILjP/1yjmWksNnXBsqFro0t945u56PCX/yRi+xwawh9+zk7Tl6ozwPK1TQ==
   dependencies:
     color-hash "^2.0.2"
     geojson "^0.5.0"


### PR DESCRIPTION
* Remove double loading of flow editor scripts
* Add icons for background, flow, and surveyor flows
* Fix spload sometimes not firing on first navigation after page load
* Add icons to flow type selection
* Fix disabled modals being able to close

<img width="539" alt="image" src="https://github.com/nyaruka/rapidpro/assets/211652/f127b374-c9b7-4431-81e3-ca6bfb631f50">

<img width="541" alt="image" src="https://github.com/nyaruka/rapidpro/assets/211652/47f57707-e847-4611-b0ff-e05b1464c5be">

<img width="594" alt="image" src="https://github.com/nyaruka/rapidpro/assets/211652/bac547d0-eb58-4251-a9e1-ec3148d71d5b">
