### PR TITLE
Improve campaign read page and include contact fire count wtih events

### DIFF
--- a/temba/campaigns/tests/test_campaign.py
+++ b/temba/campaigns/tests/test_campaign.py
@@ -49,7 +49,9 @@ class CampaignTest(TembaTest):
 
         self.assertEqual("Reminders", campaign.name)
         self.assertEqual("Reminders", str(campaign))
-        self.assertEqual(f'<Event: id={event1.id} relative_to=planting_date offset=1 flow="Test Flow">', repr(event1))
+        self.assertEqual(
+            f'<Event: id={event1.id} relative_to=planting_date offset=7 days, 0:00:00 flow="Test Flow">', repr(event1)
+        )
         self.assertEqual([event1, event2], list(campaign.get_events()))
         self.assertEqual(None, event1.get_message(contact))
         self.assertEqual("Hello", event2.get_message(contact))
@@ -122,33 +124,23 @@ class CampaignTest(TembaTest):
     def test_get_sorted_events(self):
         # create a campaign
         campaign = Campaign.create(self.org, self.editor, "Planting Reminders", self.farmers)
-
+        joined_on = self.create_field("joined_on", "Joined On", value_type=ContactField.TYPE_DATETIME)
         flow = self.create_flow("Test 1")
 
         event1 = CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, self.planting_date, offset=1, unit="W", flow=flow, delivery_hour="13"
+            self.org, self.admin, campaign, self.planting_date, offset=8, unit="D", flow=flow
         )
         event2 = CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, self.planting_date, offset=1, unit="W", flow=flow, delivery_hour="9"
+            self.org, self.admin, campaign, self.planting_date, offset=3, unit="D", flow=flow
         )
         event3 = CampaignEvent.create_flow_event(
-            self.org, self.admin, campaign, self.planting_date, offset=2, unit="W", flow=flow, delivery_hour="1"
+            self.org, self.admin, campaign, self.planting_date, offset=1, unit="W", flow=flow
         )
-
-        self.assertEqual(campaign.get_sorted_events(), [event2, event1, event3])
-
         event4 = CampaignEvent.create_flow_event(
-            self.org,
-            self.admin,
-            campaign,
-            self.planting_date,
-            offset=2,
-            unit="W",
-            flow=self.create_flow("Test 2"),
-            delivery_hour="5",
+            self.org, self.admin, campaign, joined_on, offset=24, unit="H", flow=flow
         )
 
-        self.assertEqual(campaign.get_sorted_events(), [event2, event1, event3, event4])
+        self.assertEqual(campaign.get_sorted_events(), [event4, event2, event3, event1])
 
     def test_message_event(self):
         # create a campaign with a message event 1 day after planting date

--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -27,40 +27,42 @@
   {% endif %}
 {% endblock post-title %}
 {% block content %}
-  {% if not object.events.all %}
-    <table class="list">
-      <body>
-        <tr class="empty_list">
-          <td>{% trans "No events in this campaign yet." %}</td>
-        </tr>
-      </body>
-    </table>
-  {% else %}
-    <table class="list">
+  <table class="list lined">
+    <thead>
+      <tr>
+        <th>{% trans "Field" %}</th>
+        <th>{% trans "When" %}</th>
+        <th></th>
+        <th>{% trans "Contacts" %}</th>
+      </tr>
+    </thead>
+    <tbody>
       {% for event in object.get_sorted_events %}
-        {% ifchanged %}
-          <tr>
-            <th colspan="99">{{ event.relative_to }}</th>
-          </tr>
-        {% endifchanged %}
-        <tr valign="center" data-event-id="{{ event.pk }}" class="campaign-event">
-          <td class="whitespace-nowrap">
-            <a href="{% url 'campaigns.campaignevent_read' event.campaign.uuid event.pk %}" class="linked">{{ event.offset_display }} {{ event.relative_to.name }}</a>
-          </td>
+        <tr onclick="goto(event, this)"
+            href="{% url 'campaigns.campaignevent_read' event.campaign.uuid event.id %}"
+            class="hover-linked">
+          <td class="whitespace-nowrap">{{ event.relative_to.name }}</td>
+          <td class="whitespace-nowrap">{{ event.offset_display }}</td>
           <td class="w-full">
             {% if event.event_type == 'M' %}
               <div class="message">
                 <div class="text">{{ event.get_message }}</div>
               </div>
             {% else %}
-              <div class="start-flow">
-                Start
-                <a href="{% url 'flows.flow_editor' event.flow.uuid %}" class="linked">{{ event.flow.name }}</a>
-              </div>
+              <a href="{% url 'flows.flow_editor' event.flow.uuid %}" onclick="goto(event, this)">
+                <temba-label icon="flow" primary clickable>
+                  {{ event.flow.name }}
+                </temba-label>
+              </a>
             {% endif %}
           </td>
+          <td class="whitespace-nowrap text-right">{{ event.get_fire_count|intcomma }}</td>
+        </tr>
+      {% empty %}
+        <tr class="empty_list">
+          <td colspan="99" class="text-center">{% trans "No events" %}</td>
         </tr>
       {% endfor %}
-    </table>
-  {% endif %}
+    </tbody>
+  </table>
 {% endblock content %}


### PR DESCRIPTION
* Whole row is clickable (norm in UI)
* Use button treatment for flow like trigger UI
* Includes contact fire count

before: 

<img width="798" alt="Screenshot 2025-03-11 at 11 16 07 AM" src="https://github.com/user-attachments/assets/573381ac-8354-4144-a387-66fa78023cf4" />

after:

<img width="797" alt="Screenshot 2025-03-11 at 11 14 46 AM" src="https://github.com/user-attachments/assets/799b6aec-1eff-433d-8818-399de73891bb" />
