### PR TITLE
Use icons in campaign event dropdown to indicate field type

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -540,6 +540,9 @@ class ContactField(TembaModel, DependencyMixin):
     def get_access(self, user) -> str:
         return self.agent_access if self.org.get_user_role(user) == OrgRole.AGENT else self.ACCESS_EDIT
 
+    def get_attrs(self):
+        return {"icon": "info" if self.is_proxy else "fields"}
+
     def release(self, user):
         assert not (self.is_system and self.org.is_active), "can't release system fields"
 


### PR DESCRIPTION
<img width="336" alt="Captura de pantalla 2024-05-16 a la(s) 17 36 43" src="https://github.com/nyaruka/rapidpro/assets/675558/921d8de0-4562-4473-9f07-afda4c193865">

like we do for groups

<img width="231" alt="Captura de pantalla 2024-05-16 a la(s) 17 36 20" src="https://github.com/nyaruka/rapidpro/assets/675558/a7e46c2f-09b0-4f16-9177-cdb6c5167789">
