### PR TITLE
🗑️ Fix problems with org deletion

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -717,6 +717,7 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
             trigger.release(user)
 
     def delete(self):
+        self.counts.all().delete()
         self.alerts.all().delete()
         self.sync_events.all().delete()
 

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -695,13 +695,6 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
         # disassociate them
         Channel.objects.filter(parent=self).update(parent=None)
 
-        # delete any alerts
-        self.alerts.all().delete()
-
-        # any related sync events
-        for sync_event in self.sync_events.all():
-            sync_event.release()
-
         # delay mailroom task for 5 seconds, so mailroom assets cache expires
         interrupt_channel_task.apply_async((self.id,), countdown=5)
 
@@ -722,6 +715,15 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
         for trigger in self.triggers.all():
             trigger.archive(user)
             trigger.release(user)
+
+    def delete(self):
+        self.alerts.all().delete()
+        self.sync_events.all().delete()
+
+        for trigger in self.triggers.all():
+            trigger.delete()
+
+        super().delete()
 
     def trigger_sync(self, registration_id=None):  # pragma: no cover
         """
@@ -1127,10 +1129,6 @@ class SyncEvent(SmartModel):
         sync_event.retry_messages = cmd.get("retry", cmd.get("retry_messages"))
 
         return sync_event
-
-    def release(self):
-        self.alerts.all().delete()
-        self.delete()
 
     def get_pending_messages(self):
         return getattr(self, "pending_messages", [])

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -247,9 +247,6 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         flow.refresh_from_db()
         self.assertTrue(flow.has_issues)
         self.assertNotIn(channel1, flow.channel_dependencies.all())
-
-        self.assertEqual(0, channel1.alerts.count())
-        self.assertEqual(0, channel1.sync_events.count())
         self.assertEqual(0, channel1.triggers.filter(is_active=True).count())
 
         # check that we queued a task to interrupt sessions tied to this channel
@@ -268,6 +265,12 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(1, channel2.alerts.count())
         self.assertEqual(1, channel2.sync_events.count())
         self.assertEqual(1, channel2.triggers.filter(is_active=True).count())
+
+        # now do actual delete of channel
+        channel1.msgs.all().delete()
+        channel1.delete()
+
+        self.assertFalse(Channel.objects.filter(id=channel1.id).exists())
 
     @mock_mailroom
     def test_release_android(self, mr_mocks):

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1290,11 +1290,11 @@ class Org(SmartModel):
         for c in self.campaigns.all():
             c.delete()
 
-        # delete everything associated with our flows
+        # release flows (actual deletion occurs later after contacts and tickets are gone)
+        # we want to manually release runs so we don't fire a mailroom task to do it
         for flow in self.flows.all():
-            # we want to manually release runs so we don't fire a mailroom task to do it
             flow.release(user, interrupt_sessions=False)
-            flow.delete()
+            flow.delete_runs()
 
         # delete our flow labels (deleting a label deletes its children)
         for flow_label in self.flow_labels.filter(parent=None):
@@ -1344,6 +1344,9 @@ class Org(SmartModel):
         for ticketer in self.ticketers.all():
             ticketer.release(user)
             ticketer.delete()
+
+        for flow in self.flows.all():
+            flow.delete()
 
         # release all archives objects and files for this org
         Archive.release_org_archives(self)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2152,7 +2152,7 @@ class OrgDeleteTest(TembaTest):
         flows = self._create_flow_content(org, user, channels, contacts, groups, add)
         labels = self._create_message_content(org, user, channels, contacts, groups, add)
         self._create_campaign_content(org, user, fields, groups, flows, contacts, add)
-        self._create_ticket_content(org, user, contacts, add)
+        self._create_ticket_content(org, user, contacts, flows, add)
         self._create_export_content(org, user, flows, groups, fields, labels, add)
         self._create_archive_content(org, add)
 
@@ -2220,6 +2220,8 @@ class OrgDeleteTest(TembaTest):
                 exited_on=timezone.now(),
             )
         )
+        contacts[0].current_flow = flow1
+        contacts[0].save(update_fields=("current_flow",))
 
         flow_label1 = add(FlowLabel.create(org, user, "Cool Flows"))
         flow_label2 = add(FlowLabel.create(org, user, "Crazy Flows"))
@@ -2322,12 +2324,12 @@ class OrgDeleteTest(TembaTest):
         )
         add(EventFire.objects.create(event=event1, contact=contacts[0], scheduled=timezone.now()))
 
-    def _create_ticket_content(self, org, user, contacts, add):
+    def _create_ticket_content(self, org, user, contacts, flows, add):
         ticket1 = add(self.create_ticket(org.ticketers.get(), contacts[0], "Help"))
         ticket1.events.create(org=org, contact=contacts[0], event_type="N", note="spam", created_by=user)
 
         ticketer = add(Ticketer.create(org, user, MailgunType.slug, "Email (bob)", {}))
-        add(self.create_ticket(ticketer, contacts[0], "Help"))
+        add(self.create_ticket(ticketer, contacts[0], "Help", opened_in=flows[0]))
 
     def _create_export_content(self, org, user, flows, groups, fields, labels, add):
         results = add(

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2191,9 +2191,18 @@ class OrgDeleteTest(TembaTest):
                 user,
                 flow=flow1,
                 trigger_type=Trigger.TYPE_KEYWORD,
-                channel=channels[0],
                 keyword="color",
                 match_type=Trigger.MATCH_FIRST_WORD,
+                groups=groups,
+            )
+        )
+        add(
+            Trigger.create(
+                org,
+                user,
+                flow=flow1,
+                trigger_type=Trigger.TYPE_NEW_CONVERSATION,
+                channel=channels[0],
                 groups=groups,
             )
         )


### PR DESCRIPTION
Contacts and tickets both can reference flows which creates a bit of circular dependency mess - this gets around it by deleting some flow stuff before contacts and tickets, then finally deleting the actual flow last.