### PR TITLE
Tweak CRUDL submission test methods to take user as an argument 

### DIFF
--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -1181,12 +1181,16 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # try to submit with no data
         self.assertCreateSubmit(
-            create_url, {}, form_errors={"name": "This field is required.", "group": "This field is required."}
+            create_url,
+            self.admin,
+            {},
+            form_errors={"name": "This field is required.", "group": "This field is required."},
         )
 
         # submit with valid data
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Reminders", "group": group.id},
             new_obj_query=Campaign.objects.filter(name="Reminders", group=group),
         )
@@ -1257,13 +1261,14 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with empty name
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "", "group": group1.id},
             form_errors={"name": "This field is required."},
             object_unchanged=campaign,
         )
 
         # submit with valid name
-        self.assertUpdateSubmit(update_url, {"name": "Greetings", "group": group1.id}, success_status=200)
+        self.assertUpdateSubmit(update_url, self.admin, {"name": "Greetings", "group": group1.id}, success_status=200)
 
         campaign.refresh_from_db()
         self.assertEqual("Greetings", campaign.name)
@@ -1273,7 +1278,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(1, len(mr_mocks.queued_batch_tasks))
 
         # submit with group change
-        self.assertUpdateSubmit(update_url, {"name": "Greetings", "group": group2.id}, success_status=200)
+        self.assertUpdateSubmit(update_url, self.admin, {"name": "Greetings", "group": group2.id}, success_status=200)
 
         campaign.refresh_from_db()
         self.assertEqual("Greetings", campaign.name)
@@ -1395,6 +1400,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with missing fields
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "event_type": "M",
                 "eng": "This is my message",
@@ -1407,6 +1413,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "event_type": "F",
                 "direction": "A",
@@ -1420,6 +1427,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         # can create an event with just a eng translation
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "relative_to": planting_date.id,
                 "event_type": "M",
@@ -1451,6 +1459,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         # have to submit translation for primary language
         response = self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "relative_to": planting_date.id,
                 "event_type": "M",
@@ -1468,6 +1477,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
 
         response = self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "relative_to": planting_date.id,
                 "event_type": "M",
@@ -1530,6 +1540,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         # update the event to be passive
         response = self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "relative_to": planting_date.id,
                 "event_type": "M",
@@ -1572,6 +1583,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         # translation in new language is optional
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "relative_to": planting_date.id,
                 "event_type": "M",
@@ -1709,6 +1721,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         update_url = reverse("campaigns.campaignevent_update", args=[event.id])
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "relative_to": event.relative_to.id,
                 "event_type": "M",

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1037,6 +1037,7 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         # name can't be empty
         self.assertUpdateSubmit(
             android_url,
+            self.admin,
             {"name": ""},
             form_errors={"name": "This field is required."},
             object_unchanged=android_channel,
@@ -1045,6 +1046,7 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         # make some changes
         self.assertUpdateSubmit(
             vonage_url,
+            self.admin,
             {"name": "Updated Name", "allow_international": True, "machine_detection": True},
         )
 
@@ -1077,7 +1079,9 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "You are about to delete")
 
         # submit to delete it
-        response = self.assertDeleteSubmit(delete_url, object_deactivated=self.ex_channel, success_status=200)
+        response = self.assertDeleteSubmit(
+            delete_url, self.admin, object_deactivated=self.ex_channel, success_status=200
+        )
         self.assertEqual("/org/workspace/", response["Temba-Success"])
 
         # reactivate
@@ -1093,7 +1097,7 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "is used by the following items but can still be deleted:")
         self.assertContains(response, "Color Flow")
 
-        self.assertDeleteSubmit(delete_url, object_deactivated=self.ex_channel, success_status=200)
+        self.assertDeleteSubmit(delete_url, self.admin, object_deactivated=self.ex_channel, success_status=200)
 
         flow.refresh_from_db()
         self.assertTrue(flow.has_issues)

--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -85,7 +85,7 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
         )
 
         self.assertUpdateSubmit(
-            update_url, {"name": "Updated", "welcome_message": "Welcome, please subscribe for more"}
+            update_url, self.admin, {"name": "Updated", "welcome_message": "Welcome, please subscribe for more"}
         )
 
         self.channel.refresh_from_db()

--- a/temba/classifiers/tests.py
+++ b/temba/classifiers/tests.py
@@ -159,7 +159,7 @@ class ClassifierCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.assertDeleteFetch(delete_url)
         self.assertContains(response, "You are about to delete")
 
-        response = self.assertDeleteSubmit(delete_url, object_deactivated=self.c2, success_status=200)
+        response = self.assertDeleteSubmit(delete_url, self.admin, object_deactivated=self.c2, success_status=200)
         self.assertEqual("/org/workspace/", response["Temba-Success"])
 
         # should see warning if global is being used
@@ -171,7 +171,7 @@ class ClassifierCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "is used by the following items but can still be deleted:")
         self.assertContains(response, "Color Flow")
 
-        response = self.assertDeleteSubmit(delete_url, object_deactivated=self.c1, success_status=200)
+        response = self.assertDeleteSubmit(delete_url, self.admin, object_deactivated=self.c1, success_status=200)
         self.assertEqual("/org/workspace/", response["Temba-Success"])
 
         self.flow.refresh_from_db()

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -497,6 +497,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # update all fields (removes second tel URN, adds a new Facebook URN)
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "Bobby",
                 "status": "B",
@@ -538,6 +539,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # try to update with invalid URNs
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "Bobby",
                 "status": "B",
@@ -574,6 +576,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "Bobby",
                 "status": "A",
@@ -709,7 +712,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         )
 
         # can submit with no assignee
-        response = self.assertUpdateSubmit(open_url, {"topic": general.id, "body": "Help", "assignee": ""})
+        response = self.assertUpdateSubmit(open_url, self.admin, {"topic": general.id, "body": "Help", "assignee": ""})
 
         # should have new ticket
         ticket = contact.tickets.get()
@@ -825,6 +828,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # try to submit without specifying a flow
         self.assertUpdateSubmit(
             start_url,
+            self.admin,
             data={},
             form_errors={"flow": "This field is required.", "contact_search": "This field is required."},
             object_unchanged=contact,
@@ -833,7 +837,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # submit with flow...
         contact_search = dict(query=f"uuid='{contact.uuid}'", advanced=True)
         self.assertUpdateSubmit(
-            start_url, data={"flow": background_flow.id, "contact_search": json.dumps(contact_search)}
+            start_url, self.admin, {"flow": background_flow.id, "contact_search": json.dumps(contact_search)}
         )
 
         # should now have a flow start
@@ -1451,7 +1455,7 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "You are about to delete")
         self.assertContains(response, "There is no way to undo this. Are you sure?")
 
-        self.assertDeleteSubmit(delete_group1_url, object_deactivated=group1, success_status=200)
+        self.assertDeleteSubmit(delete_group1_url, self.admin, object_deactivated=group1, success_status=200)
 
         # a group with only soft dependents can be deleted but we give warnings
         response = self.assertDeleteFetch(delete_group2_url, allow_editors=True)
@@ -1462,7 +1466,7 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, flow1.name)
         self.assertContains(response, "There is no way to undo this. Are you sure?")
 
-        self.assertDeleteSubmit(delete_group2_url, object_deactivated=group2, success_status=200)
+        self.assertDeleteSubmit(delete_group2_url, self.admin, object_deactivated=group2, success_status=200)
 
         # check that the flow is now marked as having issues
         flow1.refresh_from_db()
@@ -1479,7 +1483,7 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, f"Schedule → {flow2.name}")
         self.assertContains(response, "There is no way to undo this. Are you sure?")
 
-        self.assertDeleteSubmit(delete_group3_url, object_deactivated=group3, success_status=200)
+        self.assertDeleteSubmit(delete_group3_url, self.admin, object_deactivated=group3, success_status=200)
 
         # check that the flow is now marked as having issues
         flow2.refresh_from_db()
@@ -4060,6 +4064,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with empty name
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "", "value_type": "T", "show_in_table": True, "agent_access": "E"},
             form_errors={"name": "This field is required."},
         )
@@ -4067,6 +4072,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with invalid name
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "???", "value_type": "T", "show_in_table": True, "agent_access": "E"},
             form_errors={"name": "Can only contain letters, numbers and hypens."},
         )
@@ -4074,6 +4080,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with something that would be an invalid key
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "UUID", "value_type": "T", "show_in_table": True, "agent_access": "E"},
             form_errors={"name": "Can't be a reserved word."},
         )
@@ -4081,6 +4088,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with name of existing field
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "AGE", "value_type": "N", "show_in_table": True, "agent_access": "E"},
             form_errors={"name": "Must be unique."},
         )
@@ -4088,6 +4096,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # submit with valid data
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Goats", "value_type": "N", "show_in_table": True, "agent_access": "E"},
             new_obj_query=ContactField.user_fields.filter(
                 org=self.org, name="Goats", value_type="N", show_in_table=True, agent_access="E"
@@ -4100,6 +4109,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Age", "value_type": "N", "show_in_table": True, "agent_access": "N"},
             new_obj_query=ContactField.user_fields.filter(
                 org=self.org, name="Age", value_type="N", show_in_table=True, agent_access="N", is_active=True
@@ -4111,6 +4121,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         with override_settings(ORG_LIMIT_DEFAULTS={"fields": 2}):
             self.assertCreateSubmit(
                 create_url,
+                self.admin,
                 {"name": "Sheep", "value_type": "T", "show_in_table": True, "agent_access": "E"},
                 form_errors={
                     "__all__": "This workspace has reached its limit of 2 fields. You must delete existing ones before you can create new ones."
@@ -4141,6 +4152,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try submit without change
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "Age", "value_type": "N", "show_in_table": True, "agent_access": "V"},
             success_status=200,
         )
@@ -4148,6 +4160,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with empty name
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "", "value_type": "N", "show_in_table": True, "agent_access": "V"},
             form_errors={"name": "This field is required."},
             object_unchanged=self.age,
@@ -4156,6 +4169,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with invalid name
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "???", "value_type": "N", "show_in_table": True, "agent_access": "V"},
             form_errors={"name": "Can only contain letters, numbers and hypens."},
             object_unchanged=self.age,
@@ -4164,6 +4178,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with a name that is used by another field
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "GENDER", "value_type": "N", "show_in_table": True, "agent_access": "V"},
             form_errors={"name": "Must be unique."},
             object_unchanged=self.age,
@@ -4172,6 +4187,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # submit with different name, type and agent access
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "Age In Years", "value_type": "T", "show_in_table": False, "agent_access": "E"},
             success_status=200,
         )
@@ -4186,6 +4202,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         with override_settings(ORG_LIMIT_DEFAULTS={"fields": 2}):
             self.assertUpdateSubmit(
                 update_url,
+                self.admin,
                 {"name": "Age 2", "value_type": "T", "show_in_table": True, "agent_access": "E"},
                 success_status=200,
             )
@@ -4212,6 +4229,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with different type
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "Registered", "value_type": "T", "show_in_table": False, "agent_access": "V"},
             form_errors={"value_type": "Can't change type of date field being used by campaign events."},
             object_unchanged=registered,
@@ -4220,6 +4238,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # submit with only a different name
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "Registered On", "value_type": "D", "show_in_table": False, "agent_access": "V"},
             success_status=200,
         )
@@ -4329,14 +4348,14 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "You are about to delete")
         self.assertContains(response, "There is no way to undo this. Are you sure?")
 
-        self.assertDeleteSubmit(delete_gender_url, object_deactivated=self.gender, success_status=200)
+        self.assertDeleteSubmit(delete_gender_url, self.admin, object_deactivated=self.gender, success_status=200)
 
         # create the same field again
         self.gender = self.create_field("gender", "Gender", value_type="T")
 
         # since fields are queried by key name, try and delete it again
         # to make sure we aren't deleting the previous deleted field again
-        self.assertDeleteSubmit(delete_gender_url, object_deactivated=self.gender, success_status=200)
+        self.assertDeleteSubmit(delete_gender_url, self.admin, object_deactivated=self.gender, success_status=200)
         self.gender.refresh_from_db()
         self.assertFalse(self.gender.is_active)
 
@@ -4348,7 +4367,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "Amazing Flow")
         self.assertContains(response, "There is no way to undo this. Are you sure?")
 
-        self.assertDeleteSubmit(delete_joined_url, object_deactivated=joined_on, success_status=200)
+        self.assertDeleteSubmit(delete_joined_url, self.admin, object_deactivated=joined_on, success_status=200)
 
         # check that flow is now marked as having issues
         flow.refresh_from_db()

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -1529,6 +1529,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit without name or language
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"flow_type": "M"},
             form_errors={"name": "This field is required.", "base_language": "This field is required."},
         )
@@ -1536,6 +1537,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with a name that contains disallowed characters
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": '"Registration"', "flow_type": "M", "base_language": "eng"},
             form_errors={"name": 'Cannot contain the character: "'},
         )
@@ -1543,6 +1545,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with a name that is too long
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "X" * 65, "flow_type": "M", "base_language": "eng"},
             form_errors={"name": "Ensure this value has at most 64 characters (it has 65)."},
         )
@@ -1550,12 +1553,14 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with a name that is already used
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Registration", "flow_type": "M", "base_language": "eng"},
             form_errors={"name": "Already used by another flow."},
         )
 
         response = self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Flow 1", "flow_type": "M", "base_language": "eng"},
             new_obj_query=Flow.objects.filter(org=self.org, flow_type="M", name="Flow 1"),
         )
@@ -1571,6 +1576,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try creating a flow with invalid keywords
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "name": "Flow #1",
                 "base_language": "eng",
@@ -1585,6 +1591,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # submit with valid keywords
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "name": "Flow 1",
                 "base_language": "eng",
@@ -1602,6 +1609,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to create another flow with one of the same keywords
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "name": "Flow 2",
                 "base_language": "eng",
@@ -1618,6 +1626,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # and now it's no longer a conflict
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {
                 "name": "Flow 2",
                 "base_language": "eng",
@@ -1873,6 +1882,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to update with empty name
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "", "expires_after_minutes": 10, "ignore_triggers": True},
             form_errors={"name": "This field is required."},
             object_unchanged=flow,
@@ -1881,6 +1891,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # update all fields
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "New Name",
                 "keyword_triggers": ["test", "help"],
@@ -1899,6 +1910,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # remove one keyword and add another
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "New Name",
                 "keyword_triggers": ["help", "support"],
@@ -1917,6 +1929,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # put "test" keyword back and remove "support"
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "New Name",
                 "keyword_triggers": ["test", "help"],
@@ -1940,6 +1953,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # re-adding "support" will now restore that trigger
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "New Name",
                 "keyword_triggers": ["test", "help", "support"],
@@ -1970,6 +1984,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to update with an expires value which is only for messaging flows and an invalid retry value
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "New Name", "expires_after_minutes": 720, "ignore_triggers": True, "ivr_retry": 1234},
             form_errors={
                 "expires_after_minutes": "Select a valid choice. 720 is not one of the available choices.",
@@ -1981,6 +1996,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # update name and contact creation option to be per login
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {
                 "name": "New Name",
                 "keyword_triggers": ["test", "help"],
@@ -2012,7 +2028,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
         # update name and contact creation option to be per login
-        self.assertUpdateSubmit(update_url, {"name": "New Name", "contact_creation": "login"})
+        self.assertUpdateSubmit(update_url, self.admin, {"name": "New Name", "contact_creation": "login"})
 
         flow.refresh_from_db()
         self.assertEqual("New Name", flow.name)
@@ -2026,7 +2042,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateFetch(update_url, allow_viewers=False, allow_editors=True, form_fields=["name"])
 
         # update name and contact creation option to be per login
-        self.assertUpdateSubmit(update_url, {"name": "New Name"})
+        self.assertUpdateSubmit(update_url, self.admin, {"name": "New Name"})
 
         flow.refresh_from_db()
         self.assertEqual("New Name", flow.name)
@@ -2699,6 +2715,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         mr_mocks.parse_query("frank", cleaned='name ~ "frank"')
         self.assertUpdateSubmit(
             start_url,
+            self.admin,
             {"flow": flow.id, "contact_search": get_contact_search(query="frank")},
         )
 
@@ -2717,6 +2734,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         mr_mocks.error("query contains an error")
         self.assertUpdateSubmit(
             start_url,
+            self.admin,
             {"flow": flow.id, "contact_search": get_contact_search(query='name = "frank')},
             form_errors={"contact_search": "query contains an error"},
             object_unchanged=flow,
@@ -2725,6 +2743,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try missing contacts
         self.assertUpdateSubmit(
             start_url,
+            self.admin,
             {"flow": flow.id, "contact_search": get_contact_search(contacts=[])},
             form_errors={"contact_search": "Contacts or groups are required."},
             object_unchanged=flow,
@@ -2733,6 +2752,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to create with an empty query
         self.assertUpdateSubmit(
             start_url,
+            self.admin,
             {"flow": flow.id, "contact_search": get_contact_search(query="")},
             form_errors={"contact_search": "A contact query is required."},
             object_unchanged=flow,
@@ -2744,6 +2764,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # create flow start with exclude_in_other and exclude_reruns both left unchecked
         self.assertUpdateSubmit(
             start_url,
+            self.admin,
             {"flow": flow.id, "contact_search": get_contact_search(query=query)},
         )
 
@@ -2768,7 +2789,9 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         mr_mocks.parse_query("frank", cleaned='name ~ "frank"')
 
         start_url = f"{reverse('flows.flow_start', args=[])}?flow={flow.id}"
-        self.assertUpdateSubmit(start_url, {"flow": flow.id, "contact_search": get_contact_search(query="frank")})
+        self.assertUpdateSubmit(
+            start_url, self.admin, {"flow": flow.id, "contact_search": get_contact_search(query="frank")}
+        )
 
         start = FlowStart.objects.get()
         self.assertEqual(flow, start.flow)
@@ -3082,14 +3105,22 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         change_url = reverse("flows.flow_change_language", args=[flow.id])
 
         self.assertUpdateSubmit(
-            change_url, {"language": ""}, form_errors={"language": "This field is required."}, object_unchanged=flow
+            change_url,
+            self.admin,
+            {"language": ""},
+            form_errors={"language": "This field is required."},
+            object_unchanged=flow,
         )
 
         self.assertUpdateSubmit(
-            change_url, {"language": "fra"}, form_errors={"language": "Not a valid language."}, object_unchanged=flow
+            change_url,
+            self.admin,
+            {"language": "fra"},
+            form_errors={"language": "Not a valid language."},
+            object_unchanged=flow,
         )
 
-        self.assertUpdateSubmit(change_url, {"language": "spa"}, success_status=302)
+        self.assertUpdateSubmit(change_url, self.admin, {"language": "spa"}, success_status=302)
 
         flow_def = flow.get_definition()
         self.assertIn("eng", flow_def["localization"])
@@ -3104,7 +3135,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateFetch(export_url, allow_viewers=False, allow_editors=True, form_fields=["language"])
 
         # submit with no language
-        response = self.assertUpdateSubmit(export_url, {})
+        response = self.assertUpdateSubmit(export_url, self.admin, {})
 
         self.assertEqual(f"/flow/download_translation/?flow={flow.id}&language=", response.url)
 
@@ -3145,7 +3176,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # submit with no file
         self.assertUpdateSubmit(
-            step1_url, {}, form_errors={"po_file": "This field is required."}, object_unchanged=flow
+            step1_url, self.admin, {}, form_errors={"po_file": "This field is required."}, object_unchanged=flow
         )
 
         # submit with something that's empty
@@ -3672,7 +3703,7 @@ class FlowRunCRUDLTest(TembaTest, CRUDLTestMixin):
 
         delete_url = reverse("flows.flowrun_delete", args=[run1.id])
 
-        self.assertDeleteSubmit(delete_url, object_deleted=run1, success_status=200)
+        self.assertDeleteSubmit(delete_url, self.admin, object_deleted=run1, success_status=200)
 
         self.assertFalse(FlowRun.objects.filter(id=run1.id).exists())
         self.assertTrue(FlowRun.objects.filter(id=run2.id).exists())  # unchanged
@@ -5136,19 +5167,22 @@ class FlowLabelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateFetch(create_url, allow_viewers=False, allow_editors=True, form_fields=("name", "flows"))
 
         # try to submit without a name
-        self.assertCreateSubmit(create_url, {}, form_errors={"name": "This field is required."})
+        self.assertCreateSubmit(create_url, self.admin, {}, form_errors={"name": "This field is required."})
 
         # try to submit with an invalid name
         self.assertCreateSubmit(
-            create_url, {"name": '"Cool"\\'}, form_errors={"name": 'Cannot contain the character: "'}
+            create_url, self.admin, {"name": '"Cool"\\'}, form_errors={"name": 'Cannot contain the character: "'}
         )
 
         self.assertCreateSubmit(
-            create_url, {"name": "Cool Flows"}, new_obj_query=FlowLabel.objects.filter(org=self.org, name="Cool Flows")
+            create_url,
+            self.admin,
+            {"name": "Cool Flows"},
+            new_obj_query=FlowLabel.objects.filter(org=self.org, name="Cool Flows"),
         )
 
         # try to create with a name that's already used
-        self.assertCreateSubmit(create_url, {"name": "Cool Flows"}, form_errors={"name": "Must be unique."})
+        self.assertCreateSubmit(create_url, self.admin, {"name": "Cool Flows"}, form_errors={"name": "Must be unique."})
 
     def test_update(self):
         label = FlowLabel.create(self.org, self.admin, "Cool Flows")
@@ -5161,6 +5195,7 @@ class FlowLabelCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to update to an invalid name
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": '"Cool"\\'},
             form_errors={"name": 'Cannot contain the character: "'},
             object_unchanged=label,
@@ -5168,10 +5203,14 @@ class FlowLabelCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # try to update to a non-unique name
         self.assertUpdateSubmit(
-            update_url, {"name": "Crazy Flows"}, form_errors={"name": "Must be unique."}, object_unchanged=label
+            update_url,
+            self.admin,
+            {"name": "Crazy Flows"},
+            form_errors={"name": "Must be unique."},
+            object_unchanged=label,
         )
 
-        self.assertUpdateSubmit(update_url, {"name": "Super Cool Flows"})
+        self.assertUpdateSubmit(update_url, self.admin, {"name": "Super Cool Flows"})
 
         label.refresh_from_db()
         self.assertEqual("Super Cool Flows", label.name)
@@ -5182,7 +5221,7 @@ class FlowLabelCRUDLTest(TembaTest, CRUDLTestMixin):
         delete_url = reverse("flows.flowlabel_delete", args=[label.id])
 
         self.assertDeleteFetch(delete_url, allow_editors=True)
-        self.assertDeleteSubmit(delete_url, object_deleted=label, success_status=200)
+        self.assertDeleteSubmit(delete_url, self.admin, object_deleted=label, success_status=200)
 
 
 class SimulationTest(TembaTest):

--- a/temba/globals/tests.py
+++ b/temba/globals/tests.py
@@ -113,16 +113,20 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit with invalid name and missing value
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "/?:"},
             form_errors={"name": "Can only contain letters, numbers and hypens.", "value": "This field is required."},
         )
 
         # try to submit with name that would become invalid key
-        self.assertCreateSubmit(create_url, {"name": "-", "value": "123"}, form_errors={"name": "Isn't a valid name"})
+        self.assertCreateSubmit(
+            create_url, self.admin, {"name": "-", "value": "123"}, form_errors={"name": "Isn't a valid name"}
+        )
 
         # submit with valid values
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Secret", "value": "[xyz]"},
             success_status=200,
             new_obj_query=Global.objects.filter(org=self.org, name="Secret", value="[xyz]"),
@@ -130,12 +134,13 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # try to submit with same name
         self.assertCreateSubmit(
-            create_url, {"name": "Secret", "value": "[abc]"}, form_errors={"name": "Must be unique."}
+            create_url, self.admin, {"name": "Secret", "value": "[abc]"}, form_errors={"name": "Must be unique."}
         )
 
         # works if name is unique
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Secret2", "value": "[abc]"},
             success_status=200,
             new_obj_query=Global.objects.filter(org=self.org, name="Secret2", value="[abc]"),
@@ -144,6 +149,7 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to create another now that we've reached the limit
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "Secret3", "value": "[abc]"},
             form_errors={
                 "__all__": "This workspace has reached its limit of 4 globals. You must delete existing ones before you can create new ones."
@@ -157,10 +163,10 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # try to submit with missing value
         self.assertUpdateSubmit(
-            update_url, {}, form_errors={"value": "This field is required."}, object_unchanged=self.global1
+            update_url, self.admin, {}, form_errors={"value": "This field is required."}, object_unchanged=self.global1
         )
 
-        self.assertUpdateSubmit(update_url, {"value": "Acme Holdings"})
+        self.assertUpdateSubmit(update_url, self.admin, {"value": "Acme Holdings"})
 
         self.global1.refresh_from_db()
         self.assertEqual("Org Name", self.global1.name)
@@ -193,7 +199,7 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.assertDeleteFetch(delete_url, allow_editors=True)
         self.assertContains(response, "You are about to delete")
 
-        response = self.assertDeleteSubmit(delete_url, object_deactivated=self.global2, success_status=200)
+        response = self.assertDeleteSubmit(delete_url, self.admin, object_deactivated=self.global2, success_status=200)
         self.assertEqual("/global/", response["Temba-Success"])
 
         # should see warning if global is being used
@@ -205,7 +211,7 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, "is used by the following items but can still be deleted:")
         self.assertContains(response, "Color Flow")
 
-        response = self.assertDeleteSubmit(delete_url, object_deactivated=self.global1, success_status=200)
+        response = self.assertDeleteSubmit(delete_url, self.admin, object_deactivated=self.global1, success_status=200)
         self.assertEqual("/global/", response["Temba-Success"])
 
         self.flow.refresh_from_db()

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2870,12 +2870,16 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # try to submit an empty form
         response = self.assertCreateSubmit(
-            create_url, {}, form_errors={"name": "This field is required.", "timezone": "This field is required."}
+            create_url,
+            self.admin,
+            {},
+            form_errors={"name": "This field is required.", "timezone": "This field is required."},
         )
 
         # submit with valid values to create a new org...
         response = self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "My Other Org", "timezone": "Africa/Nairobi"},
             new_obj_query=Org.objects.filter(name="My Other Org", parent=None),
         )
@@ -2919,12 +2923,16 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # try to submit an empty form
         response = self.assertCreateSubmit(
-            create_url, {}, form_errors={"name": "This field is required.", "timezone": "This field is required."}
+            create_url,
+            self.admin,
+            {},
+            form_errors={"name": "This field is required.", "timezone": "This field is required."},
         )
 
         # submit with valid values to create a child org...
         response = self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"name": "My Child Org", "timezone": "Africa/Nairobi"},
             new_obj_query=Org.objects.filter(name="My Child Org", parent=self.org),
         )
@@ -2960,6 +2968,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         # create new org
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"type": "new", "name": "New Org", "timezone": "Africa/Nairobi"},
             new_obj_query=Org.objects.filter(name="New Org", parent=None),
         )
@@ -2967,6 +2976,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         # create child org
         self.assertCreateSubmit(
             create_url,
+            self.admin,
             {"type": "child", "name": "Child Org", "timezone": "Africa/Nairobi"},
             new_obj_query=Org.objects.filter(name="Child Org", parent=self.org),
         )
@@ -3431,6 +3441,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         # try to submit as is (empty)
         self.assertUpdateSubmit(
             langs_url,
+            self.admin,
             {},
             object_unchanged=self.org,
             form_errors={"primary_lang": "This field is required.", "input_collation": "This field is required."},
@@ -3438,7 +3449,9 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # give the org a primary language
         self.assertUpdateSubmit(
-            langs_url, {"primary_lang": '{"name":"French", "value":"fra"}', "input_collation": "confusables"}
+            langs_url,
+            self.admin,
+            {"primary_lang": '{"name":"French", "value":"fra"}', "input_collation": "confusables"},
         )
 
         self.org.refresh_from_db()
@@ -3453,6 +3466,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         # and now give it additional languages
         self.assertUpdateSubmit(
             langs_url,
+            self.admin,
             {
                 "primary_lang": '{"name":"French", "value":"fra"}',
                 "other_langs": ['{"name":"Haitian", "value":"hat"}', '{"name":"Hausa", "value":"hau"}'],

--- a/temba/tests/crudl.py
+++ b/temba/tests/crudl.py
@@ -131,10 +131,8 @@ class CRUDLTestMixin:
         as_user(org2_admin, allowed=allow_org2, check_fields=False)
         return as_user(admin, allowed=True)
 
-    def assertCreateSubmit(self, url, data, *, form_errors=None, new_obj_query=None, success_status=302):
+    def assertCreateSubmit(self, url, user, data, *, form_errors=None, new_obj_query=None, success_status=302):
         assert form_errors or new_obj_query is not None, "must specify form_errors or new_obj_query"
-
-        viewer, editor, agent, admin, org2_admin = self.get_test_users()
 
         def as_user(user, allowed):
             if allowed:
@@ -150,7 +148,7 @@ class CRUDLTestMixin:
             return self.requestView(url, user, post_data=data, checks=checks, choose_org=self.org)
 
         as_user(None, allowed=False)
-        return as_user(admin, allowed=True)
+        return as_user(user, allowed=True)
 
     def assertUpdateFetch(
         self, url, *, allow_viewers, allow_editors, allow_agents=False, allow_org2=False, form_fields=(), status=200
@@ -174,10 +172,8 @@ class CRUDLTestMixin:
         as_user(org2_admin, allowed=allow_org2)
         return as_user(admin, allowed=True)
 
-    def assertUpdateSubmit(self, url, data, *, form_errors=None, object_unchanged=None, success_status=302):
+    def assertUpdateSubmit(self, url, user, data, *, form_errors=None, object_unchanged=None, success_status=302):
         assert not form_errors or object_unchanged, "if form_errors specified, must also specify object_unchanged"
-
-        viewer, editor, agent, admin, org2_admin = self.get_test_users()
 
         def as_user(user, allowed):
             if allowed:
@@ -191,7 +187,7 @@ class CRUDLTestMixin:
             return self.requestView(url, user, post_data=data, checks=checks, choose_org=self.org)
 
         as_user(None, allowed=False)
-        return as_user(admin, allowed=True)
+        return as_user(user, allowed=True)
 
     def assertDeleteFetch(
         self, url, *, allow_viewers=False, allow_editors=False, allow_agents=False, status=200, as_modal=False
@@ -217,7 +213,7 @@ class CRUDLTestMixin:
         return as_user(admin, allowed=True)
 
     def assertDeleteSubmit(
-        self, url, *, object_unchanged=None, object_deleted=None, object_deactivated=None, success_status=302
+        self, url, user, *, object_unchanged=None, object_deleted=None, object_deactivated=None, success_status=302
     ):
         assert (
             object_unchanged or object_deleted or object_deactivated
@@ -239,8 +235,8 @@ class CRUDLTestMixin:
             return self.requestView(url, user, post_data={}, checks=checks)
 
         as_user(None, allowed=False)
-        as_user(org2_admin, allowed=False)
-        return as_user(admin, allowed=True)
+        as_user(self.admin2, allowed=False)
+        return as_user(user, allowed=True)
 
     def assertStaffOnly(self, url: str, choose_org=None):
         viewer, editor, agent, admin, org2_admin = self.get_test_users()

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -252,6 +252,7 @@ class TopicCRUDLTest(TembaTest, CRUDLTestMixin):
         update_url = reverse("tickets.topic_update", args=[system_topic.uuid])
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "My Topic"},
             form_errors={"name": "Cannot edit system topic"},
             object_unchanged=system_topic,
@@ -261,6 +262,7 @@ class TopicCRUDLTest(TembaTest, CRUDLTestMixin):
         update_url = reverse("tickets.topic_update", args=[user_topic.uuid])
         self.assertUpdateSubmit(
             update_url,
+            self.admin,
             {"name": "General"},
             form_errors={"name": "Topic already exists, please try another name"},
             object_unchanged=user_topic,
@@ -270,7 +272,7 @@ class TopicCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateFetch(update_url, allow_viewers=False, allow_editors=True, form_fields=["name"])
 
         # edit successfully
-        self.assertUpdateSubmit(update_url, {"name": "Boring Tickets"}, success_status=302)
+        self.assertUpdateSubmit(update_url, self.admin, {"name": "Boring Tickets"}, success_status=302)
 
         user_topic.refresh_from_db()
         self.assertEqual(user_topic.name, "Boring Tickets")
@@ -354,7 +356,9 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         user_topic = Topic.objects.create(org=self.org, name="Hot Topic", created_by=self.admin, modified_by=self.admin)
 
         # edit successfully
-        self.assertUpdateSubmit(update_url, {"topic": user_topic.id, "body": "This is silly"}, success_status=302)
+        self.assertUpdateSubmit(
+            update_url, self.admin, {"topic": user_topic.id, "body": "This is silly"}, success_status=302
+        )
 
         ticket.refresh_from_db()
         self.assertEqual(user_topic, ticket.topic)
@@ -583,10 +587,16 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
         self.assertUpdateSubmit(
-            update_url, {"note": ""}, form_errors={"note": "This field is required."}, object_unchanged=ticket
+            update_url,
+            self.admin,
+            {"note": ""},
+            form_errors={"note": "This field is required."},
+            object_unchanged=ticket,
         )
 
-        self.assertUpdateSubmit(update_url, {"note": "I have a bad feeling about this."}, success_status=200)
+        self.assertUpdateSubmit(
+            update_url, self.admin, {"note": "I have a bad feeling about this."}, success_status=200
+        )
 
         self.assertEqual(1, ticket.events.filter(event_type=TicketEvent.TYPE_NOTE_ADDED).count())
 


### PR DESCRIPTION
`assertCreateSubmit`, `assertUpdateSubmit`, `assertDeleteSubmit` all now require specifying the user... sometimes you want to use these with a user besides `admin`