### PR TITLE
Fix displaying updated campaign events fires multiple times

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -685,7 +685,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
         merged = []
         for fire in fires:
             event = events_by_id.get(scope_to_event_id(fire.scope))
-            if event:
+            if event and fire.scope == f"{event.id}:{event.fire_version}":
                 obj = {
                     "type": "campaign_event",
                     "scheduled": fire.fire_on.isoformat(),

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1113,18 +1113,29 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             base_language="eng",
         )
         event2 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, joined, 2, unit="D", flow=event2_flow)
+        # old fire version should not be displayed
+        ContactFire.objects.create(
+            org=self.org,
+            contact=contact1,
+            fire_type=ContactFire.TYPE_CAMPAIGN_EVENT,
+            scope=f"{event1.id}:{event1.fire_version}",  # old version
+            fire_on=timezone.now() + timedelta(days=2),
+        )
+        # update event
+        event1.fire_version += 1
+        event1.save()
         fire1 = ContactFire.objects.create(
             org=self.org,
             contact=contact1,
             fire_type=ContactFire.TYPE_CAMPAIGN_EVENT,
-            scope=f"{event1.id}:{event1.fire_version}",  # new style
+            scope=f"{event1.id}:{event1.fire_version}",  # latest version
             fire_on=timezone.now() + timedelta(days=2),
         )
         fire2 = ContactFire.objects.create(
             org=self.org,
             contact=contact1,
             fire_type=ContactFire.TYPE_CAMPAIGN_EVENT,
-            scope=f"{event2.id}",  # old style
+            scope=f"{event2.id}:{event2.fire_version}",
             fire_on=timezone.now() + timedelta(days=5),
         )
 


### PR DESCRIPTION
Currently we have an issue of displaying the contact fires for the same campaigns events multiple times since when a campaign event is update a new contact  fire is created with update the fire version


This PR makes sure we display only the contact fire with the highest fire version