### PR TITLE
Disable async activation for channel types not showing config page

### DIFF
--- a/temba/channels/types/bandwidth/type.py
+++ b/temba/channels/types/bandwidth/type.py
@@ -24,6 +24,7 @@ class BandwidthType(ChannelType):
 
     courier_url = r"^bw/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive|status)$"
     schemes = [URN.TEL_SCHEME]
+    async_activation = False
 
     claim_view = ClaimView
     claim_blurb = _("If you have an %(link)s number, you can quickly connect it using their APIs.") % {

--- a/temba/channels/types/justcall/type.py
+++ b/temba/channels/types/justcall/type.py
@@ -21,6 +21,7 @@ class JustCallType(ChannelType):
 
     courier_url = r"^jcl/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive|status)$"
     schemes = [URN.TEL_SCHEME]
+    async_activation = False
 
     claim_view = ClaimView
     claim_blurb = _("If you have a %(link)s number, you can quickly connect it using their APIs.") % {

--- a/temba/channels/types/telegram/type.py
+++ b/temba/channels/types/telegram/type.py
@@ -20,6 +20,8 @@ class TelegramType(ChannelType):
 
     courier_url = r"^tg/(?P<uuid>[a-z0-9\-]+)/receive$"
     schemes = [URN.TELEGRAM_SCHEME]
+    async_activation = False
+
     redact_response_keys = {"first_name", "last_name", "username"}
 
     claim_blurb = _(

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -29,6 +29,7 @@ class WhatsAppType(ChannelType):
 
     courier_url = r"^wac/receive"
     schemes = [URN.WHATSAPP_SCHEME]
+    async_activation = False
     template_type = "whatsapp"
 
     claim_blurb = _("If you have an enterprise WhatsApp account, you can connect it to communicate with your contacts")


### PR DESCRIPTION
The channel types do not have a config UI page so when activate fails, the channel is useless, this change will release the channel so the use can claim that again 

https://github.com/nyaruka/rapidpro/blob/a89ae1c969ae6f34b2bfad07c18814398b7b2833/temba/channels/models.py#L406-L415