### PR TITLE
Update channel log retention to 2 weeks

### DIFF
--- a/temba/channels/templatetags/channels.py
+++ b/temba/channels/templatetags/channels.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django import template
 from django.conf import settings
 from django.urls import reverse
@@ -23,9 +21,8 @@ def channel_log_link(context, obj):
         has_channel = obj.channel and obj.channel.is_active
 
         obj_age = timezone.now() - obj.created_on
-        has_logs = obj_age < (settings.RETENTION_PERIODS["channellog"] - timedelta(hours=4))
 
-        if has_channel and has_logs:
+        if has_channel and obj_age < settings.RETENTION_PERIODS["channellog"]:
             if isinstance(obj, Call):
                 logs_url = reverse("channels.channellog_call", args=[obj.channel.uuid, obj.id])
             if isinstance(obj, Msg):

--- a/temba/channels/templatetags/tests.py
+++ b/temba/channels/templatetags/tests.py
@@ -14,7 +14,7 @@ class ChannelsTest(TembaTest):
         joe = self.create_contact("Joe", phone="+1234567890")
         msg = self.create_incoming_msg(joe, "Hi")
         call = self.create_incoming_call(flow, joe)
-        old_msg = self.create_incoming_msg(joe, "Hi", created_on=timezone.now() - timedelta(days=7))
+        old_msg = self.create_incoming_msg(joe, "Hi", created_on=timezone.now() - timedelta(days=15))
         surveyor_msg = self.create_incoming_msg(joe, "Submitted", surveyor=True)
 
         call_logs_url = f"/channels/{self.channel.uuid}/logs/call/{call.id}/"

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1739,7 +1739,7 @@ class ChannelLogTest(TembaTest):
             is_error=False,
             http_logs=[],
             errors=[],
-            created_on=timezone.now() - timedelta(days=7),
+            created_on=timezone.now() - timedelta(days=15),
         )
         l2 = ChannelLog.objects.create(
             channel=self.channel,

--- a/temba/mailroom/events.py
+++ b/temba/mailroom/events.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import iso8601
 
@@ -81,10 +81,9 @@ class Event:
         """
 
         obj_age = timezone.now() - obj.created_on
-        has_logs = obj.channel and obj_age < (settings.RETENTION_PERIODS["channellog"] - timedelta(hours=4))
 
         logs_url = None
-        if has_logs:
+        if obj.channel and obj_age < settings.RETENTION_PERIODS["channellog"]:
             logs_url = _url_for_user(
                 org, user, "channels.channellog_msg", args=[obj.channel.uuid, obj.id], perm="channels.channellog_read"
             )
@@ -159,10 +158,9 @@ class Event:
     @classmethod
     def from_ivr_call(cls, org: Org, user: User, obj: Call) -> dict:
         obj_age = timezone.now() - obj.created_on
-        has_logs = obj_age < (settings.RETENTION_PERIODS["channellog"] - timedelta(hours=4))
 
         logs_url = None
-        if has_logs:
+        if obj_age < settings.RETENTION_PERIODS["channellog"]:
             logs_url = _url_for_user(
                 org, user, "channels.channellog_call", args=[obj.channel.uuid, obj.id], perm="channels.channellog_read"
             )

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -825,7 +825,7 @@ class EventTest(TembaTest):
             "Hello",
             external_id="12345",
             attachments=["image:http://a.jpg"],
-            created_on=timezone.now() - timedelta(days=10),
+            created_on=timezone.now() - timedelta(days=15),
         )
 
         self.assertEqual(
@@ -1142,7 +1142,7 @@ class EventTest(TembaTest):
 
         # create call that is too old to still have logs
         call1 = self.create_incoming_call(
-            flow, contact, status=Call.STATUS_IN_PROGRESS, created_on=timezone.now() - timedelta(days=10)
+            flow, contact, status=Call.STATUS_IN_PROGRESS, created_on=timezone.now() - timedelta(days=15)
         )
 
         # and one that will have logs

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1071,7 +1071,7 @@ ORG_LIMIT_DEFAULTS = {
 # Data retention periods - tasks trim away data older than these settings
 # -----------------------------------------------------------------------------------
 RETENTION_PERIODS = {
-    "channellog": timedelta(days=7),
+    "channellog": timedelta(days=14),
     "eventfire": timedelta(days=90),  # matches default rp-archiver behavior
     "flowsession": timedelta(days=7),
     "httplog": timedelta(days=3),

--- a/templates/channels/channellog_list.haml
+++ b/templates/channels/channellog_list.haml
@@ -4,9 +4,6 @@
 -block spa-title
   -trans "Channel Logs"
 
--block subtitle
-  -trans "Logs are kept for 7 days."
-
 -block extra-style
   {{ block.super }}
   :css
@@ -15,6 +12,11 @@
     }
 
 -block content
+  .mt-4
+    -blocktrans trimmed
+      These are the logs which have no associated message or call. To access logs for a specific message or call, use the 
+      link from the message or call itself. Logs are kept for 14 days.
+
   .mt-4.shadow.rounded-lg.rounded-bl-none.rounded-br-none.bg-white
     -include "includes/short_pagination.html"
 


### PR DESCRIPTION
We'll display logs up to 14 days, S3 will expire them at 15 days.