### PR TITLE
Add feistel cipher util functions

### DIFF
--- a/temba/utils/text/feistel.py
+++ b/temba/utils/text/feistel.py
@@ -1,0 +1,114 @@
+# Safe uppercase alphabet, base-32 (no I, L, O, 0, 1)
+ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+BASE = len(ALPHABET)  # 32
+
+# Threshold where we switch from 6 → 7 chars
+THRESHOLD_6CHARS = BASE**6  # 1,073,741,824
+
+MAX_ID = 9_999_999_999
+
+F30_BIT_SIZE = 30
+F30_HALF_SIZE = F30_BIT_SIZE // 2  # 15 bits
+F30_MASK = (1 << F30_HALF_SIZE) - 1  # 0x7FFF
+
+F34_BIT_SIZE = 34
+F34_HALF_SIZE = F34_BIT_SIZE // 2  # 17 bits
+F34_MASK = (1 << F34_HALF_SIZE) - 1  # 0x1FFFF
+
+
+def encode(id_: int, keys: tuple) -> str:
+    assert 0 < id_ <= MAX_ID, "encode requires id between 1 and 9,999,999,999"
+
+    if id_ < THRESHOLD_6CHARS:
+        obfuscated = _feistel30_encrypt(id_, keys)
+        code_length = 6
+    else:
+        # For larger IDs, use 7 characters with extended Feistel for more bits
+        # Map the ID to a range that fits in 7 characters (BASE^7)
+        # We have BASE^7 = 32^7 = 34,359,738,368 possible values
+
+        # Normalize to range [0, BASE^7 - THRESHOLD_6CHARS)
+        normalized_id = id_ - THRESHOLD_6CHARS
+
+        # Use extended Feistel cipher for larger bit space
+        obfuscated = _feistel34_encrypt(normalized_id, keys)
+        code_length = 7
+
+    chars = []
+    for _ in range(code_length):
+        chars.append(ALPHABET[obfuscated % BASE])
+        obfuscated //= BASE
+    return "".join(reversed(chars))
+
+
+def decode(code: str, keys: tuple) -> int:
+    code = code.upper()
+    num = 0
+    for c in code:
+        try:
+            idx = ALPHABET.index(c)
+        except ValueError:
+            raise ValueError(f"Invalid character '{c}' in code")
+        num = num * BASE + idx
+
+    if len(code) == 6:
+        return _feistel30_decrypt(num, keys)
+    elif len(code) == 7:
+        normalized_id = _feistel34_decrypt(num, keys)
+        return normalized_id + THRESHOLD_6CHARS
+    else:
+        raise ValueError("Code must be 6 or 7 characters")
+
+
+def _feistel30_encrypt(n: int, keys: tuple) -> int:
+    left = (n >> F30_HALF_SIZE) & F30_MASK
+    right = n & F30_MASK
+
+    for k in keys:
+        new_left = right
+        right = left ^ (_feistel_round(right, k, F30_MASK) & F30_MASK)
+        left = new_left
+
+    return (left << F30_HALF_SIZE) | right
+
+
+def _feistel30_decrypt(n: int, keys: tuple) -> int:
+    left = (n >> F30_HALF_SIZE) & F30_MASK
+    right = n & F30_MASK
+
+    for k in reversed(keys):
+        new_right = left
+        left = right ^ (_feistel_round(left, k, F30_MASK) & F30_MASK)
+        right = new_right
+
+    return (left << F30_HALF_SIZE) | right
+
+
+def _feistel34_encrypt(n: int, keys: tuple) -> int:
+    left = (n >> F34_HALF_SIZE) & F34_MASK
+    right = n & F34_MASK
+
+    for k in keys:
+        new_left = right
+        right = left ^ (_feistel_round(right, k, F34_MASK) & F34_MASK)
+        left = new_left
+
+    return (left << F34_HALF_SIZE) | right
+
+
+def _feistel34_decrypt(n: int, keys: tuple) -> int:
+    left = (n >> F34_HALF_SIZE) & F34_MASK
+    right = n & F34_MASK
+
+    for k in reversed(keys):
+        new_right = left
+        left = right ^ (_feistel_round(left, k, F34_MASK) & F34_MASK)
+        right = new_right
+
+    return (left << F34_HALF_SIZE) | right
+
+
+def _feistel_round(r: int, k: int, mask: int) -> int:
+    r = (r ^ k) * 0x45D9F3B
+    r ^= r >> 16
+    return r & mask

--- a/temba/utils/text/tests.py
+++ b/temba/utils/text/tests.py
@@ -1,5 +1,5 @@
 from temba.tests import TembaTest
-from temba.utils.text import clean_string, generate_secret, generate_token, slugify_with, truncate, unsnakify
+from temba.utils.text import clean_string, feistel, generate_secret, generate_token, slugify_with, truncate, unsnakify
 
 
 class TextTest(TembaTest):
@@ -31,3 +31,35 @@ class TextTest(TembaTest):
 
     def test_generate_token(self):
         self.assertEqual(len(generate_token()), 8)
+
+
+class FeistelTest(TembaTest):
+    def test_encode_and_decode(self):
+        keys = (0xA3B1C, 0xD2E3F, 0x1A2B3, 0xC0FFEE)
+        cases = [
+            (1, "E2E6MX"),
+            (2, "3MWB69"),
+            (3, "Q3GP9G"),
+            (4, "U6Y6T5"),
+            (5, "SJPWLU"),
+            (12345, "A6YWQL"),
+            (999_999_999, "KNGEUX"),
+            (1_073_741_823, "NVQ26R"),
+            (1_073_741_824, "GQENS3N"),
+            (1_073_741_825, "NTA3479"),
+            (1_073_741_826, "KYEKD42"),
+            (9_999_999_999, "P7U8B2J"),
+        ]
+        for id, expected_code in cases:
+            actual_code = feistel.encode(id, keys)
+            self.assertEqual(expected_code, actual_code, f"encoding mismatch for id {id}")
+
+            decoded = feistel.decode(expected_code, keys)
+            self.assertEqual(id, decoded, f"decoding mismatch for code {expected_code}")
+
+        with self.assertRaises(ValueError):
+            feistel.decode("E2E6MXXX", keys)  # too long
+        with self.assertRaises(ValueError):
+            feistel.decode("E2E6M", keys)  # too short
+        with self.assertRaises(ValueError):
+            feistel.decode("E2E6M0", keys)  # invalid char 0


### PR DESCRIPTION
Been going back and forth with GPT-5 and Claude all afternoon to get them to land on consistent code that works for 6 and 7 character codes

@norkans7 idea here is replacing "anon ids" with these codes which are still derived from the database id, but would be obfuscated and shorter.