### PR TITLE
Send emails in tests

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1084,7 +1084,6 @@ class ChannelSyncTest(TembaTest):
 
 
 class ChannelIncidentsTest(TembaTest):
-    @override_settings(SEND_EMAILS=True)
     def test_disconnected(self):
         # set our last seen to a while ago
         self.channel.last_seen = timezone.now() - timedelta(minutes=40)

--- a/temba/notifications/tests.py
+++ b/temba/notifications/tests.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime, timedelta, timezone as tzone
 
 from django.core import mail
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -126,7 +125,6 @@ class IncidentCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual({incident4, incident2}, set(response.context["ongoing"]))
 
 
-@override_settings(SEND_EMAILS=True)
 class NotificationTest(TembaTest):
     def assert_notifications(self, *, after: datetime = None, expected_json: dict, expected_users: set, email: True):
         notifications = Notification.objects.all()

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -34,7 +34,7 @@ TEST_EXCLUDE = ("smartmin",)
 # Email
 # -----------------------------------------------------------------------------------
 
-SEND_EMAILS = False
+SEND_EMAILS = TESTING  # enable sending emails in tests
 
 EMAIL_HOST = "smtp.gmail.com"
 EMAIL_HOST_USER = "server@temba.io"


### PR DESCRIPTION
And then use `mail.outbox` to test rather than patching our email send functions