### PR TITLE
Add template and template_variables fields to CampaignEvent

### DIFF
--- a/temba/campaigns/migrations/0081_campaignevent_template_and_more.py
+++ b/temba/campaigns/migrations/0081_campaignevent_template_and_more.py
@@ -1,0 +1,30 @@
+import django.contrib.postgres.fields
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("campaigns", "0080_squashed"),
+        ("templates", "0047_squashed"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="campaignevent",
+            name="template",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to="templates.template",
+            ),
+        ),
+        migrations.AddField(
+            model_name="campaignevent",
+            name="template_variables",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.TextField(), blank=True, null=True, size=None
+            ),
+        ),
+    ]

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone as tzone
 from django_valkey import get_valkey_connection
 from smartmin.models import SmartModel
 
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Sum
 from django.utils import timezone
@@ -306,8 +307,10 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
 
     # the content: either a flow or message translations
     flow = models.ForeignKey(Flow, on_delete=models.PROTECT, related_name="campaign_events", null=True, blank=True)
-    translations = models.JSONField(null=True)
+    translations = models.JSONField(null=True)  # text, attachments and quick replies by language
     base_language = models.CharField(max_length=3, null=True)  # ISO-639-3
+    template = models.ForeignKey("templates.Template", null=True, blank=True, on_delete=models.PROTECT)
+    template_variables = ArrayField(models.TextField(), null=True, blank=True)
 
     # what should happen to other runs when this event is triggered
     start_mode = models.CharField(max_length=1, choices=START_MODES_CHOICES, default=MODE_INTERRUPT)
@@ -326,6 +329,8 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
         base_language: str,
         delivery_hour=-1,
         start_mode=MODE_INTERRUPT,
+        template=None,
+        template_variables=(),
     ):
         assert campaign.org == org, "org mismatch"
         assert base_language and languages.get_name(base_language), f"{base_language} is not a valid language code"
@@ -346,6 +351,8 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
             base_language=base_language,
             delivery_hour=delivery_hour,
             start_mode=start_mode,
+            template=template,
+            template_variables=list(template_variables) if template_variables else None,
             created_by=user,
             modified_by=user,
         )


### PR DESCRIPTION
## Summary
- Adds nullable `template` (FK to `templates.Template`) and `template_variables` (text `ArrayField`) to `CampaignEvent`, plus migration `0081`.
- Extends `CampaignEvent.create_message_event(..., template=None, template_variables=())` with kw-only args so existing callers are unaffected.
- Extracted from #6570 so that the mailroom side can be built against the new schema before the view/form/template UI work lands.

## Why split from #6570
Both new columns are nullable and additive — safe to deploy ahead of the UI changes. Shipping these first lets the mailroom work proceed in parallel; the view/form/template pieces of #6570 will follow.

## Note on `blank=True`
Unlike #6570, this PR marks both fields `blank=True`. That PR removes `obj.full_clean()` from the campaign event form's `pre_save`, but we're leaving the view untouched here, so `full_clean()` still runs and would otherwise reject the new fields. The follow-up PR can drop `blank=True` (or leave it — harmless) when the view rewrite lands.

## Test plan
- [x] `makemigrations --check` → clean
- [x] `test temba.campaigns` → all tests pass (one pre-existing localstack-S3 error unrelated to this change)
- [x] `test temba.api.v2.tests.test_campaign_events temba.api.v2.tests.test_campaigns` → OK
- [x] `ruff format` / `ruff check` / `code_check.py` → clean
- [ ] Reviewer: sanity-check the migration against a prod-shaped DB