### PR TITLE
Don't require real mailroom flow inspection when using @mock_mailroom

### DIFF
--- a/temba/contacts/tests/test_fieldcrudl.py
+++ b/temba/contacts/tests/test_fieldcrudl.py
@@ -265,12 +265,12 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
 
     @mock_mailroom
     def test_usages(self, mr_mocks):
-        flow = self.get_flow("dependencies", name="Dependencies")
-        field = ContactField.user_fields.filter(is_active=True, org=self.org, key="favorite_cat").get()
-        field.value_type = ContactField.TYPE_DATETIME
-        field.save(update_fields=("value_type",))
+        field = self.create_field("joined", "Joined", value_type="D")
 
-        group = self.create_group("Farmers", query='favorite_cat != ""')
+        flow = self.create_flow("Flow")
+        flow.field_dependencies.add(field)
+
+        group = self.create_group("Farmers", query='joined != ""')
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", group)
 
         # create flow events

--- a/temba/contacts/tests/test_groupcrudl.py
+++ b/temba/contacts/tests/test_groupcrudl.py
@@ -207,8 +207,10 @@ class ContactGroupCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(404, response.status_code)
 
     def test_usages(self):
-        flow = self.get_flow("dependencies", name="Dependencies")
-        group = ContactGroup.objects.get(name="Cat Facts")
+        group = self.create_group("Cat Facts")
+
+        flow = self.create_flow("Flow")
+        flow.group_dependencies.add(group)
 
         campaign1 = Campaign.create(self.org, self.admin, "Planting Reminders", group)
         campaign2 = Campaign.create(self.org, self.admin, "Deleted", group)

--- a/temba/flows/tests/test_export.py
+++ b/temba/flows/tests/test_export.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from temba.archives.models import Archive
 from temba.contacts.models import Contact, ContactURN
-from temba.flows.models import Flow, FlowRun, ResultsExport
+from temba.flows.models import FlowRun, ResultsExport
 from temba.orgs.models import Export
 from temba.tests import TembaTest, mock_mailroom
 from temba.tests.engine import MockSessionWriter
@@ -72,15 +72,21 @@ class ResultsExportTest(TembaTest):
         color_other = flow_nodes[3]
         orange_reply = flow_nodes[1]
 
-        # add a spec for a hidden result to this flow
-        flow.metadata[Flow.METADATA_RESULTS].append(
+        flow.metadata["results"] = [
+            {
+                "key": "color",
+                "name": "Color",
+                "categories": ["Orange", "Blue", "Other", "Nothing"],
+                "node_uuids": [color_split["uuid"]],
+            },
             {
                 "key": "_color_classification",
                 "name": "_Color Classification",
                 "categories": ["Success", "Skipped", "Failure"],
-                "node_uuids": [color_split["uuid"]],
-            }
-        )
+                "node_uuids": ["773698ef-d512-477b-a404-437a2aa5b1c9"],
+            },
+        ]
+        flow.save(update_fields=("metadata",))
 
         age = self.create_field("age", "Age")
         devs = self.create_group("Devs", [self.contact])

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1132,9 +1132,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.channel.save()
 
         # clear dependencies, this will cause our flow to look like it isn't using templates
-        metadata = flow.metadata
-        flow.metadata = {}
-        flow.save(update_fields=["metadata"])
+        flow.metadata["dependencies"] = []
+        flow.save(update_fields=("metadata",))
 
         mr_mocks.flow_start_preview(query="age > 30", total=2)
         response = self.client.post(
@@ -1152,9 +1151,11 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             ],
         )
 
-        # restore our dependency
-        flow.metadata = metadata
-        flow.save(update_fields=["metadata"])
+        # make it look like we are using a template, but it doesn't exist
+        flow.metadata["dependencies"] = [
+            {"type": "template", "uuid": "f712e05c-bbed-40f1-b3d9-671bb9b60775", "name": "affirmation"}
+        ]
+        flow.save(update_fields=("metadata",))
 
         # template doesn't exit, will be warned
         mr_mocks.flow_start_preview(query="age > 30", total=2)

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -300,9 +300,12 @@ class TestClient(MailroomClient):
         if self.mocks._flow_inspect:
             return self.mocks._flow_inspect.pop(0)
 
-        # fall back to the real client - note that this why mailroom has to be running during tests
-        # and is something we might want to change in the future
-        return super().flow_inspect(org, definition)
+        return {
+            "dependencies": [],
+            "issues": [],
+            "results": [],
+            "parent_refs": [],
+        }
 
     @_client_method
     def flow_start_preview(self, org, flow, include, exclude):


### PR DESCRIPTION
Part 1 of getting rid of needing real mailroom to run unit tests