### PR TITLE
Mailroom client should use content-type header on responses to know whether to parse as JSON

### DIFF
--- a/temba/channels/types/rocketchat/tests.py
+++ b/temba/channels/types/rocketchat/tests.py
@@ -8,7 +8,7 @@ from requests.exceptions import Timeout
 from django.urls import reverse
 
 from temba.channels.models import Channel
-from temba.tests import MockResponse, TembaTest
+from temba.tests import MockJsonResponse, MockResponse, TembaTest
 
 from .client import Client, ClientError
 from .type import RocketChatType
@@ -62,7 +62,7 @@ class RocketChatMixin(TembaTest):
 class ClientTest(RocketChatMixin):
     @patch("requests.put")
     def test_settings_success(self, mock_request):
-        mock_request.return_value = MockResponse(204, {})
+        mock_request.return_value = MockJsonResponse(204, {})
         try:
             Client(self.secure_url, self.secret).settings("http://temba.io/c/1234-5678", "test-bot")
         except ClientError:

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -7,7 +7,7 @@ from django.test import override_settings
 from django.urls import reverse
 
 from temba.request_logs.models import HTTPLog
-from temba.tests import MockResponse, TembaTest
+from temba.tests import MockJsonResponse, MockResponse, TembaTest
 from temba.utils.views import TEMBA_MENU_SELECTION
 
 from ...models import Channel
@@ -40,7 +40,7 @@ class WhatsAppTypeTest(TembaTest):
         self.assertNotContains(response, claim_whatsapp_cloud_url)
 
         with patch("requests.get") as wa_cloud_get:
-            wa_cloud_get.return_value = MockResponse(400, {})
+            wa_cloud_get.return_value = MockJsonResponse(400, {})
             response = self.client.get(claim_whatsapp_cloud_url)
 
             self.assertEqual(response.status_code, 302)
@@ -51,7 +51,7 @@ class WhatsAppTypeTest(TembaTest):
 
         self.make_beta(self.admin)
         with patch("requests.get") as wa_cloud_get:
-            wa_cloud_get.return_value = MockResponse(400, {})
+            wa_cloud_get.return_value = MockJsonResponse(400, {})
             response = self.client.get(claim_whatsapp_cloud_url)
 
             self.assertEqual(response.status_code, 302)
@@ -62,54 +62,48 @@ class WhatsAppTypeTest(TembaTest):
 
         with patch("requests.get") as wa_cloud_get:
             wa_cloud_get.side_effect = [
-                MockResponse(400, {}),
+                MockJsonResponse(400, {}),
                 # missing permissions
-                MockResponse(
+                MockJsonResponse(
                     200,
-                    json.dumps({"data": {"scopes": []}}),
+                    {"data": {"scopes": []}},
                 ),
                 # success
-                MockResponse(
+                MockJsonResponse(
                     200,
-                    json.dumps(
-                        {
-                            "data": {
-                                "scopes": [
-                                    "business_management",
-                                    "whatsapp_business_management",
-                                    "whatsapp_business_messaging",
-                                ]
-                            }
+                    {
+                        "data": {
+                            "scopes": [
+                                "business_management",
+                                "whatsapp_business_management",
+                                "whatsapp_business_messaging",
+                            ]
                         }
-                    ),
+                    },
                 ),
-                MockResponse(
+                MockJsonResponse(
                     200,
-                    json.dumps(
-                        {
-                            "data": {
-                                "scopes": [
-                                    "business_management",
-                                    "whatsapp_business_management",
-                                    "whatsapp_business_messaging",
-                                ]
-                            }
+                    {
+                        "data": {
+                            "scopes": [
+                                "business_management",
+                                "whatsapp_business_management",
+                                "whatsapp_business_messaging",
+                            ]
                         }
-                    ),
+                    },
                 ),
-                MockResponse(
+                MockJsonResponse(
                     200,
-                    json.dumps(
-                        {
-                            "data": {
-                                "scopes": [
-                                    "business_management",
-                                    "whatsapp_business_management",
-                                    "whatsapp_business_messaging",
-                                ]
-                            }
+                    {
+                        "data": {
+                            "scopes": [
+                                "business_management",
+                                "whatsapp_business_management",
+                                "whatsapp_business_messaging",
+                            ]
                         }
-                    ),
+                    },
                 ),
             ]
             response = self.client.get(connect_whatsapp_cloud_url)

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -23,7 +23,7 @@ from temba.globals.models import Global
 from temba.orgs.integrations.dtone import DTOneType
 from temba.orgs.models import Export
 from temba.templates.models import Template, TemplateTranslation
-from temba.tests import CRUDLTestMixin, MockResponse, TembaTest, matchers, mock_mailroom, override_brand
+from temba.tests import CRUDLTestMixin, MockJsonResponse, TembaTest, matchers, mock_mailroom, override_brand
 from temba.tests.base import get_contact_search
 from temba.tests.engine import MockSessionWriter
 from temba.tests.s3 import MockS3Client, jsonlgz_encode
@@ -5156,7 +5156,7 @@ class SimulationTest(TembaTest):
 
         with override_settings(MAILROOM_AUTH_TOKEN="sesame", MAILROOM_URL="https://mailroom.temba.io"):
             with patch("requests.post") as mock_post:
-                mock_post.return_value = MockResponse(200, '{"session": {}}')
+                mock_post.return_value = MockJsonResponse(200, {"session": {}})
                 response = self.client.post(url, payload, content_type="application/json")
 
                 self.assertEqual(response.status_code, 200)
@@ -5194,13 +5194,13 @@ class SimulationTest(TembaTest):
 
         with override_settings(MAILROOM_AUTH_TOKEN="sesame", MAILROOM_URL="https://mailroom.temba.io"):
             with patch("requests.post") as mock_post:
-                mock_post.return_value = MockResponse(400, '{"session": {}}')
+                mock_post.return_value = MockJsonResponse(400, {"session": {}})
                 response = self.client.post(url, json.dumps(payload), content_type="application/json")
                 self.assertEqual(500, response.status_code)
 
             # start a flow
             with patch("requests.post") as mock_post:
-                mock_post.return_value = MockResponse(200, '{"session": {}}')
+                mock_post.return_value = MockJsonResponse(200, {"session": {}})
                 response = self.client.post(url, json.dumps(payload), content_type="application/json")
                 self.assertEqual(200, response.status_code)
                 self.assertEqual({}, response.json()["session"])
@@ -5226,12 +5226,12 @@ class SimulationTest(TembaTest):
             }
 
             with patch("requests.post") as mock_post:
-                mock_post.return_value = MockResponse(400, '{"session": {}}')
+                mock_post.return_value = MockJsonResponse(400, {"session": {}})
                 response = self.client.post(url, json.dumps(payload), content_type="application/json")
                 self.assertEqual(500, response.status_code)
 
             with patch("requests.post") as mock_post:
-                mock_post.return_value = MockResponse(200, '{"session": {}}')
+                mock_post.return_value = MockJsonResponse(200, {"session": {}})
                 response = self.client.post(url, json.dumps(payload), content_type="application/json")
                 self.assertEqual(200, response.status_code)
                 self.assertEqual({}, response.json()["session"])

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -336,7 +336,7 @@ class MailroomClient:
     def po_export(self, org_id: int, flow_ids: list, language: str):
         payload = {"org_id": org_id, "flow_ids": flow_ids, "language": language}
 
-        return self._request("po/export", payload, returns_json=False)
+        return self._request("po/export", payload)
 
     def po_import(self, org_id, flow_ids, language, po_data):
         payload = {"org_id": org_id, "flow_ids": flow_ids, "language": language}
@@ -380,7 +380,7 @@ class MailroomClient:
 
         return self._request("ticket/reopen", payload)
 
-    def _request(self, endpoint, payload=None, files=None, post=True, encode_json=False, returns_json=True):
+    def _request(self, endpoint, payload=None, files=None, post=True, encode_json=False):
         if logger.isEnabledFor(logging.DEBUG):  # pragma: no cover
             logger.debug("=============== %s request ===============" % endpoint)
             logger.debug(json.dumps(payload, indent=2))
@@ -400,12 +400,10 @@ class MailroomClient:
         req_fn = requests.post if post else requests.get
         response = req_fn("%s/mr/%s" % (self.base_url, endpoint), headers=headers, **kwargs)
 
-        if returns_json:
-            try:
-                resp_body = response.json()
-            except Exception:
-                resp_body = response.content
+        if response.headers.get("Content-Type") == "application/json":
+            resp_body = response.json()
         else:
+            # not all endpoints return JSON, e.g. po file export
             resp_body = response.content
 
         if response.status_code == 422:

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -13,7 +13,7 @@ from temba.flows.models import FlowRun, FlowStart
 from temba.ivr.models import Call
 from temba.mailroom.client import ContactSpec, RequestException, get_client
 from temba.msgs.models import Broadcast, Msg
-from temba.tests import MockResponse, TembaTest, matchers
+from temba.tests import MockJsonResponse, MockResponse, TembaTest, matchers
 from temba.tests.engine import MockSessionWriter
 from temba.tickets.models import TicketEvent
 from temba.utils import json
@@ -33,14 +33,14 @@ from .events import Event
 class MailroomClientTest(TembaTest):
     def test_version(self):
         with patch("requests.get") as mock_get:
-            mock_get.return_value = MockResponse(200, '{"version": "5.3.4"}')
+            mock_get.return_value = MockJsonResponse(200, {"version": "5.3.4"})
             version = get_client().version()
 
         self.assertEqual("5.3.4", version)
 
     @patch("requests.post")
     def test_android_event(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"id": 12345}')
+        mock_post.return_value = MockJsonResponse(200, {"id": 12345})
         response = get_client().android_event(
             org_id=self.org.id,
             channel_id=12,
@@ -67,7 +67,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_android_message(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"id": 12345}')
+        mock_post.return_value = MockJsonResponse(200, {"id": 12345})
         response = get_client().android_message(
             org_id=self.org.id,
             channel_id=12,
@@ -92,7 +92,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_contact_create(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"contact": {"id": 1234, "name": "", "language": ""}}')
+        mock_post.return_value = MockJsonResponse(200, {"contact": {"id": 1234, "name": "", "language": ""}})
 
         # try with empty contact spec
         response = get_client().contact_create(
@@ -111,7 +111,7 @@ class MailroomClientTest(TembaTest):
         )
 
         mock_post.reset_mock()
-        mock_post.return_value = MockResponse(200, '{"contact": {"id": 1234, "name": "Bob", "language": "eng"}}')
+        mock_post.return_value = MockJsonResponse(200, {"contact": {"id": 1234, "name": "Bob", "language": "eng"}})
 
         response = get_client().contact_create(
             self.org.id,
@@ -144,7 +144,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_contact_export(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"contact_ids": [123, 234]}')
+        mock_post.return_value = MockJsonResponse(200, {"contact_ids": [123, 234]})
 
         response = get_client().contact_export(self.org.id, 234, "age = 42")
 
@@ -157,7 +157,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_contact_export_preview(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"total": 123}')
+        mock_post.return_value = MockJsonResponse(200, {"total": 123})
 
         response = get_client().contact_export_preview(self.org.id, 234, "age = 42")
 
@@ -170,7 +170,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_contact_inspect(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"101": {}, "102": {}}')
+        mock_post.return_value = MockJsonResponse(200, {"101": {}, "102": {}})
 
         response = get_client().contact_inspect(self.org.id, [101, 102])
 
@@ -183,7 +183,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_contact_interrupt(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"sessions": 1}')
+        mock_post.return_value = MockJsonResponse(200, {"sessions": 1})
 
         response = get_client().contact_interrupt(self.org.id, 3, 345)
 
@@ -196,32 +196,26 @@ class MailroomClientTest(TembaTest):
 
     def test_contact_modify(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(
+            mock_post.return_value = MockJsonResponse(
                 200,
-                """{
+                {
                     "1": {
                         "contact": {
                             "uuid": "6393abc0-283d-4c9b-a1b3-641a035c34bf",
                             "id": 1,
                             "name": "Frank",
                             "timezone": "America/Los_Angeles",
-                            "created_on": "2018-07-06T12:30:00.123457Z"
+                            "created_on": "2018-07-06T12:30:00.123457Z",
                         },
                         "events": [
                             {
                                 "type": "contact_groups_changed",
                                 "created_on": "2018-07-06T12:30:03.123456789Z",
-                                "groups_added": [
-                                    {
-                                        "uuid": "c153e265-f7c9-4539-9dbc-9b358714b638",
-                                        "name": "Doctors"
-                                    }
-                                ]
+                                "groups_added": [{"uuid": "c153e265-f7c9-4539-9dbc-9b358714b638", "name": "Doctors"}],
                             }
-                        ]
+                        ],
                     }
-                }
-                """,
+                },
             )
 
             response = get_client().contact_modify(
@@ -265,17 +259,15 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_contact_search(self, mock_post):
-        mock_post.return_value = MockResponse(
+        mock_post.return_value = MockJsonResponse(
             200,
-            """
             {
-              "query":"name ~ \\"frank\\"",
-              "contact_ids":[1,2],
-              "total": 2,
-              "offset": 0,
-              "metadata": {"attributes":["name"]}
-            }
-            """,
+                "query": 'name ~ "frank"',
+                "contact_ids": [1, 2],
+                "total": 2,
+                "offset": 0,
+                "metadata": {"attributes": ["name"]},
+            },
         )
         response = get_client().contact_search(1, 2, "frank", "-created_on")
 
@@ -298,7 +290,7 @@ class MailroomClientTest(TembaTest):
         flow_def = {"nodes": [{"val": Decimal("1.23")}]}
 
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"language": "spa"}')
+            mock_post.return_value = MockJsonResponse(200, {"language": "spa"})
             migrated = get_client().flow_change_language(flow_def, language="spa")
 
             self.assertEqual({"language": "spa"}, migrated)
@@ -314,7 +306,7 @@ class MailroomClientTest(TembaTest):
         flow_def = {"nodes": [{"val": Decimal("1.23")}]}
 
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"dependencies":[]}')
+            mock_post.return_value = MockJsonResponse(200, {"dependencies": []})
             info = get_client().flow_inspect(self.org.id, flow_def)
 
             self.assertEqual({"dependencies": []}, info)
@@ -329,7 +321,7 @@ class MailroomClientTest(TembaTest):
         flow_def = {"nodes": [{"val": Decimal("1.23")}]}
 
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"name": "Migrated!"}')
+            mock_post.return_value = MockJsonResponse(200, {"name": "Migrated!"})
             migrated = get_client().flow_migrate(flow_def, to_version="13.1.0")
 
             self.assertEqual({"name": "Migrated!"}, migrated)
@@ -343,7 +335,7 @@ class MailroomClientTest(TembaTest):
     def test_flow_start_preview(self):
         with patch("requests.post") as mock_post:
             mock_resp = {"query": 'group = "Farmers" AND status = "active"', "total": 2345}
-            mock_post.return_value = MockResponse(200, json.dumps(mock_resp))
+            mock_post.return_value = MockJsonResponse(200, mock_resp)
             preview = get_client().flow_start_preview(
                 self.org.id,
                 flow_id=12,
@@ -381,7 +373,7 @@ class MailroomClientTest(TembaTest):
 
     def test_msg_broadcast(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, json.dumps({"id": 123}))
+            mock_post.return_value = MockJsonResponse(200, {"id": 123})
             resp = get_client().msg_broadcast(
                 self.org.id,
                 self.admin.id,
@@ -418,7 +410,7 @@ class MailroomClientTest(TembaTest):
     def test_msg_broadcast_preview(self):
         with patch("requests.post") as mock_post:
             mock_resp = {"query": 'group = "Farmers" AND status = "active"', "total": 2345}
-            mock_post.return_value = MockResponse(200, json.dumps(mock_resp))
+            mock_post.return_value = MockJsonResponse(200, mock_resp)
             preview = get_client().msg_broadcast_preview(
                 self.org.id,
                 include=Inclusions(
@@ -454,7 +446,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_msg_handle(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"msg_ids": [12345]}')
+        mock_post.return_value = MockJsonResponse(200, {"msg_ids": [12345]})
         response = get_client().msg_handle(org_id=self.org.id, msg_ids=[12345, 67890])
 
         self.assertEqual({"msg_ids": [12345]}, response)
@@ -467,7 +459,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_msg_resend(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"msg_ids": [12345]}')
+        mock_post.return_value = MockJsonResponse(200, {"msg_ids": [12345]})
         response = get_client().msg_resend(org_id=self.org.id, msg_ids=[12345, 67890])
 
         self.assertEqual({"msg_ids": [12345]}, response)
@@ -480,7 +472,7 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_msg_send(self, mock_post):
-        mock_post.return_value = MockResponse(200, '{"id": 12345}')
+        mock_post.return_value = MockJsonResponse(200, {"id": 12345})
         response = get_client().msg_send(
             org_id=self.org.id, user_id=self.admin.id, contact_id=123, text="hi", attachments=[], ticket_id=345
         )
@@ -515,7 +507,7 @@ class MailroomClientTest(TembaTest):
 
     def test_po_import(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"flows": []}')
+            mock_post.return_value = MockJsonResponse(200, {"flows": []})
             response = get_client().po_import(self.org.id, [123, 234], "spa", b'msgid "Red"\nmsgstr "Rojo"\n\n')
 
             self.assertEqual({"flows": []}, response)
@@ -529,8 +521,8 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_parse_query(self, mock_post):
-        mock_post.return_value = MockResponse(
-            200, '{"query":"name ~ \\"frank\\"", "metadata": {"attributes":["name"]}}'
+        mock_post.return_value = MockJsonResponse(
+            200, {"query": 'name ~ "frank"', "metadata": {"attributes": ["name"]}}
         )
         parsed = get_client().parse_query(self.org.id, "frank")
 
@@ -542,14 +534,14 @@ class MailroomClientTest(TembaTest):
             json={"query": "frank", "org_id": self.org.id, "parse_only": False},
         )
 
-        mock_post.return_value = MockResponse(400, '{"error":"no such field age"}')
+        mock_post.return_value = MockJsonResponse(400, {"error": "no such field age"})
 
         with self.assertRaises(RequestException):
             get_client().parse_query(1, "age > 10")
 
     def test_ticket_assign(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
+            mock_post.return_value = MockJsonResponse(200, {"changed_ids": [123]})
             response = get_client().ticket_assign(1, 12, [123, 345], 4)
 
             self.assertEqual({"changed_ids": [123]}, response)
@@ -561,7 +553,7 @@ class MailroomClientTest(TembaTest):
 
     def test_ticket_add_note(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
+            mock_post.return_value = MockJsonResponse(200, {"changed_ids": [123]})
             response = get_client().ticket_add_note(1, 12, [123, 345], "please handle")
 
             self.assertEqual({"changed_ids": [123]}, response)
@@ -573,7 +565,7 @@ class MailroomClientTest(TembaTest):
 
     def test_ticket_change_topic(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
+            mock_post.return_value = MockJsonResponse(200, {"changed_ids": [123]})
             response = get_client().ticket_change_topic(1, 12, [123, 345], 67)
 
             self.assertEqual({"changed_ids": [123]}, response)
@@ -585,7 +577,7 @@ class MailroomClientTest(TembaTest):
 
     def test_ticket_close(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
+            mock_post.return_value = MockJsonResponse(200, {"changed_ids": [123]})
             response = get_client().ticket_close(1, 12, [123, 345], force=True)
 
             self.assertEqual({"changed_ids": [123]}, response)
@@ -597,7 +589,7 @@ class MailroomClientTest(TembaTest):
 
     def test_ticket_reopen(self):
         with patch("requests.post") as mock_post:
-            mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')
+            mock_post.return_value = MockJsonResponse(200, {"changed_ids": [123]})
             response = get_client().ticket_reopen(1, 12, [123, 345])
 
             self.assertEqual({"changed_ids": [123]}, response)
@@ -609,8 +601,8 @@ class MailroomClientTest(TembaTest):
 
     @patch("requests.post")
     def test_errors(self, mock_post):
-        mock_post.return_value = MockResponse(
-            422, '{"error": "no such field age", "code": "query:unknown_property", "extra": {"property": "age"}}'
+        mock_post.return_value = MockJsonResponse(
+            422, {"error": "no such field age", "code": "query:unknown_property", "extra": {"property": "age"}}
         )
 
         with self.assertRaises(QueryValidationException) as e:
@@ -620,7 +612,7 @@ class MailroomClientTest(TembaTest):
         self.assertEqual("unknown_property", e.exception.code)
         self.assertEqual({"property": "age"}, e.exception.extra)
 
-        mock_post.return_value = MockResponse(500, '{"error": "error loading fields"}')
+        mock_post.return_value = MockJsonResponse(500, {"error": "error loading fields"})
 
         with self.assertRaises(RequestException) as e:
             get_client().contact_search(1, 2, "age > 10", "-created_on")

--- a/temba/tests/requests.py
+++ b/temba/tests/requests.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from requests import HTTPError, Request
 from requests.structures import CaseInsensitiveDict
@@ -18,10 +18,6 @@ class MockResponse:
     def __init__(self, status_code: int, body, method="GET", url="http://foo.com/", headers=None):
         if headers is None:
             headers = {}
-
-        # convert dictionaries to json if the body is passed that way
-        if isinstance(body, dict):
-            body = json.dumps(body)
 
         self.body = force_str(body)
         self.text = self.body
@@ -51,27 +47,6 @@ class MockResponse:
             raise HTTPError(request=self.request, response=self)
 
 
-class MockPost:
-    """
-    MockPost allows you to mock up a post easily within a context, initialize it with the response you want
-    requests.post to return while in your block.
-
-      with MockPost({"fields": ["name"], "query": "name = \"george\""}):
-         ...
-
-      with MockPost({"error": "invalid query"}, status=400):
-         ...
-    """
-
-    def __init__(self, response, status=200):
-        self.response = response
-        self.status = status
-
-    def __enter__(self):
-        self.patch = patch("requests.post")
-        mock = self.patch.__enter__()
-        mock.return_value = MockResponse(self.status, json.dumps(self.response), method="POST")
-        return mock
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        return self.patch.__exit__(exc_type, exc_val, exc_tb)
+class MockJsonResponse(MockResponse):
+    def __init__(self, status_code: int, data):
+        super().__init__(status_code, json.dumps(data), headers={"Content-Type": "application/json"})


### PR DESCRIPTION
And for convenience added `MockJsonResponse` for tests.