### PR TITLE
Always show name / anon id for anon orgs in contact lists

### DIFF
--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -44,13 +44,18 @@ def name_or_urn(contact, org):
 
 
 @register.filter
-def name(contact, org):
-    if contact.name:
-        return contact.name
-    elif org.is_anon:
-        return contact.anon_display
+def urn_or_anon(contact, org):
+    """
+    Renders the contact has their primary URN or anon id if org is anon
+    """
+    if not org.is_anon:
+        contact_urn = contact.get_urn()
+        if contact_urn:
+            return format_urn(contact_urn, org)
+        else:
+            return MISSING_VALUE
     else:
-        return MISSING_VALUE
+        return contact.anon_display
 
 
 @register.filter
@@ -59,15 +64,6 @@ def format_urn(urn, org):
         return ContactURN.ANON_MASK_HTML
 
     return urn.get_display(org=org, international=True)
-
-
-@register.filter
-def urn(contact, org):
-    contact_urn = contact.get_urn()
-    if contact_urn:
-        return format_urn(contact_urn, org)
-    else:
-        return MISSING_VALUE
 
 
 @register.filter

--- a/temba/contacts/templatetags/tests.py
+++ b/temba/contacts/templatetags/tests.py
@@ -1,9 +1,37 @@
-from temba.tests import TembaTest
+from temba.tests import AnonymousOrg, TembaTest
 
-from .contacts import urn_icon
+from .contacts import format_urn, name_or_urn, urn_icon, urn_or_anon
 
 
 class ContactsTest(TembaTest):
+    def test_name_or_urn(self):
+        contact1 = self.create_contact("", urns=[])
+        contact2 = self.create_contact("Ann", urns=[])
+        contact3 = self.create_contact("Bob", urns=["tel:+12024561111", "telegram:098761111"])
+        contact4 = self.create_contact("", urns=["tel:+12024562222", "telegram:098762222"])
+
+        self.assertEqual("", name_or_urn(contact1, self.org))
+        self.assertEqual("Ann", name_or_urn(contact2, self.org))
+        self.assertEqual("Bob", name_or_urn(contact3, self.org))
+        self.assertEqual("(202) 456-2222", name_or_urn(contact4, self.org))
+
+        with AnonymousOrg(self.org):
+            self.assertEqual(f"{contact1.id:010}", name_or_urn(contact1, self.org))
+            self.assertEqual("Ann", name_or_urn(contact2, self.org))
+            self.assertEqual("Bob", name_or_urn(contact3, self.org))
+            self.assertEqual(f"{contact4.id:010}", name_or_urn(contact4, self.org))
+
+    def test_urn_or_anon(self):
+        contact1 = self.create_contact("Bob", urns=[])
+        contact2 = self.create_contact("Uri", urns=["tel:+12024561414", "telegram:098765432"])
+
+        self.assertEqual("--", urn_or_anon(contact1, self.org))
+        self.assertEqual("+1 202-456-1414", urn_or_anon(contact2, self.org))
+
+        with AnonymousOrg(self.org):
+            self.assertEqual(f"{contact1.id:010}", urn_or_anon(contact1, self.org))
+            self.assertEqual(f"{contact2.id:010}", urn_or_anon(contact2, self.org))
+
     def test_urn_icon(self):
         contact = self.create_contact("Uri", urns=["tel:+1234567890", "telegram:098765432", "viber:346376373"])
         tel_urn, tg_urn, viber_urn = contact.urns.order_by("-priority")
@@ -11,3 +39,11 @@ class ContactsTest(TembaTest):
         self.assertEqual("icon-phone", urn_icon(tel_urn))
         self.assertEqual("icon-telegram", urn_icon(tg_urn))
         self.assertEqual("", urn_icon(viber_urn))
+
+    def test_format_urn(self):
+        contact = self.create_contact("Uri", urns=["tel:+12024561414"])
+
+        self.assertEqual("+1 202-456-1414", format_urn(contact.get_urn(), self.org))
+
+        with AnonymousOrg(self.org):
+            self.assertEqual("••••••••", format_urn(contact.get_urn(), self.org))

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -31,7 +31,6 @@ from temba.contacts.models import (
     ContactGroup,
     ContactImport,
     ContactImportBatch,
-    ContactURN,
     ExportContactsTask,
 )
 from temba.flows.models import ExportFlowResultsTask, Flow, FlowLabel, FlowRun, FlowSession, FlowStart, FlowStartCount
@@ -2540,7 +2539,7 @@ class AnonOrgTest(TembaTest):
         contact = self.create_contact(None, phone="+250788123123")
         self.login(self.admin)
 
-        masked = "%010d" % contact.pk
+        anon_id = f"{contact.id:010}"
 
         response = self.client.get(reverse("contacts.contact_list"))
 
@@ -2548,8 +2547,7 @@ class AnonOrgTest(TembaTest):
         self.assertNotContains(response, "788 123 123")
 
         # but the id is
-        self.assertContains(response, masked)
-        self.assertContains(response, ContactURN.ANON_MASK_HTML)
+        self.assertContains(response, anon_id)
 
         # create an outgoing message, check number doesn't appear in outbox
         msg1 = self.create_outgoing_msg(contact, "hello", status="Q")
@@ -2558,7 +2556,7 @@ class AnonOrgTest(TembaTest):
 
         self.assertEqual(set(response.context["object_list"]), {msg1})
         self.assertNotContains(response, "788 123 123")
-        self.assertContains(response, masked)
+        self.assertContains(response, anon_id)
 
         # create an incoming message, check number doesn't appear in inbox
         msg2 = self.create_incoming_msg(contact, "ok")
@@ -2567,7 +2565,7 @@ class AnonOrgTest(TembaTest):
 
         self.assertEqual(set(response.context["object_list"]), {msg2})
         self.assertNotContains(response, "788 123 123")
-        self.assertContains(response, masked)
+        self.assertContains(response, anon_id)
 
         # create an incoming flow message, check number doesn't appear in inbox
         flow = self.create_flow("Test")
@@ -2577,12 +2575,12 @@ class AnonOrgTest(TembaTest):
 
         self.assertEqual(set(response.context["object_list"]), {msg3})
         self.assertNotContains(response, "788 123 123")
-        self.assertContains(response, masked)
+        self.assertContains(response, anon_id)
 
         # check contact detail page
         response = self.client.get(reverse("contacts.contact_read", args=[contact.uuid]))
         self.assertNotContains(response, "788 123 123")
-        self.assertContains(response, masked)
+        self.assertContains(response, anon_id)
 
 
 class OrgCRUDLTest(TembaTest, CRUDLTestMixin):

--- a/templates/contacts/contact_list.html
+++ b/templates/contacts/contact_list.html
@@ -236,10 +236,10 @@
                 </td>
               {% endif %}
               <td>
-                <div class="whitespace-nowrap">{{ object|name:user_org }}</div>
+                <div class="whitespace-nowrap">{{ object.name|default:"--" }}</div>
               </td>
               <td class="w-full">
-                <div class="whitespace-nowrap">{{ object|urn:user_org }}</div>
+                <div class="whitespace-nowrap">{{ object|urn_or_anon:user_org }}</div>
               </td>
               {% for field in contact_fields %}
                 {% if field.show_in_table %}


### PR DESCRIPTION
For a non anon org, contacts look like...

<img width="558" alt="Captura de pantalla 2023-08-16 a la(s) 15 08 06" src="https://github.com/nyaruka/rapidpro/assets/675558/d514a694-92fa-4fbc-a828-8b4a2db0d5c5">

But a for anon orgs, you only see either name / anon id, and then we waste a column on a redacted URN:

<img width="552" alt="Captura de pantalla 2023-08-16 a la(s) 15 10 01" src="https://github.com/nyaruka/rapidpro/assets/675558/a95b204c-145c-44bd-8c3f-749d513a0702">

This PR makes it that column one is always name, column two is always anon id in place of a URN:

<img width="552" alt="Captura de pantalla 2023-08-16 a la(s) 15 10 30" src="https://github.com/nyaruka/rapidpro/assets/675558/1c1e4d61-ede6-4a35-9605-1afc5898d89b">
