### PR TITLE
Adjust user set verified

### DIFF
--- a/temba/staff/views.py
+++ b/temba/staff/views.py
@@ -314,9 +314,13 @@ class UserCRUDL(SmartCRUDL):
         title = "Update User"
 
         def post(self, request, *args, **kwargs):
+            obj = self.get_object()
+            if "email" in request.POST:
+                if obj.email != request.POST["email"]:
+                    obj.emailaddress_set.all().delete()
+
             if "action" in request.POST:
                 action = request.POST["action"]
-                obj = self.get_object()
 
                 if action == self.ACTION_VERIFY:
                     obj.set_verified(True)

--- a/temba/users/models.py
+++ b/temba/users/models.py
@@ -149,7 +149,7 @@ class User(TembaUUIDMixin, AbstractBaseUser, PermissionsMixin):
         """
 
         self.emailaddress_set.update_or_create(
-            primary=True, defaults={"email": self.email, "primary": True, "verified": verified}
+            email=self.email, defaults={"email": self.email, "primary": True, "verified": verified}
         )
 
     def record_auth(self):

--- a/temba/users/tests/test_user.py
+++ b/temba/users/tests/test_user.py
@@ -28,6 +28,11 @@ class UserTest(TembaTest):
         self.assertEqual(1, user.emailaddress_set.count())
         self.assertTrue(user.emailaddress_set.filter(email="jim@rapidpro.io", primary=True, verified=False).exists())
 
+        # reverify can always work
+        user.set_verified(True)
+        self.assertTrue(user.is_verified())
+        self.assertTrue(user.emailaddress_set.filter(email="jim@rapidpro.io", primary=True, verified=True).exists())
+
         user.last_name = ""
         user.save(update_fields=("last_name",))
 
@@ -36,6 +41,22 @@ class UserTest(TembaTest):
 
         self.assertEqual(user, User.objects.get_by_natural_key("jim@rapidpro.io"))
         self.assertEqual(user, User.objects.get_by_natural_key("JIM@rapidpro.io"))
+
+        # remove emailaddress object
+        user.emailaddress_set.all().delete()
+
+        self.assertFalse(user.is_verified())
+        self.assertEqual(0, user.emailaddress_set.count())
+
+        # create email address as verification process
+        user.emailaddress_set.create(email="jim@rapidpro.io")
+
+        self.assertFalse(user.is_verified())
+        self.assertEqual(1, user.emailaddress_set.count())
+
+        user.set_verified(True)
+        self.assertTrue(user.is_verified())
+        self.assertTrue(user.emailaddress_set.filter(email="jim@rapidpro.io", primary=True, verified=True).exists())
 
     def test_has_org_perm(self):
         granter = self.create_user("jim@rapidpro.io", group_names=("Granters",))


### PR DESCRIPTION
Issue:

A user tries to login and then a confirmation email is send to them and that create the emailaddress object with primary as False, that break the staff trying to verify the user

https://textit.sentry.io/issues/6747765741/

Solution is to check the email address by email and not primary field and also when a staff update the email, the email should again be verified
