### PR TITLE
Tweak layout of user edit form

### DIFF
--- a/templates/orgs/user_edit.html
+++ b/templates/orgs/user_edit.html
@@ -6,15 +6,17 @@
 {% endblock extra-style %}
 {% block fields %}
   <div class="mb-4">
-    <div class="field formax-vertical">{% render_field 'first_name' %}</div>
-    <div class="field formax-vertical">{% render_field 'last_name' %}</div>
-    <div class="field formax-vertical">{% render_field 'avatar' %}</div>
+    <div class="flex">
+      <div class="flex-auto mr-4">{% render_field 'first_name' %}</div>
+      <div class="flex-auto">{% render_field 'last_name' %}</div>
+    </div>
+    <div class="field">{% render_field 'avatar' %}</div>
     {% if form.fields.language %}
-      <div class="field formax-vertical">{% render_field 'language' %}</div>
+      <div class="field">{% render_field 'language' %}</div>
     {% endif %}
-    <div class="field formax-vertical">{% render_field 'email' %}</div>
-    <div class="field formax-vertical">{% render_field 'new_password' %}</div>
-    <div class="field formax-vertical p-4 bg-gray-100 rounded-lg mt-4 hidden" id="current-password">
+    <div class="field">{% render_field 'email' %}</div>
+    <div class="field">{% render_field 'new_password' %}</div>
+    <div class="field p-4 bg-gray-100 rounded-lg mt-4 hidden" id="current-password">
       <div class="mb-2">
         {% blocktrans trimmed %}
           Confirm your current password to save these changes


### PR DESCRIPTION
Even on mobile there's space to have these side by side

<img width="552" alt="Captura de pantalla 2024-04-24 a la(s) 13 46 53" src="https://github.com/nyaruka/rapidpro/assets/675558/78243645-4ce2-40af-b0bd-6a18700e6e69">

<img width="550" alt="Captura de pantalla 2024-04-24 a la(s) 13 49 28" src="https://github.com/nyaruka/rapidpro/assets/675558/8b7bb878-f4e9-4ebc-a879-cef82bf951fe">

and if you're not on mobile it currently looks like...

<img width="1132" alt="Captura de pantalla 2024-04-24 a la(s) 13 53 45" src="https://github.com/nyaruka/rapidpro/assets/675558/ebaf6520-0318-445f-a56a-2db215a63a3d">

