### PR TITLE
Fix parent ID lookup in import geojson

### DIFF
--- a/temba/locations/management/commands/import_geojson.py
+++ b/temba/locations/management/commands/import_geojson.py
@@ -61,6 +61,8 @@ class Command(BaseCommand):
                     parent_osm_id = str(props["is_in_country"])
                 elif level == AdminBoundary.LEVEL_DISTRICT:
                     parent_osm_id = str(props["is_in_state"])
+                elif level == AdminBoundary.LEVEL_WARD:
+                    parent_osm_id = str(props["is_in_state"])
 
             osm_id = str(props["osm_id"])
             name = props.get("name", "")


### PR DESCRIPTION
I made changes to posm to make sure the geojson has parent_id for all levels but this will help in case the geojson does not have that.