### PR TITLE
Tweak menu items for msg views and flow results

### DIFF
--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -2081,7 +2081,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(1, response.context["folders"][0]["count"])
         self.assertEqual(2, response.context["folders"][1]["count"])
 
-        self.assertEqual(("archive", "label", "download-results"), response.context["actions"])
+        self.assertEqual(("archive", "label", "export-results"), response.context["actions"])
 
         # but does appear in archived list
         response = self.client.get(reverse("flows.flow_archived"))
@@ -2168,7 +2168,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(reverse("flows.flow_filter", args=[label1.uuid]))
         self.assertEqual([flow2, flow1], list(response.context["object_list"]))
         self.assertEqual(2, len(response.context["labels"]))
-        self.assertEqual(("label", "download-results"), response.context["actions"])
+        self.assertEqual(("label", "export-results"), response.context["actions"])
 
         response = self.client.get(reverse("flows.flow_filter", args=[label2.uuid]))
         self.assertEqual([flow2], list(response.context["object_list"]))

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -800,7 +800,7 @@ class FlowCRUDL(SmartCRUDL):
 
     class List(BaseList):
         title = _("Active")
-        bulk_actions = ("archive", "label", "download-results")
+        bulk_actions = ("archive", "label", "export-results")
         menu_path = "/flow/active"
 
         def derive_queryset(self, *args, **kwargs):
@@ -810,7 +810,7 @@ class FlowCRUDL(SmartCRUDL):
 
     class Filter(BaseList, OrgObjPermsMixin):
         add_button = True
-        bulk_actions = ("label", "download-results")
+        bulk_actions = ("label", "export-results")
         slug_url_kwarg = "uuid"
 
         def derive_menu_path(self):
@@ -1374,10 +1374,10 @@ class FlowCRUDL(SmartCRUDL):
 
             if self.has_org_perm("flows.flow_export_results"):
                 menu.add_modax(
-                    _("Download"),
-                    "download-results",
+                    _("Export"),
+                    "export-results",
                     f"{reverse('flows.flow_export_results')}?ids={obj.id}",
-                    title=_("Download Results"),
+                    title=_("Export Results"),
                 )
 
             if self.has_org_perm("flows.flow_editor"):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -571,8 +571,8 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         msg1.refresh_from_db()
         self.assertEqual({label1, label3}, set(msg1.labels.all()))
 
-        self.assertContentMenu(inbox_url, self.user, ["Download"])
-        self.assertContentMenu(inbox_url, self.admin, ["New Broadcast", "New Label", "Download"])
+        self.assertContentMenu(inbox_url, self.user, ["Export"])
+        self.assertContentMenu(inbox_url, self.admin, ["Send", "New Label", "Export"])
 
     def test_flows(self):
         flow = self.create_flow("Test")
@@ -804,7 +804,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(f"/msg/labels/{label3.uuid}", response.headers[TEMBA_MENU_SELECTION])
         self.assertEqual(200, response.status_code)
         self.assertEqual(("label",), response.context["actions"])
-        self.assertContentMenu(label3_url, self.user, ["Download", "Usages"])  # no update or delete
+        self.assertContentMenu(label3_url, self.user, ["Export", "Usages"])  # no update or delete
 
         # check that non-visible messages are excluded, and messages and ordered newest to oldest
         self.assertEqual([msg6, msg3, msg2, msg1], list(response.context["object_list"]))
@@ -814,7 +814,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual({msg1, msg6}, set(response.context_data["object_list"]))
 
         # check admin users see edit and delete options for labels
-        self.assertContentMenu(label1_url, self.admin, ["Edit", "Download", "Usages", "Delete"])
+        self.assertContentMenu(label1_url, self.admin, ["Edit", "Delete", "-", "Export", "Usages"])
 
     def test_export(self):
         export_url = reverse("msgs.msg_export")
@@ -2517,7 +2517,7 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRequestDisallowed(list_url, [None, self.agent])
         self.assertListFetch(list_url, [self.user, self.editor, self.admin], context_objects=[])
         self.assertContentMenu(list_url, self.user, [])
-        self.assertContentMenu(list_url, self.admin, ["New Broadcast"])
+        self.assertContentMenu(list_url, self.admin, ["Send"])
 
         broadcast = self.create_broadcast(
             self.admin,
@@ -2533,7 +2533,7 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRequestDisallowed(scheduled_url, [None, self.agent])
         self.assertListFetch(scheduled_url, [self.user, self.editor, self.admin], context_objects=[])
         self.assertContentMenu(scheduled_url, self.user, [])
-        self.assertContentMenu(scheduled_url, self.admin, ["New Broadcast"])
+        self.assertContentMenu(scheduled_url, self.admin, ["Send"])
 
         bc1 = self.create_broadcast(
             self.admin,

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -143,13 +143,13 @@ class MsgListView(ContentMenuMixin, BulkActionMixin, SystemLabelView):
     def build_content_menu(self, menu):
         if self.has_org_perm("msgs.broadcast_create"):
             menu.add_modax(
-                _("New Broadcast"), "send-message", reverse("msgs.broadcast_create"), title=_("New Broadcast")
+                _("Send"), "send-message", reverse("msgs.broadcast_create"), title=_("New Broadcast"), as_button=True
             )
         if self.has_org_perm("msgs.label_create"):
             menu.add_modax(_("New Label"), "new-msg-label", reverse("msgs.label_create"), title=_("New Label"))
 
         if self.allow_export and self.has_org_perm("msgs.msg_export"):
-            menu.add_modax(_("Download"), "export-messages", self.derive_export_url(), title=_("Download Messages"))
+            menu.add_modax(_("Export"), "export-messages", self.derive_export_url(), title=_("Export Messages"))
 
 
 class ComposeForm(Form):
@@ -342,7 +342,7 @@ class BroadcastCRUDL(SmartCRUDL):
         def build_content_menu(self, menu):
             if self.has_org_perm("msgs.broadcast_create"):
                 menu.add_modax(
-                    _("New Broadcast"),
+                    _("Send"),
                     "new-scheduled",
                     reverse("msgs.broadcast_create"),
                     title=_("New Broadcast"),
@@ -363,7 +363,7 @@ class BroadcastCRUDL(SmartCRUDL):
         def build_content_menu(self, menu):
             if self.has_org_perm("msgs.broadcast_create"):
                 menu.add_modax(
-                    _("New Broadcast"),
+                    _("Send"),
                     "new-scheduled",
                     reverse("msgs.broadcast_create"),
                     title=_("New Broadcast"),
@@ -987,11 +987,6 @@ class MsgCRUDL(SmartCRUDL):
                     title="Edit Label",
                 )
 
-            if self.has_org_perm("msgs.msg_export"):
-                menu.add_modax(_("Download"), "export-messages", self.derive_export_url(), title=_("Download Messages"))
-
-            menu.add_modax(_("Usages"), "label-usages", reverse("msgs.label_usages", args=[self.label.uuid]))
-
             if self.has_org_perm("msgs.label_delete"):
                 menu.add_modax(
                     _("Delete"),
@@ -999,6 +994,13 @@ class MsgCRUDL(SmartCRUDL):
                     reverse("msgs.label_delete", args=[self.label.uuid]),
                     title="Delete Label",
                 )
+
+            menu.new_group()
+
+            if self.has_org_perm("msgs.msg_export"):
+                menu.add_modax(_("Export"), "export-messages", self.derive_export_url(), title=_("Export Messages"))
+
+            menu.add_modax(_("Usages"), "label-usages", reverse("msgs.label_usages", args=[self.label.uuid]))
 
         @classmethod
         def derive_url_pattern(cls, path, action):

--- a/templates/flows/flow_list.html
+++ b/templates/flows/flow_list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
   {% if org_perms.flows.flow_update %}
-    <temba-modax header="{% trans "Download Results" %}" id="export-results">
+    <temba-modax header="{% trans "Export Results" %}" id="export-results">
     </temba-modax>
     <temba-modax header="{% trans "Create Label" %}"
                  endpoint="{% url 'flows.flowlabel_create' %}"
@@ -144,7 +144,7 @@
         refreshMenu();
       }
 
-      function handleDownloadFlowResults(evt) {
+      function handleExportFlowResults(evt) {
         var endpoint = '{% url "flows.flow_export_results" %}';
         var modal = document.querySelector("#export-results");
         var ids = getCheckedIds();

--- a/templates/includes/short_pagination.html
+++ b/templates/includes/short_pagination.html
@@ -101,9 +101,9 @@
             </temba-tip>
           </div>
         {% endif %}
-        {% if 'download-results' in actions %}
-          <div onclick="handleDownloadFlowResults(event)" class="linked ml-4">
-            <temba-tip position="top" text="{{ _("Download Results") |escapejs }}">
+        {% if 'export-results' in actions %}
+          <div onclick="handleExportFlowResults(event)" class="linked ml-4">
+            <temba-tip position="top" text="{{ _("Export Results") |escapejs }}">
               <temba-icon name="download" clickable="true" class="show-loading">
               </temba-icon>
             </temba-tip>


### PR DESCRIPTION
I think the move to _Download_ wording for things that can't be re-imported was a mistake, since we use _Export_ wording elsewhere in the emails, notifications etc. It wouldn't be crazy to have an export list page that shows the recent exports of any type.

Also think we need to make it easier to find the button to send messages.

Before:

<img width="506" alt="Captura de pantalla 2024-07-17 a la(s) 10 04 43" src="https://github.com/user-attachments/assets/9fc95ccb-6975-428b-a79b-55fda33ea090">

After:

<img width="507" alt="Captura de pantalla 2024-07-17 a la(s) 10 03 37" src="https://github.com/user-attachments/assets/8321a12c-3ffc-49df-829a-eabc0017b7e9">

 * _New Label_ feels weird here but we still don't have a way to open models from the lefthand menu

Before:

<img width="508" alt="Captura de pantalla 2024-07-17 a la(s) 10 04 58" src="https://github.com/user-attachments/assets/a99f1e11-396e-4d35-aa1b-65736d1141c4">

After:

<img width="508" alt="Captura de pantalla 2024-07-17 a la(s) 10 03 45" src="https://github.com/user-attachments/assets/95878d17-98e1-4ba8-8388-7837938b8161">

Before:

<img width="507" alt="Captura de pantalla 2024-07-17 a la(s) 10 05 11" src="https://github.com/user-attachments/assets/e3e8e217-63c0-4598-b0bc-602b6cfd31ec">

After:

<img width="506" alt="Captura de pantalla 2024-07-17 a la(s) 10 03 56" src="https://github.com/user-attachments/assets/c2a9823c-cd1c-4d34-9917-e31497ea17f2">
