### PR TITLE
Ensure that SQL app migrations run after other apps

### DIFF
--- a/temba/sql/migrations/0007_squashed.py
+++ b/temba/sql/migrations/0007_squashed.py
@@ -7,6 +7,10 @@ from . import InstallSQL
 
 class Migration(migrations.Migration):
 
-    dependencies = []
+    dependencies = [
+        ("notifications", "0031_squashed"),
+        ("locations", "0032_squashed"),
+        ("tickets", "0074_squashed"),
+    ]
 
     operations = [InstallSQL("0007_functions"), InstallSQL("0007_triggers")]


### PR DESCRIPTION
Hopefully migrations run in the same order for everyone in 10.0.x otherwise this might be something that needs backported