### PR TITLE
Add auto_translate org feature

### DIFF
--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -16,7 +16,7 @@ from temba.contacts.models import URN
 from temba.flows.models import Flow, FlowLabel, FlowRun, FlowStart, FlowUserConflictException, ResultsExport
 from temba.mailroom.client.types import Exclusions
 from temba.orgs.integrations.dtone.type import DTOneType
-from temba.orgs.models import Export
+from temba.orgs.models import Export, Org
 from temba.templates.models import TemplateTranslation
 from temba.tests import CRUDLTestMixin, TembaTest, matchers, mock_mailroom
 from temba.tests.base import get_contact_search, override_brand
@@ -1140,6 +1140,10 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.setUpLocations()
 
         assert_features({"optins", "airtime", "classifier", "resthook", "locations"})
+
+        flow.org.features = [Org.FEATURE_AUTO_TRANSLATE]
+        flow.org.save(update_fields=("features",))
+        assert_features({"optins", "airtime", "classifier", "resthook", "locations", "auto_translate"})
 
     @mock_mailroom
     def test_template_warnings(self, mr_mocks):

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -760,6 +760,8 @@ class FlowCRUDL(SmartCRUDL):
                 features.append("resthook")
             if org.root_location_id:
                 features.append("locations")
+            if Org.FEATURE_AUTO_TRANSLATE in org.features:
+                features.append("auto_translate")
 
             return features
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -244,6 +244,7 @@ class Org(SmartModel):
     FEATURE_TEAMS = "teams"  # can create teams to organize agent users
     FEATURE_PROMETHEUS = "prometheus"  # can create a prometheus token to access metrics
     FEATURE_SHARED_CHANNELS = "shared_channels"  # can share channels between orgs
+    FEATURE_AUTO_TRANSLATE = "auto_translate"  # can auto translate flow content via AI models
     FEATURES_CHOICES = (
         (FEATURE_USERS, _("Users")),
         (FEATURE_NEW_ORGS, _("New Orgs")),
@@ -251,6 +252,7 @@ class Org(SmartModel):
         (FEATURE_TEAMS, _("Teams")),
         (FEATURE_PROMETHEUS, _("Prometheus")),
         (FEATURE_SHARED_CHANNELS, _("Shared Channels")),
+        (FEATURE_AUTO_TRANSLATE, _("Auto Translate")),
     )
 
     LIMIT_CHANNELS = "channels"

--- a/temba/orgs/views/views.py
+++ b/temba/orgs/views/views.py
@@ -28,9 +28,9 @@ from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.encoding import DjangoUnicodeDecodeError, force_str
 from django.utils.functional import cached_property
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 
 from temba.api.models import Resthook

--- a/templates/flows/flow_editor.html
+++ b/templates/flows/flow_editor.html
@@ -95,7 +95,7 @@
   </script>
 {% endblock extra-script %}
 {% block content %}
-  <temba-flow-editor flow="{{ object.uuid }}" features='{{ feature_filters }}' {% if "auto_translate" in request.org.features %}auto-translate{% endif %} -temba-contact-clicked="handleContactClicked" -temba-flow-clicked="handleFlowClicked" -temba-group-clicked="handleGroupClicked">
+  <temba-flow-editor flow="{{ object.uuid }}" features='{{ feature_filters }}' -temba-contact-clicked="handleContactClicked" -temba-flow-clicked="handleFlowClicked" -temba-group-clicked="handleGroupClicked">
   </temba-flow-editor>
   <temba-simulator flow="{{ object.uuid }}" -temba-follow-simulation="handleFollow">
   </temba-simulator>

--- a/templates/flows/flow_editor.html
+++ b/templates/flows/flow_editor.html
@@ -95,7 +95,7 @@
   </script>
 {% endblock extra-script %}
 {% block content %}
-  <temba-flow-editor flow="{{ object.uuid }}" features='{{ feature_filters }}' -temba-contact-clicked="handleContactClicked" -temba-flow-clicked="handleFlowClicked" -temba-group-clicked="handleGroupClicked">
+  <temba-flow-editor flow="{{ object.uuid }}" features='{{ feature_filters }}' {% if "auto_translate" in request.org.features %}auto-translate{% endif %} -temba-contact-clicked="handleContactClicked" -temba-flow-clicked="handleFlowClicked" -temba-group-clicked="handleGroupClicked">
   </temba-flow-editor>
   <temba-simulator flow="{{ object.uuid }}" -temba-follow-simulation="handleFollow">
   </temba-simulator>


### PR DESCRIPTION
Adds a new `auto_translate` org feature that, when enabled, passes the `auto-translate` attribute to the `temba-flow-editor` component to enable AI-powered translation of flow content.