### PR TITLE
Add uuid to omnibox serialized data

### DIFF
--- a/temba/contacts/omnibox.py
+++ b/temba/contacts/omnibox.py
@@ -94,10 +94,25 @@ def omnibox_serialize(org, groups, contacts, *, encode=False):
     results = []
 
     for group in groups:
-        results.append({"id": str(group.uuid), "name": group.name, "type": "group", "count": group_counts[group]})
+        group_uuid = str(group.uuid)
+        results.append(
+            {
+                "id": group_uuid,
+                "uuid": group_uuid,
+                "name": group.name,
+                "type": "group",
+                "count": group_counts[group],
+            }
+        )
 
     for contact in contacts:
-        result = {"id": str(contact.uuid), "name": contact.get_display(org), "type": "contact"}
+        contact_uuid = str(contact.uuid)
+        result = {
+            "id": contact_uuid,
+            "uuid": contact_uuid,
+            "name": contact.get_display(org),
+            "type": "contact",
+        }
 
         if not org.is_anon:
             result["urn"] = contact.get_urn_display()

--- a/temba/contacts/tests/test_contact.py
+++ b/temba/contacts/tests/test_contact.py
@@ -587,8 +587,20 @@ class ContactTest(TembaTest):
         # lookup specific contacts
         self.assertEqual(
             [
-                {"id": str(self.billy.uuid), "name": "Billy Nophone", "type": "contact", "urn": ""},
-                {"id": str(self.joe.uuid), "name": "Joe Blow", "type": "contact", "urn": "blow80"},
+                {
+                    "id": str(self.billy.uuid),
+                    "uuid": str(self.billy.uuid),
+                    "name": "Billy Nophone",
+                    "type": "contact",
+                    "urn": "",
+                },
+                {
+                    "id": str(self.joe.uuid),
+                    "uuid": str(self.joe.uuid),
+                    "name": "Joe Blow",
+                    "type": "contact",
+                    "urn": "blow80",
+                },
             ],
             omnibox_request(f"?c={self.joe.uuid},{self.billy.uuid}"),
         )
@@ -596,8 +608,14 @@ class ContactTest(TembaTest):
         # lookup specific groups
         self.assertEqual(
             [
-                {"id": str(joe_and_frank.uuid), "name": "Joe and Frank", "type": "group", "count": 2},
-                {"id": str(men.uuid), "name": "Men", "type": "group", "count": 0},
+                {
+                    "id": str(joe_and_frank.uuid),
+                    "uuid": str(joe_and_frank.uuid),
+                    "name": "Joe and Frank",
+                    "type": "group",
+                    "count": 2,
+                },
+                {"id": str(men.uuid), "uuid": str(men.uuid), "name": "Men", "type": "group", "count": 0},
             ],
             omnibox_request(f"?g={joe_and_frank.uuid},{men.uuid}"),
         )
@@ -606,10 +624,22 @@ class ContactTest(TembaTest):
         with self.assertNumQueries(9):
             self.assertEqual(
                 [
-                    {"id": str(joe_and_frank.uuid), "name": "Joe and Frank", "type": "group", "count": 2},
-                    {"id": str(men.uuid), "name": "Men", "type": "group", "count": 0},
-                    {"id": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
-                    {"id": str(open_tickets.uuid), "name": "Open Tickets", "type": "group", "count": 0},
+                    {
+                        "id": str(joe_and_frank.uuid),
+                        "uuid": str(joe_and_frank.uuid),
+                        "name": "Joe and Frank",
+                        "type": "group",
+                        "count": 2,
+                    },
+                    {"id": str(men.uuid), "uuid": str(men.uuid), "name": "Men", "type": "group", "count": 0},
+                    {"id": str(nobody.uuid), "uuid": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
+                    {
+                        "id": str(open_tickets.uuid),
+                        "uuid": str(open_tickets.uuid),
+                        "name": "Open Tickets",
+                        "type": "group",
+                        "count": 0,
+                    },
                 ],
                 omnibox_request(""),
             )
@@ -619,8 +649,20 @@ class ContactTest(TembaTest):
 
             self.assertEqual(
                 [
-                    {"id": str(self.billy.uuid), "name": "Billy Nophone", "type": "contact", "urn": ""},
-                    {"id": str(self.frank.uuid), "name": "Frank Smith", "type": "contact", "urn": "250782222222"},
+                    {
+                        "id": str(self.billy.uuid),
+                        "uuid": str(self.billy.uuid),
+                        "name": "Billy Nophone",
+                        "type": "contact",
+                        "urn": "",
+                    },
+                    {
+                        "id": str(self.frank.uuid),
+                        "uuid": str(self.frank.uuid),
+                        "name": "Frank Smith",
+                        "type": "contact",
+                        "urn": "250782222222",
+                    },
                 ],
                 omnibox_request("?search=250"),
             )
@@ -630,8 +672,20 @@ class ContactTest(TembaTest):
 
             self.assertEqual(
                 [
-                    {"id": str(joe_and_frank.uuid), "name": "Joe and Frank", "type": "group", "count": 2},
-                    {"id": str(self.frank.uuid), "name": "Frank Smith", "type": "contact", "urn": "250782222222"},
+                    {
+                        "id": str(joe_and_frank.uuid),
+                        "uuid": str(joe_and_frank.uuid),
+                        "name": "Joe and Frank",
+                        "type": "group",
+                        "count": 2,
+                    },
+                    {
+                        "id": str(self.frank.uuid),
+                        "uuid": str(self.frank.uuid),
+                        "name": "Frank Smith",
+                        "type": "contact",
+                        "urn": "250782222222",
+                    },
                 ],
                 omnibox_request("?search=FRA"),
             )
@@ -639,10 +693,22 @@ class ContactTest(TembaTest):
         # specify type filter g (all groups)
         self.assertEqual(
             [
-                {"id": str(joe_and_frank.uuid), "name": "Joe and Frank", "type": "group", "count": 2},
-                {"id": str(men.uuid), "name": "Men", "type": "group", "count": 0},
-                {"id": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
-                {"id": str(open_tickets.uuid), "name": "Open Tickets", "type": "group", "count": 0},
+                {
+                    "id": str(joe_and_frank.uuid),
+                    "uuid": str(joe_and_frank.uuid),
+                    "name": "Joe and Frank",
+                    "type": "group",
+                    "count": 2,
+                },
+                {"id": str(men.uuid), "uuid": str(men.uuid), "name": "Men", "type": "group", "count": 0},
+                {"id": str(nobody.uuid), "uuid": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
+                {
+                    "id": str(open_tickets.uuid),
+                    "uuid": str(open_tickets.uuid),
+                    "name": "Open Tickets",
+                    "type": "group",
+                    "count": 0,
+                },
             ],
             omnibox_request("?types=g"),
         )
@@ -650,8 +716,14 @@ class ContactTest(TembaTest):
         # specify type filter s (non-query groups)
         self.assertEqual(
             [
-                {"id": str(joe_and_frank.uuid), "name": "Joe and Frank", "type": "group", "count": 2},
-                {"id": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
+                {
+                    "id": str(joe_and_frank.uuid),
+                    "uuid": str(joe_and_frank.uuid),
+                    "name": "Joe and Frank",
+                    "type": "group",
+                    "count": 2,
+                },
+                {"id": str(nobody.uuid), "uuid": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
             ],
             omnibox_request("?types=s"),
         )
@@ -659,10 +731,22 @@ class ContactTest(TembaTest):
         with self.anonymous(self.org):
             self.assertEqual(
                 [
-                    {"id": str(joe_and_frank.uuid), "name": "Joe and Frank", "type": "group", "count": 2},
-                    {"id": str(men.uuid), "name": "Men", "type": "group", "count": 0},
-                    {"id": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
-                    {"id": str(open_tickets.uuid), "name": "Open Tickets", "type": "group", "count": 0},
+                    {
+                        "id": str(joe_and_frank.uuid),
+                        "uuid": str(joe_and_frank.uuid),
+                        "name": "Joe and Frank",
+                        "type": "group",
+                        "count": 2,
+                    },
+                    {"id": str(men.uuid), "uuid": str(men.uuid), "name": "Men", "type": "group", "count": 0},
+                    {"id": str(nobody.uuid), "uuid": str(nobody.uuid), "name": "Nobody", "type": "group", "count": 0},
+                    {
+                        "id": str(open_tickets.uuid),
+                        "uuid": str(open_tickets.uuid),
+                        "name": "Open Tickets",
+                        "type": "group",
+                        "count": 0,
+                    },
                 ],
                 omnibox_request(""),
             )
@@ -671,7 +755,12 @@ class ContactTest(TembaTest):
 
             self.assertEqual(
                 [
-                    {"id": str(self.billy.uuid), "name": "Billy Nophone", "type": "contact"},
+                    {
+                        "id": str(self.billy.uuid),
+                        "uuid": str(self.billy.uuid),
+                        "name": "Billy Nophone",
+                        "type": "contact",
+                    },
                 ],
                 omnibox_request("?search=Billy"),
             )

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -957,7 +957,15 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
                 "repeat_days_of_week": ["M", "F"],
                 "flow": flow1.id,
                 "groups": [group1],
-                "contacts": [{"id": str(contact1.uuid), "name": "Jim", "type": "contact", "urn": "0788 987 651"}],
+                "contacts": [
+                    {
+                        "id": str(contact1.uuid),
+                        "uuid": str(contact1.uuid),
+                        "name": "Jim",
+                        "type": "contact",
+                        "urn": "0788 987 651",
+                    }
+                ],
                 "exclude_groups": [group2],
             },
         )


### PR DESCRIPTION
I think is need to match the expected key value on https://github.com/nyaruka/temba-components/blob/821ade3da1961ba3a69881d4df9b7fa8d82d6963/src/form/select/Omnibox.ts#L30

Currently used for the contacts field on the schedule trigger create form 