### PR TITLE
Use models instead of primitives in mailroom client

### DIFF
--- a/temba/channels/android/views.py
+++ b/temba/channels/android/views.py
@@ -141,7 +141,7 @@ def sync(request, channel_id):
                 if phone and text:
                     try:
                         msg_id = mailroom.get_client().android_message(
-                            channel.org_id, channel.id, phone, text, received_on=date
+                            channel.org, channel, phone, text, received_on=date
                         )
                         extra = dict(msg_id=msg_id)
                     except mailroom.URNValidationException:
@@ -162,8 +162,8 @@ def sync(request, channel_id):
                 if phone and call_tuple not in unique_calls and ChannelEvent.is_valid_type(cmd["type"]):
                     try:
                         mailroom.get_client().android_event(
-                            channel.org_id,
-                            channel.id,
+                            channel.org,
+                            channel,
                             phone,
                             cmd["type"],
                             extra={"duration": duration},

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -300,8 +300,8 @@ class ContactCRUDL(SmartCRUDL):
                 return blocker
 
             query = self.request.GET.get("s")
-            preview = mailroom.get_client().contact_export_preview(self.request.org.id, self.group.id, query)
-            if preview["total"] > self.size_limit:
+            total = mailroom.get_client().contact_export_preview(self.request.org, self.group, query)
+            if total > self.size_limit:
                 return "too-big"
 
             return ""


### PR DESCRIPTION
Now that the import loop is broken. Pushes more logic down into the client which is better for re-use.