### PR TITLE
Tweak time limit for sessions to 89 days

### DIFF
--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -78,7 +78,7 @@ def interrupt_flow_sessions():
     Interrupt old flow sessions which have exceeded the absolute time limit
     """
 
-    before = timezone.now() - timedelta(days=90)
+    before = timezone.now() - timedelta(days=89)
     num_interrupted = 0
 
     # get old sessions and organize into lists by org

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3757,9 +3757,9 @@ class FlowSessionTest(TembaTest):
                 wait_resume_on_expire=False,
             )
 
-        create_session(self.org, timezone.now() - timedelta(days=89))
-        session2 = create_session(self.org, timezone.now() - timedelta(days=91))
-        session3 = create_session(self.org, timezone.now() - timedelta(days=92))
+        create_session(self.org, timezone.now() - timedelta(days=88))
+        session2 = create_session(self.org, timezone.now() - timedelta(days=90))
+        session3 = create_session(self.org, timezone.now() - timedelta(days=91))
         session4 = create_session(self.org2, timezone.now() - timedelta(days=92))
 
         interrupt_flow_sessions()


### PR DESCRIPTION
...so things are always interrupted before archiver gets to them. I think this is why we some times see errors like https://textit.sentry.io/issues/5226712172