### PR TITLE
Tweak how we show user verified/2FA status on list pages

### DIFF
--- a/temba/staff/views.py
+++ b/temba/staff/views.py
@@ -373,7 +373,7 @@ class UserCRUDL(SmartCRUDL):
             return context
 
         def get_2fa(self, obj):
-            return _("Yes") if obj.mfa_enabled else _("No")
+            return _("✓") if obj.mfa_enabled else _("")
 
         def get_verified(self, obj):
-            return _("Yes") if obj.email_verified else _("No")
+            return _("✓") if obj.email_verified else _("")

--- a/templates/orgs/user_list.html
+++ b/templates/orgs/user_list.html
@@ -29,18 +29,10 @@
             {% if obj.team and has_teams %}({{ obj.team.name }}){% endif %}
           </td>
           <td>
-            {% if obj.mfa_enabled %}
-              {% trans "Yes" %}
-            {% else %}
-              {% trans "No" %}
-            {% endif %}
+            {% if obj.mfa_enabled %}✓{% endif %}
           </td>
           <td>
-            {% if obj.email_verified %}
-              {% trans "Yes" %}
-            {% else %}
-              {% trans "No" %}
-            {% endif %}
+            {% if obj.email_verified %}✓{% endif %}
           </td>
           <td class="w-10">
             {% if obj.role.code != "A" or admin_count > 1 %}


### PR DESCRIPTION
For a lot of users it's not easy to spot yeses amongst noes

<img width="674" alt="Screenshot 2025-04-16 at 12 20 00" src="https://github.com/user-attachments/assets/09a8f2cb-ddb0-42fd-a6f1-f41605604906" />

becomes...

<img width="677" alt="Screenshot 2025-04-16 at 12 20 28" src="https://github.com/user-attachments/assets/e20749ff-5646-4ab8-934a-0adb3b9cd304" />
