### PR TITLE
Update @nyaruka/temba-components to 0.156.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@nyaruka/flow-editor": "1.45.3",
-    "@nyaruka/temba-components": "0.156.6",
+    "@nyaruka/temba-components": "0.156.7",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,10 +139,10 @@
     uuid "^11.1.0"
     zustand "^5.0.3"
 
-"@nyaruka/temba-components@0.156.6":
-  version "0.156.6"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.6.tgz#71741651acafb89b4e0cd0c3006c2c2334637ca2"
-  integrity sha512-BHcHpRYCetTbJVExjjhqa6uP0YYmTg+hphgWh9sAQdOGR4P+qKZrKc8BGziDPYmz6OtsA9601xwHiHAXhmKktQ==
+"@nyaruka/temba-components@0.156.7":
+  version "0.156.7"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.7.tgz#c11f1d6d8a63b4ffaf190a3267eb2f24c8284284"
+  integrity sha512-V63RfS1nyswyAGEDzSrt2k4kwYZ6OPxFxPmwhw72x59gOqzB6+KENpa5EILj17MvwStA/nz19Rg7ekoY+X6Q5Q==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.156.7](https://github.com/nyaruka/temba-components/compare/v0.156.6...v0.156.7)

- Add tests for TembaUser and Resizer [#976](https://github.com/nyaruka/temba-components/pull/976)
- Extract floating windows (issues, revisions) from Editor [#975](https://github.com/nyaruka/temba-components/pull/975)
- Move setup-worktree.sh and run.sh to shared utils [#974](https://github.com/nyaruka/temba-components/pull/974)
- Break up Editor.ts into focused modules [#973](https://github.com/nyaruka/temba-components/pull/973)
- Reduce auto-scroll sensitivity on touch devices [#971](https://github.com/nyaruka/temba-components/pull/971)
- Fix Enter key not working for quick replies on Android tablets [#972](https://github.com/nyaruka/temba-components/pull/972)