### PR TITLE
More modal cleanup

### DIFF
--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -15,7 +15,7 @@ from temba.api.support import InvalidQueryError
 from temba.contacts.models import URN
 from temba.orgs.views.mixins import OrgObjPermsMixin
 from temba.utils.models import TembaModel
-from temba.utils.views.mixins import ModalMixin, NonAtomicMixin
+from temba.utils.views.mixins import ModalFormMixin, NonAtomicMixin
 
 from .models import APIToken, BulkActionFailure
 
@@ -280,7 +280,7 @@ class APITokenCRUDL(SmartCRUDL):
     model = APIToken
     actions = ("delete",)
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class Delete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         slug_url_kwarg = "key"
         fields = ("key",)
         cancel_url = "@orgs.user_tokens"

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -15,7 +15,7 @@ from temba.orgs.views.base import BaseListView, BaseMenuView
 from temba.orgs.views.mixins import BulkActionMixin, OrgObjPermsMixin, OrgPermsMixin
 from temba.utils import languages
 from temba.utils.fields import CompletionTextarea, InputWidget, SelectWidget, TembaChoiceField
-from temba.utils.views.mixins import ContextMenuMixin, ModalMixin, SpaMixin
+from temba.utils.views.mixins import ContextMenuMixin, ModalFormMixin, SpaMixin
 
 from .models import Campaign, CampaignEvent
 
@@ -72,7 +72,7 @@ class CampaignCRUDL(SmartCRUDL):
 
             return menu
 
-    class Update(OrgObjPermsMixin, ModalMixin, SmartUpdateView):
+    class Update(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         fields = ("name", "group")
         form_class = CampaignForm
 
@@ -146,7 +146,7 @@ class CampaignCRUDL(SmartCRUDL):
                 if self.has_org_perm("campaigns.campaign_archive"):
                     menu.add_url_post(_("Archive"), reverse("campaigns.campaign_archive", args=[obj.id]))
 
-    class Create(OrgPermsMixin, ModalMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         fields = ("name", "group")
         form_class = CampaignForm
         success_url = "uuid@campaigns.campaign_read"
@@ -531,7 +531,7 @@ class CampaignEventCRUDL(SmartCRUDL):
                     title=_("Delete Event"),
                 )
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class Delete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         default_template = "smartmin/delete_confirm.html"
         submit_button_name = _("Delete")
         fields = ("uuid",)
@@ -552,7 +552,7 @@ class CampaignEventCRUDL(SmartCRUDL):
         def get_cancel_url(self):  # pragma: needs cover
             return reverse("campaigns.campaign_read", args=[self.object.campaign.uuid])
 
-    class Update(OrgObjPermsMixin, ModalMixin, SmartUpdateView):
+    class Update(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = CampaignEventForm
         default_fields = [
             "event_type",
@@ -651,7 +651,7 @@ class CampaignEventCRUDL(SmartCRUDL):
         def get_success_url(self):
             return reverse("campaigns.campaignevent_read", args=[self.object.campaign.uuid, self.object.pk])
 
-    class Create(OrgPermsMixin, ModalMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         default_fields = [
             "event_type",
             "flow_to_start",

--- a/temba/channels/types/facebookapp/views.py
+++ b/temba/channels/types/facebookapp/views.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views.mixins import OrgObjPermsMixin
 from temba.utils.text import truncate
-from temba.utils.views.mixins import ModalMixin
+from temba.utils.views.mixins import ModalFormMixin
 
 from ...models import Channel
 from ...views import ChannelTypeMixin, ClaimViewMixin
@@ -137,7 +137,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         return super().form_valid(form)
 
 
-class RefreshToken(ChannelTypeMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView):
+class RefreshToken(ChannelTypeMixin, ModalFormMixin, OrgObjPermsMixin, SmartModelActionView):
     class Form(forms.Form):
         user_access_token = forms.CharField(min_length=32, required=True, help_text=_("The User Access Token"))
         fb_user_id = forms.CharField(

--- a/temba/channels/types/instagram/views.py
+++ b/temba/channels/types/instagram/views.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.views.mixins import OrgObjPermsMixin
 from temba.utils.text import truncate
-from temba.utils.views.mixins import ModalMixin
+from temba.utils.views.mixins import ModalFormMixin
 
 from ...models import Channel
 from ...views import ChannelTypeMixin, ClaimViewMixin
@@ -168,7 +168,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         return super().form_valid(form)
 
 
-class RefreshToken(ChannelTypeMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView):
+class RefreshToken(ChannelTypeMixin, ModalFormMixin, OrgObjPermsMixin, SmartModelActionView):
     class Form(forms.Form):
         user_access_token = forms.CharField(min_length=32, required=True, help_text=_("The User Access Token"))
         fb_user_id = forms.CharField(

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -13,7 +13,6 @@ from temba.channels.views import ChannelTypeMixin
 from temba.orgs.views.mixins import OrgObjPermsMixin, OrgPermsMixin
 from temba.utils.fields import InputWidget
 from temba.utils.text import truncate
-from temba.utils.views.mixins import ContextMenuMixin, ModalMixin
 
 from ...models import Channel
 from ...views import ClaimViewMixin
@@ -219,7 +218,7 @@ class ClearSessionToken(ChannelTypeMixin, OrgPermsMixin, SmartTemplateView):
         return JsonResponse({})
 
 
-class RequestCode(ChannelTypeMixin, ModalMixin, ContextMenuMixin, OrgObjPermsMixin, SmartModelActionView):
+class RequestCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView):
     class Form(forms.Form):
         pass
 
@@ -239,11 +238,6 @@ class RequestCode(ChannelTypeMixin, ModalMixin, ContextMenuMixin, OrgObjPermsMix
 
     def derive_menu_path(self):
         return f"/settings/channels/{self.get_object().uuid}"
-
-    def build_content_menu(self, menu):
-        obj = self.get_object()
-
-        menu.add_link(_("Channel"), reverse("channels.channel_read", args=[obj.uuid]))
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -283,7 +277,7 @@ class RequestCode(ChannelTypeMixin, ModalMixin, ContextMenuMixin, OrgObjPermsMix
                 )
 
 
-class VerifyCode(ChannelTypeMixin, ModalMixin, ContextMenuMixin, OrgObjPermsMixin, SmartModelActionView):
+class VerifyCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView):
     class Form(forms.Form):
         code = forms.CharField(
             min_length=6, required=True, help_text=_("The 6-digits number verification code"), widget=InputWidget()
@@ -297,11 +291,6 @@ class VerifyCode(ChannelTypeMixin, ModalMixin, ContextMenuMixin, OrgObjPermsMixi
     template_name = "channels/types/whatsapp/verify_code.html"
     title = _("Verify Number")
     submit_button_name = _("Verify Number")
-
-    def build_content_menu(self, menu):
-        obj = self.get_object()
-
-        menu.add_link(_("Channel"), reverse("channels.channel_read", args=[obj.uuid]))
 
     def get_queryset(self):
         return Channel.objects.filter(is_active=True, org=self.request.org, channel_type=self.channel_type.code)

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -41,7 +41,7 @@ from temba.utils import countries
 from temba.utils.fields import SelectWidget
 from temba.utils.json import EpochEncoder
 from temba.utils.models import patch_queryset_count
-from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalMixin, SpaMixin
+from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalFormMixin, SpaMixin
 
 from .models import Channel, ChannelCount, ChannelLog
 
@@ -663,7 +663,7 @@ class ChannelCRUDL(SmartCRUDL):
                 encoder=EpochEncoder,
             )
 
-    class FacebookWhitelist(ComponentFormMixin, ModalMixin, OrgObjPermsMixin, SmartModelActionView):
+    class FacebookWhitelist(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartModelActionView):
         class DomainForm(forms.Form):
             whitelisted_domain = forms.URLField(
                 required=True,
@@ -733,7 +733,7 @@ class ChannelCRUDL(SmartCRUDL):
             response["Temba-Success"] = self.get_success_url()
             return response
 
-    class Update(OrgObjPermsMixin, ComponentFormMixin, ModalMixin, SmartUpdateView):
+    class Update(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         def derive_title(self):
             return _("%s Channel") % self.object.type.name
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -40,7 +40,7 @@ from temba.utils.dates import datetime_to_timestamp, timestamp_to_datetime
 from temba.utils.fields import CheckboxWidget, InputWidget, SelectWidget, TembaChoiceField
 from temba.utils.models import patch_queryset_count
 from temba.utils.models.es import IDSliceQuerySet
-from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalMixin, NonAtomicMixin, SpaMixin
+from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalFormMixin, NonAtomicMixin, SpaMixin
 
 from .forms import ContactGroupForm, CreateContactForm, UpdateContactForm
 from .models import URN, Contact, ContactExport, ContactField, ContactGroup, ContactGroupCount, ContactImport
@@ -671,7 +671,7 @@ class ContactCRUDL(SmartCRUDL):
             except ContactGroup.DoesNotExist:
                 raise Http404("Group not found")
 
-    class Create(NonAtomicMixin, ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(NonAtomicMixin, ModalFormMixin, OrgPermsMixin, SmartCreateView):
         form_class = CreateContactForm
         submit_button_name = _("Create")
 
@@ -703,7 +703,7 @@ class ContactCRUDL(SmartCRUDL):
 
             return self.render_modal_response(form)
 
-    class Update(SpaMixin, ComponentFormMixin, NonAtomicMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(ComponentFormMixin, NonAtomicMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = UpdateContactForm
         success_url = "hide"
 
@@ -781,7 +781,7 @@ class ContactCRUDL(SmartCRUDL):
 
             return self.render_modal_response(form)
 
-    class OpenTicket(ComponentFormMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class OpenTicket(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         """
         Opens a new ticket for this contact.
         """
@@ -838,7 +838,7 @@ class ContactCRUDL(SmartCRUDL):
             obj.interrupt(self.request.user)
             return obj
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Delete(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         """
         Delete this contact (can't be undone)
         """
@@ -856,7 +856,7 @@ class ContactGroupCRUDL(SmartCRUDL):
     model = ContactGroup
     actions = ("create", "update", "usages", "delete")
 
-    class Create(ComponentFormMixin, ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(ComponentFormMixin, ModalFormMixin, OrgPermsMixin, SmartCreateView):
         form_class = ContactGroupForm
         fields = ("name", "preselected_contacts", "group_query")
         success_url = "uuid@contacts.contact_filter"
@@ -890,7 +890,7 @@ class ContactGroupCRUDL(SmartCRUDL):
             kwargs["org"] = self.request.org
             return kwargs
 
-    class Update(ComponentFormMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = ContactGroupForm
         fields = ("name",)
         success_url = "uuid@contacts.contact_filter"
@@ -1011,7 +1011,7 @@ class ContactFieldCRUDL(SmartCRUDL):
     model = ContactField
     actions = ("list", "create", "update", "update_priority", "delete", "usages")
 
-    class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         class Form(ContactFieldForm):
             def clean(self):
                 super().clean()
@@ -1054,7 +1054,7 @@ class ContactFieldCRUDL(SmartCRUDL):
             )
             return self.render_modal_response(form)
 
-    class Update(FieldLookupMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(FieldLookupMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         queryset = ContactField.objects.filter(is_system=False)
         form_class = ContactFieldForm
         submit_button_name = _("Update")

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -8,6 +8,7 @@ from smartmin.views import (
     SmartCreateView,
     SmartCRUDL,
     SmartDeleteView,
+    SmartFormView,
     SmartListView,
     SmartReadView,
     SmartTemplateView,
@@ -48,7 +49,7 @@ from temba.utils.fields import (
     TembaChoiceField,
 )
 from temba.utils.text import slugify_with
-from temba.utils.views.mixins import ContextMenuMixin, ModalMixin, SpaMixin, StaffOnlyMixin
+from temba.utils.views.mixins import ContextMenuMixin, ModalFormMixin, SpaMixin, StaffOnlyMixin
 
 from .models import FlowLabel, FlowStartCount, FlowUserConflictException, FlowVersionConflictException, ResultsExport
 
@@ -156,7 +157,7 @@ class FlowRunCRUDL(SmartCRUDL):
     actions = ("delete",)
     model = FlowRun
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class Delete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         fields = ("id",)
         success_message = None
 
@@ -387,7 +388,7 @@ class FlowCRUDL(SmartCRUDL):
 
             return JsonResponse({"status": "failure", "description": error, "detail": detail}, status=400)
 
-    class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         class Form(BaseFlowForm):
             keyword_triggers = forms.CharField(
                 required=False,
@@ -494,7 +495,7 @@ class FlowCRUDL(SmartCRUDL):
             # redirect to the newly created flow
             return HttpResponseRedirect(reverse("flows.flow_editor", args=[copy.uuid]))
 
-    class Update(AllowOnlyActiveFlowMixin, ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(AllowOnlyActiveFlowMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         class BaseForm(BaseFlowForm):
             class Meta:
                 model = Flow
@@ -987,7 +988,7 @@ class FlowCRUDL(SmartCRUDL):
 
             return HttpResponseRedirect(self.get_success_url())
 
-    class ExportTranslation(OrgObjPermsMixin, ModalMixin, SmartUpdateView):
+    class ExportTranslation(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         class Form(forms.Form):
             language = forms.ChoiceField(
                 required=False,
@@ -1603,7 +1604,7 @@ class FlowCRUDL(SmartCRUDL):
                 }
             )
 
-    class Start(OrgPermsMixin, ModalMixin):
+    class Start(ModalFormMixin, OrgPermsMixin, SmartFormView):
         class Form(forms.ModelForm):
             flow = TembaChoiceField(
                 queryset=Flow.objects.none(),
@@ -1789,7 +1790,7 @@ class FlowLabelCRUDL(SmartCRUDL):
     model = FlowLabel
     actions = ("create", "update", "delete")
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class Delete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         fields = ("uuid",)
         success_url = "@flows.flow_list"
         cancel_url = "@flows.flow_list"
@@ -1803,7 +1804,7 @@ class FlowLabelCRUDL(SmartCRUDL):
             self.object.delete()
             return self.render_modal_response()
 
-    class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = FlowLabelForm
         success_url = "uuid@flows.flow_filter"
 
@@ -1812,7 +1813,7 @@ class FlowLabelCRUDL(SmartCRUDL):
             kwargs["org"] = self.request.org
             return kwargs
 
-    class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         fields = ("name", "flows")
         form_class = FlowLabelForm
         submit_button_name = _("Create")
@@ -1914,7 +1915,7 @@ class FlowStartCRUDL(SmartCRUDL):
                 )
             return JsonResponse({"results": results})
 
-    class Interrupt(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Interrupt(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         default_template = "smartmin/delete_confirm.html"
         permission = "flows.flowstart_update"
         fields = ()

--- a/temba/globals/views.py
+++ b/temba/globals/views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from temba.orgs.views.base import BaseDependencyDeleteModal, BaseListView, BaseUsagesModal
 from temba.orgs.views.mixins import OrgObjPermsMixin, OrgPermsMixin
 from temba.utils.fields import InputWidget
-from temba.utils.views.mixins import ContextMenuMixin, ModalMixin, SpaMixin
+from temba.utils.views.mixins import ContextMenuMixin, ModalFormMixin, SpaMixin
 
 from .models import Global
 
@@ -79,7 +79,7 @@ class GlobalCRUDL(SmartCRUDL):
     model = Global
     actions = ("create", "update", "delete", "list", "unused", "usages")
 
-    class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         form_class = CreateGlobalForm
         submit_button_name = _("Create")
 
@@ -99,7 +99,7 @@ class GlobalCRUDL(SmartCRUDL):
 
             return self.render_modal_response(form)
 
-    class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = UpdateGlobalForm
         submit_button_name = _("Update")
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -44,7 +44,7 @@ from temba.utils.fields import (
 from temba.utils.models import patch_queryset_count
 from temba.utils.views.mixins import (
     ContextMenuMixin,
-    ModalMixin,
+    ModalFormMixin,
     NonAtomicMixin,
     PostOnlyMixin,
     SpaMixin,
@@ -602,7 +602,7 @@ class BroadcastCRUDL(SmartCRUDL):
                     title=_("Delete Broadcast"),
                 )
 
-    class ScheduledDelete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class ScheduledDelete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         default_template = "broadcast_scheduled_delete.html"
         cancel_url = "id@msgs.broadcast_scheduled_read"
         success_url = "@msgs.broadcast_scheduled"
@@ -664,7 +664,7 @@ class BroadcastCRUDL(SmartCRUDL):
                 }
             )
 
-    class ToNode(NonAtomicMixin, ModalMixin, OrgPermsMixin, SmartCreateView):
+    class ToNode(NonAtomicMixin, ModalFormMixin, OrgPermsMixin, SmartCreateView):
         class Form(forms.ModelForm):
             text = forms.CharField(
                 widget=CompletionTextarea(
@@ -748,7 +748,7 @@ class BroadcastCRUDL(SmartCRUDL):
                 )
             return JsonResponse({"results": results})
 
-    class Interrupt(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Interrupt(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         default_template = "smartmin/delete_confirm.html"
         permission = "msgs.broadcast_update"
         fields = ()
@@ -1103,7 +1103,7 @@ class LabelCRUDL(SmartCRUDL):
     model = Label
     actions = ("create", "update", "usages", "delete")
 
-    class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         fields = ("name", "messages")
         success_url = "uuid@msgs.msg_filter"
         form_class = LabelForm
@@ -1127,7 +1127,7 @@ class LabelCRUDL(SmartCRUDL):
 
             return obj
 
-    class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = LabelForm
         success_url = "uuid@msgs.msg_filter"
         title = _("Update Label")

--- a/temba/orgs/views/base.py
+++ b/temba/orgs/views/base.py
@@ -14,7 +14,7 @@ from django.utils.translation import gettext_lazy as _
 from temba.contacts.models import ContactField, ContactGroup
 from temba.utils import on_transaction_commit
 from temba.utils.fields import SelectMultipleWidget, TembaDateField
-from temba.utils.views.mixins import ModalMixin
+from temba.utils.views.mixins import ModalFormMixin
 
 from .mixins import DependencyMixin, OrgObjPermsMixin, OrgPermsMixin
 
@@ -137,7 +137,7 @@ class BaseMenuView(OrgPermsMixin, SmartTemplateView):
         return JsonResponse({"results": self.get_menu()})
 
 
-class BaseExportModal(ModalMixin, OrgPermsMixin, SmartFormView):
+class BaseExportModal(ModalFormMixin, OrgPermsMixin, SmartFormView):
     """
     Base modal view for exports
     """
@@ -262,7 +262,7 @@ class BaseUsagesModal(DependencyMixin, OrgObjPermsMixin, SmartReadView):
         return context
 
 
-class BaseDependencyDeleteModal(DependencyMixin, ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+class BaseDependencyDeleteModal(DependencyMixin, ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
     """
     Base view for delete modals of flow dependencies
     """

--- a/temba/orgs/views/views.py
+++ b/temba/orgs/views/views.py
@@ -59,7 +59,7 @@ from temba.utils.timezones import TimeZoneFormField
 from temba.utils.views.mixins import (
     ComponentFormMixin,
     ContextMenuMixin,
-    ModalMixin,
+    ModalFormMixin,
     NonAtomicMixin,
     NoNavMixin,
     PostOnlyMixin,
@@ -405,7 +405,7 @@ class UserCRUDL(SmartCRUDL):
             context["filters"] = self.filters
             return context
 
-    class Update(StaffOnlyMixin, SpaMixin, ModalMixin, ComponentFormMixin, ContextMenuMixin, SmartUpdateView):
+    class Update(StaffOnlyMixin, ModalFormMixin, ComponentFormMixin, ContextMenuMixin, SmartUpdateView):
         class Form(UserUpdateForm):
             groups = forms.ModelMultipleChoiceField(
                 widget=SelectMultipleWidget(
@@ -444,7 +444,7 @@ class UserCRUDL(SmartCRUDL):
 
             return obj
 
-    class Delete(StaffOnlyMixin, SpaMixin, ModalMixin, SmartDeleteView):
+    class Delete(StaffOnlyMixin, ModalFormMixin, SmartDeleteView):
         fields = ("id",)
         permission = "orgs.user_update"
         submit_button_name = _("Delete")
@@ -1561,7 +1561,7 @@ class OrgCRUDL(SmartCRUDL):
                 return reverse("orgs.user_update", args=[owner.pk])
             return super().lookup_field_link(context, field, obj)
 
-    class Update(StaffOnlyMixin, SpaMixin, ModalMixin, ComponentFormMixin, SmartUpdateView):
+    class Update(StaffOnlyMixin, ModalFormMixin, ComponentFormMixin, SmartUpdateView):
         ACTION_FLAG = "flag"
         ACTION_UNFLAG = "unflag"
         ACTION_SUSPEND = "suspend"
@@ -1647,7 +1647,7 @@ class OrgCRUDL(SmartCRUDL):
             obj.limits = cleaned_data["limits"]
             return obj
 
-    class DeleteChild(SpaMixin, OrgObjPermsMixin, ModalMixin, SmartDeleteView):
+    class DeleteChild(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         cancel_url = "@orgs.org_sub_orgs"
         success_url = "@orgs.org_sub_orgs"
         fields = ("id",)
@@ -1907,7 +1907,7 @@ class OrgCRUDL(SmartCRUDL):
 
             return context
 
-    class Create(NonAtomicMixin, SpaMixin, OrgPermsMixin, ModalMixin, InferOrgMixin, SmartCreateView):
+    class Create(NonAtomicMixin, ModalFormMixin, InferOrgMixin, OrgPermsMixin, SmartCreateView):
         class Form(forms.ModelForm):
             TYPE_CHILD = "child"
             TYPE_NEW = "new"
@@ -2389,7 +2389,7 @@ class OrgCRUDL(SmartCRUDL):
         def derive_exclude(self):
             return ["language"] if len(settings.LANGUAGES) == 1 else []
 
-    class EditSubOrg(SpaMixin, ModalMixin, Edit):
+    class EditSubOrg(SpaMixin, ModalFormMixin, Edit):
         success_url = "@orgs.org_sub_orgs"
 
         def get_success_url(self):
@@ -2538,7 +2538,7 @@ class InvitationCRUDL(SmartCRUDL):
     model = Invitation
     actions = ("create",)
 
-    class Create(SpaMixin, ModalMixin, OrgPermsMixin, SmartCreateView):
+    class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         class Form(forms.ModelForm):
             ROLE_CHOICES = [(r.code, r.display) for r in (OrgRole.AGENT, OrgRole.EDITOR, OrgRole.ADMINISTRATOR)]
 

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -26,7 +26,7 @@ from temba.utils.dates import datetime_to_timestamp, timestamp_to_datetime
 from temba.utils.export import response_from_workbook
 from temba.utils.fields import InputWidget
 from temba.utils.uuid import UUID_REGEX
-from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalMixin, SpaMixin
+from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalFormMixin, SpaMixin
 
 from .forms import ShortcutForm, TopicForm
 from .models import (
@@ -48,7 +48,7 @@ class ShortcutCRUDL(SmartCRUDL):
     model = Shortcut
     actions = ("create", "update", "delete", "list")
 
-    class Create(OrgPermsMixin, ComponentFormMixin, ModalMixin, SmartCreateView):
+    class Create(ComponentFormMixin, ModalFormMixin, OrgPermsMixin, SmartCreateView):
         form_class = ShortcutForm
         success_url = "@tickets.shortcut_list"
 
@@ -60,7 +60,7 @@ class ShortcutCRUDL(SmartCRUDL):
         def save(self, obj):
             return Shortcut.create(self.request.org, self.request.user, obj.name, obj.text)
 
-    class Update(OrgObjPermsMixin, ComponentFormMixin, ModalMixin, SmartUpdateView):
+    class Update(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = ShortcutForm
         success_url = "@tickets.shortcut_list"
 
@@ -69,7 +69,7 @@ class ShortcutCRUDL(SmartCRUDL):
             kwargs["org"] = self.request.org
             return kwargs
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class Delete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         default_template = "smartmin/delete_confirm.html"
         submit_button_name = _("Delete")
         fields = ("id",)
@@ -102,7 +102,7 @@ class TopicCRUDL(SmartCRUDL):
     model = Topic
     actions = ("create", "update", "delete")
 
-    class Create(OrgPermsMixin, ComponentFormMixin, ModalMixin, SmartCreateView):
+    class Create(ComponentFormMixin, ModalFormMixin, OrgPermsMixin, SmartCreateView):
         form_class = TopicForm
         success_url = "hide"
 
@@ -114,7 +114,7 @@ class TopicCRUDL(SmartCRUDL):
         def save(self, obj):
             return Topic.create(self.request.org, self.request.user, obj.name)
 
-    class Update(OrgObjPermsMixin, ComponentFormMixin, ModalMixin, SmartUpdateView):
+    class Update(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = TopicForm
         success_url = "hide"
         slug_url_kwarg = "uuid"
@@ -124,7 +124,7 @@ class TopicCRUDL(SmartCRUDL):
             kwargs["org"] = self.request.org
             return kwargs
 
-    class Delete(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+    class Delete(ModalFormMixin, OrgObjPermsMixin, SmartDeleteView):
         default_template = "smartmin/delete_confirm.html"
         submit_button_name = _("Delete")
         slug_url_kwarg = "uuid"
@@ -151,7 +151,7 @@ class TicketCRUDL(SmartCRUDL):
     model = Ticket
     actions = ("list", "update", "folder", "note", "menu", "export_stats", "export")
 
-    class Update(OrgObjPermsMixin, ComponentFormMixin, ModalMixin, SmartUpdateView):
+    class Update(ComponentFormMixin, ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         class Form(forms.ModelForm):
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)
@@ -489,7 +489,7 @@ class TicketCRUDL(SmartCRUDL):
 
             return JsonResponse(results)
 
-    class Note(ModalMixin, ComponentFormMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Note(ModalFormMixin, ComponentFormMixin, OrgObjPermsMixin, SmartUpdateView):
         """
         Creates a note for this contact
         """

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -18,7 +18,7 @@ from temba.orgs.views.base import BaseListView, BaseMenuView
 from temba.orgs.views.mixins import BulkActionMixin, OrgObjPermsMixin, OrgPermsMixin
 from temba.schedules.models import Schedule
 from temba.utils.fields import SelectMultipleWidget, SelectWidget, TembaChoiceField, TembaMultipleChoiceField
-from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalMixin, SpaMixin
+from temba.utils.views.mixins import ComponentFormMixin, ContextMenuMixin, ModalFormMixin, SpaMixin
 
 from .models import Trigger
 
@@ -370,7 +370,7 @@ class TriggerCRUDL(SmartCRUDL):
     class CreateOptOut(BaseCreate):
         trigger_type = Trigger.TYPE_OPT_OUT
 
-    class Update(ModalMixin, ComponentFormMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(ModalFormMixin, ComponentFormMixin, OrgObjPermsMixin, SmartUpdateView):
         def get_form_class(self):
             return self.object.type.form
 

--- a/temba/utils/views/mixins.py
+++ b/temba/utils/views/mixins.py
@@ -217,7 +217,7 @@ class ContextMenuMixin:
         return super().get(request, *args, **kwargs)
 
 
-class ModalMixin(SmartFormView):
+class ModalFormMixin(SmartFormView):
     """
     TODO rework this to be an actual mixin
     """


### PR DESCRIPTION
 * Rename `ModalMixin` to `ModalFormMixin` so it's clear it's not needed for non-form modals
 * Fix places it is being wrongly combined with `ContextMenuMixin` or `SpaMixin`