### PR TITLE
Use mailroom endpoints to create messages and events during Android syncing

### DIFF
--- a/temba/channels/android/sync.py
+++ b/temba/channels/android/sync.py
@@ -87,7 +87,7 @@ def create_incoming(org, channel, urn, text, received_on, attachments=None):
     if existing:
         return existing
 
-    msg = Msg.objects.create(
+    return Msg.objects.create(
         org=org,
         channel=channel,
         contact=contact,
@@ -102,11 +102,6 @@ def create_incoming(org, channel, urn, text, received_on, attachments=None):
         status=Msg.STATUS_PENDING,
         msg_type=Msg.TYPE_TEXT,
     )
-
-    # pass off handling of the message after we commit
-    on_transaction_commit(lambda: msg.handle())
-
-    return msg
 
 
 def create_event(channel, urn, event_type, occurred_on, extra):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -650,20 +650,6 @@ class Contact(LegacyUUIDMixin, SmartModel):
         return Contact.objects.get(id=response["contact"]["id"])
 
     @classmethod
-    def resolve(cls, channel, urn):
-        """
-        Resolves a contact and URN from a channel interaction. Only used for relayer endpoints.
-        """
-        try:
-            response = mailroom.get_client().contact_resolve(channel.org_id, channel.id, urn)
-        except mailroom.MailroomException as e:
-            raise ValueError(e.response.get("error"))
-
-        contact = Contact.objects.get(id=response["contact"]["id"])
-        contact_urn = ContactURN.objects.get(id=response["urn"]["id"])
-        return contact, contact_urn
-
-    @classmethod
     def from_urn(cls, org, urn_as_string, country=None):
         """
         Looks up a contact by a URN string (which will be normalized)

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -124,6 +124,29 @@ class MailroomClient:
     def version(self):
         return self._request("", post=False).get("version")
 
+    def android_event(self, org_id: int, channel_id: int, urn: str, event_type: str, extra: dict, occurred_on):
+        payload = {
+            "org_id": org_id,
+            "channel_id": channel_id,
+            "urn": urn,
+            "event_type": event_type,
+            "extra": extra,
+            "occurred_on": occurred_on.isoformat(),
+        }
+
+        return self._request("android/event", payload)
+
+    def android_message(self, org_id: int, channel_id: int, urn: str, text: str, received_on):
+        payload = {
+            "org_id": org_id,
+            "channel_id": channel_id,
+            "urn": urn,
+            "text": text,
+            "received_on": received_on.isoformat(),
+        }
+
+        return self._request("android/message", payload)
+
     def contact_create(self, org_id: int, user_id: int, contact: ContactSpec):
         payload = {"org_id": org_id, "user_id": user_id, "contact": asdict(contact)}
 
@@ -153,11 +176,6 @@ class MailroomClient:
         }
 
         return self._request("contact/modify", payload)
-
-    def contact_resolve(self, org_id: int, channel_id: int, urn: str):
-        payload = {"org_id": org_id, "channel_id": channel_id, "urn": urn}
-
-        return self._request("contact/resolve", payload)
 
     def contact_search(
         self, org_id: int, group_id: int, query: str, sort: str, offset=0, exclude_ids=()

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -251,7 +251,12 @@ class MailroomClient:
         response = self._request("msg/broadcast_preview", payload, encode_json=True)
         return BroadcastPreview(query=response["query"], total=response["total"])
 
-    def msg_resend(self, org_id, msg_ids):
+    def msg_handle(self, org_id: int, msg_ids: list):
+        payload = {"org_id": org_id, "msg_ids": msg_ids}
+
+        return self._request("msg/handle", payload)
+
+    def msg_resend(self, org_id: int, msg_ids: list):
         payload = {"org_id": org_id, "msg_ids": msg_ids}
 
         return self._request("msg/resend", payload)

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -24,7 +24,6 @@ class HandlerTask(Enum):
 
 
 class ContactTask(Enum):
-    MSG_EVENT = "msg_event"
     CHANNEL_EVENT = "channel_event"
 
 
@@ -36,26 +35,6 @@ class BatchTask(Enum):
     SCHEDULE_CAMPAIGN_EVENT = "schedule_campaign_event"
     IMPORT_CONTACT_BATCH = "import_contact_batch"
     INTERRUPT_CHANNEL = "interrupt_channel"
-
-
-def queue_msg_handling(msg):
-    """
-    Queues the passed in message for handling in mailroom
-    """
-
-    msg_task = {
-        "channel_id": msg.channel.id,
-        "msg_id": msg.id,
-        "msg_uuid": str(msg.uuid),
-        "msg_external_id": msg.external_id,
-        "urn": str(msg.contact_urn),
-        "urn_id": msg.contact_urn_id,
-        "text": msg.text,
-        "attachments": msg.attachments,
-        "new_contact": False,  # only used by courier
-    }
-
-    _queue_handler_task(msg.org_id, msg.contact_id, ContactTask.MSG_EVENT, msg_task)
 
 
 def queue_mo_miss_event(event):

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -13,19 +13,6 @@ DEFAULT_PRIORITY = 0
 QUEUE_PATTERN = "%s:%d"
 ACTIVE_PATTERN = "%s:active"
 
-# task queues
-CONTACT_QUEUE = "c:%d:%d"
-BATCH_QUEUE = "batch"
-HANDLER_QUEUE = "handler"
-
-
-class HandlerTask(Enum):
-    CONTACT_EVENT = "handle_contact_event"
-
-
-class ContactTask(Enum):
-    CHANNEL_EVENT = "channel_event"
-
 
 class BatchTask(Enum):
     START_FLOW = "start_flow"
@@ -35,24 +22,6 @@ class BatchTask(Enum):
     SCHEDULE_CAMPAIGN_EVENT = "schedule_campaign_event"
     IMPORT_CONTACT_BATCH = "import_contact_batch"
     INTERRUPT_CHANNEL = "interrupt_channel"
-
-
-def queue_mo_miss_event(event):
-    """
-    Queues the passed in channel event to mailroom for handling
-    """
-
-    event_task = {
-        "event_id": event.id,
-        "event_type": "mo_miss",
-        "channel_id": event.channel_id,
-        "urn_id": event.contact_urn_id,
-        "extra": event.extra,
-        "created_on": event.created_on,
-        "new_contact": False,  # only used by courier
-    }
-
-    _queue_handler_task(event.org_id, event.contact_id, ContactTask.CHANNEL_EVENT, event_task)
 
 
 def queue_broadcast(broadcast):
@@ -165,27 +134,7 @@ def _queue_batch_task(org_id, task_type, task, priority):
 
     r = get_redis_connection("default")
     pipe = r.pipeline()
-    _queue_task(pipe, org_id, BATCH_QUEUE, task_type, task, priority)
-    pipe.execute()
-
-
-def _queue_handler_task(org_id, contact_id, task_type, task):
-    """
-    Adds the passed in task to the contact's queue for mailroom to process
-    """
-
-    contact_queue = CONTACT_QUEUE % (org_id, contact_id)
-    contact_task = _create_mailroom_task(task_type, task)
-
-    r = get_redis_connection("default")
-    pipe = r.pipeline()
-
-    # push our concrete task to the contact's queue
-    pipe.rpush(contact_queue, json.dumps(contact_task))
-
-    # then push a contact handling event to the org queue
-    event_task = {"contact_id": contact_id}
-    _queue_task(pipe, org_id, HANDLER_QUEUE, HandlerTask.CONTACT_EVENT, event_task, HIGH_PRIORITY)
+    _queue_task(pipe, org_id, "batch", task_type, task, priority)
     pipe.execute()
 
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -584,7 +584,7 @@ class Msg(models.Model):
         Queues this message to be handled. Only used for manual retries of failed handling.
         """
 
-        mailroom.get_client().msg_handle(self.org.id, [self.id])
+        mailroom.get_client().msg_handle(self.org_id, [self.id])
 
     def archive(self):
         """

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -579,12 +579,12 @@ class Msg(models.Model):
     def get_logs(self) -> list:
         return ChannelLog.get_logs(self.channel, self.log_uuids or [])
 
-    def handle(self):
+    def handle(self):  # pragma: no cover
         """
-        Queues this message to be handled
+        Queues this message to be handled. Only used for manual retries of failed handling.
         """
 
-        mailroom.queue_msg_handling(self)
+        mailroom.get_client().msg_handle(self.org.id, [self.id])
 
     def archive(self):
         """


### PR DESCRIPTION
Removes the need for RP to know about queueing contact tasks.. or creating messages/events.

And it doesn't add any new HTTP overhead because we were already calling mailroom `contact/resolve` to create such messages/events.