### PR TITLE
Remove codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,23 +77,8 @@ jobs:
       - name: Run tests
         run: |
           uv run coverage run manage.py test --keepdb --noinput --verbosity=2
-          uv run coverage report -i
-          uv run coverage xml
-          uv run coverage html
-
-      - name: Save coverage report as artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: coverage-report
-          path: htmlcov/
+          uv run coverage report -m --fail-under=100
 
       - name: Mailroom log
         if: failure()
         run: cat mailroom.log
-
-      - name: Upload coverage
-        if: success()
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,10 @@ jobs:
           uv run python manage.py compress --extension=".html" --settings=temba.settings_compress
 
       - name: Run tests
-        run: |
-          uv run coverage run manage.py test --keepdb --noinput --verbosity=2
-          uv run coverage report -m --fail-under=100
+        run: uv run coverage run manage.py test --keepdb --noinput --verbosity=2
+
+      - name: Coverage report
+        run: uv run coverage report -m --fail-under=100
 
       - name: Mailroom log
         if: failure()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![tag](https://img.shields.io/github/tag/nyaruka/rapidpro.svg)](https://github.com/nyaruka/rapidpro/releases)
 [![Build Status](https://github.com/nyaruka/rapidpro/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/nyaruka/rapidpro/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/nyaruka/rapidpro/branch/main/graph/badge.svg)](https://codecov.io/gh/nyaruka/rapidpro)
 
 RapidPro is a cloud based SaaS developed by [TextIt](https://textit.com) for visually building interactive messaging
 applications. To see what it can do, signup for a free trial account at [textit.com](https://textit.com).


### PR DESCRIPTION
Removes codecov as part of CI. Coverage is now printed to the workflow log and the build fails if coverage is below 100%, matching the approach used in the textit repo.

## Changes
- Drop the `codecov/codecov-action` step from `.github/workflows/ci.yml`.
- Drop `coverage xml` / `coverage html` generation and the htmlcov artifact upload.
- Replace `coverage report -i` with `coverage report -m --fail-under=100`.
- Remove the codecov badge from `README.md`.