### PR TITLE
Better channel configuration pages part 2

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -70,6 +70,7 @@ class ConfigUI:
 
             return f"https://{channel.callback_domain}{path}"
 
+    blurb: str
     endpoints: Endpoint
     show_secret: bool = False
 
@@ -115,7 +116,6 @@ class ChannelType(metaclass=ABCMeta):
     config_ui = None
 
     # TODO replace via config_ui
-    configuration_blurb = None
     show_public_addresses = False
     show_config_page = True
 
@@ -223,19 +223,6 @@ class ChannelType(metaclass=ABCMeta):
                 .render(context=Context(self.get_configuration_context_dict(channel)))
             )
         except TemplateDoesNotExist:
-            return ""
-
-    def get_configuration_blurb(self, channel):
-        """
-        Allows ChannelTypes to define the blurb to show on the channel configuration page.
-        """
-        if self.__class__.configuration_blurb is not None:
-            return (
-                Engine.get_default()
-                .from_string(str(self.configuration_blurb))
-                .render(context=Context(dict(channel=channel)))
-            )
-        else:
             return ""
 
     def get_error_ref_url(self, channel, code: str) -> str:

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -73,6 +73,7 @@ class ConfigUI:
     blurb: str = None
     endpoints: tuple[Endpoint] = ()
     show_secret: bool = False
+    show_public_ips: bool = False
 
     def get_used_endpoints(self, channel) -> list:
         """
@@ -115,9 +116,6 @@ class ChannelType(metaclass=ABCMeta):
 
     # the configuration UI - only channel types that aren't configured automatically need this
     config_ui = None
-
-    # TODO replace via config_ui
-    show_public_addresses = False
 
     update_form = None
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1143,6 +1143,10 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "To finish configuring your connection")
         self.assertEqual(f"/settings/channels/{self.ex_channel.uuid}", response.context[TEMBA_MENU_SELECTION])
 
+        # can't view configuration of channel whose type doesn't support it
+        response = self.client.get(reverse("channels.channel_configuration", args=[self.channel.uuid]))
+        self.assertRedirect(response, reverse("channels.channel_read", args=[self.channel.uuid]))
+
         # can't view configuration of channel in other org
         response = self.client.get(reverse("channels.channel_configuration", args=[self.other_org_channel.uuid]))
         self.assertLoginRedirect(response)

--- a/temba/channels/types/africastalking/type.py
+++ b/temba/channels/types/africastalking/type.py
@@ -26,11 +26,11 @@ class AfricasTalkingType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your Africa's Talking connection you'll need to set the following callback URLs on the "
-        "Africa's Talking website under your account."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Africa's Talking connection you'll need to set the following callback URLs on the "
+            "Africa's Talking website under your account."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -48,7 +48,7 @@ class AfricasTalkingType(ChannelType):
                     "then clicking on Delivery Reports."
                 ),
             ),
-        ]
+        ],
     )
 
     available_timezones = [

--- a/temba/channels/types/android/type.py
+++ b/temba/channels/types/android/type.py
@@ -26,7 +26,6 @@ class AndroidType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = -1
     free_sending = False
-    show_config_page = False
 
     def is_recommended_to(self, org, user):
         return False

--- a/temba/channels/types/arabiacell/type.py
+++ b/temba/channels/types/arabiacell/type.py
@@ -24,16 +24,15 @@ class ArabiaCellType(ChannelType):
         "link": '<a target="_blank" href="https://www.arabiacell.com/">ArabiaCell</a>'
     }
 
-    configuration_blurb = _(
-        "To finish connecting your channel, you need to have ArabiaCell configure the URL below for your short code."
-    )
-
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish connecting your channel, you need to have ArabiaCell configure the URL below for your short code."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Receive URL"),
                 help=_("This URL should be called by ArabiaCell when new messages are received."),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/bandwidth/type.py
+++ b/temba/channels/types/bandwidth/type.py
@@ -33,8 +33,6 @@ class BandwidthType(ChannelType):
         "link": '<a target="_blank" href="https://www.bandwidth.com/">Bandwidth</a>'
     }
 
-    show_config_page = False
-
     def activate(self, channel):
         domain = channel.org.get_brand_domain()
         receive_url = "https://" + domain + reverse("courier.bw", args=[channel.uuid, "receive"])

--- a/temba/channels/types/bongolive/type.py
+++ b/temba/channels/types/bongolive/type.py
@@ -26,10 +26,10 @@ class BongoLiveType(ChannelType):
         "link": '<a target="_blank" href="https://www.bongolive.co.tz/">Bongo Live</a>'
     }
 
-    configuration_blurb = _(
-        "To finish connecting your channel, you need to have Bongo Live configure the URLs below for your short code."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish connecting your channel, you need to have Bongo Live configure the URLs below for your short code."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -38,5 +38,5 @@ class BongoLiveType(ChannelType):
                     "This URL should be called by Bongo Live when new messages are received or to report DLR status."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/burstsms/type.py
+++ b/temba/channels/types/burstsms/type.py
@@ -47,10 +47,8 @@ class BurstSMSType(ChannelType):
         "link": '<a target="_blank" href="https://www.burstsms.com.au/">BurstSMS</a>'
     }
 
-    configuration_blurb = _(
-        "To finish connecting your channel, you need to set your callback URLs below for your number."
-    )
     config_ui = ConfigUI(
+        blurb=_("To finish connecting your channel, you need to set your callback URLs below for your number."),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -77,5 +75,5 @@ class BurstSMSType(ChannelType):
                     "You can set it on your settings page."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/clickatell/type.py
+++ b/temba/channels/types/clickatell/type.py
@@ -27,11 +27,11 @@ class ClickatellType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 420
 
-    configuration_blurb = _(
-        "To finish configuring your Clickatell connection you'll need to set the following callback URLs on the "
-        "Clickatell website for your integration."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Clickatell connection you'll need to set the following callback URLs on the "
+            "Clickatell website for your integration."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -51,5 +51,5 @@ class ClickatellType(ChannelType):
                     "target address to the URL below. (leave username and password blank)"
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/clickmobile/type.py
+++ b/temba/channels/types/clickmobile/type.py
@@ -28,13 +28,13 @@ class ClickMobileType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 459
 
-    configuration_blurb = _(
-        "To finish configuring your channel you need to configure Click Mobile to send new messages to the URL below."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your channel you need to configure Click Mobile to send new messages to the URL below."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
-        ]
+        ],
     )
 
     available_timezones = ["Africa/Accra", "Africa/Blantyre"]

--- a/temba/channels/types/clicksend/type.py
+++ b/temba/channels/types/clicksend/type.py
@@ -72,10 +72,8 @@ class ClickSendType(ChannelType):
         "link": '<a target="_blank" href="https://www.clicksend.com/">ClickSend</a>'
     }
 
-    configuration_blurb = _(
-        "To finish connecting your channel, you need to set your inbound SMS URL below for your number."
-    )
     config_ui = ConfigUI(
+        blurb=_("To finish connecting your channel, you need to set your inbound SMS URL below for your number."),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -87,5 +85,5 @@ class ClickSendType(ChannelType):
                     "Add a new rule, select action URL, and use the URL above, then click save."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/dartmedia/type.py
+++ b/temba/channels/types/dartmedia/type.py
@@ -26,8 +26,6 @@ class DartMediaType(ChannelType):
     schemes = [URN.TEL_SCHEME, URN.EXTERNAL_SCHEME]
     max_length = 160
 
-    show_public_addresses = True
-
     config_ui = ConfigUI(
         blurb=_(
             "To finish configuring your Dart Media connection you'll need to provide them with the following details."
@@ -51,6 +49,7 @@ class DartMediaType(ChannelType):
                 ),
             ),
         ],
+        show_public_ips=True,
     )
 
     available_timezones = ["Asia/Jakarta"]

--- a/temba/channels/types/dartmedia/type.py
+++ b/temba/channels/types/dartmedia/type.py
@@ -28,10 +28,10 @@ class DartMediaType(ChannelType):
 
     show_public_addresses = True
 
-    configuration_blurb = _(
-        "To finish configuring your Dart Media connection you'll need to provide them with the following details."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Dart Media connection you'll need to provide them with the following details."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -50,7 +50,7 @@ class DartMediaType(ChannelType):
                     "contacting your sales agent."
                 ),
             ),
-        ]
+        ],
     )
 
     available_timezones = ["Asia/Jakarta"]

--- a/temba/channels/types/dialog360/type.py
+++ b/temba/channels/types/dialog360/type.py
@@ -12,7 +12,7 @@ from temba.request_logs.models import HTTPLog
 from temba.utils.whatsapp import update_api_version
 from temba.utils.whatsapp.views import SyncLogsView, TemplatesView
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class Dialog360Type(ChannelType):
@@ -33,6 +33,8 @@ class Dialog360Type(ChannelType):
         "link": '<a target="_blank" href="https://www.360dialog.com/">360Dialog</a>'
     }
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
 
     schemes = [URN.WHATSAPP_SCHEME]
     max_length = 4096

--- a/temba/channels/types/dialog360_cloud/type.py
+++ b/temba/channels/types/dialog360_cloud/type.py
@@ -11,7 +11,7 @@ from temba.contacts.models import URN
 from temba.request_logs.models import HTTPLog
 from temba.utils.whatsapp.views import SyncLogsView, TemplatesView
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class Dialog360CloudType(ChannelType):
@@ -35,6 +35,8 @@ class Dialog360CloudType(ChannelType):
 
     schemes = [URN.WHATSAPP_SCHEME]
     max_length = 4096
+
+    config_ui = ConfigUI()  # has own template
 
     def get_urls(self):
         return [

--- a/temba/channels/types/discord/type.py
+++ b/temba/channels/types/discord/type.py
@@ -17,7 +17,6 @@ class DiscordType(ChannelType):
     courier_url = r"^ds/(?P<uuid>[a-z0-9\-]+)/receive$"
 
     name = "Discord"
-    show_config_page = False
 
     claim_blurb = _(
         "Add a %(link)s bot to send messages to Discord users for free. "

--- a/temba/channels/types/dmark/type.py
+++ b/temba/channels/types/dmark/type.py
@@ -27,13 +27,11 @@ class DMarkType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 459
 
-    configuration_blurb = _(
-        "To finish configuring your DMark channel you need to set DMark to send MO messages to the URL below."
-    )
     config_ui = ConfigUI(
+        blurb=_("To finish configuring your DMark channel you need to set DMark to send MO messages to the URL below."),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
-        ]
+        ],
     )
 
     available_timezones = ["Africa/Kampala", "Africa/Kinshasa"]

--- a/temba/channels/types/external/type.py
+++ b/temba/channels/types/external/type.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
-from ...models import Channel, ChannelType
+from ...models import Channel, ChannelType, ConfigUI
 from .views import ClaimView, UpdateForm
 
 
@@ -19,6 +19,8 @@ class ExternalType(ChannelType):
 
     claim_blurb = _("Use our pluggable API to connect an external service you already have.")
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
 
     update_form = UpdateForm
 

--- a/temba/channels/types/facebook/type.py
+++ b/temba/channels/types/facebook/type.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.contacts.models import URN
 from temba.triggers.models import Trigger
 
-from ...models import Channel, ChannelType
+from ...models import Channel, ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -27,6 +27,8 @@ class FacebookType(ChannelType):
         """<a target="_blank" href="http://developers.facebook.com">developers</a> site first."""
     )
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
 
     schemes = [URN.FACEBOOK_SCHEME]
     max_length = 320

--- a/temba/channels/types/facebookapp/type.py
+++ b/temba/channels/types/facebookapp/type.py
@@ -25,8 +25,6 @@ class FacebookAppType(ChannelType):
 
     name = "Facebook"
 
-    show_config_page = False
-
     claim_blurb = _(
         "Add a %(link)s bot to send and receive messages on behalf of one of your Facebook pages for free. You will "
         "need to connect your page by logging into your Facebook and checking the Facebook page to connect. "

--- a/temba/channels/types/firebase/type.py
+++ b/temba/channels/types/firebase/type.py
@@ -30,11 +30,11 @@ class FirebaseCloudMessagingType(ChannelType):
     free_sending = True
     quick_reply_text_size = 36
 
-    configuration_blurb = _(
-        "To use your Firebase Cloud Messaging channel you'll have to POST to the following URLs with the "
-        "parameters below."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To use your Firebase Cloud Messaging channel you'll have to POST to the following URLs with the "
+            "parameters below."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="register",
@@ -51,5 +51,5 @@ class FirebaseCloudMessagingType(ChannelType):
                     "To handle incoming messages, POST to the following URL with the parameters from, msg and fcm_token."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/freshchat/type.py
+++ b/temba/channels/types/freshchat/type.py
@@ -26,16 +26,16 @@ class FreshChatType(ChannelType):
     schemes = [URN.FRESHCHAT_SCHEME]
     free_sending = True
 
-    configuration_blurb = _(
-        "To use your FreshChat channel you'll have to configure the FreshChat server to direct "
-        "messages to the url below."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To use your FreshChat channel you'll have to configure the FreshChat server to direct "
+            "messages to the url below."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Receive URL"),
                 help=_("POST FreshChat trigger to this address."),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/globe/type.py
+++ b/temba/channels/types/globe/type.py
@@ -27,14 +27,14 @@ class GlobeType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your Globe Labs connection you'll need to set the following notify URI for SMS on your "
-        "application configuration page."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Globe Labs connection you'll need to set the following notify URI for SMS on your "
+            "application configuration page."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Notify URI")),
-        ]
+        ],
     )
 
     available_timezones = ["Asia/Manila"]

--- a/temba/channels/types/highconnection/type.py
+++ b/temba/channels/types/highconnection/type.py
@@ -27,14 +27,14 @@ class HighConnectionType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 1500
 
-    configuration_blurb = _(
-        "To finish configuring your connection you'll need to notify HighConnection of the following URL for incoming "
-        "(MO) messages."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your connection you'll need to notify HighConnection of the following URL for incoming "
+            "(MO) messages."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
-        ]
+        ],
     )
 
     available_timezones = ["Europe/Paris"]

--- a/temba/channels/types/hormuud/type.py
+++ b/temba/channels/types/hormuud/type.py
@@ -27,14 +27,14 @@ class HormuudType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your connection you'll need to notify Hormuud of the following URL for incoming "
-        "(MO) messages."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your connection you'll need to notify Hormuud of the following URL for incoming "
+            "(MO) messages."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
-        ]
+        ],
     )
 
     available_timezones = ["Africa/Mogadishu"]

--- a/temba/channels/types/hub9/type.py
+++ b/temba/channels/types/hub9/type.py
@@ -24,8 +24,6 @@ class Hub9Type(ChannelType):
     schemes = [URN.TEL_SCHEME, URN.EXTERNAL_SCHEME]
     max_length = 1600
 
-    show_public_addresses = True
-
     config_ui = ConfigUI(
         blurb=_("To finish configuring your Hub9 connection you'll need to provide them with the following details."),
         endpoints=[
@@ -47,6 +45,7 @@ class Hub9Type(ChannelType):
                 ),
             ),
         ],
+        show_public_ips=True,
     )
 
     available_timezones = ["Asia/Jakarta"]

--- a/temba/channels/types/hub9/type.py
+++ b/temba/channels/types/hub9/type.py
@@ -26,10 +26,8 @@ class Hub9Type(ChannelType):
 
     show_public_addresses = True
 
-    configuration_blurb = _(
-        "To finish configuring your Hub9 connection you'll need to provide them with the following details."
-    )
     config_ui = ConfigUI(
+        blurb=_("To finish configuring your Hub9 connection you'll need to provide them with the following details."),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -48,7 +46,7 @@ class Hub9Type(ChannelType):
                     "sales agent."
                 ),
             ),
-        ]
+        ],
     )
 
     available_timezones = ["Asia/Jakarta"]

--- a/temba/channels/types/i2sms/type.py
+++ b/temba/channels/types/i2sms/type.py
@@ -26,11 +26,11 @@ class I2SMSType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your I2SMS channel you'll need to set the message URL for the `DEFAULT` keyword as "
-        "below."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your I2SMS channel you'll need to set the message URL for the `DEFAULT` keyword as "
+            "below."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -41,5 +41,5 @@ class I2SMSType(ChannelType):
                     """Select POST HTTP Variables and check the box for "No URL Output"."""
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/infobip/type.py
+++ b/temba/channels/types/infobip/type.py
@@ -26,11 +26,11 @@ class InfobipType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 1600
 
-    configuration_blurb = _(
-        "To finish configuring your Infobip connection you'll need to set the following callback URLs on the Infobip "
-        "website under your account."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Infobip connection you'll need to set the following callback URLs on the Infobip "
+            "website under your account."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -49,5 +49,5 @@ class InfobipType(ChannelType):
                     "sales agent."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/instagram/type.py
+++ b/temba/channels/types/instagram/type.py
@@ -29,8 +29,6 @@ class InstagramType(ChannelType):
 
     name = "Instagram"
 
-    show_config_page = False
-
     claim_blurb = _("Add an %(link)s bot to send and receive messages on behalf of a business Instagram account.") % {
         "link": '<a target="_blank" href="http://instagram.com">Instagram</a>',
     }

--- a/temba/channels/types/jasmin/type.py
+++ b/temba/channels/types/jasmin/type.py
@@ -26,10 +26,8 @@ class JasminType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 1600
 
-    configuration_blurb = _(
-        "As a last step you'll need to configure Jasmin to call the following URL for MO (incoming) messages."
-    )
     config_ui = ConfigUI(
+        blurb=_("As a last step you'll need to configure Jasmin to call the following URL for MO (incoming) messages."),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -39,5 +37,5 @@ class JasminType(ChannelType):
                     "it must be configured to be called as a POST."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/jiochat/type.py
+++ b/temba/channels/types/jiochat/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -33,7 +33,9 @@ class JioChatType(ChannelType):
         "JioChat Developer Center configuration."
     )
 
-    configuration_urls = (
-        dict(label=_("Webhook URL"), url="https://{{ channel.callback_domain }}{% url 'courier.jc' channel.uuid %}"),
-        dict(label=_("Token"), url="{{ channel.config.secret }}"),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="", label=_("Webhook URL")),
+        ],
+        show_secret=True,
     )

--- a/temba/channels/types/jiochat/type.py
+++ b/temba/channels/types/jiochat/type.py
@@ -28,12 +28,11 @@ class JioChatType(ChannelType):
     max_length = 1600
     free_sending = True
 
-    configuration_blurb = _(
-        "To finish configuring your JioChat connection, you'll need to enter the following webhook URL and token on "
-        "JioChat Developer Center configuration."
-    )
-
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your JioChat connection, you'll need to enter the following webhook URL and token on "
+            "JioChat Developer Center configuration."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="", label=_("Webhook URL")),
         ],

--- a/temba/channels/types/justcall/type.py
+++ b/temba/channels/types/justcall/type.py
@@ -30,8 +30,6 @@ class JustCallType(ChannelType):
         "link": '<a target="_blank" href="https://justcall.io/">JustCall</a>'
     }
 
-    show_config_page = False
-
     def activate(self, channel):
         api_key = channel.config[Channel.CONFIG_API_KEY]
         api_secret = channel.config[Channel.CONFIG_SECRET]

--- a/temba/channels/types/kaleyra/type.py
+++ b/temba/channels/types/kaleyra/type.py
@@ -28,16 +28,16 @@ class KaleyraType(ChannelType):
     schemes = [URN.WHATSAPP_SCHEME]
     max_length = 4096
 
-    configuration_blurb = _(
-        "To finish configuring your Kaleyra connection you'll need to set the following callback URL on your Kaleyra "
-        "account."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Kaleyra connection you'll need to set the following callback URL on your Kaleyra "
+            "account."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Receive URL"),
                 help=_("To receive incoming messages, you need to set the receive URL for your Kaleyra account."),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/kannel/type.py
+++ b/temba/channels/types/kannel/type.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.channels.types.kannel.views import ClaimView
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 
 class KannelType(ChannelType):
@@ -23,6 +23,8 @@ class KannelType(ChannelType):
         "working in a few minutes."
     ) % {"link": '<a target="_blank" href="http://www.kannel.org/">Kannel</a>'}
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
 
     schemes = [URN.TEL_SCHEME]
     max_length = 1600

--- a/temba/channels/types/line/type.py
+++ b/temba/channels/types/line/type.py
@@ -24,13 +24,11 @@ class LineType(ChannelType):
     ) % {"link": '<a target="_blank" href="https://line.me">LINE</a>'}
     claim_view = ClaimView
 
-    config_ui = ConfigUI()  # has own template
+    config_ui = ConfigUI(show_public_ips=True)
 
     schemes = [URN.LINE_SCHEME]
     max_length = 1600
     free_sending = True
-
-    show_public_addresses = True
 
     def get_error_ref_url(self, channel, code: str) -> str:
         return "https://developers.line.biz/en/reference/messaging-api/#error-responses"

--- a/temba/channels/types/line/type.py
+++ b/temba/channels/types/line/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -23,6 +23,8 @@ class LineType(ChannelType):
         "Windows or iOS device and a LINE account to send and receive messages."
     ) % {"link": '<a target="_blank" href="https://line.me">LINE</a>'}
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
 
     schemes = [URN.LINE_SCHEME]
     max_length = 1600

--- a/temba/channels/types/m3tech/type.py
+++ b/temba/channels/types/m3tech/type.py
@@ -26,16 +26,14 @@ class M3TechType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your connection you'll need to notify M3Tech of the following callback URLs."
-    )
     config_ui = ConfigUI(
+        blurb=_("To finish configuring your connection you'll need to notify M3Tech of the following callback URLs."),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Received URL")),
             ConfigUI.Endpoint(courier="sent", label=_("Sent URL")),
             ConfigUI.Endpoint(courier="delivered", label=_("Delivered URL")),
             ConfigUI.Endpoint(courier="failed", label=_("Failed URL")),
-        ]
+        ],
     )
 
     available_timezones = ["Asia/Karachi"]

--- a/temba/channels/types/macrokiosk/type.py
+++ b/temba/channels/types/macrokiosk/type.py
@@ -29,10 +29,10 @@ class MacrokioskType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 1600
 
-    configuration_blurb = _(
-        "To finish configuring your MACROKIOSK connection you'll need to notify MACROKIOSK of the following URLs."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your MACROKIOSK connection you'll need to notify MACROKIOSK of the following URLs."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -46,7 +46,7 @@ class MacrokioskType(ChannelType):
                     "This endpoint should be called by MACROKIOSK when the message status changes. (delivery reports)"
                 ),
             ),
-        ]
+        ],
     )
 
     available_timezones = ["Asia/Kuala_Lumpur"]

--- a/temba/channels/types/mblox/type.py
+++ b/temba/channels/types/mblox/type.py
@@ -27,8 +27,8 @@ class MbloxType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 459
 
-    configuration_blurb = _("As a last step you'll need to set the following callback URL on your Mblox account.")
     config_ui = ConfigUI(
+        blurb=_("As a last step you'll need to set the following callback URL on your Mblox account."),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -38,5 +38,5 @@ class MbloxType(ChannelType):
                     "reports."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/messagebird/type.py
+++ b/temba/channels/types/messagebird/type.py
@@ -28,12 +28,13 @@ class MessageBirdType(ChannelType):
     schemes = [URN.TEL_SCHEME]
 
     available_timezones = SUPPORTED_TIMEZONES
-    configuration_blurb = _(
-        "To use your Messagebird channel you'll have to configure the Messagebird to send raw received SMS messages to "
-        "the URL below either with a flow or by registering the webhook with them. Configure the status URL under "
-        "Developer Settings to receive status updates for your messages."
-    )
+
     config_ui = ConfigUI(
+        blurb=_(
+            "To use your Messagebird channel you'll have to configure the Messagebird to send raw received SMS messages to "
+            "the URL below either with a flow or by registering the webhook with them. Configure the status URL under "
+            "Developer Settings to receive status updates for your messages."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -45,5 +46,5 @@ class MessageBirdType(ChannelType):
                 label=_("Status URL"),
                 help=_("Webhook address for message status calls to this address."),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/messangi/type.py
+++ b/temba/channels/types/messangi/type.py
@@ -33,18 +33,18 @@ class MessangiType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 150
 
-    configuration_blurb = _(
-        "To finish configuring your Messangi connection you'll need to set the following callback URLs on your Messangi"
-        " account."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Messangi connection you'll need to set the following callback URLs on your Messangi"
+            " account."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Receive URL"),
                 help=_("To receive incoming messages, you need to set the receive URL for your Messangi account."),
             ),
-        ]
+        ],
     )
 
     available_timezones = ["America/Jamaica"]

--- a/temba/channels/types/mtarget/type.py
+++ b/temba/channels/types/mtarget/type.py
@@ -29,12 +29,12 @@ class MtargetType(ChannelType):
         "link": '<a target="_blank" href="https://www.mtarget.fr/">Mtarget</a>'
     }
 
-    configuration_blurb = _(
-        "To finish connecting your channel, you need to have Mtarget configure the URLs below for your Service ID."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish connecting your channel, you need to have Mtarget configure the URLs below for your Service ID."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
             ConfigUI.Endpoint(courier="status", label=_("Status URL")),
-        ]
+        ],
     )

--- a/temba/channels/types/mtn/type.py
+++ b/temba/channels/types/mtn/type.py
@@ -34,7 +34,6 @@ class MtnType(ChannelType):
 
     schemes = [URN.TEL_SCHEME]
     max_length = 160
-    show_config_page = False
     async_activation = False
 
     def get_token(self, channel):

--- a/temba/channels/types/novo/type.py
+++ b/temba/channels/types/novo/type.py
@@ -30,13 +30,14 @@ class NovoType(ChannelType):
     max_length = 160
 
     config_ui = ConfigUI(
+        blurb="",
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Receive URL"),
                 help=_("To receive incoming messages, you need to set the receive URL for your Novo account."),
             ),
-        ]
+        ],
     )
 
     available_timezones = ["America/Port_of_Spain"]

--- a/temba/channels/types/novo/type.py
+++ b/temba/channels/types/novo/type.py
@@ -30,7 +30,6 @@ class NovoType(ChannelType):
     max_length = 160
 
     config_ui = ConfigUI(
-        blurb="",
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",

--- a/temba/channels/types/playmobile/type.py
+++ b/temba/channels/types/playmobile/type.py
@@ -27,15 +27,15 @@ class PlayMobileType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your Play Mobile connection you'll need to notify Play Mobile of the following URL."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Play Mobile connection you'll need to notify Play Mobile of the following URL."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Receive URL"),
                 help=_("To receive incoming messages, you need to set the receive URL for your Play Mobile account."),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/plivo/type.py
+++ b/temba/channels/types/plivo/type.py
@@ -31,8 +31,6 @@ class PlivoType(ChannelType):
     }
     claim_view = ClaimView
 
-    show_config_page = False
-
     schemes = [URN.TEL_SCHEME]
     max_length = 1600
 

--- a/temba/channels/types/redrabbit/tests.py
+++ b/temba/channels/types/redrabbit/tests.py
@@ -36,11 +36,8 @@ class RedRabbitTypeTest(TembaTest):
         self.assertEqual("+250788123123", channel.address)
         self.assertEqual("RR", channel.channel_type)
 
-        config_url = reverse("channels.channel_configuration", args=[channel.uuid])
-        self.assertRedirect(response, config_url)
-
-        response = self.client.get(config_url)
-        self.assertEqual(200, response.status_code)
+        read_url = reverse("channels.channel_read", args=[channel.uuid])
+        self.assertRedirect(response, read_url)
 
         Channel.objects.all().delete()
 

--- a/temba/channels/types/rocketchat/type.py
+++ b/temba/channels/types/rocketchat/type.py
@@ -25,8 +25,6 @@ class RocketChatType(ChannelType):
 
     name = "Rocket.Chat"
 
-    show_config_page = False
-
     claim_blurb = _("Add a %(link)s bot to send and receive messages to Rocket.Chat users.") % {
         "link": '<a target="_blank" href="https://rocket.chat/">Rocket.Chat</a>'
     }

--- a/temba/channels/types/shaqodoon/type.py
+++ b/temba/channels/types/shaqodoon/type.py
@@ -26,13 +26,13 @@ class ShaqodoonType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 1600
 
-    configuration_blurb = _(
-        "To finish configuring your Shaqodoon connection you'll need to provide Shaqodoon with the following delivery URL."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Shaqodoon connection you'll need to provide Shaqodoon with the following delivery URL."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Receive URL")),
-        ]
+        ],
     )
 
     available_timezones = ["Africa/Mogadishu"]

--- a/temba/channels/types/signalwire/type.py
+++ b/temba/channels/types/signalwire/type.py
@@ -78,15 +78,15 @@ class SignalWireType(ChannelType):
 
     async_activation = False
 
-    configuration_blurb = _("Your SignalWire channel is now connected.")
     config_ui = ConfigUI(
+        blurb=_("Your SignalWire channel is now connected."),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Inbound URL"),
                 help=_("This endpoint will be called by SignalWire when new messages are received to your number."),
             ),
-        ]
+        ],
     )
 
     def deactivate(self, channel):

--- a/temba/channels/types/slack/type.py
+++ b/temba/channels/types/slack/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -26,5 +26,6 @@ class SlackType(ChannelType):
     claim_blurb = _("Add a %(link)s bot to send and receive messages to Slack users, on your slack workspace.") % {
         "link": '<a target="_blank" href="https://slack.com">Slack</a>'
     }
-
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template

--- a/temba/channels/types/smscentral/type.py
+++ b/temba/channels/types/smscentral/type.py
@@ -27,17 +27,17 @@ class SMSCentralType(ChannelType):
     max_length = 1600
     max_tps = 1
 
-    configuration_blurb = _(
-        "To finish configuring your SMSCentral connection you'll need to notify SMSCentral of the following URL."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your SMSCentral connection you'll need to notify SMSCentral of the following URL."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Inbound URL"),
                 help=_("This endpoint should be called by SMSCentral when new messages are received to your number."),
             ),
-        ]
+        ],
     )
 
     available_timezones = ["Asia/Kathmandu"]

--- a/temba/channels/types/somleng/type.py
+++ b/temba/channels/types/somleng/type.py
@@ -37,10 +37,10 @@ class SomlengType(ChannelType):
     claim_view = ClaimView
     claim_blurb = _("Connect to a Somleng instance.")
 
-    configuration_blurb = _(
-        "To finish configuring your Somleng channel you'll need to add the following URL to your Somleng instance."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Somleng channel you'll need to add the following URL to your Somleng instance."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -66,7 +66,7 @@ class SomlengType(ChannelType):
                 help=_("Call status updates should be sent to this endpoint."),
                 roles=(Channel.ROLE_CALL, Channel.ROLE_ANSWER),
             ),
-        ]
+        ],
     )
 
     def get_error_ref_url(self, channel, code: str) -> str:

--- a/temba/channels/types/start/type.py
+++ b/temba/channels/types/start/type.py
@@ -26,17 +26,15 @@ class StartType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 1600
 
-    configuration_blurb = _(
-        "To finish configuring this channel you'll need to notify Start of the following receiving URL."
-    )
     config_ui = ConfigUI(
+        blurb=_("To finish configuring this channel you'll need to notify Start of the following receiving URL."),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Inbound URL"),
                 help=_("This endpoint should be called by when new messages are received to your number."),
             ),
-        ]
+        ],
     )
 
     available_timezones = ["Europe/Kiev"]

--- a/temba/channels/types/telegram/type.py
+++ b/temba/channels/types/telegram/type.py
@@ -21,8 +21,6 @@ class TelegramType(ChannelType):
 
     name = "Telegram"
 
-    show_config_page = False
-
     claim_blurb = _(
         "Add a %(link)s bot to send and receive messages to Telegram users for free. Your users will need an Android, "
         "Windows or iOS device and a Telegram account to send and receive messages."

--- a/temba/channels/types/telesom/type.py
+++ b/temba/channels/types/telesom/type.py
@@ -26,14 +26,14 @@ class TelesomType(ChannelType):
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
-    configuration_blurb = _(
-        "To finish configuring your Telesom connection you'll need to provide Telesom with the following delivery URL "
-        "for incoming messages."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Telesom connection you'll need to provide Telesom with the following delivery URL "
+            "for incoming messages."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Delivery URL")),
-        ]
+        ],
     )
 
     available_timezones = ["Africa/Mogadishu"]

--- a/temba/channels/types/thinq/type.py
+++ b/temba/channels/types/thinq/type.py
@@ -33,11 +33,11 @@ class ThinQType(ChannelType):
     CONFIG_API_TOKEN_USER = "api_token_user"
     CONFIG_API_TOKEN = "api_token"
 
-    configuration_blurb = _(
-        "To finish configuring your ThinQ connection you'll need to set the following callback URLs on the ThinQ "
-        "website on the SMS -> SMS Configuration page."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your ThinQ connection you'll need to set the following callback URLs on the ThinQ "
+            "website on the SMS -> SMS Configuration page."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -53,7 +53,7 @@ class ThinQType(ChannelType):
                     """Set your Delivery Confirmation URL to the above, making sure you select "Form-Data" as the Delivery Notification Format."""
                 ),
             ),
-        ]
+        ],
     )
 
     def is_available_to(self, org, user):

--- a/temba/channels/types/thinq/type.py
+++ b/temba/channels/types/thinq/type.py
@@ -24,8 +24,6 @@ class ThinQType(ChannelType):
     ) % {"link": '<a target="_blank" href="https://thinq.com">ThinQ</a>'}
     claim_view = ClaimView
 
-    show_public_addresses = True
-
     schemes = [URN.TEL_SCHEME]
     max_length = 160
 
@@ -54,6 +52,7 @@ class ThinQType(ChannelType):
                 ),
             ),
         ],
+        show_public_ips=True,
     )
 
     def is_available_to(self, org, user):

--- a/temba/channels/types/twilio/type.py
+++ b/temba/channels/types/twilio/type.py
@@ -21,7 +21,6 @@ class TwilioType(ChannelType):
 
     code = "T"
     category = ChannelType.Category.PHONE
-    show_config_page = False
 
     courier_url = r"^t/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive|status)$"
 

--- a/temba/channels/types/twilio_messaging_service/type.py
+++ b/temba/channels/types/twilio_messaging_service/type.py
@@ -34,11 +34,11 @@ class TwilioMessagingServiceType(ChannelType):
         "You can connect a messaging service from your Twilio account to benefit from %(link)s features."
     ) % {"link": '<a target="_blank" href="https://www.twilio.com/copilot">Twilio Copilot</a>'}
 
-    configuration_blurb = _(
-        "To finish configuring your Twilio Messaging Service connection you'll need to add the following URL in your "
-        "Messaging Service Inbound Settings."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Twilio Messaging Service connection you'll need to add the following URL in your "
+            "Messaging Service Inbound Settings."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -47,7 +47,7 @@ class TwilioMessagingServiceType(ChannelType):
                     "This endpoint should be called by Twilio when new messages are received by your Messaging Service."
                 ),
             ),
-        ]
+        ],
     )
 
     schemes = [URN.TEL_SCHEME]

--- a/temba/channels/types/twilio_whatsapp/type.py
+++ b/temba/channels/types/twilio_whatsapp/type.py
@@ -33,18 +33,18 @@ class TwilioWhatsappType(ChannelType):
     schemes = [URN.WHATSAPP_SCHEME]
     max_length = 1600
 
-    configuration_blurb = _(
-        "To finish configuring your Twilio WhatsApp connection you'll need to add the following URL in your Twilio "
-        "Inbound Settings. Check the Twilio WhatsApp documentation for more information."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Twilio WhatsApp connection you'll need to add the following URL in your Twilio "
+            "Inbound Settings. Check the Twilio WhatsApp documentation for more information."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
                 label=_("Request URL"),
                 help=_("This endpoint should be called by Twilio when new messages are received by your number."),
             ),
-        ]
+        ],
     )
 
     redact_request_keys = (

--- a/temba/channels/types/twitter/type.py
+++ b/temba/channels/types/twitter/type.py
@@ -35,7 +35,6 @@ class TwitterType(ChannelType):
     update_form = UpdateForm
 
     schemes = [URN.TWITTER_SCHEME, URN.TWITTERID_SCHEME]
-    show_config_page = False
     free_sending = True
     async_activation = False
 

--- a/temba/channels/types/verboice/type.py
+++ b/temba/channels/types/verboice/type.py
@@ -21,14 +21,14 @@ class VerboiceType(ChannelType):
     max_length = 1600
     schemes = [URN.TEL_SCHEME]
 
-    configuration_blurb = _(
-        "To finish configuring your connection you'll need to set the following status callback URL for your Verboice "
-        "project"
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your connection you'll need to set the following status callback URL for your Verboice "
+            "project"
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="status", label=_("Status Callback URL")),
-        ]
+        ],
     )
 
     def is_available_to(self, org, user):

--- a/temba/channels/types/viber_public/type.py
+++ b/temba/channels/types/viber_public/type.py
@@ -35,11 +35,11 @@ class ViberPublicType(ChannelType):
         "an Android, Windows or iOS device and a Viber account to send and receive messages."
     ) % {"link": '<a target="_blank" href="http://viber.com/en/">Viber</a>'}
 
-    configuration_blurb = _("Your Viber channel is connected. If needed the webhook endpoints are listed below.")
     config_ui = ConfigUI(
+        blurb=_("Your Viber channel is connected. If needed the webhook endpoints are listed below."),
         endpoints=[
             ConfigUI.Endpoint(courier="receive", label=_("Webhook URL")),
-        ]
+        ],
     )
 
     def activate(self, channel):

--- a/temba/channels/types/vk/type.py
+++ b/temba/channels/types/vk/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 CONFIG_COMMUNITY_NAME = "community_name"
@@ -28,6 +28,8 @@ class VKType(ChannelType):
         "an access token for your community first."
     ) % {"link": '<a target="_blank" href="https://vk.com/">VK</a>'}
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
 
     schemes = [URN.VK_SCHEME]
     max_length = 320

--- a/temba/channels/types/vonage/type.py
+++ b/temba/channels/types/vonage/type.py
@@ -74,11 +74,11 @@ class VonageType(ChannelType):
     max_length = 1600
     max_tps = 1
 
-    configuration_blurb = _(
-        "Your Vonage configuration URLs are as follows. These should have been set up automatically when claiming your "
-        "number, but if not you can set them from your Vonage dashboard."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "Your Vonage configuration URLs are as follows. These should have been set up automatically when claiming your "
+            "number, but if not you can set them from your Vonage dashboard."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -95,7 +95,7 @@ class VonageType(ChannelType):
                 label=_("Callback URL for Incoming Call"),
                 help=_("The callback URL is called by Vonage when you receive an incoming call."),
             ),
-        ]
+        ],
     )
 
     def is_recommended_to(self, org, user):

--- a/temba/channels/types/wavy/type.py
+++ b/temba/channels/types/wavy/type.py
@@ -43,10 +43,10 @@ class WavyType(ChannelType):
         "link": '<a target="_blank" href="https://wavy.global/en/">Movile/Wavy</a>'
     }
 
-    configuration_blurb = _(
-        "To finish connecting your channel, you need to have Movile/Wavy configure the URL below for your number."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish connecting your channel, you need to have Movile/Wavy configure the URL below for your number."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -69,5 +69,5 @@ class WavyType(ChannelType):
                     "account."
                 ),
             ),
-        ]
+        ],
     )

--- a/temba/channels/types/wechat/tests.py
+++ b/temba/channels/types/wechat/tests.py
@@ -42,7 +42,7 @@ class WeChatTypeTest(TembaTest):
         response = self.client.get(config_url)
         self.assertEqual(200, response.status_code)
 
-        self.assertContains(response, reverse("courier.wc", args=[channel.uuid]))
+        self.assertContains(response, f"https://app.rapidpro.io/c/wc/{channel.uuid}/")
         self.assertContains(response, channel.config[Channel.CONFIG_SECRET])
 
         # check we show the IP to whitelist

--- a/temba/channels/types/wechat/type.py
+++ b/temba/channels/types/wechat/type.py
@@ -30,12 +30,11 @@ class WeChatType(ChannelType):
 
     show_public_addresses = True
 
-    configuration_blurb = _(
-        "To finish configuring your WeChat connection, you'll need to enter the following webhook URL and token on "
-        "WeChat Official Accounts Platform."
-    )
-
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your WeChat connection, you'll need to enter the following webhook URL and token on "
+            "WeChat Official Accounts Platform."
+        ),
         endpoints=[
             ConfigUI.Endpoint(courier="", label=_("Webhook URL")),
         ],

--- a/temba/channels/types/wechat/type.py
+++ b/temba/channels/types/wechat/type.py
@@ -28,8 +28,6 @@ class WeChatType(ChannelType):
     max_length = 1600
     free_sending = True
 
-    show_public_addresses = True
-
     config_ui = ConfigUI(
         blurb=_(
             "To finish configuring your WeChat connection, you'll need to enter the following webhook URL and token on "
@@ -39,4 +37,5 @@ class WeChatType(ChannelType):
             ConfigUI.Endpoint(courier="", label=_("Webhook URL")),
         ],
         show_secret=True,
+        show_public_ips=True,
     )

--- a/temba/channels/types/wechat/type.py
+++ b/temba/channels/types/wechat/type.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.contacts.models import URN
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 from .views import ClaimView
 
 
@@ -35,7 +35,9 @@ class WeChatType(ChannelType):
         "WeChat Official Accounts Platform."
     )
 
-    configuration_urls = (
-        dict(label=_("Webhook URL"), url="https://{{ channel.callback_domain }}{% url 'courier.wc' channel.uuid %}"),
-        dict(label=_("Token"), url="{{ channel.config.secret }}"),
+    config_ui = ConfigUI(
+        endpoints=[
+            ConfigUI.Endpoint(courier="", label=_("Webhook URL")),
+        ],
+        show_secret=True,
     )

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -13,7 +13,7 @@ from temba.templates.models import TemplateTranslation
 from temba.utils.whatsapp import update_api_version
 from temba.utils.whatsapp.views import RefreshView, SyncLogsView, TemplatesView
 
-from ...models import ChannelType
+from ...models import ChannelType, ConfigUI
 
 CONFIG_FB_BUSINESS_ID = "fb_business_id"
 CONFIG_FB_ACCESS_TOKEN = "fb_access_token"
@@ -41,6 +41,8 @@ class WhatsAppType(ChannelType):
 
     claim_blurb = _("If you have an enterprise WhatsApp account, you can connect it to communicate with your contacts")
     claim_view = ClaimView
+
+    config_ui = ConfigUI()  # has own template
 
     schemes = [URN.WHATSAPP_SCHEME]
     max_length = 4096

--- a/temba/channels/types/whatsapp_cloud/type.py
+++ b/temba/channels/types/whatsapp_cloud/type.py
@@ -34,8 +34,6 @@ class WhatsAppCloudType(ChannelType):
 
     name = "WhatsApp Cloud"
 
-    show_config_page = False
-
     claim_blurb = _("If you have an enterprise WhatsApp account, you can connect it to communicate with your contacts")
     claim_view = ClaimView
 

--- a/temba/channels/types/yo/type.py
+++ b/temba/channels/types/yo/type.py
@@ -29,10 +29,10 @@ class YoType(ChannelType):
         "If you are based in Uganda, you can integrate with %(link)s to send and receive messages on your short code."
     ) % {"link": '<a target="_blank" href="http://www.yo.co.ug/">Yo!</a>'}
 
-    configuration_blurb = _(
-        "To finish configuring your Yo! connection you'll need to notify Yo! of the following inbound SMS URL."
-    )
     config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring your Yo! connection you'll need to notify Yo! of the following inbound SMS URL."
+        ),
         endpoints=[
             ConfigUI.Endpoint(
                 courier="receive",
@@ -42,7 +42,7 @@ class YoType(ChannelType):
                     "messages are received on your short code."
                 ),
             ),
-        ]
+        ],
     )
 
     def is_recommended_to(self, org, user):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -937,11 +937,11 @@ class ChannelCRUDL(SmartCRUDL):
         def derive_menu_path(self):
             return f"/settings/channels/{self.object.uuid}"
 
-        def get_type_template(self, channel):
+        def get_blurb_from_template(self, channel) -> str:
             try:
                 return (
                     Engine.get_default()
-                    .get_template("channels/types/%s/config.html" % self.slug)
+                    .get_template("channels/types/%s/config.html" % channel.type.slug)
                     .render(context=Context(channel.type.get_configuration_context_dict(channel)))
                 )
             except TemplateDoesNotExist:
@@ -959,12 +959,10 @@ class ChannelCRUDL(SmartCRUDL):
             else:
                 secret = None
 
-            context["type_template"] = self.get_type_template(self.object)
-            context["blurb"] = self.object.type.config_ui.blurb
+            context["blurb"] = self.get_blurb_from_template(self.object) or self.object.type.config_ui.blurb
             context["endpoints"] = endpoints
             context["secret"] = secret
-            context["show_public_addresses"] = self.object.type.show_public_addresses
-            context["ip_addresses"] = settings.IP_ADDRESSES
+            context["ip_addresses"] = settings.IP_ADDRESSES if self.object.type.config_ui.show_public_ips else None
 
             return context
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -25,7 +25,6 @@ from django.core.exceptions import ValidationError
 from django.db.models import Sum
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
-from django.template import Context, Engine
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -935,7 +934,10 @@ class ChannelCRUDL(SmartCRUDL):
                 return channel.secret or channel.config.get("secret")
             return None
 
-        def get_configuration_urls(self, channel) -> list:
+        def get_blurb(self, channel):
+            return channel.type.config_ui.blurb if channel.type.config_ui else ""
+
+        def get_endpoints(self, channel) -> list:
             urls = []
 
             if channel.type.config_ui:
@@ -952,8 +954,8 @@ class ChannelCRUDL(SmartCRUDL):
             # populate with our channel type
             channel_type = Channel.get_type_from_code(self.object.channel_type)
             context["configuration_template"] = channel_type.get_configuration_template(self.object)
-            context["configuration_blurb"] = channel_type.get_configuration_blurb(self.object)
-            context["configuration_urls"] = self.get_configuration_urls(self.object)
+            context["configuration_blurb"] = self.get_blurb(self.object)
+            context["configuration_urls"] = self.get_endpoints(self.object)
             context["configuration_secret"] = self.get_secret(self.object)
             context["show_public_addresses"] = channel_type.show_public_addresses
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -25,6 +25,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Sum
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
+from django.template import Context, Engine, TemplateDoesNotExist
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -103,7 +104,7 @@ class ClaimViewMixin(ChannelTypeMixin, OrgPermsMixin, ComponentFormMixin):
         return kwargs
 
     def get_success_url(self):
-        if self.channel_type.show_config_page:
+        if self.channel_type.config_ui:
             return reverse("channels.channel_configuration", args=[self.object.uuid])
         else:
             return reverse("channels.channel_read", args=[self.object.uuid])
@@ -487,7 +488,7 @@ class ChannelCRUDL(SmartCRUDL):
             if obj.parent:  # pragma: no cover
                 menu.add_link(_("Android Channel"), reverse("channels.channel_read", args=[obj.parent.uuid]))
 
-            if obj.type.show_config_page:
+            if obj.type.config_ui:
                 menu.add_link(_("Configuration"), reverse("channels.channel_configuration", args=[obj.uuid]))
 
             menu.add_link(_("Logs"), reverse("channels.channellog_list", args=[obj.uuid]))
@@ -926,38 +927,44 @@ class ChannelCRUDL(SmartCRUDL):
     class Configuration(SpaMixin, OrgObjPermsMixin, SmartReadView):
         slug_url_kwarg = "uuid"
 
+        def pre_process(self, *args, **kwargs):
+            channel = self.get_object()
+            if not channel.type.config_ui:
+                return HttpResponseRedirect(reverse("channels.channel_read", args=[channel.uuid]))
+
+            return super().pre_process(*args, **kwargs)
+
         def derive_menu_path(self):
             return f"/settings/channels/{self.object.uuid}"
 
-        def get_secret(self, channel) -> str:
-            if channel.type.config_ui and channel.type.config_ui.show_secret:
-                return channel.secret or channel.config.get("secret")
-            return None
-
-        def get_blurb(self, channel):
-            return channel.type.config_ui.blurb if channel.type.config_ui else ""
-
-        def get_endpoints(self, channel) -> list:
-            urls = []
-
-            if channel.type.config_ui:
-                for endpoint in channel.type.config_ui.get_used_endpoints(channel):
-                    urls.append(dict(url=endpoint.get_url(channel), label=endpoint.label, help=endpoint.help))
-
-            return urls
+        def get_type_template(self, channel):
+            try:
+                return (
+                    Engine.get_default()
+                    .get_template("channels/types/%s/config.html" % self.slug)
+                    .render(context=Context(channel.type.get_configuration_context_dict(channel)))
+                )
+            except TemplateDoesNotExist:
+                return None
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
-            context["domain"] = self.object.callback_domain
-            context["ip_addresses"] = settings.IP_ADDRESSES
 
-            # populate with our channel type
-            channel_type = Channel.get_type_from_code(self.object.channel_type)
-            context["configuration_template"] = channel_type.get_configuration_template(self.object)
-            context["configuration_blurb"] = self.get_blurb(self.object)
-            context["configuration_urls"] = self.get_endpoints(self.object)
-            context["configuration_secret"] = self.get_secret(self.object)
-            context["show_public_addresses"] = channel_type.show_public_addresses
+            endpoints = []
+            for endpoint in self.object.type.config_ui.get_used_endpoints(self.object):
+                endpoints.append(dict(url=endpoint.get_url(self.object), label=endpoint.label, help=endpoint.help))
+
+            if self.object.type.config_ui.show_secret:
+                secret = self.object.secret or self.object.config.get("secret")
+            else:
+                secret = None
+
+            context["type_template"] = self.get_type_template(self.object)
+            context["blurb"] = self.object.type.config_ui.blurb
+            context["endpoints"] = endpoints
+            context["secret"] = secret
+            context["show_public_addresses"] = self.object.type.show_public_addresses
+            context["ip_addresses"] = settings.IP_ADDRESSES
 
             return context
 

--- a/templates/channels/channel_configuration.html
+++ b/templates/channels/channel_configuration.html
@@ -23,6 +23,12 @@
       <div class="code block mt-3 mx-0 whitespace-normal">{{ url.url }}</div>
     </div>
   {% endfor %}
+  {% if configuration_secret %}
+    <div class="card mt-3 p-4 flex-shrink-0">
+      <div class="text-xl">{% trans "Webhook Secret" %}</div>
+      <div class="code block mt-3 mx-0 whitespace-normal">{{ configuration_secret }}</div>
+    </div>
+  {% endif %}
   {% if show_public_addresses %}
     <div class="mt-6 card flex-shrink-0">
       <div class="title">{% trans "IP Addresses" %}</div>

--- a/templates/channels/channel_configuration.html
+++ b/templates/channels/channel_configuration.html
@@ -9,24 +9,24 @@
   {% if object.get_country_display %}<div class="text-base">{{ object.get_country_display }}</div>{% endif %}
 {% endblock subtitle %}
 {% block content %}
-  {% if configuration_template %}
-    {{ configuration_template }}
-  {% elif configuration_blurb %}
-    {{ configuration_blurb }}
+  {% if type_template %}
+    {{ type_template }}
+  {% elif blurb %}
+    {{ blurb }}
   {% endif %}
-  {% for url in configuration_urls %}
+  {% for endpoint in endpoints %}
     <div class="card mt-3 p-4 flex-shrink-0">
-      <div class="text-xl">{{ url.label }}</div>
+      <div class="text-xl">{{ endpoint.label }}</div>
       {% if url.help %}
-      <div class="mt-2">{{ url.help }}</div>
+      <div class="mt-2">{{ endpoint.help }}</div>
       {% endif %}
-      <div class="code block mt-3 mx-0 whitespace-normal">{{ url.url }}</div>
+      <div class="code block mt-3 mx-0 whitespace-normal">{{ endpoint.url }}</div>
     </div>
   {% endfor %}
-  {% if configuration_secret %}
+  {% if secret %}
     <div class="card mt-3 p-4 flex-shrink-0">
       <div class="text-xl">{% trans "Webhook Secret" %}</div>
-      <div class="code block mt-3 mx-0 whitespace-normal">{{ configuration_secret }}</div>
+      <div class="code block mt-3 mx-0 whitespace-normal">{{ secret }}</div>
     </div>
   {% endif %}
   {% if show_public_addresses %}

--- a/templates/channels/channel_configuration.html
+++ b/templates/channels/channel_configuration.html
@@ -9,11 +9,7 @@
   {% if object.get_country_display %}<div class="text-base">{{ object.get_country_display }}</div>{% endif %}
 {% endblock subtitle %}
 {% block content %}
-  {% if type_template %}
-    {{ type_template }}
-  {% elif blurb %}
-    {{ blurb }}
-  {% endif %}
+  {{ blurb }}
   {% for endpoint in endpoints %}
     <div class="card mt-3 p-4 flex-shrink-0">
       <div class="text-xl">{{ endpoint.label }}</div>
@@ -29,12 +25,12 @@
       <div class="code block mt-3 mx-0 whitespace-normal">{{ secret }}</div>
     </div>
   {% endif %}
-  {% if show_public_addresses %}
-    <div class="mt-6 card flex-shrink-0">
-      <div class="title">{% trans "IP Addresses" %}</div>
-      <div class="mt-2">{% trans "Additionally you will need to make sure the following IP addresses are whitelisted" %}</div>
+  {% if ip_addresses %}
+  <div class="card mt-3 p-4 flex-shrink-0">
+      <div class="text-xl">{% trans "IP Addresses" %}</div>
+      <div class="mt-2">{% trans "Ensure the following IP addresses are whitelisted." %}</div>
       <div class="mt-2">
-        {% for ip_address in ip_addresses %}<div class="code inline mr-1">{{ ip_address }}</div>{% endfor %}
+        {% for addr in ip_addresses %}<div class="code inline mr-1">{{ addr }}</div>{% endfor %}
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
 * Replace `configuration_urls` with `ConfigUI.endpoints` on remaining channel types
 * Add `ConfigUI.show_secret` to replace where secret was being stuffed into `configuration_urls`
 * Replace `configuration_blurb` with `ConfigUI.blurb`
 * Replace `show_public_addreses` with `ConfigUI.show_public_ips`
 * Replace `show_config_page` with checking if `config_ui` is set (empty `ConfigUI` set on types that just use a template)