### PR TITLE
Allow the target_urls of incident notifications to differ by type

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1322,13 +1322,24 @@ class ChannelIncidentsTest(TembaTest):
 
             self.assertEqual(1, self.admin.notifications.count())
 
+            notification = self.admin.notifications.get()
+            self.assertFalse(notification.is_seen)
+
             send_notification_emails()
 
             self.assertEqual(1, len(mail.outbox))
             self.assertEqual("[Nyaruka] Incident: Channel Disconnected", mail.outbox[0].subject)
             self.assertEqual("support@mybrand.com", mail.outbox[0].from_email)
 
-        # call it again
+        # if we go to the read page of the channel, notification will be marked as seen
+        read_url = reverse("channels.channel_read", args=[self.channel.uuid])
+        self.login(self.admin)
+        self.client.get(read_url)
+
+        notification.refresh_from_db()
+        self.assertTrue(notification.is_seen)
+
+        # call task again
         check_android_channels()
 
         # still only one incident

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -34,6 +34,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.contacts.models import URN
 from temba.ivr.models import Call
 from temba.msgs.models import Msg
+from temba.notifications.views import NotificationTargetMixin
 from temba.orgs.views import DependencyDeleteModal, ModalMixin, OrgObjPermsMixin, OrgPermsMixin
 from temba.utils import countries
 from temba.utils.fields import SelectWidget
@@ -469,7 +470,7 @@ class ChannelCRUDL(SmartCRUDL):
         "facebook_whitelist",
     )
 
-    class Read(SpaMixin, OrgObjPermsMixin, ContentMenuMixin, SmartReadView):
+    class Read(SpaMixin, OrgObjPermsMixin, ContentMenuMixin, NotificationTargetMixin, SmartReadView):
         slug_url_kwarg = "uuid"
         exclude = ("id", "is_active", "created_by", "modified_by", "modified_on")
 
@@ -478,6 +479,9 @@ class ChannelCRUDL(SmartCRUDL):
 
         def get_queryset(self):
             return Channel.objects.filter(is_active=True)
+
+        def get_notification_scope(self) -> tuple:
+            return "incident:started", str(self.object.id)
 
         def build_content_menu(self, menu):
             obj = self.get_object()

--- a/temba/notifications/incidents/builtin.py
+++ b/temba/notifications/incidents/builtin.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from ..models import Incident, IncidentType
@@ -19,6 +20,12 @@ class ChannelDisconnectedIncidentType(IncidentType):
         return Incident.get_or_create(
             channel.org, ChannelDisconnectedIncidentType.slug, scope=str(channel.id), channel=channel
         )
+
+    def get_notification_scope(self, incident) -> str:
+        return str(incident.channel.id)
+
+    def get_notification_target_url(self, incident) -> str:
+        return reverse("channels.channel_read", args=[str(incident.channel.uuid)])
 
 
 class OrgFlaggedIncidentType(IncidentType):

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models import Q
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 
@@ -22,6 +23,12 @@ logger = logging.getLogger(__name__)
 class IncidentType:
     slug: str
     title: str
+
+    def get_notification_scope(self, incident) -> str:
+        return str(incident.id)
+
+    def get_notification_target_url(self, incident) -> str:
+        return reverse("notifications.incident_list")
 
     def as_json(self, incident) -> dict:
         return {

--- a/temba/notifications/tests.py
+++ b/temba/notifications/tests.py
@@ -23,13 +23,13 @@ class IncidentTest(TembaTest):
     def test_create(self):
         # we use a unique constraint to enforce uniqueness on org+type+scope for ongoing incidents which allows use of
         # INSERT .. ON CONFLICT DO NOTHING
-        incident1 = Incident.get_or_create(self.org, "incident:test", scope="scope1")
+        incident1 = Incident.get_or_create(self.org, "org:flagged", scope="scope1")
 
         # try to create another for the same scope
-        incident2 = Incident.get_or_create(self.org, "incident:test", scope="scope1")
+        incident2 = Incident.get_or_create(self.org, "org:flagged", scope="scope1")
 
         # different scope
-        incident3 = Incident.get_or_create(self.org, "incident:test", scope="scope2")
+        incident3 = Incident.get_or_create(self.org, "org:flagged", scope="scope2")
 
         self.assertEqual(incident1, incident2)
         self.assertNotEqual(incident1, incident3)
@@ -42,7 +42,7 @@ class IncidentTest(TembaTest):
         # check that once incident 1 ends, new incidents can be created for same scope
         incident1.end()
 
-        incident4 = Incident.get_or_create(self.org, "incident:test", scope="scope1")
+        incident4 = Incident.get_or_create(self.org, "org:flagged", scope="scope1")
 
         self.assertNotEqual(incident1, incident4)
         self.assertEqual(3, Notification.objects.count())

--- a/temba/notifications/types/builtin.py
+++ b/temba/notifications/types/builtin.py
@@ -79,14 +79,14 @@ class IncidentStartedNotificationType(NotificationType):
         Notification.create_all(
             incident.org,
             cls.slug,
-            scope=str(incident.id),
+            scope=incident.type.get_notification_scope(incident),
             users=incident.org.get_admins(),
             email_status=Notification.EMAIL_STATUS_PENDING,
             incident=incident,
         )
 
     def get_target_url(self, notification) -> str:
-        return reverse("notifications.incident_list")
+        return notification.incident.type.get_notification_target_url(notification.incident)
 
     def get_email_subject(self, notification) -> str:
         return _("Incident") + ": " + notification.incident.type.title

--- a/templates/notifications/email/incident_started.channel_disconnected.html
+++ b/templates/notifications/email/incident_started.channel_disconnected.html
@@ -3,9 +3,8 @@
 
 {% block notification-body %}
   <p>
-    {% url 'channels.channel_read' incident.channel.uuid as read_url %}
-    {% blocktrans trimmed with read_url=read_url %}
-    Your <a href="{{ read_url }}">Android channel</a> appears to be disconnected and hasn't been seen for some time.
+    {% blocktrans trimmed with url=branding.link|add:target_url %}
+    Your <a href="{{ url }}">Android channel</a> appears to be disconnected and hasn't been seen for some time.
     {% endblocktrans %}
   </p>
 {% endblock notification-body %}

--- a/templates/notifications/email/incident_started.channel_disconnected.txt
+++ b/templates/notifications/email/incident_started.channel_disconnected.txt
@@ -2,8 +2,7 @@
 {% load i18n %}
 
 {% block notification-body %}
-{% url 'channels.channel_read' incident.channel.uuid as read_url %}
-{% blocktrans trimmed with read_url=read_url %}
-Your Android channel ({{ read_url }}) appears to be disconnected and hasn't been seen for some time.
+{% blocktrans trimmed with url=branding.link|add:target_url %}
+Your Android channel ({{ url }}) appears to be disconnected and hasn't been seen for some time.
 {% endblocktrans %}
 {% endblock notification-body %}


### PR DESCRIPTION
Currently the target_url for notifications for incidents is just the incident list page... but it makes more sense that if you click on a channel disconnected incident notification.. it takes you to the channel read page, and viewing that page is what clears the notification.