### PR TITLE
Easier explicit cleanup of DynamoDB and Valkey after tests

### DIFF
--- a/temba/airtime/tests/test_migrations.py
+++ b/temba/airtime/tests/test_migrations.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone as tzone
 from decimal import Decimal
 
 from temba.airtime.models import AirtimeTransfer
-from temba.tests import MigrationTest
+from temba.tests import MigrationTest, cleanup
 from temba.utils import dynamo
 
 
@@ -38,6 +38,7 @@ class UpdateTransferUUIDsTest(MigrationTest):
             created_on=datetime(2025, 8, 11, 20, 36, 41, 116000, tzinfo=tzone.utc),
         )
 
+    @cleanup(dynamodb=True)
     def test_migration(self):
         self.transfer1.refresh_from_db()
         self.transfer2.refresh_from_db()

--- a/temba/contacts/tests/test_contact.py
+++ b/temba/contacts/tests/test_contact.py
@@ -19,7 +19,7 @@ from temba.mailroom import modifiers
 from temba.msgs.models import Msg, MsgFolder
 from temba.orgs.models import Org
 from temba.schedules.models import Schedule
-from temba.tests import MockJsonResponse, TembaTest, mock_mailroom
+from temba.tests import MockJsonResponse, TembaTest, cleanup, mock_mailroom
 from temba.tests.engine import MockSessionWriter
 from temba.tickets.models import Ticket
 from temba.utils import dynamo
@@ -113,6 +113,7 @@ class ContactTest(TembaTest):
 
         self.assertTrue(self.joe.interrupt(self.admin))
 
+    @cleanup(dynamodb=True)
     @mock_mailroom
     def test_release(self, mr_mocks):
         # create a contact with a message

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -16,7 +16,7 @@ from temba.mailroom.client.types import Exclusions
 from temba.msgs.models import Msg
 from temba.orgs.models import Export, OrgRole
 from temba.schedules.models import Schedule
-from temba.tests import CRUDLTestMixin, MockResponse, TembaTest, mock_mailroom
+from temba.tests import CRUDLTestMixin, MockResponse, TembaTest, cleanup, mock_mailroom
 from temba.tests.engine import MockSessionWriter
 from temba.tickets.models import Topic
 from temba.triggers.models import Trigger
@@ -752,6 +752,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(reverse("contacts.contact_history", args=["837d0842-4f6b-4751-bf21-471df75ce786"]))
         self.assertEqual(response.status_code, 404)
 
+    @cleanup(dynamodb=True)
     def test_history_session_events(self):
         joe = self.create_contact(name="Joe Blow", urns=["twitter:blow80", "tel:+250781111111"])
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -38,6 +38,7 @@ from temba.users.models import User
 from temba.utils import dynamo, json
 from temba.utils.uuid import UUID, uuid4, uuid7
 
+from .dynamo import dynamo_truncate
 from .mailroom import (
     contact_urn_lookup,
     create_broadcast,
@@ -141,12 +142,6 @@ class TembaTest(SmartminTest):
 
         self.org.country = self.country
         self.org.save(update_fields=("country",))
-
-    def tearDown(self):
-        super().tearDown()
-
-        r = get_valkey_connection()
-        r.flushdb()
 
     def login(self, user, *, choose_org=None):
         self.assertTrue(
@@ -1041,11 +1036,37 @@ def mock_uuids(method=None, *, seed=1234):
     def actual_decorator(f):
         @wraps(f)
         def wrapper(instance, *args, **kwargs):
-            _wrap_test_method(f, instance, *args, **kwargs)
+            return _wrap_test_method(f, instance, *args, **kwargs)
 
         return wrapper
 
     return actual_decorator(method) if method else actual_decorator
+
+
+def cleanup(*, valkey=False, dynamodb=False):
+    """
+    Explicit cleanup operations to perform after a test method runs.
+    """
+
+    def _wrap_test_method(f, instance, *args, **kwargs):
+        try:
+            return f(instance, *args, **kwargs)
+        finally:
+            if valkey:
+                r = get_valkey_connection()
+                r.flushdb()
+            if dynamodb:
+                dynamo_truncate(dynamo.HISTORY)
+                dynamo_truncate(dynamo.MAIN)
+
+    def actual_decorator(f):
+        @wraps(f)
+        def wrapper(instance, *args, **kwargs):
+            return _wrap_test_method(f, instance, *args, **kwargs)
+
+        return wrapper
+
+    return actual_decorator
 
 
 def get_contact_search(*, query=None, contacts=None, groups=None):

--- a/temba/tests/dynamo.py
+++ b/temba/tests/dynamo.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+
+
+def dynamo_scan_all(table) -> list:
+    """
+    Scans all items in the given DynamoDB table and returns them as a list.
+    """
+
+    assert settings.TESTING and table.name.startswith("Test"), "only for use in tests"
+
+    last_key = None
+    items = []
+
+    while True:
+        kwargs = dict(Limit=100)
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+
+        response = table.scan(**kwargs)
+
+        for item in response.get("Items", []):
+            items.append(item)
+
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+    return items
+
+
+def dynamo_truncate(table) -> int:
+    """
+    Deletes all items from the given DynamoDB table.
+    """
+
+    assert settings.TESTING and table.name.startswith("Test"), "only for use in tests"
+
+    num_deleted = 0
+    last_key = None
+
+    while True:
+        kwargs = dict(ProjectionExpression="PK, SK", Limit=100)
+        if last_key:
+            kwargs["ExclusiveStartKey"] = last_key
+
+        response = table.scan(**kwargs)
+
+        with table.batch_writer() as batch:
+            for item in response.get("Items", []):
+                batch.delete_item(Key={"PK": item["PK"], "SK": item["SK"]})
+                num_deleted += 1
+
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+
+    return num_deleted


### PR DESCRIPTION
Truncating the DynamoDB tables after every single test probably slows things down.. so let's see how far we can go being explicit