### PR TITLE
Simpler channel config URLs part 1

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -22,7 +22,7 @@ from django.db.models import Sum
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.template import Context, Engine, TemplateDoesNotExist
-from django.urls import re_path, reverse
+from django.urls import re_path
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -2405,7 +2405,7 @@ class FacebookWhitelistTest(TembaTest, CRUDLTestMixin):
         self.login(self.admin)
         response = self.client.get(read_url)
         self.assertContains(response, self.channel.name)
-        self.assertContentMenu(read_url, self.admin, ["Settings", "Logs", "Edit", "Delete", "Whitelist Domain"])
+        self.assertContentMenu(read_url, self.admin, ["Configuration", "Logs", "Edit", "Delete", "Whitelist Domain"])
 
         with patch("requests.post") as mock:
             mock.return_value = MockResponse(400, '{"error": { "message": "FB Error" } }')

--- a/temba/channels/types/africastalking/type.py
+++ b/temba/channels/types/africastalking/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -30,23 +30,25 @@ class AfricasTalkingType(ChannelType):
         "To finish configuring your Africa's Talking connection you'll need to set the following callback URLs on the "
         "Africa's Talking website under your account."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Callback URL"),
-            help=_(
-                "You can set the callback URL on your Africa's Talking account by visiting the SMS Dashboard page, "
-                "then clicking on Callback URL."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Callback URL"),
+                help=_(
+                    "You can set the callback URL on your Africa's Talking account by visiting the SMS Dashboard page, "
+                    "then clicking on Callback URL."
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label=_("Delivery URL"),
-            help=_(
-                "You can set the delivery URL on your Africa's Talking account by visiting the SMS Dashboard page, "
-                "then clicking on Delivery Reports."
+            ConfigUI.Endpoint(
+                courier="status",
+                label=_("Delivery URL"),
+                help=_(
+                    "You can set the delivery URL on your Africa's Talking account by visiting the SMS Dashboard page, "
+                    "then clicking on Delivery Reports."
+                ),
             ),
-        ),
+        ]
     )
 
     available_timezones = [

--- a/temba/channels/types/africastalking/type.py
+++ b/temba/channels/types/africastalking/type.py
@@ -30,20 +30,19 @@ class AfricasTalkingType(ChannelType):
         "To finish configuring your Africa's Talking connection you'll need to set the following callback URLs on the "
         "Africa's Talking website under your account."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Callback URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.at' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "You can set the callback URL on your Africa's Talking account by visiting the SMS Dashboard page, "
                 "then clicking on Callback URL."
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="status",
             label=_("Delivery URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.at' channel.uuid 'status' %}",
-            description=_(
+            help=_(
                 "You can set the delivery URL on your Africa's Talking account by visiting the SMS Dashboard page, "
                 "then clicking on Delivery Reports."
             ),

--- a/temba/channels/types/arabiacell/type.py
+++ b/temba/channels/types/arabiacell/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -28,10 +28,12 @@ class ArabiaCellType(ChannelType):
         "To finish connecting your channel, you need to have ArabiaCell configure the URL below for your short code."
     )
 
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("This URL should be called by ArabiaCell when new messages are received."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("This URL should be called by ArabiaCell when new messages are received."),
+            ),
+        ]
     )

--- a/temba/channels/types/arabiacell/type.py
+++ b/temba/channels/types/arabiacell/type.py
@@ -29,9 +29,9 @@ class ArabiaCellType(ChannelType):
     )
 
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{channel.callback_domain}}/c/ac/{{channel.uuid}}/receive",
-            description=_("This URL should be called by ArabiaCell when new messages are received."),
+            help=_("This URL should be called by ArabiaCell when new messages are received."),
         ),
     )

--- a/temba/channels/types/bandwidth/tests.py
+++ b/temba/channels/types/bandwidth/tests.py
@@ -52,9 +52,9 @@ class BandwidthTypeTest(TembaTest):
         self.assertEqual("250788123123", channel.address)
         self.assertEqual("BW", channel.channel_type)
 
-        config_url = reverse("channels.channel_configuration", args=[channel.uuid])
+        read_url = reverse("channels.channel_read", args=[channel.uuid])
 
-        self.assertRedirect(response, config_url)
+        self.assertRedirect(response, read_url)
 
         self.assertEqual(
             mock_post.call_args_list[0][0][0], "https://dashboard.bandwidth.com/api/accounts/account-id/applications"
@@ -65,12 +65,6 @@ class BandwidthTypeTest(TembaTest):
         self.assertEqual(
             mock_post.call_args_list[0][1]["data"],
             f"<Application><ServiceType>Messaging-V2</ServiceType><AppName>app.rapidpro.io/{channel.uuid}</AppName><InboundCallbackUrl>https://app.rapidpro.io/c/bw/{channel.uuid}/receive</InboundCallbackUrl><OutboundCallbackUrl>https://app.rapidpro.io/c/bw/{channel.uuid}/status</OutboundCallbackUrl><RequestedCallbackTypes><CallbackType>message-delivered</CallbackType><CallbackType>message-failed</CallbackType><CallbackType>message-sending</CallbackType></RequestedCallbackTypes></Application>",
-        )
-
-        response = self.client.get(config_url)
-        self.assertEqual(200, response.status_code)
-        self.assertContains(
-            response, "https://dashboard.bandwidth.com/portal/r/a/account-id/applications/e5a9e103-application_id"
         )
 
         with patch("requests.delete") as mock_delete:

--- a/temba/channels/types/bandwidth/type.py
+++ b/temba/channels/types/bandwidth/type.py
@@ -33,19 +33,7 @@ class BandwidthType(ChannelType):
         "link": '<a target="_blank" href="https://www.bandwidth.com/">Bandwidth</a>'
     }
 
-    show_config_page = True
-
-    configuration_blurb = _(
-        "To finish configuring your Bandwidth connection you need to associate the locaiton of the phone number to "
-        "the Bandwidth application on the following URLs in your Bandwidth account dashboard."
-    )
-
-    configuration_urls = (
-        dict(
-            label=_("Bandwidth application URL"),
-            url="https://dashboard.bandwidth.com/portal/r/a/{{channel.config.account_id}}/applications/{{channel.config.application_id}}",
-        ),
-    )
+    show_config_page = False
 
     def activate(self, channel):
         domain = channel.org.get_brand_domain()

--- a/temba/channels/types/bongolive/type.py
+++ b/temba/channels/types/bongolive/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -29,10 +29,14 @@ class BongoLiveType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to have Bongo Live configure the URLs below for your short code."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("This URL should be called by Bongo Live when new messages are received or to report DLR status."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_(
+                    "This URL should be called by Bongo Live when new messages are received or to report DLR status."
+                ),
+            ),
+        ]
     )

--- a/temba/channels/types/bongolive/type.py
+++ b/temba/channels/types/bongolive/type.py
@@ -29,13 +29,10 @@ class BongoLiveType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to have Bongo Live configure the URLs below for your short code."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{channel.callback_domain}}/c/bl/{{channel.uuid}}/receive",
-            description=_(
-                "This URL should be called by Bongo Live when new messages are received or to report DLR status."
-            ),
+            help=_("This URL should be called by Bongo Live when new messages are received or to report DLR status."),
         ),
     )

--- a/temba/channels/types/burstsms/type.py
+++ b/temba/channels/types/burstsms/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class BurstSMSType(ChannelType):
@@ -50,31 +50,32 @@ class BurstSMSType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to set your callback URLs below for your number."
     )
-
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_(
-                "This URL should be called by BurstSMS when new messages are received."
-                "You must set this for your number under the 'Inbound Settings' options."
-                "Select 'Yes' to the 'Forward to URL' option and enter this URL."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_(
+                    "This URL should be called by BurstSMS when new messages are received."
+                    "You must set this for your number under the 'Inbound Settings' options."
+                    "Select 'Yes' to the 'Forward to URL' option and enter this URL."
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label=_("Delivery URL"),
-            help=_(
-                "This URL should be called by BurstSMS when the status of an outgoing message is updated."
-                "You can set it on your settings page."
+            ConfigUI.Endpoint(
+                courier="status",
+                label=_("Delivery URL"),
+                help=_(
+                    "This URL should be called by BurstSMS when the status of an outgoing message is updated."
+                    "You can set it on your settings page."
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Reply URL"),
-            help=_(
-                "This URL should be called by BurstSMS when messages are replied to."
-                "You can set it on your settings page."
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Reply URL"),
+                help=_(
+                    "This URL should be called by BurstSMS when messages are replied to."
+                    "You can set it on your settings page."
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/burstsms/type.py
+++ b/temba/channels/types/burstsms/type.py
@@ -52,27 +52,27 @@ class BurstSMSType(ChannelType):
     )
 
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{channel.callback_domain}}/c/bs/{{channel.uuid}}/receive",
-            description=_(
+            help=_(
                 "This URL should be called by BurstSMS when new messages are received."
                 "You must set this for your number under the 'Inbound Settings' options."
                 "Select 'Yes' to the 'Forward to URL' option and enter this URL."
             ),
         ),
-        dict(
-            label=_("DLR callback URL"),
-            url="https://{{channel.callback_domain}}/c/bs/{{channel.uuid}}/status",
-            description=_(
+        ChannelType.Endpoint(
+            courier="status",
+            label=_("Delivery URL"),
+            help=_(
                 "This URL should be called by BurstSMS when the status of an outgoing message is updated."
                 "You can set it on your settings page."
             ),
         ),
-        dict(
-            label=_("Reply callback URL"),
-            url="https://{{channel.callback_domain}}/c/bs/{{channel.uuid}}/receive",
-            description=_(
+        ChannelType.Endpoint(
+            courier="receive",
+            label=_("Reply URL"),
+            help=_(
                 "This URL should be called by BurstSMS when messages are replied to."
                 "You can set it on your settings page."
             ),

--- a/temba/channels/types/clickatell/type.py
+++ b/temba/channels/types/clickatell/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.clickatell.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class ClickatellType(ChannelType):
@@ -31,23 +31,25 @@ class ClickatellType(ChannelType):
         "To finish configuring your Clickatell connection you'll need to set the following callback URLs on the "
         "Clickatell website for your integration."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Reply Callback"),
-            help=_(
-                "You can set the callback URL on your Clickatell account by managing your integration, "
-                """then setting your reply callback under "Two Way Settings" to HTTP POST and your target address """
-                "to the URL below. (leave username and password blank)"
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Reply Callback"),
+                help=_(
+                    "You can set the callback URL on your Clickatell account by managing your integration, "
+                    """then setting your reply callback under "Two Way Settings" to HTTP POST and your target address """
+                    "to the URL below. (leave username and password blank)"
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label=_("Delivery Notifications"),
-            help=_(
-                "You can set the delivery notification URL on your Clickatell account by managing your "
-                """integration, then setting your delivery notification URL under "Settings" to HTTP POST and your """
-                "target address to the URL below. (leave username and password blank)"
+            ConfigUI.Endpoint(
+                courier="status",
+                label=_("Delivery Notifications"),
+                help=_(
+                    "You can set the delivery notification URL on your Clickatell account by managing your "
+                    """integration, then setting your delivery notification URL under "Settings" to HTTP POST and your """
+                    "target address to the URL below. (leave username and password blank)"
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/clickatell/type.py
+++ b/temba/channels/types/clickatell/type.py
@@ -31,21 +31,20 @@ class ClickatellType(ChannelType):
         "To finish configuring your Clickatell connection you'll need to set the following callback URLs on the "
         "Clickatell website for your integration."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
             label=_("Reply Callback"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.ct' channel.uuid 'receive' %}",
-            description=_(
+            courier="receive",
+            help=_(
                 "You can set the callback URL on your Clickatell account by managing your integration, "
                 """then setting your reply callback under "Two Way Settings" to HTTP POST and your target address """
                 "to the URL below. (leave username and password blank)"
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
             label=_("Delivery Notifications"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.ct' channel.uuid 'status' %}",
-            description=_(
+            courier="status",
+            help=_(
                 "You can set the delivery notification URL on your Clickatell account by managing your "
                 """integration, then setting your delivery notification URL under "Settings" to HTTP POST and your """
                 "target address to the URL below. (leave username and password blank)"

--- a/temba/channels/types/clickatell/type.py
+++ b/temba/channels/types/clickatell/type.py
@@ -33,8 +33,8 @@ class ClickatellType(ChannelType):
     )
     configuration_urls = (
         ChannelType.Endpoint(
-            label=_("Reply Callback"),
             courier="receive",
+            label=_("Reply Callback"),
             help=_(
                 "You can set the callback URL on your Clickatell account by managing your integration, "
                 """then setting your reply callback under "Two Way Settings" to HTTP POST and your target address """
@@ -42,8 +42,8 @@ class ClickatellType(ChannelType):
             ),
         ),
         ChannelType.Endpoint(
-            label=_("Delivery Notifications"),
             courier="status",
+            label=_("Delivery Notifications"),
             help=_(
                 "You can set the delivery notification URL on your Clickatell account by managing your "
                 """integration, then setting your delivery notification URL under "Settings" to HTTP POST and your """

--- a/temba/channels/types/clickmobile/type.py
+++ b/temba/channels/types/clickmobile/type.py
@@ -31,12 +31,6 @@ class ClickMobileType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your channel you need to configure Click Mobile to send new messages to the URL below."
     )
-
-    configuration_urls = (
-        dict(
-            label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.cm' channel.uuid 'receive' %}",
-        ),
-    )
+    configuration_urls = (ChannelType.Endpoint(label=_("Receive URL"), courier="receive"),)
 
     available_timezones = ["Africa/Accra", "Africa/Blantyre"]

--- a/temba/channels/types/clickmobile/type.py
+++ b/temba/channels/types/clickmobile/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.clickmobile.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class ClickMobileType(ChannelType):
@@ -31,6 +31,10 @@ class ClickMobileType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your channel you need to configure Click Mobile to send new messages to the URL below."
     )
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
+        ]
+    )
 
     available_timezones = ["Africa/Accra", "Africa/Blantyre"]

--- a/temba/channels/types/clickmobile/type.py
+++ b/temba/channels/types/clickmobile/type.py
@@ -31,6 +31,6 @@ class ClickMobileType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your channel you need to configure Click Mobile to send new messages to the URL below."
     )
-    configuration_urls = (ChannelType.Endpoint(label=_("Receive URL"), courier="receive"),)
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
 
     available_timezones = ["Africa/Accra", "Africa/Blantyre"]

--- a/temba/channels/types/clicksend/type.py
+++ b/temba/channels/types/clicksend/type.py
@@ -77,8 +77,8 @@ class ClickSendType(ChannelType):
     )
     configuration_urls = (
         ChannelType.Endpoint(
-            label=_("Receive URL"),
             courier="receive",
+            label=_("Receive URL"),
             help=_(
                 "This URL should be called by ClickSend when new messages are received. "
                 "On your ClickSend dashboard, you can set this URL by going to SMS, then Settings, "

--- a/temba/channels/types/clicksend/type.py
+++ b/temba/channels/types/clicksend/type.py
@@ -75,12 +75,11 @@ class ClickSendType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to set your inbound SMS URL below for your number."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
             label=_("Receive URL"),
-            url="https://{{channel.callback_domain}}/c/cs/{{channel.uuid}}/receive",
-            description=_(
+            courier="receive",
+            help=_(
                 "This URL should be called by ClickSend when new messages are received. "
                 "On your ClickSend dashboard, you can set this URL by going to SMS, then Settings, "
                 "then the Inbound SMS Settings menu. "

--- a/temba/channels/types/clicksend/type.py
+++ b/temba/channels/types/clicksend/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class ClickSendType(ChannelType):
@@ -75,15 +75,17 @@ class ClickSendType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to set your inbound SMS URL below for your number."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_(
-                "This URL should be called by ClickSend when new messages are received. "
-                "On your ClickSend dashboard, you can set this URL by going to SMS, then Settings, "
-                "then the Inbound SMS Settings menu. "
-                "Add a new rule, select action URL, and use the URL above, then click save."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_(
+                    "This URL should be called by ClickSend when new messages are received. "
+                    "On your ClickSend dashboard, you can set this URL by going to SMS, then Settings, "
+                    "then the Inbound SMS Settings menu. "
+                    "Add a new rule, select action URL, and use the URL above, then click save."
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/dartmedia/type.py
+++ b/temba/channels/types/dartmedia/type.py
@@ -31,20 +31,19 @@ class DartMediaType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Dart Media connection you'll need to provide them with the following details."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Received URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.da' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "This endpoint should be called by Dart Media when new messages are received to your number. "
                 "You can set the receive URL on your Dart Media account by contacting your sales agent."
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="delivered",
             label=_("Delivered URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.da' channel.uuid 'delivered' %}",
-            description=_(
+            help=_(
                 "This endpoint should be called by Dart Media when a message has been to the final recipient. "
                 "(delivery reports) You can set the delivery callback URL on your Dart Media account by "
                 "contacting your sales agent."

--- a/temba/channels/types/dartmedia/type.py
+++ b/temba/channels/types/dartmedia/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.dartmedia.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class DartMediaType(ChannelType):
@@ -31,24 +31,26 @@ class DartMediaType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Dart Media connection you'll need to provide them with the following details."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Received URL"),
-            help=_(
-                "This endpoint should be called by Dart Media when new messages are received to your number. "
-                "You can set the receive URL on your Dart Media account by contacting your sales agent."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Received URL"),
+                help=_(
+                    "This endpoint should be called by Dart Media when new messages are received to your number. "
+                    "You can set the receive URL on your Dart Media account by contacting your sales agent."
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="delivered",
-            label=_("Delivered URL"),
-            help=_(
-                "This endpoint should be called by Dart Media when a message has been to the final recipient. "
-                "(delivery reports) You can set the delivery callback URL on your Dart Media account by "
-                "contacting your sales agent."
+            ConfigUI.Endpoint(
+                courier="delivered",
+                label=_("Delivered URL"),
+                help=_(
+                    "This endpoint should be called by Dart Media when a message has been to the final recipient. "
+                    "(delivery reports) You can set the delivery callback URL on your Dart Media account by "
+                    "contacting your sales agent."
+                ),
             ),
-        ),
+        ]
     )
 
     available_timezones = ["Asia/Jakarta"]

--- a/temba/channels/types/dmark/type.py
+++ b/temba/channels/types/dmark/type.py
@@ -30,12 +30,6 @@ class DMarkType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your DMark channel you need to set DMark to send MO messages to the URL below."
     )
-
-    configuration_urls = (
-        dict(
-            label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.dk' channel.uuid 'receive' %}",
-        ),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
 
     available_timezones = ["Africa/Kampala", "Africa/Kinshasa"]

--- a/temba/channels/types/dmark/type.py
+++ b/temba/channels/types/dmark/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.dmark.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class DMarkType(ChannelType):
@@ -30,6 +30,10 @@ class DMarkType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your DMark channel you need to set DMark to send MO messages to the URL below."
     )
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
+        ]
+    )
 
     available_timezones = ["Africa/Kampala", "Africa/Kinshasa"]

--- a/temba/channels/types/firebase/type.py
+++ b/temba/channels/types/firebase/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -34,20 +34,22 @@ class FirebaseCloudMessagingType(ChannelType):
         "To use your Firebase Cloud Messaging channel you'll have to POST to the following URLs with the "
         "parameters below."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="register",
-            label=_("Contact Register"),
-            help=_(
-                "To register contacts, POST to the following URL with the parameters urn, "
-                "fcm_token and optionally name."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="register",
+                label=_("Contact Register"),
+                help=_(
+                    "To register contacts, POST to the following URL with the parameters urn, "
+                    "fcm_token and optionally name."
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_(
-                "To handle incoming messages, POST to the following URL with the parameters from, msg and fcm_token."
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_(
+                    "To handle incoming messages, POST to the following URL with the parameters from, msg and fcm_token."
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/firebase/type.py
+++ b/temba/channels/types/firebase/type.py
@@ -34,20 +34,19 @@ class FirebaseCloudMessagingType(ChannelType):
         "To use your Firebase Cloud Messaging channel you'll have to POST to the following URLs with the "
         "parameters below."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="register",
             label=_("Contact Register"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.fcm' channel.uuid 'register' %}",
-            description=_(
+            help=_(
                 "To register contacts, POST to the following URL with the parameters urn, "
                 "fcm_token and optionally name."
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.fcm' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "To handle incoming messages, POST to the following URL with the parameters from, msg and fcm_token."
             ),
         ),

--- a/temba/channels/types/freshchat/type.py
+++ b/temba/channels/types/freshchat/type.py
@@ -30,11 +30,10 @@ class FreshChatType(ChannelType):
         "To use your FreshChat channel you'll have to configure the FreshChat server to direct "
         "messages to the url below."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.fc' channel.uuid %}",
-            description=_("POST FreshChat trigger to this address."),
+            help=_("POST FreshChat trigger to this address."),
         ),
     )

--- a/temba/channels/types/freshchat/type.py
+++ b/temba/channels/types/freshchat/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -30,10 +30,12 @@ class FreshChatType(ChannelType):
         "To use your FreshChat channel you'll have to configure the FreshChat server to direct "
         "messages to the url below."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("POST FreshChat trigger to this address."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("POST FreshChat trigger to this address."),
+            ),
+        ]
     )

--- a/temba/channels/types/globe/type.py
+++ b/temba/channels/types/globe/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.globe.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class GlobeType(ChannelType):
@@ -31,7 +31,11 @@ class GlobeType(ChannelType):
         "To finish configuring your Globe Labs connection you'll need to set the following notify URI for SMS on your "
         "application configuration page."
     )
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Notify URI")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Notify URI")),
+        ]
+    )
 
     available_timezones = ["Asia/Manila"]
 

--- a/temba/channels/types/globe/type.py
+++ b/temba/channels/types/globe/type.py
@@ -31,13 +31,7 @@ class GlobeType(ChannelType):
         "To finish configuring your Globe Labs connection you'll need to set the following notify URI for SMS on your "
         "application configuration page."
     )
-
-    configuration_urls = (
-        dict(
-            label=_("Notify URI"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.gl' channel.uuid 'receive' %}",
-        ),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Notify URI")),)
 
     available_timezones = ["Asia/Manila"]
 

--- a/temba/channels/types/highconnection/type.py
+++ b/temba/channels/types/highconnection/type.py
@@ -31,12 +31,6 @@ class HighConnectionType(ChannelType):
         "To finish configuring your connection you'll need to notify HighConnection of the following URL for incoming "
         "(MO) messages."
     )
-
-    configuration_urls = (
-        dict(
-            label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.hx' channel.uuid 'receive' %}",
-        ),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
 
     available_timezones = ["Europe/Paris"]

--- a/temba/channels/types/highconnection/type.py
+++ b/temba/channels/types/highconnection/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalCallbackClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class HighConnectionType(ChannelType):
@@ -31,6 +31,10 @@ class HighConnectionType(ChannelType):
         "To finish configuring your connection you'll need to notify HighConnection of the following URL for incoming "
         "(MO) messages."
     )
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
+        ]
+    )
 
     available_timezones = ["Europe/Paris"]

--- a/temba/channels/types/hormuud/type.py
+++ b/temba/channels/types/hormuud/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalCallbackClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class HormuudType(ChannelType):
@@ -31,6 +31,10 @@ class HormuudType(ChannelType):
         "To finish configuring your connection you'll need to notify Hormuud of the following URL for incoming "
         "(MO) messages."
     )
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
+        ]
+    )
 
     available_timezones = ["Africa/Mogadishu"]

--- a/temba/channels/types/hormuud/type.py
+++ b/temba/channels/types/hormuud/type.py
@@ -31,12 +31,6 @@ class HormuudType(ChannelType):
         "To finish configuring your connection you'll need to notify Hormuud of the following URL for incoming "
         "(MO) messages."
     )
-
-    configuration_urls = (
-        dict(
-            label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.hm' channel.uuid 'receive' %}",
-        ),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
 
     available_timezones = ["Africa/Mogadishu"]

--- a/temba/channels/types/hub9/type.py
+++ b/temba/channels/types/hub9/type.py
@@ -29,20 +29,19 @@ class Hub9Type(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Hub9 connection you'll need to provide them with the following details."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Received URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.h9' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "This endpoint should be called by Hub9 when new messages are received to your number. "
                 "You can set the receive URL on your Hub9 account by contacting your sales agent."
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="delivered",
             label=_("Delivered URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.h9' channel.uuid 'delivered' %}",
-            description=_(
+            help=_(
                 "This endpoint should be called by Hub9 when a message has been to the final recipient. "
                 "(delivery reports) You can set the delivery callback URL on your Hub9 account by contacting your "
                 "sales agent."

--- a/temba/channels/types/hub9/type.py
+++ b/temba/channels/types/hub9/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.dartmedia.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class Hub9Type(ChannelType):
@@ -29,24 +29,26 @@ class Hub9Type(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Hub9 connection you'll need to provide them with the following details."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Received URL"),
-            help=_(
-                "This endpoint should be called by Hub9 when new messages are received to your number. "
-                "You can set the receive URL on your Hub9 account by contacting your sales agent."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Received URL"),
+                help=_(
+                    "This endpoint should be called by Hub9 when new messages are received to your number. "
+                    "You can set the receive URL on your Hub9 account by contacting your sales agent."
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="delivered",
-            label=_("Delivered URL"),
-            help=_(
-                "This endpoint should be called by Hub9 when a message has been to the final recipient. "
-                "(delivery reports) You can set the delivery callback URL on your Hub9 account by contacting your "
-                "sales agent."
+            ConfigUI.Endpoint(
+                courier="delivered",
+                label=_("Delivered URL"),
+                help=_(
+                    "This endpoint should be called by Hub9 when a message has been to the final recipient. "
+                    "(delivery reports) You can set the delivery callback URL on your Hub9 account by contacting your "
+                    "sales agent."
+                ),
             ),
-        ),
+        ]
     )
 
     available_timezones = ["Asia/Jakarta"]

--- a/temba/channels/types/i2sms/type.py
+++ b/temba/channels/types/i2sms/type.py
@@ -30,12 +30,11 @@ class I2SMSType(ChannelType):
         "To finish configuring your I2SMS channel you'll need to set the message URL for the `DEFAULT` keyword as "
         "below."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Message URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.i2' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 """You can set your message URL by visiting the <a href="https://mx.i2sms.net/">I2SMS Dashboard</a>, """
                 """creating a DEFAULT keyword and using this URL as your message URL. """
                 """Select POST HTTP Variables and check the box for "No URL Output"."""

--- a/temba/channels/types/i2sms/type.py
+++ b/temba/channels/types/i2sms/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.i2sms.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class I2SMSType(ChannelType):
@@ -30,14 +30,16 @@ class I2SMSType(ChannelType):
         "To finish configuring your I2SMS channel you'll need to set the message URL for the `DEFAULT` keyword as "
         "below."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Message URL"),
-            help=_(
-                """You can set your message URL by visiting the <a href="https://mx.i2sms.net/">I2SMS Dashboard</a>, """
-                """creating a DEFAULT keyword and using this URL as your message URL. """
-                """Select POST HTTP Variables and check the box for "No URL Output"."""
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Message URL"),
+                help=_(
+                    """You can set your message URL by visiting the <a href="https://mx.i2sms.net/">I2SMS Dashboard</a>, """
+                    """creating a DEFAULT keyword and using this URL as your message URL. """
+                    """Select POST HTTP Variables and check the box for "No URL Output"."""
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/infobip/type.py
+++ b/temba/channels/types/infobip/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalCallbackClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class InfobipType(ChannelType):
@@ -30,22 +30,24 @@ class InfobipType(ChannelType):
         "To finish configuring your Infobip connection you'll need to set the following callback URLs on the Infobip "
         "website under your account."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Received URL"),
-            help=_(
-                "This endpoint should be called with a POST by Infobip when new messages are received to your number. "
-                "You can set the receive URL on your Infobip account by contacting your sales agent."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Received URL"),
+                help=_(
+                    "This endpoint should be called with a POST by Infobip when new messages are received to your number. "
+                    "You can set the receive URL on your Infobip account by contacting your sales agent."
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="delivered",
-            label=_("Delivered URL"),
-            help=_(
-                "This endpoint should be called with a POST by Infobip when a message has been to the final recipient. "
-                "(delivery reports) You can set the delivery callback URL on your Infobip account by contacting your "
-                "sales agent."
+            ConfigUI.Endpoint(
+                courier="delivered",
+                label=_("Delivered URL"),
+                help=_(
+                    "This endpoint should be called with a POST by Infobip when a message has been to the final recipient. "
+                    "(delivery reports) You can set the delivery callback URL on your Infobip account by contacting your "
+                    "sales agent."
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/infobip/type.py
+++ b/temba/channels/types/infobip/type.py
@@ -30,20 +30,19 @@ class InfobipType(ChannelType):
         "To finish configuring your Infobip connection you'll need to set the following callback URLs on the Infobip "
         "website under your account."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Received URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.ib' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "This endpoint should be called with a POST by Infobip when new messages are received to your number. "
                 "You can set the receive URL on your Infobip account by contacting your sales agent."
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="delivered",
             label=_("Delivered URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.ib' channel.uuid 'delivered' %}",
-            description=_(
+            help=_(
                 "This endpoint should be called with a POST by Infobip when a message has been to the final recipient. "
                 "(delivery reports) You can set the delivery callback URL on your Infobip account by contacting your "
                 "sales agent."

--- a/temba/channels/types/jasmin/type.py
+++ b/temba/channels/types/jasmin/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.jasmin.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class JasminType(ChannelType):
@@ -29,13 +29,15 @@ class JasminType(ChannelType):
     configuration_blurb = _(
         "As a last step you'll need to configure Jasmin to call the following URL for MO (incoming) messages."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Push Message URL"),
-            help=_(
-                "This endpoint will be called by Jasmin when new messages are received to your number, "
-                "it must be configured to be called as a POST."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Push Message URL"),
+                help=_(
+                    "This endpoint will be called by Jasmin when new messages are received to your number, "
+                    "it must be configured to be called as a POST."
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/jasmin/type.py
+++ b/temba/channels/types/jasmin/type.py
@@ -29,12 +29,11 @@ class JasminType(ChannelType):
     configuration_blurb = _(
         "As a last step you'll need to configure Jasmin to call the following URL for MO (incoming) messages."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Push Message URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.js' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "This endpoint will be called by Jasmin when new messages are received to your number, "
                 "it must be configured to be called as a POST."
             ),

--- a/temba/channels/types/kaleyra/type.py
+++ b/temba/channels/types/kaleyra/type.py
@@ -32,11 +32,10 @@ class KaleyraType(ChannelType):
         "To finish configuring your Kaleyra connection you'll need to set the following callback URL on your Kaleyra "
         "account."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.kwa' channel.uuid 'receive' %}",
-            description=_("To receive incoming messages, you need to set the receive URL for your Kaleyra account."),
+            help=_("To receive incoming messages, you need to set the receive URL for your Kaleyra account."),
         ),
     )

--- a/temba/channels/types/kaleyra/type.py
+++ b/temba/channels/types/kaleyra/type.py
@@ -1,6 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import ChannelType
+from temba.channels.models import ChannelType, ConfigUI
 from temba.channels.types.kaleyra.views import ClaimView
 from temba.contacts.models import URN
 
@@ -32,10 +32,12 @@ class KaleyraType(ChannelType):
         "To finish configuring your Kaleyra connection you'll need to set the following callback URL on your Kaleyra "
         "account."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("To receive incoming messages, you need to set the receive URL for your Kaleyra account."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("To receive incoming messages, you need to set the receive URL for your Kaleyra account."),
+            ),
+        ]
     )

--- a/temba/channels/types/m3tech/type.py
+++ b/temba/channels/types/m3tech/type.py
@@ -29,23 +29,11 @@ class M3TechType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your connection you'll need to notify M3Tech of the following callback URLs."
     )
-
     configuration_urls = (
-        dict(
-            label=_("Received URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.m3' channel.uuid 'receive' %}",
-        ),
-        dict(
-            label=_("Sent URL"), url="https://{{ channel.callback_domain }}{% url 'courier.m3' channel.uuid 'sent' %}"
-        ),
-        dict(
-            label=_("Delivered URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.m3' channel.uuid 'delivered' %}",
-        ),
-        dict(
-            label=_("Failed URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.m3' channel.uuid 'failed' %}",
-        ),
+        ChannelType.Endpoint(courier="receive", label=_("Received URL")),
+        ChannelType.Endpoint(courier="sent", label=_("Sent URL")),
+        ChannelType.Endpoint(courier="delivered", label=_("Delivered URL")),
+        ChannelType.Endpoint(courier="failed", label=_("Failed URL")),
     )
 
     available_timezones = ["Asia/Karachi"]

--- a/temba/channels/types/m3tech/type.py
+++ b/temba/channels/types/m3tech/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class M3TechType(ChannelType):
@@ -29,11 +29,13 @@ class M3TechType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your connection you'll need to notify M3Tech of the following callback URLs."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(courier="receive", label=_("Received URL")),
-        ChannelType.Endpoint(courier="sent", label=_("Sent URL")),
-        ChannelType.Endpoint(courier="delivered", label=_("Delivered URL")),
-        ChannelType.Endpoint(courier="failed", label=_("Failed URL")),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Received URL")),
+            ConfigUI.Endpoint(courier="sent", label=_("Sent URL")),
+            ConfigUI.Endpoint(courier="delivered", label=_("Delivered URL")),
+            ConfigUI.Endpoint(courier="failed", label=_("Failed URL")),
+        ]
     )
 
     available_timezones = ["Asia/Karachi"]

--- a/temba/channels/types/macrokiosk/type.py
+++ b/temba/channels/types/macrokiosk/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.macrokiosk.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class MacrokioskType(ChannelType):
@@ -32,17 +32,21 @@ class MacrokioskType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your MACROKIOSK connection you'll need to notify MACROKIOSK of the following URLs."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Inbound URL"),
-            help=_("This endpoint should be called by MACROKIOSK when new messages are received to your number."),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label=_("DLR URL"),
-            help=_("This endpoint should be called by MACROKIOSK when the message status changes. (delivery reports)"),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Inbound URL"),
+                help=_("This endpoint should be called by MACROKIOSK when new messages are received to your number."),
+            ),
+            ConfigUI.Endpoint(
+                courier="status",
+                label=_("DLR URL"),
+                help=_(
+                    "This endpoint should be called by MACROKIOSK when the message status changes. (delivery reports)"
+                ),
+            ),
+        ]
     )
 
     available_timezones = ["Asia/Kuala_Lumpur"]

--- a/temba/channels/types/macrokiosk/type.py
+++ b/temba/channels/types/macrokiosk/type.py
@@ -32,21 +32,16 @@ class MacrokioskType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your MACROKIOSK connection you'll need to notify MACROKIOSK of the following URLs."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Inbound URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.mk' channel.uuid 'receive' %}",
-            description=_(
-                "This endpoint should be called by MACROKIOSK when new messages are received to your number."
-            ),
+            help=_("This endpoint should be called by MACROKIOSK when new messages are received to your number."),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="status",
             label=_("DLR URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.mk' channel.uuid 'status' %}",
-            description=_(
-                "This endpoint should be called by MACROKIOSK when the message status changes. (delivery reports)"
-            ),
+            help=_("This endpoint should be called by MACROKIOSK when the message status changes. (delivery reports)"),
         ),
     )
 

--- a/temba/channels/types/mblox/type.py
+++ b/temba/channels/types/mblox/type.py
@@ -28,12 +28,11 @@ class MbloxType(ChannelType):
     max_length = 459
 
     configuration_blurb = _("As a last step you'll need to set the following callback URL on your Mblox account.")
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Callback URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.mb' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "This endpoint will be called by Mblox when new messages are received to your number and for delivery "
                 "reports."
             ),

--- a/temba/channels/types/mblox/type.py
+++ b/temba/channels/types/mblox/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class MbloxType(ChannelType):
@@ -28,13 +28,15 @@ class MbloxType(ChannelType):
     max_length = 459
 
     configuration_blurb = _("As a last step you'll need to set the following callback URL on your Mblox account.")
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Callback URL"),
-            help=_(
-                "This endpoint will be called by Mblox when new messages are received to your number and for delivery "
-                "reports."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Callback URL"),
+                help=_(
+                    "This endpoint will be called by Mblox when new messages are received to your number and for delivery "
+                    "reports."
+                ),
             ),
-        ),
+        ]
     )

--- a/temba/channels/types/messagebird/type.py
+++ b/temba/channels/types/messagebird/type.py
@@ -29,21 +29,19 @@ class MessageBirdType(ChannelType):
 
     available_timezones = SUPPORTED_TIMEZONES
     configuration_blurb = _(
-        "To use your Messagebirld channel you'll have to configure the Messagebird to send raw  "
-        "receivedSMS messages to the url below either with a flow or by registering the webhook with them"
-        "Shortcodes don't work with flows and require a webhook."
-        "Configure the status url under Developer Settings to receive status updates for your messages."
+        "To use your Messagebird channel you'll have to configure the Messagebird to send raw received SMS messages to "
+        "the URL below either with a flow or by registering the webhook with them. Configure the status URL under "
+        "Developer Settings to receive status updates for your messages."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.mbd' channel.uuid 'receive'%}",
-            description=_("Webhook address for inbmound messages to this address."),
+            help=_("Webhook address for inbound messages to this address."),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="status",
             label=_("Status URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.mbd' channel.uuid 'status'%}",
-            description=_("Webhook address for message status calls to this address."),
+            help=_("Webhook address for message status calls to this address."),
         ),
     )

--- a/temba/channels/types/messagebird/type.py
+++ b/temba/channels/types/messagebird/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import SUPPORTED_TIMEZONES, ClaimView
 
 
@@ -33,15 +33,17 @@ class MessageBirdType(ChannelType):
         "the URL below either with a flow or by registering the webhook with them. Configure the status URL under "
         "Developer Settings to receive status updates for your messages."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("Webhook address for inbound messages to this address."),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label=_("Status URL"),
-            help=_("Webhook address for message status calls to this address."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("Webhook address for inbound messages to this address."),
+            ),
+            ConfigUI.Endpoint(
+                courier="status",
+                label=_("Status URL"),
+                help=_("Webhook address for message status calls to this address."),
+            ),
+        ]
     )

--- a/temba/channels/types/messangi/type.py
+++ b/temba/channels/types/messangi/type.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import ChannelType
+from temba.channels.models import ChannelType, ConfigUI
 from temba.channels.types.messangi.views import ClaimView
 from temba.contacts.models import URN
 
@@ -37,12 +37,14 @@ class MessangiType(ChannelType):
         "To finish configuring your Messangi connection you'll need to set the following callback URLs on your Messangi"
         " account."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("To receive incoming messages, you need to set the receive URL for your Messangi account."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("To receive incoming messages, you need to set the receive URL for your Messangi account."),
+            ),
+        ]
     )
 
     available_timezones = ["America/Jamaica"]

--- a/temba/channels/types/messangi/type.py
+++ b/temba/channels/types/messangi/type.py
@@ -37,12 +37,11 @@ class MessangiType(ChannelType):
         "To finish configuring your Messangi connection you'll need to set the following callback URLs on your Messangi"
         " account."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.mg' channel.uuid 'receive' %}",
-            description=_("To receive incoming messages, you need to set the receive URL for your Messangi account."),
+            help=_("To receive incoming messages, you need to set the receive URL for your Messangi account."),
         ),
     )
 

--- a/temba/channels/types/mtarget/type.py
+++ b/temba/channels/types/mtarget/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -32,7 +32,9 @@ class MtargetType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to have Mtarget configure the URLs below for your Service ID."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(courier="receive", label=_("Receive URL")),
-        ChannelType.Endpoint(courier="status", label=_("Status URL")),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
+            ConfigUI.Endpoint(courier="status", label=_("Status URL")),
+        ]
     )

--- a/temba/channels/types/mtarget/type.py
+++ b/temba/channels/types/mtarget/type.py
@@ -32,14 +32,7 @@ class MtargetType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to have Mtarget configure the URLs below for your Service ID."
     )
-
     configuration_urls = (
-        dict(
-            label=_("Receive URL"),
-            url="https://{{channel.callback_domain}}{% url 'courier.mt' channel.uuid 'receive' %}",
-        ),
-        dict(
-            label=_("Status URL"),
-            url="https://{{channel.callback_domain}}{% url 'courier.mt' channel.uuid 'status' %}",
-        ),
+        ChannelType.Endpoint(courier="receive", label=_("Receive URL")),
+        ChannelType.Endpoint(courier="status", label=_("Status URL")),
     )

--- a/temba/channels/types/novo/type.py
+++ b/temba/channels/types/novo/type.py
@@ -30,10 +30,10 @@ class NovoType(ChannelType):
     max_length = 160
 
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.nv' channel.uuid 'receive' %}",
-            description=_("To receive incoming messages, you need to set the receive URL for your Novo account."),
+            help=_("To receive incoming messages, you need to set the receive URL for your Novo account."),
         ),
     )
 

--- a/temba/channels/types/novo/type.py
+++ b/temba/channels/types/novo/type.py
@@ -1,6 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import ChannelType
+from temba.channels.models import ChannelType, ConfigUI
 from temba.channels.types.novo.views import ClaimView
 from temba.contacts.models import URN
 
@@ -29,12 +29,14 @@ class NovoType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("To receive incoming messages, you need to set the receive URL for your Novo account."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("To receive incoming messages, you need to set the receive URL for your Novo account."),
+            ),
+        ]
     )
 
     available_timezones = ["America/Port_of_Spain"]

--- a/temba/channels/types/playmobile/type.py
+++ b/temba/channels/types/playmobile/type.py
@@ -1,6 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import ChannelType
+from temba.channels.models import ChannelType, ConfigUI
 from temba.channels.types.playmobile.views import ClaimView
 from temba.contacts.models import URN
 
@@ -30,10 +30,12 @@ class PlayMobileType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Play Mobile connection you'll need to notify Play Mobile of the following URL."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("To receive incoming messages, you need to set the receive URL for your Play Mobile account."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("To receive incoming messages, you need to set the receive URL for your Play Mobile account."),
+            ),
+        ]
     )

--- a/temba/channels/types/playmobile/type.py
+++ b/temba/channels/types/playmobile/type.py
@@ -30,13 +30,10 @@ class PlayMobileType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Play Mobile connection you'll need to notify Play Mobile of the following URL."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.pm' channel.uuid 'receive' %}",
-            description=_(
-                "To receive incoming messages, you need to set the receive URL for your Play Mobile account."
-            ),
+            help=_("To receive incoming messages, you need to set the receive URL for your Play Mobile account."),
         ),
     )

--- a/temba/channels/types/shaqodoon/type.py
+++ b/temba/channels/types/shaqodoon/type.py
@@ -27,13 +27,9 @@ class ShaqodoonType(ChannelType):
     max_length = 1600
 
     configuration_blurb = _(
-        "To finish configuring your Shaqodoon connection you'll need to provide Shaqodoon with the following delivery "
-        "URL for incoming messages to {{ channel.address }}."
+        "To finish configuring your Shaqodoon connection you'll need to provide Shaqodoon with the following delivery URL."
     )
-
-    configuration_urls = (
-        dict(label="", url="https://{{ channel.callback_domain }}{% url 'courier.sq' channel.uuid 'receive' %}"),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
 
     available_timezones = ["Africa/Mogadishu"]
 

--- a/temba/channels/types/shaqodoon/type.py
+++ b/temba/channels/types/shaqodoon/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.shaqodoon.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class ShaqodoonType(ChannelType):
@@ -29,7 +29,11 @@ class ShaqodoonType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Shaqodoon connection you'll need to provide Shaqodoon with the following delivery URL."
     )
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Receive URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
+        ]
+    )
 
     available_timezones = ["Africa/Mogadishu"]
 

--- a/temba/channels/types/signalwire/type.py
+++ b/temba/channels/types/signalwire/type.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.models import Channel
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import SignalWireClaimView
 
 
@@ -79,12 +79,14 @@ class SignalWireType(ChannelType):
     async_activation = False
 
     configuration_blurb = _("Your SignalWire channel is now connected.")
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Inbound URL"),
-            help=_("This endpoint will be called by SignalWire when new messages are received to your number."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Inbound URL"),
+                help=_("This endpoint will be called by SignalWire when new messages are received to your number."),
+            ),
+        ]
     )
 
     def deactivate(self, channel):

--- a/temba/channels/types/signalwire/type.py
+++ b/temba/channels/types/signalwire/type.py
@@ -79,12 +79,11 @@ class SignalWireType(ChannelType):
     async_activation = False
 
     configuration_blurb = _("Your SignalWire channel is now connected.")
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Inbound URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.sw' channel.uuid 'receive' %}",
-            description=_("This endpoint will be called by SignalWire when new messages are received to your number."),
+            help=_("This endpoint will be called by SignalWire when new messages are received to your number."),
         ),
     )
 

--- a/temba/channels/types/smscentral/type.py
+++ b/temba/channels/types/smscentral/type.py
@@ -30,14 +30,11 @@ class SMSCentralType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your SMSCentral connection you'll need to notify SMSCentral of the following URL."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Inbound URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.sc' channel.uuid 'receive' %}",
-            description=_(
-                "This endpoint should be called by SMSCentral when new messages are received to your number."
-            ),
+            help=_("This endpoint should be called by SMSCentral when new messages are received to your number."),
         ),
     )
 

--- a/temba/channels/types/smscentral/type.py
+++ b/temba/channels/types/smscentral/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class SMSCentralType(ChannelType):
@@ -30,12 +30,14 @@ class SMSCentralType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your SMSCentral connection you'll need to notify SMSCentral of the following URL."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Inbound URL"),
-            help=_("This endpoint should be called by SMSCentral when new messages are received to your number."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Inbound URL"),
+                help=_("This endpoint should be called by SMSCentral when new messages are received to your number."),
+            ),
+        ]
     )
 
     available_timezones = ["Asia/Kathmandu"]

--- a/temba/channels/types/somleng/tests.py
+++ b/temba/channels/types/somleng/tests.py
@@ -143,5 +143,30 @@ class SomlengTypeTest(TembaTest):
         response = self.client.get(reverse("channels.channel_configuration", args=[channel.uuid]))
         self.assertContains(response, reverse("courier.tw", args=[channel.uuid, "receive"]))
 
+    def test_config(self):
+        channel = self.create_channel("TW", "Somleng", "1234", role="SR")
+        config_url = reverse("channels.channel_configuration", args=[channel.uuid])
+        courier_receive_url = f"https://app.rapidpro.io/c/tw/{channel.uuid}/receive"
+        courier_status_url = f"https://app.rapidpro.io/c/tw/{channel.uuid}/status"
+        mailroom_incoming_url = f"https://app.rapidpro.io/mr/ivr/c/{channel.uuid}/incoming"
+        mailroom_status_url = f"https://app.rapidpro.io/mr/ivr/c/{channel.uuid}/status"
+
+        self.login(self.admin)
+
+        response = self.client.get(config_url)
+        self.assertContains(response, courier_receive_url)
+        self.assertContains(response, courier_status_url)
+        self.assertNotContains(response, mailroom_incoming_url)
+        self.assertNotContains(response, mailroom_status_url)
+
+        channel.role = "CA"
+        channel.save(update_fields=("role",))
+
+        response = self.client.get(config_url)
+        self.assertNotContains(response, courier_receive_url)
+        self.assertNotContains(response, courier_status_url)
+        self.assertContains(response, mailroom_incoming_url)
+        self.assertContains(response, mailroom_status_url)
+
     def test_get_error_ref_url(self):
         self.assertEqual("https://www.twilio.com/docs/api/errors/30006", SomlengType().get_error_ref_url(None, "30006"))

--- a/temba/channels/types/somleng/type.py
+++ b/temba/channels/types/somleng/type.py
@@ -40,7 +40,6 @@ class SomlengType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Somleng channel you'll need to add the following URL to your Somleng instance."
     )
-
     configuration_urls = (
         ChannelType.Endpoint(
             courier="receive",

--- a/temba/channels/types/somleng/type.py
+++ b/temba/channels/types/somleng/type.py
@@ -45,12 +45,17 @@ class SomlengType(ChannelType):
         dict(
             label=_("Somleng Host"),
             url="{{ channel.config.send_url }}",
-            description=_("The endpoint which will receive Somleng requests for this channel."),
+            description=_("The endpoint which will receive requests from this channel."),
         ),
         dict(
-            label="",
+            label="Incoming Calls",
             url="https://{{ channel.callback_domain }}{% url 'courier.tw' channel.uuid 'receive' %}",
-            description=_("Incoming messages for this channel will be sent to this endpoint."),
+            description=_("Incoming messages should be sent to this endpoint."),
+        ),
+        dict(
+            label="Status Updates",
+            url="https://{{ channel.callback_domain }}{% url 'courier.tw' channel.uuid 'status' %}",
+            description=_("Call status updates should be sent to this endpoint."),
         ),
     )
 

--- a/temba/channels/types/somleng/type.py
+++ b/temba/channels/types/somleng/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.somleng.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import Channel, ChannelType
+from ...models import Channel, ChannelType, ConfigUI
 
 
 class SomlengType(ChannelType):
@@ -40,31 +40,33 @@ class SomlengType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Somleng channel you'll need to add the following URL to your Somleng instance."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label="Incoming Messages",
-            help=_("New incoming messages should be sent to this endpoint."),
-            roles=(Channel.ROLE_RECEIVE,),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label="Message Status Updates",
-            help=_("Message status updates should be sent to this endpoint."),
-            roles=(Channel.ROLE_SEND,),
-        ),
-        ChannelType.Endpoint(
-            mailroom="incoming",
-            label="Incoming Calls",
-            help=_("New incoming calls should be sent to this endpoint."),
-            roles=(Channel.ROLE_ANSWER,),
-        ),
-        ChannelType.Endpoint(
-            mailroom="status",
-            label="Call Status Updates",
-            help=_("Call status updates should be sent to this endpoint."),
-            roles=(Channel.ROLE_CALL, Channel.ROLE_ANSWER),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label="Incoming Messages",
+                help=_("New incoming messages should be sent to this endpoint."),
+                roles=(Channel.ROLE_RECEIVE,),
+            ),
+            ConfigUI.Endpoint(
+                courier="status",
+                label="Message Status Updates",
+                help=_("Message status updates should be sent to this endpoint."),
+                roles=(Channel.ROLE_SEND,),
+            ),
+            ConfigUI.Endpoint(
+                mailroom="incoming",
+                label="Incoming Calls",
+                help=_("New incoming calls should be sent to this endpoint."),
+                roles=(Channel.ROLE_ANSWER,),
+            ),
+            ConfigUI.Endpoint(
+                mailroom="status",
+                label="Call Status Updates",
+                help=_("Call status updates should be sent to this endpoint."),
+                roles=(Channel.ROLE_CALL, Channel.ROLE_ANSWER),
+            ),
+        ]
     )
 
     def get_error_ref_url(self, channel, code: str) -> str:

--- a/temba/channels/types/somleng/type.py
+++ b/temba/channels/types/somleng/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.somleng.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import Channel, ChannelType
 
 
 class SomlengType(ChannelType):
@@ -42,20 +42,29 @@ class SomlengType(ChannelType):
     )
 
     configuration_urls = (
-        dict(
-            label=_("Somleng Host"),
-            url="{{ channel.config.send_url }}",
-            description=_("The endpoint which will receive requests from this channel."),
+        ChannelType.Endpoint(
+            courier="receive",
+            label="Incoming Messages",
+            help=_("New incoming messages should be sent to this endpoint."),
+            roles=(Channel.ROLE_RECEIVE,),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="status",
+            label="Message Status Updates",
+            help=_("Message status updates should be sent to this endpoint."),
+            roles=(Channel.ROLE_SEND,),
+        ),
+        ChannelType.Endpoint(
+            mailroom="incoming",
             label="Incoming Calls",
-            url="https://{{ channel.callback_domain }}{% url 'courier.tw' channel.uuid 'receive' %}",
-            description=_("Incoming messages should be sent to this endpoint."),
+            help=_("New incoming calls should be sent to this endpoint."),
+            roles=(Channel.ROLE_ANSWER,),
         ),
-        dict(
-            label="Status Updates",
-            url="https://{{ channel.callback_domain }}{% url 'courier.tw' channel.uuid 'status' %}",
-            description=_("Call status updates should be sent to this endpoint."),
+        ChannelType.Endpoint(
+            mailroom="status",
+            label="Call Status Updates",
+            help=_("Call status updates should be sent to this endpoint."),
+            roles=(Channel.ROLE_CALL, Channel.ROLE_ANSWER),
         ),
     )
 

--- a/temba/channels/types/start/type.py
+++ b/temba/channels/types/start/type.py
@@ -27,14 +27,13 @@ class StartType(ChannelType):
     max_length = 1600
 
     configuration_blurb = _(
-        "To finish configuring your Start connection you'll need to notify Start of the following receiving URL."
+        "To finish configuring this channel you'll need to notify Start of the following receiving URL."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Inbound URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.st' channel.uuid 'receive' %}",
-            description=_("This endpoint should be called by Start when new messages are received to your number."),
+            help=_("This endpoint should be called by when new messages are received to your number."),
         ),
     )
 

--- a/temba/channels/types/start/type.py
+++ b/temba/channels/types/start/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.views import AuthenticatedExternalClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class StartType(ChannelType):
@@ -29,12 +29,14 @@ class StartType(ChannelType):
     configuration_blurb = _(
         "To finish configuring this channel you'll need to notify Start of the following receiving URL."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Inbound URL"),
-            help=_("This endpoint should be called by when new messages are received to your number."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Inbound URL"),
+                help=_("This endpoint should be called by when new messages are received to your number."),
+            ),
+        ]
     )
 
     available_timezones = ["Europe/Kiev"]

--- a/temba/channels/types/telesom/type.py
+++ b/temba/channels/types/telesom/type.py
@@ -28,12 +28,9 @@ class TelesomType(ChannelType):
 
     configuration_blurb = _(
         "To finish configuring your Telesom connection you'll need to provide Telesom with the following delivery URL "
-        "for incoming messages to {{ channel.address }}."
+        "for incoming messages."
     )
-
-    configuration_urls = (
-        dict(label="", url="https://{{ channel.callback_domain }}{% url 'courier.ts' channel.uuid 'receive' %}"),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Delivery URL")),)
 
     available_timezones = ["Africa/Mogadishu"]
 

--- a/temba/channels/types/telesom/type.py
+++ b/temba/channels/types/telesom/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.telesom.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class TelesomType(ChannelType):
@@ -30,7 +30,11 @@ class TelesomType(ChannelType):
         "To finish configuring your Telesom connection you'll need to provide Telesom with the following delivery URL "
         "for incoming messages."
     )
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Delivery URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Delivery URL")),
+        ]
+    )
 
     available_timezones = ["Africa/Mogadishu"]
 

--- a/temba/channels/types/thinq/type.py
+++ b/temba/channels/types/thinq/type.py
@@ -4,7 +4,7 @@ from temba.channels.types.thinq.views import ClaimView
 from temba.contacts.models import URN
 from temba.utils.timezones import timezone_to_country_code
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class ThinQType(ChannelType):
@@ -37,21 +37,23 @@ class ThinQType(ChannelType):
         "To finish configuring your ThinQ connection you'll need to set the following callback URLs on the ThinQ "
         "website on the SMS -> SMS Configuration page."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Inbound SMS Configuration"),
-            help=_(
-                """Set your Inbound SMS Configuration URL to the above, making sure you select "URL" for Attachment Type."""
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Inbound SMS Configuration"),
+                help=_(
+                    """Set your Inbound SMS Configuration URL to the above, making sure you select "URL" for Attachment Type."""
+                ),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label=_("Outbound SMS Configuration"),
-            help=_(
-                """Set your Delivery Confirmation URL to the above, making sure you select "Form-Data" as the Delivery Notification Format."""
+            ConfigUI.Endpoint(
+                courier="status",
+                label=_("Outbound SMS Configuration"),
+                help=_(
+                    """Set your Delivery Confirmation URL to the above, making sure you select "Form-Data" as the Delivery Notification Format."""
+                ),
             ),
-        ),
+        ]
     )
 
     def is_available_to(self, org, user):

--- a/temba/channels/types/thinq/type.py
+++ b/temba/channels/types/thinq/type.py
@@ -29,27 +29,26 @@ class ThinQType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your ThinQ connection you'll need to set the following callback URLs on the ThinQ "
-        "website on the SMS -> SMS Configuration page."
-    )
-
     CONFIG_ACCOUNT_ID = "account_id"
     CONFIG_API_TOKEN_USER = "api_token_user"
     CONFIG_API_TOKEN = "api_token"
 
+    configuration_blurb = _(
+        "To finish configuring your ThinQ connection you'll need to set the following callback URLs on the ThinQ "
+        "website on the SMS -> SMS Configuration page."
+    )
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Inbound SMS Configuration"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.tq' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 """Set your Inbound SMS Configuration URL to the above, making sure you select "URL" for Attachment Type."""
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="status",
             label=_("Outbound SMS Configuration"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.tq' channel.uuid 'status' %}",
-            description=_(
+            help=_(
                 """Set your Delivery Confirmation URL to the above, making sure you select "Form-Data" as the Delivery Notification Format."""
             ),
         ),

--- a/temba/channels/types/twilio_messaging_service/type.py
+++ b/temba/channels/types/twilio_messaging_service/type.py
@@ -38,12 +38,11 @@ class TwilioMessagingServiceType(ChannelType):
         "To finish configuring your Twilio Messaging Service connection you'll need to add the following URL in your "
         "Messaging Service Inbound Settings."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Request URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.tms' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "This endpoint should be called by Twilio when new messages are received by your Messaging Service."
             ),
         ),

--- a/temba/channels/types/twilio_messaging_service/type.py
+++ b/temba/channels/types/twilio_messaging_service/type.py
@@ -5,7 +5,7 @@ from temba.channels.types.twilio.views import SUPPORTED_COUNTRIES, UpdateForm
 from temba.contacts.models import URN
 from temba.utils.timezones import timezone_to_country_code
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -38,14 +38,16 @@ class TwilioMessagingServiceType(ChannelType):
         "To finish configuring your Twilio Messaging Service connection you'll need to add the following URL in your "
         "Messaging Service Inbound Settings."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Request URL"),
-            help=_(
-                "This endpoint should be called by Twilio when new messages are received by your Messaging Service."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Request URL"),
+                help=_(
+                    "This endpoint should be called by Twilio when new messages are received by your Messaging Service."
+                ),
             ),
-        ),
+        ]
     )
 
     schemes = [URN.TEL_SCHEME]

--- a/temba/channels/types/twilio_whatsapp/type.py
+++ b/temba/channels/types/twilio_whatsapp/type.py
@@ -37,15 +37,11 @@ class TwilioWhatsappType(ChannelType):
         "To finish configuring your Twilio WhatsApp connection you'll need to add the following URL in your Twilio "
         "Inbound Settings. Check the Twilio WhatsApp documentation for more information."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Request URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.twa' channel.uuid 'receive' %}",
-            description=_(
-                "This endpoint should be called by Twilio when new messages are received by your Twilio WhatsApp "
-                "number."
-            ),
+            help=_("This endpoint should be called by Twilio when new messages are received by your number."),
         ),
     )
 

--- a/temba/channels/types/twilio_whatsapp/type.py
+++ b/temba/channels/types/twilio_whatsapp/type.py
@@ -4,7 +4,7 @@ from temba.channels.types.twilio.type import TwilioType
 from temba.channels.types.twilio.views import UpdateForm
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -37,12 +37,14 @@ class TwilioWhatsappType(ChannelType):
         "To finish configuring your Twilio WhatsApp connection you'll need to add the following URL in your Twilio "
         "Inbound Settings. Check the Twilio WhatsApp documentation for more information."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Request URL"),
-            help=_("This endpoint should be called by Twilio when new messages are received by your number."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Request URL"),
+                help=_("This endpoint should be called by Twilio when new messages are received by your number."),
+            ),
+        ]
     )
 
     redact_request_keys = (

--- a/temba/channels/types/verboice/type.py
+++ b/temba/channels/types/verboice/type.py
@@ -25,13 +25,7 @@ class VerboiceType(ChannelType):
         "To finish configuring your connection you'll need to set the following status callback URL for your Verboice "
         "project"
     )
-
-    configuration_urls = (
-        dict(
-            label=_("Status Callback URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.vb' channel.uuid 'status' %}",
-        ),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="status", label=_("Status Callback URL")),)
 
     def is_available_to(self, org, user):
         return False, False

--- a/temba/channels/types/verboice/type.py
+++ b/temba/channels/types/verboice/type.py
@@ -1,6 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import ChannelType
+from temba.channels.models import ChannelType, ConfigUI
 from temba.channels.types.verboice.views import ClaimView
 from temba.contacts.models import URN
 
@@ -25,7 +25,11 @@ class VerboiceType(ChannelType):
         "To finish configuring your connection you'll need to set the following status callback URL for your Verboice "
         "project"
     )
-    configuration_urls = (ChannelType.Endpoint(courier="status", label=_("Status Callback URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="status", label=_("Status Callback URL")),
+        ]
+    )
 
     def is_available_to(self, org, user):
         return False, False

--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -104,7 +104,7 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
         )
 
         # read page has link to update page
-        self.assertContentMenu(read_url, self.admin, ["Settings", "Logs", "Edit", "Delete"])
+        self.assertContentMenu(read_url, self.admin, ["Configuration", "Logs", "Edit", "Delete"])
 
     def test_get_error_ref_url(self):
         self.assertEqual(

--- a/temba/channels/types/viber_public/type.py
+++ b/temba/channels/types/viber_public/type.py
@@ -36,10 +36,7 @@ class ViberPublicType(ChannelType):
     ) % {"link": '<a target="_blank" href="http://viber.com/en/">Viber</a>'}
 
     configuration_blurb = _("Your Viber channel is connected. If needed the webhook endpoints are listed below.")
-
-    configuration_urls = (
-        dict(label=_("Webhook URL"), url="https://{{ channel.callback_domain }}{% url 'courier.vp' channel.uuid %}"),
-    )
+    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Webhook URL")),)
 
     def activate(self, channel):
         auth_token = channel.config["auth_token"]

--- a/temba/channels/types/viber_public/type.py
+++ b/temba/channels/types/viber_public/type.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView, UpdateForm
 
 
@@ -36,7 +36,11 @@ class ViberPublicType(ChannelType):
     ) % {"link": '<a target="_blank" href="http://viber.com/en/">Viber</a>'}
 
     configuration_blurb = _("Your Viber channel is connected. If needed the webhook endpoints are listed below.")
-    configuration_urls = (ChannelType.Endpoint(courier="receive", label=_("Webhook URL")),)
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="receive", label=_("Webhook URL")),
+        ]
+    )
 
     def activate(self, channel):
         auth_token = channel.config["auth_token"]

--- a/temba/channels/types/vonage/type.py
+++ b/temba/channels/types/vonage/type.py
@@ -78,24 +78,21 @@ class VonageType(ChannelType):
         "Your Vonage configuration URLs are as follows. These should have been set up automatically when claiming your "
         "number, but if not you can set them from your Vonage dashboard."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Callback URL for Inbound Messages"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.nx' channel.uuid 'receive' %}",
-            description=_("The callback URL is called by Vonage when you receive new incoming messages."),
+            help=_("The callback URL is called by Vonage when you receive new incoming messages."),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="status",
             label=_("Callback URL for Delivery Receipt"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.nx' channel.uuid 'status' %}",
-            description=_(
-                "The delivery URL is called by Vonage when a message is successfully delivered to a recipient."
-            ),
+            help=_("The delivery URL is called by Vonage when a message is successfully delivered to a recipient."),
         ),
-        dict(
+        ChannelType.Endpoint(
+            mailroom="incoming",
             label=_("Callback URL for Incoming Call"),
-            url="https://{{ channel.callback_domain }}{% url 'mailroom.ivr_handler' channel.uuid 'incoming' %}",
-            description=_("The callback URL is called by Vonage when you receive an incoming call."),
+            help=_("The callback URL is called by Vonage when you receive an incoming call."),
         ),
     )
 

--- a/temba/channels/types/vonage/type.py
+++ b/temba/channels/types/vonage/type.py
@@ -1,7 +1,7 @@
 from django.urls import re_path
 from django.utils.translation import gettext_lazy as _
 
-from temba.channels.models import ChannelType
+from temba.channels.models import ChannelType, ConfigUI
 from temba.contacts.models import URN
 from temba.utils.timezones import timezone_to_country_code
 
@@ -78,22 +78,24 @@ class VonageType(ChannelType):
         "Your Vonage configuration URLs are as follows. These should have been set up automatically when claiming your "
         "number, but if not you can set them from your Vonage dashboard."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Callback URL for Inbound Messages"),
-            help=_("The callback URL is called by Vonage when you receive new incoming messages."),
-        ),
-        ChannelType.Endpoint(
-            courier="status",
-            label=_("Callback URL for Delivery Receipt"),
-            help=_("The delivery URL is called by Vonage when a message is successfully delivered to a recipient."),
-        ),
-        ChannelType.Endpoint(
-            mailroom="incoming",
-            label=_("Callback URL for Incoming Call"),
-            help=_("The callback URL is called by Vonage when you receive an incoming call."),
-        ),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Callback URL for Inbound Messages"),
+                help=_("The callback URL is called by Vonage when you receive new incoming messages."),
+            ),
+            ConfigUI.Endpoint(
+                courier="status",
+                label=_("Callback URL for Delivery Receipt"),
+                help=_("The delivery URL is called by Vonage when a message is successfully delivered to a recipient."),
+            ),
+            ConfigUI.Endpoint(
+                mailroom="incoming",
+                label=_("Callback URL for Incoming Call"),
+                help=_("The callback URL is called by Vonage when you receive an incoming call."),
+            ),
+        ]
     )
 
     def is_recommended_to(self, org, user):

--- a/temba/channels/types/wavy/type.py
+++ b/temba/channels/types/wavy/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -46,26 +46,28 @@ class WavyType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to have Movile/Wavy configure the URL below for your number."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Receive URL"),
-            help=_("This URL should be called by Movile/Wavy when new messages are received."),
-        ),
-        ChannelType.Endpoint(
-            courier="sent",
-            label=_("Sent URL"),
-            help=_(
-                "To receive the acknowledgement of sent messages, you need to set the Sent URL for your Movile/Wavy "
-                "account."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Receive URL"),
+                help=_("This URL should be called by Movile/Wavy when new messages are received."),
             ),
-        ),
-        ChannelType.Endpoint(
-            courier="delivered",
-            label=_("Delivered URL"),
-            help=_(
-                "To receive delivery of delivered messages, you need to set the Delivered URL for your Movile/Wavy "
-                "account."
+            ConfigUI.Endpoint(
+                courier="sent",
+                label=_("Sent URL"),
+                help=_(
+                    "To receive the acknowledgement of sent messages, you need to set the Sent URL for your Movile/Wavy "
+                    "account."
+                ),
             ),
-        ),
+            ConfigUI.Endpoint(
+                courier="delivered",
+                label=_("Delivered URL"),
+                help=_(
+                    "To receive delivery of delivered messages, you need to set the Delivered URL for your Movile/Wavy "
+                    "account."
+                ),
+            ),
+        ]
     )

--- a/temba/channels/types/wavy/type.py
+++ b/temba/channels/types/wavy/type.py
@@ -46,25 +46,24 @@ class WavyType(ChannelType):
     configuration_blurb = _(
         "To finish connecting your channel, you need to have Movile/Wavy configure the URL below for your number."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.wv' channel.uuid 'receive' %}",
-            description=_("This URL should be called by Movile/Wavy when new messages are received."),
+            help=_("This URL should be called by Movile/Wavy when new messages are received."),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="sent",
             label=_("Sent URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.wv' channel.uuid 'sent' %}",
-            description=_(
+            help=_(
                 "To receive the acknowledgement of sent messages, you need to set the Sent URL for your Movile/Wavy "
                 "account."
             ),
         ),
-        dict(
+        ChannelType.Endpoint(
+            courier="delivered",
             label=_("Delivered URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.wv' channel.uuid 'delivered' %}",
-            description=_(
+            help=_(
                 "To receive delivery of delivered messages, you need to set the Delivered URL for your Movile/Wavy "
                 "account."
             ),

--- a/temba/channels/types/yo/type.py
+++ b/temba/channels/types/yo/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.yo.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class YoType(ChannelType):
@@ -32,15 +32,17 @@ class YoType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Yo! connection you'll need to notify Yo! of the following inbound SMS URL."
     )
-    configuration_urls = (
-        ChannelType.Endpoint(
-            courier="receive",
-            label=_("Inbound SMS URL"),
-            help=_(
-                "This URL should be called with a GET by Yo! when new incoming "
-                "messages are received on your short code."
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Inbound SMS URL"),
+                help=_(
+                    "This URL should be called with a GET by Yo! when new incoming "
+                    "messages are received on your short code."
+                ),
             ),
-        ),
+        ]
     )
 
     def is_recommended_to(self, org, user):

--- a/temba/channels/types/yo/type.py
+++ b/temba/channels/types/yo/type.py
@@ -32,12 +32,11 @@ class YoType(ChannelType):
     configuration_blurb = _(
         "To finish configuring your Yo! connection you'll need to notify Yo! of the following inbound SMS URL."
     )
-
     configuration_urls = (
-        dict(
+        ChannelType.Endpoint(
+            courier="receive",
             label=_("Inbound SMS URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.yo' channel.uuid 'receive' %}",
-            description=_(
+            help=_(
                 "This URL should be called with a GET by Yo! when new incoming "
                 "messages are received on your short code."
             ),

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -25,6 +25,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Sum
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
+from django.template import Context, Engine
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -40,7 +41,7 @@ from temba.utils.json import EpochEncoder
 from temba.utils.models import patch_queryset_count
 from temba.utils.views import ComponentFormMixin, ContentMenuMixin, SpaMixin
 
-from .models import Channel, ChannelCount, ChannelLog
+from .models import Channel, ChannelCount, ChannelLog, ChannelType
 
 logger = logging.getLogger(__name__)
 
@@ -488,7 +489,7 @@ class ChannelCRUDL(SmartCRUDL):
                 menu.add_link(_("Android Channel"), reverse("channels.channel_read", args=[obj.parent.uuid]))
 
             if obj.type.show_config_page:
-                menu.add_link(_("Settings"), reverse("channels.channel_configuration", args=[obj.uuid]))
+                menu.add_link(_("Configuration"), reverse("channels.channel_configuration", args=[obj.uuid]))
 
             menu.add_link(_("Logs"), reverse("channels.channellog_list", args=[obj.uuid]))
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -25,7 +25,6 @@ from django.core.exceptions import ValidationError
 from django.db.models import Sum
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
-from django.template import Context, Engine
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -41,7 +40,7 @@ from temba.utils.json import EpochEncoder
 from temba.utils.models import patch_queryset_count
 from temba.utils.views import ComponentFormMixin, ContentMenuMixin, SpaMixin
 
-from .models import Channel, ChannelCount, ChannelLog, ChannelType
+from .models import Channel, ChannelCount, ChannelLog
 
 logger = logging.getLogger(__name__)
 

--- a/templates/channels/channel_configuration.html
+++ b/templates/channels/channel_configuration.html
@@ -15,10 +15,12 @@
     {{ configuration_blurb }}
   {% endif %}
   {% for url in configuration_urls %}
-    <div class="card mt-6 flex-shrink-0">
-      <div class="title">{{ url.label }}</div>
+    <div class="card mt-3 p-4 flex-shrink-0">
+      <div class="text-xl">{{ url.label }}</div>
+      {% if url.help %}
+      <div class="mt-2">{{ url.help }}</div>
+      {% endif %}
       <div class="code inline-block mt-3 whitespace-normal">{{ url.url }}</div>
-      <div class="my-4">{{ url.help }}</div>
     </div>
   {% endfor %}
   {% if show_public_addresses %}

--- a/templates/channels/channel_configuration.html
+++ b/templates/channels/channel_configuration.html
@@ -20,7 +20,7 @@
       {% if url.help %}
       <div class="mt-2">{{ url.help }}</div>
       {% endif %}
-      <div class="code inline-block mt-3 whitespace-normal">{{ url.url }}</div>
+      <div class="code block mt-3 mx-0 whitespace-normal">{{ url.url }}</div>
     </div>
   {% endfor %}
   {% if show_public_addresses %}

--- a/templates/channels/channel_configuration.html
+++ b/templates/channels/channel_configuration.html
@@ -18,7 +18,7 @@
     <div class="card mt-6 flex-shrink-0">
       <div class="title">{{ url.label }}</div>
       <div class="code inline-block mt-3 whitespace-normal">{{ url.url }}</div>
-      <div class="my-4">{{ url.description }}</div>
+      <div class="my-4">{{ url.help }}</div>
     </div>
   {% endfor %}
   {% if show_public_addresses %}


### PR DESCRIPTION
Need a nice way to make config URLs filtered by the channel role - i.e. if you've got an IVR-only Somleng channel, don't show the courier SMS DLR endpoint. Also tweaks styling a little..

<img width="775" alt="Captura de pantalla 2023-08-22 a la(s) 15 31 20" src="https://github.com/nyaruka/rapidpro/assets/675558/5ac08f99-1dd2-4135-9aa1-83ca372fcbc7">

becomes...

<img width="774" alt="Captura de pantalla 2023-08-22 a la(s) 15 35 49" src="https://github.com/nyaruka/rapidpro/assets/675558/10e66707-b97a-492a-b823-734f0dae5f15">


