### PR TITLE
Remove spa-title and spa-style

### DIFF
--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2121,6 +2121,8 @@ class OrgCRUDL(SmartCRUDL):
             return reverse("orgs.org_manage_accounts") if still_in_org else reverse("orgs.org_choose")
 
     class ManageAccountsSubOrg(ManageAccounts):
+        menu_path = "/settings/workspaces"
+
         def pre_process(self, request, *args, **kwargs):
             pass
 

--- a/temba/utils/views.py
+++ b/temba/utils/views.py
@@ -71,6 +71,8 @@ class SpaMixin(View):
 
         if self.is_content_only():
             context["base_template"] = "spa.html"
+        else:
+            context["base_template"] = "frame.html"
 
         context["is_spa"] = True
         context["is_content_only"] = self.is_content_only()

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -1,18 +1,10 @@
 -extends "smartmin/read.html"
 -load smartmin temba compress humanize channels i18n tz
 
--block spa-title
+-block title
   %temba-urn.mr-2(scheme="{{channel.schemes|first}}")
   .flex.items-start.flex-col
     #title-text.name
-      -if object.parent
-        {{ object.parent.name }}
-      -else
-        {{ object.name|default:object.get_address_display }}
-  
--block title
-  .flex.items-start.flex-col
-    .name
       -if object.parent
         {{ object.parent.name }}
       -else

--- a/templates/channels/channellog_list.haml
+++ b/templates/channels/channellog_list.haml
@@ -1,7 +1,7 @@
 -extends "smartmin/list.html"
 -load i18n smartmin humanize temba
 
--block spa-title
+-block title
   -trans "Channel Logs"
 
 -block extra-style

--- a/templates/channels/channellog_msg.haml
+++ b/templates/channels/channellog_msg.haml
@@ -1,9 +1,6 @@
 -extends "channels/channellog_owned_base.html"
 -load i18n contacts
 
--block spa-title
-  -trans "Message Log"
-
 -block title
   -trans "Message Log"
 

--- a/templates/channels/channellog_read.haml
+++ b/templates/channels/channellog_read.haml
@@ -1,9 +1,6 @@
 -extends "smartmin/read.html"
 -load i18n compress
 
--block spa-title
-  -trans "Channel Log"
-
 -block title
   -trans "Channel Log"
 

--- a/templates/contacts/contact_list.html
+++ b/templates/contacts/contact_list.html
@@ -1,16 +1,9 @@
 {% extends "smartmin/list.html" %}
 {% load smartmin sms contacts temba i18n humanize %}
 
-{% block page-title %}
-  {% if current_group %}
-    {{ current_group.name }}
-  {% else %}
-    {{ title }}
-  {% endif %}
-{% endblock page-title %}
-{% block spa-title %}
+{% block title %}
   <div id="title-text">{{ title }}</div>
-{% endblock spa-title %}
+{% endblock title %}
 {% block title-icon %}
   <span class="title-icon">
     <div class="glyph icon-users"></div>

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -2,7 +2,7 @@
 {% load i18n humanize smartmin sms contacts compress temba channels %}
 
 {% block title %}
-  <div class="hidden" id="title-text">{{ title }}</div>
+  <div class="hidden" id="title-text">{{ title|default:"Contact Details" }}</div>
   <temba-contact-name-fetch contact="{{ object.uuid }}" -temba-refreshed="handleContactRefreshed" showLoading>
   </temba-contact-name-fetch>
 {% endblock title %}

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -1,20 +1,11 @@
 {% extends "smartmin/read.html" %}
 {% load i18n humanize smartmin sms contacts compress temba channels %}
 
-{% block buttons %}
-{% endblock buttons %}
-{% block page-title %}
-  {{ contact|name_or_urn:user_org|default:"Contact Details" }}
-{% endblock page-title %}
-{% block spa-title %}
+{% block title %}
   <div class="hidden" id="title-text">{{ title }}</div>
   <temba-contact-name-fetch contact="{{ object.uuid }}" -temba-refreshed="handleContactRefreshed" showLoading>
   </temba-contact-name-fetch>
-{% endblock spa-title %}
-{% block subtitle %}
-{% endblock subtitle %}
-{% block read-buttons %}
-{% endblock read-buttons %}
+{% endblock title %}
 {% block content %}
   <temba-tabs -temba-context-changed="handleTabChanged"
               index="{{ request.GET.tab }}"

--- a/templates/contacts/contactimport_create.html
+++ b/templates/contacts/contactimport_create.html
@@ -1,9 +1,9 @@
 {% extends "smartmin/form.html" %}
 {% load smartmin i18n humanize sms %}
 
-{% block spa-title %}
-  {% trans "Import Contacts" %}
-{% endblock spa-title %}
+{% block title %}
+  {% trans "Import Contacts" %}s
+{% endblock title %}
 {% block content %}
   <div style="min-height:41px" class="flex mb-4 flex-col">
     {% blocktrans trimmed %}

--- a/templates/contacts/contactimport_preview.html
+++ b/templates/contacts/contactimport_preview.html
@@ -4,9 +4,6 @@
 {% block title %}
   {% trans "Preview Contact Import" %}
 {% endblock title %}
-{% block spa-title %}
-  {% trans "Preview Contact Import" %}
-{% endblock spa-title %}
 {% block content %}
   <div class="summary">
     {% blocktrans trimmed with count=object.num_records %}

--- a/templates/contacts/contactimport_read.html
+++ b/templates/contacts/contactimport_read.html
@@ -4,9 +4,6 @@
 {% block title %}
   {% trans "Contact Import" %}
 {% endblock title %}
-{% block spa-title %}
-  {% trans "Contact Import" %}
-{% endblock spa-title %}
 {% block extra-script %}
   {{ block.super }}
   {% if not is_finished %}

--- a/templates/flows/flow_editor.html
+++ b/templates/flows/flow_editor.html
@@ -1,7 +1,7 @@
 {% extends "smartmin/base.html" %}
 {% load compress temba i18n %}
 
-{% block spa-style %}
+{% block extra-style %}
   {{ block.super }}
   <style type="text/css">
     .spa-content {
@@ -95,7 +95,7 @@
       border: 1px solid transparent;
     }
   </style>
-{% endblock spa-style %}
+{% endblock extra-style %}
 {% block extra-script %}
   {{ block.super }}
   <script type="text/javascript">
@@ -217,9 +217,9 @@
     </div>
   {% endif %}
 {% endblock alert-messages %}
-{% block spa-title %}
+{% block title %}
   <div class="title-text flex">
-    <div class="inline-block flex items-center text-gray-600">
+    <div class="flex items-center text-gray-600">
       {% if object.flow_type == 'V' %}
         <temba-icon name="flow_ivr" class="mr-3">
         </temba-icon>
@@ -231,9 +231,9 @@
         </temba-icon>
       {% endif %}
     </div>
-    {{ title }}
+    <div id="title-text">{{ title }}</div>
   </div>
-{% endblock spa-title %}
+{% endblock title %}
 {% block content %}
   <temba-modax header="Send Message" id="send-message-modal">
   </temba-modax>

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -144,29 +144,27 @@
             .spa-loader.hide.absolute
               .wrapper(style="display:flex;z-index:100000;margin-top:0.1em;margin-left:1em")
                 %temba-loading(size=16 units=6)
-    
+
             .spa-content.p-5
-              -block spa-style  
               -block extra-style
               -block extra-script
     
               -block page-header
-                -if title or has_content_menu
-                  .mb-4
-                    .spa-title.no-menu.flex.items-center
-                      .text-container.text-2xl.text-gray-700
-                        .flex.flex-row
-                          -block spa-title
-                            #title-text
-                              {{title}}
-                      .line.flex-grow.mr-2.ml-6
-                        .h-0.border.border-gray-200
-                      
-                      -if has_content_menu
-                        -include "spa_page_menu.html"
-                
-                    .text-lg.text-gray-600
-                        -block subtitle
+                .mb-4
+                  .spa-title.no-menu.flex.items-center
+                    .text-container.text-2xl.text-gray-700
+                      .flex.flex-row
+                        -block title
+                          #title-text
+                            {{title}}
+                    .line.flex-grow.mr-2.ml-6
+                      .h-0.border.border-gray-200
+                    
+                    -if has_content_menu
+                      -include "spa_page_menu.html"
+              
+                  .text-lg.text-gray-600
+                      -block subtitle
                       
               -block alert-messages
                 -if user_org.is_suspended

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -6,8 +6,6 @@
 {% endblock html-tag %}
   %head
     %title
-      -block page-title
-        {{title}}
 
     %meta{charset:"utf-8"}
     %meta{name:"viewport", content:"width=device-width, initial-scale=1.0"}
@@ -48,6 +46,14 @@
           menu.setFocusedItem(menuSelection);          
         }
       }
+
+      // set our initial title
+      document.addEventListener("DOMContentLoaded", function(event) {
+        const titleText = document.querySelector("#title-text");
+        if (titleText){ 
+          document.title = titleText.innerText;
+        }
+      });
 
     -block scripts
       -compress js
@@ -151,7 +157,7 @@
     
               -block page-header
                 .mb-4
-                  .spa-title.no-menu.flex.items-center
+                  .no-menu.flex.items-center
                     .text-container.text-2xl.text-gray-700
                       .flex.flex-row
                         -block title

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -170,7 +170,8 @@
                       -include "spa_page_menu.html"
               
                   .text-lg.text-gray-600
-                      -block subtitle
+                    -block subtitle
+
                       
               -block alert-messages
                 -if user_org.is_suspended

--- a/templates/orgs/org_create.haml
+++ b/templates/orgs/org_create.haml
@@ -1,3 +1,3 @@
 -extends "smartmin/create.html"
 
--block spa-title
+-block title

--- a/templates/orgs/org_edit.haml
+++ b/templates/orgs/org_edit.haml
@@ -1,7 +1,7 @@
 -extends 'smartmin/form.html'
 -load i18n
 
--block spa-title
+-block title
 
 -block summary
   .flex.items-center

--- a/templates/orgs/org_manage_accounts.haml
+++ b/templates/orgs/org_manage_accounts.haml
@@ -4,6 +4,10 @@
 -block title
   -trans "Manage Logins"
 
+-block subtitle
+  {{org.name|capfirst}}
+
+
 -block extra-style
   {{block.super}}
   :css

--- a/templates/orgs/org_sub_orgs.haml
+++ b/templates/orgs/org_sub_orgs.haml
@@ -2,11 +2,8 @@
 
 -load compress temba smartmin humanize
 -load i18n
--block page-title
-  -trans "Manage Workspaces"
-  \- {{user_org.name|capfirst}}
 
--block spa-title
+-block title
   #title-text
     -trans "Workspaces"
 

--- a/templates/orgs/user_update.haml
+++ b/templates/orgs/user_update.haml
@@ -1,4 +1,4 @@
 -extends "smartmin/update.html"
 -load i18n
 
--block spa-title
+-block title

--- a/templates/request_logs/httplog_read.haml
+++ b/templates/request_logs/httplog_read.haml
@@ -5,7 +5,7 @@
   HTTP Log - {{ object.get_log_type_display }}
 
 -block title
-  -block spa-title
+  -block title
     -if object.flow
       -trans "Flow Event"
     -elif object.classifier

--- a/templates/request_logs/httplog_read.haml
+++ b/templates/request_logs/httplog_read.haml
@@ -1,11 +1,9 @@
 -extends "smartmin/read.html"
 -load i18n compress humanize
 
--block page-title
-  HTTP Log - {{ object.get_log_type_display }}
-
 -block title
-  -block title
+
+  #title-text
     -if object.flow
       -trans "Flow Event"
     -elif object.classifier

--- a/templates/smartmin/base.html
+++ b/templates/smartmin/base.html
@@ -1,20 +1,2 @@
 {% extends base_template %}
 {% load smartmin %}
-{% block pre-content %}
-  <div class="page-header">
-    <h2>{{ title }}</h2>
-  </div>
-{% endblock pre-content %}
-{% block extra-script %}
-  {{ block.super }}
-  {# embed refresh script if refresh is active #}
-  {% if refresh %}
-    <script>
-      var refreshTimeout = parseInt("{{ refresh }}");
-
-      function scheduleRefresh() {
-        window.setTimeout(refresh, refreshTimeout);
-      }
-    </script>
-  {% endif %}
-{% endblock extra-script %}

--- a/templates/spa.haml
+++ b/templates/spa.haml
@@ -1,9 +1,5 @@
 
 :css
-  .spa-title {
-
-  }
-
   .text-container {
     min-height:2.5em;
   }
@@ -21,24 +17,22 @@
   }
 
 -block page-header
-  -if title or has_content_menu
-    .mb-4
-      .spa-title.no-menu.flex.items-center
-        .text-container.text-2xl.text-gray-700
-          .flex.flex-row
-            -block spa-title
-              #title-text
-                {{title}}
-        .line.flex-grow.mr-2.ml-6
-          .h-0.border.border-gray-200
-        
-        -if has_content_menu
-          -include "spa_page_menu.html"
+  .mb-4
+    .no-menu.flex.items-center
+      .text-container.text-2xl.text-gray-700
+        .flex.flex-row
+          -block title
+            #title-text
+              {{title}}
+      .line.flex-grow.mr-2.ml-6
+        .h-0.border.border-gray-200
+      
+      -if has_content_menu
+        -include "spa_page_menu.html"
 
-      .text-lg.text-gray-600
-        -block subtitle
+    .text-lg.text-gray-600
+      -block subtitle
 
--block spa-style
 -block extra-style
 -block extra-script
 

--- a/templates/tickets/ticket_list.haml
+++ b/templates/tickets/ticket_list.haml
@@ -3,8 +3,7 @@
 
 -block page-header
 
--block page-title
-  {{ title }}
+
 
 -block extra-style
   {{block.super}}
@@ -458,10 +457,6 @@
     });    
 
 
--block spa-title
-  #title-text
-    {{title}}
-
 -block content
 
   .page.flex-grow.flex.flex-col.min-h-0.max-h-screen
@@ -471,7 +466,8 @@
         .ticket-list.flex.flex-col.p-5.pr-0
           .flex.mb-2
               #folder-title.flex-grow.relative
-                {{title}}
+                #title-text
+                  {{title}}
             %temba-content-menu#topic-content-menu.relative(endpoint="{% url 'tickets.ticket_folder' folder status uuid %}" -temba-selection="handleContentMenuSelected(event)")
           %temba-select.mb-2(name="ticket-status" onchange="handleStatusFilterChanged(event)" value="{{status}}")
             %temba-option(name="Open" value="open" icon="tickets_open")


### PR DESCRIPTION
More consistent blocks for titles.

Now we just use block title. This is the title that is at the top of the content pane, not the page title in the tab. So, markup is allowed. For example to show an object with an icon, we might do something like this: 
```django
{% block title %}
<div class="flex">
  <temba-icon name="{{flow_icon}}"></temba-icon>
  <div id="title-text">{{flow.name}}</div>
</div>
{% endblock title %}
```

The key is to wrap the plain text portion you want to appear in the tab inside a div with the id "title-text". This isn't new, but now is a bit more  consistent throughout the app. This is used whether the page is initially loaded or navigated to in the spa.