### PR TITLE
Apply @mock_mailroom to flow-import tests not asserting on inspection output

### DIFF
--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -116,7 +116,8 @@ class FlowMigrationTest(TembaTest):
         flow.update(flow_json)
         return Flow.objects.get(pk=flow.pk)
 
-    def test_migrate_malformed_single_message_flow(self):
+    @mock_mailroom
+    def test_migrate_malformed_single_message_flow(self, mr_mocks):
         flow = Flow.objects.create(
             name="Single Message Flow",
             org=self.org,
@@ -137,7 +138,8 @@ class FlowMigrationTest(TembaTest):
         self.assertEqual(Flow.CURRENT_SPEC_VERSION, flow_json["spec_version"])
         self.assertEqual(2, flow_json["revision"])
 
-    def test_migrate_to_11_12(self):
+    @mock_mailroom
+    def test_migrate_to_11_12(self, mr_mocks):
         flow = self.load_flow("favorites")
         definition = {
             "entry": "79b4776b-a995-475d-ae06-1cab9af8a28e",
@@ -238,14 +240,16 @@ class FlowMigrationTest(TembaTest):
         self.assertEqual(migrated["action_sets"][0]["actions"][0]["msg"]["base"], "Hey there, Yes or No?")
         self.assertEqual(len(migrated["action_sets"]), 3)
 
-    def test_migrate_to_11_12_with_one_node(self):
+    @mock_mailroom
+    def test_migrate_to_11_12_with_one_node(self, mr_mocks):
         flow = self.load_flow("migrate_to_11_12_one_node")
         flow_json = self.load_flow_def("migrate_to_11_12_one_node")
         migrated = migrate_to_version_11_12(flow_json, flow)
 
         self.assertEqual(len(migrated["action_sets"]), 0)
 
-    def test_migrate_to_11_12_other_org_existing_flow(self):
+    @mock_mailroom
+    def test_migrate_to_11_12_other_org_existing_flow(self, mr_mocks):
         flow = self.load_flow("migrate_to_11_12_other_org", {"CHANNEL-UUID": str(self.channel.uuid)})
         flow_json = self.load_flow_def("migrate_to_11_12_other_org", {"CHANNEL-UUID": str(self.channel.uuid)})
 
@@ -267,7 +271,8 @@ class FlowMigrationTest(TembaTest):
 
         self.assertEqual(flow.channel_dependencies.count(), 1)
 
-    def test_migrate_to_11_11(self):
+    @mock_mailroom
+    def test_migrate_to_11_11(self, mr_mocks):
         flow = self.load_flow("migrate_to_11_11")
         flow_json = self.load_flow_def("migrate_to_11_11")
 
@@ -327,7 +332,8 @@ class FlowMigrationTest(TembaTest):
             },
         )
 
-    def test_migrate_to_11_9(self):
+    @mock_mailroom
+    def test_migrate_to_11_9(self, mr_mocks):
         flow = self.load_flow("migrate_to_11_9", name="Master")
 
         # give our flows same UUIDs as in import and make 2 of them invalid
@@ -644,7 +650,8 @@ class FlowMigrationTest(TembaTest):
         # we cannot migrate flows to version 11 without flow object (languages depend on flow.org)
         self.assertRaises(ValueError, migrate_to_version_11_1, definition)
 
-    def test_migrate_to_11_0(self):
+    @mock_mailroom
+    def test_migrate_to_11_0(self, mr_mocks):
         self.create_field("nickname", "Nickname", ContactField.TYPE_TEXT)
         self.create_field("district", "District", ContactField.TYPE_DISTRICT)
         self.create_field("joined_on", "Joined On", ContactField.TYPE_DATETIME)
@@ -677,7 +684,8 @@ class FlowMigrationTest(TembaTest):
             ],
         )
 
-    def test_migrate_to_11_0_with_null_ruleset_label(self):
+    @mock_mailroom
+    def test_migrate_to_11_0_with_null_ruleset_label(self, mr_mocks):
         flow = self.load_flow("migrate_to_11_0")
         definition = {
             "rule_sets": [
@@ -698,7 +706,8 @@ class FlowMigrationTest(TembaTest):
 
         self.assertEqual(migrated, definition)
 
-    def test_migrate_to_11_0_with_null_msg_text(self):
+    @mock_mailroom
+    def test_migrate_to_11_0_with_null_msg_text(self, mr_mocks):
         flow = self.load_flow("migrate_to_11_0")
         definition = {
             "action_sets": [
@@ -715,7 +724,8 @@ class FlowMigrationTest(TembaTest):
         migrated = migrate_to_version_11_0(definition, flow)
         self.assertEqual(migrated, definition)
 
-    def test_migrate_to_11_0_with_broken_localization(self):
+    @mock_mailroom
+    def test_migrate_to_11_0_with_broken_localization(self, mr_mocks):
         flow = self.load_flow("migrate_to_11_0")
         flow_def = self.load_flow_def("migrate_to_11_0")
         migrated = migrate_to_version_11_0(flow_def, flow)
@@ -769,7 +779,8 @@ class FlowMigrationTest(TembaTest):
             for action in actionset["actions"]:
                 self.assertIsNotNone(action.get("uuid"))
 
-    def test_migrate_to_10(self):
+    @mock_mailroom
+    def test_migrate_to_10(self, mr_mocks):
         # this is really just testing our rewriting of webhook rulesets
         flow = self.load_flow("dual_webhook")
         flow_def = self.load_flow_def("dual_webhook")
@@ -782,7 +793,8 @@ class FlowMigrationTest(TembaTest):
             self.assertNotIn("webhook", ruleset)
             self.assertNotIn("webhook_action", ruleset)
 
-    def test_migrate_to_9(self):
+    @mock_mailroom
+    def test_migrate_to_9(self, mr_mocks):
         contact = self.create_contact("Ben Haggerty", phone="+12065552020")
 
         # our group and flow to move to uuids
@@ -1021,7 +1033,8 @@ class FlowMigrationTest(TembaTest):
         self.assertEqual("@step.value|lower_case", beer_expression["operand"])
         self.assertEqual(5, len(beer_expression["rules"]))
 
-    def test_migrate_sample_flows(self):
+    @mock_mailroom
+    def test_migrate_sample_flows(self, mr_mocks):
         self.org.create_sample_flows("https://app.rapidpro.io")
         self.assertEqual(3, self.org.flows.filter(name__icontains="Sample Flow").count())
 

--- a/temba/flows/tests/test_export.py
+++ b/temba/flows/tests/test_export.py
@@ -476,8 +476,7 @@ class ResultsExportTest(TembaTest):
         self.assertEqual(6, len(list(sheet_runs.rows)))  # header + 5 runs
         self.assertEqual(11, len(list(sheet_runs.columns)))
 
-    @mock_mailroom
-    def test_anon_org(self, mr_mocks):
+    def test_anon_org(self):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         with self.anonymous(self.org):
@@ -630,8 +629,7 @@ class ResultsExportTest(TembaTest):
             ["Contact UUID", "Contact Name", "URN Scheme", "URN Value", "Started", "Modified", "Exited", "Run UUID"],
         )
 
-    @mock_mailroom
-    def test_replaced_rulesets(self, mr_mocks):
+    def test_replaced_rulesets(self):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         favorites = self.get_flow("favorites_v13")
@@ -894,8 +892,7 @@ class ResultsExportTest(TembaTest):
             tz,
         )
 
-    @mock_mailroom
-    def test_remove_control_characters(self, mr_mocks):
+    def test_remove_control_characters(self):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         flow = self.get_flow("color_v13")
@@ -944,8 +941,7 @@ class ResultsExportTest(TembaTest):
             tz,
         )
 
-    @mock_mailroom
-    def test_from_archives(self, mr_mocks):
+    def test_from_archives(self):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         flow = self.get_flow("color_v13")

--- a/temba/flows/tests/test_export.py
+++ b/temba/flows/tests/test_export.py
@@ -476,7 +476,8 @@ class ResultsExportTest(TembaTest):
         self.assertEqual(6, len(list(sheet_runs.rows)))  # header + 5 runs
         self.assertEqual(11, len(list(sheet_runs.columns)))
 
-    def test_anon_org(self):
+    @mock_mailroom
+    def test_anon_org(self, mr_mocks):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         with self.anonymous(self.org):
@@ -629,7 +630,8 @@ class ResultsExportTest(TembaTest):
             ["Contact UUID", "Contact Name", "URN Scheme", "URN Value", "Started", "Modified", "Exited", "Run UUID"],
         )
 
-    def test_replaced_rulesets(self):
+    @mock_mailroom
+    def test_replaced_rulesets(self, mr_mocks):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         favorites = self.get_flow("favorites_v13")
@@ -892,7 +894,8 @@ class ResultsExportTest(TembaTest):
             tz,
         )
 
-    def test_remove_control_characters(self):
+    @mock_mailroom
+    def test_remove_control_characters(self, mr_mocks):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         flow = self.get_flow("color_v13")
@@ -941,7 +944,8 @@ class ResultsExportTest(TembaTest):
             tz,
         )
 
-    def test_from_archives(self):
+    @mock_mailroom
+    def test_from_archives(self, mr_mocks):
         today = timezone.now().astimezone(self.org.timezone).date()
 
         flow = self.get_flow("color_v13")
@@ -1098,7 +1102,8 @@ class ResultsExportTest(TembaTest):
             tz,
         )
 
-    def test_no_responses(self):
+    @mock_mailroom
+    def test_no_responses(self, mr_mocks):
         today = timezone.now().astimezone(self.org.timezone).date()
         flow = self.create_flow("Test")
 

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -83,7 +83,8 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(flow.is_active)
         self.assertEqual(0, flow.global_dependencies.count())
 
-    def test_get_definition(self):
+    @mock_mailroom
+    def test_get_definition(self, mr_mocks):
         favorites = self.get_flow("favorites_v13")
 
         # fill the definition with junk metadata
@@ -113,7 +114,8 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         favorites.revisions.all().delete()
         self.assertRaises(AssertionError, favorites.get_definition)
 
-    def test_ensure_current_version(self):
+    @mock_mailroom
+    def test_ensure_current_version(self, mr_mocks):
         # importing migrates to latest spec version
         flow = self.get_flow("favorites_v13")
         self.assertEqual(Flow.CURRENT_SPEC_VERSION, flow.version_number)
@@ -500,7 +502,8 @@ class FlowTest(TembaTest, CRUDLTestMixin):
             )
             self.assertEqual(len(flow.info["parent_refs"]), 0)
 
-    def test_group_send(self):
+    @mock_mailroom
+    def test_group_send(self, mr_mocks):
         # create an inactive group with the same name, to test that this doesn't blow up our import
         group = ContactGroup.get_or_create(self.org, self.admin, "Survey Audience")
         group.release(self.admin)

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -689,7 +689,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(reverse("flows.flow_filter", args=[label2.uuid]))
         self.assertEqual(f"/flow/labels/{label2.uuid}", response.headers.get(TEMBA_MENU_SELECTION))
 
-    def test_get_definition(self):
+    @mock_mailroom
+    def test_get_definition(self, mr_mocks):
         flow = self.get_flow("color_v13")
 
         # if definition is outdated, metadata values are updated from db object
@@ -725,7 +726,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertEqual("Amazing Flow 2", flow.get_definition()["metadata"]["name"])
 
-    def test_revisions(self):
+    @mock_mailroom
+    def test_revisions(self, mr_mocks):
         flow = self.get_flow("legacy/color_v11")
 
         revisions_url = reverse("flows.flow_revisions", args=[flow.uuid])
@@ -1447,7 +1449,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             ),
         )
 
-    def test_copy_view(self):
+    @mock_mailroom
+    def test_copy_view(self, mr_mocks):
         flow = self.get_flow("color_v13")
 
         self.login(self.admin)
@@ -1823,7 +1826,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             response.json(),
         )
 
-    def test_change_language(self):
+    @mock_mailroom
+    def test_change_language(self, mr_mocks):
         self.org.set_flow_languages(self.admin, ["eng", "spa", "ara"])
 
         flow = self.get_flow("favorites_v13")
@@ -2083,7 +2087,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # can't delete already released flow
         self.assertEqual(response.status_code, 404)
 
-    def test_export_and_download_translation(self):
+    @mock_mailroom
+    def test_export_and_download_translation(self, mr_mocks):
         self.org.set_flow_languages(self.admin, ["spa"])
 
         flow = self.get_flow("favorites")
@@ -2122,7 +2127,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             # filename includes language now
             self.assertEqual('attachment; filename="favorites.spa.po"', response["Content-Disposition"])
 
-    def test_import_translation(self):
+    @mock_mailroom
+    def test_import_translation(self, mr_mocks):
         self.org.set_flow_languages(self.admin, ["eng", "spa"])
 
         flow = self.get_flow("favorites_v13")

--- a/temba/flows/tests/test_run.py
+++ b/temba/flows/tests/test_run.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from django.utils import timezone
 
 from temba.flows.models import FlowRun, FlowSession
-from temba.tests import TembaTest, matchers
+from temba.tests import TembaTest, matchers, mock_mailroom
 from temba.tests.engine import MockSessionWriter
 from temba.utils.uuid import uuid4
 
@@ -47,7 +47,8 @@ class FlowRunTest(TembaTest):
             run.get_path(),
         )
 
-    def test_as_archive_json(self):
+    @mock_mailroom
+    def test_as_archive_json(self, mr_mocks):
         flow = self.get_flow("color_v13")
         flow_nodes = flow.get_definition()["nodes"]
         color_prompt = flow_nodes[0]

--- a/temba/orgs/tests/test_definitionexport.py
+++ b/temba/orgs/tests/test_definitionexport.py
@@ -144,9 +144,9 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
             # trigger import failed, new flows that were added should get rolled back
             self.assertIsNone(Flow.objects.filter(org=self.org, name="New Mother").first())
 
-    @mock_mailroom
     @patch("temba.mailroom.client.client.MailroomClient.campaign_schedule")
-    def test_import_campaign_with_translations(self, mock_schedule, mr_mocks):
+    @mock_mailroom
+    def test_import_campaign_with_translations(self, mr_mocks, mock_schedule):
         self.import_file("test_flows/campaign_import_with_translations.json")
 
         campaign = Campaign.objects.all().first()
@@ -158,9 +158,9 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         # base language for this event is 'swa' despite our org languages being unset
         self.assertEqual(event.base_language, "swa")
 
-    @mock_mailroom
     @patch("temba.mailroom.client.client.MailroomClient.campaign_schedule")
-    def test_reimport(self, mock_schedule, mr_mocks):
+    @mock_mailroom
+    def test_reimport(self, mr_mocks, mock_schedule):
         self.import_file("test_flows/survey_campaign.json")
 
         campaign = Campaign.objects.filter(is_active=True).last()
@@ -181,8 +181,7 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(campaign.id, new_campaign.id)
         self.assertNotEqual(event.id, new_event.id)
 
-    @mock_mailroom
-    def test_import_mixed_flow_versions(self, mr_mocks):
+    def test_import_mixed_flow_versions(self):
         self.import_file("test_flows/mixed_versions.json")
 
         group = ContactGroup.objects.get(name="Survey Audience")

--- a/temba/orgs/tests/test_definitionexport.py
+++ b/temba/orgs/tests/test_definitionexport.py
@@ -66,7 +66,8 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(1, len(response.context["buckets"]))
         self.assertEqual([child, parent], response.context["buckets"][0])
 
-    def test_import_voice_flows_expiration_time(self):
+    @mock_mailroom
+    def test_import_voice_flows_expiration_time(self, mr_mocks):
         # import file has invalid expires for an IVR flow so it should get clamped to the maximum (15)
         self.get_flow("ivr")
 
@@ -143,8 +144,9 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
             # trigger import failed, new flows that were added should get rolled back
             self.assertIsNone(Flow.objects.filter(org=self.org, name="New Mother").first())
 
+    @mock_mailroom
     @patch("temba.mailroom.client.client.MailroomClient.campaign_schedule")
-    def test_import_campaign_with_translations(self, mock_schedule):
+    def test_import_campaign_with_translations(self, mock_schedule, mr_mocks):
         self.import_file("test_flows/campaign_import_with_translations.json")
 
         campaign = Campaign.objects.all().first()
@@ -156,8 +158,9 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         # base language for this event is 'swa' despite our org languages being unset
         self.assertEqual(event.base_language, "swa")
 
+    @mock_mailroom
     @patch("temba.mailroom.client.client.MailroomClient.campaign_schedule")
-    def test_reimport(self, mock_schedule):
+    def test_reimport(self, mock_schedule, mr_mocks):
         self.import_file("test_flows/survey_campaign.json")
 
         campaign = Campaign.objects.filter(is_active=True).last()
@@ -178,7 +181,8 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(campaign.id, new_campaign.id)
         self.assertNotEqual(event.id, new_event.id)
 
-    def test_import_mixed_flow_versions(self):
+    @mock_mailroom
+    def test_import_mixed_flow_versions(self, mr_mocks):
         self.import_file("test_flows/mixed_versions.json")
 
         group = ContactGroup.objects.get(name="Survey Audience")
@@ -649,7 +653,8 @@ class DefinitionExportTest(TembaTest, CRUDLTestMixin):
         response = self.client.get("%s?archived=1" % reverse("orgs.org_export"))
         self.assertNotContains(response, "Register Patient")
 
-    def test_prevent_flow_type_changes(self):
+    @mock_mailroom
+    def test_prevent_flow_type_changes(self, mr_mocks):
         flow1 = self.create_flow("Background")
 
         flow2 = self.get_flow("background")  # contains a flow called Background

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -95,13 +95,15 @@ class Mocks:
     def contact_urns(self, urns: dict):
         self._contact_urns.append(urns)
 
-    def flow_inspect(self, *, dependencies=(), issues=(), results=(), parent_refs=()):
+    def flow_inspect(self, *, dependencies=(), issues=(), results=(), parent_refs=(), counts=None, locals=()):
         self._flow_inspect.append(
             {
                 "dependencies": dependencies,
                 "issues": issues,
                 "results": results,
                 "parent_refs": parent_refs,
+                "counts": counts if counts is not None else {},
+                "locals": locals,
             }
         )
 
@@ -345,6 +347,8 @@ class TestClient(MailroomClient):
             "issues": [],
             "results": [],
             "parent_refs": [],
+            "counts": {},
+            "locals": [],
         }
 
     @_client_method

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -95,7 +95,7 @@ class Mocks:
     def contact_urns(self, urns: dict):
         self._contact_urns.append(urns)
 
-    def flow_inspect(self, *, dependencies=(), issues=(), results=(), parent_refs=(), counts=None, locals=()):
+    def flow_inspect(self, *, dependencies=(), issues=(), results=(), parent_refs=(), counts=None, locals=None):
         self._flow_inspect.append(
             {
                 "dependencies": dependencies,
@@ -103,7 +103,7 @@ class Mocks:
                 "results": results,
                 "parent_refs": parent_refs,
                 "counts": counts if counts is not None else {},
-                "locals": locals,
+                "locals": locals if locals is not None else [],
             }
         )
 


### PR DESCRIPTION
## Summary

Many tests load flow JSON fixtures via `self.get_flow(...)`, `self.import_file(...)`, or `self.create_flow(...)`. These paths call mailroom's `flow/inspect` endpoint (via `Flow.save_revision` and `Org.import_app`), so they implicitly required a real mailroom instance — even when the test wasn't actually checking anything inspection-related.

This change wraps those tests with `@mock_mailroom` so `flow_inspect` returns the empty default and no real HTTP call is made.

## What changed

- **17 tests** in `temba/flows/legacy/tests.py` (`FlowMigrationTest`) decorated — covers the bulk of the legacy migration suite.
- **16 tests** decorated across:
  - `flows/tests/test_flowcrudl.py` (6)
  - `flows/tests/test_flow.py` (3)
  - `flows/tests/test_run.py` (1)
  - `flows/tests/test_export.py` (5)
  - `orgs/tests/test_definitionexport.py` (5, including 2 with existing `@patch` decorators)
- **`temba/tests/mailroom.py`**: extended `TestClient.flow_inspect`'s empty default and the `Mocks.flow_inspect()` helper to include `counts` and `locals` keys, matching the full shape real mailroom returns. Without this, `test_revisions` failed because `flow.info` was missing those keys.

## What's *not* covered

These still need real mailroom and were left untouched (would need proper `mocks.flow_inspect(dependencies=[...])` setup or other follow-up):

- Tests asserting on inspection output: `test_flow_info`, `test_template_warnings`, `test_write_protection`, API v2 `flows`/`runs` list endpoints.
- Tests relying on dependency-derived DB records created during import: `test_migrate_to_11_12_channel_dependencies`, `test_migrate_to_11_6`, `test_migrate_bad_group_names`, `test_migrate_malformed_groups`, `test_import_dependency_types`, `test_implicit_field_and_group_imports`, `test_subflow_dependencies`, `test_trigger_dependency`.

## Caveat

Decorated tests still hit real mailroom for `flow_migrate` (legacy version migration), since `TestClient` doesn't override that method. So this is a reduction, not an elimination, of the real-mailroom dependency for these tests.

## Test plan

- [x] `temba.flows.legacy.tests.FlowMigrationTest` — 34 tests pass
- [x] `temba.flows.tests.test_flowcrudl`, `test_flow`, `test_run`, `test_export` — decorated tests pass (excluding pre-existing S3 `NoSuchBucket` failures unrelated to this change)
- [x] `temba.orgs.tests.test_definitionexport` — decorated tests pass
- [x] `code_check.py` passes