### PR TITLE
Tweak mailroom.contact_interrupt to not expect a return value.

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -992,14 +992,12 @@ class Contact(LegacyUUIDMixin, SmartModel):
         self.modify(user, [mod], refresh=False)
         return self.tickets.order_by("id").last()
 
-    def interrupt(self, user) -> bool:
+    def interrupt(self, user):
         """
         Interrupts this contact's current flow
         """
         if self.current_flow:
-            return mailroom.get_client().contact_interrupt(self.org, user, [self]) > 0
-
-        return False
+            mailroom.get_client().contact_interrupt(self.org, user, [self])
 
     def block(self, user):
         """
@@ -1167,7 +1165,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
         if not contacts:
             return
 
-        return mailroom.get_client().contact_interrupt(contacts[0].org, user, contacts)
+        mailroom.get_client().contact_interrupt(contacts[0].org, user, contacts)
 
     def get_groups(self, *, manual_only=False):
         """

--- a/temba/contacts/tests/test_contact.py
+++ b/temba/contacts/tests/test_contact.py
@@ -106,12 +106,11 @@ class ContactTest(TembaTest):
     @mock_mailroom
     def test_interrupt(self, mr_mocks):
         # noop when contact not in a flow
-        self.assertFalse(self.joe.interrupt(self.admin))
+        self.joe.interrupt(self.admin)
 
-        flow = self.create_flow("Test")
-        MockSessionWriter(self.joe, flow).wait().save()
+        self.joe.current_flow = self.create_flow("Test Flow")
 
-        self.assertTrue(self.joe.interrupt(self.admin))
+        self.joe.interrupt(self.admin)
 
     @cleanup(dynamodb=True)
     @mock_mailroom

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -112,11 +112,9 @@ class MailroomClient:
         return {c: resp[str(c.id)] for c in contacts}
 
     def contact_interrupt(self, org, user, contacts) -> int:
-        resp = self._request(
+        self._request(
             "contact/interrupt", {"org_id": org.id, "user_id": user.id, "contact_ids": [c.id for c in contacts]}
         )
-
-        return resp["sessions"]
 
     def contact_modify(self, org, user, contacts, modifiers: list[Modifier]):
         return self._request(

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -272,9 +272,8 @@ class MailroomClientTest(TembaTest):
         bob = self.create_contact("Bob", urns=["tel:+12340000002"])
         mock_post.return_value = MockJsonResponse(200, {"sessions": 2})
 
-        result = self.client.contact_interrupt(self.org, self.admin, [ann, bob])
+        self.client.contact_interrupt(self.org, self.admin, [ann, bob])
 
-        self.assertEqual(2, result)
         mock_post.assert_called_once_with(
             "http://localhost:8090/mr/contact/interrupt",
             headers={"User-Agent": "Temba", "Authorization": "Token sesame"},

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -271,7 +271,7 @@ class TestClient(MailroomClient):
         return {c: inspect(c) for c in contacts}
 
     @_client_method
-    def contact_interrupt(self, org, user, contacts) -> int:
+    def contact_interrupt(self, org, user, contacts):
         # get the waiting session UUIDs
         session_uuids = []
         for contact in contacts:
@@ -283,8 +283,6 @@ class TestClient(MailroomClient):
                     session_uuids.append(session.uuid)
 
         exit_sessions(session_uuids, FlowSession.STATUS_INTERRUPTED)
-
-        return len(session_uuids)
 
     @_client_method
     def contact_parse_query(self, org, query: str, parse_only: bool = False):


### PR DESCRIPTION
Which wasn't being used anyway