### PR TITLE
Include uuid in `Msg.as_archive_json()` for completeness

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -596,6 +596,7 @@ class Msg(models.Model):
         serializer = MsgReadSerializer()
 
         return {
+            "uuid": str(self.uuid),
             "id": self.id,
             "contact": {"uuid": str(self.contact.uuid), "name": self.contact.name},
             "channel": {"uuid": str(self.channel.uuid), "name": self.channel.name} if self.channel else None,

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -26,6 +26,7 @@ class MsgTest(TembaTest, CRUDLTestMixin):
         msg1 = self.create_incoming_msg(self.joe, "i'm having a problem", flow=flow)
         self.assertEqual(
             {
+                "uuid": str(msg1.uuid),
                 "id": msg1.id,
                 "contact": {"uuid": str(self.joe.uuid), "name": "Joe Blow"},
                 "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
@@ -50,6 +51,7 @@ class MsgTest(TembaTest, CRUDLTestMixin):
 
         self.assertEqual(
             {
+                "uuid": str(msg1.uuid),
                 "id": msg1.id,
                 "contact": {"uuid": str(self.joe.uuid), "name": "Joe Blow"},
                 "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
@@ -74,6 +76,7 @@ class MsgTest(TembaTest, CRUDLTestMixin):
 
         self.assertEqual(
             {
+                "uuid": str(msg2.uuid),
                 "id": msg2.id,
                 "contact": {"uuid": str(self.joe.uuid), "name": "Joe Blow"},
                 "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},


### PR DESCRIPTION
Not actually used but useful to keep this in sync with the actual archiver format