### PR TITLE
Add brand to email subjects for allauth sent emails

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1342,7 +1342,7 @@ class Invitation(SmartModel):
                 "org": self.org,
                 "invitation": self,
             },
-            _("[%(name)s] Invitation") % self.org.branding,
+            _("[%(name)s] Invitation to join workspace") % {"name": self.org.name},
         )
 
     def accept(self, user):

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1342,7 +1342,7 @@ class Invitation(SmartModel):
                 "org": self.org,
                 "invitation": self,
             },
-            _("%(name)s Invitation") % self.org.branding,
+            _("[%(name)s] Invitation") % self.org.branding,
         )
 
     def accept(self, user):

--- a/temba/orgs/tests/test_invitation.py
+++ b/temba/orgs/tests/test_invitation.py
@@ -20,7 +20,7 @@ class InvitationTest(TembaTest):
 
         self.assertEqual(1, len(mail.outbox))
         self.assertEqual(["invitededitor@textit.com"], mail.outbox[0].recipients())
-        self.assertEqual("RapidPro Invitation", mail.outbox[0].subject)
+        self.assertEqual("[RapidPro] Invitation", mail.outbox[0].subject)
         self.assertIn(f"https://app.rapidpro.io/org/join/{invitation.secret}/", mail.outbox[0].body)
 
         new_editor = User.create("invitededitor@textit.com", "Bob", "", "Qwerty123", "en-US")

--- a/temba/orgs/tests/test_invitation.py
+++ b/temba/orgs/tests/test_invitation.py
@@ -20,7 +20,7 @@ class InvitationTest(TembaTest):
 
         self.assertEqual(1, len(mail.outbox))
         self.assertEqual(["invitededitor@textit.com"], mail.outbox[0].recipients())
-        self.assertEqual("[RapidPro] Invitation", mail.outbox[0].subject)
+        self.assertEqual("[Nyaruka] Invitation to join workspace", mail.outbox[0].subject)
         self.assertIn(f"https://app.rapidpro.io/org/join/{invitation.secret}/", mail.outbox[0].body)
 
         new_editor = User.create("invitededitor@textit.com", "Bob", "", "Qwerty123", "en-US")

--- a/temba/users/tests/test_auth.py
+++ b/temba/users/tests/test_auth.py
@@ -41,7 +41,7 @@ class UserAuthTest(TembaTest):
         self.assertRedirect(response, success_url)
 
         self.assertEqual(1, len(mail.outbox))
-        self.assertEqual("Please Confirm Your Email Address", mail.outbox[0].subject)
+        self.assertEqual("[RapidPro] Please Confirm Your Email Address", mail.outbox[0].subject)
         self.assertEqual(["bobbyburgers@burgers.com"], mail.outbox[0].recipients())
 
     def test_change_password(self):

--- a/templates/account/email/account_already_exists_subject.txt
+++ b/templates/account/email/account_already_exists_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Account Already Exists{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Account Already Exists{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/email_changed_subject.txt
+++ b/templates/account/email/email_changed_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Email Changed{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Email Changed{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/email_confirm_subject.txt
+++ b/templates/account/email/email_confirm_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Email Confirmation{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Email Confirmation{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/email_confirmation_subject.txt
+++ b/templates/account/email/email_confirmation_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Please Confirm Your Email Address{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Please Confirm Your Email Address{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/email_deleted_subject.txt
+++ b/templates/account/email/email_deleted_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Email Removed{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Email Removed{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/login_code_subject.txt
+++ b/templates/account/email/login_code_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Sign-In Code{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Sign-In Code{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/password_changed_subject.txt
+++ b/templates/account/email/password_changed_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Password Changed{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Password Changed{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/password_reset_key_subject.txt
+++ b/templates/account/email/password_reset_key_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Password Reset Email{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Password Reset Email{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/password_reset_subject.txt
+++ b/templates/account/email/password_reset_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Password Reset{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Password Reset{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/password_set_subject.txt
+++ b/templates/account/email/password_set_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Password Set{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Password Set{% endblocktrans %}
 {% endautoescape %}

--- a/templates/account/email/unknown_account_subject.txt
+++ b/templates/account/email/unknown_account_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Unknown Account{% endblocktrans %}
+{% blocktrans trimmed with site_name=branding.name %}[{{ site_name }}] Unknown Account{% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
Before 
<img width="457" alt="Monosnap  TextIt Staging  Please Confirm Your Email Address - norbert@textit com - TextIt Mail 2025-04-15 15-25-44" src="https://github.com/user-attachments/assets/9776ee31-1e6d-45d1-b56f-4fb1fe148dda" />

After
<img width="579" alt="Monosnap  TextIt Staging  Please Confirm Your Email Address - norbert@textit com - TextIt Mail 2025-04-15 15-25-17" src="https://github.com/user-attachments/assets/5ca256b1-2c72-4e12-b47c-6d911bf15656" />

