### PR TITLE
Retire classic editor and force all users to new editor

### DIFF
--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -232,6 +232,13 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, reverse("flows.flow_simulate", args=[flow.uuid]))
         self.assertContains(response, 'id="rp-flow-editor"')
 
+        # ?classic param sets a 24h cookie and redirects to classic editor
+        del self.client.cookies["classic-editor"]
+        response = self.client.get(f"{flow_editor_url}?classic")
+        self.assertRedirects(response, flow_editor_url, fetch_redirect_response=False)
+        self.assertEqual(response.cookies["classic-editor"].value, "true")
+        self.assertEqual(response.cookies["classic-editor"]["max-age"], 86400)
+
         # removing the cookie goes back to new editor default
         del self.client.cookies["classic-editor"]
         response = self.client.get(flow_editor_url)

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -223,7 +223,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(response.status_code, 200)
 
         # opting out keeps user on classic editor
-        self.client.cookies["use-new-editor"] = "false"
+        self.client.cookies["classic-editor"] = "true"
         response = self.client.get(flow_editor_url)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["mutable"])
@@ -233,13 +233,13 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, 'id="rp-flow-editor"')
 
         # removing the cookie goes back to new editor default
-        del self.client.cookies["use-new-editor"]
+        del self.client.cookies["classic-editor"]
         response = self.client.get(flow_editor_url)
         self.assertRedirects(response, flow_next_url, fetch_redirect_response=False)
 
         # flows that are archived can't be edited, started or simulated
         self.login(self.admin)
-        self.client.cookies["use-new-editor"] = "false"
+        self.client.cookies["classic-editor"] = "true"
 
         flow.is_archived = True
         flow.save(update_fields=("is_archived",))

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1110,7 +1110,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         flow = self.create_flow("Test")
 
         self.login(self.admin)
-        self.client.cookies["use-new-editor"] = "false"
+        self.client.cookies["classic-editor"] = "true"
 
         def assert_features(features: set):
             response = self.client.get(reverse("flows.flow_editor", args=[flow.uuid]))

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -716,7 +716,12 @@ class FlowCRUDL(SmartCRUDL):
 
     class Editor(SpaMixin, ContextMenuMixin, BaseReadView):
         def get(self, request, *args, **kwargs):
-            if request.COOKIES.get("use-new-editor") != "false" and self.__class__.__name__ != "Next":
+            if "classic" in request.GET:
+                response = HttpResponseRedirect(reverse("flows.flow_editor", args=[kwargs["uuid"]]))
+                response.set_cookie("classic-editor", "true", path="/", max_age=86400)  # 24 hours
+                return response
+
+            if request.COOKIES.get("classic-editor") != "true" and self.__class__.__name__ != "Next":
                 return HttpResponseRedirect(reverse("flows.flow_next", args=[kwargs["uuid"]]))
             return super().get(request, *args, **kwargs)
 
@@ -832,9 +837,9 @@ class FlowCRUDL(SmartCRUDL):
         def build_context_menu(self, menu):
             super().build_context_menu(menu)
 
-            # replace "Switch to New Editor" with "Use Classic Editor"
+            # replace "Switch to New Editor" with "Classic Editor"
             menu.groups[-1] = [
-                {"type": "js", "id": "useClassicEditor", "label": str(_("Use Classic Editor")), "as_button": False}
+                {"type": "js", "id": "useClassicEditor", "label": str(_("Classic Editor")), "as_button": False}
             ]
 
     class ChangeLanguage(OrgObjPermsMixin, SmartUpdateView):

--- a/templates/flows/flow_editor.html
+++ b/templates/flows/flow_editor.html
@@ -224,7 +224,7 @@
   {{ block.super }}
   <script type="text/javascript">
     function enableNewEditor() {
-      document.cookie = 'use-new-editor=; path=/; max-age=0';
+      document.cookie = 'classic-editor=; path=/; max-age=0';
       window.location.href = '/flow/next/{{object.uuid}}/';
     }
 

--- a/templates/flows/flow_next.html
+++ b/templates/flows/flow_next.html
@@ -55,8 +55,10 @@
   {{ block.super }}
   <script type="text/javascript">
     function useClassicEditor() {
-      document.cookie = 'use-new-editor=false; path=/; max-age=31536000';
-      window.location.href = '/flow/editor/{{object.uuid}}/';
+      var dialog = document.getElementById('classic-editor-retired');
+      dialog.style = 'display:block';
+      dialog.buttons = [{ type: 'secondary', name: 'Ok', closes: true }];
+      dialog.open = true;
     }
 
     function navigateTo(url, detail) {
@@ -100,6 +102,15 @@
   </script>
 {% endblock extra-script %}
 {% block content %}
+  <temba-dialog header="{% trans "Classic Editor" %}"
+                class="hide"
+                id="classic-editor-retired">
+    <div class="p-6">
+      {% blocktrans trimmed %}
+        The Flow Editor has been refreshed with new features and improvements. We're excited about what this means for your workflows. If the new editor doesn't work as expected, please let us know using the support widget at the bottom—we're committed to making sure you have a great experience.
+      {% endblocktrans %}
+    </div>
+  </temba-dialog>
   <temba-flow-editor flow="{{ object.uuid }}" features='{{ feature_filters }}' -temba-contact-clicked="handleContactClicked" -temba-flow-clicked="handleFlowClicked" -temba-group-clicked="handleGroupClicked">
   </temba-flow-editor>
   <temba-simulator flow="{{ object.uuid }}" -temba-follow-simulation="handleFollow">


### PR DESCRIPTION
## Summary
- Renames "Use Classic Editor" menu option to "Classic Editor" and shows an informational dialog instead of switching editors
- Switches to a new `classic-editor` cookie so existing users with the old `use-new-editor` cookie are forced into the new editor
- Adds `?classic` URL parameter support for support staff to grant users 24-hour temporary classic editor access

## Test plan
- [x] Verify clicking "Classic Editor" in the menu shows the retirement dialog
- [x] Verify users with old `use-new-editor` cookie are redirected to the new editor
- [x] Verify `/flow/editor/<uuid>/?classic` sets a 24h cookie and loads the classic editor
- [x] Verify the "Switch to New Editor" button in the classic editor clears the new cookie