### PR TITLE
Update @nyaruka/temba-components to 0.156.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.156.9",
+    "@nyaruka/temba-components": "0.156.10",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nyaruka/temba-components@0.156.9":
-  version "0.156.9"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.9.tgz#3ce61ec3013c00751e4c01d13a7b3f3fef40e21f"
-  integrity sha512-4Dr+wWJ3PguAF70IOC9Ewr6MV/IbbK/gPOcsQNHoY+JtgdVyev5iOKaErZI7O8YMhj/OmAvlbLRAlxqSOlWJzA==
+"@nyaruka/temba-components@0.156.10":
+  version "0.156.10"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.10.tgz#7eb7d40b33007e34c299703051a38800d3b67dfe"
+  integrity sha512-WOPg8Jdu6KrlkwoZO1BgqxeffGMmf5T1DJVSoOveg1qJm8kVJrO+XYZ4A0cEcg4f8Yu41GKgPIyN1Gs85LFQ2g==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.156.10](https://github.com/nyaruka/temba-components/compare/v0.156.9...v0.156.10)

- Apply code formatting [#984](https://github.com/nyaruka/temba-components/pull/984)
- Make canvas context menu shortcuts declarative per flow type [#982](https://github.com/nyaruka/temba-components/pull/982)
- Hide language selector dropdown for empty flows [#983](https://github.com/nyaruka/temba-components/pull/983)
- Use RapidPro language names for ISO 639-3 codes not covered by Intl [#981](https://github.com/nyaruka/temba-components/pull/981)
- Centralize category helpers and validate reserved names across node types [#980](https://github.com/nyaruka/temba-components/pull/980)
- Refactor flow editor for DRY-ness across node and action configs [#979](https://github.com/nyaruka/temba-components/pull/979)