### PR TITLE
Fix omnibox contacts field

### DIFF
--- a/templates/utils/forms/omnibox_choice.html
+++ b/templates/utils/forms/omnibox_choice.html
@@ -1,5 +1,5 @@
 <temba-omnibox {% include "django/forms/widgets/attrs.html" %}
                name="{{ widget.name }}"
                {% if widget.value %}values="{{ widget.value }}"{% endif %}
-               endpoint="/contact/omnibox/?">
+               endpoint="/contact/omnibox/?" jsonValue="true">
 </temba-omnibox>


### PR DESCRIPTION
Scheduling for a contact was submitting undefined because the input was being serialized wrong from https://github.com/nyaruka/temba-components/blob/7457c266d01fedc848e859742ee6f8ba599de084/src/form/select/Select.ts#L1518

Adding jsonValue= true will fix that as the endpoint return JSON data

I believe that is the only place the omnibox is used 