### PR TITLE
Explicit clearing of notifications via redirect view

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -78,6 +78,10 @@ class EndpointsTest(APITestMixin, TembaTest):
         # and org being suspended
         self.org.suspend()
 
+        export1_notification = export1.notifications.get()
+        export2_notification = export2.notifications.get()
+        suspended_notification = self.admin.notifications.get(notification_type="incident:started")
+
         self.assertGet(
             endpoint_url,
             [self.admin],
@@ -85,7 +89,8 @@ class EndpointsTest(APITestMixin, TembaTest):
                 {
                     "type": "incident:started",
                     "created_on": matchers.ISODatetime(),
-                    "target_url": "/incident/",
+                    "url": f"/notification/read/{suspended_notification.id}/",
+                    "target_url": "/incident/",  # deprecated
                     "is_seen": False,
                     "incident": {
                         "type": "org:suspended",
@@ -96,6 +101,7 @@ class EndpointsTest(APITestMixin, TembaTest):
                 {
                     "type": "export:finished",
                     "created_on": matchers.ISODatetime(),
+                    "url": f"/notification/read/{export1_notification.id}/",
                     "target_url": f"/export/download/{export1.uuid}/",
                     "is_seen": False,
                     "export": {"type": "contact", "num_records": None},
@@ -111,7 +117,8 @@ class EndpointsTest(APITestMixin, TembaTest):
                 {
                     "type": "export:finished",
                     "created_on": matchers.ISODatetime(),
-                    "target_url": f"/export/download/{export2.uuid}/",
+                    "url": f"/notification/read/{export2_notification.id}/",
+                    "target_url": f"/export/download/{export2.uuid}/",  # deprecated
                     "is_seen": False,
                     "export": {"type": "ticket", "num_records": None},
                 },

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -230,6 +230,13 @@ class Notification(models.Model):
         self.email_status = Notification.EMAIL_STATUS_SENT
         self.save(update_fields=("email_status",))
 
+    def get_target_url(self) -> str:
+        return self.type.get_target_url(self)
+
+    def clear(self):
+        self.is_seen = True
+        self.save(update_fields=("is_seen",))
+
     @classmethod
     def mark_seen(cls, org, user, notification_type: str = None, *, scope: str = None):
         notifications = cls.objects.filter(org_id=org.id, user=user, is_seen=False)

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -132,16 +132,18 @@ class NotificationType:
         return ""
 
     def get_email_context(self, notification, branding: dict):
+        read_url = reverse("notifications.notification_read", args=[notification.id])
         return {
             "notification": notification,
-            "target_url": f"https://{branding['domain']}{self.get_target_url(notification)}",
+            "read_url": f"https://{branding['domain']}{read_url}",
         }
 
     def as_json(self, notification) -> dict:
         return {
             "type": notification.type.slug,
             "created_on": notification.created_on.isoformat(),
-            "target_url": self.get_target_url(notification),
+            "url": reverse("notifications.notification_read", args=[notification.id]),
+            "target_url": self.get_target_url(notification),  # deprecated
             "is_seen": notification.is_seen,
         }
 

--- a/temba/notifications/tests/test_incident.py
+++ b/temba/notifications/tests/test_incident.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone as tzone
 
+from temba.notifications.incidents.builtin import ChannelDisconnectedIncidentType
 from temba.notifications.models import Incident, Notification
 from temba.tests import TembaTest, matchers
 
@@ -82,4 +83,20 @@ class IncidentTest(TembaTest):
                 "ended_on": None,
             },
             incident.as_json(),
+        )
+
+    def test_channel_disconnected(self):
+        ChannelDisconnectedIncidentType.get_or_create(self.channel)
+        incident = Incident.objects.get()
+
+        self.assertEqual(
+            {
+                "type": "channel:disconnected",
+                "started_on": matchers.ISODatetime(),
+                "ended_on": None,
+            },
+            incident.as_json(),
+        )
+        self.assertEqual(
+            f"/channels/channel/read/{self.channel.uuid}/", incident.type.get_notification_target_url(incident)
         )

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -32,7 +32,10 @@ class NotificationTest(TembaTest):
         actual_users = set()
 
         for notification in notifications:
-            self.assertEqual(expected_json, notification.as_json())
+            expected = expected_json.copy()
+            expected["url"] = reverse("notifications.notification_read", args=[notification.id])
+
+            self.assertEqual(expected, notification.as_json())
             self.assertEqual(email, notification.email_status == Notification.EMAIL_STATUS_PENDING)
             actual_users.add(notification.user)
 

--- a/temba/notifications/tests/test_notificationcrudl.py
+++ b/temba/notifications/tests/test_notificationcrudl.py
@@ -1,0 +1,26 @@
+from django.urls import reverse
+
+from temba.contacts.models import ContactExport
+from temba.notifications.types.builtin import ExportFinishedNotificationType
+from temba.tests import CRUDLTestMixin, TembaTest
+
+
+class NotificationCRUDLTest(TembaTest, CRUDLTestMixin):
+    def test_read(self):
+        export = ContactExport.create(self.org, self.editor)
+        export.perform()
+
+        ExportFinishedNotificationType.create(export)
+
+        notification = self.editor.notifications.get(export=export, is_seen=False)
+
+        read_url = reverse("notifications.notification_read", args=[notification.id])
+
+        self.assertRequestDisallowed(read_url, [None, self.admin])
+
+        self.login(self.editor)
+        response = self.client.get(read_url)
+        self.assertRedirect(response, f"/export/download/{export.uuid}/")
+
+        notification.refresh_from_db()
+        self.assertTrue(notification.is_seen)

--- a/temba/notifications/urls.py
+++ b/temba/notifications/urls.py
@@ -1,3 +1,4 @@
-from .views import IncidentCRUDL
+from .views import IncidentCRUDL, NotificationCRUDL
 
 urlpatterns = IncidentCRUDL().as_urlpatterns()
+urlpatterns += NotificationCRUDL().as_urlpatterns()

--- a/temba/notifications/views.py
+++ b/temba/notifications/views.py
@@ -1,12 +1,32 @@
 from smartmin.views import SmartCRUDL, SmartListView
 
+from django.http import HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
 
+from temba.orgs.views.base import BaseReadView
 from temba.orgs.views.mixins import OrgPermsMixin
 from temba.utils.views.mixins import SpaMixin
 
 from .mixins import NotificationTargetMixin
-from .models import Incident
+from .models import Incident, Notification
+
+
+class NotificationCRUDL(SmartCRUDL):
+    model = Notification
+    actions = ("read",)
+
+    class Read(BaseReadView):
+        def has_permission(self, request, *args, **kwargs):
+            return self.request.user.is_authenticated
+
+        def derive_queryset(self, **kwargs):
+            return self.request.user.notifications.filter(org=self.request.org)
+
+        def render_to_response(self, context, **response_kwargs):
+            obj = self.get_object()
+            obj.clear()
+
+            return HttpResponseRedirect(obj.get_target_url())
 
 
 class IncidentCRUDL(SmartCRUDL):

--- a/templates/notifications/email/export_finished.html
+++ b/templates/notifications/email/export_finished.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block notification-body %}
-  <p>{% blocktrans with url=target_url %}Your export is ready! Download it here: {{ url }}{% endblocktrans %}</p>
+  <p>{% blocktrans with url=read_url %}Your export is ready! Download it here: {{ url }}{% endblocktrans %}</p>
 {% endblock notification-body %}

--- a/templates/notifications/email/export_finished.txt
+++ b/templates/notifications/email/export_finished.txt
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block notification-body %}
-{% blocktrans with url=target_url %}Your export is ready! Download it here: {{ url }}{% endblocktrans %}
+{% blocktrans with url=read_url %}Your export is ready! Download it here: {{ url }}{% endblocktrans %}
 {% endblock notification-body %}

--- a/templates/notifications/email/incident_started.channel_disconnected.html
+++ b/templates/notifications/email/incident_started.channel_disconnected.html
@@ -3,7 +3,7 @@
 
 {% block notification-body %}
   <p>
-    {% blocktrans trimmed with url=target_url %}
+    {% blocktrans trimmed with url=read_url %}
       Your <a href="{{ url }}">Android channel</a> appears to be disconnected and hasn't been seen for some time.
     {% endblocktrans %}
   </p>

--- a/templates/notifications/email/incident_started.channel_disconnected.txt
+++ b/templates/notifications/email/incident_started.channel_disconnected.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block notification-body %}
-{% blocktrans trimmed with url=target_url %}
+{% blocktrans trimmed with url=read_url %}
 Your Android channel ({{ url }}) appears to be disconnected and hasn't been seen for some time.
 {% endblocktrans %}
 {% endblock notification-body %}

--- a/templates/notifications/email/incident_started.channel_outdated_app.html
+++ b/templates/notifications/email/incident_started.channel_outdated_app.html
@@ -3,7 +3,7 @@
 
 {% block notification-body %}
   <p>
-    {% blocktrans trimmed with url=target_url %}
+    {% blocktrans trimmed with url=read_url %}
       Your workspace has a channel that appears to be still running an old version of the client app.
       View <a href="{{ url }}">incidents</a>
     {% endblocktrans %}

--- a/templates/notifications/email/incident_started.channel_outdated_app.txt
+++ b/templates/notifications/email/incident_started.channel_outdated_app.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block notification-body %}
-{% blocktrans trimmed with url=target_url %}
+{% blocktrans trimmed with url=read_url %}
 Your workspace has a channel that appears to be still running an old version of the client app.
 View incidents ({{ url }})
 {% endblocktrans %}

--- a/templates/notifications/email/incident_started.channel_templates_failed.html
+++ b/templates/notifications/email/incident_started.channel_templates_failed.html
@@ -3,7 +3,7 @@
 
 {% block notification-body %}
   <p>
-    {% blocktrans trimmed with url=target_url %}
+    {% blocktrans trimmed with url=read_url %}
       Your <a href="{{ url }}">WhatsApp channel</a> is currently having problems fetching templates.
     {% endblocktrans %}
   </p>

--- a/templates/notifications/email/incident_started.channel_templates_failed.txt
+++ b/templates/notifications/email/incident_started.channel_templates_failed.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block notification-body %}
-{% blocktrans trimmed with url=target_url %}
+{% blocktrans trimmed with url=read_url %}
 Your WhatsApp channel ({{ url }}) is currently having problems fetching templates.
 {% endblocktrans %}
 {% endblock notification-body %}


### PR DESCRIPTION
 * Add notification read view to clear the notification and redirect to the target URL
 * Use read view instead of target url for email notifications
 * Include read url in API results
 * Leave existing notification clearing functionality on views as is for now

Next steps
1. Updating menu component to use redirect view (https://github.com/nyaruka/temba-components/pull/498)
2. Remove notification clearing functionality on views