### PR TITLE
Change new count model squashing to discard zero counts

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1441,9 +1441,9 @@ class FlowActivityCount(SquashableModel):
             DELETE FROM %(table)s WHERE "flow_id" = %%s AND "scope" = %%s RETURNING "count"
         )
         INSERT INTO %(table)s("flow_id", "scope", "count", "is_squashed")
-        SELECT * FROM (
-            SELECT %%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)) AS "count", TRUE
-        ) s WHERE s."count" != 0;
+        SELECT %%s, %%s, s.total, TRUE FROM (
+            SELECT COALESCE(SUM("count"), 0) AS "total" FROM removed
+        ) s WHERE s.total != 0;
         """ % {
             "table": cls._meta.db_table
         }

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1441,7 +1441,9 @@ class FlowActivityCount(SquashableModel):
             DELETE FROM %(table)s WHERE "flow_id" = %%s AND "scope" = %%s RETURNING "count"
         )
         INSERT INTO %(table)s("flow_id", "scope", "count", "is_squashed")
-        VALUES (%%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
+        SELECT * FROM (
+            SELECT %%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)) AS "count", TRUE
+        ) s WHERE s."count" != 0;
         """ % {
             "table": cls._meta.db_table
         }

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -7,6 +7,7 @@ from django_redis import get_redis_connection
 from openpyxl import load_workbook
 
 from django.core.files.storage import default_storage
+from django.db import connection
 from django.db.models.functions import TruncDate
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -34,6 +35,7 @@ from temba.utils.views.mixins import TEMBA_MENU_SELECTION
 from .checks import mailroom_url
 from .models import (
     Flow,
+    FlowActivityCount,
     FlowCategoryCount,
     FlowLabel,
     FlowNodeCount,
@@ -5639,6 +5641,8 @@ class FlowActivityCountTest(TembaTest):
         flow1.counts.create(scope="foo:1", count=1)
         flow1.counts.create(scope="foo:1", count=2)
         flow1.counts.create(scope="foo:2", count=4)
+        flow1.counts.create(scope="foo:3", count=-6)
+        flow1.counts.create(scope="foo:3", count=-1)
 
         flow2 = self.create_flow("Test 2")
         flow2.counts.create(scope="foo:1", count=7)
@@ -5649,21 +5653,22 @@ class FlowActivityCountTest(TembaTest):
 
         self.assertEqual(3, flow1.counts.filter(scope="foo:1").sum())
         self.assertEqual(4, flow1.counts.filter(scope="foo:2").sum())
-        self.assertEqual(0, flow1.counts.filter(scope="foo:3").sum())  # zero if no such scope exists
+        self.assertEqual(-7, flow1.counts.filter(scope="foo:3").sum())  # negative counts supported
+        self.assertEqual(0, flow1.counts.filter(scope="foo:4").sum())  # zero if no such scope exists
         self.assertEqual(10, flow2.counts.filter(scope="foo:1").sum())
         self.assertEqual(0, flow2.counts.filter(scope="foo:2").sum())
         self.assertEqual(5, flow2.counts.filter(scope="foo:3").sum())
 
         squash_activity_counts()
 
-        self.assertEqual({"foo:1", "foo:2"}, set(flow1.counts.values_list("scope", flat=True)))
+        self.assertEqual({"foo:1", "foo:2", "foo:3"}, set(flow1.counts.values_list("scope", flat=True)))
 
         # flow2/foo:2 should be gone because it squashed to zero
         self.assertEqual({"foo:1", "foo:3"}, set(flow2.counts.values_list("scope", flat=True)))
 
         self.assertEqual(3, flow1.counts.filter(scope="foo:1").sum())
         self.assertEqual(4, flow1.counts.filter(scope="foo:2").sum())
-        self.assertEqual(0, flow1.counts.filter(scope="foo:3").sum())
+        self.assertEqual(-7, flow1.counts.filter(scope="foo:3").sum())
         self.assertEqual(10, flow2.counts.filter(scope="foo:1").sum())
         self.assertEqual(0, flow2.counts.filter(scope="foo:2").sum())
         self.assertEqual(5, flow2.counts.filter(scope="foo:3").sum())
@@ -5674,6 +5679,13 @@ class FlowActivityCountTest(TembaTest):
 
         # flow2/foo:3 should be gone because it squashed to zero
         self.assertEqual({"foo:1"}, set(flow2.counts.values_list("scope", flat=True)))
+
+        # test that model being asked to squash a set that matches no rows doesn't insert anytihng
+        with connection.cursor() as cursor:
+            sql, params = FlowActivityCount.get_squash_query(FlowActivityCount(flow_id=flow1.id, scope="foo:9"))
+            cursor.execute(sql, params)
+
+        self.assertEqual({"foo:1", "foo:2", "foo:3"}, set(flow1.counts.values_list("scope", flat=True)))
 
 
 class BackfillEngagementCountsTest(MigrationTest):

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1892,9 +1892,9 @@ class ItemCount(SquashableModel):
             DELETE FROM %(table)s WHERE "org_id" = %%s AND "scope" = %%s RETURNING "count"
         )
         INSERT INTO %(table)s("org_id", "scope", "count", "is_squashed")
-        SELECT * FROM (
-            SELECT %%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)) AS "count", TRUE
-        ) s WHERE s."count" != 0;
+        SELECT %%s, %%s, s.total, TRUE FROM (
+            SELECT COALESCE(SUM("count"), 0) AS "total" FROM removed
+        ) s WHERE s.total != 0;
         """ % {
             "table": cls._meta.db_table
         }

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1892,7 +1892,9 @@ class ItemCount(SquashableModel):
             DELETE FROM %(table)s WHERE "org_id" = %%s AND "scope" = %%s RETURNING "count"
         )
         INSERT INTO %(table)s("org_id", "scope", "count", "is_squashed")
-        VALUES (%%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)), TRUE);
+        SELECT * FROM (
+            SELECT %%s, %%s, GREATEST(0, (SELECT SUM("count") FROM removed)) AS "count", TRUE
+        ) s WHERE s."count" != 0;
         """ % {
             "table": cls._meta.db_table
         }

--- a/temba/tickets/tests.py
+++ b/temba/tickets/tests.py
@@ -246,16 +246,10 @@ class TicketTest(TembaTest):
 
         squash_item_counts()
 
-        # check new count model raw values are consistent
+        # check count model raw values are consistent
         self.assertEqual(
             {
-                f"tickets:C:{general.id}:{self.admin.id}": 0,
-                f"tickets:C:{general.id}:{self.agent.id}": 0,
-                f"tickets:C:{cats.id}:0": 0,
-                f"tickets:C:{cats.id}:{self.admin.id}": 0,
-                f"tickets:O:{general.id}:0": 0,
                 f"tickets:O:{general.id}:{self.editor.id}": 1,
-                f"tickets:O:{general.id}:{self.agent.id}": 0,
                 f"tickets:O:{cats.id}:0": 1,
                 f"tickets:O:{cats.id}:{self.admin.id}": 1,
             },


### PR DESCRIPTION
We're about to move node counts to the new count model and they have a special property - they all end up zero, and zero is already representable in the count model as non-existence. So let's not even store zeros.