### PR TITLE
Fix for updating Twilio Credentials

### DIFF
--- a/temba/channels/types/twilio/views.py
+++ b/temba/channels/types/twilio/views.py
@@ -353,8 +353,8 @@ class UpdateForm(UpdateChannelForm):
             forms.CharField(
                 max_length=128,
                 label=_("Twilio Account SID"),
-                required=True,
-                widget=InputWidget(attrs={"disabled": "disabled"}),
+                required=False,
+                disabled=True,
             ),
             default="",
         )

--- a/temba/channels/types/twilio/views.py
+++ b/temba/channels/types/twilio/views.py
@@ -353,7 +353,6 @@ class UpdateForm(UpdateChannelForm):
             forms.CharField(
                 max_length=128,
                 label=_("Twilio Account SID"),
-                required=False,
                 disabled=True,
             ),
             default="",


### PR DESCRIPTION
Account SID form widget was marked as disabled instead of the field itself. This led to weird form behavior when other fields caused a form validation error.

Fixes #4692 