### PR TITLE
Fix typos in templates

### DIFF
--- a/templates/account/email/login_code_message.html
+++ b/templates/account/email/login_code_message.html
@@ -1,4 +1,4 @@
-{% extends "accound/email/base_message.html" %}
+{% extends "account/email/base_message.html" %}
 {% load account %}
 {% load i18n %}
 

--- a/templates/ai/llm_connect_form.html
+++ b/templates/ai/llm_connect_form.html
@@ -1,4 +1,4 @@
-{% extends "smartmin_form.html" %}
+{% extends "smartmin/form.html" %}
 {% block pre-form %}
   <div style="margin-bottom:1em">{% include form_blurb %}</div>
 {% endblock pre-form %}


### PR DESCRIPTION
Fix when compressing static files

```
Error parsing template account/email/login_code_message.html: accound/email/base_message.html
Error parsing template ai/llm_connect_form.html: smartmin_form.html
```