### PR TITLE
Make sure the missing external ID we make is truncated to 64 characters

### DIFF
--- a/temba/utils/whatsapp/tasks.py
+++ b/temba/utils/whatsapp/tasks.py
@@ -140,7 +140,7 @@ def update_local_templates(channel, templates_data):
             content=content,
             variable_count=variable_count,
             status=status,
-            external_id=template.get("id", missing_external_id),
+            external_id=template.get("id", missing_external_id[:64]),
             namespace=template.get("namespace", channel_namespace),
         )
 

--- a/temba/utils/whatsapp/tests.py
+++ b/temba/utils/whatsapp/tests.py
@@ -270,17 +270,39 @@ class WhatsAppUtilsTest(TembaTest):
                 "rejected_reason": "NONE",
                 "category": "ISSUE_RESOLUTION",
             },
+            {
+                "name": "this_is_template_has_a_very_long_name,_and_not_having_an_id,_we_generate_the_external_id_from_the_name_and_truncate_that_to_64_characters",
+                "components": [
+                    {
+                        "type": "BODY",
+                        "text": "This is template has a very long name, and not having an id, we generate the external_id from the name and truncate that to 64 characters",
+                    }
+                ],
+                "language": "en_US",
+                "status": "APPROVED",
+                "namespace": "xxxxxxxx_xxxx_xxxx_xxxx_xxxxxxxxxxxx",
+                "rejected_reason": "NONE",
+                "category": "UTILITY",
+            },
         ]
 
         update_local_templates(channel, D3_templates_data)
 
-        self.assertEqual(4, Template.objects.filter(org=self.org).count())
-        self.assertEqual(6, TemplateTranslation.objects.filter(channel=channel).count())
+        self.assertEqual(5, Template.objects.filter(org=self.org).count())
+        self.assertEqual(7, TemplateTranslation.objects.filter(channel=channel).count())
         self.assertEqual(0, TemplateTranslation.objects.filter(channel=channel, namespace="").count())
         self.assertEqual(0, TemplateTranslation.objects.filter(channel=channel, namespace=None).count())
         self.assertEqual(
             sorted(
-                ["en/hello", "en_GB/hello", "fr/hello", "en/goodbye", "en/workout_activity", "kli/invalid_language"]
+                [
+                    "en/hello",
+                    "en_GB/hello",
+                    "fr/hello",
+                    "en/goodbye",
+                    "en_US/this_is_template_has_a_very_long_name,_and_not_having_an_i",
+                    "en/workout_activity",
+                    "kli/invalid_language",
+                ]
             ),
             sorted(list(TemplateTranslation.objects.filter(channel=channel).values_list("external_id", flat=True))),
         )


### PR DESCRIPTION
Whatsapp templates sync

For 360diallog, we do not get the template ID and we make an ID we store in external ID by combining the language and name.

The name can go up to 512 characters but the external ID has up to 64 characters.

This make sure we truncate the ID we make up from the name limited to 64 characters.

Fixes https://textit.sentry.io/issues/4547227349/