### PR TITLE
Update @nyaruka/temba-components to 0.156.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.156.11",
+    "@nyaruka/temba-components": "0.156.12",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nyaruka/temba-components@0.156.11":
-  version "0.156.11"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.11.tgz#8346d0c8a8c50b7b99dc477acf65fa553c29ad95"
-  integrity sha512-QHr1Bruv8htOVFq6P77LFvNpgtqzl0GCY6ndOwnOJT9TZuDpJqZNyT4XCVhbfUrSXzqUya2QfhLF6aV+2s8Z8A==
+"@nyaruka/temba-components@0.156.12":
+  version "0.156.12"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.156.12.tgz#0d661f40a4e0096e85cbccdba6fcd97c4927cd92"
+  integrity sha512-w7JyvuwPGgfOfEyrdMQm4mcwgBS0SF1/oXFjM4mFl07JCT/L6vB4IhuFy6EQPsQkRB+I1/i+8SmmaoEUpu4sYA==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"
@@ -109,7 +109,7 @@
     remarkable "^2.0.1"
     serialize-javascript "^7.0.3"
     tiny-lru "^11.2.5"
-    uuid "^13.0.0"
+    uuid "^14.0.0"
     zustand "^5.0.3"
 
 "@open-wc/lit-helpers@^0.7.0":
@@ -1380,10 +1380,10 @@ util-deprecate@^1.0.2:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
-  integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
+uuid@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 watch@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.156.12](https://github.com/nyaruka/temba-components/compare/v0.156.11...v0.156.12)

- Fix field error styling on temba-compose [#988](https://github.com/nyaruka/temba-components/pull/988)