### PR TITLE
Allow initiating flow results download form the the flow labels filte…

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2152,6 +2152,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(1, response.context["folders"][0]["count"])
         self.assertEqual(2, response.context["folders"][1]["count"])
 
+        self.assertEqual(("archive", "label", "download-results"), response.context["actions"])
+
         # but does appear in archived list
         response = self.client.get(reverse("flows.flow_archived"))
         self.assertContains(response, flow1.name)
@@ -2167,6 +2169,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # flow should no longer appear in archived list
         response = self.client.get(reverse("flows.flow_archived"))
         self.assertNotContains(response, flow1.name)
+        self.assertEqual(("restore",), response.context["actions"])
 
         # but does appear in normal list
         response = self.client.get(reverse("flows.flow_list"))
@@ -2236,6 +2239,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(reverse("flows.flow_filter", args=[label1.uuid]))
         self.assertEqual([flow2, flow1], list(response.context["object_list"]))
         self.assertEqual(2, len(response.context["labels"]))
+        self.assertEqual(("label", "download-results"), response.context["actions"])
 
         response = self.client.get(reverse("flows.flow_filter", args=[label2.uuid]))
         self.assertEqual([flow2], list(response.context["object_list"]))

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -850,7 +850,7 @@ class FlowCRUDL(SmartCRUDL):
 
     class Filter(BaseList, OrgObjPermsMixin):
         add_button = True
-        bulk_actions = ("label",)
+        bulk_actions = ("label", "download-results")
         slug_url_kwarg = "uuid"
 
         def derive_menu_path(self):


### PR DESCRIPTION
Customer need to download results of many flows at the same time and it is easier to select flows by their labels

The change was easy to add since that will only work for flows that the user selected and the label filtering is only showing flows that are not archived.

