### PR TITLE
Add new simpler chat history endpoint

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timedelta, timezone as tzone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 import iso8601
 import phonenumbers
@@ -626,6 +627,13 @@ class Contact(LegacyUUIDMixin, SmartModel):
         """
         groups = org.groups.filter(group_type__in=ContactGroup.CONTACT_STATUS_TYPES)
         return {g.group_type: count for g, count in ContactGroup.get_member_counts(groups).items()}
+
+    def get_history(
+        self, user, *, before: UUID = None, after: UUID = None, ticket: UUID = None, limit: int
+    ) -> list[dict]:
+        from temba.mailroom.events import Event
+
+        return Event.get_by_contact(self, user, before=before, after=after, ticket=ticket, limit=limit)
 
     def get_scheduled_broadcasts(self):
         return (

--- a/temba/mailroom/tests/test_event.py
+++ b/temba/mailroom/tests/test_event.py
@@ -1,4 +1,5 @@
 import base64
+from uuid import UUID
 
 import iso8601
 from boto3.dynamodb.types import Binary
@@ -10,10 +11,20 @@ from temba.utils import dynamo
 
 class EventTest(TembaTest):
     @cleanup(dynamodb=True)
-    def test_get_by_period(self):
+    def test_get_by_contact(self):
         contact = self.create_contact("Jim", phone="+593979111111", uuid="7e8ff9aa-4b60-49e2-81a6-e79c92635c1e")
 
         items = [
+            {
+                "PK": "con#b3ceb401-c9ce-4f4b-b1e7-ed87d77750ad",  # different contact
+                "SK": "evt#019880eb-e422-7d67-8967-adec64636000",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_language_changed",
+                    "created_on": "2025-08-06T19:46:39.778889794Z",
+                    "language": "spa",
+                },
+            },
             {
                 "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
                 "SK": "evt#019880eb-e422-7d67-993f-cdec64636001",  # 1: (last char is 1...5)
@@ -126,7 +137,405 @@ class EventTest(TembaTest):
             for item in items:
                 writer.put_item(item)
 
-        self.assert_fetched(
+        self.assert_get_by_contact(
+            contact,
+            self.admin,
+            before=UUID("019880eb-e555-7ce9-9ea3-95bf693ee005"),  # event 5 (exclusive)
+            limit=5,
+            expected=[
+                {
+                    "uuid": "019880eb-e4f1-761b-bc99-750003cf8004",
+                    "type": "msg_received",
+                    "created_on": "2025-08-06T19:46:39.985439836Z",
+                    "msg": {
+                        "text": "Hello?",
+                    },
+                    "_deleted": {"created_on": "2025-09-08T19:46:39.985439836Z", "by_contact": True},  # injected
+                },
+                {
+                    "uuid": "019880eb-e488-76d2-a8c4-872e95772003",
+                    "type": "contact_groups_changed",
+                    "created_on": "2025-08-06T19:46:39.880448169Z",
+                    "groups_added": [{"uuid": "fac9a1bd-6db5-4efb-8899-097acda87f96", "name": "Youth"}],
+                    "_user": None,
+                },
+                {
+                    "uuid": "019880eb-e488-7652-beb6-0051d9cd6002",
+                    "type": "contact_field_changed",
+                    "created_on": "2025-08-06T19:46:39.880430294Z",
+                    "field": {"key": "age", "name": "Age"},
+                    "value": {"text": "44"},
+                    "_user": None,  # cleared
+                },
+                {
+                    "uuid": "019880eb-e422-7d67-993f-cdec64636001",
+                    "type": "contact_language_changed",
+                    "created_on": "2025-08-06T19:46:39.778889794Z",
+                    "language": "spa",
+                    "_user": {"uuid": str(self.admin.uuid), "name": "Andy", "avatar": None},  # refreshed
+                },
+            ],
+        )
+
+        # limit to 3 items
+        self.assert_get_by_contact(
+            contact,
+            self.admin,
+            before=UUID("019880eb-e555-7ce9-9ea3-95bf693ee005"),  # event 5 (exclusive)
+            limit=3,
+            expected=[
+                "019880eb-e4f1-761b-bc99-750003cf8004",
+                "019880eb-e488-76d2-a8c4-872e95772003",
+                "019880eb-e488-7652-beb6-0051d9cd6002",
+            ],
+        )
+
+        # get events after event 6 (returned order is now ascending)
+        self.assert_get_by_contact(
+            contact,
+            self.admin,
+            after=UUID("01988abd-1dad-7309-b8b4-adb8380ef006"),  # event 6 (exclusive)
+            limit=5,
+            expected=[
+                {
+                    "uuid": "019a9336-9228-71f0-becb-a56435927007",
+                    "type": "msg_created",
+                    "created_on": "2025-11-17T19:06:58.472135Z",
+                    "msg": {"text": "Oops"},
+                    "unsendable_reason": "no_route",
+                },
+                {
+                    "uuid": "019a9336-9228-73e8-b4f5-3a2b42593008",
+                    "type": "msg_created",
+                    "created_on": "2025-11-17T19:06:58.472259Z",
+                    "msg": {
+                        "text": "Trying again",
+                        "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
+                    },
+                    "_status": {"created_on": "2025-11-17T19:07:58.472259Z", "status": "wired"},
+                    "_logs_url": f"/channels/channel/logs/{self.channel.uuid}/msg/019a9336-9228-73e8-b4f5-3a2b42593008/",
+                },
+            ],
+        )
+
+        # try with user that can't view channel logs
+        self.assert_get_by_contact(
+            contact,
+            self.editor,
+            after=UUID("01988abd-1dad-7309-b8b4-adb8380ef006"),  # event 6 (exclusive)
+            limit=5,
+            expected=[
+                {
+                    "uuid": "019a9336-9228-71f0-becb-a56435927007",
+                    "type": "msg_created",
+                    "created_on": "2025-11-17T19:06:58.472135Z",
+                    "msg": {"text": "Oops"},
+                    "unsendable_reason": "no_route",
+                },
+                {
+                    "uuid": "019a9336-9228-73e8-b4f5-3a2b42593008",
+                    "type": "msg_created",
+                    "created_on": "2025-11-17T19:06:58.472259Z",
+                    "msg": {
+                        "text": "Trying again",
+                        "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
+                    },
+                    "_status": {"created_on": "2025-11-17T19:07:58.472259Z", "status": "wired"},
+                },
+            ],
+        )
+
+    @cleanup(dynamodb=True)
+    def test_get_by_contact_ticket_filtering(self):
+        contact = self.create_contact(
+            name="Joe Blow", urns=["twitter:blow80", "tel:+250781111111"], uuid="7e8ff9aa-4b60-49e2-81a6-e79c92635c1e"
+        )
+
+        items = [
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-71f0-becb-a56435927677",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_urns_changed",
+                    "created_on": "2025-11-17T19:06:58.472135Z",
+                    "urns": ["twitter:blow80", "tel:+250781111111", "twitter:joey"],
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593bb0",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_field_changed",
+                    "created_on": "2025-11-17T19:06:58.472259Z",
+                    "field": {"key": "age", "name": "Age"},
+                    "value": None,
+                },
+            },
+            {  # open ticket #1
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-75c8-8824-0dd4f9484be9",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "ticket_opened",
+                    "created_on": "2025-11-17T19:06:58.472386Z",
+                    "ticket": {
+                        "uuid": "01994f4f-45ba-7f25-a785-b52e19b16c6b",
+                        "status": "open",
+                        "topic": {"uuid": "0d261518-d7d6-410d-bbae-0ef822d8f865", "name": "General"},
+                    },
+                },
+            },
+            {  # assign ticket #1
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-77b8-805c-facb06b1af7c",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "ticket_assignee_changed",
+                    "created_on": "2025-11-17T19:06:58.472509Z",
+                    "ticket_uuid": "01994f4f-45ba-7f25-a785-b52e19b16c6b",
+                    "assignee": None,
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-79a0-9f72-232125ced67d",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_language_changed",
+                    "created_on": "2025-11-17T19:06:58.472633Z",
+                    "language": "spa",
+                },
+            },
+            {  # close ticket #1
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-7b7d-b068-89df0c04df2f",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "ticket_closed",
+                    "created_on": "2025-11-17T19:06:58.472755Z",
+                    "ticket_uuid": "01994f4f-45ba-7f25-a785-b52e19b16c6b",
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-7d59-b7c2-25c3d7091357",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_field_changed",
+                    "created_on": "2025-11-17T19:06:58.472876Z",
+                    "field": {"key": "gender", "name": "Gender"},
+                    "value": {"text": "M"},
+                },
+            },
+            {  # open ticket #2
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-7f2e-bb18-26c5f392fec5",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "ticket_opened",
+                    "created_on": "2025-11-17T19:06:58.472996Z",
+                    "ticket": {
+                        "uuid": "01994f50-ecb1-7b96-944e-64bcbe0cbdd2",
+                        "status": "open",
+                        "topic": {"uuid": "472a7a73-96cb-4736-b567-056d987cc5b4", "name": "Weather"},
+                    },
+                },
+            },
+            {  # note added to ticket #2
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9229-71c1-a6f9-695b374c13a3",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "ticket_note_added",
+                    "created_on": "2025-11-17T19:06:58.473117Z",
+                    "ticket_uuid": "01994f50-ecb1-7b96-944e-64bcbe0cbdd2",
+                    "note": "This looks important!",
+                },
+            },
+        ]
+        with dynamo.HISTORY.batch_writer() as writer:
+            for item in items:
+                writer.put_item(item)
+
+        # by default we only include basic ticket event types
+        self.assert_get_by_contact(
+            contact,
+            self.admin,
+            before=UUID("019a9dc5-b384-7b2d-a1e1-a315a2ebe926"),  # in the future
+            expected=[
+                "019a9336-9228-7f2e-bb18-26c5f392fec5",  # ticket_opened for ticket 2
+                "019a9336-9228-7d59-b7c2-25c3d7091357",
+                "019a9336-9228-7b7d-b068-89df0c04df2f",  # ticket_closed for ticket 1
+                "019a9336-9228-79a0-9f72-232125ced67d",
+                "019a9336-9228-75c8-8824-0dd4f9484be9",  # ticket_opened for ticket 1
+                "019a9336-9228-73e8-b4f5-3a2b42593bb0",
+                "019a9336-9228-71f0-becb-a56435927677",
+            ],
+        )
+
+        # if we specify ticket 1 then we get only events for that ticket
+        self.assert_get_by_contact(
+            contact,
+            self.admin,
+            before=UUID("019a9dc5-b384-7b2d-a1e1-a315a2ebe926"),  # in the future
+            ticket=UUID("01994f4f-45ba-7f25-a785-b52e19b16c6b"),
+            expected=[
+                "019a9336-9228-7d59-b7c2-25c3d7091357",
+                "019a9336-9228-7b7d-b068-89df0c04df2f",  # ticket_closed for ticket 1
+                "019a9336-9228-79a0-9f72-232125ced67d",
+                "019a9336-9228-77b8-805c-facb06b1af7c",  # ticket_assignee_changed for ticket 1
+                "019a9336-9228-75c8-8824-0dd4f9484be9",  # ticket_opened for ticket 1
+                "019a9336-9228-73e8-b4f5-3a2b42593bb0",
+                "019a9336-9228-71f0-becb-a56435927677",
+            ],
+        )
+
+        # likewise for ticket 2
+        self.assert_get_by_contact(
+            contact,
+            self.admin,
+            before=UUID("019a9dc5-b384-7b2d-a1e1-a315a2ebe926"),  # in the future
+            ticket=UUID("01994f50-ecb1-7b96-944e-64bcbe0cbdd2"),
+            expected=[
+                "019a9336-9229-71c1-a6f9-695b374c13a3",  # ticket_note_added for ticket 2
+                "019a9336-9228-7f2e-bb18-26c5f392fec5",  # ticket_opened for ticket 2
+                "019a9336-9228-7d59-b7c2-25c3d7091357",
+                "019a9336-9228-79a0-9f72-232125ced67d",
+                "019a9336-9228-73e8-b4f5-3a2b42593bb0",
+                "019a9336-9228-71f0-becb-a56435927677",
+            ],
+        )
+
+    @cleanup(dynamodb=True)
+    def test_get_by_period(self):
+        contact = self.create_contact("Jim", phone="+593979111111", uuid="7e8ff9aa-4b60-49e2-81a6-e79c92635c1e")
+
+        items = [
+            {
+                "PK": "con#b3ceb401-c9ce-4f4b-b1e7-ed87d77750ad",  # different contact
+                "SK": "evt#019880eb-e422-7d67-8967-adec64636000",
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_language_changed",
+                    "created_on": "2025-08-06T19:46:39.778889794Z",
+                    "language": "spa",
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019880eb-e422-7d67-993f-cdec64636001",  # 1: (last char is 1...5)
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_language_changed",
+                    "created_on": "2025-08-06T19:46:39.778889794Z",
+                    "language": "spa",
+                    "_user": {"uuid": str(self.admin.uuid), "name": "Andrew"},  # name wrong
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019880eb-e488-7652-beb6-0051d9cd6002",  # 2
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_field_changed",
+                    "created_on": "2025-08-06T19:46:39.880430294Z",
+                    "field": {"key": "age", "name": "Age"},
+                    "value": {"text": "44"},
+                    "_user": {"uuid": "e99c9705-8cc3-4063-8c54-fa702cbac867", "name": "Jimmy"},  # user no longer exists
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019880eb-e488-76d2-a8c4-872e95772003",  # 3
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_groups_changed",
+                    "created_on": "2025-08-06T19:46:39.880448169Z",  # less than 1ms after previous event
+                    "groups_added": [{"uuid": "fac9a1bd-6db5-4efb-8899-097acda87f96", "name": "Youth"}],
+                    "_user": None,  # in theory shouldn't happen but who knows
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019880eb-e4f1-761b-bc99-750003cf8004",  # 4
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "msg_received",
+                    "created_on": "2025-08-06T19:46:39.985439836Z",
+                    "msg": {"text": "Hello?"},
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019880eb-e4f1-761b-bc99-750003cf8004#del",  # delete tag for event 4
+                "OrgID": self.org.id,
+                "Data": {
+                    "created_on": "2025-09-08T19:46:39.985439836Z",
+                    "by_contact": True,
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019880eb-e555-7ce9-9ea3-95bf693ee005",  # 5
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_name_changed",
+                    "created_on": "2025-08-06T19:46:40.085871336Z",
+                    "name": "Robert",
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#01988abd-1dad-7309-b8b4-adb8380ef006",  # 6
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "contact_status_changed",
+                    "created_on": "2025-08-06T19:47:40.085871336Z",
+                    "status": "blocked",
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-71f0-becb-a56435927007",  # 7
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "msg_created",
+                    "created_on": "2025-11-17T19:06:58.472135Z",
+                    "msg": {"text": "Oops"},  # no channel or URN
+                    "unsendable_reason": "no_route",
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593008",  # 8
+                "OrgID": self.org.id,
+                "Data": {
+                    "type": "msg_created",
+                    "created_on": "2025-11-17T19:06:58.472259Z",
+                    "msg": {
+                        "text": "Trying again",
+                        "channel": {"uuid": str(self.channel.uuid), "name": self.channel.name},
+                    },
+                },
+            },
+            {
+                "PK": "con#7e8ff9aa-4b60-49e2-81a6-e79c92635c1e",
+                "SK": "evt#019a9336-9228-73e8-b4f5-3a2b42593008#sts",  # status tag for event 8
+                "OrgID": self.org.id,
+                "Data": {
+                    "created_on": "2025-11-17T19:07:58.472259Z",
+                    "status": "wired",
+                },
+            },
+        ]
+
+        with dynamo.HISTORY.batch_writer() as writer:
+            for item in items:
+                writer.put_item(item)
+
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-08-06T18:46:40.085871336Z"),
@@ -167,7 +576,7 @@ class EventTest(TembaTest):
             ],
         )
 
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-08-06T18:46:40.085871336Z"),
@@ -180,7 +589,7 @@ class EventTest(TembaTest):
             ],
         )
 
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-08-06T19:46:39.880430294Z"),  # event 2 (inclusive)
@@ -193,7 +602,7 @@ class EventTest(TembaTest):
             ],
         )
 
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-08-06T19:46:40.085871336Z"),
@@ -202,7 +611,7 @@ class EventTest(TembaTest):
             expected=[],
         )
 
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-11-17T19:06:58.472135Z"),
@@ -231,7 +640,7 @@ class EventTest(TembaTest):
         )
 
         # try with user that can't view channel logs
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.editor,
             iso8601.parse_date("2025-11-17T19:06:58.472135Z"),
@@ -373,7 +782,7 @@ class EventTest(TembaTest):
                 writer.put_item(item)
 
         # by default we only include basic ticket event types
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-11-17T00:00Z"),
@@ -390,7 +799,7 @@ class EventTest(TembaTest):
         )
 
         # if we specify ticket 1 then we get only events for that ticket
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-11-17T00:00Z"),
@@ -408,7 +817,7 @@ class EventTest(TembaTest):
         )
 
         # likewise for ticket 2
-        self.assert_fetched(
+        self.assert_get_by_period(
             contact,
             self.admin,
             iso8601.parse_date("2025-11-17T00:00Z"),
@@ -471,8 +880,16 @@ class EventTest(TembaTest):
         self.assertEqual("session_triggered", event["type"])
         self.assertEqual({"uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d", "name": "Registration Flow"}, event["flow"])
 
-    def assert_fetched(self, contact, user, after, before, *, limit=50, ticket=None, expected: list):
+    def assert_get_by_period(self, contact, user, after, before, *, limit=50, ticket=None, expected: list):
         fetched = Event.get_by_period(contact, user, after=after, before=before, ticket_uuid=ticket, limit=limit)
+
+        if expected and isinstance(expected[0], str):
+            self.assertEqual(expected, [e["uuid"] for e in fetched])
+        else:
+            self.assertEqual(expected, [e for e in fetched])
+
+    def assert_get_by_contact(self, contact, user, *, after=None, before=None, limit=50, ticket=None, expected: list):
+        fetched = Event.get_by_contact(contact, user, after=after, before=before, ticket=ticket, limit=limit)
 
         if expected and isinstance(expected[0], str):
             self.assertEqual(expected, [e["uuid"] for e in fetched])

--- a/temba/tests/matchers.py
+++ b/temba/tests/matchers.py
@@ -59,7 +59,12 @@ class UUIDString(String):
     """
 
     def __new__(cls, version: int):
-        return super().__new__(cls, pattern=UUID_REGEX[version])
+        v = super().__new__(cls, pattern=UUID_REGEX[version])
+        v.version = version
+        return v
+
+    def __repr__(self):
+        return f"<Any:UUIDString:version={self.version}>"
 
 
 class List(MatcherMixin, list):


### PR DESCRIPTION
Widget initializes and calls uuidv7 function to get the anchor UUID value. That is used as initial value for before or after.

**Getting chat history**

Frontend calls `chat/<contact-uuid>?before=<uuid>[&ticket=<ticket-uuid>]`

 * Query table with `SK < evt#<uuid>` and `ScanForward=False`
 * Keep reading up to 51 items, filtering by ticket
 * Return 
   - `events`: first 50 items, newest first
   - `next`: uuid of last event IF if 51st event exists

Frontend records `next` to use as before in next call. If it's not set there's no more history so no more calls.

**Getting new chat events**

Frontend calls `chat/<contact-uuid>?after=<uuid>[&ticket=<ticket-uuid>]`

 * Query table with `SK > evt#<uuid>` and `ScanForward=True`
 * Keep reading up to 51 items, filtering by ticket
 * Return
   - `events`: first 50 items, order reversed so newest first
   - `next`: uuid of first event IF 51st event exists

Frontend records `next` to use as after in next call... if it's set.. otherwise keeps using the anchor UUID.