### PR TITLE
Improve campaign event read page and prefetch fire counts

### DIFF
--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -181,13 +181,16 @@ class Campaign(TembaModel):
             campaign.schedule_async()
 
     def get_events(self):
-        return self.events.filter(is_active=True).order_by("id").select_related("flow", "relative_to")
+        return self.events.filter(is_active=True).select_related("flow", "relative_to")
 
     def get_sorted_events(self):
         """
-        Returns events sorted by relative_to and offset
+        Gets events sorted by relative_to+offset and with fire counts prefetched.
         """
-        return sorted(self.get_events(), key=lambda e: (e.relative_to.name, e.get_offset()))
+
+        events = sorted(self.get_events(), key=lambda e: (e.relative_to.name, e.get_offset()))
+        self.prefetch_fire_counts(events)
+        return events
 
     def prefetch_fire_counts(self, events):
         """

--- a/temba/campaigns/tests/test_event.py
+++ b/temba/campaigns/tests/test_event.py
@@ -78,7 +78,7 @@ class CampaignEventTest(TembaTest):
         self.assertEqual(1, event2.get_fire_count())
 
         # can also be prefetched
-        events = campaign.get_events()
+        events = campaign.get_events().order_by("id")
         campaign.prefetch_fire_counts(events)
 
         self.assertEqual(2, events[0].get_fire_count())

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -148,6 +148,11 @@ class CampaignCRUDL(SmartCRUDL):
                 if self.has_org_perm("campaigns.campaign_archive"):
                     menu.add_url_post(_("Archive"), reverse("campaigns.campaign_archive", args=[obj.id]))
 
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+            context["events"] = self.object.get_sorted_events()
+            return context
+
     class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         fields = ("name", "group")
         form_class = CampaignForm
@@ -466,12 +471,11 @@ class CampaignEventCRUDL(SmartCRUDL):
     )
 
     class Read(SpaMixin, OrgObjPermsMixin, ContextMenuMixin, SmartReadView):
+        title = _("Event History")
+
         @classmethod
         def derive_url_pattern(cls, path, action):
             return r"^%s/%s/(?P<campaign_uuid>[0-9a-f-]+)/(?P<pk>\d+)/$" % (path, action)
-
-        def derive_title(self):
-            return _("Event History")
 
         def derive_menu_path(self):
             return f"/campaign/{'archived' if self.get_object().campaign.is_archived else 'active'}/"
@@ -500,6 +504,7 @@ class CampaignEventCRUDL(SmartCRUDL):
                     "event-update",
                     reverse("campaigns.campaignevent_update", args=[obj.id]),
                     title=_("Edit Event"),
+                    as_button=True,
                 )
 
             if self.has_org_perm("campaigns.campaignevent_delete"):

--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -37,7 +37,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for event in object.get_sorted_events %}
+      {% for event in events %}
         <tr onclick="goto(event, this)"
             href="{% url 'campaigns.campaignevent_read' event.campaign.uuid event.id %}"
             class="hover-linked">
@@ -56,7 +56,13 @@
               </a>
             {% endif %}
           </td>
-          <td class="whitespace-nowrap text-right">{{ event.get_fire_count|intcomma }}</td>
+          <td class="whitespace-nowrap text-right">
+            {% if event.status == 'S' %}
+              <span class="text-gray-400">{% trans "Scheduling" %}</span>
+            {% else %}
+              {{ event.get_fire_count|intcomma }}
+            {% endif %}
+          </td>
         </tr>
       {% empty %}
         <tr class="empty_list">

--- a/templates/campaigns/campaignevent_read.html
+++ b/templates/campaigns/campaignevent_read.html
@@ -1,11 +1,23 @@
 {% extends "smartmin/read.html" %}
 {% load smartmin sms temba humanize contacts i18n %}
 
-{% block subtitle %}
-  <div class="event-details p-4 bg-gray-200 rounded-lg mt-4">{{ object.offset_display }} {{ object.relative_to.name }}</div>
-{% endblock subtitle %}
 {% block content %}
-  <div class="event-details p-4 bg-gray-200 rounded-lg mb-6">
+  {% if object.status == 'S' %}
+    <temba-alert level="info" class="mb-4">
+      {% trans "This event is currently being scheduled and can't be edited again until that completes." %}
+    </temba-alert>
+  {% endif %}
+  <div class="flex mb-4">
+    <div class="flex-1 p-4 bg-gray-200 rounded-lg mr-4">
+      <temba-icon name="schedule" class="inline-block mr-2">
+      </temba-icon>
+      {{ object.offset_display }} <b>{{ object.relative_to.name }}</b>
+    </div>
+    <div class="flex-1 p-4 bg-gray-200 rounded-lg">
+      <b>{{ object.get_fire_count|intcomma }}</b> scheduled contacts
+    </div>
+  </div>
+  <div class="event-details p-4 bg-gray-200 rounded-lg mb-4">
     {% if object.event_type == 'M' %}
       <div class="cap-label">{% trans "Send Message" %}</div>
       <div class="text-gray-600">{{ object.get_message }}</div>
@@ -16,15 +28,15 @@
       </div>
     {% endif %}
   </div>
-  <table class="list">
+  <table class="list lined">
     <thead>
       <tr>
-        <th colspan="99">{% trans "Recent Events" %}</th>
+        <th colspan="99">{% trans "Recent Contacts" %}</th>
       </tr>
     </thead>
     <tbody>
       {% for fire in recent_fires %}
-        <tr class="event_fire">
+        <tr>
           <td>
             <a href="{% url 'contacts.contact_read' fire.contact.uuid %}" class="name linked">{{ fire.contact.name }}</a>
           </td>
@@ -38,65 +50,3 @@
     </tbody>
   </table>
 {% endblock content %}
-{% block extra-style %}
-  {{ block.super }}
-  <style type="text/css">
-    h2 a {
-      text-decoration: none;
-      color: inherit;
-    }
-
-    h2 a:hover {
-      text-decoration: none;
-      color: inherit;
-    }
-
-    h4 {
-      margin-bottom: 6px;
-    }
-
-    .total {
-      color: #999;
-      font-size: 12px;
-      text-align: right;
-      margin-top: -5px;
-    }
-
-    .name {
-      display: inline-block;
-      width: 150px;
-    }
-
-    .relative-to {
-      display: inline-block;
-      margin-left: 10px;
-    }
-
-    .message {
-      font-size: 15px;
-      line-height: 17px;
-      border: 0px solid green;
-      color: #999;
-      margin-left: -13px;
-    }
-
-    .message .text {
-      position: relative;
-      z-index: 1;
-      letter-spacing: 0.1em;
-      top: -10px;
-      left: 14px;
-      right: -14px;
-      margin-right: 25px;
-    }
-
-    .message .icon-left-quote {
-      position: relative;
-      z-index: 0;
-      top: -5px;
-      font-size: 28px;
-      color: #eee;
-      margin-right: 4px;
-    }
-  </style>
-{% endblock extra-style %}


### PR DESCRIPTION
 * Show on event list when an event is being re-scheduled....
 
<img width="584" alt="Screenshot 2025-03-11 at 1 14 12 PM" src="https://github.com/user-attachments/assets/bb8332c2-decd-4933-b992-e6c926582824" />

* Show on read page and also show number of scheduled contacts:

<img width="582" alt="Screenshot 2025-03-11 at 1 08 54 PM" src="https://github.com/user-attachments/assets/7665d431-9233-432a-8bc4-68b26fe3e049" />

Current view for comparison: 

<img width="584" alt="Screenshot 2025-03-11 at 1 16 11 PM" src="https://github.com/user-attachments/assets/f178a56a-e9c9-4b1f-9f22-2802e3591c3c" />