### PR TITLE
Validate channel variable in the body for EX channels

### DIFF
--- a/temba/channels/types/external/tests.py
+++ b/temba/channels/types/external/tests.py
@@ -59,7 +59,7 @@ class ExternalTypeTest(TembaTest):
             response.context["form"], "body", "Invalid JSON, make sure to remove quotes around variables"
         )
 
-        post_data["body"] = '{"from":{{from_no_plus}},"to":{{to_no_plus}},"text":{{text}} }'
+        post_data["body"] = '{"from":{{from_no_plus}},"to":{{to_no_plus}},"text":{{text}},"channel":{{channel}} }'
         response = self.client.post(url, post_data)
         channel = Channel.objects.get()
 
@@ -74,7 +74,7 @@ class ExternalTypeTest(TembaTest):
         self.assertEqual(channel.channel_type, "EX")
         self.assertEqual(Channel.ENCODING_SMART, channel.config[Channel.CONFIG_ENCODING])
         self.assertEqual(
-            '{"from":{{from_no_plus}},"to":{{to_no_plus}},"text":{{text}} }',
+            '{"from":{{from_no_plus}},"to":{{to_no_plus}},"text":{{text}},"channel":{{channel}} }',
             channel.config[ExternalType.CONFIG_SEND_BODY],
         )
         self.assertEqual("SENT", channel.config[ExternalType.CONFIG_MT_RESPONSE_CHECK])

--- a/temba/channels/types/external/views.py
+++ b/temba/channels/types/external/views.py
@@ -114,6 +114,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
                 "to_no_plus": "",
                 "id": "",
                 "quick_replies": "",
+                "channel": "",
             }
             replaced_body = ExternalType.replace_variables(
                 cleaned_data.get("body"), variables, content_type=content_type

--- a/templates/channels/types/external/claim.html
+++ b/templates/channels/types/external/claim.html
@@ -35,6 +35,10 @@
       <div class="code">quick_replies</div>
       {% trans "the quick replies for this message, formatted according to send method and content type" %}
     </li>
+    <li>
+      <div class="code">channel</div>
+      {% trans "the channel UUID" %}
+    </li>
   </ul>
   <div class="mb-2">
     {% blocktrans trimmed %}


### PR DESCRIPTION
`{{channel}}` was not mention on the claim page and not properly validated as well in https://github.com/nyaruka/rapidpro/pull/5487
This PR fixes that