### PR TITLE
Add celery task to recreate campaign events when archiving

### DIFF
--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -31,7 +31,9 @@ class Campaign(TembaModel):
         self.save(update_fields=("is_archived", "modified_by", "modified_on"))
 
         # recreate events so existing event fires will be ignored
-        self.recreate_events()
+        from .tasks import recreate_events
+
+        on_transaction_commit(lambda: recreate_events.delay(self.id))
 
     def recreate_events(self):
         """

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -30,11 +30,6 @@ class Campaign(TembaModel):
         self.modified_on = timezone.now()
         self.save(update_fields=("is_archived", "modified_by", "modified_on"))
 
-        # recreate events so existing event fires will be ignored
-        from .tasks import recreate_events
-
-        on_transaction_commit(lambda: recreate_events.delay(self.id))
-
     def recreate_events(self):
         """
         Recreates all the events in this campaign - called when something like the group changes.

--- a/temba/campaigns/tasks.py
+++ b/temba/campaigns/tasks.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
 
+from celery import shared_task
+
 from django.conf import settings
 from django.utils import timezone
 
-from temba.campaigns.models import EventFire
+from temba.campaigns.models import Campaign, EventFire
 from temba.utils.crons import cron_task
 from temba.utils.models import delete_in_batches
 
@@ -27,3 +29,9 @@ def trim_event_fires():
         num_deleted += delete_in_batches(EventFire.objects.filter(fired__lt=trim_before), post_delete=can_continue)
 
     return {"deleted": num_deleted}
+
+
+@shared_task
+def recreate_events(campaign_id):
+    campaign = Campaign.objects.get(id=campaign_id)
+    campaign.recreate_events()

--- a/temba/campaigns/tasks.py
+++ b/temba/campaigns/tasks.py
@@ -1,11 +1,9 @@
 from datetime import timedelta
 
-from celery import shared_task
-
 from django.conf import settings
 from django.utils import timezone
 
-from temba.campaigns.models import Campaign, EventFire
+from temba.campaigns.models import EventFire
 from temba.utils.crons import cron_task
 from temba.utils.models import delete_in_batches
 
@@ -29,9 +27,3 @@ def trim_event_fires():
         num_deleted += delete_in_batches(EventFire.objects.filter(fired__lt=trim_before), post_delete=can_continue)
 
     return {"deleted": num_deleted}
-
-
-@shared_task
-def recreate_events(campaign_id):
-    campaign = Campaign.objects.get(id=campaign_id)
-    campaign.recreate_events()


### PR DESCRIPTION
This fixes the issue of timing out when a user try to archive a campaign with many events.
