### PR TITLE
Don't use error level alerts for form errors

### DIFF
--- a/templates/contacts/contact_list.html
+++ b/templates/contacts/contact_list.html
@@ -78,9 +78,9 @@
     </form>
   </div>
   {% if search_error %}
-    <temba-alert level="error" class="mt-4">
+    <div class="alert alert-error mt-4">
       {{ search_error }}
-    </temba-alert>
+    </div>
   {% endif %}
   {% if org_perms.contacts.contact_delete %}
     <temba-dialog header="{{ _("Delete Selected Contacts") |escapejs }}"

--- a/templates/contacts/contactimport_preview.html
+++ b/templates/contacts/contactimport_preview.html
@@ -13,11 +13,7 @@
   </div>
   <form method="post" enctype="multipart/form-data" class="smartmin-form horizontal-form">
     {% csrf_token %}
-    {% if form.non_field_errors %}
-      <temba-alert level="error" class="form-errors">
-        {{ form.non_field_errors }}
-      </temba-alert>
-    {% endif %}
+    {% if form.non_field_errors %}<div class="alert alert-error form-errors">{{ form.non_field_errors }}</div>{% endif %}
     <div class="card w-full">
       {% block fields %}
         <fieldset>

--- a/templates/orgs/login/confirm_access.html
+++ b/templates/orgs/login/confirm_access.html
@@ -14,11 +14,7 @@
       <temba-textinput name="password" placeholder="{{ _("Password") |escape }}" password="true">
       </temba-textinput>
     </div>
-    {% if form.password.errors %}
-      <temba-alert level="error" class="mt-4">
-        {{ form.password.errors }}
-      </temba-alert>
-    {% endif %}
+    {% if form.password.errors %}<div class="alert alert-error mt-4">{{ form.password.errors }}</div>{% endif %}
     <div class="mt-6">
       <input type="submit" value="{{ _("Confirm") |escape }}" class="button-primary">
     </div>

--- a/templates/orgs/login/login.html
+++ b/templates/orgs/login/login.html
@@ -9,14 +9,10 @@
   {% blocktrans trimmed %}
     Please sign in with your email address and password.
   {% endblocktrans %}
-  <form method="POST" id="login-form">
+  <form method="post" id="login-form">
     {% csrf_token %}
     {% for field, errors in form.errors.items %}
-      {% if field == '__all__' %}
-        <temba-alert level="error" class="my-4">
-          {{ errors }}
-        </temba-alert>
-      {% endif %}
+      {% if field == '__all__' %}<div class="alert alert-error my-4">{{ errors }}</div>{% endif %}
     {% endfor %}
     <div class="mt-4">
       <input type="text"
@@ -26,19 +22,11 @@
              value="{% if form.username.value %}{{ form.username.value|escape }}{% endif %}"
              class="input">
     </div>
-    {% if form.username.errors %}
-      <temba-alert level="error" class="mt-4">
-        {{ form.username.errors }}
-      </temba-alert>
-    {% endif %}
+    {% if form.username.errors %}<div class="alert alert-error mt-4">{{ form.username.errors }}</div>{% endif %}
     <div class="mt-4">
       <input type="password" name="password" placeholder="{{ _("Password") |escapejs }}" class="input">
     </div>
-    {% if form.password.errors %}
-      <temba-alert level="error" class="mt-4">
-        {{ form.password.errors }}
-      </temba-alert>
-    {% endif %}
+    {% if form.password.errors %}<div class="alert alert-error mt-4">{{ form.password.errors }}</div>{% endif %}
     <div class="mt-2 text-right">
       <a href="/user/forget/">Forgot your password?</a>
     </div>

--- a/templates/orgs/login/two_factor_backup.html
+++ b/templates/orgs/login/two_factor_backup.html
@@ -17,11 +17,7 @@
       <temba-textinput name="token" maxlength="8" placeholder="{{ _("8-character token") |escape }}">
       </temba-textinput>
     </div>
-    {% if form.token.errors %}
-      <temba-alert level="error" class="mt-4">
-        {{ form.token.errors }}
-      </temba-alert>
-    {% endif %}
+    {% if form.token.errors %}<div class="alert alert-error mt-4">{{ form.token.errors }}</div>{% endif %}
     <div class="mt-2 text-right">
       <a href="{% url 'users.two_factor_verify' %}">{% trans "Use Device" %}</a>
     </div>

--- a/templates/orgs/login/two_factor_verify.html
+++ b/templates/orgs/login/two_factor_verify.html
@@ -16,11 +16,7 @@
     <div class="mt-4">
       <input name="otp" maxlength="6" placeholder="{{ _("6-digit code") |escape }}" class="input">
     </div>
-    {% if form.otp.errors %}
-      <temba-alert level="error" class="mt-4">
-        {{ form.otp.errors }}
-      </temba-alert>
-    {% endif %}
+    {% if form.otp.errors %}<div class="alert alert-error mt-4">{{ form.otp.errors }}</div>{% endif %}
     <div class="mt-2 text-right">
       <a href="{% url 'users.two_factor_backup' %}">{% trans "Use Backup Token" %}</a>
     </div>


### PR DESCRIPTION
as alert component:

<img width="416" alt="Captura de pantalla 2024-05-15 a la(s) 14 25 15" src="https://github.com/nyaruka/rapidpro/assets/675558/b3af9f3a-41e3-4391-ad3d-8b26d53add36">

as alert styled div:

<img width="420" alt="Captura de pantalla 2024-05-15 a la(s) 14 24 48" src="https://github.com/nyaruka/rapidpro/assets/675558/687f409f-beba-410a-a8dc-d94f6a1eb0e4">

as alert component:

<img width="394" alt="Captura de pantalla 2024-05-15 a la(s) 14 26 16" src="https://github.com/nyaruka/rapidpro/assets/675558/3effe2ce-2a37-4944-9d6a-2d8053a86a38">

as alert styled div:

<img width="395" alt="Captura de pantalla 2024-05-15 a la(s) 14 26 49" src="https://github.com/nyaruka/rapidpro/assets/675558/7c662885-ceaf-4ee2-be7f-ffa9d9913ffb">

as alert component:

<img width="466" alt="330889588-36e6a2d6-9856-4fcd-881d-2f4d6b5a9a66" src="https://github.com/nyaruka/rapidpro/assets/675558/9aea76f6-d2d5-4e31-a1f5-9f70cca3b43d">

as alert styled div:

<img width="412" alt="330889601-397d67c4-7bc0-40f5-8f9f-31b9991fb7f5" src="https://github.com/nyaruka/rapidpro/assets/675558/ba6974d7-f648-4ddf-9240-a52d4149ce47">
