### PR TITLE
Cleanup flow SMTP formax and show parent settings as default to match mailroom changes

### DIFF
--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1503,265 +1503,6 @@ class OrgTest(TembaTest):
         response = self.client.get(resthook_url)
         self.assertEqual([], list(response.context["current_resthooks"]))
 
-    @override_settings(HOSTNAME="rapidpro.io", SEND_EMAILS=True)
-    def test_smtp_server(self):
-        self.login(self.admin)
-
-        settings_url = reverse("orgs.org_workspace")
-        config_url = reverse("orgs.org_smtp_server")
-
-        # orgs without SMTP settings see default from address
-        response = self.client.get(settings_url)
-        self.assertContains(response, "Emails sent from flows will be sent from <b>no-reply@temba.io</b>.")
-        self.assertEqual("no-reply@temba.io", response.context["from_email_default"])
-        self.assertEqual(None, response.context["from_email_custom"])
-
-        self.assertIsNone(self.org.flow_smtp)
-
-        response = self.client.post(config_url, dict(disconnect="false"), follow=True)
-        self.assertEqual(
-            '[{"message": "You must enter a from email", "code": ""}]',
-            response.context["form"].errors["__all__"].as_json(),
-        )
-        self.assertEqual(len(mail.outbox), 0)
-
-        response = self.client.post(config_url, {"from_email": "foobar.com", "disconnect": "false"}, follow=True)
-        self.assertEqual(
-            '[{"message": "Please enter a valid email address", "code": ""}]',
-            response.context["form"].errors["__all__"].as_json(),
-        )
-        self.assertEqual(len(mail.outbox), 0)
-
-        response = self.client.post(config_url, {"from_email": "foo@bar.com", "disconnect": "false"}, follow=True)
-        self.assertEqual(
-            '[{"message": "You must enter the SMTP host", "code": ""}]',
-            response.context["form"].errors["__all__"].as_json(),
-        )
-        self.assertEqual(len(mail.outbox), 0)
-
-        response = self.client.post(
-            config_url,
-            {"from_email": "foo@bar.com", "smtp_host": "smtp.example.com", "disconnect": "false"},
-            follow=True,
-        )
-        self.assertEqual(
-            '[{"message": "You must enter the SMTP username", "code": ""}]',
-            response.context["form"].errors["__all__"].as_json(),
-        )
-        self.assertEqual(len(mail.outbox), 0)
-
-        response = self.client.post(
-            config_url,
-            {
-                "from_email": "foo@bar.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "support@example.com",
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-        self.assertEqual(
-            '[{"message": "You must enter the SMTP password", "code": ""}]',
-            response.context["form"].errors["__all__"].as_json(),
-        )
-        self.assertEqual(len(mail.outbox), 0)
-
-        response = self.client.post(
-            config_url,
-            {
-                "from_email": "foo@bar.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "support@example.com",
-                "smtp_password": "secret",
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-        self.assertEqual(
-            '[{"message": "You must enter the SMTP port", "code": ""}]',
-            response.context["form"].errors["__all__"].as_json(),
-        )
-        self.assertEqual(len(mail.outbox), 0)
-
-        with patch("temba.utils.email.send_custom_smtp_email") as mock_send_smtp_email:
-            mock_send_smtp_email.side_effect = smtplib.SMTPException("SMTP Error")
-            response = self.client.post(
-                config_url,
-                {
-                    "from_email": "foo@bar.com",
-                    "smtp_host": "smtp.example.com",
-                    "smtp_username": "support@example.com",
-                    "smtp_password": "secret",
-                    "smtp_port": "465",
-                    "disconnect": "false",
-                },
-                follow=True,
-            )
-            self.assertEqual(
-                '[{"message": "Failed to send email with STMP server configuration with error \'SMTP Error\'", "code": ""}]',
-                response.context["form"].errors["__all__"].as_json(),
-            )
-            self.assertEqual(len(mail.outbox), 0)
-
-            mock_send_smtp_email.side_effect = Exception("Unexpected Error")
-            response = self.client.post(
-                config_url,
-                {
-                    "from_email": "foo@bar.com",
-                    "smtp_host": "smtp.example.com",
-                    "smtp_username": "support@example.com",
-                    "smtp_password": "secret",
-                    "smtp_port": "465",
-                    "disconnect": "false",
-                },
-                follow=True,
-            )
-            self.assertEqual(
-                '[{"message": "Failed to send email with STMP server configuration", "code": ""}]',
-                response.context["form"].errors["__all__"].as_json(),
-            )
-            self.assertEqual(len(mail.outbox), 0)
-
-        response = self.client.post(
-            config_url,
-            {
-                "from_email": "foo@bar.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "support@example.com",
-                "smtp_password": "secret",
-                "smtp_port": "465",
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-        self.assertEqual(len(mail.outbox), 1)
-
-        self.org.refresh_from_db()
-        self.assertEqual(
-            r"smtp://support%40example.com:secret@smtp.example.com:465/?from=foo%40bar.com&tls=true", self.org.flow_smtp
-        )
-
-        response = self.client.get(config_url)
-        self.assertEqual("no-reply@temba.io", response.context["from_email_default"])
-        self.assertEqual("foo@bar.com", response.context["from_email_custom"])
-
-        self.client.post(
-            config_url,
-            {
-                "from_email": "support@example.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "support@example.com",
-                "smtp_password": "secret",
-                "smtp_port": "465",
-                "name": "DO NOT CHANGE ME",
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-
-        # name shouldn't change
-        self.org.refresh_from_db()
-        self.assertEqual(self.org.name, "Nyaruka")
-        self.assertEqual(
-            r"smtp://support%40example.com:secret@smtp.example.com:465/?from=support%40example.com&tls=true",
-            self.org.flow_smtp,
-        )
-
-        self.client.post(
-            config_url,
-            {
-                "from_email": "support@example.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "support@example.com",
-                "smtp_password": "",
-                "smtp_port": "465",
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-
-        # password shouldn't change
-        self.org.refresh_from_db()
-        self.assertEqual(
-            r"smtp://support%40example.com:secret@smtp.example.com:465/?from=support%40example.com&tls=true",
-            self.org.flow_smtp,
-        )
-
-        response = self.client.post(
-            config_url,
-            {
-                "from_email": "support@example.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "help@example.com",
-                "smtp_password": "",
-                "smtp_port": "465",
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-
-        # should have error for blank password
-        self.assertEqual(
-            '[{"message": "You must enter the SMTP password", "code": ""}]',
-            response.context["form"].errors["__all__"].as_json(),
-        )
-
-        self.client.post(config_url, dict(disconnect="true"), follow=True)
-
-        self.org.refresh_from_db()
-        self.assertIsNone(self.org.flow_smtp)
-
-        response = self.client.post(
-            config_url,
-            {
-                "from_email": " support@example.com",
-                "smtp_host": " smtp.example.com",
-                "smtp_username": "support@example.com",
-                "smtp_password": "secret ",
-                "smtp_port": "465 ",
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-
-        self.org.refresh_from_db()
-        self.assertEqual(
-            r"smtp://support%40example.com:secret@smtp.example.com:465/?from=support%40example.com&tls=true",
-            self.org.flow_smtp,
-        )
-
-        response = self.client.post(
-            config_url,
-            {
-                "from_email": "support@example.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "support@example.com",
-                "smtp_password": "secre/t",
-                "smtp_port": 465,
-                "disconnect": "false",
-            },
-            follow=True,
-        )
-
-        self.org.refresh_from_db()
-        self.assertEqual(
-            r"smtp://support%40example.com:secre%2Ft@smtp.example.com:465/?from=support%40example.com&tls=true",
-            self.org.flow_smtp,
-        )
-
-        response = self.client.get(config_url)
-        self.assertDictEqual(
-            response.context["view"].derive_initial(),
-            {
-                "from_email": "support@example.com",
-                "smtp_host": "smtp.example.com",
-                "smtp_username": "support@example.com",
-                "smtp_password": "secre/t",
-                "smtp_port": 465,
-                "disconnect": "false",
-            },
-        )
-
     def test_org_get_limit(self):
         self.assertEqual(self.org.get_limit(Org.LIMIT_FIELDS), 250)
         self.assertEqual(self.org.get_limit(Org.LIMIT_GROUPS), 250)
@@ -2451,6 +2192,150 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # should have an extra menu options for workspaces and users
         self.assertMenu(f"{reverse('orgs.org_menu')}settings/", 8)
+
+    @override_settings(SEND_EMAILS=True)
+    def test_smtp_server(self):
+        self.login(self.admin)
+
+        settings_url = reverse("orgs.org_workspace")
+        config_url = reverse("orgs.org_smtp_server")
+
+        # orgs without SMTP settings see default from address
+        response = self.client.get(settings_url)
+        self.assertContains(response, "Emails sent from flows will be sent from <b>no-reply@temba.io</b>.")
+        self.assertEqual("no-reply@temba.io", response.context["from_email_default"])  # from settings
+        self.assertEqual(None, response.context["from_email_custom"])
+
+        # make org a child to a parent that alsos doesn't have SMTP settings
+        self.org.parent = self.org2
+        self.org.save(update_fields=("parent",))
+
+        response = self.client.get(config_url)
+        self.assertEqual("no-reply@temba.io", response.context["from_email_default"])
+        self.assertIsNone(response.context["from_email_custom"])
+
+        # give parent custom SMTP settings
+        self.org2.flow_smtp = "smtp://bob%40acme.com:secret@example.com/?from=bob%40acme.com&tls=true"
+        self.org2.save(update_fields=("flow_smtp",))
+
+        response = self.client.get(config_url)
+        self.assertEqual("bob@acme.com", response.context["from_email_default"])
+        self.assertIsNone(response.context["from_email_custom"])
+
+        # try submitting without any data
+        response = self.client.post(config_url, {})
+        self.assertFormError(response, "form", "from_email", "This field is required.")
+        self.assertFormError(response, "form", "smtp_host", "This field is required.")
+        self.assertFormError(response, "form", "smtp_username", "This field is required.")
+        self.assertFormError(response, "form", "smtp_password", "This field is required.")
+        self.assertFormError(response, "form", "smtp_port", "This field is required.")
+        self.assertEqual(len(mail.outbox), 0)
+
+        # try submitting an invalid from address
+        response = self.client.post(config_url, {"from_email": "foobar.com", "disconnect": "false"})
+        self.assertFormError(response, "form", "from_email", "Please enter a valid email address.")
+        self.assertEqual(len(mail.outbox), 0)
+
+        # mock email sending so test send fails
+        with patch("temba.orgs.views.send_custom_smtp_email") as mock_send:
+            mock_send.side_effect = smtplib.SMTPException("boom")
+
+            response = self.client.post(
+                config_url,
+                {
+                    "from_email": "foo@bar.com",
+                    "smtp_host": "smtp.example.com",
+                    "smtp_username": "support@example.com",
+                    "smtp_password": "secret",
+                    "smtp_port": "465",
+                    "disconnect": "false",
+                },
+            )
+            self.assertFormError(
+                response, "form", None, "Failed to send email with STMP server configuration with error 'boom'"
+            )
+            self.assertEqual(len(mail.outbox), 0)
+
+            mock_send.side_effect = Exception("Unexpected Error")
+            response = self.client.post(
+                config_url,
+                {
+                    "from_email": "foo@bar.com",
+                    "smtp_host": "smtp.example.com",
+                    "smtp_username": "support@example.com",
+                    "smtp_password": "secret",
+                    "smtp_port": "465",
+                    "disconnect": "false",
+                },
+                follow=True,
+            )
+            self.assertFormError(response, "form", None, "Failed to send email with STMP server configuration")
+            self.assertEqual(len(mail.outbox), 0)
+
+        # submit with valid fields
+        self.client.post(
+            config_url,
+            {
+                "from_email": "  foo@bar.com  ",  # check trimming
+                "smtp_host": "smtp.example.com",
+                "smtp_username": "support@example.com",
+                "smtp_password": " secret ",
+                "smtp_port": "465",
+                "disconnect": "false",
+            },
+        )
+        self.assertEqual(len(mail.outbox), 1)
+
+        self.org.refresh_from_db()
+        self.assertEqual(
+            r"smtp://support%40example.com:secret@smtp.example.com:465/?from=foo%40bar.com&tls=true", self.org.flow_smtp
+        )
+
+        response = self.client.get(config_url)
+        self.assertEqual("bob@acme.com", response.context["from_email_default"])
+        self.assertEqual("foo@bar.com", response.context["from_email_custom"])
+
+        # password can be omitted when editing
+        self.client.post(
+            config_url,
+            {
+                "from_email": "support@example.com",
+                "smtp_host": "smtp.example.com",
+                "smtp_username": "support@example.com",
+                "smtp_password": "",
+                "smtp_port": "465",
+                "disconnect": "false",
+            },
+            follow=True,
+        )
+
+        # password shouldn't change
+        self.org.refresh_from_db()
+        self.assertEqual(
+            r"smtp://support%40example.com:secret@smtp.example.com:465/?from=support%40example.com&tls=true",
+            self.org.flow_smtp,
+        )
+
+        # unless username is changing
+        response = self.client.post(
+            config_url,
+            {
+                "from_email": "support@example.com",
+                "smtp_host": "smtp.example.com",
+                "smtp_username": "help@example.com",
+                "smtp_password": "",
+                "smtp_port": "465",
+                "disconnect": "false",
+            },
+            follow=True,
+        )
+        self.assertFormError(response, "form", "smtp_password", "This field is required.")
+
+        # submit with disconnect flag
+        self.client.post(config_url, {"disconnect": "true"})
+
+        self.org.refresh_from_db()
+        self.assertIsNone(self.org.flow_smtp)
 
     def test_join(self):
         # if invitation secret is invalid, redirect to root

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -52,7 +52,7 @@ from temba.formax import FormaxMixin
 from temba.notifications.mixins import NotificationTargetMixin
 from temba.orgs.tasks import send_user_verification_email
 from temba.utils import analytics, get_anonymous_user, json, languages, str_to_bool
-from temba.utils.email import is_valid_address
+from temba.utils.email import is_valid_address, send_custom_smtp_email
 from temba.utils.fields import ArbitraryJsonChoiceField, CheckboxWidget, InputWidget, SelectMultipleWidget, SelectWidget
 from temba.utils.timezones import TimeZoneFormField
 from temba.utils.views import (
@@ -1682,67 +1682,63 @@ class OrgCRUDL(SmartCRUDL):
 
             def clean(self):
                 super().clean()
-                if self.cleaned_data.get("disconnect", "false") == "false":
-                    from_email = self.cleaned_data.get("from_email", None)
-                    smtp_host = self.cleaned_data.get("smtp_host", None)
-                    smtp_username = self.cleaned_data.get("smtp_username", None)
-                    smtp_password = self.cleaned_data.get("smtp_password", None)
-                    smtp_port = self.cleaned_data.get("smtp_port", None)
 
-                    existing_smtp_server = urlparse(self.instance.flow_smtp)
-                    existing_username = ""
-                    if existing_smtp_server.username:
-                        existing_username = unquote(existing_smtp_server.username)
-                    if not smtp_password and existing_username == smtp_username and existing_smtp_server.password:
-                        smtp_password = unquote(existing_smtp_server.password)
+                # don't validate email setting fields if we're disconnecting
+                if self.cleaned_data.get("disconnect", "false") == "true":
+                    return self.cleaned_data
 
-                    if not from_email:
-                        raise ValidationError(_("You must enter a from email"))
+                from_email = self.cleaned_data.get("from_email", None)
+                host = self.cleaned_data.get("smtp_host", None)
+                username = self.cleaned_data.get("smtp_username", None)
+                password = self.cleaned_data.get("smtp_password", None)
+                port = self.cleaned_data.get("smtp_port", None)
 
-                    parsed = parseaddr(from_email)
-                    if not is_valid_address(parsed[1]):
-                        raise ValidationError(_("Please enter a valid email address"))
+                # if editing existing settings, and username isn't changing, password can be omitted
+                existing = urlparse(self.instance.flow_smtp)
+                existing_username = unquote(existing.username) if existing.username else ""
+                if not password and existing_username == username and existing.password:
+                    password = unquote(existing.password)
+                    self.cleaned_data["smtp_password"] = password
 
-                    if not smtp_host:
-                        raise ValidationError(_("You must enter the SMTP host"))
+                if not from_email:
+                    self.add_error("from_email", _("This field is required."))
+                elif not is_valid_address(parseaddr(from_email)[1]):
+                    self.add_error("from_email", _("Please enter a valid email address."))
 
-                    if not smtp_username:
-                        raise ValidationError(_("You must enter the SMTP username"))
+                if not host:
+                    self.add_error("smtp_host", _("This field is required."))
+                if not username:
+                    self.add_error("smtp_username", _("This field is required."))
+                if not password:
+                    self.add_error("smtp_password", _("This field is required."))
+                if not port:
+                    self.add_error("smtp_port", _("This field is required."))
 
-                    if not smtp_password:
-                        raise ValidationError(_("You must enter the SMTP password"))
+                # if individual fields look valid, do an actual email test...
+                if self.is_valid():
+                    admin_emails = [admin.email for admin in self.instance.get_admins().order_by("email")]
 
-                    if not smtp_port:
-                        raise ValidationError(_("You must enter the SMTP port"))
-
-                    self.cleaned_data["smtp_password"] = smtp_password
+                    branding = self.instance.branding
+                    subject = _("%(name)s SMTP configuration test") % branding
+                    body = (
+                        _(
+                            "This email is a test to confirm the custom SMTP server configuration added to your %(name)s account."
+                        )
+                        % branding
+                    )
 
                     try:
-                        from temba.utils.email import send_custom_smtp_email
-
-                        admin_emails = [admin.email for admin in self.instance.get_admins().order_by("email")]
-
-                        branding = self.instance.branding
-                        subject = _("%(name)s SMTP configuration test") % branding
-                        body = (
-                            _(
-                                "This email is a test to confirm the custom SMTP server configuration added to your %(name)s account."
-                            )
-                            % branding
-                        )
-
                         send_custom_smtp_email(
                             admin_emails,
                             subject,
                             body,
                             from_email,
-                            smtp_host,
-                            smtp_port,
-                            smtp_username,
-                            smtp_password,
+                            host,
+                            port,
+                            username,
+                            password,
                             use_tls=True,
                         )
-
                     except smtplib.SMTPException as e:
                         raise ValidationError(
                             _("Failed to send email with STMP server configuration with error '%s'") % str(e)
@@ -1803,15 +1799,18 @@ class OrgCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
             org = self.get_object()
-            from_email_custom = None
 
-            if org.flow_smtp:
-                parsed_smtp_server = urlparse(org.flow_smtp)
-                from_email_params = parse_qs(parsed_smtp_server.query).get("from")
-                if from_email_params:
-                    from_email_custom = parseaddr(from_email_params[0])[1]  # extract address only
+            def extract_from(smtp_url: str) -> str:
+                from_param = parse_qs(urlparse(smtp_url).query).get("from")
+                return parseaddr(from_param[0])[1] if from_param else None
 
-            context["from_email_default"] = settings.FLOW_FROM_EMAIL
+            from_email_default = settings.FLOW_FROM_EMAIL
+            if org.is_child and org.parent.flow_smtp:
+                from_email_default = extract_from(org.parent.flow_smtp)
+
+            from_email_custom = extract_from(org.flow_smtp) if org.flow_smtp else None
+
+            context["from_email_default"] = from_email_default
             context["from_email_custom"] = from_email_custom
             return context
 

--- a/templates/orgs/org_smtp_server.html
+++ b/templates/orgs/org_smtp_server.html
@@ -8,27 +8,26 @@
 {% endblock summary %}
 {% block pre-form %}
   <div class="mb-4">
-    {% blocktrans trimmed with brand=branding.name %}
-      You can add your own email configuration for emails sent from flows.
-    {% endblocktrans %}
-  </div>
-  {% if object.flow_smtp and request.META.HTTP_X_FORMAX %}
-    <div class="mb-4">
+    {% if object.flow_smtp %}
       {% blocktrans trimmed with from_email=from_email_custom %}
-        If you no longer want to use {{ from_email }} to send emails, you can <a href='javascript:confirmSMTPRemove();'>remove your SMTP settings</a>.
+        If you no longer want to use this configuration to send emails from flows, <a href='javascript:confirmSMTPRemove();'>click here.</a>
+      {% endblocktrans %}
+    {% else %}
+      {% blocktrans trimmed %}
+        You can add your own email configuration for emails sent from flows.
+      {% endblocktrans %}
+    {% endif %}
+  </div>
+  <div class="remove-smtp hide">
+    <div class="title">{% trans "Remove SMTP Settings" %}</div>
+    <div class="body">
+      {% blocktrans trimmed with from_email=from_email_default %}
+        Removing these settings will mean that emails sent from flows will come from <b>{{ from_email }}</b>.
+        Are you sure you want to continue?
       {% endblocktrans %}
     </div>
-    <div class="remove-smtp hide">
-      <div class="title">{% trans "Remove SMTP Settings" %}</div>
-      <div class="body">
-        {% blocktrans trimmed with from_email=from_email_default %}
-          Removing these settings will mean that emails sent from flows will come from {{ from_email }}.
-          Are you sure you want to continue?
-        {% endblocktrans %}
-      </div>
-      <div href="{% url "orgs.org_smtp_server" %}?disconnect=true" id="remove-smtp-form"></div>
-    </div>
-  {% endif %}
+    <div href="{% url "orgs.org_smtp_server" %}?disconnect=true" id="remove-smtp-form"></div>
+  </div>
 {% endblock pre-form %}
 {% block fields %}
   {% render_field 'from_email' %}


### PR DESCRIPTION
Form was kinda annoying in that it would show one error at a time and errors weren't located with their fields.

<img width="774" alt="Captura de pantalla 2024-02-06 a la(s) 16 12 00" src="https://github.com/nyaruka/rapidpro/assets/675558/77943c05-33d0-4c02-a0f5-b7af73ba98f6">
<img width="770" alt="Captura de pantalla 2024-02-06 a la(s) 16 12 08" src="https://github.com/nyaruka/rapidpro/assets/675558/9a8d46d0-efc9-4290-8eee-0406a870e8dd">
<img width="773" alt="Captura de pantalla 2024-02-06 a la(s) 16 11 38" src="https://github.com/nyaruka/rapidpro/assets/675558/35d20ff9-2428-4a09-ba0d-6bd65ac42ea2">

