### PR TITLE
Revert "Remove no longer needed custom auth backend"

### DIFF
--- a/temba/orgs/backend.py
+++ b/temba/orgs/backend.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.backends import ModelBackend
+
+from temba.users.models import User
+
+
+class AuthenticationBackend(ModelBackend):
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        try:
+            user = User.objects.get(username__iexact=username)
+            if user.check_password(password):
+                return user
+            else:
+                return None
+        except User.DoesNotExist:
+            # Run the default password hasher once to reduce the timing
+            # difference between an existing and a non-existing user (#20760).
+            User().set_password(password)
+
+    def get_user(self, user_id):
+        try:
+            user = User.objects.get(id=user_id)
+        except User.DoesNotExist:  # pragma: no cover
+            return None
+        return user if self.user_can_authenticate(user) else None

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -613,6 +613,8 @@ API_PERMISSIONS = {
 LOGIN_URL = "/users/login/"
 LOGIN_REDIRECT_URL = "/org/choose/"
 
+AUTHENTICATION_BACKENDS = ("temba.orgs.backend.AuthenticationBackend",)
+
 AUTH_USER_MODEL = "users.User"
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator", "OPTIONS": {"min_length": 8}},


### PR DESCRIPTION
oops turns out we've always looked up usernames case insensitively