### PR TITLE
Fix API explorer, to show results in the correct container

### DIFF
--- a/temba/api/v2/tests/test_base.py
+++ b/temba/api/v2/tests/test_base.py
@@ -248,6 +248,7 @@ class EndpointsTest(APITest):
         self.login(self.editor)
         response = self.client.get(explorer_url)
         self.assertEqual(200, response.status_code)
+        self.assertEqual(response.context["active_org"], self.org)
 
         self.login(self.admin)
 

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -101,6 +101,7 @@ class ExplorerView(OrgPermsMixin, SmartTemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["active_org"] = self.derive_org()
 
         context["endpoints"] = [
             ArchivesEndpoint.get_read_explorer(),


### PR DESCRIPTION
So that the workspace variable in https://github.com/nyaruka/rapidpro/blob/f0cbbdb8f96bd20632a48f808df0f6e8c49e2982/templates/frame.html#L56 
is properly assigned.
