### PR TITLE
Add outbox monitor for large queues

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.35.1",
-    "@nyaruka/temba-components": "0.104.1",
+    "@nyaruka/temba-components": "0.105.1",
     "codemirror": "5.18.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/templates/flows/flowstart_list.html
+++ b/templates/flows/flowstart_list.html
@@ -9,78 +9,80 @@
     }
   </style>
 {% endblock extra-style %}
-{% block table %}
-  <table class="list lined header">
-    <thead>
-      <tr>
-        <th colspan="3">
-          <div class="flex justify-end">
-            <div class="flow-start-type-selector flex">
-              <div onclick="goto(event, this)"
-                   href="{% url 'flows.flowstart_list' %}"
-                   class="{% if not filtered %}is-active{% endif %} linked mr-1">{% trans "All" %}</div>
-              |
-              <div onclick="goto(event, this)"
-                   href="{% url 'flows.flowstart_list' %}?type=manual"
-                   class="{% if filtered %}is-active{% endif %} linked ml-1">{% trans "Manual" %}</div>
-            </div>
-          </div>
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for obj in object_list %}
+{% block content %}
+  <div class="flex-grow overflow-y-auto shadow rounded-b-lg">
+    <table class="list lined header scrolled">
+      <thead>
         <tr>
-          <td width="16px">
-            {% if obj.status == "P" or obj.status == "S" %}
-              <temba-icon name="progress_spinner" spin>
-              </temba-icon>
-            {% elif obj.status == "C" %}
-              <temba-icon name="check">
-              </temba-icon>
-            {% elif obj.status == "F" %}
-              <temba-icon name="error">
-              </temba-icon>
-            {% endif %}
-          </td>
-          <td>
-            {% if obj.flow.is_active %}
-              <a href="{% url 'flows.flow_editor' obj.flow.uuid %}">{{ obj.flow.name }}</a>
-            {% else %}
-              {% trans "A deleted flow" %}
-            {% endif %}
-            {% if obj.start_type == "M" %}
-              {% blocktrans trimmed with user=obj.created_by %}
-                was started by {{ user }}
-              {% endblocktrans %}
-            {% elif obj.start_type == "Z" %}
-              {% trans "was started by Zapier" %}
-            {% else %}
-              {% trans "was started by an API call" %}
-            {% endif %}
-            <div style="padding-top: 10px; max-height: 150px; overflow-y: auto;" class="flex flex-wrap">
-              {% include "includes/recipients.html" with groups=obj.groups.all contacts=obj.contacts.all query=obj.query %}
-              {% include "includes/exclusions.html" with exclusions=obj.exclusions %}
-            </div>
-          </td>
-          <td style="text-align: right">
-            <div class="flex flex-col">
-              <div>{{ obj.created_on|timedate }}</div>
-              <div style="padding-top: 10px; font-size: 11px">
-                {% blocktrans trimmed with count=obj.run_count|intcomma count counter=obj.run_count %}
-                  <b>{{ count }}</b> run
-                {% plural %}
-                  <b>{{ count }}</b> runs
-                {% endblocktrans %}
+          <th colspan="3">
+            <div class="flex justify-end">
+              <div class="flow-start-type-selector flex">
+                <div onclick="goto(event, this)"
+                     href="{% url 'flows.flowstart_list' %}"
+                     class="{% if not filtered %}is-active{% endif %} linked mr-1">{% trans "All" %}</div>
+                |
+                <div onclick="goto(event, this)"
+                     href="{% url 'flows.flowstart_list' %}?type=manual"
+                     class="{% if filtered %}is-active{% endif %} linked ml-1">{% trans "Manual" %}</div>
               </div>
             </div>
-          </td>
+          </th>
         </tr>
-      {% empty %}
-        <tr class="empty_list">
-          <td colspan="99">{% trans "No flow starts" %}</td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-{% endblock table %}
+      </thead>
+      <tbody>
+        {% for obj in object_list %}
+          <tr>
+            <td width="16px">
+              {% if obj.status == "P" or obj.status == "S" %}
+                <temba-icon name="progress_spinner" spin>
+                </temba-icon>
+              {% elif obj.status == "C" %}
+                <temba-icon name="check">
+                </temba-icon>
+              {% elif obj.status == "F" %}
+                <temba-icon name="error">
+                </temba-icon>
+              {% endif %}
+            </td>
+            <td>
+              {% if obj.flow.is_active %}
+                <a href="{% url 'flows.flow_editor' obj.flow.uuid %}">{{ obj.flow.name }}</a>
+              {% else %}
+                {% trans "A deleted flow" %}
+              {% endif %}
+              {% if obj.start_type == "M" %}
+                {% blocktrans trimmed with user=obj.created_by %}
+                  was started by {{ user }}
+                {% endblocktrans %}
+              {% elif obj.start_type == "Z" %}
+                {% trans "was started by Zapier" %}
+              {% else %}
+                {% trans "was started by an API call" %}
+              {% endif %}
+              <div style="padding-top: 10px; max-height: 150px; overflow-y: auto;" class="flex flex-wrap">
+                {% include "includes/recipients.html" with groups=obj.groups.all contacts=obj.contacts.all query=obj.query %}
+                {% include "includes/exclusions.html" with exclusions=obj.exclusions %}
+              </div>
+            </td>
+            <td style="text-align: right">
+              <div class="flex flex-col">
+                <div>{{ obj.created_on|timedate }}</div>
+                <div style="padding-top: 10px; font-size: 11px">
+                  {% blocktrans trimmed with count=obj.run_count|intcomma count counter=obj.run_count %}
+                    <b>{{ count }}</b> run
+                  {% plural %}
+                    <b>{{ count }}</b> runs
+                  {% endblocktrans %}
+                </div>
+              </div>
+            </td>
+          </tr>
+        {% empty %}
+          <tr class="empty_list">
+            <td colspan="99">{% trans "No flow starts" %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock content %}

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -211,6 +211,8 @@
                 </temba-menu>
               </div>
               <div class="flex-grow spa-container flex flex-col initial-load">
+                <temba-outbox-monitor>
+                </temba-outbox-monitor>
                 <div class="spa-loader hide absolute">
                   <div style="display:flex;z-index:100000;margin-top:0.1em;margin-left:1em" class="wrapper">
                     <temba-loading size="16" units="6">

--- a/templates/request_logs/httplog_webhooks.html
+++ b/templates/request_logs/httplog_webhooks.html
@@ -1,43 +1,45 @@
 {% extends "smartmin/list.html" %}
 {% load i18n temba humanize %}
 
-{% block table %}
-  <table class="list lined header">
-    <thead>
-      <tr>
-        <th>{% trans "Flow" %}</th>
-        <th>{% trans "URL" %}</th>
-        <th style="width:100px;">{% trans "Status" %}</th>
-        <th style="width:100px;">{% trans "Elapsed" %}</th>
-        <th style="width:100px;" class="text-right">{% trans "Time" %}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for obj in object_list %}
-        <tr class="{% if obj.is_error %}warning{% endif %}">
-          <td class="clickable">
-            <a href="{% url "flows.flow_editor" obj.flow.uuid %}" class="linked">{{ obj.flow.name }}</a>
-          </td>
-          <td class="clickable">
-            <a href="{% url "request_logs.httplog_read" obj.id %}" class="linked">{{ obj.url|truncatechars:128 }}</a>
-          </td>
-          <td class="clickable">
-            <a href="{% url "request_logs.httplog_read" obj.id %}" class="linked">{{ obj.status_code|default:"--" }}</a>
-          </td>
-          <td class="whitespace-nowrap">
-            {% if obj.request_time %}
-              {{ obj.request_time|intcomma }}ms
-            {% else %}
-              {{ "--" }}
-            {% endif %}
-          </td>
-          <td class="text-right whitespace-nowrap">{{ obj.created_on|datetime }}</td>
-        </tr>
-      {% empty %}
+{% block content %}
+  <div class="flex-grow overflow-y-auto shadow rounded-b-lg">
+    <table class="list lined header scrolled" style="100%">
+      <thead>
         <tr>
-          <td colspan="99" class="text-center">{% trans "No webhook calls yet" %}</td>
+          <th>{% trans "Flow" %}</th>
+          <th>{% trans "URL" %}</th>
+          <th style="width:100px;">{% trans "Status" %}</th>
+          <th style="width:100px;">{% trans "Elapsed" %}</th>
+          <th style="width:100px;" class="text-right">{% trans "Time" %}</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-{% endblock table %}
+      </thead>
+      <tbody>
+        {% for obj in object_list %}
+          <tr class="{% if obj.is_error %}warning{% endif %}">
+            <td class="clickable">
+              <a href="{% url "flows.flow_editor" obj.flow.uuid %}" class="linked">{{ obj.flow.name }}</a>
+            </td>
+            <td class="clickable">
+              <a href="{% url "request_logs.httplog_read" obj.id %}" class="linked">{{ obj.url|truncatechars:128 }}</a>
+            </td>
+            <td class="clickable">
+              <a href="{% url "request_logs.httplog_read" obj.id %}" class="linked">{{ obj.status_code|default:"--" }}</a>
+            </td>
+            <td class="whitespace-nowrap">
+              {% if obj.request_time %}
+                {{ obj.request_time|intcomma }}ms
+              {% else %}
+                {{ "--" }}
+              {% endif %}
+            </td>
+            <td class="text-right whitespace-nowrap">{{ obj.created_on|datetime }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="99" class="text-center">{% trans "No webhook calls yet" %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock content %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,10 +103,10 @@
     serialize-javascript "^6.0.2"
     tiny-lru "^11.2.5"
 
-"@nyaruka/temba-components@0.104.1":
-  version "0.104.1"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.104.1.tgz#0c1e3c271f647db4cab61f199299e33abc2a5067"
-  integrity sha512-6ZfegDR80nQ70CZHJ+r9QRgqPFRn8JQQHfkWymmvguBOTI9WUxtd7qtFQHY1PBI7EnDckAD/4/LsUeuN17zxfg==
+"@nyaruka/temba-components@0.105.1":
+  version "0.105.1"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.105.1.tgz#92b7838fa8910417d5a069a1dc06bd7733b9187d"
+  integrity sha512-TbDZ/eIXz+Q4UnxxTP9Jz6bItvPV+sxfuHNiZo7lgwbnQBgOx7vGT+h1scGwwQAixNkWqgHDWBXINVULfnrSKw==
   dependencies:
     "@lit/localize" "^0.12.1"
     color-hash "^2.0.2"


### PR DESCRIPTION
The monitor is presented on the top of each spa page. I noticed two list pages that didn't scroll properly which is now more likely to happen when the monitor is visible. So this PR also includes that.