### PR TITLE
Remove flow-editor from STATICFILES_DIRS

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -133,7 +133,6 @@ TESTFILES_DIR = os.path.join(PROJECT_DIR, "../testfiles")
 STATICFILES_DIRS = (
     os.path.join(PROJECT_DIR, "../static"),
     os.path.join(PROJECT_DIR, "../media"),
-    os.path.join(PROJECT_DIR, "../node_modules/@nyaruka/flow-editor/build"),
     os.path.join(PROJECT_DIR, "../node_modules/@nyaruka/temba-components/dist/static"),
     os.path.join(PROJECT_DIR, "../node_modules"),
     os.path.join(PROJECT_DIR, "../node_modules/react/umd"),


### PR DESCRIPTION
Drops the legacy `@nyaruka/flow-editor/build` path from `STATICFILES_DIRS` since it's no longer needed.