### PR TITLE
Remove no longer used flow_type field on queued flow starts

### DIFF
--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -134,7 +134,6 @@ def queue_flow_start(start):
         "org_id": org_id,
         "created_by_id": start.created_by_id,
         "flow_id": start.flow_id,
-        "flow_type": start.flow.flow_type,
         "contact_ids": list(start.contacts.values_list("id", flat=True)),
         "group_ids": list(start.groups.values_list("id", flat=True)),
         "urns": start.urns or [],

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -645,7 +645,6 @@ class MailroomQueueTest(TembaTest):
                     "org_id": self.org.id,
                     "created_by_id": self.admin.id,
                     "flow_id": flow.id,
-                    "flow_type": "M",
                     "contact_ids": [jim.id],
                     "group_ids": [bobs.id],
                     "urns": ["tel:+1234567890", "twitter:bobby"],


### PR DESCRIPTION
Not used as of https://github.com/nyaruka/mailroom/pull/164