### PR TITLE
Remove messages block that duplicates alert-messages

### DIFF
--- a/templates/dashboard/home.html
+++ b/templates/dashboard/home.html
@@ -1,8 +1,6 @@
 {% extends "smartmin/base.html" %}
 {% load smartmin temba compress i18n humanize tz %}
 
-{% block messages %}
-{% endblock messages %}
 {% block content %}
   <script src="https://rawgit.com/highcharts/rounded-corners/master/rounded-corners.js"></script>
   <div class="card scrollable flex-shrink-0" id="range-group">

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -163,13 +163,6 @@
         </temba-store>
       {% endif %}
       <div class="flex flex-col h-full">
-        {% if messages %}
-          {% block messages %}
-            {% if messages %}
-              {% for msg in messages %}<div class="alert alert-{{ message.tags }}">{{ msg }}</div>{% endfor %}
-            {% endif %}
-          {% endblock messages %}
-        {% endif %}
         {% block post-header %}
         {% endblock post-header %}
         <!-- Content -->

--- a/templates/no_nav.html
+++ b/templates/no_nav.html
@@ -43,6 +43,18 @@
             {% endblock top-right %}
           </div>
         </div>
+        {% block alert-messages %}
+          {% if user_org.is_suspended %}
+            {% include "org_suspended_include.html" %}
+          {% endif %}
+          {% if messages %}
+            {% for msg in messages %}
+              <temba-alert class="mb-3">
+                {{ msg }}
+              </temba-alert>
+            {% endfor %}
+          {% endif %}
+        {% endblock alert-messages %}
         {% block content %}
         {% endblock content %}
       </div>

--- a/templates/public/public_welcome.html
+++ b/templates/public/public_welcome.html
@@ -39,8 +39,7 @@
     }
   </style>
 {% endblock extra-style %}
-{% block messages %}
-{% endblock messages %}
+
 {% block content %}
   {% if 'success' in request.GET.keys %}
     {% blocktrans with name=branding.name %}


### PR DESCRIPTION
We'll display the messages once in `alert-messages` block

https://github.com/nyaruka/rapidpro/blob/631e6b4cf628dd8b7e1aaff1af0a0664b4c576f6/templates/frame.html#L258-L269