### PR TITLE
Filter deleted shortcuts from internal shortcuts endpoint

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -147,6 +147,8 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         shortcut1 = Shortcut.create(self.org, self.admin, "Planes", "Planes are...")
         shortcut2 = Shortcut.create(self.org, self.admin, "Trains", "Trains are...")
+        deleted = Shortcut.create(self.org, self.admin, "Deleted", "Deleted shortcut")
+        deleted.release(self.admin)
         Shortcut.create(self.org2, self.admin, "Cars", "Other org")
 
         self.assertGet(

--- a/temba/api/internal/views.py
+++ b/temba/api/internal/views.py
@@ -125,6 +125,9 @@ class ShortcutsEndpoint(ListAPIMixin, BaseEndpoint):
     serializer_class = serializers.ShortcutReadSerializer
     pagination_class = ModifiedOnCursorPagination
 
+    def get_queryset(self):
+        return super().get_queryset().filter(org=self.request.org, is_active=True)
+
 
 class TemplatesEndpoint(ListAPIMixin, BaseEndpoint):
     """


### PR DESCRIPTION
The internal `ShortcutsEndpoint` was missing a queryset filter, so soft-deleted shortcuts (where `release()` sets `is_active=False`) were leaking into the API and showing up in the UI. Added a `get_queryset()` override that filters by `org` and `is_active=True`, mirroring the pattern used by `LLMsEndpoint`. Also extended `test_shortcuts` to create and release a shortcut and assert it's excluded from results.