### PR TITLE
Fix paging on archive list pages and make styling consistent with other list views

### DIFF
--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -325,12 +325,12 @@ class ArchivesEndpoint(ListAPIMixin, BaseEndpoint):
 
     A `GET` returns the archives for your organization with the following fields.
 
-      * **archive_type** - the type of the archive, one of `message`or `run` (filterable as `archive_type`).
+      * **archive_type** - the type of the archive, one of `message` or `run` (filterable as `archive_type`).
       * **start_date** - the UTC date of the archive (string) (filterable as `before` and `after`).
       * **period** - `daily` for daily archives, `monthly` for monthly archives (filterable as `period`).
       * **record_count** - number of records in the archive (int).
-      * **size** - size of the gziped archive content (int).
-      * **hash** - MD5 hash of the gziped archive (string).
+      * **size** - size of the gzipped archive content (int).
+      * **hash** - MD5 hash of the gzipped archive (string).
       * **download_url** - temporary download URL of the archive (string).
 
     Example:
@@ -345,13 +345,13 @@ class ArchivesEndpoint(ListAPIMixin, BaseEndpoint):
             "count": 248,
             "results": [
             {
-                "archive_type":"message",
-                "start_date":"2017-02-20",
-                "period":"daily",
-                "record_count":1432,
-                "size":2304,
-                "hash":"feca9988b7772c003204a28bd741d0d0",
-                "download_url":"<redacted>"
+                "archive_type": "message",
+                "start_date": "2017-02-20",
+                "period": "daily",
+                "record_count": 1432,
+                "size": 2304,
+                "hash": "feca9988b7772c003204a28bd741d0d0",
+                "download_url": "https://..."
             },
             ...
         }

--- a/temba/archives/tests.py
+++ b/temba/archives/tests.py
@@ -204,14 +204,7 @@ class ArchiveTest(TembaTest):
 
 
 class ArchiveCRUDLTest(TembaTest, CRUDLTestMixin):
-    def test_empty_list(self):
-        response = self.assertListFetch(reverse("archives.archive_run"), [self.editor], context_objects=[])
-        self.assertContains(response, "No archives found")
-
-        response = self.assertListFetch(reverse("archives.archive_message"), [self.editor], context_objects=[])
-        self.assertContains(response, "No archives found")
-
-    def test_archive_type_filter(self):
+    def test_list_views(self):
         # a daily archive that has been rolled up and will not appear in the results
         d1 = self.create_archive(Archive.TYPE_MSG, "D", date(2020, 7, 31), [{"id": 1}, {"id": 2}])
         m1 = self.create_archive(Archive.TYPE_MSG, "M", date(2020, 7, 1), [{"id": 1}, {"id": 2}], rollup_of=(d1,))

--- a/temba/archives/views.py
+++ b/temba/archives/views.py
@@ -13,48 +13,39 @@ from .models import Archive
 class ArchiveCRUDL(SmartCRUDL):
     model = Archive
     actions = ("read", "run", "message")
-    permissions = True
 
     class BaseList(BaseListView):
-        title = _("Archive")
         fields = ("url", "start_date", "period", "record_count", "size")
         default_order = ("-start_date", "-period", "archive_type")
-        paginate_by = 250
+        default_template = "archives/archive_list.html"
 
         def derive_queryset(self, **kwargs):
-            queryset = super().derive_queryset(**kwargs)
-
-            # filter by our archive type
-            return queryset.filter(archive_type=self.get_archive_type()).exclude(rollup_id__isnull=False)
-
-        def get_context_data(self, **kwargs):
-            context = super().get_context_data(**kwargs)
-            context["archive_types"] = Archive.TYPE_CHOICES
-            context["selected"] = self.get_archive_type()
-            return context
+            # filter by our archive type and exclude archives included in rollups
+            return (
+                super()
+                .derive_queryset(**kwargs)
+                .filter(archive_type=self.get_archive_type())
+                .exclude(rollup_id__isnull=False)
+            )
 
     class Run(BaseList):
+        title = _("Run Archives")
         menu_path = "/settings/archives/run"
 
         @classmethod
         def derive_url_pattern(cls, path, action):
             return r"^%s/%s/$" % (path, Archive.TYPE_FLOWRUN)
 
-        def derive_title(self):
-            return _("Run Archives")
-
         def get_archive_type(self):
             return Archive.TYPE_FLOWRUN
 
     class Message(BaseList):
+        title = _("Message Archives")
         menu_path = "/settings/archives/message"
 
         @classmethod
         def derive_url_pattern(cls, path, action):
             return r"^%s/%s/$" % (path, Archive.TYPE_MSG)
-
-        def derive_title(self):
-            return _("Message Archives")
 
         def get_archive_type(self):
             return Archive.TYPE_MSG

--- a/temba/utils/__init__.py
+++ b/temba/utils/__init__.py
@@ -44,14 +44,6 @@ def format_number(val):
     return val
 
 
-def sizeof_fmt(num, suffix="b"):
-    for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
-        if abs(num) < 1024.0:
-            return "%3.1f %s%s" % (num, unit, suffix)
-        num /= 1024.0
-    return "%.1f %s%s" % (num, "Y", suffix)
-
-
 def chunk_list(iterable, size):
     """
     Splits a very large list into evenly sized chunks.

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -28,7 +28,6 @@ from . import (
     percentage,
     redact,
     set_nested_key,
-    sizeof_fmt,
     str_to_bool,
 )
 from .checks import storage
@@ -40,18 +39,6 @@ from .timezones import TimeZoneFormField, timezone_to_country_code
 
 
 class InitTest(TembaTest):
-    def test_sizeof_fmt(self):
-        self.assertEqual("512.0 b", sizeof_fmt(512))
-        self.assertEqual("1.0 Kb", sizeof_fmt(1024))
-        self.assertEqual("1.0 Mb", sizeof_fmt(1024**2))
-        self.assertEqual("1.0 Gb", sizeof_fmt(1024**3))
-        self.assertEqual("1.0 Tb", sizeof_fmt(1024**4))
-        self.assertEqual("1.0 Pb", sizeof_fmt(1024**5))
-        self.assertEqual("1.0 Eb", sizeof_fmt(1024**6))
-        self.assertEqual("1.0 Zb", sizeof_fmt(1024**7))
-        self.assertEqual("1.0 Yb", sizeof_fmt(1024**8))
-        self.assertEqual("1024.0 Yb", sizeof_fmt(1024**9))
-
     def test_str_to_bool(self):
         self.assertFalse(str_to_bool(None))
         self.assertFalse(str_to_bool(""))

--- a/templates/archives/archive_list.html
+++ b/templates/archives/archive_list.html
@@ -1,115 +1,41 @@
-{% extends "smartmin/list.html" %}
-{% load smartmin sms temba compress i18n humanize %}
+{% extends "orgs/base/list.html" %}
+{% load i18n humanize temba %}
 
-{% block page-title %}
-  {{ title }}
-{% endblock page-title %}
-{% block content %}
-  {% if object_list %}
-    <table class="archives list lined">
-      <thead>
-        <th>{% trans "Records" %}</th>
-        <th>{% trans "Size" %}</th>
-        <th>{% trans "Period" %}</th>
-        <th></th>
-      </thead>
-      {% for archive in object_list %}
-        <tr class="archive-row">
-          <td class="archive-record-count cell">
-            <div class="pl-6">{{ archive.record_count|intcomma }}</div>
-          </td>
-          <td class="archive-size cell whitespace-nowrap">
-            <div class="pl-32">{{ archive.size_display }}</div>
-          </td>
-          <td class="archive-period cell w-full">
-            {% if archive.period == 'D' %}
-              {{ archive.start_date|date:"M j, Y" }}
-            {% else %}
-              {{ archive.start_date|date:"F Y" }}
-            {% endif %}
-          </td>
-          <td style="--icon-color:#bbb">
-            <temba-icon clickable="true"
-                        name="download"
-                        onclick="downloadFile(event, '{% url 'archives.archive_read' archive.id %}')">
-            </temba-icon>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-  {% else %}
-    {% blocktrans trimmed %}
-      No archives found. Archives are created after 90 days of inactivity for messages and flow runs. Check back later to
-      see a list of all archives.
-    {% endblocktrans %}
-  {% endif %}
-  {% block paginator %}
-    {% if object_list.count %}
-      {% include "includes/short_pagination.html" %}
-    {% endif %}
-  {% endblock paginator %}
-{% endblock content %}
-{% block extra-style %}
-  <style type="text/css">
-    .page-content {
-      align-self: auto;
-      max-width: 1024px;
-    }
-
-    .cell {
-      overflow: clip;
-      padding: 5px 5px 5px 5px;
-
-    }
-
-    .archive-row {}
-
-    .archive-period {
-      text-align: right;
-    }
-
-    .archive-size {
-      text-align: right;
-    }
-
-    .archive-record-count {
-      width: 130px;
-      text-align: right;
-    }
-
-    .archives {
-      width: 100%;
-    }
-
-    .archive-icon {
-      width: 30px;
-      text-align: center;
-    }
-
-    thead {
-      border-top: none;
-    }
-
-    table.archives.list thead th {
-      text-align: right;
-    }
-
-    table.archives.list thead th.name {
-      text-align: left;
-    }
-
-    th.empty {
-      border: 0px solid green;
-    }
-
-    .icon {
-      color: #ddd;
-      padding-top: 2px;
-    }
-
-    .icon:hover {
-      color: #aaa;
-      cursor: pointer;
-    }
-  </style>
-{% endblock extra-style %}
+{% block table %}
+  <table class="list lined scrolled">
+    <thead>
+      <th>{% trans "Period" %}</th>
+      <th style="text-align:right">{% trans "Records" %}</th>
+      <th style="text-align:right">{% trans "Size" %}</th>
+      <th></th>
+    </thead>
+    {% for archive in object_list %}
+      <tr>
+        <td>
+          {% if archive.period == 'D' %}
+            {{ archive.start_date|date:"M j, Y" }}
+          {% else %}
+            {{ archive.start_date|date:"F Y" }}
+          {% endif %}
+        </td>
+        <td style="text-align:right">{{ archive.record_count|intcomma }}</td>
+        <td style="text-align:right">{{ archive.size_display }}</td>
+        <td class="w-10" style="--icon-color:#bbb">
+          <temba-icon clickable="true"
+                      name="download"
+                      onclick="downloadFile(event, '{% url 'archives.archive_read' archive.id %}')">
+          </temba-icon>
+        </td>
+      </tr>
+    {% empty %}
+      <tr class="empty_list">
+        <td colspan="99" class="text-center">
+          {% blocktrans trimmed %}
+            No archives found. Archives are created after 90 days of inactivity for messages and flow runs. Check back later to
+            see a list of all archives.
+          {% endblocktrans %}
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock table %}

--- a/templates/archives/archive_list.html
+++ b/templates/archives/archive_list.html
@@ -1,6 +1,13 @@
 {% extends "orgs/base/list.html" %}
 {% load i18n humanize temba %}
 
+{% block pre-table %}
+  <div class="mb-4">
+    {% blocktrans trimmed %}
+      Archives are created after 90 days of inactivity for messages and flow runs.
+    {% endblocktrans %}
+  </div>
+{% endblock pre-table %}
 {% block table %}
   <table class="list lined scrolled">
     <thead>
@@ -19,7 +26,7 @@
           {% endif %}
         </td>
         <td style="text-align:right">{{ archive.record_count|intcomma }}</td>
-        <td style="text-align:right">{{ archive.size_display }}</td>
+        <td style="text-align:right">{{ archive.size|filesizeformat }}</td>
         <td class="w-10" style="--icon-color:#bbb">
           <temba-icon clickable="true"
                       name="download"
@@ -29,12 +36,7 @@
       </tr>
     {% empty %}
       <tr class="empty_list">
-        <td colspan="99" class="text-center">
-          {% blocktrans trimmed %}
-            No archives found. Archives are created after 90 days of inactivity for messages and flow runs. Check back later to
-            see a list of all archives.
-          {% endblocktrans %}
-        </td>
+        <td colspan="99" class="text-center">{% trans "No archives" %}</td>
       </tr>
     {% endfor %}
   </table>

--- a/templates/archives/archive_message.html
+++ b/templates/archives/archive_message.html
@@ -1,1 +1,0 @@
-{% extends 'archives/archive_list.html' %}

--- a/templates/archives/archive_run.html
+++ b/templates/archives/archive_run.html
@@ -1,1 +1,0 @@
-{% extends 'archives/archive_list.html' %}


### PR DESCRIPTION
 * Use top paging like other views
 * Use same page size
 * Put period on left of table
 * Use std django filter to format size (correctly uses `MB` instead of `Mb`)

before:

<img width="566" alt="Captura de pantalla 2024-10-23 a la(s) 15 52 49" src="https://github.com/user-attachments/assets/0dc67fea-20a8-49c1-b76b-b749fb5e6a8b">
<img width="567" alt="Captura de pantalla 2024-10-23 a la(s) 15 53 03" src="https://github.com/user-attachments/assets/727cf326-05a2-416b-ba8d-be7807a48095">

after:

<img width="533" alt="Captura de pantalla 2024-10-23 a la(s) 16 09 02" src="https://github.com/user-attachments/assets/dd24cb38-9166-4c05-be61-97545bd32d71">

