### PR TITLE
Add skeleton staff only mailgun channel type

### DIFF
--- a/temba/channels/types/mailgun/__init__.py
+++ b/temba/channels/types/mailgun/__init__.py
@@ -1,0 +1,1 @@
+from .type import MailgunType  # noqa

--- a/temba/channels/types/mailgun/tests.py
+++ b/temba/channels/types/mailgun/tests.py
@@ -1,0 +1,31 @@
+from django.urls import reverse
+
+from temba.tests import TembaTest
+
+from ...models import Channel
+
+
+class MailgunTypeTest(TembaTest):
+    def test_claim(self):
+        claim_url = reverse("channels.types.mailgun.claim")
+
+        self.login(self.admin)
+
+        response = self.client.get(reverse("channels.channel_claim"))
+        self.assertNotContains(response, claim_url)
+
+        self.login(self.customer_support, choose_org=self.org)
+
+        response = self.client.get(reverse("channels.channel_claim"))
+        self.assertContains(response, claim_url)
+
+        response = self.client.get(claim_url)
+        self.assertEqual(200, response.status_code)
+
+        response = self.client.post(claim_url, {"address": "acme.com", "sending_key": "0123456789"}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        channel = Channel.objects.get(channel_type="MLG")
+        self.assertEqual("Mailgun: acme.com", channel.name)
+        self.assertEqual("acme.com", channel.address)
+        self.assertEqual({"auth_token": "0123456789"}, channel.config)

--- a/temba/channels/types/mailgun/type.py
+++ b/temba/channels/types/mailgun/type.py
@@ -1,0 +1,41 @@
+from django.utils.translation import gettext_lazy as _
+
+from temba.contacts.models import URN
+
+from ...models import ChannelType, ConfigUI
+from .views import ClaimView
+
+
+class MailgunType(ChannelType):
+    """
+    A Mailgun email channel.
+    """
+
+    code = "MLG"
+    name = "Mailgun"
+    category = ChannelType.Category.API
+
+    courier_url = r"^mlg/(?P<uuid>[a-z0-9\-]+)/receive$"
+    schemes = [URN.EMAIL_SCHEME]
+
+    claim_blurb = _("Add a %(link)s channel to send and receive messages as emails.") % {
+        "link": '<a target="_blank" href="https://mailgun.com/">Mailgun</a>'
+    }
+    claim_view = ClaimView
+
+    config_ui = ConfigUI(
+        blurb=_(
+            "To finish configuring this channel, you'll need to add the following webhook to your domain for the "
+            "Delivered Messages event type."
+        ),
+        endpoints=[
+            ConfigUI.Endpoint(
+                courier="receive",
+                label=_("Delivery URL"),
+                help=_("Webhook URL for the Delivered Messages event type."),
+            ),
+        ],
+    )
+
+    def is_available_to(self, org, user):
+        return user.is_staff, user.is_staff

--- a/temba/channels/types/mailgun/views.py
+++ b/temba/channels/types/mailgun/views.py
@@ -1,0 +1,34 @@
+from smartmin.views import SmartFormView
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from ...models import Channel
+from ...views import ClaimViewMixin
+
+
+class ClaimView(ClaimViewMixin, SmartFormView):
+    class Form(ClaimViewMixin.Form):
+        address = forms.CharField(label=_("Domain"), help_text=_("The email domain you have configured in Mailgun."))
+        sending_key = forms.CharField(
+            label=_("Sending API key"),
+            help_text=_("A sending API key you have configured for this domain."),
+            max_length=50,
+        )
+
+    form_class = Form
+
+    def form_valid(self, form):
+        domain = form.cleaned_data["address"]
+
+        self.object = Channel.create(
+            self.request.org,
+            self.request.user,
+            None,
+            self.channel_type,
+            name=f"Mailgun: {domain}",
+            address=domain,
+            config={Channel.CONFIG_AUTH_TOKEN: form.cleaned_data["sending_key"]},
+        )
+
+        return super().form_valid(form)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -869,6 +869,7 @@ CHANNEL_TYPES = [
     "temba.channels.types.m3tech.M3TechType",
     "temba.channels.types.macrokiosk.MacrokioskType",
     "temba.channels.types.mblox.MbloxType",
+    "temba.channels.types.mailgun.MailgunType",
     "temba.channels.types.messagebird.MessageBirdType",
     "temba.channels.types.messangi.MessangiType",
     "temba.channels.types.mtn.MtnType",


### PR DESCRIPTION
The final user facing version should probably get a general API key, list domains, add webhook automatically.