### PR TITLE
Tweak user update and delete forms to return 404 for users not in the current org

### DIFF
--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2944,6 +2944,9 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertUpdateFetch(update_url, [self.admin], form_fields={"role": "T"})
 
+        # check can't update user not in the current org
+        self.assertRequestDisallowed(reverse("orgs.user_update", args=[self.admin2.id]), [self.admin])
+
         # role field for viewers defaults to editor
         update_url = reverse("orgs.user_update", args=[self.user.id])
 
@@ -2983,6 +2986,9 @@ class UserCRUDLTest(TembaTest, CRUDLTestMixin):
         self.org.save(update_fields=("features",))
 
         self.assertRequestDisallowed(delete_url, [None, self.user, self.editor, self.agent])
+
+        # check can't delete user not in the current org
+        self.assertRequestDisallowed(reverse("orgs.user_delete", args=[self.admin2.id]), [self.admin])
 
         response = self.assertDeleteFetch(delete_url, [self.admin], as_modal=True)
         self.assertContains(

--- a/temba/orgs/views/views.py
+++ b/temba/orgs/views/views.py
@@ -396,6 +396,9 @@ class UserCRUDL(SmartCRUDL):
         def get_object_org(self):
             return self.request.org
 
+        def get_queryset(self):
+            return self.request.org.get_users()
+
         def derive_initial(self):
             # viewers default to editors
             role = self.request.org.get_user_role(self.object)
@@ -425,6 +428,9 @@ class UserCRUDL(SmartCRUDL):
 
         def get_object_org(self):
             return self.request.org
+
+        def get_queryset(self):
+            return self.request.org.get_users()
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Not critical because the only thing these views can change is the user's role in the current org.. but important to fix this in case one day we extend what can be updated here.