### PR TITLE
Hard delete template translations that no longer exist on the channel side

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -659,8 +659,8 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
         for incident in self.incidents.filter(ended_on=None):
             incident.end()
 
-        # any template translations for this channel are marked inactive
-        self.template_translations.filter(is_active=True).update(is_active=False)
+        # delete template translations for this channel
+        self.template_translations.all().delete()
 
     def delete(self):
         for trigger in self.triggers.all():

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -234,7 +234,7 @@ class ChannelTest(TembaTest, CRUDLTestMixin):
         self.assertNotIn(channel1, flow.channel_dependencies.all())
         self.assertEqual(0, channel1.triggers.filter(is_active=True).count())
         self.assertEqual(0, channel1.incidents.filter(ended_on=None).count())
-        self.assertEqual(0, channel1.template_translations.filter(is_active=True).count())
+        self.assertEqual(0, channel1.template_translations.count())
 
         # check that we queued a task to interrupt sessions tied to this channel
         self.assertEqual(

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -1307,18 +1307,16 @@ class OrgDeleteTest(TembaTest):
 
         add(WebHookEvent.objects.create(org=org, resthook=resthook, data={}))
 
-        template_trans1 = add(
-            TemplateTranslation.get_or_create(
-                channels[0],
-                "hello",
-                locale="eng-US",
-                status=TemplateTranslation.STATUS_APPROVED,
-                external_id="1234",
-                external_locale="en_US",
-                namespace="foo_namespace",
-                components=[{"name": "body", "type": "body/text", "content": "Hello", "variables": {}, "params": []}],
-                variables=[],
-            )
+        template_trans1 = TemplateTranslation.get_or_create(
+            channels[0],
+            "hello",
+            locale="eng-US",
+            status=TemplateTranslation.STATUS_APPROVED,
+            external_id="1234",
+            external_locale="en_US",
+            namespace="foo_namespace",
+            components=[{"name": "body", "type": "body/text", "content": "Hello", "variables": {}, "params": []}],
+            variables=[],
         )
         add(template_trans1.template)
         flow1.template_dependencies.add(template_trans1.template)

--- a/temba/templates/tests.py
+++ b/temba/templates/tests.py
@@ -83,21 +83,6 @@ class TemplateTest(TembaTest):
         self.assertEqual(3, TemplateTranslation.objects.filter(channel=channel1).count())
         self.assertEqual(1, TemplateTranslation.objects.filter(channel=channel2).count())
 
-        # trim them
-        TemplateTranslation.trim(channel1, [hello_eng, hello_fra])
-
-        # non-included translations should be inactive now
-        hello_eng.refresh_from_db()
-        self.assertTrue(hello_eng.is_active)
-        hello_fra.refresh_from_db()
-        self.assertTrue(hello_fra.is_active)
-        goodbye_fra.refresh_from_db()
-        self.assertFalse(goodbye_fra.is_active)
-
-        # but not for other channels
-        goodbye_fra_other_channel.refresh_from_db()
-        self.assertTrue(hello_eng.is_active)
-
     def test_update_local(self):
         channel = self.create_channel("WA", "Channel 1", "1234")
 
@@ -145,8 +130,7 @@ class TemplateTest(TembaTest):
         )
 
         self.assertEqual({"hello", "goodbye"}, set(Template.objects.values_list("name", flat=True)))
-        self.assertEqual(1, TemplateTranslation.objects.filter(channel=channel, is_active=True).count())
-        self.assertEqual(2, TemplateTranslation.objects.filter(channel=channel, is_active=False).count())
+        self.assertEqual(1, channel.template_translations.count())
 
     @patch("temba.templates.models.TemplateTranslation.update_local")
     @patch("temba.channels.types.twilio_whatsapp.TwilioWhatsappType.fetch_templates")


### PR DESCRIPTION
We don't often hard delete anything but:

  1. These aren't things people are authoring in RP - they can always be re-synced from the channel if they still exist
  2. Marking things as inactive and then active again is kinda weird
  3. The thing you probably should be able to soft delete is the template.