### PR TITLE
Allow flow selection on flow broadcast form

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -872,7 +872,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             allow_viewers=False,
             allow_editors=True,
             allow_org2=True,
-            form_fields=["contact_search", "flow"],
+            form_fields=["flow", "contact_search"],
         )
 
         self.assertEqual([background_flow] + sample_flows, list(response.context["form"].fields["flow"].queryset))

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2779,7 +2779,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             allow_viewers=False,
             allow_editors=True,
             allow_org2=True,
-            form_fields=["contact_search", "flow"],
+            form_fields=["flow", "contact_search"],
         )
 
         # create flow start with a query

--- a/templates/flows/flow_broadcast.html
+++ b/templates/flows/flow_broadcast.html
@@ -63,10 +63,10 @@
   {{ block.super }}
   <script type="text/javascript">
     {
-
       const modax = getModax("#start-flow");
       const modalBody = modax.shadowRoot;
       const queryWidget = modalBody.querySelector("temba-contact-search");
+      const flowSelect = modalBody.querySelector("temba-select[name='flow']");
 
       queryWidget.addEventListener("temba-content-changed", function(e) {
         if (e.detail.reset || (e.detail.blockers && e.detail.blockers.length > 0)) {
@@ -75,6 +75,20 @@
           modax.disabled = e.detail.total == 0;
         }
       });
+
+      if (flowSelect) {
+        flowSelect.addEventListener("change", function(evt) {
+          if (this.selection) {
+            var flowType = this.selection.type;
+            modax.disabled = true;
+            queryWidget.in_a_flow = flowType !== 'B';
+            queryWidget.started_previously = true;
+            queryWidget.not_seen_since_days = true;
+            queryWidget.endpoint = "/flow/preview_start/" + this.value + "/";
+            queryWidget.refresh();
+          }
+        });
+      }
 
       const handleDialogButton = function(event) {
         const modax = getModax("#start-flow");


### PR DESCRIPTION
Flow is hidden when starting from the flow page. When selecting a flow after contact selection, the exclusions are now empty until a flow is selected. Then the appropriate checkboxes appear.