### PR TITLE
Add cpAddress parameter as optional for MTN channel type

### DIFF
--- a/temba/channels/types/mtn/tests.py
+++ b/temba/channels/types/mtn/tests.py
@@ -47,6 +47,7 @@ class MtnTypeTest(TembaTest):
             post_data["country"] = "RW"
             post_data["consumer_key"] = "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo"
             post_data["consumer_secret"] = "barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar"
+            post_data["cp_address"] = "FOO"
 
             response = self.client.post(url, post_data)
 
@@ -58,6 +59,7 @@ class MtnTypeTest(TembaTest):
             self.assertEqual("MTN", channel.channel_type)
             self.assertEqual(post_data["consumer_key"], channel.config[Channel.CONFIG_API_KEY])
             self.assertEqual(post_data["consumer_secret"], channel.config[Channel.CONFIG_AUTH_TOKEN])
+            self.assertEqual(post_data["cp_address"], channel.config[MtnType.CP_ADDRESS])
             self.assertEqual("sub-123", channel.config["mtn_subscription_id"])
 
             self.assertEqual(mock_post.call_count, 2)

--- a/temba/channels/types/mtn/type.py
+++ b/temba/channels/types/mtn/type.py
@@ -15,6 +15,8 @@ class MtnType(ChannelType):
     An MTN Developer Portal channel (https://developers.mtn.com/)
     """
 
+    CP_ADDRESS = "cp_address"
+
     code = "MTN"
     category = ChannelType.Category.PHONE
 

--- a/temba/channels/types/mtn/views.py
+++ b/temba/channels/types/mtn/views.py
@@ -25,6 +25,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         )
         consumer_key = forms.CharField(required=True, help_text=_("The Consumer key"))
         consumer_secret = forms.CharField(required=True, help_text=_("The Consumer secret"))
+        cp_address = forms.CharField(required=False, help_text=_("The CP Address (if provided by MTN)"))
 
     form_class = Form
 
@@ -37,6 +38,9 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             Channel.CONFIG_API_KEY: cleaned_data.get("consumer_key"),
             Channel.CONFIG_AUTH_TOKEN: cleaned_data.get("consumer_secret"),
         }
+
+        if cleaned_data.get("cp_address"):
+            config[self.channel_type.CP_ADDRESS] = cleaned_data.get("cp_address")
 
         self.object = Channel.create(
             self.request.org,


### PR DESCRIPTION
We can merge this once the parameter is more clear how it is needed.

Now we can experiment with https://github.com/nyaruka/courier/pull/599 deployed alone