### PR TITLE
Fix and cleanup views for accepting invitations

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1530,6 +1530,11 @@ class Invitation(SmartModel):
 
         send_template_email(to_email, subject, template, context, self.org.branding)
 
+    def release(self):
+        self.is_active = False
+        self.modified_on = timezone.now()
+        self.save(update_fields=("is_active", "modified_on"))
+
 
 class BackupToken(models.Model):
     """

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -356,7 +356,6 @@ PERMISSIONS = {
     "msgs.msg": ("archive", "export", "label", "menu"),
     "orgs.org": (
         "country",
-        "create_login",
         "create",
         "dashboard",
         "delete_child",

--- a/templates/orgs/org_join.html
+++ b/templates/orgs/org_join.html
@@ -1,41 +1,44 @@
 {% extends "smartmin/base.html" %}
 {% load i18n smartmin %}
 
-{% block styles %}
+{% block extra-style %}
   {{ block.super }}
   <style type="text/css">
     .content-card {
-      width: 28rem;
+      width: 32rem;
     }
   </style>
-{% endblock styles %}
+{% endblock extra-style %}
 {% block content %}
+  <div class="mb-8">
+    {% blocktrans trimmed with org=invitation.org %}
+      Sign in to join the <b>{{ org }}</b> workspace.
+    {% endblocktrans %}
+  </div>
   <form method="post"
-        action="{% url 'users.user_login' %}?next={% url 'orgs.org_join_accept' secret %}"
+        action="{% url 'users.user_login' %}?next={% url 'orgs.org_join_accept' invitation.secret %}"
         class="mt-6"
         id="login-form">
     <fieldset>
       <div class="control-group">
         <temba-textinput type="text"
-                         name="username"
-                         maxlenght="150"
-                         label="{% trans 'Email Address' %}"
-                         value="{{ email }}"
-                         disabled
-                         id="id_username">
+                         name="email"
+                         label="{% trans "Email Address" %}"
+                         value="{{ invitation.email }}"
+                         disabled>
         </temba-textinput>
       </div>
       <div class="control-group">
         <temba-textinput type="password"
                          name="password"
-                         label="{% trans 'Password' %}"
-                         placeholder="{% trans 'Your password, at least eight letters please' %}"
-                         password
-                         id="id_password">
+                         label="{% trans "Password" %}"
+                         placeholder="{% trans "Your password" %}"
+                         password>
         </temba-textinput>
       </div>
     </fieldset>
     {% csrf_token %}
+    <input type="hidden" name="username" value="{{ invitation.email }}">
     <input type="submit" value="Login" class="button-primary">
   </form>
 {% endblock content %}

--- a/templates/orgs/org_join_accept.html
+++ b/templates/orgs/org_join_accept.html
@@ -4,19 +4,17 @@
 {% block content %}
   <div class="flex w-full mb-4">
     <div class="flex-grow ml-1">
-      {% blocktrans trimmed with name=org.name %}
-        You have been invited to join {{ name }}.
+      {% blocktrans trimmed with org=invitation.org.name %}
+        You have been invited to join the <b>{{ org }}</b> workspace.
       {% endblocktrans %}
-    </br>
-    {% trans "Please click Join to accept the invitation." %}
+    </div>
   </div>
-</div>
-<div class="flex w-full mb-4">
-  <div class="flex-grow ml-1">
-    <form method="post" encrypt="multipart/form-data" class="mb-4">
-      {% csrf_token %}
-      <input type="submit" value="{{ submit_button_name }}" class="button-primary">
-    </form>
+  <div class="flex w-full mb-4">
+    <div class="flex-grow ml-1">
+      <form method="post" encrypt="multipart/form-data" class="mb-4">
+        {% csrf_token %}
+        <input type="submit" value="{{ submit_button_name }}" class="button-primary">
+      </form>
+    </div>
   </div>
-</div>
 {% endblock content %}

--- a/templates/orgs/org_join_signup.html
+++ b/templates/orgs/org_join_signup.html
@@ -1,6 +1,5 @@
 {% extends "smartmin/update.html" %}
-{% load smartmin %}
-{% load i18n %}
+{% load smartmin i18n %}
 
 {% block extra-style %}
   {{ block.super }}
@@ -14,13 +13,20 @@
     }
   </style>
 {% endblock extra-style %}
+{% block pre-form %}
+  <div class="mb-8">
+    {% blocktrans trimmed with org=invitation.org %}
+      Create a new login to join the <b>{{ org }}</b> workspace.
+    {% endblocktrans %}
+  </div>
+{% endblock pre-form %}
 {% block fields %}
   <div class="control-group">
     <temba-textinput type="text"
                      name="username"
                      maxlength="150"
-                     label="{% trans 'Email Address' %}"
-                     value="{{ email }}"
+                     label="{% trans "Email Address" %}"
+                     value="{{ invitation.email }}"
                      disabled
                      id="id_username">
     </temba-textinput>
@@ -31,14 +37,3 @@
     <div class="flex-grow">{% render_field 'last_name' %}</div>
   </div>
 {% endblock fields %}
-{% block extra-script %}
-  {{ block.super }}
-  <script type="text/javascript">
-    $(function() {
-      $(".formax-icon, .formax-summary").on('click', function() {
-        $(this).parents(".formax-section").toggleClass('open');
-        $(this).parents(".formax-section").siblings('formax-section').removeClass('open');
-      });
-    });
-  </script>
-{% endblock extra-script %}


### PR DESCRIPTION
Includes some UI tweaks:

<img width="478" alt="Captura de pantalla 2023-10-25 a la(s) 11 19 03" src="https://github.com/nyaruka/rapidpro/assets/675558/1066782e-a2ee-408b-811c-6b937f4f1853">

becomes:

<img width="482" alt="Captura de pantalla 2023-10-25 a la(s) 11 18 16" src="https://github.com/nyaruka/rapidpro/assets/675558/2413d898-952d-43b2-965e-7b5ca93c185b">

and 

<img width="458" alt="Captura de pantalla 2023-10-25 a la(s) 13 31 43" src="https://github.com/nyaruka/rapidpro/assets/675558/55dc0689-2053-42ae-8343-058359f9ff04">

becomes

<img width="442" alt="Captura de pantalla 2023-10-25 a la(s) 13 30 37" src="https://github.com/nyaruka/rapidpro/assets/675558/4c048062-4c3a-49f6-8ccc-5ce1912279ce">

and 

<img width="581" alt="Captura de pantalla 2023-10-25 a la(s) 13 48 57" src="https://github.com/nyaruka/rapidpro/assets/675558/ebfcb1dd-07ab-4ef6-948a-4006e79cd4ec">

becomes

<img width="493" alt="Captura de pantalla 2023-10-25 a la(s) 14 02 06" src="https://github.com/nyaruka/rapidpro/assets/675558/7bdbafbd-03d4-4b32-937d-edb7cddbe3cc">