### PR TITLE
More reorg of mailroom types

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -4819,8 +4819,8 @@ class EndpointsTest(APITest):
             num_queries=NUM_BASE_SESSION_QUERIES + 1,
         )
 
-    @patch("temba.mailroom.client.MailroomClient.ticket_close")
-    @patch("temba.mailroom.client.MailroomClient.ticket_reopen")
+    @patch("temba.mailroom.client.client.MailroomClient.ticket_close")
+    @patch("temba.mailroom.client.client.MailroomClient.ticket_reopen")
     def test_tickets(self, mock_ticket_reopen, mock_ticket_close):
         endpoint_url = reverse("api.v2.tickets") + ".json"
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1694,7 +1694,7 @@ class ContactTest(TembaTest, CRUDLTestMixin):
             message="Sent 7 days after planting date",
         )
 
-    @patch("temba.mailroom.client.MailroomClient.contact_modify")
+    @patch("temba.mailroom.client.client.MailroomClient.contact_modify")
     def test_block_and_stop(self, mock_contact_modify):
         mock_contact_modify.return_value = {self.joe.id: {"contact": {}, "events": []}}
 
@@ -2792,7 +2792,7 @@ class ContactTest(TembaTest, CRUDLTestMixin):
             mods,
         )
 
-    @patch("temba.mailroom.client.MailroomClient.contact_modify")
+    @patch("temba.mailroom.client.client.MailroomClient.contact_modify")
     def test_bulk_modify_with_no_contacts(self, mock_contact_modify):
         mock_contact_modify.return_value = {}
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3170,7 +3170,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(f"/flow/download_translation/?flow={flow.id}&language=", response.url)
 
         # check fetching the PO from the download link
-        with patch("temba.mailroom.client.MailroomClient.po_export") as mock_po_export:
+        with patch("temba.mailroom.client.client.MailroomClient.po_export") as mock_po_export:
             mock_po_export.return_value = b'msgid "Red"\nmsgstr "Roja"\n\n'
             self.assertRequestDisallowed(response.url, [None, self.user, self.agent, self.admin2])
             response = self.assertReadFetch(response.url, [self.editor, self.admin])
@@ -3185,7 +3185,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(f"/flow/download_translation/?flow={flow.id}&language=spa", response.url)
 
         # check fetching the PO from the download link
-        with patch("temba.mailroom.client.MailroomClient.po_export") as mock_po_export:
+        with patch("temba.mailroom.client.client.MailroomClient.po_export") as mock_po_export:
             mock_po_export.return_value = b'msgid "Red"\nmsgstr "Roja"\n\n'
             response = self.requestView(response.url, self.admin)
 
@@ -3306,7 +3306,7 @@ msgstr "Azul"
         self.assertEqual({"language": "spa"}, response.context["form"].initial)
 
         # confirm the import
-        with patch("temba.mailroom.client.MailroomClient.po_import") as mock_po_import:
+        with patch("temba.mailroom.client.client.MailroomClient.po_import") as mock_po_import:
             mock_po_import.return_value = {"flows": [flow.get_definition()]}
 
             response = self.requestView(step2_url, self.admin, post_data={"language": "spa"})

--- a/temba/mailroom/__init__.py
+++ b/temba/mailroom/__init__.py
@@ -1,2 +1,11 @@
-from .client import *  # noqa
+from django.conf import settings
+
+from .client.exceptions import *  # noqa
+from .client.types import *  # noqa
 from .queue import *  # noqa
+
+
+def get_client():
+    from .client.client import MailroomClient
+
+    return MailroomClient(settings.MAILROOM_URL, settings.MAILROOM_AUTH_TOKEN)

--- a/temba/mailroom/client/__init__.py
+++ b/temba/mailroom/client/__init__.py
@@ -1,1 +1,0 @@
-from .client import *  # noqa

--- a/temba/mailroom/client/exceptions.py
+++ b/temba/mailroom/client/exceptions.py
@@ -1,0 +1,88 @@
+from django.utils.translation import gettext_lazy as _
+
+
+class RequestException(Exception):
+    """
+    Exception for requests to mailroom that return a non-422 error status.
+    """
+
+    def __init__(self, endpoint, request, response):
+        self.endpoint = endpoint
+        self.request = request
+        self.response = response
+
+        try:
+            self.error = response.json().get("error")
+        except Exception:
+            self.error = response.content.decode("utf-8")
+
+    def __str__(self):
+        return self.error
+
+
+class FlowValidationException(Exception):
+    """
+    Request that fails because the provided flow definition is invalid.
+    """
+
+    def __init__(self, error: str):
+        self.error = error
+
+    def __str__(self):
+        return self.error
+
+
+class QueryValidationException(Exception):
+    """
+    Request that fails because the provided contact query is invalid.
+    """
+
+    messages = {
+        "syntax": _("Invalid query syntax."),
+        "invalid_number": _("Unable to convert '%(value)s' to a number."),
+        "invalid_date": _("Unable to convert '%(value)s' to a date."),
+        "invalid_language": _("'%(value)s' is not a valid language code."),
+        "invalid_flow": _("'%(value)s' is not a valid flow name."),
+        "invalid_group": _("'%(value)s' is not a valid group name."),
+        "invalid_partial_name": _("Using ~ with name requires token of at least %(min_token_length)s characters."),
+        "invalid_partial_urn": _("Using ~ with URN requires value of at least %(min_value_length)s characters."),
+        "unsupported_contains": _("Can only use ~ with name or URN values."),
+        "unsupported_comparison": _("Can only use %(operator)s with number or date values."),
+        "unsupported_setcheck": _("Can't check whether '%(property)s' is set or not set."),
+        "unknown_property": _("Can't resolve '%(property)s' to a field or URN scheme."),
+        "unknown_property_type": _("Prefixes must be 'fields' or 'urns'."),
+        "redacted_urns": _("Can't query on URNs in an anonymous workspace."),
+    }
+
+    def __init__(self, error: str, code: str, extra: dict = None):
+        self.error = error
+        self.code = code
+        self.extra = extra or {}
+
+    def __str__(self):
+        if self.code and self.code in self.messages:
+            return self.messages[self.code] % self.extra
+
+        return self.error
+
+
+class URNValidationException(Exception):
+    """
+    Request that fails because the provided contact URN is invalid or taken.
+    """
+
+    def __init__(self, error: str, code: str, index: int):
+        self.error = error
+        self.code = code
+        self.index = index
+
+    def __str__(self):
+        return self.error
+
+
+class EmptyBroadcastException(Exception):
+    """
+    Request that fails because the because a the requested broadcast would have no recipients.
+    """
+
+    pass

--- a/temba/mailroom/client/types.py
+++ b/temba/mailroom/client/types.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ContactSpec:
+    """
+    Describes a contact to be created
+    """
+
+    name: str
+    language: str
+    urns: list[str]
+    fields: dict[str, str]
+    groups: list[str]
+
+
+@dataclass
+class Inclusions:
+    group_uuids: list = field(default_factory=list)
+    contact_uuids: list = field(default_factory=list)
+    query: str = ""
+
+
+@dataclass
+class Exclusions:
+    non_active: bool = False  # contacts who are blocked, stopped or archived
+    in_a_flow: bool = False  # contacts who are currently in a flow (including this one)
+    started_previously: bool = False  # contacts who have been in this flow in the last 90 days
+    not_seen_since_days: int = 0  # contacts who have not been seen for more than this number of days
+
+
+@dataclass(frozen=True)
+class QueryMetadata:
+    """
+    Contact query metadata
+    """
+
+    attributes: list = field(default_factory=list)
+    schemes: list = field(default_factory=list)
+    fields: list = field(default_factory=list)
+    groups: list = field(default_factory=list)
+    allow_as_group: bool = False
+
+
+@dataclass(frozen=True)
+class ParsedQuery:
+    query: str
+    metadata: QueryMetadata
+
+
+@dataclass(frozen=True)
+class SearchResults:
+    query: str
+    total: int
+    contact_ids: list
+    metadata: QueryMetadata
+
+
+@dataclass(frozen=True)
+class BroadcastPreview:
+    query: str
+    total: int
+
+
+@dataclass(frozen=True)
+class StartPreview:
+    query: str
+    total: int
+
+
+@dataclass
+class URNResult:
+    normalized: str
+    contact_id: int = None
+    error: str = None
+    e164: bool = False
+
+
+@dataclass
+class ScheduleSpec:
+    """
+    Describes a schedule to be created
+    """
+
+    start: str
+    repeat_period: str
+    repeat_days_of_week: str = None

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -728,7 +728,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(sent_url + "?search=joe")
         self.assertEqual([msg1, msg2], list(response.context_data["object_list"]))
 
-    @patch("temba.mailroom.client.MailroomClient.msg_resend")
+    @patch("temba.mailroom.client.client.MailroomClient.msg_resend")
     def test_failed(self, mock_msg_resend):
         contact1 = self.create_contact("Joe Blow", phone="+250788000001")
         msg1 = self.create_outgoing_msg(contact1, "message number 1", status="F")

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -4061,7 +4061,7 @@ class BulkExportTest(TembaTest):
         self.assertEqual(set(parent.field_dependencies.all()), {age, gender})
         self.assertEqual(set(parent.group_dependencies.all()), {farmers})
 
-    @patch("temba.mailroom.client.MailroomClient.flow_inspect")
+    @patch("temba.mailroom.client.client.MailroomClient.flow_inspect")
     def test_import_flow_issues(self, mock_flow_inspect):
         mock_flow_inspect.side_effect = [
             {

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -18,14 +18,7 @@ from temba.channels.models import Channel, ChannelEvent
 from temba.contacts.models import URN, Contact, ContactField, ContactGroup, ContactURN
 from temba.flows.models import FlowRun, FlowSession
 from temba.locations.models import AdminBoundary
-from temba.mailroom.client import (
-    ContactSpec,
-    EmptyBroadcastException,
-    Exclusions,
-    MailroomClient,
-    ScheduleSpec,
-    URNResult,
-)
+from temba.mailroom.client.client import MailroomClient
 from temba.mailroom.modifiers import Modifier
 from temba.msgs.models import Broadcast, Msg, OptIn
 from temba.orgs.models import Org
@@ -189,7 +182,7 @@ class TestClient(MailroomClient):
         return {"id": msg.id, "duplicate": False}
 
     @_client_method
-    def contact_create(self, org_id: int, user_id: int, contact: ContactSpec):
+    def contact_create(self, org_id: int, user_id: int, contact: mailroom.ContactSpec):
         org = Org.objects.get(id=org_id)
         user = User.objects.get(id=user_id)
 
@@ -288,7 +281,7 @@ class TestClient(MailroomClient):
 
     @_client_method
     def contact_urns(self, org_id: int, urns: list[str]):
-        results = [URNResult(normalized=urn) for urn in urns]
+        results = [mailroom.URNResult(normalized=urn) for urn in urns]
 
         if self.mocks._contact_urns:
             urn_by_id_or_err = self.mocks._contact_urns.pop(0)
@@ -322,9 +315,9 @@ class TestClient(MailroomClient):
         urns: list,
         query: str,
         node_uuid: str,
-        exclude: Exclusions,
+        exclude: mailroom.Exclusions,
         optin_id: int,
-        schedule: ScheduleSpec,
+        schedule: mailroom.ScheduleSpec,
     ):
         org = Org.objects.get(id=org_id)
         user = User.objects.get(id=user_id)
@@ -904,7 +897,7 @@ def create_broadcast(
     urns: list,
     query: str,
     node_uuid: str,
-    exclude: Exclusions,
+    exclude: mailroom.Exclusions,
     optin,
     schedule,
 ) -> Broadcast:
@@ -918,9 +911,9 @@ def create_broadcast(
         )
 
     if not (groups or contacts or urns or query):
-        raise EmptyBroadcastException()
+        raise mailroom.EmptyBroadcastException()
 
-    if schedule and isinstance(schedule, ScheduleSpec):
+    if schedule and isinstance(schedule, mailroom.ScheduleSpec):
         schedule = Schedule.objects.create(
             org=org,
             repeat_period=schedule.repeat_period,

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -44,39 +44,39 @@ class TicketTest(TembaTest):
         self.assertEqual(f"Ticket[uuid={ticket.uuid}, topic=General]", str(ticket))
 
         # test bulk assignment
-        with patch("temba.mailroom.client.MailroomClient.ticket_assign") as mock_assign:
+        with patch("temba.mailroom.client.client.MailroomClient.ticket_assign") as mock_assign:
             Ticket.bulk_assign(self.org, self.admin, [ticket], self.agent)
 
         mock_assign.assert_called_once_with(self.org.id, self.admin.id, [ticket.id], self.agent.id)
         mock_assign.reset_mock()
 
         # test bulk un-assignment
-        with patch("temba.mailroom.client.MailroomClient.ticket_assign") as mock_assign:
+        with patch("temba.mailroom.client.client.MailroomClient.ticket_assign") as mock_assign:
             Ticket.bulk_assign(self.org, self.admin, [ticket], None)
 
         mock_assign.assert_called_once_with(self.org.id, self.admin.id, [ticket.id], None)
         mock_assign.reset_mock()
 
         # test bulk adding a note
-        with patch("temba.mailroom.client.MailroomClient.ticket_add_note") as mock_add_note:
+        with patch("temba.mailroom.client.client.MailroomClient.ticket_add_note") as mock_add_note:
             Ticket.bulk_add_note(self.org, self.admin, [ticket], "please handle")
 
         mock_add_note.assert_called_once_with(self.org.id, self.admin.id, [ticket.id], "please handle")
 
         # test bulk changing topic
-        with patch("temba.mailroom.client.MailroomClient.ticket_change_topic") as mock_change_topic:
+        with patch("temba.mailroom.client.client.MailroomClient.ticket_change_topic") as mock_change_topic:
             Ticket.bulk_change_topic(self.org, self.admin, [ticket], topic)
 
         mock_change_topic.assert_called_once_with(self.org.id, self.admin.id, [ticket.id], topic.id)
 
         # test bulk closing
-        with patch("temba.mailroom.client.MailroomClient.ticket_close") as mock_close:
+        with patch("temba.mailroom.client.client.MailroomClient.ticket_close") as mock_close:
             Ticket.bulk_close(self.org, self.admin, [ticket], force=True)
 
         mock_close.assert_called_once_with(self.org.id, self.admin.id, [ticket.id], force=True)
 
         # test bulk re-opening
-        with patch("temba.mailroom.client.MailroomClient.ticket_reopen") as mock_reopen:
+        with patch("temba.mailroom.client.client.MailroomClient.ticket_reopen") as mock_reopen:
             Ticket.bulk_reopen(self.org, self.admin, [ticket])
 
         mock_reopen.assert_called_once_with(self.org.id, self.admin.id, [ticket.id])


### PR DESCRIPTION
There is a point to all this... have the client class be able to import app models and app models be able to access the client without creating an import loop.