### PR TITLE
Rework CRUDL tests to take explicit lists of users

### DIFF
--- a/temba/channels/types/viber_public/tests.py
+++ b/temba/channels/types/viber_public/tests.py
@@ -77,11 +77,9 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
         update_url = reverse("channels.channel_update", args=[self.channel.id])
         read_url = reverse("channels.channel_read", args=[self.channel.uuid])
 
+        self.assertRequestDisallowed(update_url, [None, self.user, self.agent, self.admin2])
         self.assertUpdateFetch(
-            update_url,
-            allow_viewers=False,
-            allow_editors=True,
-            form_fields={"name": "Viber", "welcome_message": ""},
+            update_url, [self.editor, self.admin], form_fields={"name": "Viber", "welcome_message": ""}
         )
 
         self.assertUpdateSubmit(
@@ -94,8 +92,7 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
 
         self.assertUpdateFetch(
             update_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields={"name": "Updated", "welcome_message": "Welcome, please subscribe for more"},
         )
 
@@ -103,11 +100,11 @@ class ViberPublicTypeTest(TembaTest, CRUDLTestMixin):
         self.assertContentMenu(read_url, self.admin, ["Configuration", "Logs", "Edit", "Delete"])
 
         # staff users see extra log policy field
-        self.login(self.customer_support, choose_org=self.org)
-        response = self.client.get(update_url)
-        self.assertEqual(
-            ["name", "log_policy", "welcome_message", "loc"],
-            list(response.context["form"].fields.keys()),
+        self.assertUpdateFetch(
+            update_url,
+            [self.customer_support],
+            form_fields=["name", "log_policy", "welcome_message"],
+            choose_org=self.org,
         )
 
     def test_get_error_ref_url(self):

--- a/temba/classifiers/tests.py
+++ b/temba/classifiers/tests.py
@@ -156,8 +156,10 @@ class ClassifierCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_delete(self):
         delete_url = reverse("classifiers.classifier_delete", args=[self.c2.uuid])
 
+        self.assertRequestDisallowed(delete_url, [None, self.user, self.editor, self.agent, self.admin2])
+
         # fetch delete modal
-        response = self.assertDeleteFetch(delete_url)
+        response = self.assertDeleteFetch(delete_url, [self.admin])
         self.assertContains(response, "You are about to delete")
 
         response = self.assertDeleteSubmit(delete_url, self.admin, object_deactivated=self.c2, success_status=200)
@@ -168,7 +170,7 @@ class ClassifierCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertFalse(self.flow.has_issues)
 
-        response = self.assertDeleteFetch(delete_url)
+        response = self.assertDeleteFetch(delete_url, [self.admin])
         self.assertContains(response, "is used by the following items but can still be deleted:")
         self.assertContains(response, "Color Flow")
 

--- a/temba/globals/tests.py
+++ b/temba/globals/tests.py
@@ -108,7 +108,8 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_create(self):
         create_url = reverse("globals.global_create")
 
-        self.assertCreateFetch(create_url, allow_viewers=False, allow_editors=True, form_fields=["name", "value"])
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
+        self.assertCreateFetch(create_url, [self.editor, self.admin], form_fields=["name", "value"])
 
         # try to submit with invalid name and missing value
         self.assertCreateSubmit(
@@ -159,7 +160,8 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_update(self):
         update_url = reverse("globals.global_update", args=[self.global1.id])
 
-        self.assertUpdateFetch(update_url, allow_viewers=False, allow_editors=True, form_fields=["value"])
+        self.assertRequestDisallowed(update_url, [None, self.user, self.agent, self.admin2])
+        self.assertUpdateFetch(update_url, [self.editor, self.admin], form_fields=["value"])
 
         # try to submit with missing value
         self.assertUpdateSubmit(
@@ -196,8 +198,10 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_delete(self):
         delete_url = reverse("globals.global_delete", args=[self.global2.uuid])
 
+        self.assertRequestDisallowed(delete_url, [None, self.user, self.agent, self.admin2])
+
         # fetch delete modal
-        response = self.assertDeleteFetch(delete_url, allow_editors=True)
+        response = self.assertDeleteFetch(delete_url, [self.editor, self.admin])
         self.assertContains(response, "You are about to delete")
 
         response = self.assertDeleteSubmit(delete_url, self.admin, object_deactivated=self.global2, success_status=200)
@@ -208,7 +212,7 @@ class GlobalCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertFalse(self.flow.has_issues)
 
-        response = self.assertDeleteFetch(delete_url, allow_editors=True)
+        response = self.assertDeleteFetch(delete_url, [self.admin])
         self.assertContains(response, "is used by the following items but can still be deleted:")
         self.assertContains(response, "Color Flow")
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -825,7 +825,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRequestDisallowed(export_url, [None, self.agent])
         response = self.assertUpdateFetch(
             export_url + "?l=I",
-            [self.user, self.editor, self.admin, self.admin2],
+            [self.user, self.editor, self.admin],
             form_fields=(
                 "start_date",
                 "end_date",

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -822,11 +822,10 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         testers = self.create_group("Testers", contacts=[])
         gender = self.create_field("gender", "Gender")
 
+        self.assertRequestDisallowed(export_url, [None, self.agent])
         response = self.assertUpdateFetch(
             export_url + "?l=I",
-            allow_viewers=True,
-            allow_editors=True,
-            allow_org2=True,
+            [self.user, self.editor, self.admin, self.admin2],
             form_fields=(
                 "start_date",
                 "end_date",
@@ -2008,8 +2007,8 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             process=False,
         )
 
-        self.assertCreateFetch(create_url, allow_viewers=False, allow_editors=True, form_fields=("omnibox",))
-        self.login(self.admin)
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
+        self.assertCreateFetch(create_url, [self.editor, self.admin], form_fields=("omnibox",))
 
         # initialize form based on a contact
         response = self.client.get(f"{create_url}?c={self.joe.uuid}")
@@ -2128,7 +2127,8 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         update_url = reverse("msgs.broadcast_update", args=[broadcast.id])
 
-        self.assertUpdateFetch(update_url, allow_viewers=False, allow_editors=True, form_fields=("omnibox",))
+        self.assertRequestDisallowed(update_url, [None, self.user, self.agent, self.admin2])
+        self.assertUpdateFetch(update_url, [self.editor, self.admin], form_fields=("omnibox",))
         self.login(self.admin)
 
         response = self.process_wizard(
@@ -2349,12 +2349,11 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             .save()
         ).session.runs.get()
 
+        self.assertRequestDisallowed(to_node_url, [None, self.user, self.agent])
+
         # initialize form based on a flow node UUID
         self.assertCreateFetch(
-            f"{to_node_url}?node={color_split['uuid']}&count=1",
-            allow_viewers=False,
-            allow_editors=True,
-            form_fields=["text"],
+            f"{to_node_url}?node={color_split['uuid']}&count=1", [self.editor, self.admin], form_fields=["text"]
         )
 
         response = self.assertCreateSubmit(
@@ -2378,6 +2377,12 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         self.assertEqual("hide", response["Temba-Success"])
         self.assertEqual(1, Broadcast.objects.count())
+
+        # if org has no send channel, show blocker
+        response = self.assertCreateFetch(
+            f"{to_node_url}?node=4ba8fcfa-f213-4164-a8d4-daede0a02144&count=1", [self.admin2], form_fields=["text"]
+        )
+        self.assertContains(response, "To get started you need to")
 
     def test_list(self):
         list_url = reverse("msgs.broadcast_list")
@@ -2492,8 +2497,10 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
 
         delete_url = reverse("msgs.broadcast_scheduled_delete", args=[broadcast.id])
 
+        self.assertRequestDisallowed(delete_url, [None, self.user, self.agent, self.admin2])
+
         # fetch the delete modal
-        response = self.assertDeleteFetch(delete_url, allow_editors=True, as_modal=True)
+        response = self.assertDeleteFetch(delete_url, [self.editor, self.admin], as_modal=True)
         self.assertContains(response, "You are about to delete")
 
         # submit the delete modal
@@ -2626,7 +2633,8 @@ class LabelCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_create(self):
         create_url = reverse("msgs.label_create")
 
-        self.assertCreateFetch(create_url, allow_viewers=False, allow_editors=True, form_fields=("name", "messages"))
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
+        self.assertCreateFetch(create_url, [self.editor, self.admin], form_fields=("name", "messages"))
 
         # try to create label with invalid name
         self.assertCreateSubmit(
@@ -2670,9 +2678,8 @@ class LabelCRUDLTest(TembaTest, CRUDLTestMixin):
         label1_url = reverse("msgs.label_update", args=[label1.id])
         label2_url = reverse("msgs.label_update", args=[label2.id])
 
-        self.assertUpdateFetch(
-            label2_url, allow_viewers=False, allow_editors=True, form_fields={"name": "Sales", "messages": None}
-        )
+        self.assertRequestDisallowed(label2_url, [None, self.user, self.agent, self.admin2])
+        self.assertUpdateFetch(label2_url, [self.editor, self.admin], form_fields={"name": "Sales", "messages": None})
 
         # try to update to invalid name
         self.assertUpdateSubmit(
@@ -2694,8 +2701,10 @@ class LabelCRUDLTest(TembaTest, CRUDLTestMixin):
 
         delete_url = reverse("msgs.label_delete", args=[label.uuid])
 
+        self.assertRequestDisallowed(delete_url, [None, self.user, self.agent, self.admin2])
+
         # fetch delete modal
-        response = self.assertDeleteFetch(delete_url, allow_editors=True)
+        response = self.assertDeleteFetch(delete_url, [self.editor, self.admin], as_modal=True)
         self.assertContains(response, "You are about to delete")
 
         # submit to delete it
@@ -2711,7 +2720,7 @@ class LabelCRUDLTest(TembaTest, CRUDLTestMixin):
         flow.label_dependencies.add(label)
         self.assertFalse(flow.has_issues)
 
-        response = self.assertDeleteFetch(delete_url, allow_editors=True)
+        response = self.assertDeleteFetch(delete_url, [self.admin])
         self.assertContains(response, "is used by the following items but can still be deleted:")
         self.assertContains(response, "Color Flow")
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -3089,8 +3089,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         delete_url = reverse("orgs.org_delete_child", args=[child.id])
 
         self.assertRequestDisallowed(delete_url, [None, self.user, self.editor, self.agent, self.admin2])
-
-        self.assertDeleteFetch(delete_url, [self.admin])
+        self.assertDeleteFetch(delete_url, [self.admin], choose_org=self.org)
 
         # schedule for deletion
         response = self.client.get(delete_url)

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2761,7 +2761,8 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.org2.save(update_fields=("features",))
 
         # since we can only create new orgs, we don't show type as an option
-        self.assertCreateFetch(create_url, allow_viewers=False, allow_editors=False, form_fields=["name", "timezone"])
+        self.assertRequestDisallowed(create_url, [None, self.user, self.editor, self.agent])
+        self.assertCreateFetch(create_url, [self.admin], form_fields=["name", "timezone"])
 
         # try to submit an empty form
         response = self.assertCreateSubmit(
@@ -2814,7 +2815,8 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.org2.save(update_fields=("features",))
 
         # since we can only create child orgs, we don't show type as an option
-        self.assertCreateFetch(create_url, allow_viewers=False, allow_editors=False, form_fields=["name", "timezone"])
+        self.assertRequestDisallowed(create_url, [None, self.user, self.editor, self.agent])
+        self.assertCreateFetch(create_url, [self.admin], form_fields=["name", "timezone"])
 
         # try to submit an empty form
         response = self.assertCreateSubmit(
@@ -2853,12 +2855,8 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.org2.save(update_fields=("features",))
 
         # because we can create both new orgs and child orgs, type is an option
-        self.assertCreateFetch(
-            create_url,
-            allow_viewers=False,
-            allow_editors=False,
-            form_fields=["type", "name", "timezone"],
-        )
+        self.assertRequestDisallowed(create_url, [None, self.user, self.editor, self.agent])
+        self.assertCreateFetch(create_url, [self.admin], form_fields=["type", "name", "timezone"])
 
         # create new org
         self.assertCreateSubmit(
@@ -3090,7 +3088,9 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         child = self.org.create_new(self.admin, "Child Workspace", self.org.timezone, as_child=True)
         delete_url = reverse("orgs.org_delete_child", args=[child.id])
 
-        self.assertDeleteFetch(delete_url)
+        self.assertRequestDisallowed(delete_url, [None, self.user, self.editor, self.agent, self.admin2])
+
+        self.assertDeleteFetch(delete_url, [self.admin])
 
         # schedule for deletion
         response = self.client.get(delete_url)
@@ -3329,13 +3329,8 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual("English", response.context["primary_lang"])
         self.assertEqual([], response.context["other_langs"])
 
-        self.assertUpdateFetch(
-            langs_url,
-            allow_viewers=False,
-            allow_editors=False,
-            allow_org2=True,  # is same URL across orgs
-            form_fields=["primary_lang", "other_langs", "input_collation"],
-        )
+        self.assertRequestDisallowed(langs_url, [None, self.user, self.editor, self.agent])
+        self.assertUpdateFetch(langs_url, [self.admin], form_fields=["primary_lang", "other_langs", "input_collation"])
 
         # initial should do a match on code only
         response = self.client.get(f"{langs_url}?initial=fra", HTTP_X_REQUESTED_WITH="XMLHttpRequest")

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -636,10 +636,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         group1 = self.create_group("Group 1", contacts=[])
         group2 = self.create_group("Group 2", contacts=[])
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
             create_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields=["keywords", "match_type", "flow", "channel", "groups", "exclude_groups"],
         )
 
@@ -752,10 +752,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.create_flow("Flow 4", flow_type=Flow.TYPE_SURVEY)
         self.create_flow("Flow 5", is_system=True)
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
             create_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields=[
                 "start_datetime",
                 "repeat_period",
@@ -871,10 +871,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         create_url = reverse("triggers.trigger_create_inbound_call")
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
             create_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields=["action", "voice_flow", "msg_flow", "channel", "groups", "exclude_groups"],
         )
 
@@ -941,8 +941,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         create_url = reverse("triggers.trigger_create_missed_call")
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
-            create_url, allow_viewers=False, allow_editors=True, form_fields=["flow", "groups", "exclude_groups"]
+            create_url, [self.editor, self.admin], form_fields=["flow", "groups", "exclude_groups"]
         )
 
         # flow options should be messaging and voice flows
@@ -980,11 +981,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         channel2 = self.create_channel("VP", "Viber Channel", "1234567")
         self.create_channel("A", "Android Channel", "+1234")
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
-            create_url,
-            allow_viewers=False,
-            allow_editors=True,
-            form_fields=["flow", "channel", "groups", "exclude_groups"],
+            create_url, [self.editor, self.admin], form_fields=["flow", "channel", "groups", "exclude_groups"]
         )
 
         # flow options should show messaging and voice flows
@@ -1040,10 +1039,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         channel2 = self.create_channel("FB", "Facebook 2", "2345678")
         self.create_channel("A", "Android Channel", "+1234")
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
             create_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields=["referrer_id", "flow", "channel", "groups", "exclude_groups"],
         )
 
@@ -1117,11 +1116,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         group1 = self.create_group("Group 1", contacts=[])
         group2 = self.create_group("Group 2", contacts=[])
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
-            create_url,
-            allow_viewers=False,
-            allow_editors=True,
-            form_fields=["flow", "channel", "groups", "exclude_groups"],
+            create_url, [self.editor, self.admin], form_fields=["flow", "channel", "groups", "exclude_groups"]
         )
 
         # flow options should show messaging and voice flows
@@ -1184,8 +1181,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         create_url = reverse("triggers.trigger_create_closed_ticket")
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
-            create_url, allow_viewers=False, allow_editors=True, form_fields=["flow", "groups", "exclude_groups"]
+            create_url, [self.editor, self.admin], form_fields=["flow", "groups", "exclude_groups"]
         )
 
         # flow options should be messaging, voice and background flows
@@ -1222,11 +1220,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         create_url = reverse("triggers.trigger_create_opt_in")
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
-            create_url,
-            allow_viewers=False,
-            allow_editors=True,
-            form_fields=["flow", "channel", "groups", "exclude_groups"],
+            create_url, [self.editor, self.admin], form_fields=["flow", "channel", "groups", "exclude_groups"]
         )
 
         # flow options should be messaging and background flows
@@ -1284,11 +1280,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         create_url = reverse("triggers.trigger_create_opt_out")
 
+        self.assertRequestDisallowed(create_url, [None, self.user, self.agent])
         response = self.assertCreateFetch(
-            create_url,
-            allow_viewers=False,
-            allow_editors=True,
-            form_fields=["flow", "channel", "groups", "exclude_groups"],
+            create_url, [self.editor, self.admin], form_fields=["flow", "channel", "groups", "exclude_groups"]
         )
 
         # flow options should be messaging and background flows
@@ -1349,10 +1343,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         update_url = reverse("triggers.trigger_update", args=[trigger.id])
 
+        self.assertRequestDisallowed(update_url, [None, self.user, self.agent, self.admin2])
         self.assertUpdateFetch(
             update_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields={
                 "keywords": ["join", "start"],
                 "match_type": "O",
@@ -1412,10 +1406,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         update_url = reverse("triggers.trigger_update", args=[trigger.id])
 
+        self.assertRequestDisallowed(update_url, [None, self.user, self.agent, self.admin2])
         self.assertUpdateFetch(
             update_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields={
                 "action": "answer",
                 "voice_flow": flow2,
@@ -1441,8 +1435,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         # check form shows correct initial values now
         self.assertUpdateFetch(
             update_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.admin],
             form_fields={
                 "action": "hangup",
                 "voice_flow": None,
@@ -1483,10 +1476,10 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         update_url = reverse("triggers.trigger_update", args=[trigger.id])
 
+        self.assertRequestDisallowed(update_url, [None, self.user, self.agent, self.admin2])
         self.assertUpdateFetch(
             update_url,
-            allow_viewers=False,
-            allow_editors=True,
+            [self.editor, self.admin],
             form_fields={
                 "start_datetime": schedule.next_fire,
                 "repeat_period": "W",


### PR DESCRIPTION
They're kinda janky right now because sometimes a form shows different things depending on the user