### PR TITLE
Fix migration to add uuid field to airtime transfers

### DIFF
--- a/temba/airtime/migrations/0028_airtimetransfer_uuid.py
+++ b/temba/airtime/migrations/0028_airtimetransfer_uuid.py
@@ -15,6 +15,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="airtimetransfer",
             name="uuid",
+            field=models.UUIDField(null=True),
+        ),
+        migrations.AlterField(
+            model_name="airtimetransfer",
+            name="uuid",
             field=models.UUIDField(default=temba.utils.uuid.uuid4, null=True),
         ),
     ]


### PR DESCRIPTION
It currently sets the same UUID on all transfers. Need to set default in separate operation.