### PR TITLE
Fetching messages by label should include archived messages

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -4213,11 +4213,11 @@ class EndpointsTest(APITest):
 
         # filter by label name
         response = self.getJSON(msgs_url, "label=Spam")
-        self.assertResultsById(response, [joe_msg3, frank_msg1])
+        self.assertResultsById(response, [frank_msg3, joe_msg3, frank_msg1])
 
         # filter by label UUID
         response = self.getJSON(msgs_url, "label=%s" % label.uuid)
-        self.assertResultsById(response, [joe_msg3, frank_msg1])
+        self.assertResultsById(response, [frank_msg3, joe_msg3, frank_msg1])
 
         # filter by invalid label
         response = self.getJSON(msgs_url, "label=invalid")

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2640,7 +2640,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
             if contact:
                 queryset = queryset.filter(contact=contact)
             else:
-                queryset = queryset.filter(pk=-1)
+                queryset = queryset.none()
 
         # filter by label name/uuid (optional)
         label_ref = params.get("label")
@@ -2651,16 +2651,16 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
 
             label = Label.get_active_for_org(org).filter(label_filter).first()
             if label:
-                queryset = queryset.filter(labels=label, visibility=Msg.VISIBILITY_VISIBLE)
+                queryset = queryset.filter(labels=label)
             else:
-                queryset = queryset.filter(pk=-1)
+                queryset = queryset.none()
 
         # use prefetch rather than select_related for foreign keys to avoid joins
         queryset = queryset.prefetch_related(
             Prefetch("contact", queryset=Contact.objects.only("uuid", "name")),
             Prefetch("contact_urn", queryset=ContactURN.objects.only("scheme", "path", "display")),
             Prefetch("channel", queryset=Channel.objects.only("uuid", "name")),
-            Prefetch("labels", queryset=Label.objects.only("uuid", "name").order_by("pk")),
+            Prefetch("labels", queryset=Label.objects.only("uuid", "name").order_by("id")),
             Prefetch("flow", queryset=Flow.objects.only("uuid", "name")),
         )
 


### PR DESCRIPTION
I think the reason it doesn't is because the first version of CasePro fetched its message views on the fly from RP and it needed it to be this way. I don't see anyone calling the API endpoint with the label param currently.