### PR TITLE
Simplify how we render API docs pages

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -296,17 +296,3 @@ class APIToken(models.Model):
 
     def __str__(self):
         return self.key
-
-
-def get_or_create_api_token(org, user):
-    """
-    Gets or creates an API token for this user. If user doen't have access to the API, this returns None.
-    """
-
-    try:
-        token = APIToken.get_or_create(org, user)
-        return token.key
-    except ValueError:
-        pass
-
-    return None

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -136,14 +136,13 @@ class DocumentationRenderer(BrowsableAPIRenderer):
     instead have a separate API explorer page. This render then just displays the endpoint docs.
     """
 
+    template = "api/v2/docs.html"
+
     def get_context(self, data, accepted_media_type, renderer_context):
         view = renderer_context["view"]
         request = renderer_context["request"]
         response = renderer_context["response"]
         renderer = self.get_default_renderer(view)
-
-        org = request.org
-        user = request.user
 
         return {
             "content": self.get_content(renderer, data, accepted_media_type, renderer_context),
@@ -152,21 +151,7 @@ class DocumentationRenderer(BrowsableAPIRenderer):
             "response": response,
             "description": view.get_view_description(html=True),
             "name": self.get_name(view),
-            "breadcrumblist": self.get_breadcrumbs(request),
-            "api_token": user.get_api_token(org) if (org and user) else None,
         }
-
-    def render(self, data, accepted_media_type=None, renderer_context=None):
-        """
-        Usually one customizes the browsable view by overriding the rest_framework/api.html template but we have two
-        versions of the API to support with two different templates.
-        """
-        if not renderer_context:  # pragma: needs cover
-            raise ValueError("Can't render without context")
-
-        self.template = "api/v2/api_root.html"
-
-        return super().render(data, accepted_media_type, renderer_context)
 
 
 class CreatedOnCursorPagination(CursorPagination):

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -136,7 +136,7 @@ class DocumentationRenderer(BrowsableAPIRenderer):
     instead have a separate API explorer page. This render then just displays the endpoint docs.
     """
 
-    template = "api/v2/docs.html"
+    template = "api/docs.html"
 
     def get_context(self, data, accepted_media_type, renderer_context):
         view = renderer_context["view"]

--- a/temba/api/urls.py
+++ b/temba/api/urls.py
@@ -3,7 +3,7 @@ from django.urls import re_path
 from django.views.generic import RedirectView
 
 urlpatterns = [
-    re_path(r"^api/$", RedirectView.as_view(pattern_name="api.v2", permanent=False), name="api"),
+    re_path(r"^api/$", RedirectView.as_view(pattern_name="api.v2.root", permanent=False), name="api"),
     re_path(r"^api/internal/", include("temba.api.internal.urls")),
     re_path(r"^api/v2/", include("temba.api.v2.urls")),
 ]

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -653,34 +653,20 @@ class EndpointsTest(APITest):
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_HTTPS", "https"))
     def test_root(self):
-        root_url = reverse("api.v2")
+        root_url = reverse("api.v2.root")
 
         # browse as HTML anonymously (should still show docs)
         response = self.getHTML(root_url)
-        self.assertContains(response, "We provide a RESTful JSON API", status_code=403)
+        self.assertContains(response, "We provide a RESTful JSON API", status_code=200)
 
         # same thing if user navigates to just /api
         response = self.client.get(reverse("api"), follow=True)
-        self.assertContains(response, "We provide a RESTful JSON API", status_code=403)
+        self.assertContains(response, "We provide a RESTful JSON API", status_code=200)
 
         # try to browse as JSON anonymously
         response = self.getJSON(root_url)
-        self.assertResponseError(response, None, "Authentication credentials were not provided.", status_code=403)
-
-        # login as administrator
-        self.login(self.admin)
-        token = self.admin.get_api_token(self.org)
-        self.assertIsInstance(token, str)
-        self.assertEqual(len(token), 40)
-        self.assertEqual(token, self.admin.get_api_token(self.org))  # subsequent calls return same token
-
-        # browse as HTML
-        response = self.getHTML(root_url)
-        self.assertContains(response, token, status_code=200)  # displays their API token
-
-        # browse as JSON
-        response = self.getJSON(root_url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
+        self.assertIsInstance(response.json(), dict)
         self.assertEqual(response.json()["runs"], "https://testserver:80/api/v2/runs")  # endpoints are listed
 
     def test_explorer(self):

--- a/temba/api/v2/urls.py
+++ b/temba/api/v2/urls.py
@@ -41,7 +41,7 @@ from .views import (
 )
 
 urlpatterns = [
-    re_path(r"^$", RootView.as_view(), name="api.v2"),
+    re_path(r"^$", RootView.as_view(), name="api.v2.root"),
     re_path(r"^explorer/$", ExplorerView.as_view(), name="api.v2.explorer"),
     re_path(r"^authenticate$", AuthenticateView.as_view(), name="api.v2.authenticate"),
     # ========== endpoints A-Z ===========

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -282,9 +282,13 @@ class User(AuthUser):
         return UserSettings.objects.get_or_create(user=self)[0]
 
     def get_api_token(self, org) -> str:
-        from temba.api.models import get_or_create_api_token
+        from temba.api.models import APIToken
 
-        return get_or_create_api_token(org, self)
+        try:
+            token = APIToken.get_or_create(org, self)
+            return token.key
+        except ValueError:
+            return None
 
     def recover_password(self, branding: dict):
         """

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -131,13 +131,15 @@ class UserTest(TembaTest):
     def test_model(self):
         user = User.create("jim@rapidpro.io", "Jim", "McFlow", password="super")
         self.org.add_user(user, OrgRole.EDITOR)
-        self.org2.add_user(user, OrgRole.EDITOR)
+        self.org2.add_user(user, OrgRole.AGENT)
 
         self.assertEqual("Jim McFlow", user.name)
         self.assertFalse(user.is_alpha)
         self.assertFalse(user.is_beta)
         self.assertEqual({"email": "jim@rapidpro.io", "name": "Jim McFlow"}, user.as_engine_ref())
         self.assertEqual([self.org, self.org2], list(user.get_orgs().order_by("id")))
+        self.assertEqual(40, len(user.get_api_token(self.org)))
+        self.assertIsNone(user.get_api_token(self.org2))  # can't generate API token as agent
 
         user.last_name = ""
         user.save(update_fields=("last_name",))

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -797,8 +797,6 @@ CELERY_BEAT_SCHEDULE = {
 # -----------------------------------------------------------------------------------
 
 REST_FRAMEWORK = {
-    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
-    "DEFAULT_AUTHENTICATION_CLASSES": ("temba.api.support.APISessionAuthentication",),
     "DEFAULT_THROTTLE_RATES": {
         "v2": "2500/hour",
         "v2.contacts": "2500/hour",
@@ -807,7 +805,6 @@ REST_FRAMEWORK = {
         "v2.runs": "2500/hour",
     },
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
-    "DEFAULT_RENDERER_CLASSES": ("temba.api.support.DocumentationRenderer", "rest_framework.renderers.JSONRenderer"),
     "PAGE_SIZE": 250,
     "EXCEPTION_HANDLER": "temba.api.support.temba_exception_handler",
 }

--- a/templates/api/docs.html
+++ b/templates/api/docs.html
@@ -1,8 +1,8 @@
 {% extends "no_nav.html" %}
-{% load rest_framework static smartmin %}
+{% load rest_framework static smartmin i18n %}
 
 {% block head-title %}
-  {{ branding.name }} API v2
+  {{ name }}
 {% endblock head-title %}
 {% block page-top %}
 {% endblock page-top %}
@@ -118,57 +118,17 @@
     strong {
       font-weight: bold;
     }
-
-    .breadcrumb {
-      display: flex;
-      flex-wrap: wrap;
-    }
-
-    .token {
-      white-space: nowrap;
-    }
   </style>
 {% endblock extra-style %}
 {% block content %}
-  {% block breadcrumbs %}
-    <div class="breadcrumb">
-      <div class="ml-1">
-        <a href="/">{{ branding.name }}</a>
-        <span class="divider">&rsaquo;</span>
-      </div>
-      {% for breadcrumb_name, breadcrumb_url in breadcrumblist %}
-        <div class="mx-1">
-          <a href="{{ breadcrumb_url }}" {% if forloop.last %}class="active"{% endif %}>
-            {% if forloop.first %}
-              API v2
-            {% else %}
-              {{ breadcrumb_name }}
-            {% endif %}
-          </a>
-          {% if not forloop.last %}<span class="divider">&rsaquo;</span>{% endif %}
-        </div>
-      {% endfor %}
-      <li class="mr-4" style="flex-grow:1"></li>
-      {% if api_token %}
-        <li class="token" style="color: #666">API Token: {{ api_token }}</li>
-      {% else %}
-        <li class="pull-right">Log in to get your API Token</li>
-      {% endif %}
-    </div>
-  {% endblock breadcrumbs %}
-  <!-- Content -->
   <div id="content" class="px-8 pb-8">
     <div class="content-main">
       <div class="flex mb-8">
-        <div class="flex-grow page-title">
-          {% if name == "Root" %}
-            {{ branding.name }} API v2
-          {% else %}
-            {{ name }}
-          {% endif %}
+        <div class="flex-grow page-title">{{ name }}</div>
+        <div>
+          {% block api-menu %}
+          {% endblock api-menu %}
         </div>
-        <temba-button href='{% url "api.v2.explorer" %}' name="API Explorer">
-        </temba-button>
       </div>
       {{ description }}
     </div>

--- a/templates/api/v2/docs.html
+++ b/templates/api/v2/docs.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block api-menu %}
-  <a class="button ml-4" href="{% url "api.v2.root" %}">{% trans "Endpoints" %}</a>
-  <a class="button ml-4" href="{% url "api.v2.explorer" %}">{% trans "Explorer" %}</a>
+  <a class="button-light ml-4" href="{% url "api.v2.root" %}">{% trans "Endpoints" %}</a>
+  <a class="button-light ml-4" href="{% url "api.v2.explorer" %}">{% trans "Explorer" %}</a>
 {% endblock api-menu %}

--- a/templates/api/v2/docs.html
+++ b/templates/api/v2/docs.html
@@ -1,0 +1,7 @@
+{% extends "api/docs.html" %}
+{% load i18n %}
+
+{% block api-menu %}
+  <a class="button ml-4" href="{% url "api.v2.root" %}">{% trans "Endpoints" %}</a>
+  <a class="button ml-4" href="{% url "api.v2.explorer" %}">{% trans "Explorer" %}</a>
+{% endblock api-menu %}

--- a/templates/api/v2/explorer.html
+++ b/templates/api/v2/explorer.html
@@ -10,7 +10,7 @@
       <li>
         <a href="/">{{ branding.name }}</a>
         <span class="divider">&rsaquo;</span>
-        <a href="{% url 'api.v2' %}">API v2</a>
+        <a href="{% url 'api.v2.root' %}">API v2</a>
         <span class="divider">&rsaquo;</span>
       </li>
       <li class="mr-4 ml-1">

--- a/templates/orgs/user_token.html
+++ b/templates/orgs/user_token.html
@@ -9,7 +9,7 @@
       {% endblocktrans %}
     </div>
     <div class="buttons">
-      <div onclick="goto(event)" href="{% url 'api.v2' %}" class="button-light">{% trans "API Docs" %}</div>
+      <div onclick="goto(event)" href="{% url 'api.v2.root' %}" class="button-light">{% trans "API Docs" %}</div>
     </div>
   </div>
 {% endblock summary %}


### PR DESCRIPTION
Stop showing API tokens on docs pages, and rework templates to sbetter support different APIs

before 

<img width="809" alt="Captura de pantalla 2023-11-20 a la(s) 16 51 41" src="https://github.com/nyaruka/rapidpro/assets/675558/0bfc635f-2736-48b1-9614-2d051fffe9f3">

after

<img width="795" alt="Captura de pantalla 2023-11-20 a la(s) 16 51 05" src="https://github.com/nyaruka/rapidpro/assets/675558/62b19bea-c518-4477-8a2e-9d4607226e6a">
