### PR TITLE
Don't migrate flows when listing campaign events

### DIFF
--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -229,11 +229,7 @@ class Campaign(TembaModel):
         """
         events = list(self.events.filter(is_active=True))
 
-        for evt in events:
-            if evt.flow.is_system:
-                evt.flow.ensure_current_version()
-
-        return sorted(events, key=lambda e: e.relative_to.pk * 100_000 + e.minute_offset())
+        return sorted(events, key=lambda e: (e.relative_to.id, e.minute_offset()))
 
     def delete(self):
         """

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -179,7 +179,7 @@ class CampaignTest(TembaTest):
             created_by=self.admin,
             modified_by=self.admin,
             saved_by=self.admin,
-            version_number=3,
+            version_number="13.4.0",
             flow_type="V",
         )
 
@@ -189,13 +189,7 @@ class CampaignTest(TembaTest):
             self.org, self.admin, campaign, self.planting_date, offset=2, unit="W", flow=flow, delivery_hour="5"
         )
 
-        self.assertEqual(flow.version_number, 3)
         self.assertEqual(campaign.get_sorted_events(), [event2, event1, event3, event4])
-
-        flow.refresh_from_db()
-
-        self.assertNotEqual(flow.version_number, 3)
-        self.assertEqual(flow.version_number, Flow.CURRENT_SPEC_VERSION)
 
     def test_message_event(self):
         # create a campaign with a message event 1 day after planting date


### PR DESCRIPTION
Cannot remember why we do this and it's causing timeouts for campaigns with a lot of events.