### PR TITLE
Add is_available_to hook to LLMType

### DIFF
--- a/temba/ai/models.py
+++ b/temba/ai/models.py
@@ -45,6 +45,12 @@ class LLMType(metaclass=ABCMeta):
 
         return settings.LLM_TYPES[self.__module__ + "." + self.__class__.__name__]
 
+    def is_available_to(self, org, user) -> bool:
+        """
+        Determines whether this LLM type is available to the given user.
+        """
+        return True
+
 
 class LLM(TembaModel, DependencyMixin):
     """

--- a/temba/ai/tests/test_llm.py
+++ b/temba/ai/tests/test_llm.py
@@ -22,6 +22,11 @@ class LLMTest(TembaTest):
         self.assertEqual(1, LLM.objects.filter(is_active=False).count())
         self.assertEqual(2, LLM.objects.count())
 
+    def test_is_available_to(self):
+        # by default available to any user
+        self.assertTrue(OpenAIType().is_available_to(self.org, self.admin))
+        self.assertTrue(OpenAIType().is_available_to(self.org, self.editor))
+
     @mock_mailroom
     def test_translate(self, mr_mocks):
         openai = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {})

--- a/temba/ai/tests/test_llmcrudl.py
+++ b/temba/ai/tests/test_llmcrudl.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import override_settings
 from django.urls import reverse
 
@@ -35,6 +37,18 @@ class LLMCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.assertListFetch(list_url, [self.editor, self.admin], context_object_count=2)
             self.assertContains(response, "You have reached the per-workspace limit")
             self.assertContentMenu(list_url, self.admin, [])
+
+        # types that aren't available to the user are hidden from the menu
+        with patch.object(AnthropicType, "is_available_to", lambda self, org, user: user.is_staff):
+            self.assertContentMenu(
+                list_url, self.admin, ["New DeepSeek", "New Google", "New OpenAI", "New Azure OpenAI"]
+            )
+            self.assertContentMenu(
+                list_url,
+                self.customer_support,
+                ["New Anthropic", "New DeepSeek", "New Google", "New OpenAI", "New Azure OpenAI"],
+                choose_org=self.org,
+            )
 
     def test_update(self):
         update_url = reverse("ai.llm_update", args=[self.openai.uuid])

--- a/temba/ai/views.py
+++ b/temba/ai/views.py
@@ -100,7 +100,11 @@ class LLMCRUDL(SmartCRUDL):
 
         def build_context_menu(self, menu):
             if self.has_org_perm("ai.llm_connect") and not self.is_limit_reached():
+                org = self.request.org
+                user = self.request.user
                 for llm_type in LLM.get_types():
+                    if not llm_type.is_available_to(org, user):
+                        continue
                     menu.add_modax(
                         f"New {llm_type.name}",
                         f"new-{llm_type.slug}",


### PR DESCRIPTION
Adds an `is_available_to(org, user) -> bool` method to `LLMType`, mirroring the pattern already used on `ChannelType` (see [ChipType](temba/channels/types/chip/type.py)). `LLMCRUDL.List.build_context_menu` now skips types for which it returns false.

Motivation: we want to introduce a new LLM type that is initially staff-only. Existing types inherit the default `True` and are unaffected.

Scope matches channel-type behaviour: the menu entry is hidden, but the connect URL remains registered — no view-level gating.

## Test plan
- [ ] `./manage.py test temba.ai.tests.test_llm temba.ai.tests.test_llmcrudl`
- [ ] Confirm existing types (openai, anthropic, google, deepseek, openai_azure) still appear in the "New model" menu for admins