### PR TITLE
Allow perms to be made API specific so that we can limit agent UI access

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -82,7 +82,7 @@ class APIPermission(BasePermission):
             else:
                 return False
 
-            has_perm = role.has_perm(permission)
+            has_perm = role.has_api_perm(permission)
 
             # viewers can only ever get from the API
             if role == OrgRole.VIEWER:

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -4279,7 +4279,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             list_url,
             allow_viewers=True,
             allow_editors=True,
-            allow_agents=True,
+            allow_agents=False,
             context_objects=[self.age, self.gender, self.state],
         )
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -373,11 +373,21 @@ class OrgRole(Enum):
         perms = self.group.permissions.select_related("content_type")
         return {f"{p.content_type.app_label}.{p.codename}" for p in perms}
 
+    @cached_property
+    def api_permissions(self) -> set:
+        return set(settings.API_PERMISSION.get(self.group_name, ()))
+
     def has_perm(self, permission: str) -> bool:
         """
         Returns whether this role has the given permission
         """
         return permission in self.permissions
+
+    def has_api_perm(self, permission: str) -> bool:
+        """
+        Returns whether this role has the given permission in the context of an API request.
+        """
+        return self.has_perm(permission) or permission in self.api_permissions
 
 
 class Org(SmartModel):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -696,8 +696,6 @@ GROUP_PERMISSIONS = {
     "Agents": (
         "contacts.contact_api",
         "contacts.contact_history",
-        "contacts.contactfield_list",
-        "contacts.contactgroup_list",
         "msgs.media_api",
         "msgs.msg_api",
         "notifications.notification_list",
@@ -716,6 +714,14 @@ GROUP_PERMISSIONS = {
         "tickets.topic_api",
     ),
     "Prometheus": (),
+}
+
+# extra permissions that only apply to API requests (wildcard notation not supported here)
+API_PERMISSIONS = {
+    "Agents": (
+        "contacts.contactfield_list",
+        "contacts.contactgroup_list",
+    )
 }
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Contains https://github.com/nyaruka/rapidpro/pull/4868