### PR TITLE
Fix updating keyword triggers for flows

### DIFF
--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -408,7 +408,7 @@ class FlowCRUDL(SmartCRUDL):
         class Form(BaseFlowForm):
             keyword_triggers = forms.CharField(
                 required=False,
-                label=_("Global keyword triggers"),
+                label=_("Keyword triggers"),
                 help_text=_("When a user sends any of these keywords they will begin this flow"),
                 widget=SelectWidget(
                     attrs={
@@ -540,7 +540,7 @@ class FlowCRUDL(SmartCRUDL):
         class BaseOnlineForm(BaseFlowForm):
             keyword_triggers = forms.CharField(
                 required=False,
-                label=_("Global keyword triggers"),
+                label=_("Keyword triggers"),
                 help_text=_("When a user sends any of these keywords they will begin this flow"),
                 widget=SelectWidget(
                     attrs={

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
@@ -536,14 +537,23 @@ class FlowCRUDL(SmartCRUDL):
                 fields = ("name", "contact_creation")
                 widgets = {"name": InputWidget()}
 
-        class VoiceForm(BaseForm):
-            ivr_retry = forms.ChoiceField(
-                label=_("Retry call if unable to connect"),
-                help_text=_("Retries call three times for the chosen interval"),
-                initial=60,
-                choices=Call.RETRY_CHOICES,
-                widget=SelectWidget(attrs={"widget_only": False}),
+        class BaseOnlineForm(BaseFlowForm):
+            keyword_triggers = forms.CharField(
+                required=False,
+                label=_("Global keyword triggers"),
+                help_text=_("When a user sends any of these keywords they will begin this flow"),
+                widget=SelectWidget(
+                    attrs={
+                        "widget_only": False,
+                        "multi": True,
+                        "searchable": True,
+                        "tags": True,
+                        "space_select": True,
+                        "placeholder": _("Keywords"),
+                    }
+                ),
             )
+
             expires_after_minutes = forms.ChoiceField(
                 label=_("Expire inactive contacts"),
                 help_text=_("When inactive contacts should be removed from the flow"),
@@ -551,64 +561,38 @@ class FlowCRUDL(SmartCRUDL):
                 choices=Flow.EXPIRES_CHOICES[Flow.TYPE_VOICE],
                 widget=SelectWidget(attrs={"widget_only": False}),
             )
-            keyword_triggers = forms.CharField(
-                required=False,
-                label=_("Global keyword triggers"),
-                help_text=_("When a user sends any of these keywords they will begin this flow"),
-                widget=SelectWidget(
-                    attrs={
-                        "widget_only": False,
-                        "multi": True,
-                        "searchable": True,
-                        "tags": True,
-                        "space_select": True,
-                        "placeholder": _("Keywords"),
-                    }
-                ),
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+                existing_keywords = set(
+                    self.instance.triggers.filter(is_archived=False, trigger_type=Trigger.TYPE_KEYWORD).values_list(
+                        "keyword", flat=True
+                    )
+                )
+
+                self.fields["keyword_triggers"].initial = list(sorted(existing_keywords))
+
+        class VoiceForm(BaseOnlineForm):
+            ivr_retry = forms.ChoiceField(
+                label=_("Retry call if unable to connect"),
+                help_text=_("Retries call three times for the chosen interval"),
+                initial=60,
+                choices=Call.RETRY_CHOICES,
+                widget=SelectWidget(attrs={"widget_only": False}),
             )
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 
-                metadata = self.instance.metadata
-
-                # IVR retries
-                ivr_retry = self.fields["ivr_retry"]
-                ivr_retry.initial = metadata.get("ivr_retry", self.fields["ivr_retry"].initial)
-
-                flow_triggers = Trigger.objects.filter(
-                    org=self.instance.org,
-                    flow=self.instance,
-                    is_archived=False,
-                    groups=None,
-                    trigger_type=Trigger.TYPE_KEYWORD,
-                ).order_by("created_on")
-
-                keyword_triggers = self.fields["keyword_triggers"]
-                keyword_triggers.initial = ",".join(t.keyword for t in flow_triggers)
+                self.fields["ivr_retry"].initial = self.instance.metadata.get("ivr_retry", 60)
 
             class Meta:
                 model = Flow
                 fields = ("name", "keyword_triggers", "expires_after_minutes", "ignore_triggers", "ivr_retry")
                 widgets = {"name": InputWidget(), "ignore_triggers": CheckboxWidget()}
 
-        class MessagingForm(BaseForm):
-            keyword_triggers = forms.CharField(
-                required=False,
-                label=_("Global keyword triggers"),
-                help_text=_("When a user sends any of these keywords they will begin this flow"),
-                widget=SelectWidget(
-                    attrs={
-                        "widget_only": False,
-                        "multi": True,
-                        "searchable": True,
-                        "tags": True,
-                        "space_select": True,
-                        "placeholder": _("Keywords"),
-                    }
-                ),
-            )
-
+        class MessagingForm(BaseOnlineForm):
             expires_after_minutes = forms.ChoiceField(
                 label=_("Expire inactive contacts"),
                 help_text=_("When inactive contacts should be removed from the flow"),
@@ -616,20 +600,6 @@ class FlowCRUDL(SmartCRUDL):
                 choices=Flow.EXPIRES_CHOICES[Flow.TYPE_MESSAGE],
                 widget=SelectWidget(attrs={"widget_only": False}),
             )
-
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-
-                flow_triggers = Trigger.objects.filter(
-                    org=self.instance.org,
-                    flow=self.instance,
-                    is_archived=False,
-                    groups=None,
-                    trigger_type=Trigger.TYPE_KEYWORD,
-                ).order_by("created_on")
-
-                keyword_triggers = self.fields["keyword_triggers"]
-                keyword_triggers.initial = list([t.keyword for t in flow_triggers])
 
             class Meta:
                 model = Flow
@@ -668,49 +638,52 @@ class FlowCRUDL(SmartCRUDL):
             return obj
 
         def post_save(self, obj):
-            keywords = set()
-            user = self.request.user
-            org = self.request.org
+            keyword_triggers = self.form.cleaned_data.get("keyword_triggers")
 
-            if "keyword_triggers" in self.form.cleaned_data:
-                # get existing keyword triggers for this flow
-                existing = obj.triggers.filter(trigger_type=Trigger.TYPE_KEYWORD, is_archived=False, groups=None)
-                existing_keywords = {t.keyword for t in existing}
+            if keyword_triggers is not None:
+                new_keywords = sorted(set([k for k in keyword_triggers.split(",") if k]))
 
-                if len(self.form.cleaned_data["keyword_triggers"]) > 0:
-                    keywords = set(self.form.cleaned_data["keyword_triggers"].split(","))
+                self.update_triggers(obj, self.request.user, new_keywords)
 
-                removed_keywords = existing_keywords.difference(keywords)
-                for keyword in removed_keywords:
-                    obj.triggers.filter(keyword=keyword, groups=None, is_archived=False).update(is_archived=True)
-
-                added_keywords = keywords.difference(existing_keywords)
-                archived_keywords = [
-                    t.keyword
-                    for t in obj.triggers.filter(
-                        org=org, flow=obj, trigger_type=Trigger.TYPE_KEYWORD, is_archived=True, groups=None
-                    )
-                ]
-
-                # set difference does not have a deterministic order, we need to sort the keywords
-                for keyword in sorted(added_keywords):
-                    # first check if the added keyword is not amongst archived
-                    if keyword in archived_keywords:  # pragma: needs cover
-                        obj.triggers.filter(org=org, flow=obj, keyword=keyword, groups=None).update(is_archived=False)
-                    else:
-                        Trigger.objects.create(
-                            org=org,
-                            keyword=keyword,
-                            trigger_type=Trigger.TYPE_KEYWORD,
-                            match_type=Trigger.MATCH_FIRST_WORD,
-                            flow=obj,
-                            created_by=user,
-                            modified_by=user,
-                        )
-
-            on_transaction_commit(lambda: update_session_wait_expires.delay(obj.pk))
+            on_transaction_commit(lambda: update_session_wait_expires.delay(obj.id))
 
             return obj
+
+        def update_triggers(self, flow, user, new_keywords: list):
+            # get existing keyword triggers for this flow by their keyword
+            existing_keywords = defaultdict(list)
+            for trigger in flow.triggers.filter(trigger_type=Trigger.TYPE_KEYWORD, is_archived=False):
+                existing_keywords[trigger.keyword].append(trigger)
+
+            # archive any triggers for keywords not in the new set
+            for keyword, triggers in existing_keywords.items():
+                if keyword not in new_keywords:
+                    for trigger in triggers:
+                        trigger.archive(user)
+
+            for keyword in new_keywords:
+                if keyword not in existing_keywords:
+                    # look for archived trigger with default empty settings that we can restore
+                    archived = flow.triggers.filter(
+                        trigger_type=Trigger.TYPE_KEYWORD,
+                        keyword=keyword,
+                        is_archived=True,
+                        channel=None,
+                        groups=None,
+                        exclude_groups=None,
+                    ).first()
+
+                    if archived:
+                        archived.restore(user)
+                    else:
+                        Trigger.create(
+                            flow.org,
+                            user,
+                            Trigger.TYPE_KEYWORD,
+                            flow,
+                            keyword=keyword,
+                            match_type=Trigger.MATCH_FIRST_WORD,
+                        )
 
     class BaseList(SpaMixin, OrgFilterMixin, OrgPermsMixin, BulkActionMixin, ContentMenuMixin, SmartListView):
         title = _("Flows")


### PR DESCRIPTION
Previously editing of keyword triggers from flow update only looked at "Global" keyword triggers (no group filtering) - but now it will consider any trigger with that keyword.