### PR TITLE
Harden request validation in android sync and org switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.45.3",
-    "@nyaruka/temba-components": "0.156.7",
+    "@nyaruka/temba-components": "0.156.8",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.45.3",
-    "@nyaruka/temba-components": "0.156.6",
+    "@nyaruka/temba-components": "0.156.7",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/temba/channels/android/views.py
+++ b/temba/channels/android/views.py
@@ -77,9 +77,9 @@ def sync(request, channel_id):
     # base64 and url sanitize
     signature = base64.urlsafe_b64encode(signature).strip()
 
-    if request_signature != signature:
+    if not hmac.compare_digest(request_signature, signature):
         return JsonResponse(
-            {"error_id": 1, "error": "Invalid signature: '%(request)s'" % {"request": request_signature}, "cmds": []},
+            {"error_id": 1, "error": "Invalid signature", "cmds": []},
             status=401,
         )
 

--- a/temba/orgs/views/tests/test_orgcrudl.py
+++ b/temba/orgs/views/tests/test_orgcrudl.py
@@ -1193,3 +1193,9 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRedirect(response, "/msg")
         self.assertEqual(str(self.org2.uuid), self.client.session["org_uuid"])
         self.assertEqual(self.org2.id, self.client.session["org_id"])
+
+        # external next URL should be ignored and fall back to start
+        response = self.client.post(
+            reverse("orgs.org_switch"), {"other_org": self.org2.id, "next": "https://evil.example.com/"}
+        )
+        self.assertRedirect(response, reverse("orgs.org_start"))

--- a/temba/orgs/views/tests/test_orgcrudl.py
+++ b/temba/orgs/views/tests/test_orgcrudl.py
@@ -1199,3 +1199,9 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
             reverse("orgs.org_switch"), {"other_org": self.org2.id, "next": "https://evil.example.com/"}
         )
         self.assertRedirect(response, reverse("orgs.org_start"))
+
+        # schemeless external URL should also be rejected
+        response = self.client.post(
+            reverse("orgs.org_switch"), {"other_org": self.org2.id, "next": "//evil.example.com/"}
+        )
+        self.assertRedirect(response, reverse("orgs.org_start"))

--- a/temba/orgs/views/views.py
+++ b/temba/orgs/views/views.py
@@ -1100,7 +1100,11 @@ class OrgCRUDL(SmartCRUDL):
         def form_valid(self, form):
             switch_to_org(self.request, form.cleaned_data["other_org"])
             success_url = form.cleaned_data["next"]
-            if not success_url or not url_has_allowed_host_and_scheme(success_url, allowed_hosts=None):
+            if not success_url or not url_has_allowed_host_and_scheme(
+                success_url,
+                allowed_hosts={self.request.get_host()},
+                require_https=self.request.is_secure(),
+            ):
                 success_url = reverse("orgs.org_start")
             return HttpResponseRedirect(success_url)
 

--- a/temba/orgs/views/views.py
+++ b/temba/orgs/views/views.py
@@ -28,6 +28,7 @@ from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.encoding import DjangoUnicodeDecodeError, force_str
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -1098,7 +1099,9 @@ class OrgCRUDL(SmartCRUDL):
         # valid form means we set our org and redirect to next
         def form_valid(self, form):
             switch_to_org(self.request, form.cleaned_data["other_org"])
-            success_url = form.cleaned_data["next"] or reverse("orgs.org_start")
+            success_url = form.cleaned_data["next"]
+            if not success_url or not url_has_allowed_host_and_scheme(success_url, allowed_hosts=None):
+                success_url = reverse("orgs.org_start")
             return HttpResponseRedirect(success_url)
 
     class Start(SmartTemplateView):

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,10 +139,10 @@
     uuid "^11.1.0"
     zustand "^5.0.3"
 
-"@nyaruka/temba-components@0.156.6":
-  version "0.156.6"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.6.tgz#71741651acafb89b4e0cd0c3006c2c2334637ca2"
-  integrity sha512-BHcHpRYCetTbJVExjjhqa6uP0YYmTg+hphgWh9sAQdOGR4P+qKZrKc8BGziDPYmz6OtsA9601xwHiHAXhmKktQ==
+"@nyaruka/temba-components@0.156.7":
+  version "0.156.7"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.7.tgz#c11f1d6d8a63b4ffaf190a3267eb2f24c8284284"
+  integrity sha512-V63RfS1nyswyAGEDzSrt2k4kwYZ6OPxFxPmwhw72x59gOqzB6+KENpa5EILj17MvwStA/nz19Rg7ekoY+X6Q5Q==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,10 +139,10 @@
     uuid "^11.1.0"
     zustand "^5.0.3"
 
-"@nyaruka/temba-components@0.156.7":
-  version "0.156.7"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.7.tgz#c11f1d6d8a63b4ffaf190a3267eb2f24c8284284"
-  integrity sha512-V63RfS1nyswyAGEDzSrt2k4kwYZ6OPxFxPmwhw72x59gOqzB6+KENpa5EILj17MvwStA/nz19Rg7ekoY+X6Q5Q==
+"@nyaruka/temba-components@0.156.8":
+  version "0.156.8"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.8.tgz#beecf6d5bc8206d128f8049dc68c00c87bf7130c"
+  integrity sha512-MTvAZ6CKJV+hjfqv4Zb+Mq89B0wzm6xJArrHXrOKU6v5b9KY/JTeTcNP1O9i+mXuclDC2aUYq4hfXrs5EgXQCw==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Summary

- Use `hmac.compare_digest` instead of `!=` for signature check in android sync view, and simplify the error message
- Validate `next` URL parameter in org switch view before redirecting

## Test plan

- [ ] Android sync endpoint still accepts valid signed requests
- [ ] Invalid signatures still return 401
- [ ] Org switch with a valid relative `next` URL still redirects correctly
- [ ] Org switch with no `next` or an external URL falls back to start page