### PR TITLE
Group trigger types into folders

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -703,10 +703,8 @@ GROUP_PERMISSIONS = {
         "tickets.ticketer_api",
         "tickets.topic_api",
         "tickets.ticket_export",
-        "triggers.trigger_archived",
         "triggers.trigger_list",
         "triggers.trigger_menu",
-        "triggers.trigger_type",
     ),
     "Agents": (
         "contacts.contact_api",

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -19,7 +19,6 @@ class TriggerType:
     code = None  # single char code used for database model
     slug = None  # used for URLs
     name = None
-    title = None  # used for list page title
 
     # flow types allowed for this type
     allowed_flow_types = ()

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -16,6 +16,7 @@ from temba.utils.views import TEMBA_MENU_SELECTION
 
 from .models import Trigger
 from .types import KeywordTriggerType
+from .views import Folder
 
 
 class TriggerTest(TembaTest):
@@ -31,6 +32,9 @@ class TriggerTest(TembaTest):
 
         self.assertEqual("Catch All → Test Flow", catchall.name)
         self.assertEqual('Trigger[type=C, flow="Test Flow"]', str(catchall))
+
+        self.assertEqual(Folder.TICKETS, Folder.from_slug("tickets"))
+        self.assertIsNone(Folder.from_slug("xx"))
 
     def test_archive_conflicts(self):
         flow = self.create_flow("Test")

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -1612,7 +1612,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(list_url)
         self.assertContains(response, trigger7.keyword)
 
-    def test_type_lists(self):
+    def test_folder(self):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
         flow3 = self.create_flow("Flow 3", org=self.org2)
@@ -1630,9 +1630,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
             self.org2, self.admin, Trigger.TYPE_KEYWORD, flow3, keyword="other", match_type=Trigger.MATCH_ONLY_WORD
         )
 
-        keyword_url = reverse("triggers.trigger_type", kwargs={"type": "keyword"})
-        referral_url = reverse("triggers.trigger_type", kwargs={"type": "referral"})
-        catchall_url = reverse("triggers.trigger_type", kwargs={"type": "catch_all"})
+        keyword_url = reverse("triggers.trigger_folder", kwargs={"folder": "keyword"})
+        referral_url = reverse("triggers.trigger_folder", kwargs={"folder": "referral"})
+        catchall_url = reverse("triggers.trigger_folder", kwargs={"folder": "catch_all"})
 
         response = self.assertListFetch(
             keyword_url, allow_viewers=True, allow_editors=True, context_objects=[trigger2, trigger1]

--- a/temba/triggers/types.py
+++ b/temba/triggers/types.py
@@ -53,7 +53,6 @@ class KeywordTriggerType(TriggerType):
     code = Trigger.TYPE_KEYWORD
     slug = "keyword"
     name = _("Keyword")
-    title = _("Keyword Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE)
     export_fields = TriggerType.export_fields + ("keyword", "match_type")
     required_fields = TriggerType.required_fields + ("keyword",)
@@ -85,7 +84,6 @@ class CatchallTriggerType(TriggerType):
     code = Trigger.TYPE_CATCH_ALL
     slug = "catch_all"
     name = _("Catch All")
-    title = _("Catch All Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE)
     form = Form
 
@@ -132,7 +130,6 @@ class ScheduledTriggerType(TriggerType):
     code = Trigger.TYPE_SCHEDULE
     slug = "schedule"
     name = _("Schedule")
-    title = _("Schedule Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE, Flow.TYPE_BACKGROUND)
     exportable = False
     form = Form
@@ -198,7 +195,6 @@ class InboundCallTriggerType(TriggerType):
     code = Trigger.TYPE_INBOUND_CALL
     slug = "inbound_call"
     name = _("Inbound Call")
-    title = _("Inbound Call Triggers")
     allowed_flow_types = (Flow.TYPE_VOICE, Flow.TYPE_MESSAGE, Flow.TYPE_BACKGROUND)
     form = Form
 
@@ -215,7 +211,6 @@ class MissedCallTriggerType(TriggerType):
     code = Trigger.TYPE_MISSED_CALL
     slug = "missed_call"
     name = _("Missed Call")
-    title = _("Missed Call Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_BACKGROUND)
     form = Form
 
@@ -246,7 +241,6 @@ class NewConversationTriggerType(TriggerType):
     code = Trigger.TYPE_NEW_CONVERSATION
     slug = "new_conversation"
     name = _("New Conversation")
-    title = _("New Conversation Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE,)
     export_fields = TriggerType.export_fields + ("channel",)
     required_fields = TriggerType.required_fields + ("channel",)
@@ -286,7 +280,6 @@ class ReferralTriggerType(TriggerType):
     code = Trigger.TYPE_REFERRAL
     slug = "referral"
     name = _("Referral")
-    title = _("Referral Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE,)
     export_fields = TriggerType.export_fields + ("channel",)
     form = Form
@@ -304,7 +297,6 @@ class ClosedTicketTriggerType(TriggerType):
     code = Trigger.TYPE_CLOSED_TICKET
     slug = "closed_ticket"
     name = _("Closed Ticket")
-    title = _("Closed Ticket Triggers")
     allowed_flow_types = (Flow.TYPE_MESSAGE, Flow.TYPE_VOICE, Flow.TYPE_BACKGROUND)
     form = Form
 

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from smartmin.views import SmartCreateView, SmartCRUDL, SmartListView, SmartTemplateView, SmartUpdateView
 
 from django import forms
@@ -27,6 +29,35 @@ from temba.utils.fields import (
 from temba.utils.views import BulkActionMixin, ComponentFormMixin, ContentMenuMixin, SpaMixin
 
 from .models import Trigger
+
+
+class Folder(Enum):
+    KEYWORD = (_("Keyword"), _("Keyword Triggers"), (Trigger.TYPE_KEYWORD,))
+    CATCH_ALL = (_("Catch All"), _("Catch All Triggers"), (Trigger.TYPE_CATCH_ALL,))
+    SCHEDULE = (_("Scheduled"), _("Scheduled Triggers"), (Trigger.TYPE_SCHEDULE,))
+    CALLS = (_("Calls"), _("Call Triggers"), (Trigger.TYPE_INBOUND_CALL, Trigger.TYPE_MISSED_CALL))
+    NEW_CONVERSATION = (_("New Conversation"), _("New Conversation Triggers"), (Trigger.TYPE_NEW_CONVERSATION,))
+    REFERRAL = (_("Referral"), _("Referral Triggers"), (Trigger.TYPE_REFERRAL,))
+    TICKETS = (_("Tickets"), _("Ticket Triggers"), (Trigger.TYPE_CLOSED_TICKET,))
+
+    def __init__(self, display, title, types):
+        self.display = display
+        self.title = title
+        self.types = types
+
+    @property
+    def slug(self) -> str:
+        return self.name.lower()
+
+    def get_count(self, org) -> int:
+        return org.triggers.filter(trigger_type__in=self.types, is_active=True, is_archived=False).count()
+
+    @classmethod
+    def from_slug(cls, slug: str):
+        for folder in cls:
+            if folder.slug == slug:
+                return folder
+        return None
 
 
 class BaseTriggerForm(forms.ModelForm):
@@ -202,7 +233,7 @@ class TriggerCRUDL(SmartCRUDL):
         "list",
         "menu",
         "archived",
-        "type",
+        "folder",
     )
 
     class Menu(MenuMixin, SmartTemplateView):
@@ -213,8 +244,6 @@ class TriggerCRUDL(SmartCRUDL):
         def derive_menu(self):
             org = self.request.org
             menu = []
-
-            from .types import TYPES_BY_SLUG
 
             org_triggers = org.triggers.filter(is_active=True)
             menu.append(
@@ -241,14 +270,14 @@ class TriggerCRUDL(SmartCRUDL):
 
             menu.append(self.create_divider())
 
-            for slug, trigger_type in TYPES_BY_SLUG.items():
-                count = org_triggers.filter(trigger_type=trigger_type.code, is_archived=False).count()
+            for folder in Folder:
+                count = folder.get_count(org)
                 if count:
                     menu.append(
                         self.create_menu_item(
-                            name=trigger_type.name,
+                            name=folder.display,
                             count=count,
-                            href=reverse("triggers.trigger_type", kwargs={"type": slug}),
+                            href=reverse("triggers.trigger_folder", kwargs={"folder": folder.slug}),
                         )
                     )
 
@@ -452,18 +481,10 @@ class TriggerCRUDL(SmartCRUDL):
         Base class for list views
         """
 
+        permission = "triggers.trigger_list"
         fields = ("name",)
         default_template = "triggers/trigger_list.html"
         search_fields = ("keyword__icontains", "flow__name__icontains", "channel__name__icontains")
-
-        def get_context_data(self, **kwargs):
-            context = super().get_context_data(**kwargs)
-
-            org = self.request.org
-            context["main_folders"] = self.get_main_folders(org)
-            context["type_folders"] = self.get_type_folders(org)
-            context["request_url"] = self.request.path
-            return context
 
         def get_queryset(self, *args, **kwargs):
             qs = super().get_queryset(*args, **kwargs)
@@ -489,21 +510,6 @@ class TriggerCRUDL(SmartCRUDL):
                     count=org.triggers.filter(is_active=True, is_archived=True).count(),
                 ),
             ]
-
-        def get_type_folders(self, org):
-            from .types import TYPES_BY_SLUG
-
-            org_triggers = org.triggers.filter(is_active=True, is_archived=False)
-            folders = []
-            for slug, trigger_type in TYPES_BY_SLUG.items():
-                folders.append(
-                    dict(
-                        label=trigger_type.name,
-                        url=reverse("triggers.trigger_type", kwargs={"type": slug}),
-                        count=org_triggers.filter(trigger_type=trigger_type.code).count(),
-                    )
-                )
-            return folders
 
     class List(BaseList):
         """
@@ -539,7 +545,7 @@ class TriggerCRUDL(SmartCRUDL):
         def get_queryset(self, *args, **kwargs):
             return super().get_queryset(*args, **kwargs).filter(is_archived=True)
 
-    class Type(BaseList):
+    class Folder(BaseList):
         """
         Type filtered list view
         """
@@ -548,19 +554,17 @@ class TriggerCRUDL(SmartCRUDL):
 
         @classmethod
         def derive_url_pattern(cls, path, action):
-            from .types import TYPES_BY_SLUG
-
-            return rf"^%s/%s/(?P<type>{'|'.join(TYPES_BY_SLUG.keys())}+)/$" % (path, action)
+            return rf"^%s/%s/(?P<folder>{'|'.join([f.slug for f in Folder])}+)/$" % (path, action)
 
         @property
-        def trigger_type(self):
-            return Trigger.get_type(slug=self.kwargs["type"])
+        def folder(self):
+            return Folder.from_slug(slug=self.kwargs["folder"])
 
         def derive_menu_path(self):
-            return f"/trigger/{self.trigger_type.slug}"
+            return f"/trigger/{self.folder.slug}"
 
         def derive_title(self):
-            return self.trigger_type.title
+            return self.folder.title
 
         def get_queryset(self, *args, **kwargs):
-            return super().get_queryset(*args, **kwargs).filter(is_archived=False, trigger_type=self.trigger_type.code)
+            return super().get_queryset(*args, **kwargs).filter(is_archived=False, trigger_type__in=self.folder.types)

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -497,20 +497,6 @@ class TriggerCRUDL(SmartCRUDL):
             )
             return qs
 
-        def get_main_folders(self, org):
-            return [
-                dict(
-                    label=_("All"),
-                    url=reverse("triggers.trigger_list"),
-                    count=org.triggers.filter(is_active=True, is_archived=False).count(),
-                ),
-                dict(
-                    label=_("Archived"),
-                    url=reverse("triggers.trigger_archived"),
-                    count=org.triggers.filter(is_active=True, is_archived=True).count(),
-                ),
-            ]
-
     class List(BaseList):
         """
         Non-archived triggers of all types

--- a/temba/utils/templatetags/temba.py
+++ b/temba/utils/templatetags/temba.py
@@ -35,7 +35,7 @@ OBJECT_URLS = {
     Campaign: lambda o: reverse("campaigns.campaign_read", args=[o.uuid]),
     CampaignEvent: lambda o: reverse("campaigns.campaign_read", args=[o.uuid]),
     ContactGroup: lambda o: reverse("contacts.contact_filter", args=[o.uuid]),
-    Trigger: lambda o: reverse("triggers.trigger_type", args=[o.type.slug]),
+    Trigger: lambda o: reverse("triggers.trigger_list"),
 }
 
 


### PR DESCRIPTION
We used to do this.. not sure why we got rid of it. But it seems nicer to have a a folder of triggers called "OptIns" that includes Opt-In and Opt-Out.. or if we added another type of ticket trigger it would live with "Tickets" 