### PR TITLE
Create status groups with randomized names to avoid conflicts with real group names

### DIFF
--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -3686,9 +3686,6 @@ class EndpointsTest(APITest):
         # try to create another group with same name
         self.assertPost(endpoint_url, self.admin, {"name": "reporters"}, errors={"name": "This field must be unique."})
 
-        # try to create another group with same name as a system group..
-        self.assertPost(endpoint_url, self.admin, {"name": "blocked"}, errors={"name": "This field must be unique."})
-
         # it's fine if a group in another org has that name
         self.assertPost(endpoint_url, self.admin, {"name": "Spammers"}, status=201)
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1430,7 +1430,7 @@ class ContactGroup(LegacyUUIDMixin, TembaModel, DependencyMixin):
         assert not org.groups.filter(is_system=True).exists(), "org already has system groups"
 
         org.groups.create(
-            name="Active",
+            name="\\Active",  # to avoid name collisions with real groups
             group_type=ContactGroup.TYPE_DB_ACTIVE,
             is_system=True,
             status=cls.STATUS_READY,
@@ -1438,7 +1438,7 @@ class ContactGroup(LegacyUUIDMixin, TembaModel, DependencyMixin):
             modified_by=org.modified_by,
         )
         org.groups.create(
-            name="Blocked",
+            name="\\Blocked",
             group_type=ContactGroup.TYPE_DB_BLOCKED,
             is_system=True,
             status=cls.STATUS_READY,
@@ -1446,7 +1446,7 @@ class ContactGroup(LegacyUUIDMixin, TembaModel, DependencyMixin):
             modified_by=org.modified_by,
         )
         org.groups.create(
-            name="Stopped",
+            name="\\Stopped",
             group_type=ContactGroup.TYPE_DB_STOPPED,
             is_system=True,
             status=cls.STATUS_READY,
@@ -1454,7 +1454,7 @@ class ContactGroup(LegacyUUIDMixin, TembaModel, DependencyMixin):
             modified_by=org.modified_by,
         )
         org.groups.create(
-            name="Archived",
+            name="\\Archived",
             group_type=ContactGroup.TYPE_DB_ARCHIVED,
             is_system=True,
             status=cls.STATUS_READY,

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1349,10 +1349,6 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.post(url, {"name": "Customers"})
         self.assertFormError(response.context["form"], "name", "Already used by another group.")
 
-        # try to create with name that's already taken by a system group
-        response = self.client.post(url, {"name": "blocked"})
-        self.assertFormError(response.context["form"], "name", "Already used by another group.")
-
         # create with valid name (that will be trimmed)
         response = self.client.post(url, {"name": "first  "})
         self.assertNoFormErrors(response)
@@ -5017,7 +5013,7 @@ class ContactExportTest(TembaTest):
         contact5 = self.create_contact("George", urns=["tel:+1234567777"], status=Contact.STATUS_STOPPED)
 
         # export a specified status group of contacts (Stopped)
-        sheets, export = self._export(self.org.groups.get(name="Stopped"), with_groups=[group1])
+        sheets, export = self._export(self.org.groups.get(group_type="S"), with_groups=[group1])
         self.assertExcelSheet(
             sheets[0],
             [

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2477,7 +2477,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         sample_flows = set(org.flows.values_list("name", flat=True))
 
         self.assertEqual({"created_on", "last_seen_on"}, system_fields)
-        self.assertEqual({"Active", "Archived", "Blocked", "Stopped", "Open Tickets"}, system_groups)
+        self.assertEqual({"\\Active", "\\Archived", "\\Blocked", "\\Stopped", "Open Tickets"}, system_groups)
         self.assertEqual(
             {"Sample Flow - Order Status Checker", "Sample Flow - Satisfaction Survey", "Sample Flow - Simple Poll"},
             sample_flows,


### PR DESCRIPTION
All in on status groups shouldn't be actual groups