### PR TITLE
Fix tickets list, to show compose properly on Firefox

### DIFF
--- a/templates/tickets/ticket_list.haml
+++ b/templates/tickets/ticket_list.haml
@@ -464,7 +464,7 @@
 
 -block content
 
-  .page.flex-grow.flex.flex-col.min-h-0
+  .page.flex-grow.flex.flex-col.min-h-0.max-h-screen
     .flex.ticket-ui
       %temba-resizer.flex.flex-row(-temba-resized="handleTicketListResized")
 


### PR DESCRIPTION
Fixes issue of Firefox where the `temba contact history` component grows vertically and pushes the compose below the screen.

`max-h-screen` fixes that by setting the max height to the screen height