### PR TITLE
Templates UI updates

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -130,71 +130,70 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertDeleteNotAllowed(endpoint_url)
 
         org2channel = self.create_channel("A", "Org2Channel", "123456", country="RW", org=self.org2)
-        tpl1 = self.create_template("hello")
-        tpl2 = self.create_template("goodbye")
-
-        # create some templates
-        tpl1.base_translation = TemplateTranslation.get_or_create(
-            self.channel,
+        tpl1 = self.create_template(
             "hello",
-            locale="eng-US",
-            status=TemplateTranslation.STATUS_APPROVED,
-            external_id="1234",
-            external_locale="en_US",
-            namespace="foo_namespace",
-            components=[
-                {
-                    "name": "body",
-                    "type": "body/text",
-                    "content": "Hi {{1}}",
-                    "variables": {"1": 0},
-                    "params": [{"type": "text"}],
-                }
+            [
+                TemplateTranslation(
+                    channel=self.channel,
+                    locale="eng-US",
+                    status=TemplateTranslation.STATUS_APPROVED,
+                    external_id="1234",
+                    external_locale="en_US",
+                    namespace="foo_namespace",
+                    components=[
+                        {
+                            "name": "body",
+                            "type": "body/text",
+                            "content": "Hi {{1}}",
+                            "variables": {"1": 0},
+                            "params": [{"type": "text"}],
+                        }
+                    ],
+                    variables=[{"type": "text"}],
+                ),
+                TemplateTranslation(
+                    channel=self.channel,
+                    locale="fra-FR",
+                    status=TemplateTranslation.STATUS_PENDING,
+                    external_id="5678",
+                    external_locale="fr_FR",
+                    namespace="foo_namespace",
+                    components=[
+                        {
+                            "name": "body",
+                            "type": "body/text",
+                            "content": "Bonjour {{1}}",
+                            "variables": {"1": 0},
+                            "params": [{"type": "text"}],
+                        }
+                    ],
+                    variables=[{"type": "text"}],
+                ),
             ],
-            variables=[{"type": "text"}],
         )
-        tpl1.save(update_fields=("base_translation",))
-
-        TemplateTranslation.get_or_create(
-            self.channel,
-            "hello",
-            locale="fra-FR",
-            status=TemplateTranslation.STATUS_PENDING,
-            external_id="5678",
-            external_locale="fr_FR",
-            namespace="foo_namespace",
-            components=[
-                {
-                    "name": "body",
-                    "type": "body/text",
-                    "content": "Bonjour {{1}}",
-                    "variables": {"1": 0},
-                    "params": [{"type": "text"}],
-                }
-            ],
-            variables=[{"type": "text"}],
-        )
-
-        tpl2.base_translation = TemplateTranslation.get_or_create(
-            self.channel,
+        tpl2 = self.create_template(
             "goodbye",
-            locale="eng-US",
-            status=TemplateTranslation.STATUS_PENDING,
-            external_id="6789",
-            external_locale="en_US",
-            namespace="foo_namespace",
-            components=[
-                {
-                    "name": "body",
-                    "type": "body/text",
-                    "content": "Goodbye {{1}}",
-                    "variables": {"1": 0},
-                    "params": [{"type": "text"}],
-                }
+            [
+                TemplateTranslation(
+                    channel=self.channel,
+                    locale="eng-US",
+                    status=TemplateTranslation.STATUS_PENDING,
+                    external_id="6789",
+                    external_locale="en_US",
+                    namespace="foo_namespace",
+                    components=[
+                        {
+                            "name": "body",
+                            "type": "body/text",
+                            "content": "Goodbye {{1}}",
+                            "variables": {"1": 0},
+                            "params": [{"type": "text"}],
+                        }
+                    ],
+                    variables=[{"type": "text"}],
+                )
             ],
-            variables=[{"type": "text"}],
         )
-        tpl2.save(update_fields=("base_translation",))
 
         # templates on other org to test filtering
         TemplateTranslation.get_or_create(

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2589,7 +2589,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
         # create the template, but no translations
-        self.create_template("affirmation", uuid="f712e05c-bbed-40f1-b3d9-671bb9b60775")
+        self.create_template("affirmation", [], uuid="f712e05c-bbed-40f1-b3d9-671bb9b60775")
 
         # will be warned again
         mr_mocks.flow_start_preview(query="age > 30", total=2)

--- a/temba/templates/models.py
+++ b/temba/templates/models.py
@@ -69,7 +69,8 @@ class Template(TembaModel, DependencyMixin):
         qs = super().annotate_usage(queryset)
 
         return qs.annotate(
-            translation_count=Count("translations"), channel_count=Count("translations__channel", distinct=True)
+            locale_count=Count("translations__locale", distinct=True),
+            channel_count=Count("translations__channel", distinct=True),
         )
 
     def update_base(self, exclude=None):

--- a/temba/templates/tests.py
+++ b/temba/templates/tests.py
@@ -305,30 +305,31 @@ class TemplateCRUDLTest(CRUDLTestMixin, TembaTest):
         list_url = reverse("templates.template_list")
 
         channel = self.create_channel("D3C", "360Dialog channel", address="1234")
-        template1 = self.create_template("hello")
-        template2 = self.create_template("goodbye")
-
-        TemplateTranslation.objects.create(
-            template=template1, channel=channel, locale="eng-US", status=TemplateTranslation.STATUS_APPROVED
+        template1 = self.create_template(
+            "hello",
+            [
+                TemplateTranslation(channel=channel, locale="eng-US", status=TemplateTranslation.STATUS_APPROVED),
+                TemplateTranslation(channel=channel, locale="spa", status=TemplateTranslation.STATUS_APPROVED),
+                TemplateTranslation(channel=self.channel, locale="eng-US", status=TemplateTranslation.STATUS_PENDING),
+            ],
         )
-        TemplateTranslation.objects.create(
-            template=template1, channel=channel, locale="spa", status=TemplateTranslation.STATUS_APPROVED
+        template2 = self.create_template(
+            "goodbye", [TemplateTranslation(channel=channel, locale="eng", status=TemplateTranslation.STATUS_PENDING)]
         )
-        TemplateTranslation.objects.create(
-            template=template2, channel=channel, locale="eng", status=TemplateTranslation.STATUS_PENDING
-        )
-        TemplateTranslation.objects.create(
-            template=template1, channel=self.channel, locale="eng-US", status=TemplateTranslation.STATUS_PENDING
-        )
+        self.create_template("empty", [])  # templates with no translations shouldn't appear
 
         # add template and translation in other org
         channel_other_org = self.create_channel("D3C", "360Dialog channel", address="2345", org=self.org2)
-        template_other_org = self.create_template("hello", org=self.org2)
-        TemplateTranslation.objects.create(
-            template=template_other_org,
-            channel=channel_other_org,
-            locale="eng",
-            status=TemplateTranslation.STATUS_PENDING,
+        self.create_template(
+            "hello",
+            [
+                TemplateTranslation(
+                    channel=channel_other_org,
+                    locale="eng",
+                    status=TemplateTranslation.STATUS_PENDING,
+                )
+            ],
+            org=self.org2,
         )
 
         self.assertRequestDisallowed(list_url, [None, self.agent])
@@ -337,67 +338,66 @@ class TemplateCRUDLTest(CRUDLTestMixin, TembaTest):
         )
 
         self.assertContains(response, "goodbye")
-        self.assertContains(response, "1 translation,")
+        self.assertContains(response, "1 language,")
         self.assertContains(response, "hello")
-        self.assertContains(response, "3 translations,")
+        self.assertContains(response, "2 languages,")
 
     def test_read(self):
         channel = self.create_channel("D3C", "360Dialog channel", address="1234")
-        template1 = self.create_template("hello")
-
-        TemplateTranslation.objects.create(
-            template=template1,
-            channel=channel,
-            locale="eng-US",
-            status=TemplateTranslation.STATUS_PENDING,
-            components=[
-                {
-                    "name": "body",
-                    "type": "body/text",
-                    "content": "Hello {{1}}",
-                    "variables": {"1": 0},
-                    "params": [{"type": "text"}],
-                }
+        template1 = self.create_template(
+            "hello",
+            [
+                TemplateTranslation(
+                    channel=channel,
+                    locale="eng-US",
+                    status=TemplateTranslation.STATUS_PENDING,
+                    components=[
+                        {
+                            "name": "body",
+                            "type": "body/text",
+                            "content": "Hello {{1}}",
+                            "variables": {"1": 0},
+                            "params": [{"type": "text"}],
+                        }
+                    ],
+                    variables=[{"type": "text"}],
+                ),
+                TemplateTranslation(
+                    channel=channel,
+                    locale="spa",
+                    status=TemplateTranslation.STATUS_APPROVED,
+                    components=[
+                        {
+                            "name": "body",
+                            "type": "body/text",
+                            "content": "Hola {{1}}",
+                            "variables": {"1": 0},
+                            "params": [{"type": "text"}],
+                        }
+                    ],
+                    variables=[{"type": "text"}],
+                ),
+                TemplateTranslation(
+                    channel=self.channel,
+                    locale="eng-US",
+                    status=TemplateTranslation.STATUS_REJECTED,
+                    components=[
+                        {
+                            "name": "body",
+                            "type": "body/text",
+                            "content": "Hello {{1}}",
+                            "variables": {"1": 0},
+                            "params": [{"type": "text"}],
+                        }
+                    ],
+                    variables=[{"type": "text"}],
+                ),
             ],
-            variables=[{"type": "text"}],
-        )
-        TemplateTranslation.objects.create(
-            template=template1,
-            channel=channel,
-            locale="spa",
-            status=TemplateTranslation.STATUS_APPROVED,
-            components=[
-                {
-                    "name": "body",
-                    "type": "body/text",
-                    "content": "Hola {{1}}",
-                    "variables": {"1": 0},
-                    "params": [{"type": "text"}],
-                }
-            ],
-            variables=[{"type": "text"}],
-        )
-        TemplateTranslation.objects.create(
-            template=template1,
-            channel=self.channel,
-            locale="eng-US",
-            status=TemplateTranslation.STATUS_REJECTED,
-            components=[
-                {
-                    "name": "body",
-                    "type": "body/text",
-                    "content": "Hello {{1}}",
-                    "variables": {"1": 0},
-                    "params": [{"type": "text"}],
-                }
-            ],
-            variables=[{"type": "text"}],
         )
 
         # create translation for other template
-        template2 = self.create_template("goodbye")
-        TemplateTranslation.objects.create(
-            template=template2, channel=channel, locale="eng", status=TemplateTranslation.STATUS_PENDING
+        self.create_template(
+            "goodbye", [TemplateTranslation(channel=channel, locale="eng", status=TemplateTranslation.STATUS_PENDING)]
         )
 
         read_url = reverse("templates.template_read", args=[template1.uuid])

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -721,14 +721,21 @@ class TembaTest(SmartminTest):
             extra=extra,
         )
 
-    def create_template(self, name: str, org=None, uuid=None):
-        return Template.objects.create(
+    def create_template(self, name: str, translations: list, org=None, uuid=None):
+        template = Template.objects.create(
             uuid=uuid or uuid4(),
             org=org or self.org,
             name=name,
             created_by=self.admin,
             modified_by=self.admin,
         )
+        for trans in translations:
+            trans.template = template
+            trans.save()
+
+        template.update_base()
+
+        return template
 
     def create_ticket(
         self,

--- a/templates/templates/includes/translation.html
+++ b/templates/templates/includes/translation.html
@@ -1,0 +1,41 @@
+{% load smartmin templates %}
+
+<div max-width="100%" class="flex translation">
+  <div width="70%" class="flex-grow p-4">
+    {% for comp in translation.components %}
+      <div width="100%" class="my-1">
+        {% if comp.type == "header/text" %}
+          <div class="text-lg font-normal">{{ comp.content|handlebars }}</div>
+        {% elif comp.type == "header/media" %}
+          {% if comp.content %}
+            <div class="text-lg font-normal">{{ comp.content }}</div>
+          {% else %}
+            <span class="inline-block p-2 bg-gray-200 rounded-lg">{{ translation.variables.0.type|upper }}</span>
+          {% endif %}
+        {% elif comp.type == "body/text" %}
+          <div>{{ comp.content|handlebars }}</div>
+        {% elif comp.type == "footer/text" %}
+          <div class="text-sm">{{ comp.content|handlebars }}</div>
+        {% endif %}
+      </div>
+    {% endfor %}
+    <div class="my-4 flex">
+      {% for comp in translation.components %}
+        {% if comp.type|slice:":7" == "button/" %}
+          <div width="100%" class="border mr-2 p-2 rounded-lg">{{ comp.display|default:comp.content|handlebars }}</div>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+  <div class="p-4 whitespace-nowrap">
+    {# djlint:off #}
+    <a href="{% url 'channels.channel_read' translation.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ translation.channel.type.icon }}" clickable class="mr-1 mb-1">{{ translation.channel }}</temba-label></a>
+    {# djlint:on #}
+    <temba-label icon="language">
+      {{ translation.locale }}
+    </temba-label>
+    <temba-label icon="{{ status_icons|field:translation.status }}" class="ml-2">
+      {{ translation.get_status_display }}
+    </temba-label>
+  </div>
+</div>

--- a/templates/templates/template_list.html
+++ b/templates/templates/template_list.html
@@ -5,7 +5,7 @@
   <div class="mb-4">
     {% blocktrans trimmed %}
       Templates are refreshed from supporting channels every 15 minutes and templates with the same name will be merged
-      into a single template with multiple translations.
+      into a single multi-lingual template.
     {% endblocktrans %}
   </div>
   {% block pre-table %}
@@ -21,7 +21,7 @@
             <td style="min-width: 50px">{{ obj.name }}</td>
             <td>
               {# djlint:off #}
-              {% blocktrans trimmed count counter=obj.translation_count %}{{ counter }} translation{% plural %}{{ counter }} translations{% endblocktrans %},
+              {% blocktrans trimmed count counter=obj.locale_count %}{{ counter }} language{% plural %}{{ counter }} languages{% endblocktrans %},
               {# djlint:on #}
               {% blocktrans trimmed count counter=obj.channel_count %}
                 {{ counter }} channel

--- a/templates/templates/template_read.html
+++ b/templates/templates/template_read.html
@@ -1,57 +1,21 @@
 {% extends "smartmin/read.html" %}
-{% load i18n smartmin templates %}
+{% load i18n smartmin %}
 
 {% block title-text %}
   {% trans "Template" %}: {{ object.name }}
 {% endblock title-text %}
 {% block content %}
-  <div class="card p-0 m-0">
-    {% for translation in translations %}
-      <div max-width="100%" class="flex translation">
-        <div width="70%" class="flex-grow p-4">
-          {% for comp in translation.components %}
-            <div width="100%" class="my-1">
-              {% if comp.type == "header/text" %}
-                <div class="text-lg font-normal">{{ comp.content|handlebars }}</div>
-              {% elif comp.type == "header/media" %}
-                {% if comp.content %}
-                  <div class="text-lg font-normal">{{ comp.content }}</div>
-                {% else %}
-                  <span class="inline-block p-2 bg-gray-200 rounded-lg">{{ translation.variables.0.type|upper }}</span>
-                {% endif %}
-              {% elif comp.type == "body/text" %}
-                <div>{{ comp.content|handlebars }}</div>
-              {% elif comp.type == "footer/text" %}
-                <div class="text-sm">{{ comp.content|handlebars }}</div>
-              {% endif %}
-            </div>
-          {% endfor %}
-          <div class="my-4 flex">
-            {% for comp in translation.components %}
-              {% if comp.type|slice:":7" == "button/" %}
-                <div width="100%" class="border mr-2 p-2 rounded-lg">{{ comp.display|default:comp.content|handlebars }}</div>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </div>
-        <div class="p-4 whitespace-nowrap">
-          {# djlint:off #}
-          <a href="{% url 'channels.channel_read' translation.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ translation.channel.type.icon }}" clickable class="mr-1 mb-1">{{ translation.channel }}</temba-label></a>
-          {# djlint:on #}
-          <temba-label icon="language">
-            {{ translation.locale }}
-          </temba-label>
-          <temba-label icon="{{ status_icons|field:translation.status }}" class="ml-2">
-            {{ translation.get_status_display }}
-          </temba-label>
-        </div>
-      </div>
-    {% empty %}
-      <tr class="empty">
-        <td>{% trans "No translations." %}</td>
-      </tr>
-    {% endfor %}
-  </div>
+  {% if base_translation %}
+    <div class="card p-0 m-0">{% include "templates/includes/translation.html" with translation=base_translation %}</div>
+  {% endif %}
+  {% if other_translations %}
+    <div class="mt-2 mb-2 text-lg text-center">{% trans "Other Languages" %}</div>
+    <div class="card p-0 m-0">
+      {% for translation in other_translations %}
+        {% include "templates/includes/translation.html" with translation=translation %}
+      {% endfor %}
+    </div>
+  {% endif %}
 {% endblock content %}
 {% block extra-style %}
   {{ block.super }}


### PR DESCRIPTION
* Exclude empty templates from list
* Show base translation apart on read page
* Use "languages" wording instead of "translations"

<img width="1079" alt="Captura de pantalla 2024-07-11 a la(s) 11 54 31" src="https://github.com/nyaruka/rapidpro/assets/675558/3cf925dc-9ea9-438a-a3aa-6407e063b2f6">

<img width="1080" alt="Captura de pantalla 2024-07-11 a la(s) 11 54 41" src="https://github.com/nyaruka/rapidpro/assets/675558/fa6ef6d8-0293-40c4-969e-649127690bf3">
