### PR TITLE
Fix flushing redis in tests

### DIFF
--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytz
-import redis
+from django_redis import get_redis_connection
 from smartmin.tests import SmartminTest
 
 from django.conf import settings
@@ -144,9 +144,7 @@ class TembaTest(SmartminTest):
     def tearDown(self):
         super().tearDown()
 
-        # Clear the redis cache. Out of paranoia we don't even use the configured cache settings but instead hardcode
-        # to the local test instance.
-        r = redis.StrictRedis(host="localhost", port=6379, db=10)
+        r = get_redis_connection()
         r.flushdb()
 
         clear_flow_users()


### PR DESCRIPTION
This worked when test redis was always accessible via localhost... our settings already enforce that redis during tests is on port 10, otherwise 15.. so I don't think we need to be so paranoid.