### PR TITLE
Add 'Send Now' to broadcast creation

### DIFF
--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2069,7 +2069,14 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.process_wizard(
             "update",
             update_url,
-            get_broadcast_form_data(self.org, updated_text, [], [self.joe], "2021-06-24 12:00", "W", ["M", "F"]),
+            get_broadcast_form_data(
+                self.org,
+                updated_text,
+                contacts=[self.joe],
+                start_datetime="2021-06-24 12:00",
+                repeat_period="W",
+                repeat_days_of_week=["M", "F"],
+            ),
         )
         self.assertEqual(302, response.status_code)
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -146,8 +146,10 @@ class MsgListView(ContentMenuMixin, BulkActionMixin, SystemLabelView):
         return context
 
     def build_content_menu(self, menu):
-        if self.has_org_perm("msgs.broadcast_send"):
-            menu.add_modax(_("Send Message"), "send-message", reverse("msgs.broadcast_send"), title=_("Send Message"))
+        if self.has_org_perm("msgs.broadcast_create"):
+            menu.add_modax(
+                _("New Broadcast"), "send-message", reverse("msgs.broadcast_create"), title=_("New Broadcast")
+            )
         if self.has_org_perm("msgs.label_create"):
             menu.add_modax(_("New Label"), "new-msg-label", reverse("msgs.label_create"), title=_("New Label"))
 
@@ -179,9 +181,29 @@ class ComposeForm(Form):
 
 
 class ScheduleForm(ScheduleFormMixin):
+    SEND_NOW = "now"
+    SEND_LATER = "later"
+
+    SEND_CHOICES = (
+        (SEND_NOW, _("Send right now")),
+        (SEND_LATER, _("Schedule for later")),
+    )
+
+    send_when = forms.ChoiceField(choices=SEND_CHOICES, widget=forms.RadioSelect(attrs={"widget_only": True}))
+
     def __init__(self, org, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["start_datetime"].required = False
         self.set_org(org)
+
+    def clean(self):
+        start_datetime = self.data.get("schedule-start_datetime", None)
+        if self.data["schedule-send_when"] == ScheduleForm.SEND_LATER and not start_datetime:
+            raise forms.ValidationError(_("Select when you would like the broadcast to be sent"))
+        return super().clean()
+
+    class Meta:
+        fields = [f for f in ScheduleFormMixin.Meta.fields] + ["send_when"]
 
 
 class TargetForm(Form):
@@ -223,12 +245,25 @@ class BroadcastCRUDL(SmartCRUDL):
     model = Broadcast
 
     class Create(OrgPermsMixin, SmartWizardView):
-        form_list = [("compose", ComposeForm), ("target", TargetForm), ("schedule", ScheduleForm)]
+        form_list = [("target", TargetForm), ("compose", ComposeForm), ("schedule", ScheduleForm)]
         success_url = "@msgs.broadcast_scheduled"
         submit_button_name = _("Create Broadcast")
 
         def get_form_kwargs(self, step):
             return {"org": self.request.org}
+
+        def get_form_initial(self, step):
+            initial = {}
+            contact_uuids = [_ for _ in self.request.GET.get("c", "").split(",") if _]
+            if contact_uuids:
+                params = {}
+                if len(contact_uuids) > 0:
+                    params["c"] = ",".join(contact_uuids)
+
+                results = omnibox_query(self.org, **params)
+                initial["omnibox"] = omnibox_results_to_dict(self.org, results)
+                return initial
+            return super().get_form_initial(step)
 
         def done(self, form_list, form_dict, **kwargs):
             user = self.request.user
@@ -240,13 +275,16 @@ class BroadcastCRUDL(SmartCRUDL):
             recipients = form_dict["target"].cleaned_data["omnibox"]
 
             schedule_form = form_dict["schedule"]
-            start_time = schedule_form.cleaned_data["start_datetime"]
-            repeat_period = schedule_form.cleaned_data["repeat_period"]
-            repeat_days_of_week = schedule_form.cleaned_data["repeat_days_of_week"]
+            send_when = schedule_form.cleaned_data["send_when"]
+            schedule = None
 
-            schedule = Schedule.create_schedule(
-                org, user, start_time, repeat_period, repeat_days_of_week=repeat_days_of_week
-            )
+            if send_when == ScheduleForm.SEND_LATER:
+                start_time = schedule_form.cleaned_data["start_datetime"]
+                repeat_period = schedule_form.cleaned_data["repeat_period"]
+                repeat_days_of_week = schedule_form.cleaned_data["repeat_days_of_week"]
+                schedule = Schedule.create_schedule(
+                    org, user, start_time, repeat_period, repeat_days_of_week=repeat_days_of_week
+                )
 
             self.object = Broadcast.create(
                 org,
@@ -258,10 +296,14 @@ class BroadcastCRUDL(SmartCRUDL):
                 schedule=schedule,
             )
 
+            # if we are sending now, just kick it off now
+            if send_when == ScheduleForm.SEND_NOW:
+                self.object.send_async()
+
             return HttpResponseRedirect(self.get_success_url())
 
     class Update(OrgObjPermsMixin, SmartWizardUpdateView):
-        form_list = [("compose", ComposeForm), ("target", TargetForm), ("schedule", ScheduleForm)]
+        form_list = [("target", TargetForm), ("compose", ComposeForm), ("schedule", ScheduleForm)]
         success_url = "id@msgs.broadcast_scheduled_read"
         template_name = "msgs/broadcast_create.html"
         submit_button_name = _("Save Broadcast")
@@ -272,19 +314,20 @@ class BroadcastCRUDL(SmartCRUDL):
         def get_form_initial(self, step):
             org = self.request.org
 
-            if step == "compose":
-                translation = self.object.get_translation()
-                compose = compose_serialize(translation)
-                return {"compose": compose}
-
             if step == "target":
                 recipients = [*self.object.groups.all(), *self.object.contacts.all()]
                 omnibox = omnibox_results_to_dict(org, recipients)
                 return {"omnibox": omnibox}
 
+            if step == "compose":
+                translation = self.object.get_translation()
+                compose = compose_serialize(translation)
+                return {"compose": compose}
+
             if step == "schedule":
                 schedule = self.object.schedule
                 return {
+                    "send_when": ScheduleForm.SEND_LATER if schedule.next_fire else ScheduleForm.SEND_NOW,
                     "start_datetime": schedule.next_fire,
                     "repeat_period": schedule.repeat_period,
                     "repeat_days_of_week": list(schedule.repeat_days_of_week) if schedule.repeat_days_of_week else [],
@@ -362,7 +405,7 @@ class BroadcastCRUDL(SmartCRUDL):
         def build_content_menu(self, menu):
             obj = self.get_object()
 
-            if self.has_org_perm("msgs.broadcast_update"):
+            if self.has_org_perm("msgs.broadcast_update") and obj.schedule.next_fire:
                 menu.add_modax(
                     _("Edit"),
                     "edit-broadcast",

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -531,18 +531,6 @@ class BroadcastCRUDL(SmartCRUDL):
 
         def derive_initial(self):
             initial = super().derive_initial()
-
-            org = self.request.org
-            contact_uuids = [_ for _ in self.request.GET.get("c", "").split(",") if _]
-
-            if contact_uuids:
-                params = {}
-                if len(contact_uuids) > 0:
-                    params["c"] = ",".join(contact_uuids)
-
-                results = omnibox_query(org, **params)
-                initial["omnibox"] = omnibox_results_to_dict(org, results)
-
             initial["step_node"] = self.request.GET.get("step_node", None)
             return initial
 

--- a/templates/contacts/contact_list.html
+++ b/templates/contacts/contact_list.html
@@ -353,14 +353,17 @@
 
     function handleSendMessageClicked() {
       // when we click send, include any clicked messages in our modax request
-      var sendEndpoint = "{% url 'msgs.broadcast_send' %}";
-      var sendModal = document.querySelector("#send-message-modal");
+      var sendEndpoint = "{% url 'msgs.broadcast_create' %}";
+      var sendModal = document.querySelector("#shared-modax");
+      sendModal.header = '{{_("New Broadcast")|escapejs}}';
       var ids = getCheckedUuids();
       if (ids.length > 0) {
         sendModal.setAttribute("endpoint", sendEndpoint + '?c=' + ids);
       } else {
         sendModal.setAttribute("endpoint", sendEndpoint);
       }
+
+      sendModal.open = true;
     }
 
     // keeps track if we are on a link or not

--- a/templates/includes/short_pagination.html
+++ b/templates/includes/short_pagination.html
@@ -61,16 +61,12 @@
         {% endif %}
         {% if 'send' in actions %}
           {% if org_perms.msgs.broadcast_send and not reply_disabled %}
-            <temba-modax header="{{ _("Send Message") |escapejs }}"
-                         endpoint="{% url 'msgs.broadcast_send' %}"
-                         id="send-message-modal">
-              <div onclick="handleSendMessageClicked()" class="linked ml-4">
-                <temba-tip position="top" text="{{ _("Send Message") |escapejs }}">
-                  <temba-icon name="message" clickable="true">
-                  </temba-icon>
-                </temba-tip>
-              </div>
-            </temba-modax>
+            <div onclick="handleSendMessageClicked()" class="linked ml-4">
+              <temba-tip position="top" text="{{ _("New Broadcast") |escapejs }}">
+                <temba-icon name="message" clickable="true">
+                </temba-icon>
+              </temba-tip>
+            </div>
           {% endif %}
         {% endif %}
         {% if 'delete' in actions %}

--- a/templates/msgs/broadcast_create_schedule.html
+++ b/templates/msgs/broadcast_create_schedule.html
@@ -13,7 +13,7 @@
     }
 
     #schedule_fields {
-      margin-left: 1.5rem;
+      margin: 0 1.5em;
     }
 
     #id_schedule-send_when_1 {
@@ -35,8 +35,6 @@
     var sendWhen = modalBody.querySelector("#id_schedule-send_when");
     var scheduleFields = modalBody.querySelector("#schedule_fields");
     var sendNow = modalBody.querySelector("#id_schedule-send_when_0");
-
-    console.log(modalBody);
 
     if (sendWhen) {
       sendWhen.addEventListener("change", function(event) {

--- a/templates/msgs/broadcast_create_schedule.html
+++ b/templates/msgs/broadcast_create_schedule.html
@@ -1,11 +1,29 @@
 {% extends "utils/forms/wizard.html" %}
-{% load i18n %}
+{% load i18n smartmin %}
 
 {% block extra-style %}
   {{ block.super }}
   <style>
     .hidden {
       display: none;
+    }
+
+    .field_send_when .control-label {
+      display: none;
+    }
+
+    #schedule_fields {
+      margin-left: 1.5rem;
+    }
+
+    #id_schedule-send_when_1 {
+      margin-top: 0.5em;
+    }
+
+    .disabled {
+      pointer-events: none;
+      opacity: 0.5;
+      user-select: none;
     }
   </style>
 {% endblock extra-style %}
@@ -14,6 +32,27 @@
     var modalBody = getModax("#shared-modax").shadowRoot;
     var repeatPeriod = modalBody.querySelector("#id_schedule-repeat_period");
     var repeatDays = modalBody.querySelector(".repeat-days-container");
+    var sendWhen = modalBody.querySelector("#id_schedule-send_when");
+    var scheduleFields = modalBody.querySelector("#schedule_fields");
+    var sendNow = modalBody.querySelector("#id_schedule-send_when_0");
+
+    console.log(modalBody);
+
+    if (sendWhen) {
+      sendWhen.addEventListener("change", function(event) {
+        var sendType = event.target.value;
+        if (sendType == "now") {
+          scheduleFields.classList.add("disabled");
+        } else {
+          scheduleFields.classList.remove("disabled");
+        }
+      });
+    }
+
+    {% if form.send_when.value != "later" %}
+    sendNow.click();
+    scheduleFields.classList.add("disabled");
+    {% endif %}
 
     if (repeatPeriod) {
       repeatPeriod.addEventListener("change", function(event) {
@@ -28,5 +67,6 @@
   </script>
 {% endblock extra-script %}
 {% block fields %}
-  {% include "includes/schedule_fields.html" with form=form %}
+  {% render_field 'send_when' %}
+  <div id="schedule_fields">{% include "includes/schedule_fields.html" with form=form %}</div>
 {% endblock fields %}

--- a/templates/msgs/message_box.html
+++ b/templates/msgs/message_box.html
@@ -158,14 +158,16 @@
     }
 
     function handleSendMessageClicked() {
-      var sendEndpoint = "{% url 'msgs.broadcast_send' %}";
-      var sendModal = document.querySelector("#send-message-modal");
+      var sendEndpoint = "{% url 'msgs.broadcast_create' %}";
+      var sendModal = document.querySelector("#shared_modax");
       var msgIds = getCheckedIds();
       if (msgIds.length > 0) {
         sendModal.setAttribute("endpoint", sendEndpoint + '?m=' + msgIds);
       } else {
         sendModal.setAttribute("endpoint", sendEndpoint);
       }
+
+      sendModal.open = true;
     }
     {% endif %}
 

--- a/templates/public/public_welcome.html
+++ b/templates/public/public_welcome.html
@@ -185,8 +185,8 @@
           {% endblocktrans %}
         </div>
         <div class="mt-6">
-          <temba-modax endpoint="{% url 'msgs.broadcast_send' %}"
-                       header="{{ _("Send Message") |escapejs }}"
+          <temba-modax endpoint="{% url 'msgs.broadcast_create' %}"
+                       header="{{ _("New Broadcast") |escapejs }}"
                        class="inline-block mb-1">
             <div class="button-primary lift">{% trans "Send Message" %}</div>
           </temba-modax>


### PR DESCRIPTION
 * Selection at the end of broadcast creation pipeline to send now or schedule for later
 * Switch Send Message to New Broadcast and point it to the broadcast pipleline. This includes on contact lists and the message inbox
<img width="617" alt="image" src="https://github.com/nyaruka/rapidpro/assets/211652/732ae3aa-4b5e-41d6-b481-e10fe5d64d25">
