### PR TITLE
Update llm_translate to use batched shape

### DIFF
--- a/temba/ai/models.py
+++ b/temba/ai/models.py
@@ -96,8 +96,8 @@ class LLM(TembaModel, DependencyMixin):
 
         return TYPES[self.llm_type]
 
-    def translate(self, from_language: str, to_language: str, text: str) -> str:
-        return mailroom.get_client().llm_translate(self, from_language, to_language, text)["text"]
+    def translate(self, source: str, target: str, items: dict[str, list[str]]) -> dict[str, list[str]]:
+        return mailroom.get_client().llm_translate(self, source, target, items)
 
     def release(self, user):
         super().release(user)

--- a/temba/ai/tests/test_llm.py
+++ b/temba/ai/tests/test_llm.py
@@ -26,7 +26,10 @@ class LLMTest(TembaTest):
     def test_translate(self, mr_mocks):
         openai = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {})
 
-        mr_mocks.llm_translate("Hola")
-        self.assertEqual(openai.translate("eng", "spa", "Hello"), "Hola")
+        items = {"a1:text": ["Hello"]}
+        translated = {"a1:text": ["Hola"]}
 
-        self.assertEqual(call(openai, "eng", "spa", "Hello"), mr_mocks.calls["llm_translate"][-1])
+        mr_mocks.llm_translate(translated)
+        self.assertEqual(openai.translate("eng", "spa", items), translated)
+
+        self.assertEqual(call(openai, "eng", "spa", items), mr_mocks.calls["llm_translate"][-1])

--- a/temba/ai/tests/test_llmcrudl.py
+++ b/temba/ai/tests/test_llmcrudl.py
@@ -62,13 +62,16 @@ class LLMCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertRequestDisallowed(translate_url, [None, self.agent])
 
-        mr_mocks.llm_translate("Hola")
+        translated = {"a1:text": ["Hola"]}
+        mr_mocks.llm_translate(translated)
 
         self.login(self.editor)
         response = self.client.post(
-            translate_url, {"text": "Hello", "lang": {"from": "eng", "to": "spa"}}, content_type="application/json"
+            translate_url,
+            {"source": "eng", "target": "spa", "items": {"a1:text": ["Hello"]}},
+            content_type="application/json",
         )
-        self.assertEqual(response.json(), {"result": "Hola"})
+        self.assertEqual(response.json(), {"items": translated})
 
     def test_delete(self):
         list_url = reverse("ai.llm_list")

--- a/temba/ai/tests/test_llmcrudl.py
+++ b/temba/ai/tests/test_llmcrudl.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from temba.ai.models import LLM
 from temba.ai.types.anthropic.type import AnthropicType
 from temba.ai.types.openai.type import OpenAIType
+from temba.mailroom.client.exceptions import AIServiceException
 from temba.tests import CRUDLTestMixin, TembaTest, mock_mailroom
 from temba.utils.views.mixins import TEMBA_MENU_SELECTION
 
@@ -72,6 +73,17 @@ class LLMCRUDLTest(TembaTest, CRUDLTestMixin):
             content_type="application/json",
         )
         self.assertEqual(response.json(), {"items": translated})
+
+        # LLM service failure (bad credentials, rate limit, etc.) returns 400 to the client
+        mr_mocks.exception(AIServiceException("rate limit exceeded", "unknown", "", ""))
+
+        response = self.client.post(
+            translate_url,
+            {"source": "eng", "target": "spa", "items": {"a1:text": ["Hello"]}},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"error": "rate limit exceeded"})
 
     def test_delete(self):
         list_url = reverse("ai.llm_list")

--- a/temba/ai/views.py
+++ b/temba/ai/views.py
@@ -132,11 +132,11 @@ class LLMCRUDL(SmartCRUDL):
             data = json.loads(request.body)
 
             try:
-                translated = self.object.translate(data["lang"]["from"], data["lang"]["to"], data["text"])
+                items = self.object.translate(data["source"], data["target"], data["items"])
             except mailroom.AIServiceException:  # pragma: no cover
                 return JsonResponse({"error": "LLM was not able to translate as requested"}, status=400)
 
-            return JsonResponse({"result": translated})
+            return JsonResponse({"items": items})
 
     class Delete(BaseDependencyDeleteModal):
         cancel_url = "@ai.llm_list"

--- a/temba/ai/views.py
+++ b/temba/ai/views.py
@@ -133,8 +133,8 @@ class LLMCRUDL(SmartCRUDL):
 
             try:
                 items = self.object.translate(data["source"], data["target"], data["items"])
-            except mailroom.AIServiceException:  # pragma: no cover
-                return JsonResponse({"error": "LLM was not able to translate as requested"}, status=400)
+            except mailroom.AIServiceException as e:
+                return JsonResponse({"error": str(e)}, status=400)
 
             return JsonResponse({"items": items})
 

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -252,17 +252,18 @@ class MailroomClient:
 
         return RecipientsPreview(query=resp["query"], total=resp["total"])
 
-    def llm_translate(self, llm, from_language: str, to_language: str, text: str) -> dict:
-        return self._request(
+    def llm_translate(self, llm, source: str, target: str, items: dict[str, list[str]]) -> dict[str, list[str]]:
+        resp = self._request(
             "llm/translate",
             {
                 "org_id": llm.org_id,
                 "llm_id": llm.id,
-                "from_language": from_language,
-                "to_language": to_language,
-                "text": text,
+                "source": source,
+                "target": target,
+                "items": items,
             },
         )
+        return resp["items"]
 
     def msg_broadcast(
         self,

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -17,7 +17,6 @@ from temba.utils import json
 from .. import modifiers
 from .client import MailroomClient
 from .exceptions import (
-    AIServiceException,
     FlowValidationException,
     QueryValidationException,
     RequestException,
@@ -616,10 +615,19 @@ class MailroomClientTest(TembaTest):
     def test_llm_translate(self, mock_post):
         llm = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {})
 
-        mock_post.return_value = MockJsonResponse(200, {"text": "Hola mundo"})
-        response = self.client.llm_translate(llm, from_language="eng", to_language="spa", text="Hello world")
+        items = {
+            "a1f0e2c4:text": ["Hello world"],
+            "a1f0e2c4:quick_replies": ["Yes", "No"],
+        }
+        translated = {
+            "a1f0e2c4:text": ["Hola mundo"],
+            "a1f0e2c4:quick_replies": ["Sí", "No"],
+        }
 
-        self.assertEqual({"text": "Hola mundo"}, response)
+        mock_post.return_value = MockJsonResponse(200, {"items": translated})
+        response = self.client.llm_translate(llm, source="eng", target="spa", items=items)
+
+        self.assertEqual(translated, response)
 
         mock_post.assert_called_once_with(
             "http://localhost:8090/mr/llm/translate",
@@ -627,29 +635,11 @@ class MailroomClientTest(TembaTest):
             json={
                 "org_id": self.org.id,
                 "llm_id": llm.id,
-                "from_language": "eng",
-                "to_language": "spa",
-                "text": "Hello world",
+                "source": "eng",
+                "target": "spa",
+                "items": items,
             },
         )
-
-        mock_post.return_value = MockJsonResponse(
-            422,
-            {
-                "code": "ai:reasoning",
-                "error": "not able to translate",
-                "extra": {"instructions": "Translate", "input": "Hi there", "response": "<CANT>"},
-            },
-        )
-
-        with self.assertRaises(AIServiceException) as e:
-            self.client.llm_translate(llm, from_language="eng", to_language="spa", text="Hello world")
-
-        self.assertEqual("not able to translate", e.exception.error)
-        self.assertEqual("reasoning", e.exception.code)
-        self.assertEqual("Translate", e.exception.instructions)
-        self.assertEqual("Hi there", e.exception.input)
-        self.assertEqual("not able to translate", str(e.exception))
 
     @patch("requests.post")
     def test_msg_broadcast(self, mock_post):

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -17,6 +17,7 @@ from temba.utils import json
 from .. import modifiers
 from .client import MailroomClient
 from .exceptions import (
+    AIServiceException,
     FlowValidationException,
     QueryValidationException,
     RequestException,
@@ -640,6 +641,21 @@ class MailroomClientTest(TembaTest):
                 "items": items,
             },
         )
+
+        mock_post.return_value = MockJsonResponse(
+            422,
+            {
+                "code": "ai:unknown",
+                "error": "rate limit exceeded",
+                "extra": {"instructions": "", "input": ""},
+            },
+        )
+
+        with self.assertRaises(AIServiceException) as e:
+            self.client.llm_translate(llm, source="eng", target="spa", items=items)
+
+        self.assertEqual("rate limit exceeded", e.exception.error)
+        self.assertEqual("unknown", e.exception.code)
 
     @patch("requests.post")
     def test_msg_broadcast(self, mock_post):

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -111,8 +111,8 @@ class Mocks:
 
         self._flow_start_preview.append(mock)
 
-    def llm_translate(self, text):
-        self._llm_translate.append(text)
+    def llm_translate(self, items: dict):
+        self._llm_translate.append(items)
 
     def msg_broadcast_preview(self, query, total):
         def mock(org):
@@ -364,10 +364,10 @@ class TestClient(MailroomClient):
         return mock(org)
 
     @_client_method
-    def llm_translate(self, llm, from_language: str, to_language: str, text: str) -> dict:
+    def llm_translate(self, llm, source: str, target: str, items: dict[str, list[str]]) -> dict[str, list[str]]:
         assert self.mocks._llm_translate, "missing llm_translate mock"
 
-        return {"text": self.mocks._llm_translate.pop(0)}
+        return self.mocks._llm_translate.pop(0)
 
     @_client_method
     def msg_broadcast(


### PR DESCRIPTION
## Summary

Updates the mailroom client and translate endpoint to match the new batched shape introduced in [mailroom#1052](https://github.com/nyaruka/mailroom/pull/1052).

The mailroom `POST /mi/llm/translate` endpoint now takes a map of items keyed by an opaque caller id (e.g. `"uuid:property"`) → array of strings, and returns the same shape. Items the LLM can't translate are simply absent from the response.

## Changes

- `MailroomClient.llm_translate(llm, source, target, items)` — renames `from_language`/`to_language` → `source`/`target`, takes/returns `dict[str, list[str]]`.
- `LLM.translate` — passes through the items map.
- `Translate` view — accepts `{source, target, items}` and returns `{items}`.
- Test mocks and tests updated. Removed the `<CANT>` / `AIServiceException` case from `test_llm_translate` since per-item failures are now silently absent rather than raised as 422s.

## Test plan

- [x] `temba.ai.tests` and `temba.mailroom.client.tests.MailroomClientTest.test_llm_translate` pass
- [x] `code_check.py` clean