### PR TITLE
Simplify validation of params field on flow starts endpoint to allow any JSON object up to 10K chars when encoded

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -8,8 +8,6 @@ import pycountry
 import regex
 from rest_framework import serializers
 
-from django.conf import settings
-
 from temba import mailroom
 from temba.archives.models import Archive
 from temba.campaigns.models import Campaign, CampaignEvent
@@ -31,6 +29,7 @@ from ..validators import UniqueForOrgValidator
 from . import fields
 
 INVALID_EXTRA_KEY_CHARS = regex.compile(r"[^a-zA-Z0-9_]")
+FLOW_START_EXTRA_SIZE = 256  # used for extra passed to flow start API endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ def _normalize_extra(extra, count):
         for k, v in extra.items():
             (normalized[normalize_key(k)], count) = _normalize_extra(v, count)
 
-            if count >= settings.FLOW_START_PARAMS_SIZE:
+            if count >= FLOW_START_EXTRA_SIZE:
                 break
 
         return normalized, count
@@ -78,7 +77,7 @@ def _normalize_extra(extra, count):
         for i, v in enumerate(extra):
             (normalized[str(i)], count) = _normalize_extra(v, count)
 
-            if count >= settings.FLOW_START_PARAMS_SIZE:
+            if count >= FLOW_START_EXTRA_SIZE:
                 break
 
         return normalized, count
@@ -1135,6 +1134,8 @@ class FlowStartReadSerializer(ReadSerializer):
 
 
 class FlowStartWriteSerializer(WriteSerializer):
+    PARAMS_MAX_LENGTH = 10_000
+
     flow = fields.FlowField()
     contacts = fields.ContactField(many=True, required=False)
     groups = fields.ContactGroupField(many=True, required=False)
@@ -1153,7 +1154,13 @@ class FlowStartWriteSerializer(WriteSerializer):
         return normalize_extra(value)
 
     def validate_params(self, value):
-        return self.validate_extra(value)
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Must be a valid JSON object")
+
+        if len(json.dumps(value)) > self.PARAMS_MAX_LENGTH:
+            raise serializers.ValidationError("Cannot exceed 10,000 characters encoded.")
+
+        return value
 
     def validate(self, data):
         # need at least one of urns, groups or contacts

--- a/temba/api/v2/tests/test_base.py
+++ b/temba/api/v2/tests/test_base.py
@@ -44,7 +44,7 @@ class EndpointsTest(APITest):
         )
         self.assertContains(response, "Server Error. Site administrators have been notified.", status_code=500)
 
-    @override_settings(FLOW_START_PARAMS_SIZE=4)
+    @patch("temba.api.v2.serializers.FLOW_START_EXTRA_SIZE", 4)
     def test_normalize_extra(self):
         self.assertEqual(OrderedDict(), normalize_extra({}))
         self.assertEqual(

--- a/temba/api/v2/tests/test_flow_starts.py
+++ b/temba/api/v2/tests/test_flow_starts.py
@@ -161,7 +161,7 @@ class FlowStartsEndpointTest(APITest):
             errors={"params": "Must be a valid JSON object"},
         )
 
-        # a list is valid JSON, but extra has to be a dict
+        # a list is valid JSON, but params has to be a dict
         self.assertPost(
             endpoint_url,
             self.admin,
@@ -174,6 +174,21 @@ class FlowStartsEndpointTest(APITest):
                 "params": [1],
             },
             errors={"params": "Must be a valid JSON object"},
+        )
+
+        # params can be at most 10K characters encoded
+        self.assertPost(
+            endpoint_url,
+            self.admin,
+            {
+                "urns": ["tel:+12067791212"],
+                "contacts": [joe.uuid],
+                "groups": [hans_group.uuid],
+                "flow": flow.uuid,
+                "restart_participants": False,
+                "params": {"foo": "a" * 10000},
+            },
+            errors={"params": "Cannot exceed 10,000 characters encoded."},
         )
 
         # invalid URN

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -3092,7 +3092,7 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
      * **urns** - the URNs you want to start in this flow (array of up to 100 strings, optional)
      * **restart_participants** - whether to restart participants already in this flow (optional, defaults to true)
      * **exclude_active** - whether to exclude contacts currently in other flow (optional, defaults to false)
-     * **params** - extra parameters to pass to the flow start (object, accessible via `@trigger.params` in the flow)
+     * **params** - extra parameters to pass to the flow start (object, must be at most 10K characters, accessible via `@trigger.params` in the flow)
 
     Example:
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -850,7 +850,6 @@ MAILROOM_AUTH_TOKEN = None
 # -----------------------------------------------------------------------------------
 
 MSG_FIELD_SIZE = 640  # used for broadcast text, message text, and message campaign events
-FLOW_START_PARAMS_SIZE = 256  # used for params passed to flow start API endpoint
 GLOBAL_VALUE_SIZE = 10_000  # max length of global values
 
 ORG_LIMIT_DEFAULTS = {


### PR DESCRIPTION
The current logic is trims the number of keys, the values within those keys etc, and is too complicated to explain on the endpoint docs page.

We still support the old field name `extra` and I've left that with the existing validation logic in case anyone absolutely needs it to work that way.