### PR TITLE
Update Instagram docs broken link

### DIFF
--- a/templates/channels/types/instagram/claim.haml
+++ b/templates/channels/types/instagram/claim.haml
@@ -14,8 +14,8 @@
     #fb-guide
       %ol.steps
         %li
-          -trans "The page must be linked to your instagram business account, so check how to link"
-          %a(href="https://help.instagram.com/399237934150902") here
+          -trans "The Facebook page must be linked to your instagram business account, so check how to link them"
+          %a(href="https://help.instagram.com/570895513091465") here
           first.
 
         %li


### PR DESCRIPTION
Old link no longer works, and tweak the message to be more clear.