### PR TITLE
Undocument the templates API endpoint and add locale field to translations

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -23,7 +23,7 @@ from temba.locations.models import AdminBoundary
 from temba.mailroom import modifiers
 from temba.msgs.models import Broadcast, Label, Media, Msg, OptIn
 from temba.orgs.models import Org, OrgRole
-from temba.templates.models import Template, TemplateTranslation
+from temba.templates.models import Template
 from temba.tickets.models import Ticket, Ticketer, Topic
 from temba.utils import json, on_transaction_commit
 from temba.utils.fields import NameValidator
@@ -1576,14 +1576,11 @@ class TemplateReadSerializer(ReadSerializer):
 
     def get_translations(self, obj):
         translations = []
-        for translation in (
-            TemplateTranslation.objects.filter(template=obj, is_active=True)
-            .order_by("language")
-            .select_related("channel")
-        ):
+        for translation in obj.translations.all():
             translations.append(
                 {
-                    "language": translation.language,
+                    "language": translation.locale[:3],
+                    "locale": translation.locale,
                     "content": translation.content,
                     "namespace": translation.namespace,
                     "variable_count": translation.variable_count,


### PR DESCRIPTION
It needs to change to support more complex templates.. and it doesn't feel like a thing we need to expose to end users