### PR TITLE
Remove input/text columns from results exports

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1652,7 +1652,6 @@ class ResultsExport(ExportType):
             field_name, flow_name = result_field["name"], result_field["flow_name"]
             columns.append(f"{field_name} (Category) - {flow_name}")
             columns.append(f"{field_name} (Value) - {flow_name}")
-            columns.append(f"{field_name} (Text) - {flow_name}")
 
         return columns
 
@@ -1793,8 +1792,7 @@ class ResultsExport(ExportType):
                     node_result = results_by_key.get(result_field["key"], {})
                 node_category = node_result.get("category", "")
                 node_value = node_result.get("value", "")
-                node_input = node_result.get("input", "")
-                result_values += [node_category, node_value, node_input]
+                result_values += [node_category, node_value]
 
             # build the whole row
             runs_sheet_row = contact_values

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -3573,7 +3573,7 @@ class ResultsExportTest(TembaTest):
 
         # check runs sheet...
         self.assertEqual(6, len(list(sheet_runs.rows)))  # header + 5 runs
-        self.assertEqual(12, len(list(sheet_runs.columns)))
+        self.assertEqual(11, len(list(sheet_runs.columns)))
 
         self.assertExcelRow(
             sheet_runs,
@@ -3590,7 +3590,6 @@ class ResultsExportTest(TembaTest):
                 "Run UUID",
                 "Color (Category) - Colors",
                 "Color (Value) - Colors",
-                "Color (Text) - Colors",
             ],
         )
 
@@ -3607,7 +3606,6 @@ class ResultsExportTest(TembaTest):
                 contact3_run1.modified_on,
                 "",
                 contact3_run1.uuid,
-                "",
                 "",
                 "",
             ],
@@ -3629,7 +3627,6 @@ class ResultsExportTest(TembaTest):
                 contact1_run1.uuid,
                 "Orange",
                 "orange",
-                "orange",
             ],
             tz,
         )
@@ -3649,7 +3646,6 @@ class ResultsExportTest(TembaTest):
                 contact2_run1.uuid,
                 "Other",
                 "green",
-                "green",
             ],
             tz,
         )
@@ -3667,7 +3663,6 @@ class ResultsExportTest(TembaTest):
                 contact2_run2.modified_on,
                 "",
                 contact2_run2.uuid,
-                "",
                 "",
                 "",
             ],
@@ -3689,7 +3684,6 @@ class ResultsExportTest(TembaTest):
                 contact1_run2.uuid,
                 "Blue",
                 "blue",
-                " blue ",
             ],
             tz,
         )
@@ -3708,7 +3702,7 @@ class ResultsExportTest(TembaTest):
         sheet_runs = workbook.worksheets[0]
 
         self.assertEqual(4, len(list(sheet_runs.rows)))  # header + 3 runs
-        self.assertEqual(12, len(list(sheet_runs.columns)))
+        self.assertEqual(11, len(list(sheet_runs.columns)))
 
         self.assertExcelRow(
             sheet_runs,
@@ -3725,7 +3719,6 @@ class ResultsExportTest(TembaTest):
                 "Run UUID",
                 "Color (Category) - Colors",
                 "Color (Value) - Colors",
-                "Color (Text) - Colors",
             ],
         )
 
@@ -3743,7 +3736,6 @@ class ResultsExportTest(TembaTest):
                 contact1_run1.exited_on,
                 contact1_run1.uuid,
                 "Orange",
-                "orange",
                 "orange",
             ],
             tz,
@@ -3763,7 +3755,6 @@ class ResultsExportTest(TembaTest):
                 contact2_run1.exited_on,
                 contact2_run1.uuid,
                 "Other",
-                "green",
                 "green",
             ],
             tz,
@@ -3786,7 +3777,7 @@ class ResultsExportTest(TembaTest):
 
         # check runs sheet...
         self.assertEqual(4, len(list(sheet_runs.rows)))  # header + 3 runs
-        self.assertEqual(15, len(list(sheet_runs.columns)))
+        self.assertEqual(14, len(list(sheet_runs.columns)))
 
         self.assertExcelRow(
             sheet_runs,
@@ -3806,7 +3797,6 @@ class ResultsExportTest(TembaTest):
                 "Run UUID",
                 "Color (Category) - Colors",
                 "Color (Value) - Colors",
-                "Color (Text) - Colors",
             ],
         )
 
@@ -3827,7 +3817,6 @@ class ResultsExportTest(TembaTest):
                 contact1_run1.exited_on,
                 contact1_run1.uuid,
                 "Orange",
-                "orange",
                 "orange",
             ],
             tz,
@@ -3851,7 +3840,7 @@ class ResultsExportTest(TembaTest):
 
         # check runs sheet...
         self.assertEqual(6, len(list(sheet_runs.rows)))  # header + 5 runs
-        self.assertEqual(11, len(list(sheet_runs.columns)))
+        self.assertEqual(10, len(list(sheet_runs.columns)))
 
     def test_anon_org(self):
         today = timezone.now().astimezone(self.org.timezone).date()
@@ -3894,7 +3883,6 @@ class ResultsExportTest(TembaTest):
                     "Run UUID",
                     "Color (Category) - Colors",
                     "Color (Value) - Colors",
-                    "Color (Text) - Colors",
                 ],
             )
 
@@ -3911,7 +3899,6 @@ class ResultsExportTest(TembaTest):
                     run1.exited_on,
                     run1.uuid,
                     "Orange",
-                    "orange",
                     "orange",
                 ],
                 self.org.timezone,
@@ -4165,7 +4152,7 @@ class ResultsExportTest(TembaTest):
 
         # check runs sheet...
         self.assertEqual(6, len(list(sheet_runs.rows)))  # header + 5 runs
-        self.assertEqual(18, len(list(sheet_runs.columns)))
+        self.assertEqual(15, len(list(sheet_runs.columns)))
 
         self.assertExcelRow(
             sheet_runs,
@@ -4182,13 +4169,10 @@ class ResultsExportTest(TembaTest):
                 "Run UUID",
                 "Color (Category) - Favorites",
                 "Color (Value) - Favorites",
-                "Color (Text) - Favorites",
                 "Beer (Category) - Favorites",
                 "Beer (Value) - Favorites",
-                "Beer (Text) - Favorites",
                 "Name (Category) - Favorites",
                 "Name (Value) - Favorites",
-                "Name (Text) - Favorites",
             ],
         )
 
@@ -4205,9 +4189,6 @@ class ResultsExportTest(TembaTest):
                 contact3_run1.modified_on,
                 "",
                 contact3_run1.uuid,
-                "",
-                "",
-                "",
                 "",
                 "",
                 "",
@@ -4233,9 +4214,6 @@ class ResultsExportTest(TembaTest):
                 contact1_run1.uuid,
                 "Red",
                 "red",
-                "red",
-                "",
-                "",
                 "",
                 "",
                 "",
@@ -4259,9 +4237,6 @@ class ResultsExportTest(TembaTest):
                 contact2_run1.uuid,
                 "Green",
                 "green",
-                "green",
-                "",
-                "",
                 "",
                 "",
                 "",
@@ -4289,9 +4264,6 @@ class ResultsExportTest(TembaTest):
                 "",
                 "",
                 "",
-                "",
-                "",
-                "",
             ],
             tz,
         )
@@ -4311,9 +4283,6 @@ class ResultsExportTest(TembaTest):
                 contact1_run2.uuid,
                 "Blue",
                 "blue",
-                " blue ",
-                "",
-                "",
                 "",
                 "",
                 "",
@@ -4365,7 +4334,6 @@ class ResultsExportTest(TembaTest):
                 "",
                 run1.uuid,
                 "Other",
-                "ngertin.",
                 "ngertin.",
             ],
             tz,
@@ -4484,7 +4452,6 @@ class ResultsExportTest(TembaTest):
                 contact1_run.uuid,
                 "Other",
                 "green",
-                "green",
             ],
             tz,
         )
@@ -4502,7 +4469,6 @@ class ResultsExportTest(TembaTest):
                 contact2_run.uuid,
                 "Blue",
                 "blue",
-                "blue",
             ],
             tz,
         )
@@ -4518,7 +4484,6 @@ class ResultsExportTest(TembaTest):
                 contact3_run.modified_on,
                 "",
                 contact3_run.uuid,
-                "",
                 "",
                 "",
             ],


### PR DESCRIPTION
This is almost always the message text and in the case of open ended questions it just repeats the result value.

I'd like to remove this and see what pushback we get if any.