### PR TITLE
Save authentication FCM config as JSON dumps

### DIFF
--- a/temba/channels/types/firebase/tests.py
+++ b/temba/channels/types/firebase/tests.py
@@ -62,7 +62,7 @@ class FirebaseCloudMessagingTypeTest(TembaTest):
         self.assertEqual(
             channel.config,
             {
-                "FCM_CREDENTIALS_JSON": {"foo": "bar", "baz": "abc", "private_key_id": "abcde12345"},
+                "FCM_CREDENTIALS_JSON": '{"foo": "bar", "baz": "abc", "private_key_id": "abcde12345"}',
                 "FCM_TITLE": "FCM Channel",
                 "FCM_NOTIFICATION": True,
             },

--- a/temba/channels/types/firebase/views.py
+++ b/temba/channels/types/firebase/views.py
@@ -1,3 +1,5 @@
+import json
+
 from smartmin.views import SmartFormView
 
 from django import forms
@@ -41,7 +43,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         title = form.cleaned_data.get("title")
         authentication_json = form.cleaned_data.get("authentication_json")
         address = form.cleaned_data.get("address")
-        config = {"FCM_TITLE": title, "FCM_CREDENTIALS_JSON": authentication_json}
+        config = {"FCM_TITLE": title, "FCM_CREDENTIALS_JSON": json.dumps(authentication_json)}
 
         if form.cleaned_data.get("send_notification") == "True":
             config["FCM_NOTIFICATION"] = True


### PR DESCRIPTION
Fixes https://textit.sentry.io/issues/5686387015/ as courier expects the config as a string and marshals that into JSON
https://github.com/nyaruka/courier/blob/d78749478c8a64ed865935d54771e61531ca48dc/handlers/firebase/handler.go#L257