### PR TITLE
Allow releasing FBA channels even if we cannot reach the API to deact…

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -645,8 +645,11 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
         # any triggers associated with our channel get archived and released
         for trigger in self.triggers.filter(is_active=True):
-            trigger.archive(user)
-            trigger.release(user)
+            try:
+                trigger.archive(user)
+                trigger.release(user)
+            except Exception as e:
+                logger.error(f"Unable to deactivate a channel trigger: {str(e)}", exc_info=True)
 
         # any open incidents are ended
         for incident in self.incidents.filter(ended_on=None):

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -647,9 +647,10 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
         for trigger in self.triggers.filter(is_active=True):
             try:
                 trigger.archive(user)
-                trigger.release(user)
             except Exception as e:
                 logger.error(f"Unable to deactivate a channel trigger: {str(e)}", exc_info=True)
+
+            trigger.release(user)
 
         # any open incidents are ended
         for incident in self.incidents.filter(ended_on=None):

--- a/temba/channels/types/facebookapp/type.py
+++ b/temba/channels/types/facebookapp/type.py
@@ -76,7 +76,7 @@ class FacebookAppType(ChannelType):
                 url, json=body, params={"access_token": access_token}, headers={"Content-Type": "application/json"}
             )
 
-            if response.status_code != 200:  # pragma: no cover
+            if response.status_code != 200:
                 raise Exception("Unable to update call to action: %s" % response.text)
 
     def get_redact_values(self, channel) -> tuple:  # pragma: needs cover


### PR DESCRIPTION
This fixes issue when releasing an FBA channel with an outdated token when a user change his password
https://textit.sentry.io/issues/6089017008/

Before, the release was just failing with raising an exception

Current, we'll log the error but continue to release the channel