### PR TITLE
Pre-migrate test fixtures + mock TestClient.flow_migrate

### DIFF
--- a/media/test_flows/all_dependency_types.json
+++ b/media/test_flows/all_dependency_types.json
@@ -156,8 +156,7 @@
       "revision": 11,
       "spec_version": "14.4.0",
       "type": "messaging",
-      "uuid": "ee765ff2-96b0-440a-b108-393f613466bb",
-      "version": "13.0.0"
+      "uuid": "ee765ff2-96b0-440a-b108-393f613466bb"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/all_dependency_types.json
+++ b/media/test_flows/all_dependency_types.json
@@ -1,162 +1,162 @@
 {
-  "version": "11.12",
+  "version": "13",
   "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "name": "New Child",
-      "uuid": "c866af22-8eff-41e5-9471-73c26c30f16b",
-      "language": "base",
-      "type": "messaging",
-      "nodes": [],
-      "spec_version": "13.0.0",
+      "expire_after_minutes": 10080,
+      "language": "und",
       "metadata": {
         "saved_on": "2019-05-30T15:07:33.090001+00:00"
       },
+      "name": "New Child",
+      "nodes": [],
       "revision": 1,
-      "expire_after_minutes": 10080
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "c866af22-8eff-41e5-9471-73c26c30f16b"
     },
     {
-      "name": "All Dep Types",
-      "uuid": "ee765ff2-96b0-440a-b108-393f613466bb",
-      "spec_version": "13.0.0",
-      "language": "base",
-      "type": "messaging",
-      "nodes": [
-        {
-          "uuid": "56e0cd46-6383-4779-9150-76f49025dab2",
-          "actions": [
-            {
-              "type": "add_contact_groups",
-              "groups": [
-                {
-                  "uuid": "967b469b-fd34-46a5-90f9-40430d6db2a4",
-                  "name": "Farmers"
-                }
-              ],
-              "uuid": "a025ddc3-3647-4143-829f-6842a755f952"
-            },
-            {
-              "type": "add_input_labels",
-              "labels": [
-                {
-                  "uuid": "c4812623-7932-4477-9b91-a1e4a9cb161f",
-                  "name": "Spam"
-                }
-              ],
-              "uuid": "b477b687-c17c-49aa-9b3f-e93e4f1b6361"
-            },
-            {
-              "uuid": "f0f5b9e0-086e-4437-b06c-927d598c7a81",
-              "type": "set_contact_field",
-              "field": {
-                "key": "gender",
-                "name": "Gender"
-              },
-              "value": "M"
-            },
-            {
-              "attachments": [],
-              "text": "Hi you are @fields.age years old",
-              "type": "send_msg",
-              "quick_replies": [],
-              "uuid": "5179bc35-93fe-4381-82d2-2edf86f0700d"
-            },
-            {
-              "uuid": "c350ce82-6a85-40a6-8655-f54d82572dea",
-              "type": "set_contact_channel",
-              "channel": {
-                "uuid": "5c2c874a-771c-4602-a84a-767fb0d55c6c",
-                "name": "Android"
-              }
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "6039c668-15a9-4ce5-a612-8d3b0562d84d",
-              "destination_uuid": "11ce89d0-c752-4fc1-9657-d6d3133dec1f"
-            }
-          ]
-        },
-        {
-          "uuid": "11ce89d0-c752-4fc1-9657-d6d3133dec1f",
-          "actions": [
-            {
-              "uuid": "b9d082fa-2228-47ac-8060-2567485418fe",
-              "type": "enter_flow",
-              "flow": {
-                "uuid": "c866af22-8eff-41e5-9471-73c26c30f16b",
-                "name": "New Child"
-              }
-            }
-          ],
-          "router": {
-            "type": "switch",
-            "operand": "@child.run.status",
-            "cases": [
-              {
-                "uuid": "dc807281-709c-4f12-b1ca-8da079da21d4",
-                "type": "has_only_text",
-                "arguments": [
-                  "completed"
-                ],
-                "category_uuid": "1398284f-7aeb-4a5a-8350-91e84960ec18"
-              },
-              {
-                "uuid": "ab88f469-d82a-4735-97e4-a33baad8841b",
-                "arguments": [
-                  "expired"
-                ],
-                "type": "has_only_text",
-                "category_uuid": "ff763fb3-9515-4c80-a211-3d4837adc2c8"
-              }
-            ],
-            "categories": [
-              {
-                "uuid": "1398284f-7aeb-4a5a-8350-91e84960ec18",
-                "name": "Complete",
-                "exit_uuid": "c78e1f77-a67d-47ab-bde3-18f92168ecec"
-              },
-              {
-                "uuid": "ff763fb3-9515-4c80-a211-3d4837adc2c8",
-                "name": "Expired",
-                "exit_uuid": "b4a75a38-86ae-4d25-8073-abb6cd1cd252"
-              }
-            ],
-            "default_category_uuid": "ff763fb3-9515-4c80-a211-3d4837adc2c8"
-          },
-          "exits": [
-            {
-              "uuid": "c78e1f77-a67d-47ab-bde3-18f92168ecec",
-              "destination_uuid": null
-            },
-            {
-              "uuid": "b4a75a38-86ae-4d25-8073-abb6cd1cd252",
-              "destination_uuid": null
-            }
-          ]
-        }
-      ],
       "_ui": {
         "nodes": {
+          "11ce89d0-c752-4fc1-9657-d6d3133dec1f": {
+            "config": {},
+            "position": {
+              "left": 120,
+              "top": 400
+            },
+            "type": "split_by_subflow"
+          },
           "56e0cd46-6383-4779-9150-76f49025dab2": {
             "position": {
               "left": 0,
               "top": 0
             },
             "type": "execute_actions"
-          },
-          "11ce89d0-c752-4fc1-9657-d6d3133dec1f": {
-            "type": "split_by_subflow",
-            "position": {
-              "left": 120,
-              "top": 400
-            },
-            "config": {}
           }
         }
       },
-      "revision": 11,
       "expire_after_minutes": 10080,
+      "language": "und",
+      "name": "All Dep Types",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "groups": [
+                {
+                  "name": "Farmers",
+                  "uuid": "967b469b-fd34-46a5-90f9-40430d6db2a4"
+                }
+              ],
+              "type": "add_contact_groups",
+              "uuid": "a025ddc3-3647-4143-829f-6842a755f952"
+            },
+            {
+              "labels": [
+                {
+                  "name": "Spam",
+                  "uuid": "c4812623-7932-4477-9b91-a1e4a9cb161f"
+                }
+              ],
+              "type": "add_input_labels",
+              "uuid": "b477b687-c17c-49aa-9b3f-e93e4f1b6361"
+            },
+            {
+              "field": {
+                "key": "gender",
+                "name": "Gender"
+              },
+              "type": "set_contact_field",
+              "uuid": "f0f5b9e0-086e-4437-b06c-927d598c7a81",
+              "value": "M"
+            },
+            {
+              "attachments": [],
+              "quick_replies": [],
+              "text": "Hi you are @fields.age years old",
+              "type": "send_msg",
+              "uuid": "5179bc35-93fe-4381-82d2-2edf86f0700d"
+            },
+            {
+              "channel": {
+                "name": "Android",
+                "uuid": "5c2c874a-771c-4602-a84a-767fb0d55c6c"
+              },
+              "type": "set_contact_channel",
+              "uuid": "c350ce82-6a85-40a6-8655-f54d82572dea"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "11ce89d0-c752-4fc1-9657-d6d3133dec1f",
+              "uuid": "6039c668-15a9-4ce5-a612-8d3b0562d84d"
+            }
+          ],
+          "uuid": "56e0cd46-6383-4779-9150-76f49025dab2"
+        },
+        {
+          "actions": [
+            {
+              "flow": {
+                "name": "New Child",
+                "uuid": "c866af22-8eff-41e5-9471-73c26c30f16b"
+              },
+              "type": "enter_flow",
+              "uuid": "b9d082fa-2228-47ac-8060-2567485418fe"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": null,
+              "uuid": "c78e1f77-a67d-47ab-bde3-18f92168ecec"
+            },
+            {
+              "destination_uuid": null,
+              "uuid": "b4a75a38-86ae-4d25-8073-abb6cd1cd252"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "completed"
+                ],
+                "category_uuid": "1398284f-7aeb-4a5a-8350-91e84960ec18",
+                "type": "has_only_text",
+                "uuid": "dc807281-709c-4f12-b1ca-8da079da21d4"
+              },
+              {
+                "arguments": [
+                  "expired"
+                ],
+                "category_uuid": "ff763fb3-9515-4c80-a211-3d4837adc2c8",
+                "type": "has_only_text",
+                "uuid": "ab88f469-d82a-4735-97e4-a33baad8841b"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "c78e1f77-a67d-47ab-bde3-18f92168ecec",
+                "name": "Complete",
+                "uuid": "1398284f-7aeb-4a5a-8350-91e84960ec18"
+              },
+              {
+                "exit_uuid": "b4a75a38-86ae-4d25-8073-abb6cd1cd252",
+                "name": "Expired",
+                "uuid": "ff763fb3-9515-4c80-a211-3d4837adc2c8"
+              }
+            ],
+            "default_category_uuid": "ff763fb3-9515-4c80-a211-3d4837adc2c8",
+            "operand": "@child.run.status",
+            "type": "switch"
+          },
+          "uuid": "11ce89d0-c752-4fc1-9657-d6d3133dec1f"
+        }
+      ],
+      "revision": 11,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "ee765ff2-96b0-440a-b108-393f613466bb",
       "version": "13.0.0"
     }
   ],

--- a/media/test_flows/background.json
+++ b/media/test_flows/background.json
@@ -3,36 +3,6 @@
   "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "name": "Background",
-      "uuid": "1ff89517-5735-466b-be31-682b49521cbf",
-      "spec_version": "13.1.0",
-      "language": "eng",
-      "type": "messaging_background",
-      "nodes": [
-        {
-          "uuid": "cf80a41e-c7b2-46ea-994d-b2301589276b",
-          "actions": [
-            {
-              "attachments": [],
-              "text": "Nothing to see here",
-              "type": "send_msg",
-              "quick_replies": [],
-              "uuid": "16c21cf7-8987-430d-bb5a-243f3b5ce2ad"
-            },
-            {
-              "uuid": "6e9c9b9e-9de5-49ee-a74f-4c7fbfdda9d0",
-              "type": "set_contact_name",
-              "name": "Bob"
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "b52df965-88c1-4933-b48a-8b96a8baacda",
-              "destination_uuid": null
-            }
-          ]
-        }
-      ],
       "_ui": {
         "nodes": {
           "cf80a41e-c7b2-46ea-994d-b2301589276b": {
@@ -44,12 +14,42 @@
           }
         }
       },
-      "revision": 6,
-      "expire_after_minutes": 10080,
+      "expire_after_minutes": 0,
+      "language": "eng",
+      "localization": {},
       "metadata": {
         "expires": 10080
       },
-      "localization": {}
+      "name": "Background",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "attachments": [],
+              "quick_replies": [],
+              "text": "Nothing to see here",
+              "type": "send_msg",
+              "uuid": "16c21cf7-8987-430d-bb5a-243f3b5ce2ad"
+            },
+            {
+              "name": "Bob",
+              "type": "set_contact_name",
+              "uuid": "6e9c9b9e-9de5-49ee-a74f-4c7fbfdda9d0"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": null,
+              "uuid": "b52df965-88c1-4933-b48a-8b96a8baacda"
+            }
+          ],
+          "uuid": "cf80a41e-c7b2-46ea-994d-b2301589276b"
+        }
+      ],
+      "revision": 6,
+      "spec_version": "14.4.0",
+      "type": "messaging_background",
+      "uuid": "1ff89517-5735-466b-be31-682b49521cbf"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/campaign_import_with_translations.json
+++ b/media/test_flows/campaign_import_with_translations.json
@@ -27,7 +27,7 @@
       "name": "When"
     }
   ],
-  "version": 10,
+  "version": "13",
   "site": "https://app.rapidpro.io",
   "flows": [],
   "triggers": []

--- a/media/test_flows/cataclysm.json
+++ b/media/test_flows/cataclysm.json
@@ -3,279 +3,279 @@
   "site": "https://textit.in",
   "flows": [
     {
-      "uuid": "ef9603ff-3886-4e5e-8870-0f643b6098de",
-      "name": "Cataclysmic",
-      "spec_version": "13.0.0",
-      "language": "eng",
-      "type": "messaging",
-      "revision": 49,
+      "_ui": {
+        "nodes": {
+          "35416fea-787d-48c1-b839-76eca089ad2e": {
+            "position": {
+              "left": 319,
+              "top": 468
+            },
+            "type": "execute_actions"
+          },
+          "c4462613-5936-42cc-a286-82e5f1816793": {
+            "position": {
+              "left": 294,
+              "top": 0
+            },
+            "type": "split_by_groups"
+          },
+          "d21be990-5e48-4e4b-995f-c9df8f38e517": {
+            "position": {
+              "left": 319,
+              "top": 323
+            },
+            "type": "execute_actions"
+          },
+          "eca0f1d7-59ef-4a7c-a4a9-9bbd049eb144": {
+            "position": {
+              "left": 76,
+              "top": 99
+            },
+            "type": "execute_actions"
+          },
+          "ef389049-d2e3-4343-b91f-13ea2db5f943": {
+            "position": {
+              "left": 558,
+              "top": 94
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
       "expire_after_minutes": 10080,
+      "language": "eng",
       "localization": {},
+      "name": "Cataclysmic",
       "nodes": [
         {
-          "uuid": "c4462613-5936-42cc-a286-82e5f1816793",
+          "exits": [
+            {
+              "destination_uuid": "eca0f1d7-59ef-4a7c-a4a9-9bbd049eb144",
+              "uuid": "17d69564-60c9-4a56-be8b-34e98a2ce14a"
+            },
+            {
+              "destination_uuid": "ef389049-d2e3-4343-b91f-13ea2db5f943",
+              "uuid": "a9ec4d0a-2ddd-4a13-a1d2-c63ce9916a04"
+            }
+          ],
           "router": {
-            "type": "switch",
-            "result_name": "Response 1",
-            "categories": [
-              {
-                "uuid": "bcd7af2a-7ef0-43a6-a216-31ff1ef8efbe",
-                "name": "Cat Facts",
-                "exit_uuid": "17d69564-60c9-4a56-be8b-34e98a2ce14a"
-              },
-              {
-                "uuid": "a4b4b713-630e-4255-b82a-44bd32dd566f",
-                "name": "Other",
-                "exit_uuid": "a9ec4d0a-2ddd-4a13-a1d2-c63ce9916a04"
-              }
-            ],
-            "operand": "@contact.groups",
             "cases": [
               {
-                "uuid": "de523358-923a-442a-a51d-940e80e51d36",
-                "type": "has_group",
                 "arguments": [
                   "c7bc1eef-b7aa-4959-ab90-3e33e0d3b1f9",
                   "Cat Facts"
                 ],
-                "category_uuid": "bcd7af2a-7ef0-43a6-a216-31ff1ef8efbe"
+                "category_uuid": "bcd7af2a-7ef0-43a6-a216-31ff1ef8efbe",
+                "type": "has_group",
+                "uuid": "de523358-923a-442a-a51d-940e80e51d36"
               }
             ],
-            "default_category_uuid": "a4b4b713-630e-4255-b82a-44bd32dd566f"
+            "categories": [
+              {
+                "exit_uuid": "17d69564-60c9-4a56-be8b-34e98a2ce14a",
+                "name": "Cat Facts",
+                "uuid": "bcd7af2a-7ef0-43a6-a216-31ff1ef8efbe"
+              },
+              {
+                "exit_uuid": "a9ec4d0a-2ddd-4a13-a1d2-c63ce9916a04",
+                "name": "Other",
+                "uuid": "a4b4b713-630e-4255-b82a-44bd32dd566f"
+              }
+            ],
+            "default_category_uuid": "a4b4b713-630e-4255-b82a-44bd32dd566f",
+            "operand": "@contact.groups",
+            "result_name": "Response 1",
+            "type": "switch"
           },
-          "exits": [
-            {
-              "uuid": "17d69564-60c9-4a56-be8b-34e98a2ce14a",
-              "destination_uuid": "eca0f1d7-59ef-4a7c-a4a9-9bbd049eb144"
-            },
-            {
-              "uuid": "a9ec4d0a-2ddd-4a13-a1d2-c63ce9916a04",
-              "destination_uuid": "ef389049-d2e3-4343-b91f-13ea2db5f943"
-            }
-          ]
+          "uuid": "c4462613-5936-42cc-a286-82e5f1816793"
         },
         {
-          "uuid": "ef389049-d2e3-4343-b91f-13ea2db5f943",
           "actions": [
             {
+              "groups": [
+                {
+                  "name": "Catnado",
+                  "uuid": "bc4d7100-60ac-44f0-aa78-0ec9373d2c2f"
+                }
+              ],
               "type": "remove_contact_groups",
-              "uuid": "cea907a8-af81-49af-92e6-f246e52179fe",
-              "groups": [
-                {
-                  "uuid": "bc4d7100-60ac-44f0-aa78-0ec9373d2c2f",
-                  "name": "Catnado"
-                }
-              ]
+              "uuid": "cea907a8-af81-49af-92e6-f246e52179fe"
             },
             {
+              "text": "You are not a cat fan. Hissssss.",
               "type": "send_msg",
-              "uuid": "394a328f-f829-43f2-9975-fe2f27c8b786",
-              "text": "You are not a cat fan. Hissssss."
+              "uuid": "394a328f-f829-43f2-9975-fe2f27c8b786"
             }
           ],
           "exits": [
             {
-              "uuid": "9ba78afa-948e-44c5-992f-84030f2eaa6b",
-              "destination_uuid": "d21be990-5e48-4e4b-995f-c9df8f38e517"
+              "destination_uuid": "d21be990-5e48-4e4b-995f-c9df8f38e517",
+              "uuid": "9ba78afa-948e-44c5-992f-84030f2eaa6b"
             }
-          ]
+          ],
+          "uuid": "ef389049-d2e3-4343-b91f-13ea2db5f943"
         },
         {
-          "uuid": "eca0f1d7-59ef-4a7c-a4a9-9bbd049eb144",
           "actions": [
             {
-              "type": "add_contact_groups",
-              "uuid": "feb7a33e-bc8b-44d8-9112-bc4e910fe304",
               "groups": [
                 {
-                  "uuid": "1966e54a-fc30-4a96-81ea-9b0185b8b7de",
-                  "name": "Cat Fanciers"
+                  "name": "Cat Fanciers",
+                  "uuid": "1966e54a-fc30-4a96-81ea-9b0185b8b7de"
                 }
-              ]
+              ],
+              "type": "add_contact_groups",
+              "uuid": "feb7a33e-bc8b-44d8-9112-bc4e910fe304"
             },
             {
-              "type": "add_contact_groups",
-              "uuid": "ca82f0e0-43ca-426c-a77c-93cf297b8e7c",
               "groups": [
                 {
-                  "uuid": "bc4d7100-60ac-44f0-aa78-0ec9373d2c2f",
-                  "name": "Catnado"
+                  "name": "Catnado",
+                  "uuid": "bc4d7100-60ac-44f0-aa78-0ec9373d2c2f"
                 }
-              ]
+              ],
+              "type": "add_contact_groups",
+              "uuid": "ca82f0e0-43ca-426c-a77c-93cf297b8e7c"
             },
             {
+              "text": "You are a cat fan! Purrrrr.",
               "type": "send_msg",
-              "uuid": "d57e9e9f-ada4-4a22-99ef-b8bf3dbcdcae",
-              "text": "You are a cat fan! Purrrrr."
+              "uuid": "d57e9e9f-ada4-4a22-99ef-b8bf3dbcdcae"
             }
           ],
           "exits": [
             {
-              "uuid": "55f88a1e-73ad-4b6d-9a04-626046bbe5a8",
-              "destination_uuid": "d21be990-5e48-4e4b-995f-c9df8f38e517"
+              "destination_uuid": "d21be990-5e48-4e4b-995f-c9df8f38e517",
+              "uuid": "55f88a1e-73ad-4b6d-9a04-626046bbe5a8"
             }
-          ]
+          ],
+          "uuid": "eca0f1d7-59ef-4a7c-a4a9-9bbd049eb144"
         },
         {
-          "uuid": "d21be990-5e48-4e4b-995f-c9df8f38e517",
           "actions": [
             {
-              "type": "set_contact_channel",
-              "uuid": "78c58574-9f91-4c27-855e-73eacc99c395",
               "channel": {
-                "uuid": "bd55bb31-8ed4-4f89-b903-7103aa3762be",
-                "name": "Telegram: TextItBot"
-              }
+                "name": "Telegram: TextItBot",
+                "uuid": "bd55bb31-8ed4-4f89-b903-7103aa3762be"
+              },
+              "type": "set_contact_channel",
+              "uuid": "78c58574-9f91-4c27-855e-73eacc99c395"
             }
           ],
           "exits": [
             {
-              "uuid": "c86638a9-2688-47c9-83ec-7f10ef49de1e",
-              "destination_uuid": "35416fea-787d-48c1-b839-76eca089ad2e"
+              "destination_uuid": "35416fea-787d-48c1-b839-76eca089ad2e",
+              "uuid": "c86638a9-2688-47c9-83ec-7f10ef49de1e"
             }
-          ]
+          ],
+          "uuid": "d21be990-5e48-4e4b-995f-c9df8f38e517"
         },
         {
-          "uuid": "35416fea-787d-48c1-b839-76eca089ad2e",
           "actions": [
             {
+              "text": "All done.",
               "type": "send_msg",
-              "uuid": "30d35b8f-f439-482a-91b1-d3b1a4351071",
-              "text": "All done."
+              "uuid": "30d35b8f-f439-482a-91b1-d3b1a4351071"
             },
             {
+              "groups": [
+                {
+                  "name": "Cat Blasts",
+                  "uuid": "47b1b36c-7736-47b9-b63a-c0ebfb610e61"
+                }
+              ],
+              "text": "Hey Cat Fans!",
               "type": "send_broadcast",
-              "uuid": "a7b6def8-d315-49bd-82e4-85887f39babe",
-              "groups": [
-                {
-                  "uuid": "47b1b36c-7736-47b9-b63a-c0ebfb610e61",
-                  "name": "Cat Blasts"
-                }
-              ],
-              "text": "Hey Cat Fans!"
+              "uuid": "a7b6def8-d315-49bd-82e4-85887f39babe"
             },
             {
-              "type": "start_session",
-              "uuid": "540965e5-bdfe-4416-b4dd-449220b1c588",
+              "flow": {
+                "name": "Cataclysmic",
+                "uuid": "ef9603ff-3886-4e5e-8870-0f643b6098de"
+              },
               "groups": [
                 {
-                  "uuid": "22a48356-71e9-4ae1-9f93-4021855c0bd5",
-                  "name": "Cat Alerts"
+                  "name": "Cat Alerts",
+                  "uuid": "22a48356-71e9-4ae1-9f93-4021855c0bd5"
                 }
               ],
-              "flow": {
-                "uuid": "ef9603ff-3886-4e5e-8870-0f643b6098de",
-                "name": "Cataclysmic"
-              }
+              "type": "start_session",
+              "uuid": "540965e5-bdfe-4416-b4dd-449220b1c588"
             }
           ],
           "exits": [
             {
               "uuid": "f2ef5066-434d-42bc-a5cb-29c59e51432f"
             }
-          ]
+          ],
+          "uuid": "35416fea-787d-48c1-b839-76eca089ad2e"
         }
       ],
+      "revision": 49,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "ef9603ff-3886-4e5e-8870-0f643b6098de"
+    },
+    {
       "_ui": {
         "nodes": {
-          "35416fea-787d-48c1-b839-76eca089ad2e": {
-            "type": "execute_actions",
+          "0429d1f9-82ed-4198-80a2-3b213aa11fd5": {
             "position": {
-              "left": 319,
-              "top": 468
-            }
-          },
-          "c4462613-5936-42cc-a286-82e5f1816793": {
-            "type": "split_by_groups",
-            "position": {
-              "left": 294,
+              "left": 100,
               "top": 0
-            }
-          },
-          "d21be990-5e48-4e4b-995f-c9df8f38e517": {
-            "type": "execute_actions",
-            "position": {
-              "left": 319,
-              "top": 323
-            }
-          },
-          "eca0f1d7-59ef-4a7c-a4a9-9bbd049eb144": {
-            "type": "execute_actions",
-            "position": {
-              "left": 76,
-              "top": 99
-            }
-          },
-          "ef389049-d2e3-4343-b91f-13ea2db5f943": {
-            "type": "execute_actions",
-            "position": {
-              "left": 558,
-              "top": 94
-            }
+            },
+            "type": "execute_actions"
           }
         },
         "stickies": {}
-      }
-    },
-    {
-      "uuid": "d6dd96b1-d500-4c7a-9f9c-eae3f2a2a7c5",
-      "name": "Catastrophe",
-      "spec_version": "13.0.0",
-      "language": "eng",
-      "type": "messaging",
-      "revision": 1,
+      },
       "expire_after_minutes": 10080,
+      "language": "eng",
       "localization": {},
+      "name": "Catastrophe",
       "nodes": [
         {
-          "uuid": "0429d1f9-82ed-4198-80a2-3b213aa11fd5",
           "actions": [
             {
-              "type": "add_contact_groups",
-              "uuid": "11f61fc6-834e-4cbc-88ee-c834279345e6",
               "groups": [
                 {
-                  "uuid": "22a48356-71e9-4ae1-9f93-4021855c0bd5",
-                  "name": "Cat Alerts"
+                  "name": "Cat Alerts",
+                  "uuid": "22a48356-71e9-4ae1-9f93-4021855c0bd5"
                 },
                 {
-                  "uuid": "c7bc1eef-b7aa-4959-ab90-3e33e0d3b1f9",
-                  "name": "Cat Facts"
+                  "name": "Cat Facts",
+                  "uuid": "c7bc1eef-b7aa-4959-ab90-3e33e0d3b1f9"
                 },
                 {
-                  "uuid": "47b1b36c-7736-47b9-b63a-c0ebfb610e61",
-                  "name": "Cat Blasts"
+                  "name": "Cat Blasts",
+                  "uuid": "47b1b36c-7736-47b9-b63a-c0ebfb610e61"
                 },
                 {
-                  "uuid": "1966e54a-fc30-4a96-81ea-9b0185b8b7de",
-                  "name": "Cat Fanciers"
+                  "name": "Cat Fanciers",
+                  "uuid": "1966e54a-fc30-4a96-81ea-9b0185b8b7de"
                 },
                 {
-                  "uuid": "bc4d7100-60ac-44f0-aa78-0ec9373d2c2f",
-                  "name": "Catnado"
+                  "name": "Catnado",
+                  "uuid": "bc4d7100-60ac-44f0-aa78-0ec9373d2c2f"
                 }
-              ]
+              ],
+              "type": "add_contact_groups",
+              "uuid": "11f61fc6-834e-4cbc-88ee-c834279345e6"
             }
           ],
           "exits": [
             {
               "uuid": "029a7c9d-c935-4ed1-9573-543ded29d954"
             }
-          ]
+          ],
+          "uuid": "0429d1f9-82ed-4198-80a2-3b213aa11fd5"
         }
       ],
-      "_ui": {
-        "nodes": {
-          "0429d1f9-82ed-4198-80a2-3b213aa11fd5": {
-            "type": "execute_actions",
-            "position": {
-              "left": 100,
-              "top": 0
-            }
-          }
-        },
-        "stickies": {}
-      }
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "d6dd96b1-d500-4c7a-9f9c-eae3f2a2a7c5"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/color_v13.json
+++ b/media/test_flows/color_v13.json
@@ -1,196 +1,196 @@
 {
-    "version": "13.0.0",
+    "version": "13",
     "flows": [
         {
-            "uuid": "ca45c8dd-d882-4f56-8522-1cdda67fd5b5",
-            "name": "Colors",
-            "spec_version": "13.0.0",
-            "language": "base",
-            "type": "messaging",
-            "revision": 1,
+            "_ui": {
+                "nodes": {
+                    "286af277-1b4d-4218-8175-0f6315c25b61": {
+                        "position": {
+                            "left": 3,
+                            "top": 3
+                        },
+                        "type": "execute_actions"
+                    },
+                    "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2": {
+                        "position": {
+                            "left": 5,
+                            "top": 5
+                        },
+                        "type": "wait_for_response"
+                    },
+                    "be2ca165-1f64-46ec-80c2-a1762d83b522": {
+                        "position": {
+                            "left": 2,
+                            "top": 2
+                        },
+                        "type": "execute_actions"
+                    },
+                    "cf4991ac-24ef-405b-9e4a-6f2e7767f8b2": {
+                        "position": {
+                            "left": 4,
+                            "top": 4
+                        },
+                        "type": "execute_actions"
+                    },
+                    "e50ac2d5-0704-4970-a450-690b1d03e77f": {
+                        "position": {
+                            "left": 1,
+                            "top": 1
+                        },
+                        "type": "execute_actions"
+                    }
+                },
+                "stickies": {}
+            },
             "expire_after_minutes": 720,
+            "language": "und",
             "localization": {
                 "fra": {
                     "98388930-7a0f-4eb8-9a0a-09be2f006420": {
                         "text": [
-                            "Quelle est votre couleur préférée?"
+                            "Quelle est votre couleur pr\u00e9f\u00e9r\u00e9e?"
                         ]
                     }
                 }
             },
+            "name": "Colors",
             "nodes": [
                 {
-                    "uuid": "e50ac2d5-0704-4970-a450-690b1d03e77f",
                     "actions": [
                         {
+                            "text": "What is your favorite color?",
                             "type": "send_msg",
-                            "uuid": "98388930-7a0f-4eb8-9a0a-09be2f006420",
-                            "text": "What is your favorite color?"
+                            "uuid": "98388930-7a0f-4eb8-9a0a-09be2f006420"
                         }
                     ],
                     "exits": [
                         {
-                            "uuid": "bfd3aaf4-a69b-4bd7-b875-136a72b6c3cf",
-                            "destination_uuid": "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2"
+                            "destination_uuid": "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2",
+                            "uuid": "bfd3aaf4-a69b-4bd7-b875-136a72b6c3cf"
                         }
-                    ]
+                    ],
+                    "uuid": "e50ac2d5-0704-4970-a450-690b1d03e77f"
                 },
                 {
-                    "uuid": "be2ca165-1f64-46ec-80c2-a1762d83b522",
                     "actions": [
                         {
+                            "text": "I love orange too! You said: @input which is category: @results.color.category_localized You are: @(format_urn(urns.tel)) SMS: @input Flow: @results",
                             "type": "send_msg",
-                            "uuid": "cf57f270-c9d7-4826-b3cc-7bfc22ac4ef6",
-                            "text": "I love orange too! You said: @input which is category: @results.color.category_localized You are: @(format_urn(urns.tel)) SMS: @input Flow: @results"
+                            "uuid": "cf57f270-c9d7-4826-b3cc-7bfc22ac4ef6"
                         }
                     ],
                     "exits": [
                         {
                             "uuid": "7e2ef75f-f637-4aac-9f08-1c903ba8ee31"
                         }
-                    ]
+                    ],
+                    "uuid": "be2ca165-1f64-46ec-80c2-a1762d83b522"
                 },
                 {
-                    "uuid": "286af277-1b4d-4218-8175-0f6315c25b61",
                     "actions": [
                         {
+                            "text": "Blue is sad. :(",
                             "type": "send_msg",
-                            "uuid": "d6aee40b-3710-4358-b0a6-c0ddc1d7734e",
-                            "text": "Blue is sad. :("
+                            "uuid": "d6aee40b-3710-4358-b0a6-c0ddc1d7734e"
                         }
                     ],
                     "exits": [
                         {
                             "uuid": "364af3c6-65e6-4167-a76b-157090eaf030"
                         }
-                    ]
+                    ],
+                    "uuid": "286af277-1b4d-4218-8175-0f6315c25b61"
                 },
                 {
-                    "uuid": "cf4991ac-24ef-405b-9e4a-6f2e7767f8b2",
                     "actions": [
                         {
+                            "text": "That is a funny color. Try again.",
                             "type": "send_msg",
-                            "uuid": "ca798d2d-2c95-468a-a857-74797a4d5301",
-                            "text": "That is a funny color. Try again."
+                            "uuid": "ca798d2d-2c95-468a-a857-74797a4d5301"
                         }
                     ],
                     "exits": [
                         {
-                            "uuid": "dceea983-7d66-4ad5-aa76-7c163db8443a",
-                            "destination_uuid": "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2"
+                            "destination_uuid": "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2",
+                            "uuid": "dceea983-7d66-4ad5-aa76-7c163db8443a"
                         }
-                    ]
+                    ],
+                    "uuid": "cf4991ac-24ef-405b-9e4a-6f2e7767f8b2"
                 },
                 {
-                    "uuid": "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2",
-                    "router": {
-                        "type": "switch",
-                        "wait": {
-                            "type": "msg"
-                        },
-                        "result_name": "Color",
-                        "categories": [
-                            {
-                                "uuid": "890ba12e-f0d7-4525-85de-407c77acf86e",
-                                "name": "Orange",
-                                "exit_uuid": "9d5990f9-92ed-45f5-9348-32aa25ee6790"
-                            },
-                            {
-                                "uuid": "fca57502-67f2-43a1-870d-387d7b51b8dc",
-                                "name": "Blue",
-                                "exit_uuid": "6d24941a-6e46-4baf-aded-27c8f81c3d44"
-                            },
-                            {
-                                "uuid": "77fdb926-36c4-41a3-9bab-4605c8563b38",
-                                "name": "Other",
-                                "exit_uuid": "5aefa366-6e0d-4e22-8cd1-2d5f0560f9ac"
-                            },
-                            {
-                                "uuid": "b28cd893-2bc6-4b39-8316-6f523f87d68c",
-                                "name": "Nothing",
-                                "exit_uuid": "218be679-47c4-48c2-9eba-3b45cbab29b2"
-                            }
-                        ],
-                        "operand": "@input",
-                        "cases": [
-                            {
-                                "uuid": "09be1819-ee63-49de-b1b3-820cb64cce69",
-                                "type": "has_all_words",
-                                "arguments": [
-                                    "orange"
-                                ],
-                                "category_uuid": "890ba12e-f0d7-4525-85de-407c77acf86e"
-                            },
-                            {
-                                "uuid": "8027a88f-8378-48e9-adac-3046a24d9327",
-                                "type": "has_all_words",
-                                "arguments": [
-                                    "blue"
-                                ],
-                                "category_uuid": "fca57502-67f2-43a1-870d-387d7b51b8dc"
-                            }
-                        ],
-                        "default_category_uuid": "b28cd893-2bc6-4b39-8316-6f523f87d68c"
-                    },
                     "exits": [
                         {
-                            "uuid": "9d5990f9-92ed-45f5-9348-32aa25ee6790",
-                            "destination_uuid": "be2ca165-1f64-46ec-80c2-a1762d83b522"
+                            "destination_uuid": "be2ca165-1f64-46ec-80c2-a1762d83b522",
+                            "uuid": "9d5990f9-92ed-45f5-9348-32aa25ee6790"
                         },
                         {
-                            "uuid": "6d24941a-6e46-4baf-aded-27c8f81c3d44",
-                            "destination_uuid": "286af277-1b4d-4218-8175-0f6315c25b61"
+                            "destination_uuid": "286af277-1b4d-4218-8175-0f6315c25b61",
+                            "uuid": "6d24941a-6e46-4baf-aded-27c8f81c3d44"
                         },
                         {
-                            "uuid": "5aefa366-6e0d-4e22-8cd1-2d5f0560f9ac",
-                            "destination_uuid": "cf4991ac-24ef-405b-9e4a-6f2e7767f8b2"
+                            "destination_uuid": "cf4991ac-24ef-405b-9e4a-6f2e7767f8b2",
+                            "uuid": "5aefa366-6e0d-4e22-8cd1-2d5f0560f9ac"
                         },
                         {
                             "uuid": "218be679-47c4-48c2-9eba-3b45cbab29b2"
                         }
-                    ]
+                    ],
+                    "router": {
+                        "cases": [
+                            {
+                                "arguments": [
+                                    "orange"
+                                ],
+                                "category_uuid": "890ba12e-f0d7-4525-85de-407c77acf86e",
+                                "type": "has_all_words",
+                                "uuid": "09be1819-ee63-49de-b1b3-820cb64cce69"
+                            },
+                            {
+                                "arguments": [
+                                    "blue"
+                                ],
+                                "category_uuid": "fca57502-67f2-43a1-870d-387d7b51b8dc",
+                                "type": "has_all_words",
+                                "uuid": "8027a88f-8378-48e9-adac-3046a24d9327"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "exit_uuid": "9d5990f9-92ed-45f5-9348-32aa25ee6790",
+                                "name": "Orange",
+                                "uuid": "890ba12e-f0d7-4525-85de-407c77acf86e"
+                            },
+                            {
+                                "exit_uuid": "6d24941a-6e46-4baf-aded-27c8f81c3d44",
+                                "name": "Blue",
+                                "uuid": "fca57502-67f2-43a1-870d-387d7b51b8dc"
+                            },
+                            {
+                                "exit_uuid": "5aefa366-6e0d-4e22-8cd1-2d5f0560f9ac",
+                                "name": "Other",
+                                "uuid": "77fdb926-36c4-41a3-9bab-4605c8563b38"
+                            },
+                            {
+                                "exit_uuid": "218be679-47c4-48c2-9eba-3b45cbab29b2",
+                                "name": "Nothing",
+                                "uuid": "b28cd893-2bc6-4b39-8316-6f523f87d68c"
+                            }
+                        ],
+                        "default_category_uuid": "b28cd893-2bc6-4b39-8316-6f523f87d68c",
+                        "operand": "@input",
+                        "result_name": "Color",
+                        "type": "switch",
+                        "wait": {
+                            "type": "msg"
+                        }
+                    },
+                    "uuid": "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2"
                 }
             ],
-            "_ui": {
-                "nodes": {
-                    "286af277-1b4d-4218-8175-0f6315c25b61": {
-                        "type": "execute_actions",
-                        "position": {
-                            "left": 3,
-                            "top": 3
-                        }
-                    },
-                    "9a4dca3c-5381-4f0d-8e20-dac3b1e962a2": {
-                        "type": "wait_for_response",
-                        "position": {
-                            "left": 5,
-                            "top": 5
-                        }
-                    },
-                    "be2ca165-1f64-46ec-80c2-a1762d83b522": {
-                        "type": "execute_actions",
-                        "position": {
-                            "left": 2,
-                            "top": 2
-                        }
-                    },
-                    "cf4991ac-24ef-405b-9e4a-6f2e7767f8b2": {
-                        "type": "execute_actions",
-                        "position": {
-                            "left": 4,
-                            "top": 4
-                        }
-                    },
-                    "e50ac2d5-0704-4970-a450-690b1d03e77f": {
-                        "type": "execute_actions",
-                        "position": {
-                            "left": 1,
-                            "top": 1
-                        }
-                    }
-                },
-                "stickies": {}
-            }
+            "revision": 1,
+            "spec_version": "14.4.0",
+            "type": "messaging",
+            "uuid": "ca45c8dd-d882-4f56-8522-1cdda67fd5b5"
         }
     ]
 }

--- a/media/test_flows/dependencies.json
+++ b/media/test_flows/dependencies.json
@@ -1,445 +1,546 @@
 {
   "campaigns": [],
-  "version": 11.12,
+  "version": "13",
   "site": "https://textit.in",
   "flows": [
     {
-      "entry": "49bdff55-717c-48df-a44c-ac596b7f3321",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "06717975-4c39-40a9-8185-96e57698a7bd": {
+            "position": {
+              "left": 56,
+              "top": 1221
+            },
+            "type": "split_by_expression"
+          },
+          "2eefb600-d52d-4cab-8636-67d4d923b630": {
+            "position": {
+              "left": 305,
+              "top": 341
+            },
+            "type": "split_by_webhook"
+          },
+          "3fe6756e-81b3-4ad0-a5f4-2c6f29cdde54": {
+            "position": {
+              "left": 140,
+              "top": 1078
+            },
+            "type": "split_by_groups"
+          },
+          "49bdff55-717c-48df-a44c-ac596b7f3321": {
+            "position": {
+              "left": 51,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "b6d0a62f-de37-460f-9d09-302a6f906b73": {
+            "position": {
+              "left": 21,
+              "top": 769
+            },
+            "type": "execute_actions"
+          },
+          "bbc9b80e-e99c-4d07-a4df-1b793643d5cb": {
+            "position": {
+              "left": 64,
+              "top": 552
+            },
+            "type": "execute_actions"
+          },
+          "cec4c5c5-5a46-4fd2-a2ce-0e5cf108bf59": {
+            "position": {
+              "left": 47,
+              "top": 441
+            },
+            "type": "wait_for_response"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {
+        "fra": {
+          "3eaae046-b037-4e17-a8e7-f6dd418a315a": {
+            "text": [
+              "This is in the @fields.french_message"
+            ]
+          },
+          "aada603e-4b53-4049-93ae-bfb24722150a": {
+            "text": [
+              "French @(10 / fields.french_age & fields.french_fries)."
+            ]
+          },
+          "e8879619-af92-45e3-af2d-7158e25cd977": {
+            "name": [
+              "French Rule"
+            ]
+          },
+          "e957abed-e629-45ea-ab8b-7e173204aea7": {
+            "arguments": [
+              "@fields.french_rule"
+            ]
+          }
+        }
+      },
+      "name": "Dependencies",
+      "nodes": [
         {
-          "uuid": "49bdff55-717c-48df-a44c-ac596b7f3321",
-          "x": 51,
-          "y": 0,
-          "destination": "2eefb600-d52d-4cab-8636-67d4d923b630",
           "actions": [
             {
-              "type": "del_group",
-              "uuid": "1813c13f-1e82-4b20-aa96-c7c54785965e",
               "groups": [
                 {
-                  "uuid": "91746f38-ac2f-4b8c-ae59-43342c0d86f6",
-                  "name": "Dog Facts"
+                  "name": "Dog Facts",
+                  "uuid": "91746f38-ac2f-4b8c-ae59-43342c0d86f6"
                 }
-              ]
+              ],
+              "type": "remove_contact_groups",
+              "uuid": "1813c13f-1e82-4b20-aa96-c7c54785965e"
             },
             {
-              "type": "add_group",
-              "uuid": "3ec1d7d2-f6a0-4950-a5f2-3a3653209fa0",
               "groups": [
                 {
-                  "uuid": "a263eba5-4b86-4d72-8793-a6b789a3cd9d",
-                  "name": "Cat Facts"
+                  "name": "Cat Facts",
+                  "uuid": "a263eba5-4b86-4d72-8793-a6b789a3cd9d"
                 }
-              ]
+              ],
+              "type": "add_contact_groups",
+              "uuid": "3ec1d7d2-f6a0-4950-a5f2-3a3653209fa0"
             },
             {
-              "type": "save",
+              "field": {
+                "key": "favorite_cat",
+                "name": "Favorite Cat"
+              },
+              "type": "set_contact_field",
               "uuid": "cccc7794-ff03-4f11-8256-d31143459514",
-              "label": "Favorite Cat",
-              "field": "favorite_cat",
               "value": "Scottish Fold"
             },
             {
-              "type": "reply",
-              "uuid": "aada603e-4b53-4049-93ae-bfb24722150a",
-              "msg": {
-                "fra": "French @(10 / contact.french_age & contact.french_fries).",
-                "eng": "You are @contact.contact_age years old. @(CONCATENATE(\"Your CHW is \", contact.chw)). Your score is @(MAX(parent.contact.top, child.contact.bottom)). On @((DATEVALUE(\"24-10-2017\") + TIMEVALUE(\"12:30\"))). Thanks @parent.contact!"
-              },
-              "media": {
-                "eng": "image:@contact.attachment"
-              },
-              "quick_replies": [],
-              "send_all": false
+              "attachments": [
+                "image:@fields.attachment"
+              ],
+              "text": "You are @fields.contact_age years old. @(\"Your CHW is \" & fields.chw). Your score is @(max(parent.fields.top, child.fields.bottom)). On @((replace_time(date(\"24-10-2017\"), time(\"12:30\")))). Thanks @parent.contact!",
+              "type": "send_msg",
+              "uuid": "aada603e-4b53-4049-93ae-bfb24722150a"
             }
           ],
-          "exit_uuid": "8a840060-bada-46a3-99d7-41dac10383ce"
+          "exits": [
+            {
+              "destination_uuid": "2eefb600-d52d-4cab-8636-67d4d923b630",
+              "uuid": "8a840060-bada-46a3-99d7-41dac10383ce"
+            }
+          ],
+          "uuid": "49bdff55-717c-48df-a44c-ac596b7f3321"
         },
         {
-          "uuid": "bbc9b80e-e99c-4d07-a4df-1b793643d5cb",
-          "x": 64,
-          "y": 552,
-          "destination": "b6d0a62f-de37-460f-9d09-302a6f906b73",
           "actions": [
             {
-              "type": "send",
-              "uuid": "3eaae046-b037-4e17-a8e7-f6dd418a315a",
-              "msg": {
-                "fra": "This is in the @contact.french_message",
-                "eng": "This is a @contact.message"
-              },
-              "contacts": [],
-              "groups": [],
-              "variables": [
-                {
-                  "id": "@contact.recipient"
-                }
-              ],
-              "media": {}
+              "method": "GET",
+              "result_name": "Response 1",
+              "type": "call_webhook",
+              "url": "http://www.google.com/@(url_encode(fields.webhook))/endpoint.json",
+              "uuid": "44ca3caf-ba50-41d8-8648-5c086355e6d7"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "cec4c5c5-5a46-4fd2-a2ce-0e5cf108bf59",
+              "uuid": "93e0559e-993c-4fad-8a40-99813261135d"
             },
             {
-              "type": "email",
-              "uuid": "95e6f13a-cedb-46e5-980f-37b7e171dad3",
-              "emails": [
+              "uuid": "de783d61-7a65-47cb-a1af-76d0f3d35982"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "200",
+                  "299"
+                ],
+                "category_uuid": "144addab-71c5-4136-ad8f-c41b82fbfb3c",
+                "type": "has_number_between",
+                "uuid": "6c7bb7e0-13e0-4169-adec-5853be888e99"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "93e0559e-993c-4fad-8a40-99813261135d",
+                "name": "Success",
+                "uuid": "144addab-71c5-4136-ad8f-c41b82fbfb3c"
+              },
+              {
+                "exit_uuid": "de783d61-7a65-47cb-a1af-76d0f3d35982",
+                "name": "Failure",
+                "uuid": "8652c49e-45ad-4919-9f9c-b4f812d655a7"
+              }
+            ],
+            "default_category_uuid": "8652c49e-45ad-4919-9f9c-b4f812d655a7",
+            "operand": "@webhook.status",
+            "type": "switch"
+          },
+          "uuid": "2eefb600-d52d-4cab-8636-67d4d923b630"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "bbc9b80e-e99c-4d07-a4df-1b793643d5cb",
+              "uuid": "d6b990aa-f38a-40bc-8a13-a0293bbbfb65"
+            },
+            {
+              "uuid": "91f38720-f9db-4699-bb77-fcc673ce5b32"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "@fields.rule"
+                ],
+                "category_uuid": "e8879619-af92-45e3-af2d-7158e25cd977",
+                "type": "has_any_word",
+                "uuid": "e957abed-e629-45ea-ab8b-7e173204aea7"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "d6b990aa-f38a-40bc-8a13-a0293bbbfb65",
+                "name": "Rule",
+                "uuid": "e8879619-af92-45e3-af2d-7158e25cd977"
+              },
+              {
+                "exit_uuid": "91f38720-f9db-4699-bb77-fcc673ce5b32",
+                "name": "Other",
+                "uuid": "76bd6b0a-7c3b-4e7c-97c9-3148bdc8f70d"
+              }
+            ],
+            "default_category_uuid": "76bd6b0a-7c3b-4e7c-97c9-3148bdc8f70d",
+            "operand": "@input",
+            "result_name": "Response 2",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "cec4c5c5-5a46-4fd2-a2ce-0e5cf108bf59"
+        },
+        {
+          "actions": [
+            {
+              "legacy_vars": [
+                "@fields.recipient"
+              ],
+              "text": "This is a @fields.message",
+              "type": "send_broadcast",
+              "uuid": "3eaae046-b037-4e17-a8e7-f6dd418a315a"
+            },
+            {
+              "addresses": [
                 "test@rapidpro.io"
               ],
-              "subject": "Subject @contact.subject",
-              "msg": "Email @contact.email_message"
+              "body": "Email @fields.email_message",
+              "subject": "Subject @fields.subject",
+              "type": "send_email",
+              "uuid": "95e6f13a-cedb-46e5-980f-37b7e171dad3"
             }
           ],
-          "exit_uuid": "a89bc4bf-9bfa-4494-b6f6-cd66cc58bedb"
+          "exits": [
+            {
+              "destination_uuid": "b6d0a62f-de37-460f-9d09-302a6f906b73",
+              "uuid": "a89bc4bf-9bfa-4494-b6f6-cd66cc58bedb"
+            }
+          ],
+          "uuid": "bbc9b80e-e99c-4d07-a4df-1b793643d5cb"
         },
         {
-          "uuid": "b6d0a62f-de37-460f-9d09-302a6f906b73",
-          "x": 21,
-          "y": 769,
-          "destination": "3fe6756e-81b3-4ad0-a5f4-2c6f29cdde54",
           "actions": [
             {
-              "type": "save",
+              "field": {
+                "key": "next_cat_fact",
+                "name": "Next Cat Fact"
+              },
+              "type": "set_contact_field",
               "uuid": "083a62d2-261a-4122-bc2f-1dac8ca17e99",
-              "label": "Next Cat Fact",
-              "field": "next_cat_fact",
-              "value": "@contact.last_cat_fact"
+              "value": "@fields.last_cat_fact"
             },
             {
-              "type": "add_group",
-              "uuid": "0e4525c0-64f6-416a-8c3d-2bedcd1b4dbc",
               "groups": [
-                "@contact.cat_breed"
-              ]
-            },
-            {
-              "type": "del_group",
-              "uuid": "0b3bff5c-6cd1-40e8-9127-43580e69e0d6",
-              "groups": [
-                "@contact.organization"
-              ]
-            },
-            {
-              "type": "trigger-flow",
-              "uuid": "b4691b19-1909-4ada-8d33-a5a462b2f20a",
-              "flow": {
-                "uuid": "2b118e66-960f-4ba5-abb9-2b250916d4ff",
-                "name": "Child Flow"
-              },
-              "contacts": [],
-              "groups": [],
-              "variables": [
                 {
-                  "id": "@contact.other_phone"
+                  "name_match": "@fields.cat_breed"
                 }
-              ]
+              ],
+              "type": "add_contact_groups",
+              "uuid": "0e4525c0-64f6-416a-8c3d-2bedcd1b4dbc"
+            },
+            {
+              "groups": [
+                {
+                  "name_match": "@fields.organization"
+                }
+              ],
+              "type": "remove_contact_groups",
+              "uuid": "0b3bff5c-6cd1-40e8-9127-43580e69e0d6"
+            },
+            {
+              "flow": {
+                "name": "Child Flow",
+                "uuid": "2b118e66-960f-4ba5-abb9-2b250916d4ff"
+              },
+              "legacy_vars": [
+                "@fields.other_phone"
+              ],
+              "type": "start_session",
+              "uuid": "b4691b19-1909-4ada-8d33-a5a462b2f20a"
             }
           ],
-          "exit_uuid": "366a02fd-8621-4ebc-b4fe-5acf4c9df926"
+          "exits": [
+            {
+              "destination_uuid": "3fe6756e-81b3-4ad0-a5f4-2c6f29cdde54",
+              "uuid": "366a02fd-8621-4ebc-b4fe-5acf4c9df926"
+            }
+          ],
+          "uuid": "b6d0a62f-de37-460f-9d09-302a6f906b73"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "06717975-4c39-40a9-8185-96e57698a7bd",
+              "uuid": "1b30b5dc-0bfc-4742-9074-a2fd36eac6a0"
+            },
+            {
+              "uuid": "26fc3a7e-5ba5-4fad-bc0d-339aabcc26bd"
+            },
+            {
+              "uuid": "105262ad-ba0e-4f41-975a-b67713e874ea"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "04483ae2-9282-4aa1-9758-4914f5a73c0d",
+                  "Monkey Facts"
+                ],
+                "category_uuid": "070f70ce-3ddb-4e21-a0cb-41a9dbd85bf3",
+                "type": "has_group",
+                "uuid": "da80d098-bb84-432e-985b-609fbfa715a6"
+              },
+              {
+                "arguments": [
+                  "bffe656c-8c88-45f0-92f8-d603f5dcd861",
+                  "Fish Facts"
+                ],
+                "category_uuid": "ddcbfdab-81dc-4a06-b8ae-412bc2880658",
+                "type": "has_group",
+                "uuid": "832d32b2-7031-411a-bf5e-1ce3c010cd63"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "1b30b5dc-0bfc-4742-9074-a2fd36eac6a0",
+                "name": "Monkey Facts",
+                "uuid": "070f70ce-3ddb-4e21-a0cb-41a9dbd85bf3"
+              },
+              {
+                "exit_uuid": "26fc3a7e-5ba5-4fad-bc0d-339aabcc26bd",
+                "name": "Fish Facts",
+                "uuid": "ddcbfdab-81dc-4a06-b8ae-412bc2880658"
+              },
+              {
+                "exit_uuid": "105262ad-ba0e-4f41-975a-b67713e874ea",
+                "name": "Other",
+                "uuid": "f576f2b3-e800-4525-b6ea-e01b1c7dd2ac"
+              }
+            ],
+            "default_category_uuid": "f576f2b3-e800-4525-b6ea-e01b1c7dd2ac",
+            "operand": "@contact.groups",
+            "result_name": "Group Split",
+            "type": "switch"
+          },
+          "uuid": "3fe6756e-81b3-4ad0-a5f4-2c6f29cdde54"
+        },
+        {
+          "exits": [
+            {
+              "uuid": "e9325fd9-30c7-49da-9868-0ff7c6ba9573"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "e9325fd9-30c7-49da-9868-0ff7c6ba9573",
+                "name": "All Responses",
+                "uuid": "8c6ea73e-9a05-478e-a396-a8f25d404429"
+              }
+            ],
+            "default_category_uuid": "8c6ea73e-9a05-478e-a396-a8f25d404429",
+            "operand": "@(if(is_error(fields.expression_split), \"@contact.expression_split\", fields.expression_split))",
+            "result_name": "Response 4",
+            "type": "switch"
+          },
+          "uuid": "06717975-4c39-40a9-8185-96e57698a7bd"
         }
       ],
-      "rule_sets": [
-        {
-          "uuid": "2eefb600-d52d-4cab-8636-67d4d923b630",
-          "x": 305,
-          "y": 341,
-          "label": "Response 1",
-          "rules": [
-            {
-              "uuid": "93e0559e-993c-4fad-8a40-99813261135d",
-              "category": {
-                "eng": "Success"
-              },
-              "destination": "cec4c5c5-5a46-4fd2-a2ce-0e5cf108bf59",
-              "destination_type": "R",
-              "test": {
-                "type": "webhook_status",
-                "status": "success"
-              },
-              "label": null
-            },
-            {
-              "uuid": "de783d61-7a65-47cb-a1af-76d0f3d35982",
-              "category": {
-                "eng": "Failure"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "webhook_status",
-                "status": "failure"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "webhook",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {
-            "webhook": "http://www.google.com/@(contact.webhook)/endpoint.json",
-            "webhook_action": "GET",
-            "webhook_headers": []
-          }
-        },
-        {
-          "uuid": "cec4c5c5-5a46-4fd2-a2ce-0e5cf108bf59",
-          "x": 47,
-          "y": 441,
-          "label": "Response 2",
-          "rules": [
-            {
-              "uuid": "d6b990aa-f38a-40bc-8a13-a0293bbbfb65",
-              "category": {
-                "fra": "French Rule",
-                "eng": "Rule"
-              },
-              "destination": "bbc9b80e-e99c-4d07-a4df-1b793643d5cb",
-              "destination_type": "A",
-              "test": {
-                "type": "contains_any",
-                "test": {
-                  "fra": "@contact.french_rule",
-                  "eng": "@contact.rule"
-                }
-              },
-              "label": null
-            },
-            {
-              "uuid": "91f38720-f9db-4699-bb77-fcc673ce5b32",
-              "category": {
-                "eng": "Other"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        },
-        {
-          "uuid": "3fe6756e-81b3-4ad0-a5f4-2c6f29cdde54",
-          "x": 140,
-          "y": 1078,
-          "label": "Group Split",
-          "rules": [
-            {
-              "uuid": "1b30b5dc-0bfc-4742-9074-a2fd36eac6a0",
-              "category": {
-                "eng": "Monkey Facts"
-              },
-              "destination": "06717975-4c39-40a9-8185-96e57698a7bd",
-              "destination_type": "R",
-              "test": {
-                "type": "in_group",
-                "test": {
-                  "name": "Monkey Facts",
-                  "uuid": "04483ae2-9282-4aa1-9758-4914f5a73c0d"
-                }
-              },
-              "label": null
-            },
-            {
-              "uuid": "26fc3a7e-5ba5-4fad-bc0d-339aabcc26bd",
-              "category": {
-                "eng": "Fish Facts"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "in_group",
-                "test": {
-                  "name": "Fish Facts",
-                  "uuid": "bffe656c-8c88-45f0-92f8-d603f5dcd861"
-                }
-              },
-              "label": null
-            },
-            {
-              "uuid": "105262ad-ba0e-4f41-975a-b67713e874ea",
-              "category": {
-                "eng": "Other"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "group",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        },
-        {
-          "uuid": "06717975-4c39-40a9-8185-96e57698a7bd",
-          "x": 56,
-          "y": 1221,
-          "label": "Response 4",
-          "rules": [
-            {
-              "uuid": "e9325fd9-30c7-49da-9868-0ff7c6ba9573",
-              "category": {
-                "eng": "All Responses"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "expression",
-          "response_type": "",
-          "operand": "@contact.expression_split",
-          "config": {}
-        }
-      ],
-      "base_language": "eng",
-      "flow_type": "M",
-      "version": "11.12",
-      "metadata": {
-        "expires": 10080,
-        "revision": 1,
-        "uuid": "845f5a05-e92e-46fa-9444-cde06fb53ea0",
-        "name": "Dependencies",
-        "saved_on": "2019-11-21T22:23:03.745441Z"
-      }
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "845f5a05-e92e-46fa-9444-cde06fb53ea0"
     },
     {
-      "entry": "5d70c460-ae57-4fa8-b88d-27bc6d7f602c",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "3cc660aa-9a93-40a3-9eb9-29e9c1567dae": {
+            "position": {
+              "left": 725,
+              "top": 89
+            },
+            "type": "execute_actions"
+          },
+          "5d70c460-ae57-4fa8-b88d-27bc6d7f602c": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "d42cf9c9-7044-4aa5-8bad-2bdac6ae8090": {
+            "position": {
+              "left": 258,
+              "top": 146
+            },
+            "type": "wait_for_response"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {
+        "fra": {
+          "dcfc12c6-e55d-4710-b67a-b165fa6b3a20": {
+            "arguments": [
+              "grune"
+            ]
+          }
+        }
+      },
+      "name": "Child Flow",
+      "nodes": [
         {
-          "uuid": "5d70c460-ae57-4fa8-b88d-27bc6d7f602c",
-          "x": 100,
-          "y": 0,
-          "destination": "d42cf9c9-7044-4aa5-8bad-2bdac6ae8090",
           "actions": [
             {
-              "type": "reply",
-              "uuid": "19b93945-4a7c-483c-8f5c-c58cb7ae11e6",
-              "msg": {
-                "eng": "What is your favorite color? @step.value"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "What is your favorite color? @input",
+              "type": "send_msg",
+              "uuid": "19b93945-4a7c-483c-8f5c-c58cb7ae11e6"
             }
           ],
-          "exit_uuid": "19537ca9-7354-4648-9f87-0588ec8c31bb"
+          "exits": [
+            {
+              "destination_uuid": "d42cf9c9-7044-4aa5-8bad-2bdac6ae8090",
+              "uuid": "19537ca9-7354-4648-9f87-0588ec8c31bb"
+            }
+          ],
+          "uuid": "5d70c460-ae57-4fa8-b88d-27bc6d7f602c"
         },
         {
-          "uuid": "3cc660aa-9a93-40a3-9eb9-29e9c1567dae",
-          "x": 725,
-          "y": 89,
-          "destination": "d42cf9c9-7044-4aa5-8bad-2bdac6ae8090",
           "actions": [
             {
-              "type": "reply",
-              "uuid": "b79bb401-3389-410a-81cd-6c80100a8c7a",
-              "msg": {
-                "eng": "don't know that one"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "don't know that one",
+              "type": "send_msg",
+              "uuid": "b79bb401-3389-410a-81cd-6c80100a8c7a"
             }
           ],
-          "exit_uuid": "685bef1b-f7c7-4931-912e-ab97d6b1575e"
-        }
-      ],
-      "rule_sets": [
+          "exits": [
+            {
+              "destination_uuid": "d42cf9c9-7044-4aa5-8bad-2bdac6ae8090",
+              "uuid": "685bef1b-f7c7-4931-912e-ab97d6b1575e"
+            }
+          ],
+          "uuid": "3cc660aa-9a93-40a3-9eb9-29e9c1567dae"
+        },
         {
-          "uuid": "d42cf9c9-7044-4aa5-8bad-2bdac6ae8090",
-          "x": 258,
-          "y": 146,
-          "label": "Color",
-          "rules": [
+          "exits": [
             {
-              "uuid": "d60e12cc-d404-4713-a153-1f1a61f96a44",
-              "category": {
-                "eng": "Red"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "contains_any",
-                "test": {
-                  "eng": "Red"
-                }
-              },
-              "label": null
+              "uuid": "d60e12cc-d404-4713-a153-1f1a61f96a44"
             },
             {
-              "uuid": "cb71ddfd-d2f4-411e-b39f-fd9936686aff",
-              "category": {
-                "eng": "Green"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "contains_any",
-                "test": {
-                  "fra": "grune",
-                  "eng": "Green"
-                }
-              },
-              "label": null
+              "uuid": "cb71ddfd-d2f4-411e-b39f-fd9936686aff"
             },
             {
-              "uuid": "6b54b491-8a8a-4ed3-af2b-a28da80ee3fc",
-              "category": {
-                "eng": "Blue"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "contains_any",
-                "test": {
-                  "eng": "Blue"
-                }
-              },
-              "label": null
+              "uuid": "6b54b491-8a8a-4ed3-af2b-a28da80ee3fc"
             },
             {
-              "uuid": "539ef77c-4e44-4d9b-9649-cc719fb65da3",
-              "category": {
-                "eng": "Other"
-              },
-              "destination": "3cc660aa-9a93-40a3-9eb9-29e9c1567dae",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
+              "destination_uuid": "3cc660aa-9a93-40a3-9eb9-29e9c1567dae",
+              "uuid": "539ef77c-4e44-4d9b-9649-cc719fb65da3"
             }
           ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Red"
+                ],
+                "category_uuid": "080868ef-7e45-4b2b-9d3a-8736114e05ab",
+                "type": "has_any_word",
+                "uuid": "2e2a18b2-0d69-46d1-ba3e-9803dd96d6a1"
+              },
+              {
+                "arguments": [
+                  "Green"
+                ],
+                "category_uuid": "34fd4bc2-842a-4817-87f8-273f9180ee87",
+                "type": "has_any_word",
+                "uuid": "dcfc12c6-e55d-4710-b67a-b165fa6b3a20"
+              },
+              {
+                "arguments": [
+                  "Blue"
+                ],
+                "category_uuid": "fa46ff86-a783-4eef-b18d-fdbb54ee692c",
+                "type": "has_any_word",
+                "uuid": "6f2359f2-a213-4e87-9e40-465d42c03b10"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "d60e12cc-d404-4713-a153-1f1a61f96a44",
+                "name": "Red",
+                "uuid": "080868ef-7e45-4b2b-9d3a-8736114e05ab"
+              },
+              {
+                "exit_uuid": "cb71ddfd-d2f4-411e-b39f-fd9936686aff",
+                "name": "Green",
+                "uuid": "34fd4bc2-842a-4817-87f8-273f9180ee87"
+              },
+              {
+                "exit_uuid": "6b54b491-8a8a-4ed3-af2b-a28da80ee3fc",
+                "name": "Blue",
+                "uuid": "fa46ff86-a783-4eef-b18d-fdbb54ee692c"
+              },
+              {
+                "exit_uuid": "539ef77c-4e44-4d9b-9649-cc719fb65da3",
+                "name": "Other",
+                "uuid": "6399d529-db40-442a-89a9-462a4daa6158"
+              }
+            ],
+            "default_category_uuid": "6399d529-db40-442a-89a9-462a4daa6158",
+            "operand": "@input",
+            "result_name": "Color",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "d42cf9c9-7044-4aa5-8bad-2bdac6ae8090"
         }
       ],
-      "base_language": "eng",
-      "flow_type": "M",
-      "version": "11.12",
-      "metadata": {
-        "expires": 10080,
-        "revision": 1,
-        "uuid": "2b118e66-960f-4ba5-abb9-2b250916d4ff",
-        "name": "Child Flow",
-        "saved_on": "2019-11-21T22:23:03.749707Z"
-      }
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "2b118e66-960f-4ba5-abb9-2b250916d4ff"
     }
   ],
   "triggers": []

--- a/media/test_flows/dependencies_v13.json
+++ b/media/test_flows/dependencies_v13.json
@@ -153,14 +153,29 @@
           "uuid": "a234e4eb-a8b6-42fd-81e7-a0ae3f41b436"
         }
       ],
-      "spec_version": "13.1.0",
+      "revision": 6,
+      "spec_version": "14.4.0",
       "type": "messaging",
-      "uuid": "f310f98f-abd7-42ce-92d5-fca1cb100e7a",
-      "revision": 6
+      "uuid": "f310f98f-abd7-42ce-92d5-fca1cb100e7a"
     },
     {
       "_ui": {
         "nodes": {
+          "23a6a459-c166-4571-9235-917a9112a548": {
+            "position": {
+              "left": 360,
+              "top": 720
+            },
+            "type": "split_by_groups"
+          },
+          "25fc63ef-fadd-48f0-926d-44a0302110c3": {
+            "config": {},
+            "position": {
+              "left": 300,
+              "top": 920
+            },
+            "type": "split_by_intent"
+          },
           "26914a1f-3242-4f1d-95f0-c879f1a1f781": {
             "position": {
               "left": 51,
@@ -175,6 +190,28 @@
             },
             "type": "split_by_webhook"
           },
+          "58965da0-5e83-4cea-a49f-a35a75b89454": {
+            "position": {
+              "left": 60,
+              "top": 560
+            },
+            "type": "execute_actions"
+          },
+          "70b3ab7e-3ca1-4fa5-ad15-c3767ad25281": {
+            "config": {},
+            "position": {
+              "left": 540,
+              "top": 920
+            },
+            "type": "split_by_ticket"
+          },
+          "bf69a5bf-7e2a-4a4a-965d-e67b8ee8086b": {
+            "position": {
+              "left": 60,
+              "top": 920
+            },
+            "type": "split_by_expression"
+          },
           "c3affccf-a1a8-41c4-a59e-6ca929572014": {
             "position": {
               "left": 360,
@@ -188,43 +225,6 @@
               "top": 400
             },
             "type": "execute_actions"
-          },
-          "58965da0-5e83-4cea-a49f-a35a75b89454": {
-            "position": {
-              "left": 60,
-              "top": 560
-            },
-            "type": "execute_actions"
-          },
-          "23a6a459-c166-4571-9235-917a9112a548": {
-            "position": {
-              "left": 360,
-              "top": 720
-            },
-            "type": "split_by_groups"
-          },
-          "bf69a5bf-7e2a-4a4a-965d-e67b8ee8086b": {
-            "position": {
-              "left": 60,
-              "top": 920
-            },
-            "type": "split_by_expression"
-          },
-          "25fc63ef-fadd-48f0-926d-44a0302110c3": {
-            "type": "split_by_intent",
-            "position": {
-              "left": 300,
-              "top": 920
-            },
-            "config": {}
-          },
-          "70b3ab7e-3ca1-4fa5-ad15-c3767ad25281": {
-            "type": "split_by_ticket",
-            "position": {
-              "left": 540,
-              "top": 920
-            },
-            "config": {}
           }
         },
         "stickies": {}
@@ -295,18 +295,18 @@
               "attachments": [
                 "image:@fields.attachment"
               ],
+              "quick_replies": [],
               "text": "Welcome to @globals.org_name. You are @fields.contact_age years old. @(\"Your CHW is \" & fields.chw). Your score is @(max(parent.fields.top, child.fields.bottom)). On @((replace_time(date(\"24-10-2017\"), time(\"12:30\")))). Thanks @parent.contact!",
               "type": "send_msg",
-              "uuid": "1cc3ba01-6f66-44e5-a163-eac92772555a",
-              "quick_replies": []
+              "uuid": "1cc3ba01-6f66-44e5-a163-eac92772555a"
             },
             {
-              "uuid": "4d2eda1a-74ae-49dd-bd7c-c6abc2b4eee4",
-              "type": "set_contact_channel",
               "channel": {
-                "uuid": "d53efbea-379f-4634-95fd-d9879b28220d",
-                "name": "RapidPro Test"
-              }
+                "name": "RapidPro Test",
+                "uuid": "d53efbea-379f-4634-95fd-d9879b28220d"
+              },
+              "type": "set_contact_channel",
+              "uuid": "4d2eda1a-74ae-49dd-bd7c-c6abc2b4eee4"
             }
           ],
           "exits": [
@@ -340,19 +340,12 @@
             "cases": [
               {
                 "arguments": [
-                  "Success"
+                  "200",
+                  "299"
                 ],
                 "category_uuid": "3725b3f7-c0dd-4f7b-955f-b271ab2ed9da",
-                "type": "has_only_text",
+                "type": "has_number_between",
                 "uuid": "78424150-e0b2-4527-9547-f16d7303150b"
-              },
-              {
-                "arguments": [
-                  "Failure"
-                ],
-                "category_uuid": "64e6d7eb-a335-4aae-90f2-24bfd82dd0ae",
-                "type": "has_only_text",
-                "uuid": "3e4baef9-0759-442e-9e0d-65038d39e0b2"
               }
             ],
             "categories": [
@@ -368,12 +361,13 @@
               }
             ],
             "default_category_uuid": "64e6d7eb-a335-4aae-90f2-24bfd82dd0ae",
-            "operand": "@results.response_1.category",
+            "operand": "@webhook.status",
             "type": "switch"
           },
           "uuid": "3a6f263f-6e6e-4aa3-9126-0f2c562aec9d"
         },
         {
+          "actions": [],
           "exits": [
             {
               "destination_uuid": "db644a63-2ea0-4da1-8c74-a58effb01c41",
@@ -414,8 +408,7 @@
               "type": "msg"
             }
           },
-          "uuid": "c3affccf-a1a8-41c4-a59e-6ca929572014",
-          "actions": []
+          "uuid": "c3affccf-a1a8-41c4-a59e-6ca929572014"
         },
         {
           "actions": [
@@ -487,8 +480,8 @@
             },
             {
               "optin": {
-                "uuid": "ec03a6da-861d-4ee1-9ec2-71dd0e9c9b70",
-                "name": "Cat Facts"
+                "name": "Cat Facts",
+                "uuid": "ec03a6da-861d-4ee1-9ec2-71dd0e9c9b70"
               },
               "type": "request_optin",
               "uuid": "a71f6917-f291-4b85-8b2d-68198bbb52db"
@@ -503,18 +496,19 @@
           "uuid": "58965da0-5e83-4cea-a49f-a35a75b89454"
         },
         {
+          "actions": [],
           "exits": [
             {
               "destination_uuid": "bf69a5bf-7e2a-4a4a-965d-e67b8ee8086b",
               "uuid": "627b3081-4dce-4867-aa64-43985bfce98e"
             },
             {
-              "uuid": "880080f2-0ec8-4c28-9505-c6f85fed72e4",
-              "destination_uuid": "25fc63ef-fadd-48f0-926d-44a0302110c3"
+              "destination_uuid": "25fc63ef-fadd-48f0-926d-44a0302110c3",
+              "uuid": "880080f2-0ec8-4c28-9505-c6f85fed72e4"
             },
             {
-              "uuid": "2570cb5b-084c-424b-b16c-bde2ab2e05f7",
-              "destination_uuid": "70b3ab7e-3ca1-4fa5-ad15-c3767ad25281"
+              "destination_uuid": "70b3ab7e-3ca1-4fa5-ad15-c3767ad25281",
+              "uuid": "2570cb5b-084c-424b-b16c-bde2ab2e05f7"
             }
           ],
           "router": {
@@ -560,10 +554,10 @@
             "result_name": "Group Split",
             "type": "switch"
           },
-          "uuid": "23a6a459-c166-4571-9235-917a9112a548",
-          "actions": []
+          "uuid": "23a6a459-c166-4571-9235-917a9112a548"
         },
         {
+          "actions": [],
           "exits": [
             {
               "uuid": "380a5dfe-6408-4393-af9d-eee667a6a53c"
@@ -583,66 +577,21 @@
             "result_name": "Response 4",
             "type": "switch"
           },
-          "uuid": "bf69a5bf-7e2a-4a4a-965d-e67b8ee8086b",
-          "actions": []
+          "uuid": "bf69a5bf-7e2a-4a4a-965d-e67b8ee8086b"
         },
         {
-          "uuid": "25fc63ef-fadd-48f0-926d-44a0302110c3",
           "actions": [
             {
-              "uuid": "7ebd7be9-18d4-4d06-b69e-63d11d7bb72e",
-              "type": "call_classifier",
-              "result_name": "_Result Classification",
-              "input": "@input.text",
               "classifier": {
-                "uuid": "891a1c5d-1140-4fd0-bd0d-a919ea25abb6",
-                "name": "Feelings"
-              }
+                "name": "Feelings",
+                "uuid": "891a1c5d-1140-4fd0-bd0d-a919ea25abb6"
+              },
+              "input": "@input.text",
+              "result_name": "_Result Classification",
+              "type": "call_classifier",
+              "uuid": "7ebd7be9-18d4-4d06-b69e-63d11d7bb72e"
             }
           ],
-          "router": {
-            "cases": [
-              {
-                "arguments": [
-                  "None",
-                  ".9"
-                ],
-                "type": "has_top_intent",
-                "uuid": "f7889a15-9d27-47e4-8132-011fd3e56473",
-                "category_uuid": "0a1fb250-2a5f-4995-81eb-0be34ee76f6d"
-              },
-              {
-                "uuid": "08cb55c0-9a89-41fb-a1d7-52f1aa65f5b9",
-                "type": "has_category",
-                "arguments": [
-                  "Success",
-                  "Skipped"
-                ],
-                "category_uuid": "d1c69a12-68d9-435a-80be-f1409b57c62f"
-              }
-            ],
-            "operand": "@results._result_classification",
-            "categories": [
-              {
-                "uuid": "0a1fb250-2a5f-4995-81eb-0be34ee76f6d",
-                "name": "None",
-                "exit_uuid": "89a4604e-d8bc-4836-8810-84ef86d7998c"
-              },
-              {
-                "uuid": "f113da14-35e1-4cd4-a0dc-c259f5e6f2e5",
-                "name": "Failure",
-                "exit_uuid": "509b4d09-c262-4fcb-a20d-ad2d431d1229"
-              },
-              {
-                "uuid": "d1c69a12-68d9-435a-80be-f1409b57c62f",
-                "name": "Other",
-                "exit_uuid": "4936d570-f4b4-407c-842f-59cf0b7bd54b"
-              }
-            ],
-            "type": "switch",
-            "default_category_uuid": "f113da14-35e1-4cd4-a0dc-c259f5e6f2e5",
-            "result_name": "Result"
-          },
           "exits": [
             {
               "uuid": "89a4604e-d8bc-4836-8810-84ef86d7998c"
@@ -653,62 +602,107 @@
             {
               "uuid": "509b4d09-c262-4fcb-a20d-ad2d431d1229"
             }
-          ]
-        },
-        {
-          "uuid": "70b3ab7e-3ca1-4fa5-ad15-c3767ad25281",
-          "actions": [
-            {
-              "uuid": "78f73b5c-b842-4b7c-ac74-54a2b1e31b79",
-              "type": "open_ticket",
-              "topic": {"uuid": "4d7a8306-acab-41e8-957b-cba523e60fa5", "name": "Support"},
-              "body": "@results",
-              "result_name": "Result"
-            }
           ],
           "router": {
-            "type": "switch",
-            "operand": "@results.result",
             "cases": [
               {
-                "uuid": "e8af44bc-e5e0-46e7-816d-2eee0cf1928c",
-                "type": "has_category",
                 "arguments": [
-                  "Success"
+                  "None",
+                  ".9"
                 ],
-                "category_uuid": "9ae9400a-eb5d-491a-bae8-ae295811c9d1"
+                "category_uuid": "0a1fb250-2a5f-4995-81eb-0be34ee76f6d",
+                "type": "has_top_intent",
+                "uuid": "f7889a15-9d27-47e4-8132-011fd3e56473"
+              },
+              {
+                "arguments": [
+                  "Success",
+                  "Skipped"
+                ],
+                "category_uuid": "d1c69a12-68d9-435a-80be-f1409b57c62f",
+                "type": "has_category",
+                "uuid": "08cb55c0-9a89-41fb-a1d7-52f1aa65f5b9"
               }
             ],
             "categories": [
               {
-                "uuid": "9ae9400a-eb5d-491a-bae8-ae295811c9d1",
-                "name": "Success",
-                "exit_uuid": "35d0d802-0d0f-418b-9028-5a0812761e97"
+                "exit_uuid": "89a4604e-d8bc-4836-8810-84ef86d7998c",
+                "name": "None",
+                "uuid": "0a1fb250-2a5f-4995-81eb-0be34ee76f6d"
               },
               {
-                "uuid": "494df32e-1b36-4fd4-978a-0769c8b3b5ac",
+                "exit_uuid": "509b4d09-c262-4fcb-a20d-ad2d431d1229",
                 "name": "Failure",
-                "exit_uuid": "2ec47a11-ee11-48b3-9207-3431fd354274"
+                "uuid": "f113da14-35e1-4cd4-a0dc-c259f5e6f2e5"
+              },
+              {
+                "exit_uuid": "4936d570-f4b4-407c-842f-59cf0b7bd54b",
+                "name": "Other",
+                "uuid": "d1c69a12-68d9-435a-80be-f1409b57c62f"
               }
             ],
-            "default_category_uuid": "494df32e-1b36-4fd4-978a-0769c8b3b5ac"
+            "default_category_uuid": "f113da14-35e1-4cd4-a0dc-c259f5e6f2e5",
+            "operand": "@results._result_classification",
+            "result_name": "Result",
+            "type": "switch"
           },
+          "uuid": "25fc63ef-fadd-48f0-926d-44a0302110c3"
+        },
+        {
+          "actions": [
+            {
+              "note": "@results",
+              "topic": {
+                "name": "Support",
+                "uuid": "4d7a8306-acab-41e8-957b-cba523e60fa5"
+              },
+              "type": "open_ticket",
+              "uuid": "78f73b5c-b842-4b7c-ac74-54a2b1e31b79"
+            }
+          ],
           "exits": [
             {
-              "uuid": "35d0d802-0d0f-418b-9028-5a0812761e97",
-              "destination_uuid": null
+              "destination_uuid": null,
+              "uuid": "35d0d802-0d0f-418b-9028-5a0812761e97"
             },
             {
-              "uuid": "2ec47a11-ee11-48b3-9207-3431fd354274",
-              "destination_uuid": null
+              "destination_uuid": null,
+              "uuid": "2ec47a11-ee11-48b3-9207-3431fd354274"
             }
-          ]
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [],
+                "category_uuid": "9ae9400a-eb5d-491a-bae8-ae295811c9d1",
+                "type": "has_text",
+                "uuid": "e8af44bc-e5e0-46e7-816d-2eee0cf1928c"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "35d0d802-0d0f-418b-9028-5a0812761e97",
+                "name": "Success",
+                "uuid": "9ae9400a-eb5d-491a-bae8-ae295811c9d1"
+              },
+              {
+                "exit_uuid": "2ec47a11-ee11-48b3-9207-3431fd354274",
+                "name": "Failure",
+                "uuid": "494df32e-1b36-4fd4-978a-0769c8b3b5ac"
+              }
+            ],
+            "default_category_uuid": "494df32e-1b36-4fd4-978a-0769c8b3b5ac",
+            "operand": "@locals._new_ticket",
+            "result_name": "Result",
+            "type": "switch"
+          },
+          "uuid": "70b3ab7e-3ca1-4fa5-ad15-c3767ad25281"
         }
       ],
-      "spec_version": "13.1.0",
+      "revision": 22,
+      "spec_version": "14.4.0",
       "type": "messaging",
-      "uuid": "89894985-f68d-4a1b-b49e-4ea6dfc5e76a",
-      "revision": 22
+      "uuid": "89894985-f68d-4a1b-b49e-4ea6dfc5e76a"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/dependencies_voice.json
+++ b/media/test_flows/dependencies_voice.json
@@ -1,94 +1,124 @@
 {
-  "campaigns": [], 
-  "version": 10, 
-  "site": "https://textit.in", 
+  "campaigns": [],
+  "version": "13",
+  "site": "https://textit.in",
   "flows": [
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "72344181-7921-4974-8976-fb63bfb61dd1": {
+            "position": {
+              "left": 37,
+              "top": 229
+            },
+            "type": "execute_actions"
+          },
+          "86f2ce52-cfdd-425a-a1ec-1a9105349047": {
+            "position": {
+              "left": 36,
+              "top": 121
+            },
+            "type": "wait_for_response"
+          },
+          "cc1873f9-767c-4f21-a606-06c2a343bc57": {
+            "position": {
+              "left": 34,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 1,
+      "language": "eng",
+      "localization": {},
+      "name": "Voice Dependencies",
+      "nodes": [
         {
-          "y": 0, 
-          "x": 34, 
-          "destination": "86f2ce52-cfdd-425a-a1ec-1a9105349047", 
-          "uuid": "cc1873f9-767c-4f21-a606-06c2a343bc57", 
           "actions": [
             {
-              "recording": null, 
-              "msg": {
-                "eng": "This is how you @contact.play_message!"
-              }, 
-              "type": "say", 
+              "text": "This is how you @fields.play_message!",
+              "type": "say_msg",
               "uuid": "673a18ac-b952-4b8f-a6af-7b3760af5cb6"
             }
-          ]
-        }, 
+          ],
+          "exits": [
+            {
+              "destination_uuid": "86f2ce52-cfdd-425a-a1ec-1a9105349047",
+              "uuid": "02a4ef4e-d23f-4115-90d5-34c621f130e7"
+            }
+          ],
+          "uuid": "cc1873f9-767c-4f21-a606-06c2a343bc57"
+        },
         {
-          "y": 229, 
-          "x": 37, 
-          "destination": null, 
-          "uuid": "72344181-7921-4974-8976-fb63bfb61dd1", 
+          "exits": [
+            {
+              "destination_uuid": "72344181-7921-4974-8976-fb63bfb61dd1",
+              "uuid": "5289d5df-ee7a-4f41-98b1-3663b1d77ddc"
+            },
+            {
+              "uuid": "9ba2d7bc-b8e7-4c7e-a997-a9da49c72efe"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "@fields.voice_rule"
+                ],
+                "category_uuid": "69f9586a-db78-4394-8eed-1707091390ab",
+                "type": "has_number_eq",
+                "uuid": "0f2edaf6-df6d-4f35-8ee5-f642823adcd5"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "5289d5df-ee7a-4f41-98b1-3663b1d77ddc",
+                "name": "1",
+                "uuid": "69f9586a-db78-4394-8eed-1707091390ab"
+              },
+              {
+                "exit_uuid": "9ba2d7bc-b8e7-4c7e-a997-a9da49c72efe",
+                "name": "Other",
+                "uuid": "009527d0-26f1-443d-a369-35311ade8642"
+              }
+            ],
+            "default_category_uuid": "009527d0-26f1-443d-a369-35311ade8642",
+            "operand": "@input.text",
+            "result_name": "Button",
+            "type": "switch",
+            "wait": {
+              "hint": {
+                "terminated_by": "",
+                "type": "digits"
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "86f2ce52-cfdd-425a-a1ec-1a9105349047"
+        },
+        {
           "actions": [
             {
-              "url": "@contact.voice_recording", 
-              "type": "play", 
+              "audio_url": "@fields.voice_recording",
+              "type": "play_audio",
               "uuid": "512eb20d-56d2-4f3c-b04d-917a3bea3088"
             }
-          ]
-        }
-      ], 
-      "version": 10, 
-      "flow_type": "V", 
-      "entry": "cc1873f9-767c-4f21-a606-06c2a343bc57", 
-      "rule_sets": [
-        {
-          "uuid": "86f2ce52-cfdd-425a-a1ec-1a9105349047", 
-          "rules": [
+          ],
+          "exits": [
             {
-              "category": {
-                "base": "1", 
-                "eng": "1"
-              }, 
-              "uuid": "5289d5df-ee7a-4f41-98b1-3663b1d77ddc", 
-              "destination": "72344181-7921-4974-8976-fb63bfb61dd1", 
-              "label": null, 
-              "destination_type": "A", 
-              "test": {
-                "test": "@contact.voice_rule", 
-                "type": "eq"
-              }
-            }, 
-            {
-              "category": {
-                "base": "All Responses", 
-                "eng": "Other"
-              }, 
-              "uuid": "9ba2d7bc-b8e7-4c7e-a997-a9da49c72efe", 
-              "destination": null, 
-              "label": null, 
-              "destination_type": null, 
-              "test": {
-                "type": "true"
-              }
+              "uuid": "60361615-124e-4bd4-804b-58045c3f283f"
             }
-          ], 
-          "ruleset_type": "wait_digits", 
-          "label": "Button", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 121, 
-          "x": 36, 
-          "config": {}
+          ],
+          "uuid": "72344181-7921-4974-8976-fb63bfb61dd1"
         }
-      ], 
-      "metadata": {
-        "expires": 1, 
-        "revision": 22, 
-        "uuid": "e05a2116-20b5-4641-833d-f7184a13ddd5", 
-        "name": "Voice Dependencies", 
-        "saved_on": "2017-10-05T20:05:37.219777Z"
-      }
+      ],
+      "revision": 22,
+      "spec_version": "14.4.0",
+      "type": "voice",
+      "uuid": "e05a2116-20b5-4641-833d-f7184a13ddd5"
     }
-  ], 
+  ],
   "triggers": []
 }

--- a/media/test_flows/favorites.json
+++ b/media/test_flows/favorites.json
@@ -1,314 +1,403 @@
 {
-  "version": 7,
+  "version": "13",
   "flows": [
     {
-      "version": 7,
-      "flow_type": "M",
-      "base_language": "base",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "10e483a8-5ffb-4c4f-917b-d43ce86c1d65": {
+            "position": {
+              "left": 191,
+              "top": 805
+            },
+            "type": "execute_actions"
+          },
+          "127f3736-77ce-4006-9ab0-0c07cea88956": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830": {
+            "position": {
+              "left": 98,
+              "top": 129
+            },
+            "type": "wait_for_response"
+          },
+          "44471ade-7979-4c94-8028-6cfb68836337": {
+            "position": {
+              "left": 131,
+              "top": 237
+            },
+            "type": "execute_actions"
+          },
+          "89c5624e-3320-4668-a066-308865133080": {
+            "position": {
+              "left": 191,
+              "top": 535
+            },
+            "type": "execute_actions"
+          },
+          "a269683d-8229-4870-8585-be8320b9d8ca": {
+            "position": {
+              "left": 512,
+              "top": 265
+            },
+            "type": "execute_actions"
+          },
+          "a5fc5f8a-f562-4b03-a54f-51928f9df07e": {
+            "position": {
+              "left": 112,
+              "top": 387
+            },
+            "type": "wait_for_response"
+          },
+          "ba95c5cd-e428-4a15-8b4b-23dd43943f2c": {
+            "position": {
+              "left": 191,
+              "top": 702
+            },
+            "type": "wait_for_response"
+          },
+          "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f": {
+            "position": {
+              "left": 456,
+              "top": 8
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 720,
+      "language": "und",
+      "localization": {},
+      "name": "Favorites",
+      "nodes": [
         {
-          "y": 0,
-          "x": 100,
-          "destination": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
-          "uuid": "127f3736-77ce-4006-9ab0-0c07cea88956",
           "actions": [
             {
-              "msg": {
-                "base": "What is your favorite color?"
-              },
-              "type": "reply"
+              "text": "What is your favorite color?",
+              "type": "send_msg",
+              "uuid": "5bf79253-907f-404f-a6c2-e5e9283c06a8"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "destination_uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
+              "uuid": "e1f1773b-8ffd-43b6-9e5a-df7926011d6f"
+            }
+          ],
+          "uuid": "127f3736-77ce-4006-9ab0-0c07cea88956"
         },
         {
-          "y": 237,
-          "x": 131,
-          "destination": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
-          "uuid": "44471ade-7979-4c94-8028-6cfb68836337",
           "actions": [
             {
-              "msg": {
-                "base": "Good choice, I like @flow.color.category too! What is your favorite beer?"
-              },
-              "type": "reply"
+              "text": "I don't know that color. Try again.",
+              "type": "send_msg",
+              "uuid": "3ec7e0c9-0776-4908-b4a2-781ee5af8268"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "destination_uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
+              "uuid": "cdb58636-c05f-4f6a-8cef-464277a6a785"
+            }
+          ],
+          "uuid": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f"
         },
         {
-          "y": 8,
-          "x": 456,
-          "destination": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
-          "uuid": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f",
-          "actions": [
+          "exits": [
             {
-              "msg": {
-                "base": "I don't know that color. Try again."
-              },
-              "type": "reply"
+              "destination_uuid": "44471ade-7979-4c94-8028-6cfb68836337",
+              "uuid": "8cd25a3f-0be2-494b-8b4c-3a4f0de7f9b2"
+            },
+            {
+              "destination_uuid": "44471ade-7979-4c94-8028-6cfb68836337",
+              "uuid": "db2863cf-7fda-4489-9345-d44dacf4e750"
+            },
+            {
+              "destination_uuid": "44471ade-7979-4c94-8028-6cfb68836337",
+              "uuid": "2f462678-b176-49c1-bb5c-6e152502b0db"
+            },
+            {
+              "uuid": "6f463a78-b176-49c1-bb5c-6e152502b0db"
+            },
+            {
+              "destination_uuid": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f",
+              "uuid": "df4455c2-806b-4af4-8ea9-f40278ec10e4"
             }
-          ]
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Red"
+                ],
+                "category_uuid": "90c90ab0-2cf4-4d64-bf7c-a4e0f2aff1e0",
+                "type": "has_any_word",
+                "uuid": "a9a7ec2b-607e-4561-9e16-134e6dd86cbf"
+              },
+              {
+                "arguments": [
+                  "Green"
+                ],
+                "category_uuid": "a3241418-bd5b-4658-b430-fabcb6b3f448",
+                "type": "has_any_word",
+                "uuid": "fa0644e6-6cf0-4b78-a88d-3f6174e442f4"
+              },
+              {
+                "arguments": [
+                  "Blue"
+                ],
+                "category_uuid": "dd2ac88e-768c-4f35-b750-a548d9fa908f",
+                "type": "has_any_word",
+                "uuid": "fc8cb261-4da7-4eb4-8fd5-1a1d698cd045"
+              },
+              {
+                "arguments": [
+                  "Navy"
+                ],
+                "category_uuid": "dd2ac88e-768c-4f35-b750-a548d9fa908f",
+                "type": "has_any_word",
+                "uuid": "453b7e2c-dfad-4d49-8d18-3b94b3433f07"
+              },
+              {
+                "arguments": [
+                  "Cyan"
+                ],
+                "category_uuid": "f6434115-cb46-49ce-916e-0f10853599d2",
+                "type": "has_any_word",
+                "uuid": "f545edcd-68cf-4689-95bc-fe7b488e035e"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "8cd25a3f-0be2-494b-8b4c-3a4f0de7f9b2",
+                "name": "Red",
+                "uuid": "90c90ab0-2cf4-4d64-bf7c-a4e0f2aff1e0"
+              },
+              {
+                "exit_uuid": "db2863cf-7fda-4489-9345-d44dacf4e750",
+                "name": "Green",
+                "uuid": "a3241418-bd5b-4658-b430-fabcb6b3f448"
+              },
+              {
+                "exit_uuid": "2f462678-b176-49c1-bb5c-6e152502b0db",
+                "name": "Blue",
+                "uuid": "dd2ac88e-768c-4f35-b750-a548d9fa908f"
+              },
+              {
+                "exit_uuid": "6f463a78-b176-49c1-bb5c-6e152502b0db",
+                "name": "Cyan",
+                "uuid": "f6434115-cb46-49ce-916e-0f10853599d2"
+              },
+              {
+                "exit_uuid": "df4455c2-806b-4af4-8ea9-f40278ec10e4",
+                "name": "Other",
+                "uuid": "ed15fabc-4353-485e-9de5-854ce2b83f83"
+              }
+            ],
+            "default_category_uuid": "ed15fabc-4353-485e-9de5-854ce2b83f83",
+            "operand": "@input",
+            "result_name": "Color",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830"
         },
         {
-          "y": 535,
-          "x": 191,
-          "destination": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c",
-          "uuid": "89c5624e-3320-4668-a066-308865133080",
           "actions": [
             {
-              "msg": {
-                "base": "Mmmmm... delicious @flow.beer.category. If only they made @flow.color|lower_case @flow.beer.category! Lastly, what is your name?"
-              },
-              "type": "reply"
+              "text": "Good choice, I like @results.color.category_localized too! What is your favorite beer?",
+              "type": "send_msg",
+              "uuid": "6163897d-9498-4c93-b50f-8e5d7585aec0"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "destination_uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
+              "uuid": "c86f0b8f-9b8d-47f6-ad6c-b5885f8b0695"
+            }
+          ],
+          "uuid": "44471ade-7979-4c94-8028-6cfb68836337"
         },
         {
-          "y": 265,
-          "x": 512,
-          "destination": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
-          "uuid": "a269683d-8229-4870-8585-be8320b9d8ca",
           "actions": [
             {
-              "msg": {
-                "base": "I don't know that one, try again please."
-              },
-              "type": "reply"
+              "text": "I don't know that one, try again please.",
+              "type": "send_msg",
+              "uuid": "8785c996-390b-4fd3-a265-f635e0f719d0"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "destination_uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
+              "uuid": "7d091dc5-f797-48dc-b167-1ed1952949ae"
+            }
+          ],
+          "uuid": "a269683d-8229-4870-8585-be8320b9d8ca"
         },
         {
-          "y": 805,
-          "x": 191,
-          "destination": null,
-          "uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
+          "exits": [
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "ea304225-332e-49d4-9768-1e804cd0b6c2"
+            },
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "57f8688e-c263-43d7-bd06-bdb98f0c58a8"
+            },
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "670f0205-bb39-4e12-ae95-5e29251b8a3e"
+            },
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "2ff4713f-c62f-445c-880c-de8f6532d090"
+            },
+            {
+              "destination_uuid": "a269683d-8229-4870-8585-be8320b9d8ca",
+              "uuid": "1fc4c133-d038-4f75-a69e-6e7e3190e5d8"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Mutzig"
+                ],
+                "category_uuid": "674f8e20-93c6-498b-9342-988aa2d8154d",
+                "type": "has_any_word",
+                "uuid": "d64bd1f8-b983-4270-9fa2-fdca6f4c9197"
+              },
+              {
+                "arguments": [
+                  "Primus"
+                ],
+                "category_uuid": "b77da30f-987f-4682-a3e5-502e6239fd79",
+                "type": "has_any_word",
+                "uuid": "1e7f594c-a5f2-4e38-a428-a5180af46216"
+              },
+              {
+                "arguments": [
+                  "Turbo King"
+                ],
+                "category_uuid": "40b73c2f-d65f-409a-83ff-86b85b639b08",
+                "type": "has_any_word",
+                "uuid": "c87e5d40-686d-4f1d-8c0a-beb863faa7ac"
+              },
+              {
+                "arguments": [
+                  "Skol"
+                ],
+                "category_uuid": "ec9f0385-e5dc-4e61-beb7-1a349cd1ebd0",
+                "type": "has_any_word",
+                "uuid": "df5a992f-aa29-450d-aa94-f814d29e0e99"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "ea304225-332e-49d4-9768-1e804cd0b6c2",
+                "name": "Mutzig",
+                "uuid": "674f8e20-93c6-498b-9342-988aa2d8154d"
+              },
+              {
+                "exit_uuid": "57f8688e-c263-43d7-bd06-bdb98f0c58a8",
+                "name": "Primus",
+                "uuid": "b77da30f-987f-4682-a3e5-502e6239fd79"
+              },
+              {
+                "exit_uuid": "670f0205-bb39-4e12-ae95-5e29251b8a3e",
+                "name": "Turbo King",
+                "uuid": "40b73c2f-d65f-409a-83ff-86b85b639b08"
+              },
+              {
+                "exit_uuid": "2ff4713f-c62f-445c-880c-de8f6532d090",
+                "name": "Skol",
+                "uuid": "ec9f0385-e5dc-4e61-beb7-1a349cd1ebd0"
+              },
+              {
+                "exit_uuid": "1fc4c133-d038-4f75-a69e-6e7e3190e5d8",
+                "name": "Other",
+                "uuid": "4014ec59-960f-49c9-969a-f06d946e050d"
+              }
+            ],
+            "default_category_uuid": "4014ec59-960f-49c9-969a-f06d946e050d",
+            "operand": "@input",
+            "result_name": "Beer",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e"
+        },
+        {
           "actions": [
             {
-              "msg": {
-                "base": "Thanks @flow.name, we are all done!"
-              },
-              "type": "reply"
+              "text": "Mmmmm... delicious @results.beer.category_localized. If only they made @(lower(results.color)) @results.beer.category_localized! Lastly, what is your name?",
+              "type": "send_msg",
+              "uuid": "1c738618-f494-4ce1-aada-7acd9d2af88d"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "destination_uuid": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c",
+              "uuid": "f06c208b-63c1-4504-8ea7-f2eb3f727fc4"
+            }
+          ],
+          "uuid": "89c5624e-3320-4668-a066-308865133080"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
+              "uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783",
+                "name": "All Responses",
+                "uuid": "af4a28a4-e477-4097-8c2e-2ac7eb2cadf6"
+              }
+            ],
+            "default_category_uuid": "af4a28a4-e477-4097-8c2e-2ac7eb2cadf6",
+            "operand": "@input",
+            "result_name": "Name",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c"
+        },
+        {
+          "actions": [
+            {
+              "text": "Thanks @results.name, we are all done!",
+              "type": "send_msg",
+              "uuid": "3a69c0fc-b1cf-4817-93f2-bfb50f304846"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "275259f6-f6db-408a-b6a9-7a0218ca74eb"
+            }
+          ],
+          "uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65"
         }
       ],
-      "last_saved": "2015-09-15T02:37:08.805578Z",
-      "entry": "127f3736-77ce-4006-9ab0-0c07cea88956",
-      "rule_sets": [
-        {
-          "uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
-          "webhook_action": null,
-          "rules": [
-            {
-              "test": {
-                "test": {
-                  "base": "Red"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Red"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "8cd25a3f-0be2-494b-8b4c-3a4f0de7f9b2",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Green"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Green"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "db2863cf-7fda-4489-9345-d44dacf4e750",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Blue"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Blue"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "2f462678-b176-49c1-bb5c-6e152502b0db",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Navy"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Blue"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "ecaeb59a-d7f1-4c21-a207-b2a29cc2488f",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Cyan"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Cyan"
-              },
-              "destination": null,
-              "uuid": "6f463a78-b176-49c1-bb5c-6e152502b0db",
-              "destination_type": null
-            },
-            {
-              "test": {
-                "test": "true",
-                "type": "true"
-              },
-              "category": {
-                "base": "Other"
-              },
-              "destination": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f",
-              "uuid": "df4455c2-806b-4af4-8ea9-f40278ec10e4",
-              "destination_type": "A"
-            }
-          ],
-          "webhook": null,
-          "ruleset_type": "wait_message",
-          "label": "Color",
-          "operand": "@step.value",
-          "finished_key": null,
-          "response_type": "",
-          "y": 129,
-          "x": 98,
-          "config": {}
-        },
-        {
-          "uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
-          "webhook_action": null,
-          "rules": [
-            {
-              "test": {
-                "test": {
-                  "base": "Mutzig"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Mutzig"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "ea304225-332e-49d4-9768-1e804cd0b6c2",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Primus"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Primus"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "57f8688e-c263-43d7-bd06-bdb98f0c58a8",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Turbo King"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Turbo King"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "670f0205-bb39-4e12-ae95-5e29251b8a3e",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Skol"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Skol"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "2ff4713f-c62f-445c-880c-de8f6532d090",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": "true",
-                "type": "true"
-              },
-              "category": {
-                "base": "Other"
-              },
-              "destination": "a269683d-8229-4870-8585-be8320b9d8ca",
-              "uuid": "1fc4c133-d038-4f75-a69e-6e7e3190e5d8",
-              "destination_type": "A"
-            }
-          ],
-          "webhook": null,
-          "ruleset_type": "wait_message",
-          "label": "Beer",
-          "operand": "@step.value",
-          "finished_key": null,
-          "response_type": "",
-          "y": 387,
-          "x": 112,
-          "config": {}
-        },
-        {
-          "uuid": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c",
-          "webhook_action": null,
-          "rules": [
-            {
-              "test": {
-                "test": "true",
-                "type": "true"
-              },
-              "category": {
-                "base": "All Responses"
-              },
-              "destination": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
-              "uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783",
-              "destination_type": "A"
-            }
-          ],
-          "webhook": null,
-          "ruleset_type": "wait_message",
-          "label": "Name",
-          "operand": "@step.value",
-          "finished_key": null,
-          "response_type": "",
-          "y": 702,
-          "x": 191,
-          "config": {}
-        }
-      ],
-      "metadata": {
-        "notes": [],
-        "name": "Favorites",
-        "id": 35559,
-        "expires": 720,
-        "revision": 1
-      }
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "fb41a52c-ee56-4bd9-9849-5bf1e8a7633f"
     }
   ],
   "triggers": []

--- a/media/test_flows/favorites_v13.json
+++ b/media/test_flows/favorites_v13.json
@@ -2,410 +2,410 @@
   "version": "13",
   "flows": [
     {
-      "uuid": "aef60b1e-14ab-4095-81ee-fce02b3e320d",
-      "name": "Favorites",
-      "spec_version": "13.0.0",
-      "language": "eng",
-      "type": "messaging",
-      "revision": 1,
+      "_ui": {
+        "nodes": {
+          "062479aa-51c8-4aac-b8e0-78385ad005a3": {
+            "position": {
+              "left": 112,
+              "top": 387
+            },
+            "type": "wait_for_response"
+          },
+          "0cb93acd-d8ec-43cf-82b6-b550e4a671e0": {
+            "position": {
+              "left": 191,
+              "top": 805
+            },
+            "type": "execute_actions"
+          },
+          "1f437f8e-36af-4762-a150-374a832c3bd3": {
+            "position": {
+              "left": 456,
+              "top": 8
+            },
+            "type": "execute_actions"
+          },
+          "2428f8f2-2ab0-4af5-80d3-3dab5b8918cd": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a": {
+            "position": {
+              "left": 131,
+              "top": 237
+            },
+            "type": "execute_actions"
+          },
+          "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c": {
+            "position": {
+              "left": 191,
+              "top": 535
+            },
+            "type": "execute_actions"
+          },
+          "5ebd5006-67d8-4df5-b584-14cee383e720": {
+            "position": {
+              "left": 98,
+              "top": 129
+            },
+            "type": "wait_for_response"
+          },
+          "5f45d985-a193-4872-8b03-1da3106395fa": {
+            "position": {
+              "left": 512,
+              "top": 265
+            },
+            "type": "execute_actions"
+          },
+          "c3232f80-09a1-4d10-a0f5-3d429e6d9b6e": {
+            "position": {
+              "left": 191,
+              "top": 702
+            },
+            "type": "wait_for_response"
+          }
+        },
+        "stickies": {}
+      },
       "expire_after_minutes": 720,
+      "language": "eng",
       "localization": {
         "spa": {
           "376d00df-75cf-4760-86c1-d481634a30ec": {
             "text": [
-              "¿Cuál es tu color favorito?"
+              "\u00bfCu\u00e1l es tu color favorito?"
             ]
           }
         }
       },
+      "name": "Favorites",
       "nodes": [
         {
-          "uuid": "2428f8f2-2ab0-4af5-80d3-3dab5b8918cd",
           "actions": [
             {
+              "text": "What is your favorite color?",
               "type": "send_msg",
-              "uuid": "376d00df-75cf-4760-86c1-d481634a30ec",
-              "text": "What is your favorite color?"
+              "uuid": "376d00df-75cf-4760-86c1-d481634a30ec"
             }
           ],
           "exits": [
             {
-              "uuid": "090a8427-acdf-47a6-be7a-9b6302d05356",
-              "destination_uuid": "5ebd5006-67d8-4df5-b584-14cee383e720"
+              "destination_uuid": "5ebd5006-67d8-4df5-b584-14cee383e720",
+              "uuid": "090a8427-acdf-47a6-be7a-9b6302d05356"
             }
-          ]
+          ],
+          "uuid": "2428f8f2-2ab0-4af5-80d3-3dab5b8918cd"
         },
         {
-          "uuid": "1f437f8e-36af-4762-a150-374a832c3bd3",
           "actions": [
             {
+              "text": "I don't know that color. Try again.",
               "type": "send_msg",
-              "uuid": "19eb8b27-fe59-4930-bc37-6d37493c5ee8",
-              "text": "I don't know that color. Try again."
+              "uuid": "19eb8b27-fe59-4930-bc37-6d37493c5ee8"
             }
           ],
           "exits": [
             {
-              "uuid": "f13b79b5-fd09-411e-909e-af8ba6cb743e",
-              "destination_uuid": "5ebd5006-67d8-4df5-b584-14cee383e720"
+              "destination_uuid": "5ebd5006-67d8-4df5-b584-14cee383e720",
+              "uuid": "f13b79b5-fd09-411e-909e-af8ba6cb743e"
             }
-          ]
+          ],
+          "uuid": "1f437f8e-36af-4762-a150-374a832c3bd3"
         },
         {
-          "uuid": "5ebd5006-67d8-4df5-b584-14cee383e720",
-          "router": {
-            "type": "switch",
-            "wait": {
-              "type": "msg"
-            },
-            "result_name": "Color",
-            "categories": [
-              {
-                "uuid": "68d8b65c-84e3-435c-9f8a-ba8e89d5a1f1",
-                "name": "Red",
-                "exit_uuid": "20b48b36-2d0e-4374-a84f-59e523ff0426"
-              },
-              {
-                "uuid": "53d69d24-7078-4090-96d3-38ecc0352a64",
-                "name": "Green",
-                "exit_uuid": "e04becf4-dc27-42f5-9cd0-8f952e8409fa"
-              },
-              {
-                "uuid": "c4ab7930-c8a1-4472-81f0-11ffb3480b90",
-                "name": "Blue",
-                "exit_uuid": "cccd0ae4-6c62-4935-bcb0-f11d4efa9cb3"
-              },
-              {
-                "uuid": "dff296b4-75a4-4074-b029-6b2d2e83f29f",
-                "name": "Cyan",
-                "exit_uuid": "d9b6c3cf-2b3f-4dca-b2a3-2a32c1e24109"
-              },
-              {
-                "uuid": "84013945-f2a6-49e7-b3b0-3e5e84bb16f2",
-                "name": "Other",
-                "exit_uuid": "f1f0affb-e998-4664-be72-24cd25bf88e5"
-              }
-            ],
-            "operand": "@input",
-            "cases": [
-              {
-                "uuid": "8d86fdbd-3cfe-4ee1-b5a1-625ec98dca01",
-                "type": "has_any_word",
-                "arguments": [
-                  "Red"
-                ],
-                "category_uuid": "68d8b65c-84e3-435c-9f8a-ba8e89d5a1f1"
-              },
-              {
-                "uuid": "e31e5d32-43d5-4130-bd98-46661e3397c7",
-                "type": "has_any_word",
-                "arguments": [
-                  "Green"
-                ],
-                "category_uuid": "53d69d24-7078-4090-96d3-38ecc0352a64"
-              },
-              {
-                "uuid": "45e38343-3c3c-4803-994b-d31fbf45ba0f",
-                "type": "has_any_word",
-                "arguments": [
-                  "Blue"
-                ],
-                "category_uuid": "c4ab7930-c8a1-4472-81f0-11ffb3480b90"
-              },
-              {
-                "uuid": "6c64080a-df3d-4b0c-8a49-d8af7a03bdc5",
-                "type": "has_any_word",
-                "arguments": [
-                  "Navy"
-                ],
-                "category_uuid": "c4ab7930-c8a1-4472-81f0-11ffb3480b90"
-              },
-              {
-                "uuid": "6a529877-278f-462c-9a34-2b6c28d11ebe",
-                "type": "has_any_word",
-                "arguments": [
-                  "Cyan"
-                ],
-                "category_uuid": "dff296b4-75a4-4074-b029-6b2d2e83f29f"
-              }
-            ],
-            "default_category_uuid": "84013945-f2a6-49e7-b3b0-3e5e84bb16f2"
-          },
           "exits": [
             {
-              "uuid": "20b48b36-2d0e-4374-a84f-59e523ff0426",
-              "destination_uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a"
+              "destination_uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a",
+              "uuid": "20b48b36-2d0e-4374-a84f-59e523ff0426"
             },
             {
-              "uuid": "e04becf4-dc27-42f5-9cd0-8f952e8409fa",
-              "destination_uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a"
+              "destination_uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a",
+              "uuid": "e04becf4-dc27-42f5-9cd0-8f952e8409fa"
             },
             {
-              "uuid": "cccd0ae4-6c62-4935-bcb0-f11d4efa9cb3",
-              "destination_uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a"
+              "destination_uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a",
+              "uuid": "cccd0ae4-6c62-4935-bcb0-f11d4efa9cb3"
             },
             {
               "uuid": "d9b6c3cf-2b3f-4dca-b2a3-2a32c1e24109"
             },
             {
-              "uuid": "f1f0affb-e998-4664-be72-24cd25bf88e5",
-              "destination_uuid": "1f437f8e-36af-4762-a150-374a832c3bd3"
-            }
-          ]
-        },
-        {
-          "uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a",
-          "actions": [
-            {
-              "type": "send_msg",
-              "uuid": "78b70aa9-e711-4465-bf07-34b058c93cbd",
-              "text": "Good choice, I like @results.color.category_localized too! What is your favorite beer?"
+              "destination_uuid": "1f437f8e-36af-4762-a150-374a832c3bd3",
+              "uuid": "f1f0affb-e998-4664-be72-24cd25bf88e5"
             }
           ],
-          "exits": [
-            {
-              "uuid": "5441857e-194d-43f9-bb52-74d9c675ccbd",
-              "destination_uuid": "062479aa-51c8-4aac-b8e0-78385ad005a3"
-            }
-          ]
-        },
-        {
-          "uuid": "5f45d985-a193-4872-8b03-1da3106395fa",
-          "actions": [
-            {
-              "type": "send_msg",
-              "uuid": "80205984-ace0-4ce2-afad-77d4d85bff14",
-              "text": "I don't know that one, try again please."
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "2176d62a-fe34-4101-987f-45e36d02ccb2",
-              "destination_uuid": "062479aa-51c8-4aac-b8e0-78385ad005a3"
-            }
-          ]
-        },
-        {
-          "uuid": "062479aa-51c8-4aac-b8e0-78385ad005a3",
           "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Red"
+                ],
+                "category_uuid": "68d8b65c-84e3-435c-9f8a-ba8e89d5a1f1",
+                "type": "has_any_word",
+                "uuid": "8d86fdbd-3cfe-4ee1-b5a1-625ec98dca01"
+              },
+              {
+                "arguments": [
+                  "Green"
+                ],
+                "category_uuid": "53d69d24-7078-4090-96d3-38ecc0352a64",
+                "type": "has_any_word",
+                "uuid": "e31e5d32-43d5-4130-bd98-46661e3397c7"
+              },
+              {
+                "arguments": [
+                  "Blue"
+                ],
+                "category_uuid": "c4ab7930-c8a1-4472-81f0-11ffb3480b90",
+                "type": "has_any_word",
+                "uuid": "45e38343-3c3c-4803-994b-d31fbf45ba0f"
+              },
+              {
+                "arguments": [
+                  "Navy"
+                ],
+                "category_uuid": "c4ab7930-c8a1-4472-81f0-11ffb3480b90",
+                "type": "has_any_word",
+                "uuid": "6c64080a-df3d-4b0c-8a49-d8af7a03bdc5"
+              },
+              {
+                "arguments": [
+                  "Cyan"
+                ],
+                "category_uuid": "dff296b4-75a4-4074-b029-6b2d2e83f29f",
+                "type": "has_any_word",
+                "uuid": "6a529877-278f-462c-9a34-2b6c28d11ebe"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "20b48b36-2d0e-4374-a84f-59e523ff0426",
+                "name": "Red",
+                "uuid": "68d8b65c-84e3-435c-9f8a-ba8e89d5a1f1"
+              },
+              {
+                "exit_uuid": "e04becf4-dc27-42f5-9cd0-8f952e8409fa",
+                "name": "Green",
+                "uuid": "53d69d24-7078-4090-96d3-38ecc0352a64"
+              },
+              {
+                "exit_uuid": "cccd0ae4-6c62-4935-bcb0-f11d4efa9cb3",
+                "name": "Blue",
+                "uuid": "c4ab7930-c8a1-4472-81f0-11ffb3480b90"
+              },
+              {
+                "exit_uuid": "d9b6c3cf-2b3f-4dca-b2a3-2a32c1e24109",
+                "name": "Cyan",
+                "uuid": "dff296b4-75a4-4074-b029-6b2d2e83f29f"
+              },
+              {
+                "exit_uuid": "f1f0affb-e998-4664-be72-24cd25bf88e5",
+                "name": "Other",
+                "uuid": "84013945-f2a6-49e7-b3b0-3e5e84bb16f2"
+              }
+            ],
+            "default_category_uuid": "84013945-f2a6-49e7-b3b0-3e5e84bb16f2",
+            "operand": "@input",
+            "result_name": "Color",
             "type": "switch",
             "wait": {
               "type": "msg"
+            }
+          },
+          "uuid": "5ebd5006-67d8-4df5-b584-14cee383e720"
+        },
+        {
+          "actions": [
+            {
+              "text": "Good choice, I like @results.color.category_localized too! What is your favorite beer?",
+              "type": "send_msg",
+              "uuid": "78b70aa9-e711-4465-bf07-34b058c93cbd"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "062479aa-51c8-4aac-b8e0-78385ad005a3",
+              "uuid": "5441857e-194d-43f9-bb52-74d9c675ccbd"
+            }
+          ],
+          "uuid": "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a"
+        },
+        {
+          "actions": [
+            {
+              "text": "I don't know that one, try again please.",
+              "type": "send_msg",
+              "uuid": "80205984-ace0-4ce2-afad-77d4d85bff14"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "062479aa-51c8-4aac-b8e0-78385ad005a3",
+              "uuid": "2176d62a-fe34-4101-987f-45e36d02ccb2"
+            }
+          ],
+          "uuid": "5f45d985-a193-4872-8b03-1da3106395fa"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c",
+              "uuid": "21a78fbf-7445-489f-a1f8-fe09f51a7cc8"
             },
-            "result_name": "Beer",
-            "categories": [
-              {
-                "uuid": "af49a4c8-f543-4af8-87ad-a6e909618ef0",
-                "name": "Mutzig",
-                "exit_uuid": "21a78fbf-7445-489f-a1f8-fe09f51a7cc8"
-              },
-              {
-                "uuid": "331e9580-1a68-4e7b-9c71-ab1b1f8d3a52",
-                "name": "Primus",
-                "exit_uuid": "f913f78f-d10d-4570-a0c7-a60bc541da0f"
-              },
-              {
-                "uuid": "9306acc3-e399-4530-ac3d-61ed1ac8d02a",
-                "name": "Turbo King",
-                "exit_uuid": "5fc932d5-3639-4427-8cec-ffd8b3bdf92d"
-              },
-              {
-                "uuid": "7652184e-4894-4777-9fc6-7a2b74603de5",
-                "name": "Skol",
-                "exit_uuid": "983fc99c-e5a7-434d-ace1-3d0735c3203f"
-              },
-              {
-                "uuid": "2b12a35e-d1c9-4c7e-ab4e-4e2fad23b541",
-                "name": "Other",
-                "exit_uuid": "d94b0d5a-317a-4bca-abd7-a6dd9cde3549"
-              }
-            ],
-            "operand": "@input",
+            {
+              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c",
+              "uuid": "f913f78f-d10d-4570-a0c7-a60bc541da0f"
+            },
+            {
+              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c",
+              "uuid": "5fc932d5-3639-4427-8cec-ffd8b3bdf92d"
+            },
+            {
+              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c",
+              "uuid": "983fc99c-e5a7-434d-ace1-3d0735c3203f"
+            },
+            {
+              "destination_uuid": "5f45d985-a193-4872-8b03-1da3106395fa",
+              "uuid": "d94b0d5a-317a-4bca-abd7-a6dd9cde3549"
+            }
+          ],
+          "router": {
             "cases": [
               {
-                "uuid": "6637e18f-25ac-48d5-bead-14eb3135b95e",
-                "type": "has_any_word",
                 "arguments": [
                   "Mutzig"
                 ],
-                "category_uuid": "af49a4c8-f543-4af8-87ad-a6e909618ef0"
+                "category_uuid": "af49a4c8-f543-4af8-87ad-a6e909618ef0",
+                "type": "has_any_word",
+                "uuid": "6637e18f-25ac-48d5-bead-14eb3135b95e"
               },
               {
-                "uuid": "7a05c16a-ae8d-4da3-834b-8a82dcb1783b",
-                "type": "has_any_word",
                 "arguments": [
                   "Primus"
                 ],
-                "category_uuid": "331e9580-1a68-4e7b-9c71-ab1b1f8d3a52"
+                "category_uuid": "331e9580-1a68-4e7b-9c71-ab1b1f8d3a52",
+                "type": "has_any_word",
+                "uuid": "7a05c16a-ae8d-4da3-834b-8a82dcb1783b"
               },
               {
-                "uuid": "74bfc581-8cfe-4f94-aa05-3c152cb96c0a",
-                "type": "has_any_word",
                 "arguments": [
                   "Turbo King"
                 ],
-                "category_uuid": "9306acc3-e399-4530-ac3d-61ed1ac8d02a"
+                "category_uuid": "9306acc3-e399-4530-ac3d-61ed1ac8d02a",
+                "type": "has_any_word",
+                "uuid": "74bfc581-8cfe-4f94-aa05-3c152cb96c0a"
               },
               {
-                "uuid": "a35a4481-17a5-4cad-ad86-e1db4636bed8",
-                "type": "has_any_word",
                 "arguments": [
                   "Skol"
                 ],
-                "category_uuid": "7652184e-4894-4777-9fc6-7a2b74603de5"
+                "category_uuid": "7652184e-4894-4777-9fc6-7a2b74603de5",
+                "type": "has_any_word",
+                "uuid": "a35a4481-17a5-4cad-ad86-e1db4636bed8"
               }
             ],
-            "default_category_uuid": "2b12a35e-d1c9-4c7e-ab4e-4e2fad23b541"
-          },
-          "exits": [
-            {
-              "uuid": "21a78fbf-7445-489f-a1f8-fe09f51a7cc8",
-              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c"
-            },
-            {
-              "uuid": "f913f78f-d10d-4570-a0c7-a60bc541da0f",
-              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c"
-            },
-            {
-              "uuid": "5fc932d5-3639-4427-8cec-ffd8b3bdf92d",
-              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c"
-            },
-            {
-              "uuid": "983fc99c-e5a7-434d-ace1-3d0735c3203f",
-              "destination_uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c"
-            },
-            {
-              "uuid": "d94b0d5a-317a-4bca-abd7-a6dd9cde3549",
-              "destination_uuid": "5f45d985-a193-4872-8b03-1da3106395fa"
+            "categories": [
+              {
+                "exit_uuid": "21a78fbf-7445-489f-a1f8-fe09f51a7cc8",
+                "name": "Mutzig",
+                "uuid": "af49a4c8-f543-4af8-87ad-a6e909618ef0"
+              },
+              {
+                "exit_uuid": "f913f78f-d10d-4570-a0c7-a60bc541da0f",
+                "name": "Primus",
+                "uuid": "331e9580-1a68-4e7b-9c71-ab1b1f8d3a52"
+              },
+              {
+                "exit_uuid": "5fc932d5-3639-4427-8cec-ffd8b3bdf92d",
+                "name": "Turbo King",
+                "uuid": "9306acc3-e399-4530-ac3d-61ed1ac8d02a"
+              },
+              {
+                "exit_uuid": "983fc99c-e5a7-434d-ace1-3d0735c3203f",
+                "name": "Skol",
+                "uuid": "7652184e-4894-4777-9fc6-7a2b74603de5"
+              },
+              {
+                "exit_uuid": "d94b0d5a-317a-4bca-abd7-a6dd9cde3549",
+                "name": "Other",
+                "uuid": "2b12a35e-d1c9-4c7e-ab4e-4e2fad23b541"
+              }
+            ],
+            "default_category_uuid": "2b12a35e-d1c9-4c7e-ab4e-4e2fad23b541",
+            "operand": "@input",
+            "result_name": "Beer",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
             }
-          ]
+          },
+          "uuid": "062479aa-51c8-4aac-b8e0-78385ad005a3"
         },
         {
-          "uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c",
           "actions": [
             {
+              "text": "Mmmmm... delicious @results.beer.category_localized. If only they made @(lower(results.color)) @results.beer.category_localized! Lastly, what is your name?",
               "type": "send_msg",
-              "uuid": "697a5489-1761-4347-a7d9-6d339a90d172",
-              "text": "Mmmmm... delicious @results.beer.category_localized. If only they made @(lower(results.color)) @results.beer.category_localized! Lastly, what is your name?"
+              "uuid": "697a5489-1761-4347-a7d9-6d339a90d172"
             }
           ],
           "exits": [
             {
-              "uuid": "f700d0dc-875a-489c-a60b-be8e5a5d001e",
-              "destination_uuid": "c3232f80-09a1-4d10-a0f5-3d429e6d9b6e"
+              "destination_uuid": "c3232f80-09a1-4d10-a0f5-3d429e6d9b6e",
+              "uuid": "f700d0dc-875a-489c-a60b-be8e5a5d001e"
             }
-          ]
+          ],
+          "uuid": "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c"
         },
         {
-          "uuid": "c3232f80-09a1-4d10-a0f5-3d429e6d9b6e",
+          "exits": [
+            {
+              "destination_uuid": "0cb93acd-d8ec-43cf-82b6-b550e4a671e0",
+              "uuid": "dbdbfd1d-736a-44ab-bc7b-d38b6578ce7d"
+            }
+          ],
           "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "dbdbfd1d-736a-44ab-bc7b-d38b6578ce7d",
+                "name": "All Responses",
+                "uuid": "a5f36454-e219-484b-b150-835d5d5c237b"
+              }
+            ],
+            "default_category_uuid": "a5f36454-e219-484b-b150-835d5d5c237b",
+            "operand": "@input",
+            "result_name": "Name",
             "type": "switch",
             "wait": {
               "type": "msg"
-            },
-            "result_name": "Name",
-            "categories": [
-              {
-                "uuid": "a5f36454-e219-484b-b150-835d5d5c237b",
-                "name": "All Responses",
-                "exit_uuid": "dbdbfd1d-736a-44ab-bc7b-d38b6578ce7d"
-              }
-            ],
-            "operand": "@input",
-            "cases": [],
-            "default_category_uuid": "a5f36454-e219-484b-b150-835d5d5c237b"
-          },
-          "exits": [
-            {
-              "uuid": "dbdbfd1d-736a-44ab-bc7b-d38b6578ce7d",
-              "destination_uuid": "0cb93acd-d8ec-43cf-82b6-b550e4a671e0"
             }
-          ]
+          },
+          "uuid": "c3232f80-09a1-4d10-a0f5-3d429e6d9b6e"
         },
         {
-          "uuid": "0cb93acd-d8ec-43cf-82b6-b550e4a671e0",
           "actions": [
             {
+              "text": "Thanks @results.name, we are all done!",
               "type": "send_msg",
-              "uuid": "0c434831-e81b-4d24-906f-c0d8fd33798e",
-              "text": "Thanks @results.name, we are all done!"
+              "uuid": "0c434831-e81b-4d24-906f-c0d8fd33798e"
             }
           ],
           "exits": [
             {
               "uuid": "1219b2ce-364a-45d2-b2f4-1cedc88491c2"
             }
-          ]
+          ],
+          "uuid": "0cb93acd-d8ec-43cf-82b6-b550e4a671e0"
         }
       ],
-      "_ui": {
-        "nodes": {
-          "062479aa-51c8-4aac-b8e0-78385ad005a3": {
-            "type": "wait_for_response",
-            "position": {
-              "left": 112,
-              "top": 387
-            }
-          },
-          "0cb93acd-d8ec-43cf-82b6-b550e4a671e0": {
-            "type": "execute_actions",
-            "position": {
-              "left": 191,
-              "top": 805
-            }
-          },
-          "1f437f8e-36af-4762-a150-374a832c3bd3": {
-            "type": "execute_actions",
-            "position": {
-              "left": 456,
-              "top": 8
-            }
-          },
-          "2428f8f2-2ab0-4af5-80d3-3dab5b8918cd": {
-            "type": "execute_actions",
-            "position": {
-              "left": 100,
-              "top": 0
-            }
-          },
-          "2cfa2b56-3bcc-4b7a-ab3b-7c32daf64e1a": {
-            "type": "execute_actions",
-            "position": {
-              "left": 131,
-              "top": 237
-            }
-          },
-          "3337a123-a7ae-496c-b94c-3f2dd3fd2f9c": {
-            "type": "execute_actions",
-            "position": {
-              "left": 191,
-              "top": 535
-            }
-          },
-          "5ebd5006-67d8-4df5-b584-14cee383e720": {
-            "type": "wait_for_response",
-            "position": {
-              "left": 98,
-              "top": 129
-            }
-          },
-          "5f45d985-a193-4872-8b03-1da3106395fa": {
-            "type": "execute_actions",
-            "position": {
-              "left": 512,
-              "top": 265
-            }
-          },
-          "c3232f80-09a1-4d10-a0f5-3d429e6d9b6e": {
-            "type": "wait_for_response",
-            "position": {
-              "left": 191,
-              "top": 702
-            }
-          }
-        },
-        "stickies": {}
-      }
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "aef60b1e-14ab-4095-81ee-fce02b3e320d"
     }
   ]
 }

--- a/media/test_flows/group_send_flow.json
+++ b/media/test_flows/group_send_flow.json
@@ -1,44 +1,51 @@
 {
-  "version": 8, 
+  "version": "13",
   "flows": [
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "9855bdb6-7cd1-4d48-813f-516b651fee28": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Group Send Flow",
+      "nodes": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": null, 
-          "uuid": "9855bdb6-7cd1-4d48-813f-516b651fee28", 
           "actions": [
             {
-              "msg": {
-                "eng": "It is time for a new survey."
-              }, 
-              "variables": [], 
-              "type": "send", 
               "groups": [
                 {
-                  "name": "Survey Audience", 
-                  "id": 195
+                  "name": "Survey Audience",
+                  "uuid": "e17c6643-610a-4ffc-80d1-2ed583788d9d"
                 }
-              ], 
-              "contacts": []
+              ],
+              "text": "It is time for a new survey.",
+              "type": "send_broadcast",
+              "uuid": "dc21cfe1-6c0f-4bb2-9918-6dc00e8d530f"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "uuid": "82cfbbbe-867b-445b-926b-6a717199bc91"
+            }
+          ],
+          "uuid": "9855bdb6-7cd1-4d48-813f-516b651fee28"
         }
-      ], 
-      "version": 8, 
-      "flow_type": "F", 
-      "entry": "9855bdb6-7cd1-4d48-813f-516b651fee28", 
-      "rule_sets": [], 
-      "metadata": {
-        "expires": 10080, 
-        "revision": 1, 
-        "id": 43122, 
-        "name": "Group Send Flow", 
-        "saved_on": "2015-12-07T17:14:50.591634Z"
-      }
+      ],
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "92474cb5-7d9c-42a1-8953-5f81824a660d"
     }
-  ], 
+  ],
   "triggers": []
 }

--- a/media/test_flows/ivr.json
+++ b/media/test_flows/ivr.json
@@ -1,253 +1,334 @@
 {
-  "version": "11.9",
+  "version": "13",
   "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "entry": "5679acf0-18f4-4702-ad22-d01e01d2827f",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "0b0e557a-288d-410f-a42f-eedc1af4efb1": {
+            "position": {
+              "left": 368,
+              "top": 691
+            },
+            "type": "execute_actions"
+          },
+          "115c5218-effa-4044-9f2a-5fb23ff64fe8": {
+            "position": {
+              "left": 143,
+              "top": 154
+            },
+            "type": "wait_for_response"
+          },
+          "4f07a96e-52fe-482a-bbd0-a5d7bd0ad0bc": {
+            "position": {
+              "left": 137,
+              "top": 938
+            },
+            "type": "wait_for_response"
+          },
+          "5679acf0-18f4-4702-ad22-d01e01d2827f": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "642da6dd-fbc4-472a-858f-a17a7b471d7c": {
+            "position": {
+              "left": 162,
+              "top": 568
+            },
+            "type": "wait_for_response"
+          },
+          "823184c8-fc3b-49bc-9ede-1d791cf4f2ce": {
+            "position": {
+              "left": 84,
+              "top": 740
+            },
+            "type": "execute_actions"
+          },
+          "b8305102-9ed5-431d-ae0d-13cdf4b310a8": {
+            "position": {
+              "left": 96,
+              "top": 355
+            },
+            "type": "execute_actions"
+          },
+          "bec6993f-1f95-41fa-bc26-518ea10954b2": {
+            "position": {
+              "left": 420,
+              "top": 265
+            },
+            "type": "execute_actions"
+          },
+          "f633f119-6aa8-43df-9dc7-9518356ca53a": {
+            "position": {
+              "left": 104,
+              "top": 1083
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 15,
+      "language": "und",
+      "localization": {},
+      "name": "IVR Flow",
+      "nodes": [
         {
-          "uuid": "5679acf0-18f4-4702-ad22-d01e01d2827f",
-          "x": 100,
-          "y": 0,
-          "destination": "115c5218-effa-4044-9f2a-5fb23ff64fe8",
           "actions": [
             {
-              "type": "say",
-              "uuid": "d684f2d6-ba31-49f7-8ea3-7fdf65cc1a25",
-              "msg": {
-                "base": "Hello there. Please enter one or two. @(if(is_error(extra.ref_id), \"\", \"Your reference id is \" & extra.ref_id)) @(if(is_error(parent.contact), \"\", \"This flow was triggered by \" & parent.contact))"
-              },
-              "recording": null
+              "text": "Hello there. Please enter one or two. @(if(is_error(legacy_extra.ref_id), \"\", \"Your reference id is \" & legacy_extra.ref_id)) @(if(is_error(parent.contact), \"\", \"This flow was triggered by \" & parent.contact))",
+              "type": "say_msg",
+              "uuid": "d684f2d6-ba31-49f7-8ea3-7fdf65cc1a25"
             }
           ],
-          "exit_uuid": "808ba5ea-07c8-4834-ba17-13760c493a69"
-        },
-        {
-          "uuid": "bec6993f-1f95-41fa-bc26-518ea10954b2",
-          "x": 420,
-          "y": 265,
-          "destination": "115c5218-effa-4044-9f2a-5fb23ff64fe8",
-          "actions": [
+          "exits": [
             {
-              "type": "say",
-              "uuid": "2d52487c-58d3-40a8-816a-1720687596a9",
-              "msg": {
-                "base": "Sorry, that is not one or two, try again."
-              },
-              "recording": null
+              "destination_uuid": "115c5218-effa-4044-9f2a-5fb23ff64fe8",
+              "uuid": "808ba5ea-07c8-4834-ba17-13760c493a69"
             }
           ],
-          "exit_uuid": "30479153-d138-41d6-a291-e56611b519f6"
+          "uuid": "5679acf0-18f4-4702-ad22-d01e01d2827f"
         },
         {
-          "uuid": "b8305102-9ed5-431d-ae0d-13cdf4b310a8",
-          "x": 96,
-          "y": 355,
-          "destination": "642da6dd-fbc4-472a-858f-a17a7b471d7c",
-          "actions": [
+          "exits": [
             {
-              "type": "say",
-              "uuid": "f684b8f5-dba2-4365-bd53-e9d7695a8069",
-              "msg": {
-                "base": "Great! You said @flow.choice.category. Ok, now enter a number 1 to 100 then press pound."
-              },
-              "recording": null
-            }
-          ],
-          "exit_uuid": "6a407019-7933-4be0-b236-8f4cc3a6395d"
-        },
-        {
-          "uuid": "0b0e557a-288d-410f-a42f-eedc1af4efb1",
-          "x": 368,
-          "y": 691,
-          "destination": "642da6dd-fbc4-472a-858f-a17a7b471d7c",
-          "actions": [
-            {
-              "type": "say",
-              "uuid": "7d627f20-8449-414a-9e5a-dd574aa5421f",
-              "msg": {
-                "base": "Sorry, that's too big. Enter a number 1 to 100 then press pound."
-              },
-              "recording": null
-            }
-          ],
-          "exit_uuid": "fb357767-5bd1-4493-b5a4-4a0101cd943e"
-        },
-        {
-          "uuid": "823184c8-fc3b-49bc-9ede-1d791cf4f2ce",
-          "x": 84,
-          "y": 740,
-          "destination": "4f07a96e-52fe-482a-bbd0-a5d7bd0ad0bc",
-          "actions": [
-            {
-              "type": "say",
-              "uuid": "b6ed54a3-c36e-456c-a09e-933a726ab7b8",
-              "msg": {
-                "base": "You picked the number @flow.number, excellent choice. Ok now tell me briefly why you are happy today."
-              },
-              "recording": null
-            }
-          ],
-          "exit_uuid": "8d4f62e7-44cd-4254-92fb-c5f87c7d6722"
-        },
-        {
-          "uuid": "f633f119-6aa8-43df-9dc7-9518356ca53a",
-          "x": 104,
-          "y": 1083,
-          "destination": null,
-          "actions": [
-            {
-              "type": "say",
-              "uuid": "72771ff9-c279-4dd9-8d51-5a78abc73681",
-              "msg": {
-                "base": "You said"
-              },
-              "recording": null
+              "destination_uuid": "b8305102-9ed5-431d-ae0d-13cdf4b310a8",
+              "uuid": "8eec4c4e-2b03-4d79-a172-dcce2b47476b"
             },
             {
-              "type": "play",
-              "uuid": "36e9dde4-b5ca-4abb-aca2-6aa95dbcd4c7",
-              "url": "@flow.happy"
+              "destination_uuid": "b8305102-9ed5-431d-ae0d-13cdf4b310a8",
+              "uuid": "cd624366-c2f7-4d59-9c64-623075a4e860"
             },
             {
-              "type": "say",
-              "uuid": "b6b66a37-4a66-4720-a80f-dd61d905b299",
-              "msg": {
-                "base": "I hope hearing that makes you feel better. Good day and good bye."
-              },
-              "recording": null
+              "destination_uuid": "bec6993f-1f95-41fa-bc26-518ea10954b2",
+              "uuid": "8b10e0b7-8944-4938-b674-7784b98fcb9c"
             }
           ],
-          "exit_uuid": "e92ace81-10cc-4124-94b6-53b2d4eb580c"
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "1"
+                ],
+                "category_uuid": "3299d91b-7239-48da-9a6e-fabb2864edf2",
+                "type": "has_number_eq",
+                "uuid": "8b90a3e4-c048-4754-bb9b-988ea7e0a2d7"
+              },
+              {
+                "arguments": [
+                  "2"
+                ],
+                "category_uuid": "1bdc771d-8bd7-41ac-885c-89e06927f8b2",
+                "type": "has_number_eq",
+                "uuid": "dcd84efe-a2b9-4e96-b88a-ce64acb4ce80"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "8eec4c4e-2b03-4d79-a172-dcce2b47476b",
+                "name": "One",
+                "uuid": "3299d91b-7239-48da-9a6e-fabb2864edf2"
+              },
+              {
+                "exit_uuid": "cd624366-c2f7-4d59-9c64-623075a4e860",
+                "name": "Two",
+                "uuid": "1bdc771d-8bd7-41ac-885c-89e06927f8b2"
+              },
+              {
+                "exit_uuid": "8b10e0b7-8944-4938-b674-7784b98fcb9c",
+                "name": "Other",
+                "uuid": "77011003-b8c7-4c98-b792-e99c2242aeab"
+              }
+            ],
+            "default_category_uuid": "77011003-b8c7-4c98-b792-e99c2242aeab",
+            "operand": "@input.text",
+            "result_name": "Choice",
+            "type": "switch",
+            "wait": {
+              "hint": {
+                "count": 1,
+                "type": "digits"
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "115c5218-effa-4044-9f2a-5fb23ff64fe8"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry, that is not one or two, try again.",
+              "type": "say_msg",
+              "uuid": "2d52487c-58d3-40a8-816a-1720687596a9"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "115c5218-effa-4044-9f2a-5fb23ff64fe8",
+              "uuid": "30479153-d138-41d6-a291-e56611b519f6"
+            }
+          ],
+          "uuid": "bec6993f-1f95-41fa-bc26-518ea10954b2"
+        },
+        {
+          "actions": [
+            {
+              "text": "Great! You said @results.choice.category_localized. Ok, now enter a number 1 to 100 then press pound.",
+              "type": "say_msg",
+              "uuid": "f684b8f5-dba2-4365-bd53-e9d7695a8069"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "642da6dd-fbc4-472a-858f-a17a7b471d7c",
+              "uuid": "6a407019-7933-4be0-b236-8f4cc3a6395d"
+            }
+          ],
+          "uuid": "b8305102-9ed5-431d-ae0d-13cdf4b310a8"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "823184c8-fc3b-49bc-9ede-1d791cf4f2ce",
+              "uuid": "bee16125-9b14-429f-a1f4-16072bbf1b05"
+            },
+            {
+              "destination_uuid": "0b0e557a-288d-410f-a42f-eedc1af4efb1",
+              "uuid": "71349e21-95e4-4e0d-805f-84234fd3686f"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "1",
+                  "100"
+                ],
+                "category_uuid": "49ecab9e-362c-4a69-a9ae-72c608b5e0a4",
+                "type": "has_number_between",
+                "uuid": "63829167-8bb5-49e7-bce7-0386e386e7b5"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "bee16125-9b14-429f-a1f4-16072bbf1b05",
+                "name": "1 - 100",
+                "uuid": "49ecab9e-362c-4a69-a9ae-72c608b5e0a4"
+              },
+              {
+                "exit_uuid": "71349e21-95e4-4e0d-805f-84234fd3686f",
+                "name": "Other",
+                "uuid": "fc30fb4b-09ba-4059-b721-75ca1c4c15a4"
+              }
+            ],
+            "default_category_uuid": "fc30fb4b-09ba-4059-b721-75ca1c4c15a4",
+            "operand": "@input.text",
+            "result_name": "Number",
+            "type": "switch",
+            "wait": {
+              "hint": {
+                "terminated_by": "",
+                "type": "digits"
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "642da6dd-fbc4-472a-858f-a17a7b471d7c"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry, that's too big. Enter a number 1 to 100 then press pound.",
+              "type": "say_msg",
+              "uuid": "7d627f20-8449-414a-9e5a-dd574aa5421f"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "642da6dd-fbc4-472a-858f-a17a7b471d7c",
+              "uuid": "fb357767-5bd1-4493-b5a4-4a0101cd943e"
+            }
+          ],
+          "uuid": "0b0e557a-288d-410f-a42f-eedc1af4efb1"
+        },
+        {
+          "actions": [
+            {
+              "text": "You picked the number @results.number, excellent choice. Ok now tell me briefly why you are happy today.",
+              "type": "say_msg",
+              "uuid": "b6ed54a3-c36e-456c-a09e-933a726ab7b8"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "4f07a96e-52fe-482a-bbd0-a5d7bd0ad0bc",
+              "uuid": "8d4f62e7-44cd-4254-92fb-c5f87c7d6722"
+            }
+          ],
+          "uuid": "823184c8-fc3b-49bc-9ede-1d791cf4f2ce"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "f633f119-6aa8-43df-9dc7-9518356ca53a",
+              "uuid": "f6bb8df4-bcb3-4ec4-8180-11c9988a8c3f"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "f6bb8df4-bcb3-4ec4-8180-11c9988a8c3f",
+                "name": "All Responses",
+                "uuid": "f31fc1f9-559d-478e-b12b-498fcec21128"
+              }
+            ],
+            "default_category_uuid": "f31fc1f9-559d-478e-b12b-498fcec21128",
+            "operand": "@input",
+            "result_name": "Happy",
+            "type": "switch",
+            "wait": {
+              "hint": {
+                "type": "audio"
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "4f07a96e-52fe-482a-bbd0-a5d7bd0ad0bc"
+        },
+        {
+          "actions": [
+            {
+              "text": "You said",
+              "type": "say_msg",
+              "uuid": "72771ff9-c279-4dd9-8d51-5a78abc73681"
+            },
+            {
+              "audio_url": "@results.happy",
+              "type": "play_audio",
+              "uuid": "36e9dde4-b5ca-4abb-aca2-6aa95dbcd4c7"
+            },
+            {
+              "text": "I hope hearing that makes you feel better. Good day and good bye.",
+              "type": "say_msg",
+              "uuid": "b6b66a37-4a66-4720-a80f-dd61d905b299"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "e92ace81-10cc-4124-94b6-53b2d4eb580c"
+            }
+          ],
+          "uuid": "f633f119-6aa8-43df-9dc7-9518356ca53a"
         }
       ],
-      "rule_sets": [
-        {
-          "uuid": "115c5218-effa-4044-9f2a-5fb23ff64fe8",
-          "x": 143,
-          "y": 154,
-          "label": "Choice",
-          "rules": [
-            {
-              "uuid": "8eec4c4e-2b03-4d79-a172-dcce2b47476b",
-              "category": {
-                "base": "One"
-              },
-              "destination": "b8305102-9ed5-431d-ae0d-13cdf4b310a8",
-              "destination_type": "A",
-              "test": {
-                "type": "eq",
-                "test": 1
-              },
-              "label": null
-            },
-            {
-              "uuid": "cd624366-c2f7-4d59-9c64-623075a4e860",
-              "category": {
-                "base": "Two"
-              },
-              "destination": "b8305102-9ed5-431d-ae0d-13cdf4b310a8",
-              "destination_type": "A",
-              "test": {
-                "type": "eq",
-                "test": 2
-              },
-              "label": null
-            },
-            {
-              "uuid": "8b10e0b7-8944-4938-b674-7784b98fcb9c",
-              "category": {
-                "base": "Other"
-              },
-              "destination": "bec6993f-1f95-41fa-bc26-518ea10954b2",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_digit",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        },
-        {
-          "uuid": "642da6dd-fbc4-472a-858f-a17a7b471d7c",
-          "x": 162,
-          "y": 568,
-          "label": "Number",
-          "rules": [
-            {
-              "uuid": "bee16125-9b14-429f-a1f4-16072bbf1b05",
-              "category": {
-                "base": "1 - 100"
-              },
-              "destination": "823184c8-fc3b-49bc-9ede-1d791cf4f2ce",
-              "destination_type": "A",
-              "test": {
-                "type": "between",
-                "min": "1",
-                "max": "100"
-              },
-              "label": null
-            },
-            {
-              "uuid": "71349e21-95e4-4e0d-805f-84234fd3686f",
-              "category": {
-                "base": "Other"
-              },
-              "destination": "0b0e557a-288d-410f-a42f-eedc1af4efb1",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_digits",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        },
-        {
-          "uuid": "4f07a96e-52fe-482a-bbd0-a5d7bd0ad0bc",
-          "x": 137,
-          "y": 938,
-          "label": "Happy",
-          "rules": [
-            {
-              "uuid": "f6bb8df4-bcb3-4ec4-8180-11c9988a8c3f",
-              "category": {
-                "base": "All Responses"
-              },
-              "destination": "f633f119-6aa8-43df-9dc7-9518356ca53a",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_recording",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        }
-      ],
-      "base_language": "base",
-      "flow_type": "V",
-      "version": "11.9",
-      "metadata": {
-        "name": "IVR Flow",
-        "saved_on": "2019-01-23T18:11:13.738547Z",
-        "revision": 25,
-        "uuid": "3d089d93-cbfe-408b-8d70-8c450cfc57b1",
-        "expires": 25
-      }
+      "revision": 25,
+      "spec_version": "14.4.0",
+      "type": "voice",
+      "uuid": "3d089d93-cbfe-408b-8d70-8c450cfc57b1"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/mailroom/background.json
+++ b/media/test_flows/mailroom/background.json
@@ -3,36 +3,6 @@
   "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "name": "Background",
-      "uuid": "1ff89517-5735-466b-be31-682b49521cbf",
-      "spec_version": "13.1.0",
-      "language": "eng",
-      "type": "messaging_background",
-      "nodes": [
-        {
-          "uuid": "cf80a41e-c7b2-46ea-994d-b2301589276b",
-          "actions": [
-            {
-              "attachments": [],
-              "text": "Nothing to see here",
-              "type": "send_msg",
-              "quick_replies": [],
-              "uuid": "16c21cf7-8987-430d-bb5a-243f3b5ce2ad"
-            },
-            {
-              "uuid": "6e9c9b9e-9de5-49ee-a74f-4c7fbfdda9d0",
-              "type": "set_contact_name",
-              "name": "Bob"
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "b52df965-88c1-4933-b48a-8b96a8baacda",
-              "destination_uuid": null
-            }
-          ]
-        }
-      ],
       "_ui": {
         "nodes": {
           "cf80a41e-c7b2-46ea-994d-b2301589276b": {
@@ -44,12 +14,42 @@
           }
         }
       },
-      "revision": 6,
-      "expire_after_minutes": 10080,
+      "expire_after_minutes": 0,
+      "language": "eng",
+      "localization": {},
       "metadata": {
         "expires": 10080
       },
-      "localization": {}
+      "name": "Background",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "attachments": [],
+              "quick_replies": [],
+              "text": "Nothing to see here",
+              "type": "send_msg",
+              "uuid": "16c21cf7-8987-430d-bb5a-243f3b5ce2ad"
+            },
+            {
+              "name": "Bob",
+              "type": "set_contact_name",
+              "uuid": "6e9c9b9e-9de5-49ee-a74f-4c7fbfdda9d0"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": null,
+              "uuid": "b52df965-88c1-4933-b48a-8b96a8baacda"
+            }
+          ],
+          "uuid": "cf80a41e-c7b2-46ea-994d-b2301589276b"
+        }
+      ],
+      "revision": 6,
+      "spec_version": "14.4.0",
+      "type": "messaging_background",
+      "uuid": "1ff89517-5735-466b-be31-682b49521cbf"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/mailroom/contact_surveyor.json
+++ b/media/test_flows/mailroom/contact_surveyor.json
@@ -1,269 +1,319 @@
 {
-  "version": "11.6",
+  "version": "13",
   "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "entry": "036901e0-abb8-4979-92cb-f0d43aeb5b68",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "036901e0-abb8-4979-92cb-f0d43aeb5b68": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "1a7612b5-777d-4af3-a657-077c46f242d9": {
+            "position": {
+              "left": 237,
+              "top": 361
+            },
+            "type": "wait_for_response"
+          },
+          "2d55c61f-384c-4a07-a17e-1e42fc543dd9": {
+            "position": {
+              "left": 102,
+              "top": 464
+            },
+            "type": "execute_actions"
+          },
+          "39fe1ce0-7dee-445e-9945-48c72a05cef5": {
+            "position": {
+              "left": 237,
+              "top": 93
+            },
+            "type": "wait_for_response"
+          },
+          "52a6784b-f51f-42c7-8c6a-3e5ec42603bb": {
+            "position": {
+              "left": 228,
+              "top": 712
+            },
+            "type": "wait_for_response"
+          },
+          "6d5703f9-938c-4c2f-9cc7-7d1bbe328095": {
+            "position": {
+              "left": 108,
+              "top": 875
+            },
+            "type": "execute_actions"
+          },
+          "73dda1a7-9152-45f1-993a-e7d01eb028db": {
+            "position": {
+              "left": 100,
+              "top": 175
+            },
+            "type": "execute_actions"
+          },
+          "8a2e088e-3657-4fa6-86fb-8d788db03709": {
+            "position": {
+              "left": 542,
+              "top": 281
+            },
+            "type": "execute_actions"
+          },
+          "a500d367-e944-4ba4-ab21-216b702f41c4": {
+            "position": {
+              "left": 522,
+              "top": 638
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Contact Surveyor",
+      "nodes": [
         {
-          "uuid": "036901e0-abb8-4979-92cb-f0d43aeb5b68",
-          "x": 100,
-          "y": 0,
-          "destination": "39fe1ce0-7dee-445e-9945-48c72a05cef5",
           "actions": [
             {
-              "type": "reply",
-              "uuid": "67aafaf6-b375-461c-8357-fd760423f96c",
-              "msg": {
-                "base": "Hi there. What's your name?"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "Hi there. What's your name?",
+              "type": "send_msg",
+              "uuid": "67aafaf6-b375-461c-8357-fd760423f96c"
             }
           ],
-          "exit_uuid": "706853c2-831b-4dd8-8073-cd51b21d94d6"
-        },
-        {
-          "uuid": "73dda1a7-9152-45f1-993a-e7d01eb028db",
-          "x": 100,
-          "y": 175,
-          "destination": "1a7612b5-777d-4af3-a657-077c46f242d9",
-          "actions": [
+          "exits": [
             {
-              "type": "save",
-              "uuid": "fac97ece-b9ab-4480-a6dd-9968cb5ebe79",
-              "label": "Contact Name",
-              "field": "name",
-              "value": "@flow.name"
-            },
-            {
-              "type": "reply",
-              "uuid": "a5141d43-14a1-4e40-914c-f2b33b3645de",
-              "msg": {
-                "base": "Thanks @contact.name. What's your phone number?"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "destination_uuid": "39fe1ce0-7dee-445e-9945-48c72a05cef5",
+              "uuid": "706853c2-831b-4dd8-8073-cd51b21d94d6"
             }
           ],
-          "exit_uuid": "5e7a398e-eebe-4b32-8600-374659f56d9e"
+          "uuid": "036901e0-abb8-4979-92cb-f0d43aeb5b68"
         },
         {
-          "uuid": "2d55c61f-384c-4a07-a17e-1e42fc543dd9",
-          "x": 102,
-          "y": 464,
-          "destination": "52a6784b-f51f-42c7-8c6a-3e5ec42603bb",
+          "exits": [
+            {
+              "destination_uuid": "73dda1a7-9152-45f1-993a-e7d01eb028db",
+              "uuid": "bb999ff8-5eb3-45f6-bec6-a0430105b0ca"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "bb999ff8-5eb3-45f6-bec6-a0430105b0ca",
+                "name": "All Responses",
+                "uuid": "9fc53385-db50-4079-998c-3da261a15c78"
+              }
+            ],
+            "default_category_uuid": "9fc53385-db50-4079-998c-3da261a15c78",
+            "operand": "@input",
+            "result_name": "Name",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "39fe1ce0-7dee-445e-9945-48c72a05cef5"
+        },
+        {
           "actions": [
             {
-              "type": "save",
-              "uuid": "a3bea28b-b1b0-4db1-af75-090973f9eb63",
-              "label": "Phone Number",
-              "field": "tel_e164",
-              "value": "@flow.phone"
+              "name": "@results.name",
+              "type": "set_contact_name",
+              "uuid": "fac97ece-b9ab-4480-a6dd-9968cb5ebe79"
             },
             {
-              "type": "add_group",
-              "uuid": "5126bb19-6ca1-4a9c-a9ef-30f4dd3761f4",
+              "text": "Thanks @contact.name. What's your phone number?",
+              "type": "send_msg",
+              "uuid": "a5141d43-14a1-4e40-914c-f2b33b3645de"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "1a7612b5-777d-4af3-a657-077c46f242d9",
+              "uuid": "5e7a398e-eebe-4b32-8600-374659f56d9e"
+            }
+          ],
+          "uuid": "73dda1a7-9152-45f1-993a-e7d01eb028db"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry that doesn't look like a phone number. Try again.",
+              "type": "send_msg",
+              "uuid": "bde2299b-7f35-4ad9-98c3-7e8db18c34ac"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "1a7612b5-777d-4af3-a657-077c46f242d9",
+              "uuid": "edf187b4-d9c1-4aa1-b26e-5c8c5f481a39"
+            }
+          ],
+          "uuid": "8a2e088e-3657-4fa6-86fb-8d788db03709"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "2d55c61f-384c-4a07-a17e-1e42fc543dd9",
+              "uuid": "0c047d03-3b61-4ff2-8bc8-43a89cf1087b"
+            },
+            {
+              "destination_uuid": "8a2e088e-3657-4fa6-86fb-8d788db03709",
+              "uuid": "6d614e50-ee98-412c-aee6-0916d10ed0ff"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "category_uuid": "3f56e77d-eea3-4bb9-8364-480ee90a0dd8",
+                "type": "has_phone",
+                "uuid": "fe4cfc67-2377-43f3-bbfa-b8e79c6a85c7"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "0c047d03-3b61-4ff2-8bc8-43a89cf1087b",
+                "name": "phone",
+                "uuid": "3f56e77d-eea3-4bb9-8364-480ee90a0dd8"
+              },
+              {
+                "exit_uuid": "6d614e50-ee98-412c-aee6-0916d10ed0ff",
+                "name": "Other",
+                "uuid": "44e5ef77-2454-4b2a-9056-d1acb6ac3db3"
+              }
+            ],
+            "default_category_uuid": "44e5ef77-2454-4b2a-9056-d1acb6ac3db3",
+            "operand": "@input",
+            "result_name": "Phone",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "1a7612b5-777d-4af3-a657-077c46f242d9"
+        },
+        {
+          "actions": [
+            {
+              "path": "@results.phone",
+              "scheme": "tel",
+              "type": "add_contact_urn",
+              "uuid": "a3bea28b-b1b0-4db1-af75-090973f9eb63"
+            },
+            {
               "groups": [
                 {
-                  "uuid": "6696cabf-eb5e-42bf-bcc6-f0c8be9b1316",
-                  "name": "Testers"
+                  "name": "Testers",
+                  "uuid": "6696cabf-eb5e-42bf-bcc6-f0c8be9b1316"
                 }
-              ]
+              ],
+              "type": "add_contact_groups",
+              "uuid": "5126bb19-6ca1-4a9c-a9ef-30f4dd3761f4"
             },
             {
-              "type": "reply",
-              "uuid": "7e198e6b-4640-4123-b3a9-0a44a06bd919",
-              "msg": {
-                "base": "Finally, what is your age?"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "Finally, what is your age?",
+              "type": "send_msg",
+              "uuid": "7e198e6b-4640-4123-b3a9-0a44a06bd919"
             }
           ],
-          "exit_uuid": "4e483159-af9f-48a4-907f-c875fde66c70"
-        },
-        {
-          "uuid": "8a2e088e-3657-4fa6-86fb-8d788db03709",
-          "x": 542,
-          "y": 281,
-          "destination": "1a7612b5-777d-4af3-a657-077c46f242d9",
-          "actions": [
+          "exits": [
             {
-              "type": "reply",
-              "uuid": "bde2299b-7f35-4ad9-98c3-7e8db18c34ac",
-              "msg": {
-                "base": "Sorry that doesn't look like a phone number. Try again."
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "destination_uuid": "52a6784b-f51f-42c7-8c6a-3e5ec42603bb",
+              "uuid": "4e483159-af9f-48a4-907f-c875fde66c70"
             }
           ],
-          "exit_uuid": "edf187b4-d9c1-4aa1-b26e-5c8c5f481a39"
+          "uuid": "2d55c61f-384c-4a07-a17e-1e42fc543dd9"
         },
         {
-          "uuid": "6d5703f9-938c-4c2f-9cc7-7d1bbe328095",
-          "x": 108,
-          "y": 875,
-          "destination": null,
           "actions": [
             {
-              "type": "save",
+              "text": "Sorry that doesn't look like an age value. Try again.",
+              "type": "send_msg",
+              "uuid": "2f39296b-37ed-4d16-b5bc-f3bfeb6b7691"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "52a6784b-f51f-42c7-8c6a-3e5ec42603bb",
+              "uuid": "27ffbd14-4345-4588-a41f-683b08ba14e7"
+            }
+          ],
+          "uuid": "a500d367-e944-4ba4-ab21-216b702f41c4"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "6d5703f9-938c-4c2f-9cc7-7d1bbe328095",
+              "uuid": "34d09b52-ac85-44a4-b4f4-c7a3b489fcf8"
+            },
+            {
+              "destination_uuid": "a500d367-e944-4ba4-ab21-216b702f41c4",
+              "uuid": "65e0c7b2-ea5f-48ad-a42c-411789155185"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "category_uuid": "4d2bde38-e67d-412f-95ee-f4b1dd04dea1",
+                "type": "has_number",
+                "uuid": "db926eb7-3f5a-43cd-9573-cb52cfaafec3"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "34d09b52-ac85-44a4-b4f4-c7a3b489fcf8",
+                "name": "numeric",
+                "uuid": "4d2bde38-e67d-412f-95ee-f4b1dd04dea1"
+              },
+              {
+                "exit_uuid": "65e0c7b2-ea5f-48ad-a42c-411789155185",
+                "name": "Other",
+                "uuid": "cb929527-fa45-4810-b321-76dbf8b50a23"
+              }
+            ],
+            "default_category_uuid": "cb929527-fa45-4810-b321-76dbf8b50a23",
+            "operand": "@input",
+            "result_name": "Age",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "52a6784b-f51f-42c7-8c6a-3e5ec42603bb"
+        },
+        {
+          "actions": [
+            {
+              "field": {
+                "key": "age",
+                "name": "Age"
+              },
+              "type": "set_contact_field",
               "uuid": "76abbb4a-ab65-4e82-8b6a-7222fa14eb8a",
-              "label": "Age",
-              "field": "age",
-              "value": "@flow.age"
+              "value": "@results.age"
             },
             {
-              "type": "reply",
-              "uuid": "40790c5a-4afc-4c80-856d-7414e53d5de8",
-              "msg": {
-                "base": "Thanks @contact.name. You are @contact.age and your phone number is @contact.tel"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "Thanks @contact.name. You are @fields.age and your phone number is @(format_urn(urns.tel))",
+              "type": "send_msg",
+              "uuid": "40790c5a-4afc-4c80-856d-7414e53d5de8"
             }
           ],
-          "exit_uuid": "6bab242d-85d5-4afe-b6e7-5fe7c98f187e"
-        },
-        {
-          "uuid": "a500d367-e944-4ba4-ab21-216b702f41c4",
-          "x": 522,
-          "y": 638,
-          "destination": "52a6784b-f51f-42c7-8c6a-3e5ec42603bb",
-          "actions": [
+          "exits": [
             {
-              "type": "reply",
-              "uuid": "2f39296b-37ed-4d16-b5bc-f3bfeb6b7691",
-              "msg": {
-                "base": "Sorry that doesn't look like an age value. Try again."
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "uuid": "6bab242d-85d5-4afe-b6e7-5fe7c98f187e"
             }
           ],
-          "exit_uuid": "27ffbd14-4345-4588-a41f-683b08ba14e7"
+          "uuid": "6d5703f9-938c-4c2f-9cc7-7d1bbe328095"
         }
       ],
-      "rule_sets": [
-        {
-          "uuid": "39fe1ce0-7dee-445e-9945-48c72a05cef5",
-          "x": 237,
-          "y": 93,
-          "label": "Name",
-          "rules": [
-            {
-              "uuid": "bb999ff8-5eb3-45f6-bec6-a0430105b0ca",
-              "category": {
-                "base": "All Responses"
-              },
-              "destination": "73dda1a7-9152-45f1-993a-e7d01eb028db",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        },
-        {
-          "uuid": "1a7612b5-777d-4af3-a657-077c46f242d9",
-          "x": 237,
-          "y": 361,
-          "label": "Phone",
-          "rules": [
-            {
-              "uuid": "0c047d03-3b61-4ff2-8bc8-43a89cf1087b",
-              "category": {
-                "base": "phone"
-              },
-              "destination": "2d55c61f-384c-4a07-a17e-1e42fc543dd9",
-              "destination_type": "A",
-              "test": {
-                "type": "phone"
-              },
-              "label": null
-            },
-            {
-              "uuid": "6d614e50-ee98-412c-aee6-0916d10ed0ff",
-              "category": {
-                "base": "Other"
-              },
-              "destination": "8a2e088e-3657-4fa6-86fb-8d788db03709",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        },
-        {
-          "uuid": "52a6784b-f51f-42c7-8c6a-3e5ec42603bb",
-          "x": 228,
-          "y": 712,
-          "label": "Age",
-          "rules": [
-            {
-              "uuid": "34d09b52-ac85-44a4-b4f4-c7a3b489fcf8",
-              "category": {
-                "base": "numeric"
-              },
-              "destination": "6d5703f9-938c-4c2f-9cc7-7d1bbe328095",
-              "destination_type": "A",
-              "test": {
-                "type": "number"
-              },
-              "label": null
-            },
-            {
-              "uuid": "65e0c7b2-ea5f-48ad-a42c-411789155185",
-              "category": {
-                "base": "Other"
-              },
-              "destination": "a500d367-e944-4ba4-ab21-216b702f41c4",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        }
-      ],
-      "base_language": "base",
-      "flow_type": "S",
-      "version": "11.7",
-      "metadata": {
-        "name": "Contact Surveyor",
-        "saved_on": "2018-12-18T14:47:55.302852Z",
-        "revision": 16,
-        "uuid": "ed8cf8d4-a42c-4ce1-a7e3-44a2918e3cec",
-        "expires": 10080,
-        "contact_creation": "run",
-        "ivr_retry_failed_events": null
-      }
+      "revision": 16,
+      "spec_version": "14.4.0",
+      "type": "messaging_offline",
+      "uuid": "ed8cf8d4-a42c-4ce1-a7e3-44a2918e3cec"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/mailroom/favorites_timeout.json
+++ b/media/test_flows/mailroom/favorites_timeout.json
@@ -1,340 +1,438 @@
 {
-  "version": 7,
+  "version": "13",
   "flows": [
     {
-      "version": 7,
-      "flow_type": "M",
-      "base_language": "base",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "10e483a8-5ffb-4c4f-917b-d43ce86c1d65": {
+            "position": {
+              "left": 191,
+              "top": 805
+            },
+            "type": "execute_actions"
+          },
+          "127f3736-77ce-4006-9ab0-0c07cea88956": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830": {
+            "position": {
+              "left": 98,
+              "top": 129
+            },
+            "type": "wait_for_response"
+          },
+          "44471ade-7979-4c94-8028-6cfb68836337": {
+            "position": {
+              "left": 131,
+              "top": 237
+            },
+            "type": "execute_actions"
+          },
+          "89c5624e-3320-4668-a066-308865133080": {
+            "position": {
+              "left": 191,
+              "top": 535
+            },
+            "type": "execute_actions"
+          },
+          "a269683d-8229-4870-8585-be8320b9d8ca": {
+            "position": {
+              "left": 512,
+              "top": 265
+            },
+            "type": "execute_actions"
+          },
+          "a5fc5f8a-f562-4b03-a54f-51928f9df07e": {
+            "position": {
+              "left": 112,
+              "top": 387
+            },
+            "type": "wait_for_response"
+          },
+          "ba95c5cd-e428-4a15-8b4b-23dd43943f2c": {
+            "position": {
+              "left": 191,
+              "top": 702
+            },
+            "type": "wait_for_response"
+          },
+          "ba96d1c6-c721-470a-a04c-74015b1fdd35": {
+            "position": {
+              "left": 752,
+              "top": 1278
+            },
+            "type": "execute_actions"
+          },
+          "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f": {
+            "position": {
+              "left": 456,
+              "top": 8
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 720,
+      "language": "und",
+      "localization": {},
+      "name": "Favorites",
+      "nodes": [
         {
-          "y": 0,
-          "x": 100,
-          "destination": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
-          "uuid": "127f3736-77ce-4006-9ab0-0c07cea88956",
           "actions": [
             {
-              "msg": {
-                "base": "What is your favorite color?"
-              },
-              "type": "reply"
+              "text": "What is your favorite color?",
+              "type": "send_msg",
+              "uuid": "4e259736-4888-426d-be3a-a3c1de5120f5"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "destination_uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
+              "uuid": "5d9a517b-34cb-4267-adde-e1a07419e85d"
+            }
+          ],
+          "uuid": "127f3736-77ce-4006-9ab0-0c07cea88956"
         },
         {
-          "y": 237,
-          "x": 131,
-          "destination": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
-          "uuid": "44471ade-7979-4c94-8028-6cfb68836337",
           "actions": [
             {
-              "msg": {
-                "base": "Good choice, I like @flow.color.category too! What is your favorite beer?"
-              },
-              "type": "reply"
+              "text": "I don't know that color. Try again.",
+              "type": "send_msg",
+              "uuid": "2af81b6a-efda-4efa-b8b9-69f84323396e"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "destination_uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
+              "uuid": "141f77de-2945-46be-a838-1f0fcffcf8c9"
+            }
+          ],
+          "uuid": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f"
         },
         {
-          "y": 8,
-          "x": 456,
-          "destination": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
-          "uuid": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f",
-          "actions": [
+          "exits": [
             {
-              "msg": {
-                "base": "I don't know that color. Try again."
-              },
-              "type": "reply"
+              "destination_uuid": "44471ade-7979-4c94-8028-6cfb68836337",
+              "uuid": "8cd25a3f-0be2-494b-8b4c-3a4f0de7f9b2"
+            },
+            {
+              "destination_uuid": "44471ade-7979-4c94-8028-6cfb68836337",
+              "uuid": "db2863cf-7fda-4489-9345-d44dacf4e750"
+            },
+            {
+              "destination_uuid": "44471ade-7979-4c94-8028-6cfb68836337",
+              "uuid": "2f462678-b176-49c1-bb5c-6e152502b0db"
+            },
+            {
+              "uuid": "6f463a78-b176-49c1-bb5c-6e152502b0db"
+            },
+            {
+              "destination_uuid": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f",
+              "uuid": "df4455c2-806b-4af4-8ea9-f40278ec10e4"
+            },
+            {
+              "destination_uuid": "ba96d1c6-c721-470a-a04c-74015b1fdd35",
+              "uuid": "1023e76b-bd81-4720-a95e-a54a8fc3c328"
             }
-          ]
-        },
-        {
-          "y": 535,
-          "x": 191,
-          "destination": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c",
-          "uuid": "89c5624e-3320-4668-a066-308865133080",
-          "actions": [
-            {
-              "msg": {
-                "base": "Mmmmm... delicious @flow.beer.category. If only they made @flow.color|lower_case @flow.beer.category! Lastly, what is your name?"
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Red"
+                ],
+                "category_uuid": "cb07e9ec-b35b-4691-9c9b-1afc05be44cb",
+                "type": "has_any_word",
+                "uuid": "6c85d739-3dc5-45d6-a285-75bf12ed3628"
               },
-              "type": "reply"
-            }
-          ]
-        },
-        {
-          "y": 265,
-          "x": 512,
-          "destination": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
-          "uuid": "a269683d-8229-4870-8585-be8320b9d8ca",
-          "actions": [
-            {
-              "msg": {
-                "base": "I don't know that one, try again please."
+              {
+                "arguments": [
+                  "Green"
+                ],
+                "category_uuid": "b1d17a2f-f309-407a-80ee-4bbf24a57d13",
+                "type": "has_any_word",
+                "uuid": "b7fd8f3e-dda5-4112-b95c-ad5cf9f7f41f"
               },
-              "type": "reply"
-            }
-          ]
-        },
-        {
-          "y": 805,
-          "x": 191,
-          "destination": null,
-          "uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
-          "actions": [
-            {
-              "msg": {
-                "base": "Thanks @flow.name, we are all done!"
+              {
+                "arguments": [
+                  "Blue"
+                ],
+                "category_uuid": "72c091b1-18a8-4306-8f5d-e43b16719bdf",
+                "type": "has_any_word",
+                "uuid": "03f52b5f-5be0-4a4f-b0da-b0f93dfe2299"
               },
-              "type": "reply"
-            }
-          ]
-        },
-        {
-          "uuid": "ba96d1c6-c721-470a-a04c-74015b1fdd35",
-          "x": 752,
-          "y": 1278,
-          "destination": null,
-          "actions": [
-            {
-              "type": "reply",
-              "msg": {
-                "base": "Sorry you can't participate right now, I'll try again later."
+              {
+                "arguments": [
+                  "Navy"
+                ],
+                "category_uuid": "72c091b1-18a8-4306-8f5d-e43b16719bdf",
+                "type": "has_any_word",
+                "uuid": "365cf70e-1da6-474b-9d21-6d36dca057f0"
+              },
+              {
+                "arguments": [
+                  "Cyan"
+                ],
+                "category_uuid": "cf42fa68-d425-49d2-8e70-62514d4c1a32",
+                "type": "has_any_word",
+                "uuid": "ba27a29a-51e5-4831-8ce4-134c25690142"
               }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "8cd25a3f-0be2-494b-8b4c-3a4f0de7f9b2",
+                "name": "Red",
+                "uuid": "cb07e9ec-b35b-4691-9c9b-1afc05be44cb"
+              },
+              {
+                "exit_uuid": "db2863cf-7fda-4489-9345-d44dacf4e750",
+                "name": "Green",
+                "uuid": "b1d17a2f-f309-407a-80ee-4bbf24a57d13"
+              },
+              {
+                "exit_uuid": "2f462678-b176-49c1-bb5c-6e152502b0db",
+                "name": "Blue",
+                "uuid": "72c091b1-18a8-4306-8f5d-e43b16719bdf"
+              },
+              {
+                "exit_uuid": "6f463a78-b176-49c1-bb5c-6e152502b0db",
+                "name": "Cyan",
+                "uuid": "cf42fa68-d425-49d2-8e70-62514d4c1a32"
+              },
+              {
+                "exit_uuid": "df4455c2-806b-4af4-8ea9-f40278ec10e4",
+                "name": "Other",
+                "uuid": "24eb0497-d2c9-40c0-a395-1de5bd551a06"
+              },
+              {
+                "exit_uuid": "1023e76b-bd81-4720-a95e-a54a8fc3c328",
+                "name": "No Response",
+                "uuid": "4add4766-0835-4526-aa02-8fea6ace3a4a"
+              }
+            ],
+            "default_category_uuid": "24eb0497-d2c9-40c0-a395-1de5bd551a06",
+            "operand": "@input",
+            "result_name": "Color",
+            "type": "switch",
+            "wait": {
+              "timeout": {
+                "category_uuid": "4add4766-0835-4526-aa02-8fea6ace3a4a",
+                "seconds": 300
+              },
+              "type": "msg"
             }
-          ]
+          },
+          "uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830"
+        },
+        {
+          "actions": [
+            {
+              "text": "Good choice, I like @results.color.category_localized too! What is your favorite beer?",
+              "type": "send_msg",
+              "uuid": "e15d8918-e336-440a-8810-1c000141e99e"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
+              "uuid": "7ab9daee-94ba-4ecf-ae61-64b2b9e6880b"
+            }
+          ],
+          "uuid": "44471ade-7979-4c94-8028-6cfb68836337"
+        },
+        {
+          "actions": [
+            {
+              "text": "I don't know that one, try again please.",
+              "type": "send_msg",
+              "uuid": "7b462574-545d-4cbf-8577-44aa9568e337"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
+              "uuid": "d0de6ca1-eeb7-45a1-b6cb-4d47e2b7403b"
+            }
+          ],
+          "uuid": "a269683d-8229-4870-8585-be8320b9d8ca"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "ea304225-332e-49d4-9768-1e804cd0b6c2"
+            },
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "57f8688e-c263-43d7-bd06-bdb98f0c58a8"
+            },
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "670f0205-bb39-4e12-ae95-5e29251b8a3e"
+            },
+            {
+              "destination_uuid": "89c5624e-3320-4668-a066-308865133080",
+              "uuid": "2ff4713f-c62f-445c-880c-de8f6532d090"
+            },
+            {
+              "destination_uuid": "a269683d-8229-4870-8585-be8320b9d8ca",
+              "uuid": "1fc4c133-d038-4f75-a69e-6e7e3190e5d8"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Mutzig"
+                ],
+                "category_uuid": "7c8281bb-86f0-44da-a331-f001a41e15fa",
+                "type": "has_any_word",
+                "uuid": "dfa8a1e2-78bd-41b7-afeb-0e5e70f56061"
+              },
+              {
+                "arguments": [
+                  "Primus"
+                ],
+                "category_uuid": "882e25fd-c691-4712-b8d1-5f0503bfb15c",
+                "type": "has_any_word",
+                "uuid": "95d46e15-dcb1-4a08-94fb-4da436b530ad"
+              },
+              {
+                "arguments": [
+                  "Turbo King"
+                ],
+                "category_uuid": "3c15bef4-9b4a-406d-804e-1148aee6db19",
+                "type": "has_any_word",
+                "uuid": "e4013208-02bc-4881-98bb-ca54b3b60d33"
+              },
+              {
+                "arguments": [
+                  "Skol"
+                ],
+                "category_uuid": "4d694098-cf40-4a5e-ac17-99aacbf56743",
+                "type": "has_any_word",
+                "uuid": "3af1fbf7-0baa-4cce-9f63-a99e5ae47d7a"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "ea304225-332e-49d4-9768-1e804cd0b6c2",
+                "name": "Mutzig",
+                "uuid": "7c8281bb-86f0-44da-a331-f001a41e15fa"
+              },
+              {
+                "exit_uuid": "57f8688e-c263-43d7-bd06-bdb98f0c58a8",
+                "name": "Primus",
+                "uuid": "882e25fd-c691-4712-b8d1-5f0503bfb15c"
+              },
+              {
+                "exit_uuid": "670f0205-bb39-4e12-ae95-5e29251b8a3e",
+                "name": "Turbo King",
+                "uuid": "3c15bef4-9b4a-406d-804e-1148aee6db19"
+              },
+              {
+                "exit_uuid": "2ff4713f-c62f-445c-880c-de8f6532d090",
+                "name": "Skol",
+                "uuid": "4d694098-cf40-4a5e-ac17-99aacbf56743"
+              },
+              {
+                "exit_uuid": "1fc4c133-d038-4f75-a69e-6e7e3190e5d8",
+                "name": "Other",
+                "uuid": "45977913-3961-432e-a39c-05aa915ab61b"
+              }
+            ],
+            "default_category_uuid": "45977913-3961-432e-a39c-05aa915ab61b",
+            "operand": "@input",
+            "result_name": "Beer",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e"
+        },
+        {
+          "actions": [
+            {
+              "text": "Mmmmm... delicious @results.beer.category_localized. If only they made @(lower(results.color)) @results.beer.category_localized! Lastly, what is your name?",
+              "type": "send_msg",
+              "uuid": "4fb14dc1-dc45-490f-8c6a-fdaa131521e2"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c",
+              "uuid": "7a3fcfe4-5a9b-4f31-9310-2b2d2759ffe6"
+            }
+          ],
+          "uuid": "89c5624e-3320-4668-a066-308865133080"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
+              "uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783",
+                "name": "All Responses",
+                "uuid": "c5efb2bf-5651-4e2a-8ff5-4697b22ff190"
+              }
+            ],
+            "default_category_uuid": "c5efb2bf-5651-4e2a-8ff5-4697b22ff190",
+            "operand": "@input",
+            "result_name": "Name",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c"
+        },
+        {
+          "actions": [
+            {
+              "text": "Thanks @results.name, we are all done!",
+              "type": "send_msg",
+              "uuid": "d2ebd546-796b-4886-914f-cd6811f9d091"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "4940accf-42b3-4b4f-951c-ee284114e74b"
+            }
+          ],
+          "uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry you can't participate right now, I'll try again later.",
+              "type": "send_msg",
+              "uuid": "37994549-7a80-436c-a6f8-af585bb9b168"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "955a7ba1-667d-4caa-a1a3-a8f6c113e2c4"
+            }
+          ],
+          "uuid": "ba96d1c6-c721-470a-a04c-74015b1fdd35"
         }
       ],
-      "last_saved": "2015-09-15T02:37:08.805578Z",
-      "entry": "127f3736-77ce-4006-9ab0-0c07cea88956",
-      "rule_sets": [
-        {
-          "uuid": "2bff5c33-9d29-4cfc-8bb7-0a1b9f97d830",
-          "webhook_action": null,
-          "rules": [
-            {
-              "test": {
-                "test": {
-                  "base": "Red"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Red"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "8cd25a3f-0be2-494b-8b4c-3a4f0de7f9b2",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Green"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Green"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "db2863cf-7fda-4489-9345-d44dacf4e750",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Blue"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Blue"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "2f462678-b176-49c1-bb5c-6e152502b0db",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Navy"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Blue"
-              },
-              "destination": "44471ade-7979-4c94-8028-6cfb68836337",
-              "uuid": "ecaeb59a-d7f1-4c21-a207-b2a29cc2488f",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Cyan"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Cyan"
-              },
-              "destination": null,
-              "uuid": "6f463a78-b176-49c1-bb5c-6e152502b0db",
-              "destination_type": null
-            },
-            {
-              "test": {
-                "test": "true",
-                "type": "true"
-              },
-              "category": {
-                "base": "Other"
-              },
-              "destination": "f9adf38f-ab18-49d3-a8ac-db2fe8f1e77f",
-              "uuid": "df4455c2-806b-4af4-8ea9-f40278ec10e4",
-              "destination_type": "A"
-            },
-            {
-              "uuid": "1023e76b-bd81-4720-a95e-a54a8fc3c328",
-              "category": {
-                "base": "No Response"
-              },
-              "destination": "ba96d1c6-c721-470a-a04c-74015b1fdd35",
-              "destination_type": "A",
-              "test": {
-                "type": "timeout",
-                "minutes": 5
-              }
-            }
-          ],
-          "webhook": null,
-          "ruleset_type": "wait_message",
-          "label": "Color",
-          "operand": "@step.value",
-          "finished_key": null,
-          "response_type": "",
-          "y": 129,
-          "x": 98,
-          "config": {}
-        },
-        {
-          "uuid": "a5fc5f8a-f562-4b03-a54f-51928f9df07e",
-          "webhook_action": null,
-          "rules": [
-            {
-              "test": {
-                "test": {
-                  "base": "Mutzig"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Mutzig"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "ea304225-332e-49d4-9768-1e804cd0b6c2",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Primus"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Primus"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "57f8688e-c263-43d7-bd06-bdb98f0c58a8",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Turbo King"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Turbo King"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "670f0205-bb39-4e12-ae95-5e29251b8a3e",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": {
-                  "base": "Skol"
-                },
-                "type": "contains_any"
-              },
-              "category": {
-                "base": "Skol"
-              },
-              "destination": "89c5624e-3320-4668-a066-308865133080",
-              "uuid": "2ff4713f-c62f-445c-880c-de8f6532d090",
-              "destination_type": "A"
-            },
-            {
-              "test": {
-                "test": "true",
-                "type": "true"
-              },
-              "category": {
-                "base": "Other"
-              },
-              "destination": "a269683d-8229-4870-8585-be8320b9d8ca",
-              "uuid": "1fc4c133-d038-4f75-a69e-6e7e3190e5d8",
-              "destination_type": "A"
-            }
-          ],
-          "webhook": null,
-          "ruleset_type": "wait_message",
-          "label": "Beer",
-          "operand": "@step.value",
-          "finished_key": null,
-          "response_type": "",
-          "y": 387,
-          "x": 112,
-          "config": {}
-        },
-        {
-          "uuid": "ba95c5cd-e428-4a15-8b4b-23dd43943f2c",
-          "webhook_action": null,
-          "rules": [
-            {
-              "test": {
-                "test": "true",
-                "type": "true"
-              },
-              "category": {
-                "base": "All Responses"
-              },
-              "destination": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
-              "uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783",
-              "destination_type": "A"
-            }
-          ],
-          "webhook": null,
-          "ruleset_type": "wait_message",
-          "label": "Name",
-          "operand": "@step.value",
-          "finished_key": null,
-          "response_type": "",
-          "y": 702,
-          "x": 191,
-          "config": {}
-        }
-      ],
-      "metadata": {
-        "notes": [],
-        "name": "Favorites",
-        "id": 35559,
-        "expires": 720,
-        "revision": 1
-      }
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "526a3278-3575-4d18-b5f7-84b79002e6ec"
     }
   ],
   "triggers": []

--- a/media/test_flows/mailroom/incoming_extra.json
+++ b/media/test_flows/mailroom/incoming_extra.json
@@ -1,48 +1,50 @@
 {
-  "version": "11.10",
+  "version": "13",
   "site": "https://textit.in",
   "flows": [
     {
-      "entry": "849133b9-732e-4e62-9da3-48132960d38c",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "849133b9-732e-4e62-9da3-48132960d38c": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Extra Flow",
+      "nodes": [
         {
-          "uuid": "849133b9-732e-4e62-9da3-48132960d38c",
-          "x": 100,
-          "y": 0,
-          "destination": null,
           "actions": [
             {
-              "type": "save",
-              "uuid": "4c7439f0-38a5-44c5-a35f-e9a72c459445",
-              "label": "Contact Name",
-              "field": "name",
-              "value": "@extra.name"
+              "name": "@legacy_extra.name",
+              "type": "set_contact_name",
+              "uuid": "4c7439f0-38a5-44c5-a35f-e9a72c459445"
             },
             {
-              "type": "reply",
-              "uuid": "c58fed5a-81b8-487e-a360-320b3a3ab4e3",
-              "msg": {
-                "eng": "Great to meet you @contact.name. Your age is @extra.age."
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "Great to meet you @contact.name. Your age is @legacy_extra.age.",
+              "type": "send_msg",
+              "uuid": "c58fed5a-81b8-487e-a360-320b3a3ab4e3"
             }
           ],
-          "exit_uuid": "f0129714-a2b1-413c-9d8f-38673e0173ac"
+          "exits": [
+            {
+              "uuid": "f0129714-a2b1-413c-9d8f-38673e0173ac"
+            }
+          ],
+          "uuid": "849133b9-732e-4e62-9da3-48132960d38c"
         }
       ],
-      "rule_sets": [],
-      "base_language": "eng",
-      "flow_type": "M",
-      "version": "11.10",
-      "metadata": {
-        "name": "Extra Flow",
-        "saved_on": "2019-02-06T22:58:44.870273Z",
-        "revision": 4,
-        "uuid": "dc9a2be2-7706-4539-b9ef-4cbb42bce34e",
-        "expires": 10080
-      }
+      "revision": 4,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "dc9a2be2-7706-4539-b9ef-4cbb42bce34e"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/mailroom/ivr_flow.json
+++ b/media/test_flows/mailroom/ivr_flow.json
@@ -5,17 +5,10 @@
     {
       "_ui": {
         "nodes": {
-          "44ddbbbd-be98-439c-b809-cf14f694b28b": {
+          "26090582-43bc-48d9-a40a-916811117fc9": {
             "position": {
-              "left": 100,
-              "top": 0
-            },
-            "type": "execute_actions"
-          },
-          "f0de487c-35ad-4fb1-a710-1076147313f2": {
-            "position": {
-              "left": 140,
-              "top": 220
+              "left": 162,
+              "top": 568
             },
             "type": "wait_for_response"
           },
@@ -26,19 +19,27 @@
             },
             "type": "execute_actions"
           },
-          "ba77561e-aa7e-4efa-baeb-1e19fbdd100d": {
+          "4402d305-eb6a-4e29-aa4d-6423bc0a4896": {
             "position": {
-              "left": 96,
-              "top": 355
+              "left": 84,
+              "top": 740
             },
             "type": "execute_actions"
           },
-          "26090582-43bc-48d9-a40a-916811117fc9": {
+          "44ddbbbd-be98-439c-b809-cf14f694b28b": {
             "position": {
-              "left": 162,
-              "top": 568
+              "left": 100,
+              "top": 0
             },
-            "type": "wait_for_response"
+            "type": "execute_actions"
+          },
+          "76f0fefc-cde6-4aed-b306-fe2de726db6f": {
+            "config": {},
+            "position": {
+              "left": 220,
+              "top": 1400
+            },
+            "type": "wait_for_dial"
           },
           "9cddd0a1-5af2-49ae-8376-1817c23be88e": {
             "position": {
@@ -47,10 +48,10 @@
             },
             "type": "execute_actions"
           },
-          "4402d305-eb6a-4e29-aa4d-6423bc0a4896": {
+          "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd": {
             "position": {
-              "left": 84,
-              "top": 740
+              "left": 300,
+              "top": 1600
             },
             "type": "execute_actions"
           },
@@ -61,20 +62,12 @@
             },
             "type": "wait_for_response"
           },
-          "e10c8b96-4cec-4b0a-a0ea-95bc87d3aece": {
+          "ba77561e-aa7e-4efa-baeb-1e19fbdd100d": {
             "position": {
-              "left": 104,
-              "top": 1083
+              "left": 96,
+              "top": 355
             },
             "type": "execute_actions"
-          },
-          "76f0fefc-cde6-4aed-b306-fe2de726db6f": {
-            "type": "wait_for_dial",
-            "position": {
-              "left": 220,
-              "top": 1400
-            },
-            "config": {}
           },
           "c5bb9e75-6349-4d01-ab1e-944acc476447": {
             "position": {
@@ -83,18 +76,25 @@
             },
             "type": "execute_actions"
           },
-          "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd": {
+          "e10c8b96-4cec-4b0a-a0ea-95bc87d3aece": {
             "position": {
-              "left": 300,
-              "top": 1600
+              "left": 104,
+              "top": 1083
             },
             "type": "execute_actions"
+          },
+          "f0de487c-35ad-4fb1-a710-1076147313f2": {
+            "position": {
+              "left": 140,
+              "top": 220
+            },
+            "type": "wait_for_response"
           }
         },
         "stickies": {}
       },
       "expire_after_minutes": 5,
-      "language": "base",
+      "language": "und",
       "localization": {},
       "metadata": {
         "expires": 10080
@@ -118,6 +118,7 @@
           "uuid": "44ddbbbd-be98-439c-b809-cf14f694b28b"
         },
         {
+          "actions": [],
           "exits": [
             {
               "destination_uuid": "ba77561e-aa7e-4efa-baeb-1e19fbdd100d",
@@ -180,8 +181,7 @@
               "type": "msg"
             }
           },
-          "uuid": "f0de487c-35ad-4fb1-a710-1076147313f2",
-          "actions": []
+          "uuid": "f0de487c-35ad-4fb1-a710-1076147313f2"
         },
         {
           "actions": [
@@ -216,6 +216,7 @@
           "uuid": "ba77561e-aa7e-4efa-baeb-1e19fbdd100d"
         },
         {
+          "actions": [],
           "exits": [
             {
               "destination_uuid": "4402d305-eb6a-4e29-aa4d-6423bc0a4896",
@@ -262,8 +263,7 @@
               "type": "msg"
             }
           },
-          "uuid": "26090582-43bc-48d9-a40a-916811117fc9",
-          "actions": []
+          "uuid": "26090582-43bc-48d9-a40a-916811117fc9"
         },
         {
           "actions": [
@@ -298,6 +298,7 @@
           "uuid": "4402d305-eb6a-4e29-aa4d-6423bc0a4896"
         },
         {
+          "actions": [],
           "exits": [
             {
               "destination_uuid": "e10c8b96-4cec-4b0a-a0ea-95bc87d3aece",
@@ -324,8 +325,7 @@
               "type": "msg"
             }
           },
-          "uuid": "b2b7d368-5a6d-4ced-a066-8217ed5bf146",
-          "actions": []
+          "uuid": "b2b7d368-5a6d-4ced-a066-8217ed5bf146"
         },
         {
           "actions": [
@@ -347,93 +347,92 @@
           ],
           "exits": [
             {
-              "uuid": "f2404f7d-2be6-4500-b61a-703db5459b61",
-              "destination_uuid": "76f0fefc-cde6-4aed-b306-fe2de726db6f"
+              "destination_uuid": "76f0fefc-cde6-4aed-b306-fe2de726db6f",
+              "uuid": "f2404f7d-2be6-4500-b61a-703db5459b61"
             }
           ],
           "uuid": "e10c8b96-4cec-4b0a-a0ea-95bc87d3aece"
         },
         {
-          "uuid": "76f0fefc-cde6-4aed-b306-fe2de726db6f",
           "actions": [],
-          "router": {
-            "type": "switch",
-            "wait": {
-              "type": "dial",
-              "phone": "2065551212"
+          "exits": [
+            {
+              "destination_uuid": "c5bb9e75-6349-4d01-ab1e-944acc476447",
+              "uuid": "e5855edc-295b-4205-85a5-29790f59a295"
             },
-            "default_category_uuid": "20753879-0261-428f-bcd8-b7be67c9b8cd",
-            "categories": [
-              {
-                "uuid": "568923e0-c3d1-467a-8589-1b5deb5f2e6b",
-                "name": "Answered",
-                "exit_uuid": "e5855edc-295b-4205-85a5-29790f59a295"
-              },
-              {
-                "uuid": "00823422-a217-4d07-8676-85d777bac975",
-                "name": "No Answer",
-                "exit_uuid": "ee12cb3f-6d47-4ff6-9712-0b749231a9d4"
-              },
-              {
-                "uuid": "3e009811-9bc0-491b-b8a0-6f2625fceed8",
-                "name": "Busy",
-                "exit_uuid": "52bd89f8-6834-4466-aea2-05d80a4ac3be"
-              },
-              {
-                "uuid": "20753879-0261-428f-bcd8-b7be67c9b8cd",
-                "name": "Failed",
-                "exit_uuid": "b11e71e2-b90d-463b-b350-f13d5a991148"
-              }
-            ],
+            {
+              "destination_uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd",
+              "uuid": "ee12cb3f-6d47-4ff6-9712-0b749231a9d4"
+            },
+            {
+              "destination_uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd",
+              "uuid": "52bd89f8-6834-4466-aea2-05d80a4ac3be"
+            },
+            {
+              "destination_uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd",
+              "uuid": "b11e71e2-b90d-463b-b350-f13d5a991148"
+            }
+          ],
+          "router": {
             "cases": [
               {
-                "uuid": "a3abc973-0e94-49ad-92c0-860c6d92b804",
-                "type": "has_only_text",
                 "arguments": [
                   "answered"
                 ],
-                "category_uuid": "568923e0-c3d1-467a-8589-1b5deb5f2e6b"
+                "category_uuid": "568923e0-c3d1-467a-8589-1b5deb5f2e6b",
+                "type": "has_only_text",
+                "uuid": "a3abc973-0e94-49ad-92c0-860c6d92b804"
               },
               {
-                "uuid": "3b261a79-dc91-482d-a9f4-d54d901dc065",
-                "type": "has_only_text",
                 "arguments": [
                   "no_answer"
                 ],
-                "category_uuid": "00823422-a217-4d07-8676-85d777bac975"
+                "category_uuid": "00823422-a217-4d07-8676-85d777bac975",
+                "type": "has_only_text",
+                "uuid": "3b261a79-dc91-482d-a9f4-d54d901dc065"
               },
               {
-                "uuid": "ace33089-dbc0-47dd-a6ff-051bd8e4c1c9",
-                "type": "has_only_text",
                 "arguments": [
                   "busy"
                 ],
-                "category_uuid": "3e009811-9bc0-491b-b8a0-6f2625fceed8"
+                "category_uuid": "3e009811-9bc0-491b-b8a0-6f2625fceed8",
+                "type": "has_only_text",
+                "uuid": "ace33089-dbc0-47dd-a6ff-051bd8e4c1c9"
               }
             ],
-            "operand": "@(default(resume.dial.status, \"\"))"
-          },
-          "exits": [
-            {
-              "uuid": "e5855edc-295b-4205-85a5-29790f59a295",
-              "destination_uuid": "c5bb9e75-6349-4d01-ab1e-944acc476447"
-            },
-            {
-              "uuid": "ee12cb3f-6d47-4ff6-9712-0b749231a9d4",
-              "destination_uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd"
-            },
-            {
-              "uuid": "52bd89f8-6834-4466-aea2-05d80a4ac3be",
-              "destination_uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd"
-            },
-            {
-              "uuid": "b11e71e2-b90d-463b-b350-f13d5a991148",
-              "destination_uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd"
+            "categories": [
+              {
+                "exit_uuid": "e5855edc-295b-4205-85a5-29790f59a295",
+                "name": "Answered",
+                "uuid": "568923e0-c3d1-467a-8589-1b5deb5f2e6b"
+              },
+              {
+                "exit_uuid": "ee12cb3f-6d47-4ff6-9712-0b749231a9d4",
+                "name": "No Answer",
+                "uuid": "00823422-a217-4d07-8676-85d777bac975"
+              },
+              {
+                "exit_uuid": "52bd89f8-6834-4466-aea2-05d80a4ac3be",
+                "name": "Busy",
+                "uuid": "3e009811-9bc0-491b-b8a0-6f2625fceed8"
+              },
+              {
+                "exit_uuid": "b11e71e2-b90d-463b-b350-f13d5a991148",
+                "name": "Failed",
+                "uuid": "20753879-0261-428f-bcd8-b7be67c9b8cd"
+              }
+            ],
+            "default_category_uuid": "20753879-0261-428f-bcd8-b7be67c9b8cd",
+            "operand": "@(default(resume.dial.status, \"\"))",
+            "type": "switch",
+            "wait": {
+              "phone": "2065551212",
+              "type": "dial"
             }
-          ]
+          },
+          "uuid": "76f0fefc-cde6-4aed-b306-fe2de726db6f"
         },
         {
-          "uuid": "c5bb9e75-6349-4d01-ab1e-944acc476447",
           "actions": [
             {
               "text": "Great, they answered.",
@@ -443,13 +442,13 @@
           ],
           "exits": [
             {
-              "uuid": "82e15b5d-b005-40cf-aa34-72d36b1809c8",
-              "destination_uuid": null
+              "destination_uuid": null,
+              "uuid": "82e15b5d-b005-40cf-aa34-72d36b1809c8"
             }
-          ]
+          ],
+          "uuid": "c5bb9e75-6349-4d01-ab1e-944acc476447"
         },
         {
-          "uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd",
           "actions": [
             {
               "text": "We didn't get through.",
@@ -459,16 +458,17 @@
           ],
           "exits": [
             {
-              "uuid": "7f379aae-8008-4785-9ca2-c5963aebec1a",
-              "destination_uuid": null
+              "destination_uuid": null,
+              "uuid": "7f379aae-8008-4785-9ca2-c5963aebec1a"
             }
-          ]
+          ],
+          "uuid": "b227a3e5-bcfb-4d77-b4ac-a4a2500e0cbd"
         }
       ],
-      "spec_version": "13.1.0",
+      "revision": 7,
+      "spec_version": "14.4.0",
       "type": "voice",
-      "uuid": "5fdf1652-f034-4265-ad14-eccc3019d6c7",
-      "revision": 7
+      "uuid": "5fdf1652-f034-4265-ad14-eccc3019d6c7"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/mailroom/parent_child_expiration.json
+++ b/media/test_flows/mailroom/parent_child_expiration.json
@@ -1,243 +1,297 @@
 {
-  "version": "11.11",
+  "version": "13",
   "site": "https://textit.in",
   "flows": [
     {
-      "entry": "b834eea1-443c-4201-99f9-fcd1e4c5eac0",
-      "action_sets": [
-        {
-          "uuid": "b834eea1-443c-4201-99f9-fcd1e4c5eac0",
-          "x": 69,
-          "y": 0,
-          "destination": "fc0caf53-8d87-469a-97a5-153cbb63a7a1",
-          "actions": [
-            {
-              "type": "reply",
-              "uuid": "f7d5f2c4-1e55-4926-8306-2538eaadabe3",
-              "msg": {
-                "eng": "This is parent"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
-            }
-          ],
-          "exit_uuid": "1e25f7de-96ca-4f8c-94cc-f0bb23bde9b2"
-        },
-        {
-          "uuid": "672802f8-4432-4244-99b0-404af1b285b7",
-          "x": 121,
-          "y": 280,
-          "destination": "6594a948-fdbf-482a-af5c-7b01d39121da",
-          "actions": [
-            {
-              "type": "reply",
-              "uuid": "98fa3ef8-eeee-46d2-a735-cdf6fc2374c2",
-              "msg": {
-                "eng": "Completed"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
-            }
-          ],
-          "exit_uuid": "d138f858-ff92-40ae-80b5-5b0893066012"
-        },
-        {
-          "uuid": "b8bb71fb-d27b-42a6-98a4-2e73c137c2e8",
-          "x": 431,
-          "y": 276,
-          "destination": "6594a948-fdbf-482a-af5c-7b01d39121da",
-          "actions": [
-            {
-              "type": "reply",
-              "uuid": "4cbfa0fb-d622-4e25-ab5e-37d35602baf8",
-              "msg": {
-                "eng": "Expired"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
-            }
-          ],
-          "exit_uuid": "d5ccef96-250f-41c1-b66d-914774ba0381"
-        },
-        {
-          "uuid": "36b55887-3fe3-49be-b3c7-2abdf288fdbb",
-          "x": 267,
-          "y": 585,
-          "destination": null,
-          "actions": [
-            {
-              "type": "reply",
-              "uuid": "fe65073d-79f5-489b-a811-c539f727f276",
-              "msg": {
-                "eng": "Ended"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
-            }
-          ],
-          "exit_uuid": "15194711-df3d-4519-8009-bc52061c2b88"
-        }
-      ],
-      "rule_sets": [
-        {
-          "uuid": "fc0caf53-8d87-469a-97a5-153cbb63a7a1",
-          "x": 299,
-          "y": 99,
-          "label": "Response 1",
-          "rules": [
-            {
-              "uuid": "17ce588f-1eca-45ab-a94b-a93872556f77",
-              "category": {
-                "eng": "Completed"
-              },
-              "destination": "672802f8-4432-4244-99b0-404af1b285b7",
-              "destination_type": "A",
-              "test": {
-                "type": "subflow",
-                "exit_type": "completed"
-              },
-              "label": null
+      "_ui": {
+        "nodes": {
+          "36b55887-3fe3-49be-b3c7-2abdf288fdbb": {
+            "position": {
+              "left": 267,
+              "top": 585
             },
-            {
-              "uuid": "cca1bd3d-1e88-4c5c-80e2-451d39700672",
-              "category": {
-                "eng": "Expired"
-              },
-              "destination": "b8bb71fb-d27b-42a6-98a4-2e73c137c2e8",
-              "destination_type": "A",
-              "test": {
-                "type": "subflow",
-                "exit_type": "expired"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "subflow",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {
-            "flow": {
-              "name": "child",
-              "uuid": "c4dd3c3a-1c7c-4bb8-a8c4-11aaec1a4fea"
-            }
+            "type": "execute_actions"
+          },
+          "6594a948-fdbf-482a-af5c-7b01d39121da": {
+            "position": {
+              "left": 252,
+              "top": 434
+            },
+            "type": "wait_for_response"
+          },
+          "672802f8-4432-4244-99b0-404af1b285b7": {
+            "position": {
+              "left": 121,
+              "top": 280
+            },
+            "type": "execute_actions"
+          },
+          "b834eea1-443c-4201-99f9-fcd1e4c5eac0": {
+            "position": {
+              "left": 69,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "b8bb71fb-d27b-42a6-98a4-2e73c137c2e8": {
+            "position": {
+              "left": 431,
+              "top": 276
+            },
+            "type": "execute_actions"
+          },
+          "fc0caf53-8d87-469a-97a5-153cbb63a7a1": {
+            "position": {
+              "left": 299,
+              "top": 99
+            },
+            "type": "split_by_subflow"
           }
         },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "parent",
+      "nodes": [
         {
-          "uuid": "6594a948-fdbf-482a-af5c-7b01d39121da",
-          "x": 252,
-          "y": 434,
-          "label": "End",
-          "rules": [
-            {
-              "uuid": "dd86be4e-8c54-4ef6-84dc-6f786fe2c7b1",
-              "category": {
-                "eng": "All Responses"
-              },
-              "destination": "36b55887-3fe3-49be-b3c7-2abdf288fdbb",
-              "destination_type": "A",
-              "test": {
-                "type": "true"
-              },
-              "label": null
-            }
-          ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
-        }
-      ],
-      "base_language": "eng",
-      "flow_type": "M",
-      "version": "11.11",
-      "metadata": {
-        "name": "parent",
-        "saved_on": "2019-02-19T21:38:35.335104Z",
-        "revision": 33,
-        "uuid": "2cdcd8d9-a210-4269-a0cd-f4a07cc4f68a",
-        "expires": 10080
-      }
-    },
-    {
-      "entry": "f94a3ae8-7f2d-40eb-8430-017be1c48a62",
-      "action_sets": [
-        {
-          "uuid": "f94a3ae8-7f2d-40eb-8430-017be1c48a62",
-          "x": 100,
-          "y": 0,
-          "destination": "6b35ab7c-e517-40a1-b3dd-006bc66afc61",
           "actions": [
             {
-              "type": "reply",
-              "uuid": "45f8719d-5d66-42d7-b126-38df067dd78b",
-              "msg": {
-                "eng": "Child"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "This is parent",
+              "type": "send_msg",
+              "uuid": "f7d5f2c4-1e55-4926-8306-2538eaadabe3"
             }
           ],
-          "exit_uuid": "de31d5ec-7e00-4391-a5d1-ad28cd39faa7"
-        }
-      ],
-      "rule_sets": [
-        {
-          "uuid": "6b35ab7c-e517-40a1-b3dd-006bc66afc61",
-          "x": 233,
-          "y": 162,
-          "label": "Response 1",
-          "rules": [
+          "exits": [
             {
-              "uuid": "97e713bf-1027-4c67-a884-0cefc1d5a6f3",
-              "category": {
-                "eng": "All Responses"
+              "destination_uuid": "fc0caf53-8d87-469a-97a5-153cbb63a7a1",
+              "uuid": "1e25f7de-96ca-4f8c-94cc-f0bb23bde9b2"
+            }
+          ],
+          "uuid": "b834eea1-443c-4201-99f9-fcd1e4c5eac0"
+        },
+        {
+          "actions": [
+            {
+              "flow": {
+                "name": "child",
+                "uuid": "c4dd3c3a-1c7c-4bb8-a8c4-11aaec1a4fea"
               },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "true"
-              },
-              "label": null
+              "type": "enter_flow",
+              "uuid": "45b4b6bd-1a87-460b-ba95-e39e147f7732"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "672802f8-4432-4244-99b0-404af1b285b7",
+              "uuid": "17ce588f-1eca-45ab-a94b-a93872556f77"
             },
             {
-              "uuid": "2d792a87-b07f-4e9b-b82e-61d0278811c6",
-              "category": {
-                "eng": "No Response"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "timeout",
-                "minutes": 1
-              },
-              "label": null
+              "destination_uuid": "b8bb71fb-d27b-42a6-98a4-2e73c137c2e8",
+              "uuid": "cca1bd3d-1e88-4c5c-80e2-451d39700672"
             }
           ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "completed"
+                ],
+                "category_uuid": "f90efbe2-2a29-4e50-abe0-33faa5ac1172",
+                "type": "has_only_text",
+                "uuid": "5465e3cc-0d3d-48e8-8c7d-1aee9d4937cc"
+              },
+              {
+                "arguments": [
+                  "expired"
+                ],
+                "category_uuid": "1dbd060f-6cf5-4982-93e0-4504af167055",
+                "type": "has_only_text",
+                "uuid": "2f1c39d0-250d-45f6-93f4-0755a081c82f"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "17ce588f-1eca-45ab-a94b-a93872556f77",
+                "name": "Completed",
+                "uuid": "f90efbe2-2a29-4e50-abe0-33faa5ac1172"
+              },
+              {
+                "exit_uuid": "cca1bd3d-1e88-4c5c-80e2-451d39700672",
+                "name": "Expired",
+                "uuid": "1dbd060f-6cf5-4982-93e0-4504af167055"
+              }
+            ],
+            "default_category_uuid": "",
+            "operand": "@child.status",
+            "result_name": "Response 1",
+            "type": "switch"
+          },
+          "uuid": "fc0caf53-8d87-469a-97a5-153cbb63a7a1"
+        },
+        {
+          "actions": [
+            {
+              "text": "Expired",
+              "type": "send_msg",
+              "uuid": "4cbfa0fb-d622-4e25-ab5e-37d35602baf8"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "6594a948-fdbf-482a-af5c-7b01d39121da",
+              "uuid": "d5ccef96-250f-41c1-b66d-914774ba0381"
+            }
+          ],
+          "uuid": "b8bb71fb-d27b-42a6-98a4-2e73c137c2e8"
+        },
+        {
+          "actions": [
+            {
+              "text": "Completed",
+              "type": "send_msg",
+              "uuid": "98fa3ef8-eeee-46d2-a735-cdf6fc2374c2"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "6594a948-fdbf-482a-af5c-7b01d39121da",
+              "uuid": "d138f858-ff92-40ae-80b5-5b0893066012"
+            }
+          ],
+          "uuid": "672802f8-4432-4244-99b0-404af1b285b7"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "36b55887-3fe3-49be-b3c7-2abdf288fdbb",
+              "uuid": "dd86be4e-8c54-4ef6-84dc-6f786fe2c7b1"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "dd86be4e-8c54-4ef6-84dc-6f786fe2c7b1",
+                "name": "All Responses",
+                "uuid": "abbfa780-8fd3-4720-ae24-60b30c3f3177"
+              }
+            ],
+            "default_category_uuid": "abbfa780-8fd3-4720-ae24-60b30c3f3177",
+            "operand": "@input",
+            "result_name": "End",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "6594a948-fdbf-482a-af5c-7b01d39121da"
+        },
+        {
+          "actions": [
+            {
+              "text": "Ended",
+              "type": "send_msg",
+              "uuid": "fe65073d-79f5-489b-a811-c539f727f276"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "15194711-df3d-4519-8009-bc52061c2b88"
+            }
+          ],
+          "uuid": "36b55887-3fe3-49be-b3c7-2abdf288fdbb"
         }
       ],
-      "base_language": "eng",
-      "flow_type": "M",
-      "version": "11.11",
-      "metadata": {
-        "name": "child",
-        "saved_on": "2019-02-19T21:26:35.104036Z",
-        "revision": 12,
-        "uuid": "c4dd3c3a-1c7c-4bb8-a8c4-11aaec1a4fea",
-        "expires": 5,
-        "ivr_retry_failed_events": null
-      }
+      "revision": 33,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "2cdcd8d9-a210-4269-a0cd-f4a07cc4f68a"
+    },
+    {
+      "_ui": {
+        "nodes": {
+          "6b35ab7c-e517-40a1-b3dd-006bc66afc61": {
+            "position": {
+              "left": 233,
+              "top": 162
+            },
+            "type": "wait_for_response"
+          },
+          "f94a3ae8-7f2d-40eb-8430-017be1c48a62": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 5,
+      "language": "eng",
+      "localization": {},
+      "name": "child",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "Child",
+              "type": "send_msg",
+              "uuid": "45f8719d-5d66-42d7-b126-38df067dd78b"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "6b35ab7c-e517-40a1-b3dd-006bc66afc61",
+              "uuid": "de31d5ec-7e00-4391-a5d1-ad28cd39faa7"
+            }
+          ],
+          "uuid": "f94a3ae8-7f2d-40eb-8430-017be1c48a62"
+        },
+        {
+          "exits": [
+            {
+              "uuid": "97e713bf-1027-4c67-a884-0cefc1d5a6f3"
+            },
+            {
+              "uuid": "2d792a87-b07f-4e9b-b82e-61d0278811c6"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "97e713bf-1027-4c67-a884-0cefc1d5a6f3",
+                "name": "All Responses",
+                "uuid": "00281a29-46b7-419e-b4d4-3585a5ee821c"
+              },
+              {
+                "exit_uuid": "2d792a87-b07f-4e9b-b82e-61d0278811c6",
+                "name": "No Response",
+                "uuid": "f8566ece-fd21-42b1-af10-e0b450151ba5"
+              }
+            ],
+            "default_category_uuid": "00281a29-46b7-419e-b4d4-3585a5ee821c",
+            "operand": "@input",
+            "result_name": "Response 1",
+            "type": "switch",
+            "wait": {
+              "timeout": {
+                "category_uuid": "f8566ece-fd21-42b1-af10-e0b450151ba5",
+                "seconds": 60
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "6b35ab7c-e517-40a1-b3dd-006bc66afc61"
+        }
+      ],
+      "revision": 12,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "c4dd3c3a-1c7c-4bb8-a8c4-11aaec1a4fea"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/mailroom/pick_a_number.json
+++ b/media/test_flows/mailroom/pick_a_number.json
@@ -1,88 +1,157 @@
 {
   "campaigns": [],
-  "version": 3,
+  "version": "13",
   "site": "http://rapidpro.io",
   "flows": [
     {
-      "definition": {
-        "rule_sets": [
-          {
-            "y": 106,
-            "x": 100,
-            "response_type": "C",
-            "rules": [
+      "_ui": {
+        "nodes": {
+          "06bb3899-5de4-4cbc-ad5f-70b9634d80c4": {
+            "position": {
+              "left": 100,
+              "top": 106
+            },
+            "type": "wait_for_response"
+          },
+          "2f2adf23-87db-41d3-9436-afe48ab5403c": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "9a8ba8b2-8c80-4635-9f5d-015c15fdc44a": {
+            "position": {
+              "left": 118,
+              "top": 228
+            },
+            "type": "execute_actions"
+          },
+          "fa15e3c4-cd1a-4b95-9303-352e7e4ae19f": {
+            "config": {
+              "operand": {
+                "id": "name",
+                "name": "Name",
+                "type": "property"
+              }
+            },
+            "position": {
+              "left": 300,
+              "top": 300
+            },
+            "type": "split_by_contact_field"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Pick a Number",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "Pick a number between 1-10.",
+              "type": "send_msg",
+              "uuid": "12d17773-4696-4228-8a37-b119a0ab093f"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "06bb3899-5de4-4cbc-ad5f-70b9634d80c4",
+              "uuid": "cc734b14-b31c-4e63-b0dd-88ce6dd9ed53"
+            }
+          ],
+          "uuid": "2f2adf23-87db-41d3-9436-afe48ab5403c"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "9a8ba8b2-8c80-4635-9f5d-015c15fdc44a",
+              "uuid": "41418f9d-73e5-43b8-a341-3f7af70e13c1"
+            },
+            {
+              "uuid": "e53c2616-7b8d-4821-968a-4488e9980454"
+            }
+          ],
+          "router": {
+            "cases": [
               {
-                "test": {
-                  "max": "10",
-                  "type": "between",
-                  "min": "1"
-                },
-                "destination": "9a8ba8b2-8c80-4635-9f5d-015c15fdc44a",
-                "uuid": "41418f9d-73e5-43b8-a341-3f7af70e13c1"
+                "arguments": [
+                  "1",
+                  "10"
+                ],
+                "category_uuid": "9a7a9f28-5bea-4da7-a288-7ed3c2b2eeb3",
+                "type": "has_number_between",
+                "uuid": "3b21826c-59b2-410f-aded-5fd5f40fec16"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "41418f9d-73e5-43b8-a341-3f7af70e13c1",
+                "name": "1-10",
+                "uuid": "9a7a9f28-5bea-4da7-a288-7ed3c2b2eeb3"
               },
               {
-                "test": {
-                  "test": "true",
-                  "type": "true"
-                },
-                "category": "Other",
-                "destination": null,
-                "uuid": "e53c2616-7b8d-4821-968a-4488e9980454"
+                "exit_uuid": "e53c2616-7b8d-4821-968a-4488e9980454",
+                "name": "Other",
+                "uuid": "e91c9c0b-a761-47e6-8527-b6055ebe39b3"
               }
             ],
-            "uuid": "06bb3899-5de4-4cbc-ad5f-70b9634d80c4",
-            "label": "number"
+            "default_category_uuid": "e91c9c0b-a761-47e6-8527-b6055ebe39b3",
+            "operand": "@input",
+            "result_name": "number",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
           },
-          {
-            "y": 300,
-            "x": 300,
-            "response_type": "C",
-            "rules": [
+          "uuid": "06bb3899-5de4-4cbc-ad5f-70b9634d80c4"
+        },
+        {
+          "actions": [
+            {
+              "text": "You picked @results.number!",
+              "type": "send_msg",
+              "uuid": "70588336-7b9e-45c3-b83d-605243646251"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "b4573ddf-f28c-4aa6-8574-4fe3b9827882"
+            }
+          ],
+          "uuid": "9a8ba8b2-8c80-4635-9f5d-015c15fdc44a"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "06bb3899-5de4-4cbc-ad5f-70b9634d80c4",
+              "uuid": "586e84c2-d9b5-45d7-ac2e-f0640c040f30"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
               {
-                "test": {
-                  "test": "true",
-                  "type": "true"
-                },
-                "category": "All Responses",
-                "destination": "06bb3899-5de4-4cbc-ad5f-70b9634d80c4",
-                "uuid": "586e84c2-d9b5-45d7-ac2e-f0640c040f30"
+                "exit_uuid": "586e84c2-d9b5-45d7-ac2e-f0640c040f30",
+                "name": "All Responses",
+                "uuid": "b9840285-a708-4845-b9c6-b2a7b28fa650"
               }
             ],
-            "uuid": "fa15e3c4-cd1a-4b95-9303-352e7e4ae19f",
-            "label": "passive",
-            "operand": "@contact.name"
-          }
-        ],
-        "action_sets": [
-          {
-            "y": 0,
-            "x": 100,
-            "destination": "06bb3899-5de4-4cbc-ad5f-70b9634d80c4",
-            "uuid": "2f2adf23-87db-41d3-9436-afe48ab5403c",
-            "actions": [
-              {
-                "msg": "Pick a number between 1-10.",
-                "type": "reply"
-              }
-            ]
+            "default_category_uuid": "b9840285-a708-4845-b9c6-b2a7b28fa650",
+            "operand": "@contact.name",
+            "result_name": "passive",
+            "type": "switch"
           },
-          {
-            "y": 228,
-            "x": 118,
-            "destination": null,
-            "uuid": "9a8ba8b2-8c80-4635-9f5d-015c15fdc44a",
-            "actions": [
-              {
-                "msg": "You picked @flow.number!",
-                "type": "reply"
-              }
-            ]
-          }
-        ]
-      },
-      "flow_type": "F",
-      "name": "Pick a Number",
-      "id": 2100
+          "uuid": "fa15e3c4-cd1a-4b95-9303-352e7e4ae19f"
+        }
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "dd034104-4a78-4aad-9beb-e9d79d8c84a9"
     }
   ],
   "triggers": []

--- a/media/test_flows/mailroom/send_all.json
+++ b/media/test_flows/mailroom/send_all.json
@@ -1,40 +1,47 @@
 {
-  "campaigns": [], 
-  "version": 10, 
-  "site": "https://app.rapidpro.io", 
+  "campaigns": [],
+  "version": "13",
+  "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "14fb87aa-22cc-4e9a-a8d6-dd4640426bed": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Send All",
+      "nodes": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": null, 
-          "uuid": "14fb87aa-22cc-4e9a-a8d6-dd4640426bed", 
           "actions": [
             {
-              "msg": {
-                "eng": "Hey, how are you?"
-              }, 
-              "media": {}, 
-              "send_all": true, 
-              "type": "reply"
+              "text": "Hey, how are you?",
+              "type": "send_msg",
+              "uuid": "88d51772-7cde-4001-a16d-7ad932a7cd2d"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "uuid": "cd58fa97-1dad-44eb-8265-5f3e962a0da9"
+            }
+          ],
+          "uuid": "14fb87aa-22cc-4e9a-a8d6-dd4640426bed"
         }
-      ], 
-      "version": 10, 
-      "flow_type": "F", 
-      "entry": "14fb87aa-22cc-4e9a-a8d6-dd4640426bed", 
-      "rule_sets": [], 
-      "metadata": {
-        "expires": 10080, 
-        "revision": 1, 
-        "uuid": "4b8089fb-bb10-4cbc-800f-a0aa8bb21713", 
-        "name": "Send All", 
-        "saved_on": "2017-03-16T14:53:04.119831Z"
-      }
+      ],
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "4b8089fb-bb10-4cbc-800f-a0aa8bb21713"
     }
-  ], 
+  ],
   "triggers": []
 }

--- a/media/test_flows/mailroom/sms_form.json
+++ b/media/test_flows/mailroom/sms_form.json
@@ -1,298 +1,352 @@
 {
-  "version": 5,
+  "version": "13",
   "flows": [
     {
-      "definition": {
-        "base_language": "eng",
-        "action_sets": [
-          {
-            "y": 0,
-            "x": 119,
-            "destination": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
-            "uuid": "2e6aaa75-ffb7-4c48-baee-57e4149e452c",
-            "actions": [
-              {
-                "msg": {
-                  "eng": "What is your age, sex, location? Separate your responses with a space. For example \"15 f seattle\"."
-                },
-                "type": "reply"
-              }
-            ]
+      "_ui": {
+        "nodes": {
+          "0b18b474-00ab-40a0-af25-5d7c91aa64d7": {
+            "position": {
+              "left": 116,
+              "top": 234
+            },
+            "type": "execute_actions"
           },
-          {
-            "y": 265,
-            "x": 904,
-            "destination": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
-            "uuid": "9f1c79ae-581a-45ff-a9ea-4096f8231aad",
-            "actions": [
-              {
-                "msg": {
-                  "eng": "Sorry, @flow.age doesn't look like a valid age, please try again."
-                },
-                "type": "reply"
-              }
-            ]
+          "1cc063a7-afea-460d-b8a0-c8c2a2e37e35": {
+            "position": {
+              "left": 831,
+              "top": 414
+            },
+            "type": "execute_actions"
           },
-          {
-            "y": 414,
-            "x": 831,
-            "destination": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
-            "uuid": "1cc063a7-afea-460d-b8a0-c8c2a2e37e35",
-            "actions": [
-              {
-                "msg": {
-                  "eng": "Sorry, @flow.gender doesn't look like a valid gender. Try again."
-                },
-                "type": "reply"
-              }
-            ]
+          "2e6aaa75-ffb7-4c48-baee-57e4149e452c": {
+            "position": {
+              "left": 119,
+              "top": 0
+            },
+            "type": "execute_actions"
           },
-          {
-            "y": 571,
-            "x": 735,
-            "destination": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
-            "uuid": "6be94ef5-bffc-4864-bd71-8e7cd87d7178",
-            "actions": [
-              {
-                "msg": {
-                  "eng": "I don't know the location @flow.location. Please try again."
-                },
-                "type": "reply"
+          "3d8c9a32-fe04-4b95-9b2c-c66dd4ff2b24": {
+            "config": {
+              "delimiter": " ",
+              "index": 2,
+              "operand": {
+                "id": "message_form"
               }
-            ]
+            },
+            "position": {
+              "left": 366,
+              "top": 486
+            },
+            "type": "split_by_run_result_delimited"
           },
-          {
-            "y": 234,
-            "x": 116,
-            "destination": null,
-            "uuid": "0b18b474-00ab-40a0-af25-5d7c91aa64d7",
-            "actions": [
-              {
-                "msg": {
-                  "eng": "Thanks for your submission. We have that as:\n\n@flow.age / @flow.gender / @flow.location"
-                },
-                "type": "reply"
+          "6be94ef5-bffc-4864-bd71-8e7cd87d7178": {
+            "position": {
+              "left": 735,
+              "top": 571
+            },
+            "type": "execute_actions"
+          },
+          "9f1c79ae-581a-45ff-a9ea-4096f8231aad": {
+            "position": {
+              "left": 904,
+              "top": 265
+            },
+            "type": "execute_actions"
+          },
+          "b7563d6f-279a-4b19-bff6-0ee3ccfa5d5f": {
+            "config": {
+              "delimiter": " ",
+              "index": 0,
+              "operand": {
+                "id": "message_form"
               }
-            ]
+            },
+            "position": {
+              "left": 460,
+              "top": 226
+            },
+            "type": "split_by_run_result_delimited"
+          },
+          "d0e01dde-dcd2-43e9-8f8e-ae1699a80395": {
+            "position": {
+              "left": 459,
+              "top": 117
+            },
+            "type": "wait_for_response"
+          },
+          "eb669471-fadf-489b-9ce6-c10bb4add673": {
+            "config": {
+              "delimiter": " ",
+              "index": 1,
+              "operand": {
+                "id": "message_form"
+              }
+            },
+            "position": {
+              "left": 385,
+              "top": 344
+            },
+            "type": "split_by_run_result_delimited"
           }
-        ],
-        "last_saved": "2015-08-05T19:02:29.296446Z",
-        "entry": "2e6aaa75-ffb7-4c48-baee-57e4149e452c",
-        "rule_sets": [
-          {
-            "uuid": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
-            "webhook_action": null,
-            "rules": [
-              {
-                "category": {
-                  "base": "All Responses",
-                  "eng": "All Responses"
-                },
-                "uuid": "bb0c523f-d216-4bf3-8794-664a9d9b3ccb",
-                "destination": "b7563d6f-279a-4b19-bff6-0ee3ccfa5d5f",
-                "destination_type": "R",
-                "test": {
-                  "test": "true",
-                  "type": "true"
-                },
-                "config": {
-                  "type": "true",
-                  "verbose_name": "contains anything",
-                  "name": "Other",
-                  "operands": 0
-                }
-              }
-            ],
-            "webhook": null,
-            "ruleset_type": "wait_message",
-            "label": "Message Form",
-            "operand": "@step.value",
-            "finished_key": null,
-            "response_type": "",
-            "y": 117,
-            "x": 459,
-            "config": {}
-          },
-          {
-            "uuid": "b7563d6f-279a-4b19-bff6-0ee3ccfa5d5f",
-            "webhook_action": null,
-            "rules": [
-              {
-                "test": {
-                  "max": "100",
-                  "type": "between",
-                  "min": "0"
-                },
-                "category": {
-                  "base": "0 - 100",
-                  "eng": "0 - 100"
-                },
-                "destination": "eb669471-fadf-489b-9ce6-c10bb4add673",
-                "uuid": "a9c7276e-2f5d-4e6d-9efd-2b8d39c3ec50",
-                "destination_type": "R"
-              },
-              {
-                "category": {
-                  "base": "Other",
-                  "eng": "Other"
-                },
-                "uuid": "83ce1500-c6e6-4eb1-8feb-76cd439c6e36",
-                "destination": "9f1c79ae-581a-45ff-a9ea-4096f8231aad",
-                "destination_type": "A",
-                "test": {
-                  "test": "true",
-                  "type": "true"
-                },
-                "config": {
-                  "type": "true",
-                  "verbose_name": "contains anything",
-                  "name": "Other",
-                  "operands": 0
-                }
-              }
-            ],
-            "webhook": null,
-            "ruleset_type": "form_field",
-            "label": "Age",
-            "operand": "@flow.message_form",
-            "finished_key": null,
-            "response_type": "",
-            "y": 226,
-            "x": 460,
-            "config": {
-              "field_delimiter": " ",
-              "field_index": 0
-            }
-          },
-          {
-            "uuid": "eb669471-fadf-489b-9ce6-c10bb4add673",
-            "webhook_action": null,
-            "rules": [
-              {
-                "test": {
-                  "test": {
-                    "eng": "Male m"
-                  },
-                  "base": "Male m",
-                  "type": "contains_any"
-                },
-                "category": {
-                  "base": "Male",
-                  "eng": "Male"
-                },
-                "destination": "3d8c9a32-fe04-4b95-9b2c-c66dd4ff2b24",
-                "uuid": "bda1d6b0-2b8d-4ddb-a888-3e41b3243a0f",
-                "destination_type": "R"
-              },
-              {
-                "test": {
-                  "test": {
-                    "eng": "Female f"
-                  },
-                  "base": "Female f",
-                  "type": "contains_any"
-                },
-                "category": {
-                  "base": "Female",
-                  "eng": "Female"
-                },
-                "destination": "3d8c9a32-fe04-4b95-9b2c-c66dd4ff2b24",
-                "uuid": "4b8421ab-209f-4638-a267-82c4f83c73b2",
-                "destination_type": "R"
-              },
-              {
-                "category": {
-                  "base": "Other",
-                  "eng": "Other"
-                },
-                "uuid": "b61d7b97-21ab-4df5-a475-d16122aba572",
-                "destination": "1cc063a7-afea-460d-b8a0-c8c2a2e37e35",
-                "destination_type": "A",
-                "test": {
-                  "test": "true",
-                  "type": "true"
-                },
-                "config": {
-                  "type": "true",
-                  "verbose_name": "contains anything",
-                  "name": "Other",
-                  "operands": 0
-                }
-              }
-            ],
-            "webhook": null,
-            "ruleset_type": "form_field",
-            "label": "Gender",
-            "operand": "@flow.message_form",
-            "finished_key": null,
-            "response_type": "",
-            "y": 344,
-            "x": 385,
-            "config": {
-              "field_delimiter": " ",
-              "field_index": 1
-            }
-          },
-          {
-            "uuid": "3d8c9a32-fe04-4b95-9b2c-c66dd4ff2b24",
-            "webhook_action": null,
-            "rules": [
-              {
-                "test": {
-                  "test": {
-                    "eng": "seattle chicago miami"
-                  },
-                  "base": "seattle chicago miami",
-                  "type": "contains_any"
-                },
-                "category": {
-                  "base": "Valid",
-                  "eng": "Valid"
-                },
-                "destination": "0b18b474-00ab-40a0-af25-5d7c91aa64d7",
-                "uuid": "1b36cb64-b0ce-43cc-9b50-8f45f29c9643",
-                "destination_type": "A"
-              },
-              {
-                "category": {
-                  "base": "Other",
-                  "eng": "Other"
-                },
-                "uuid": "b9419b3c-0cd0-4956-93ac-b6fd0da2964a",
-                "destination": "6be94ef5-bffc-4864-bd71-8e7cd87d7178",
-                "destination_type": "A",
-                "test": {
-                  "test": "true",
-                  "type": "true"
-                },
-                "config": {
-                  "type": "true",
-                  "verbose_name": "contains anything",
-                  "name": "Other",
-                  "operands": 0
-                }
-              }
-            ],
-            "webhook": null,
-            "ruleset_type": "form_field",
-            "label": "Location",
-            "operand": "@flow.message_form",
-            "finished_key": null,
-            "response_type": "",
-            "y": 486,
-            "x": 366,
-            "config": {
-              "field_delimiter": " ",
-              "field_index": 2
-            }
-          }
-        ],
-        "metadata": {}
+        },
+        "stickies": {}
       },
-      "expires": 10080,
-      "id": 34393,
-      "flow_type": "F",
-      "name": "SMS Form"
+      "expire_after_minutes": 0,
+      "language": "eng",
+      "localization": {},
+      "name": "SMS Form",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "What is your age, sex, location? Separate your responses with a space. For example \"15 f seattle\".",
+              "type": "send_msg",
+              "uuid": "df38e0f5-2118-4cb8-bf5f-6715ce05c5f5"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
+              "uuid": "da0b87ee-5beb-41c8-a285-a6b885304ab4"
+            }
+          ],
+          "uuid": "2e6aaa75-ffb7-4c48-baee-57e4149e452c"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "b7563d6f-279a-4b19-bff6-0ee3ccfa5d5f",
+              "uuid": "bb0c523f-d216-4bf3-8794-664a9d9b3ccb"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "bb0c523f-d216-4bf3-8794-664a9d9b3ccb",
+                "name": "All Responses",
+                "uuid": "472bd5c2-3e04-4c13-8d1e-8682bc264c41"
+              }
+            ],
+            "default_category_uuid": "472bd5c2-3e04-4c13-8d1e-8682bc264c41",
+            "operand": "@input",
+            "result_name": "Message Form",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "eb669471-fadf-489b-9ce6-c10bb4add673",
+              "uuid": "a9c7276e-2f5d-4e6d-9efd-2b8d39c3ec50"
+            },
+            {
+              "destination_uuid": "9f1c79ae-581a-45ff-a9ea-4096f8231aad",
+              "uuid": "83ce1500-c6e6-4eb1-8feb-76cd439c6e36"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "0",
+                  "100"
+                ],
+                "category_uuid": "c74654d1-6fe2-4727-8a2c-5759e9711344",
+                "type": "has_number_between",
+                "uuid": "ea373dfd-0ff4-4629-aac1-11139459d11d"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "a9c7276e-2f5d-4e6d-9efd-2b8d39c3ec50",
+                "name": "0 - 100",
+                "uuid": "c74654d1-6fe2-4727-8a2c-5759e9711344"
+              },
+              {
+                "exit_uuid": "83ce1500-c6e6-4eb1-8feb-76cd439c6e36",
+                "name": "Other",
+                "uuid": "7a95d343-9518-472d-a080-804071b59c8b"
+              }
+            ],
+            "default_category_uuid": "7a95d343-9518-472d-a080-804071b59c8b",
+            "operand": "@(field(results.message_form, 0, \" \"))",
+            "result_name": "Age",
+            "type": "switch"
+          },
+          "uuid": "b7563d6f-279a-4b19-bff6-0ee3ccfa5d5f"
+        },
+        {
+          "actions": [
+            {
+              "text": "Thanks for your submission. We have that as:\n\n@results.age / @results.gender / @results.location",
+              "type": "send_msg",
+              "uuid": "a6aa8390-0a2d-443a-ba03-d7ed94038f0a"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "cce97819-2766-477a-8088-87423f16573c"
+            }
+          ],
+          "uuid": "0b18b474-00ab-40a0-af25-5d7c91aa64d7"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry, @results.age doesn't look like a valid age, please try again.",
+              "type": "send_msg",
+              "uuid": "2e5fe8c9-490a-4453-ba34-27b9de3b9f16"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
+              "uuid": "e19af06c-7bef-4547-bb79-3aa5c29e2a03"
+            }
+          ],
+          "uuid": "9f1c79ae-581a-45ff-a9ea-4096f8231aad"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "3d8c9a32-fe04-4b95-9b2c-c66dd4ff2b24",
+              "uuid": "bda1d6b0-2b8d-4ddb-a888-3e41b3243a0f"
+            },
+            {
+              "destination_uuid": "3d8c9a32-fe04-4b95-9b2c-c66dd4ff2b24",
+              "uuid": "4b8421ab-209f-4638-a267-82c4f83c73b2"
+            },
+            {
+              "destination_uuid": "1cc063a7-afea-460d-b8a0-c8c2a2e37e35",
+              "uuid": "b61d7b97-21ab-4df5-a475-d16122aba572"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Male m"
+                ],
+                "category_uuid": "aeed1446-9a11-4187-bf10-f6a3e5925bb5",
+                "type": "has_any_word",
+                "uuid": "e48e3c86-9297-4d05-ac99-223cde55cecc"
+              },
+              {
+                "arguments": [
+                  "Female f"
+                ],
+                "category_uuid": "357c7a34-b061-4e5c-9ea0-2078676bc251",
+                "type": "has_any_word",
+                "uuid": "33f74f75-c7ee-4f27-94f2-f617c49a9c1e"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "bda1d6b0-2b8d-4ddb-a888-3e41b3243a0f",
+                "name": "Male",
+                "uuid": "aeed1446-9a11-4187-bf10-f6a3e5925bb5"
+              },
+              {
+                "exit_uuid": "4b8421ab-209f-4638-a267-82c4f83c73b2",
+                "name": "Female",
+                "uuid": "357c7a34-b061-4e5c-9ea0-2078676bc251"
+              },
+              {
+                "exit_uuid": "b61d7b97-21ab-4df5-a475-d16122aba572",
+                "name": "Other",
+                "uuid": "e87ea167-0b7d-401c-9c2a-09a22b879fe4"
+              }
+            ],
+            "default_category_uuid": "e87ea167-0b7d-401c-9c2a-09a22b879fe4",
+            "operand": "@(field(results.message_form, 1, \" \"))",
+            "result_name": "Gender",
+            "type": "switch"
+          },
+          "uuid": "eb669471-fadf-489b-9ce6-c10bb4add673"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry, @results.gender doesn't look like a valid gender. Try again.",
+              "type": "send_msg",
+              "uuid": "9ed4d362-e60e-4376-998b-5a70ba618320"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
+              "uuid": "f8fb5498-20a1-4c42-b7ab-d492dbec7efd"
+            }
+          ],
+          "uuid": "1cc063a7-afea-460d-b8a0-c8c2a2e37e35"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "0b18b474-00ab-40a0-af25-5d7c91aa64d7",
+              "uuid": "1b36cb64-b0ce-43cc-9b50-8f45f29c9643"
+            },
+            {
+              "destination_uuid": "6be94ef5-bffc-4864-bd71-8e7cd87d7178",
+              "uuid": "b9419b3c-0cd0-4956-93ac-b6fd0da2964a"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "seattle chicago miami"
+                ],
+                "category_uuid": "10b5ab8c-a9ce-4480-a404-f83eafdad98f",
+                "type": "has_any_word",
+                "uuid": "a22f33c1-6b51-4360-867d-e5d76470ac80"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "1b36cb64-b0ce-43cc-9b50-8f45f29c9643",
+                "name": "Valid",
+                "uuid": "10b5ab8c-a9ce-4480-a404-f83eafdad98f"
+              },
+              {
+                "exit_uuid": "b9419b3c-0cd0-4956-93ac-b6fd0da2964a",
+                "name": "Other",
+                "uuid": "bda4282f-1b8f-4bb1-8713-42abd4203a55"
+              }
+            ],
+            "default_category_uuid": "bda4282f-1b8f-4bb1-8713-42abd4203a55",
+            "operand": "@(field(results.message_form, 2, \" \"))",
+            "result_name": "Location",
+            "type": "switch"
+          },
+          "uuid": "3d8c9a32-fe04-4b95-9b2c-c66dd4ff2b24"
+        },
+        {
+          "actions": [
+            {
+              "text": "I don't know the location @results.location. Please try again.",
+              "type": "send_msg",
+              "uuid": "dcdd3d20-f7e7-4f39-b70c-e711b0722661"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "d0e01dde-dcd2-43e9-8f8e-ae1699a80395",
+              "uuid": "0dadc691-7abd-499a-a28d-fcf0fc4c8066"
+            }
+          ],
+          "uuid": "6be94ef5-bffc-4864-bd71-8e7cd87d7178"
+        }
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "8b53d166-57c2-4943-8e93-a2b4077ec88e"
     }
   ],
   "triggers": []

--- a/media/test_flows/media_survey.json
+++ b/media/test_flows/media_survey.json
@@ -1,202 +1,278 @@
 {
-  "version": 8, 
+  "version": "13",
   "flows": [
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "19d6bdaf-c134-4b90-8f56-60a301060d99": {
+            "position": {
+              "left": 112,
+              "top": 337
+            },
+            "type": "wait_for_response"
+          },
+          "5610d5e4-0b8f-4bef-a5d2-1a1ea61fbb1e": {
+            "position": {
+              "left": 114,
+              "top": 803
+            },
+            "type": "wait_for_response"
+          },
+          "81f732f4-2a35-4283-9b77-abc4a09e5aa2": {
+            "position": {
+              "left": 126,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "893191e2-dd1a-4904-8bd5-1df0e8ef44c2": {
+            "position": {
+              "left": 129,
+              "top": 675
+            },
+            "type": "execute_actions"
+          },
+          "8c6d835f-4d34-4f9e-978f-2f0e161577b5": {
+            "position": {
+              "left": 128,
+              "top": 449
+            },
+            "type": "execute_actions"
+          },
+          "bc2581b8-209c-47a8-b041-ba06faf7eab9": {
+            "position": {
+              "left": 130,
+              "top": 922
+            },
+            "type": "execute_actions"
+          },
+          "e3138a39-5df2-4c6a-918a-a94e7044022c": {
+            "position": {
+              "left": 127,
+              "top": 226
+            },
+            "type": "execute_actions"
+          },
+          "f7a21353-6050-4bed-bd42-b3627ac140d1": {
+            "position": {
+              "left": 113,
+              "top": 566
+            },
+            "type": "wait_for_response"
+          },
+          "fc80c25f-2099-453e-a4a8-9fa826ff3bd4": {
+            "position": {
+              "left": 111,
+              "top": 108
+            },
+            "type": "wait_for_response"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "eng",
+      "localization": {},
+      "name": "Media Survey",
+      "nodes": [
         {
-          "y": 449, 
-          "x": 128, 
-          "destination": "f7a21353-6050-4bed-bd42-b3627ac140d1", 
-          "uuid": "8c6d835f-4d34-4f9e-978f-2f0e161577b5", 
           "actions": [
             {
-              "msg": {
-                "eng": "Send your location"
-              }, 
-              "type": "reply"
+              "text": "What is your name?",
+              "type": "send_msg",
+              "uuid": "57b54958-32bb-459f-81b1-1f4a2c99b218"
             }
-          ]
-        }, 
+          ],
+          "exits": [
+            {
+              "destination_uuid": "fc80c25f-2099-453e-a4a8-9fa826ff3bd4",
+              "uuid": "80a5814c-a514-4056-937f-1387b9c0bc5f"
+            }
+          ],
+          "uuid": "81f732f4-2a35-4283-9b77-abc4a09e5aa2"
+        },
         {
-          "y": 226, 
-          "x": 127, 
-          "destination": "19d6bdaf-c134-4b90-8f56-60a301060d99", 
-          "uuid": "e3138a39-5df2-4c6a-918a-a94e7044022c", 
+          "exits": [
+            {
+              "destination_uuid": "e3138a39-5df2-4c6a-918a-a94e7044022c",
+              "uuid": "6ca9ffbe-2f99-47eb-a750-8c153799c3b6"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "6ca9ffbe-2f99-47eb-a750-8c153799c3b6",
+                "name": "All Responses",
+                "uuid": "bd543961-4501-479f-9dd7-7f2b12f8e0a3"
+              }
+            ],
+            "default_category_uuid": "bd543961-4501-479f-9dd7-7f2b12f8e0a3",
+            "operand": "@input",
+            "result_name": "Name",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "fc80c25f-2099-453e-a4a8-9fa826ff3bd4"
+        },
+        {
           "actions": [
             {
-              "msg": {
-                "eng": "Send a profile pic"
-              }, 
-              "type": "reply"
+              "text": "Send a profile pic",
+              "type": "send_msg",
+              "uuid": "ff42a9a5-349a-4e5a-9497-1baab21810e4"
             }
-          ]
-        }, 
+          ],
+          "exits": [
+            {
+              "destination_uuid": "19d6bdaf-c134-4b90-8f56-60a301060d99",
+              "uuid": "9bbede29-acc6-4dd6-b9bd-ba4472bc7643"
+            }
+          ],
+          "uuid": "e3138a39-5df2-4c6a-918a-a94e7044022c"
+        },
         {
-          "y": 0, 
-          "x": 126, 
-          "destination": "fc80c25f-2099-453e-a4a8-9fa826ff3bd4", 
-          "uuid": "81f732f4-2a35-4283-9b77-abc4a09e5aa2", 
+          "exits": [
+            {
+              "destination_uuid": "8c6d835f-4d34-4f9e-978f-2f0e161577b5",
+              "uuid": "df070bac-d85f-4fba-bf1b-7c7215e8b41f"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "df070bac-d85f-4fba-bf1b-7c7215e8b41f",
+                "name": "All Responses",
+                "uuid": "58066e6e-3947-4f83-ae1a-6fb44a20c9d9"
+              }
+            ],
+            "default_category_uuid": "58066e6e-3947-4f83-ae1a-6fb44a20c9d9",
+            "operand": "@input",
+            "result_name": "Photo",
+            "type": "switch",
+            "wait": {
+              "hint": {
+                "type": "image"
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "19d6bdaf-c134-4b90-8f56-60a301060d99"
+        },
+        {
           "actions": [
             {
-              "msg": {
-                "eng": "What is your name?"
-              }, 
-              "type": "reply"
+              "text": "Send your location",
+              "type": "send_msg",
+              "uuid": "674cf412-98e2-472a-9f4b-d47d66644da4"
             }
-          ]
-        }, 
+          ],
+          "exits": [
+            {
+              "destination_uuid": "f7a21353-6050-4bed-bd42-b3627ac140d1",
+              "uuid": "7b0e4103-092b-4286-b7f8-d633d3a38be9"
+            }
+          ],
+          "uuid": "8c6d835f-4d34-4f9e-978f-2f0e161577b5"
+        },
         {
-          "y": 922, 
-          "x": 130, 
-          "destination": null, 
-          "uuid": "bc2581b8-209c-47a8-b041-ba06faf7eab9", 
+          "exits": [
+            {
+              "destination_uuid": "893191e2-dd1a-4904-8bd5-1df0e8ef44c2",
+              "uuid": "c0337ee3-0c9c-472f-a265-71f3604f5056"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "c0337ee3-0c9c-472f-a265-71f3604f5056",
+                "name": "All Responses",
+                "uuid": "30bfc106-ab3d-4851-91ee-33d7a3bbb036"
+              }
+            ],
+            "default_category_uuid": "30bfc106-ab3d-4851-91ee-33d7a3bbb036",
+            "operand": "@input",
+            "result_name": "Location",
+            "type": "switch",
+            "wait": {
+              "hint": {
+                "type": "location"
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "f7a21353-6050-4bed-bd42-b3627ac140d1"
+        },
+        {
           "actions": [
             {
-              "msg": {
-                "eng": "Name: @flow.name \nPhoto: @flow.photo\nVideo: @flow.video\nLocation: @flow.location"
-              }, 
-              "type": "reply"
+              "text": "Send a video of yourself doing something awesome.",
+              "type": "send_msg",
+              "uuid": "587d3be4-a013-4449-b015-0b12d13d7d49"
             }
-          ]
-        }, 
+          ],
+          "exits": [
+            {
+              "destination_uuid": "5610d5e4-0b8f-4bef-a5d2-1a1ea61fbb1e",
+              "uuid": "34276d2a-d612-4363-9b9e-cba69f31f994"
+            }
+          ],
+          "uuid": "893191e2-dd1a-4904-8bd5-1df0e8ef44c2"
+        },
         {
-          "y": 675, 
-          "x": 129, 
-          "destination": "5610d5e4-0b8f-4bef-a5d2-1a1ea61fbb1e", 
-          "uuid": "893191e2-dd1a-4904-8bd5-1df0e8ef44c2", 
+          "exits": [
+            {
+              "destination_uuid": "bc2581b8-209c-47a8-b041-ba06faf7eab9",
+              "uuid": "ac5f4e3e-1075-4844-8784-7d715691a23c"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "ac5f4e3e-1075-4844-8784-7d715691a23c",
+                "name": "All Responses",
+                "uuid": "50c9afbf-4fed-44b4-b377-f7dcc44cd00b"
+              }
+            ],
+            "default_category_uuid": "50c9afbf-4fed-44b4-b377-f7dcc44cd00b",
+            "operand": "@input",
+            "result_name": "Video",
+            "type": "switch",
+            "wait": {
+              "hint": {
+                "type": "video"
+              },
+              "type": "msg"
+            }
+          },
+          "uuid": "5610d5e4-0b8f-4bef-a5d2-1a1ea61fbb1e"
+        },
+        {
           "actions": [
             {
-              "msg": {
-                "eng": "Send a video of yourself doing something awesome."
-              }, 
-              "type": "reply"
+              "text": "Name: @results.name \nPhoto: @results.photo\nVideo: @results.video\nLocation: @results.location",
+              "type": "send_msg",
+              "uuid": "1c016840-d61e-4ab8-b689-3c07450a4a38"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "uuid": "1d7afbc6-f53e-4c87-a66f-6121f292c056"
+            }
+          ],
+          "uuid": "bc2581b8-209c-47a8-b041-ba06faf7eab9"
         }
-      ], 
-      "version": 8, 
-      "flow_type": "S", 
-      "entry": "81f732f4-2a35-4283-9b77-abc4a09e5aa2", 
-      "rule_sets": [
-        {
-          "uuid": "f7a21353-6050-4bed-bd42-b3627ac140d1", 
-          "webhook_action": null, 
-          "rules": [
-            {
-              "test": {
-                "test": "true", 
-                "type": "true"
-              }, 
-              "category": {
-                "eng": "All Responses"
-              }, 
-              "destination": "893191e2-dd1a-4904-8bd5-1df0e8ef44c2", 
-              "uuid": "c0337ee3-0c9c-472f-a265-71f3604f5056", 
-              "destination_type": "A"
-            }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_gps", 
-          "label": "Location", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 566, 
-          "x": 113, 
-          "config": {}
-        }, 
-        {
-          "uuid": "19d6bdaf-c134-4b90-8f56-60a301060d99", 
-          "webhook_action": null, 
-          "rules": [
-            {
-              "test": {
-                "test": "true", 
-                "type": "true"
-              }, 
-              "category": {
-                "eng": "All Responses"
-              }, 
-              "destination": "8c6d835f-4d34-4f9e-978f-2f0e161577b5", 
-              "uuid": "df070bac-d85f-4fba-bf1b-7c7215e8b41f", 
-              "destination_type": "A"
-            }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_photo", 
-          "label": "Photo", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 337, 
-          "x": 112, 
-          "config": {}
-        }, 
-        {
-          "uuid": "fc80c25f-2099-453e-a4a8-9fa826ff3bd4", 
-          "webhook_action": null, 
-          "rules": [
-            {
-              "test": {
-                "test": "true", 
-                "type": "true"
-              }, 
-              "category": {
-                "eng": "All Responses"
-              }, 
-              "destination": "e3138a39-5df2-4c6a-918a-a94e7044022c", 
-              "uuid": "6ca9ffbe-2f99-47eb-a750-8c153799c3b6", 
-              "destination_type": "A"
-            }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_message", 
-          "label": "Name", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 108, 
-          "x": 111, 
-          "config": {}
-        }, 
-        {
-          "uuid": "5610d5e4-0b8f-4bef-a5d2-1a1ea61fbb1e", 
-          "webhook_action": null, 
-          "rules": [
-            {
-              "test": {
-                "test": "true", 
-                "type": "true"
-              }, 
-              "category": {
-                "eng": "All Responses"
-              }, 
-              "destination": "bc2581b8-209c-47a8-b041-ba06faf7eab9", 
-              "uuid": "ac5f4e3e-1075-4844-8784-7d715691a23c", 
-              "destination_type": "A"
-            }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_video", 
-          "label": "Video", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 803, 
-          "x": 114, 
-          "config": {}
-        }
-      ], 
-      "metadata": {
-        "name": "Media Survey", 
-        "contact_creation": "run", 
-        "expires": 10080, 
-        "saved_on": "2016-02-27T00:23:19.801198Z", 
-        "id": 35613, 
-        "revision": 169
-      }
+      ],
+      "revision": 169,
+      "spec_version": "14.4.0",
+      "type": "messaging_offline",
+      "uuid": "9097ec00-3af0-4eef-988d-26c5094ce4ec"
     }
-  ], 
+  ],
   "triggers": []
 }

--- a/media/test_flows/new_mother.json
+++ b/media/test_flows/new_mother.json
@@ -1,59 +1,78 @@
 {
   "campaigns": [],
-  "version": 3,
+  "version": "13",
   "site": "http://rapidpro.io",
   "flows": [
     {
-      "definition": {
-        "rule_sets": [],
-        "entr": "d2ed3c4c-c4d0-4f54-b0b0-6eaa5afd33f8",
-        "action_sets": [
-          {
-            "y": 0,
-            "x": 100,
-            "destination": null,
-            "uuid": "d2ed3c4c-c4d0-4f54-b0b0-6eaa5afd33f8",
-            "actions": [
-              {
-                "msg": "You've been registered as a new mother, congratulations on having sex at least once. Your CHW is @extra.contact.phone",
-                "type": "reply"
-              },
-              {
-                "field": "chw",
-                "type": "save",
-                "value": "@extra.contact.tel_e164",
-                "label": "CHW"
-              },
-              {
-                "field": "expected_delivery_date",
-                "type": "save",
-                "value": "@extra.flow.edd",
-                "label": "Expected Delivery Date"
-              },
-              {
-                "field": "name",
-                "type": "save",
-                "value": "@extra.flow.name",
-                "label": "Contact Name"
-              },
-              {
-                "type": "add_group",
-                "groups": [ 
-                  {
-                  "name": "Expecting Mothers"
-                  }
-                ]
-              }
-            ]
+      "_ui": {
+        "nodes": {
+          "d2ed3c4c-c4d0-4f54-b0b0-6eaa5afd33f8": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
           }
-        ],
-        "metadata": {
-          "notes": []
-        }
+        },
+        "stickies": {}
       },
-      "flow_type": "F",
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
       "name": "New Mother",
-      "id": 1500
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "You've been registered as a new mother, congratulations on having sex at least once. Your CHW is @parent.fields.phone",
+              "type": "send_msg",
+              "uuid": "8ba1aab5-0e9b-406b-a350-906cff6139db"
+            },
+            {
+              "field": {
+                "key": "chw",
+                "name": "CHW"
+              },
+              "type": "set_contact_field",
+              "uuid": "a3046be6-698e-4f21-914a-504065b3d616",
+              "value": "@(default(urn_parts(parent.urns.tel).path, \"\"))"
+            },
+            {
+              "field": {
+                "key": "expected_delivery_date",
+                "name": "Expected Delivery Date"
+              },
+              "type": "set_contact_field",
+              "uuid": "e4bc2d63-1ff9-4a6e-b428-9949ae469dcd",
+              "value": "@parent.results.edd"
+            },
+            {
+              "name": "@parent.results.name",
+              "type": "set_contact_name",
+              "uuid": "32af2113-a319-4b2c-817b-d12b43958ffd"
+            },
+            {
+              "groups": [
+                {
+                  "name_match": "Expecting Mothers"
+                }
+              ],
+              "type": "add_contact_groups",
+              "uuid": "ed296ddc-d904-4ee3-a4c8-96332d1a4676"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "85f2ea68-f477-4cfa-971e-e7d7db013c56"
+            }
+          ],
+          "uuid": "d2ed3c4c-c4d0-4f54-b0b0-6eaa5afd33f8"
+        }
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "31c99659-e09f-4351-9c54-9d73f7fadc31"
     }
   ],
   "triggers": []

--- a/media/test_flows/parent_child_trigger.json
+++ b/media/test_flows/parent_child_trigger.json
@@ -1,119 +1,161 @@
 {
-  "campaigns": [], 
-  "version": 9, 
-  "site": "https://app.rapidpro.io", 
+  "campaigns": [],
+  "version": "13",
+  "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "9aabeefc-1f7f-4522-8f33-26632a1e30e0": {
+            "position": {
+              "left": 146,
+              "top": 149
+            },
+            "type": "split_by_subflow"
+          },
+          "bfad640d-f106-418c-b4d6-1758f8556d8c": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Parent Flow",
+      "nodes": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": "9aabeefc-1f7f-4522-8f33-26632a1e30e0", 
-          "uuid": "bfad640d-f106-418c-b4d6-1758f8556d8c", 
           "actions": [
             {
-              "msg": {
-                "eng": "This is the parent flow"
-              }, 
-              "type": "reply"
+              "text": "This is the parent flow",
+              "type": "send_msg",
+              "uuid": "67b6c3c7-c50a-4eb0-80b3-8c5940639ed1"
             }
-          ]
-        }
-      ], 
-      "version": 9, 
-      "flow_type": "F", 
-      "entry": "bfad640d-f106-418c-b4d6-1758f8556d8c", 
-      "rule_sets": [
+          ],
+          "exits": [
+            {
+              "destination_uuid": "9aabeefc-1f7f-4522-8f33-26632a1e30e0",
+              "uuid": "b244decf-37c1-4d2f-b901-0014824e2382"
+            }
+          ],
+          "uuid": "bfad640d-f106-418c-b4d6-1758f8556d8c"
+        },
         {
-          "uuid": "9aabeefc-1f7f-4522-8f33-26632a1e30e0", 
-          "webhook_action": null, 
-          "rules": [
+          "actions": [
             {
-              "test": {
-                "type": "subflow", 
-                "exit_type": "completed"
-              }, 
-              "category": {
-                "eng": "Completed"
-              }, 
+              "flow": {
+                "name": "Child Flow",
+                "uuid": "c541b853-e33d-4fbb-8086-99e5d8ed6dc2"
+              },
+              "type": "enter_flow",
+              "uuid": "42d1a95f-79ad-45ff-8849-ed9378b03cab"
+            }
+          ],
+          "exits": [
+            {
               "uuid": "7d569e59-dfb8-402f-ad12-c91446c3705e"
-            }, 
+            },
             {
-              "test": {
-                "type": "subflow", 
-                "exit_type": "expired"
-              }, 
-              "category": {
-                "eng": "Expired"
-              }, 
               "uuid": "41772f9e-cc13-4775-b88d-63f2a8e2ddef"
             }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "subflow", 
-          "label": "Response 1", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 149, 
-          "x": 146, 
-          "config": {
-            "flow": {
-              "name": "Child Flow", 
-              "uuid": "c541b853-e33d-4fbb-8086-99e5d8ed6dc2"
-            }
-          }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "completed"
+                ],
+                "category_uuid": "f3ecb815-9203-447b-bb74-1c32370a1fd7",
+                "type": "has_only_text",
+                "uuid": "f6af930a-89a1-4f31-b307-eabd46388e01"
+              },
+              {
+                "arguments": [
+                  "expired"
+                ],
+                "category_uuid": "e2c12b1e-6094-4ee9-b149-a57403be68e0",
+                "type": "has_only_text",
+                "uuid": "75cd299c-e7e6-4511-a6df-0e3631acb5f2"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "7d569e59-dfb8-402f-ad12-c91446c3705e",
+                "name": "Completed",
+                "uuid": "f3ecb815-9203-447b-bb74-1c32370a1fd7"
+              },
+              {
+                "exit_uuid": "41772f9e-cc13-4775-b88d-63f2a8e2ddef",
+                "name": "Expired",
+                "uuid": "e2c12b1e-6094-4ee9-b149-a57403be68e0"
+              }
+            ],
+            "default_category_uuid": "",
+            "operand": "@child.status",
+            "result_name": "Response 1",
+            "type": "switch"
+          },
+          "uuid": "9aabeefc-1f7f-4522-8f33-26632a1e30e0"
         }
-      ], 
-      "metadata": {
-        "expires": 10080, 
-        "revision": 3, 
-        "uuid": "1ddf2d46-0cce-4c33-8049-9ebbbe28bb61", 
-        "name": "Parent Flow", 
-        "saved_on": "2016-08-18T20:57:34.525716Z"
-      }
-    }, 
+      ],
+      "revision": 3,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "1ddf2d46-0cce-4c33-8049-9ebbbe28bb61"
+    },
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "9f93e107-1e21-4e55-97c5-dbbfeca405a4": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Child Flow",
+      "nodes": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": null, 
-          "uuid": "9f93e107-1e21-4e55-97c5-dbbfeca405a4", 
           "actions": [
             {
-              "msg": {
-                "eng": "This is the child flow."
-              }, 
-              "type": "reply"
+              "text": "This is the child flow.",
+              "type": "send_msg",
+              "uuid": "413fe4b7-61af-4114-83a6-d0ed4a2d4886"
             }
-          ]
+          ],
+          "exits": [
+            {
+              "uuid": "c9bdaed8-61f5-4e8a-8dc8-16c4fc8cd956"
+            }
+          ],
+          "uuid": "9f93e107-1e21-4e55-97c5-dbbfeca405a4"
         }
-      ], 
-      "version": 9, 
-      "flow_type": "F", 
-      "entry": "9f93e107-1e21-4e55-97c5-dbbfeca405a4", 
-      "rule_sets": [], 
-      "metadata": {
-        "expires": 10080, 
-        "revision": 1, 
-        "uuid": "c541b853-e33d-4fbb-8086-99e5d8ed6dc2", 
-        "name": "Child Flow", 
-        "saved_on": "2016-08-18T20:57:02.559064Z"
-      }
+      ],
+      "revision": 1,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "c541b853-e33d-4fbb-8086-99e5d8ed6dc2"
     }
-  ], 
+  ],
   "triggers": [
     {
-      "trigger_type": "K", 
+      "trigger_type": "K",
       "flow": {
-        "name": "Child Flow", 
+        "name": "Child Flow",
         "uuid": "c541b853-e33d-4fbb-8086-99e5d8ed6dc2"
-      }, 
-      "groups": [], 
-      "keyword": "child", 
+      },
+      "groups": [],
+      "keyword": "child",
       "channel": null
     }
   ]

--- a/media/test_flows/parent_without_its_child.json
+++ b/media/test_flows/parent_without_its_child.json
@@ -81,8 +81,7 @@
       "revision": 7,
       "spec_version": "14.4.0",
       "type": "messaging",
-      "uuid": "6228646f-6c67-4237-a2d9-6e2c6060e8cd",
-      "version": "13.0.0"
+      "uuid": "6228646f-6c67-4237-a2d9-6e2c6060e8cd"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/parent_without_its_child.json
+++ b/media/test_flows/parent_without_its_child.json
@@ -1,87 +1,87 @@
 {
-  "version": "11.12",
+  "version": "13",
   "site": "https://textit.staging.nyaruka.com",
   "flows": [
     {
-      "name": "Single Parent",
-      "uuid": "6228646f-6c67-4237-a2d9-6e2c6060e8cd",
-      "spec_version": "13.0.0",
-      "language": "eng",
-      "type": "messaging",
-      "nodes": [
-        {
-          "uuid": "18ba4d96-1393-4db0-93e4-5adc5aedf736",
-          "actions": [
-            {
-              "uuid": "24e46982-4376-4078-b5c2-039d341bd951",
-              "type": "enter_flow",
-              "flow": {
-                "uuid": "a925453e-ad31-46bd-858a-e01136732181",
-                "name": "New Child"
-              }
-            }
-          ],
-          "router": {
-            "type": "switch",
-            "operand": "@child.run.status",
-            "cases": [
-              {
-                "uuid": "f976a429-f740-45b7-a532-7414f60b271d",
-                "type": "has_only_text",
-                "arguments": [
-                  "completed"
-                ],
-                "category_uuid": "552cbd8f-f0fb-4013-bc3a-f27810ee53cf"
-              },
-              {
-                "uuid": "90b00afd-8f26-43df-979e-e0e754f60bbc",
-                "arguments": [
-                  "expired"
-                ],
-                "type": "has_only_text",
-                "category_uuid": "f79974c7-cfe7-45ff-90a5-ffbcae3bb201"
-              }
-            ],
-            "categories": [
-              {
-                "uuid": "552cbd8f-f0fb-4013-bc3a-f27810ee53cf",
-                "name": "Complete",
-                "exit_uuid": "d15dcab5-ccb2-425f-aeaa-f0a3f307370c"
-              },
-              {
-                "uuid": "f79974c7-cfe7-45ff-90a5-ffbcae3bb201",
-                "name": "Expired",
-                "exit_uuid": "ba8ffb45-793b-4cd0-a998-01a36e0dcc3d"
-              }
-            ],
-            "default_category_uuid": "f79974c7-cfe7-45ff-90a5-ffbcae3bb201"
-          },
-          "exits": [
-            {
-              "uuid": "d15dcab5-ccb2-425f-aeaa-f0a3f307370c",
-              "destination_uuid": null
-            },
-            {
-              "uuid": "ba8ffb45-793b-4cd0-a998-01a36e0dcc3d",
-              "destination_uuid": null
-            }
-          ]
-        }
-      ],
       "_ui": {
         "nodes": {
           "18ba4d96-1393-4db0-93e4-5adc5aedf736": {
-            "type": "split_by_subflow",
+            "config": {},
             "position": {
               "left": 0,
               "top": 0
             },
-            "config": {}
+            "type": "split_by_subflow"
           }
         }
       },
-      "revision": 7,
       "expire_after_minutes": 10080,
+      "language": "eng",
+      "name": "Single Parent",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "flow": {
+                "name": "New Child",
+                "uuid": "a925453e-ad31-46bd-858a-e01136732181"
+              },
+              "type": "enter_flow",
+              "uuid": "24e46982-4376-4078-b5c2-039d341bd951"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": null,
+              "uuid": "d15dcab5-ccb2-425f-aeaa-f0a3f307370c"
+            },
+            {
+              "destination_uuid": null,
+              "uuid": "ba8ffb45-793b-4cd0-a998-01a36e0dcc3d"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "completed"
+                ],
+                "category_uuid": "552cbd8f-f0fb-4013-bc3a-f27810ee53cf",
+                "type": "has_only_text",
+                "uuid": "f976a429-f740-45b7-a532-7414f60b271d"
+              },
+              {
+                "arguments": [
+                  "expired"
+                ],
+                "category_uuid": "f79974c7-cfe7-45ff-90a5-ffbcae3bb201",
+                "type": "has_only_text",
+                "uuid": "90b00afd-8f26-43df-979e-e0e754f60bbc"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "d15dcab5-ccb2-425f-aeaa-f0a3f307370c",
+                "name": "Complete",
+                "uuid": "552cbd8f-f0fb-4013-bc3a-f27810ee53cf"
+              },
+              {
+                "exit_uuid": "ba8ffb45-793b-4cd0-a998-01a36e0dcc3d",
+                "name": "Expired",
+                "uuid": "f79974c7-cfe7-45ff-90a5-ffbcae3bb201"
+              }
+            ],
+            "default_category_uuid": "f79974c7-cfe7-45ff-90a5-ffbcae3bb201",
+            "operand": "@child.run.status",
+            "type": "switch"
+          },
+          "uuid": "18ba4d96-1393-4db0-93e4-5adc5aedf736"
+        }
+      ],
+      "revision": 7,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "6228646f-6c67-4237-a2d9-6e2c6060e8cd",
       "version": "13.0.0"
     }
   ],

--- a/media/test_flows/rating_10.json
+++ b/media/test_flows/rating_10.json
@@ -3,110 +3,6 @@
   "site": "https://textit.in",
   "flows": [
     {
-      "name": "Rate us",
-      "uuid": "d6a23704-c558-40c0-b850-5102cf69896c",
-      "spec_version": "13.1.0",
-      "language": "eng",
-      "type": "messaging",
-      "nodes": [
-        {
-          "uuid": "07ed96e6-f74a-4227-b160-661c80878fb0",
-          "actions": [
-            {
-              "attachments": [],
-              "text": "How do you rate the experience? Answer with a number below 10",
-              "type": "send_msg",
-              "quick_replies": [],
-              "uuid": "9009d06d-946c-4119-90c0-0325114cc30c"
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "43ea0a1d-8338-4fce-ba16-13899f76968e",
-              "destination_uuid": "eb12cb19-76fe-4111-bb70-3113c30a2e50"
-            }
-          ]
-        },
-        {
-          "uuid": "eabac992-9968-46a1-b6af-9fb5b9f5090a",
-          "actions": [
-            {
-              "attachments": [],
-              "text": "Please, pick a valid number ",
-              "type": "send_msg",
-              "quick_replies": [],
-              "uuid": "968d0d5e-2395-4010-ba7b-10dd9e95843e"
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "36d2706d-f0a1-4c9b-8da3-713c0bf61b4b",
-              "destination_uuid": "eb12cb19-76fe-4111-bb70-3113c30a2e50"
-            }
-          ]
-        },
-        {
-          "uuid": "eb12cb19-76fe-4111-bb70-3113c30a2e50",
-          "actions": [],
-          "router": {
-            "type": "switch",
-            "default_category_uuid": "cc09e8f5-0fb5-4168-b542-942de524517a",
-            "cases": [
-              {
-                "arguments": [],
-                "type": "has_number",
-                "uuid": "86da7229-534f-47a6-b799-2b6928f3570a",
-                "category_uuid": "49a015a4-47a8-48c8-93ad-e5cf83005c84"
-              }
-            ],
-            "categories": [
-              {
-                "uuid": "49a015a4-47a8-48c8-93ad-e5cf83005c84",
-                "name": "Has Number",
-                "exit_uuid": "6a269277-9431-444f-8dec-c21d8117e187"
-              },
-              {
-                "uuid": "cc09e8f5-0fb5-4168-b542-942de524517a",
-                "name": "Other",
-                "exit_uuid": "4abba910-c497-4d62-a379-94209cb476ca"
-              }
-            ],
-            "operand": "@input.text",
-            "wait": {
-              "type": "msg"
-            },
-            "result_name": "Result 1"
-          },
-          "exits": [
-            {
-              "uuid": "6a269277-9431-444f-8dec-c21d8117e187",
-              "destination_uuid": "e5a55d43-1c26-4e1d-bc71-6f054cf31ae8"
-            },
-            {
-              "uuid": "4abba910-c497-4d62-a379-94209cb476ca",
-              "destination_uuid": "eabac992-9968-46a1-b6af-9fb5b9f5090a"
-            }
-          ]
-        },
-        {
-          "uuid": "e5a55d43-1c26-4e1d-bc71-6f054cf31ae8",
-          "actions": [
-            {
-              "attachments": [],
-              "text": "Thank, we recorded your answer as @results.result_1",
-              "type": "send_msg",
-              "quick_replies": [],
-              "uuid": "d583e1f1-2a97-4a26-b523-d65d92b6723e"
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "25cdd176-e322-431c-bb32-5092fc0a462e",
-              "destination_uuid": null
-            }
-          ]
-        }
-      ],
       "_ui": {
         "nodes": {
           "07ed96e6-f74a-4227-b160-661c80878fb0": {
@@ -115,16 +11,6 @@
               "top": 0
             },
             "type": "execute_actions"
-          },
-          "eb12cb19-76fe-4111-bb70-3113c30a2e50": {
-            "type": "wait_for_response",
-            "position": {
-              "left": 20,
-              "top": 200
-            },
-            "config": {
-              "cases": {}
-            }
           },
           "e5a55d43-1c26-4e1d-bc71-6f054cf31ae8": {
             "position": {
@@ -139,15 +25,129 @@
               "top": 60
             },
             "type": "execute_actions"
+          },
+          "eb12cb19-76fe-4111-bb70-3113c30a2e50": {
+            "config": {
+              "cases": {}
+            },
+            "position": {
+              "left": 20,
+              "top": 200
+            },
+            "type": "wait_for_response"
           }
         }
       },
-      "revision": 7,
       "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
       "metadata": {
         "revision": 1
       },
-      "localization": {}
+      "name": "Rate us",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "attachments": [],
+              "quick_replies": [],
+              "text": "How do you rate the experience? Answer with a number below 10",
+              "type": "send_msg",
+              "uuid": "9009d06d-946c-4119-90c0-0325114cc30c"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "eb12cb19-76fe-4111-bb70-3113c30a2e50",
+              "uuid": "43ea0a1d-8338-4fce-ba16-13899f76968e"
+            }
+          ],
+          "uuid": "07ed96e6-f74a-4227-b160-661c80878fb0"
+        },
+        {
+          "actions": [
+            {
+              "attachments": [],
+              "quick_replies": [],
+              "text": "Please, pick a valid number ",
+              "type": "send_msg",
+              "uuid": "968d0d5e-2395-4010-ba7b-10dd9e95843e"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "eb12cb19-76fe-4111-bb70-3113c30a2e50",
+              "uuid": "36d2706d-f0a1-4c9b-8da3-713c0bf61b4b"
+            }
+          ],
+          "uuid": "eabac992-9968-46a1-b6af-9fb5b9f5090a"
+        },
+        {
+          "actions": [],
+          "exits": [
+            {
+              "destination_uuid": "e5a55d43-1c26-4e1d-bc71-6f054cf31ae8",
+              "uuid": "6a269277-9431-444f-8dec-c21d8117e187"
+            },
+            {
+              "destination_uuid": "eabac992-9968-46a1-b6af-9fb5b9f5090a",
+              "uuid": "4abba910-c497-4d62-a379-94209cb476ca"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [],
+                "category_uuid": "49a015a4-47a8-48c8-93ad-e5cf83005c84",
+                "type": "has_number",
+                "uuid": "86da7229-534f-47a6-b799-2b6928f3570a"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "6a269277-9431-444f-8dec-c21d8117e187",
+                "name": "Has Number",
+                "uuid": "49a015a4-47a8-48c8-93ad-e5cf83005c84"
+              },
+              {
+                "exit_uuid": "4abba910-c497-4d62-a379-94209cb476ca",
+                "name": "Other",
+                "uuid": "cc09e8f5-0fb5-4168-b542-942de524517a"
+              }
+            ],
+            "default_category_uuid": "cc09e8f5-0fb5-4168-b542-942de524517a",
+            "operand": "@input.text",
+            "result_name": "Result 1",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "eb12cb19-76fe-4111-bb70-3113c30a2e50"
+        },
+        {
+          "actions": [
+            {
+              "attachments": [],
+              "quick_replies": [],
+              "text": "Thank, we recorded your answer as @results.result_1",
+              "type": "send_msg",
+              "uuid": "d583e1f1-2a97-4a26-b523-d65d92b6723e"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": null,
+              "uuid": "25cdd176-e322-431c-bb32-5092fc0a462e"
+            }
+          ],
+          "uuid": "e5a55d43-1c26-4e1d-bc71-6f054cf31ae8"
+        }
+      ],
+      "revision": 7,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "d6a23704-c558-40c0-b850-5102cf69896c"
     }
   ],
   "campaigns": [],

--- a/media/test_flows/subflow.json
+++ b/media/test_flows/subflow.json
@@ -1,274 +1,378 @@
 {
-  "campaigns": [], 
-  "version": 9, 
-  "site": "https://textit.in", 
+  "campaigns": [],
+  "version": "13",
+  "site": "https://textit.in",
   "flows": [
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "12345678-6dde-47ae-84e5-40383bafb0d6": {
+            "position": {
+              "left": 641,
+              "top": 386
+            },
+            "type": "execute_actions"
+          },
+          "2be31f2e-e38c-42da-8626-7b668f5c2bcb": {
+            "position": {
+              "left": 590,
+              "top": 65
+            },
+            "type": "execute_actions"
+          },
+          "4dd51bcf-6dde-47ae-84e5-40383bafb0d6": {
+            "position": {
+              "left": 341,
+              "top": 386
+            },
+            "type": "execute_actions"
+          },
+          "546c368a-90ef-4145-8da6-20b8bb198b31": {
+            "position": {
+              "left": 248,
+              "top": 272
+            },
+            "type": "split_by_subflow"
+          },
+          "accd6da2-1c2c-4962-bd66-51f75c3d89d8": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "c89414cf-7c07-42ce-9135-86a5a036f651": {
+            "position": {
+              "left": 278,
+              "top": 154
+            },
+            "type": "wait_for_response"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Parent Flow",
+      "nodes": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651", 
-          "uuid": "accd6da2-1c2c-4962-bd66-51f75c3d89d8", 
           "actions": [
             {
-              "msg": {
-                "eng": "This is a parent flow. What would you like to do?"
-              }, 
-              "type": "reply"
+              "text": "This is a parent flow. What would you like to do?",
+              "type": "send_msg",
+              "uuid": "e0ef17ae-d53e-423f-8390-76bd9e506043"
             }
-          ]
-        }, 
-        {
-          "y": 65, 
-          "x": 590, 
-          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651", 
-          "uuid": "2be31f2e-e38c-42da-8626-7b668f5c2bcb", 
-          "actions": [
+          ],
+          "exits": [
             {
-              "msg": {
-                "eng": "I don't recognize that command."
-              }, 
-              "type": "reply"
+              "destination_uuid": "c89414cf-7c07-42ce-9135-86a5a036f651",
+              "uuid": "a650a7a4-80a4-4483-856c-b7815364f9f0"
             }
-          ]
-        }, 
-        {
-          "y": 386, 
-          "x": 341, 
-          "destination": "c89414cf-7c07-42ce-9135-86a5a036f651",
-          "uuid": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6", 
-          "actions": [
-            {
-              "msg": {
-                "eng": "@flow.subflow.category: You picked @child.color.category."
-              }, 
-              "type": "reply"
-            }
-          ]
+          ],
+          "uuid": "accd6da2-1c2c-4962-bd66-51f75c3d89d8"
         },
         {
-          "y": 386,
-          "x": 641,
-          "destination": null,
-          "uuid": "12345678-6dde-47ae-84e5-40383bafb0d6",
           "actions": [
             {
-              "msg": {
-                "eng": "You expired out of the subflow"
-              },
-              "type": "reply"
+              "text": "I don't recognize that command.",
+              "type": "send_msg",
+              "uuid": "43b6e657-d578-4c37-9150-50462ce98672"
             }
-          ]
-        }
-      ], 
-      "version": 8, 
-      "flow_type": "F", 
-      "entry": "accd6da2-1c2c-4962-bd66-51f75c3d89d8", 
-      "rule_sets": [
-        {
-          "uuid": "c89414cf-7c07-42ce-9135-86a5a036f651", 
-          "webhook_action": null, 
-          "rules": [
+          ],
+          "exits": [
             {
-              "test": {
-                "test": {
-                  "eng": "color"
-                }, 
-                "type": "contains_any"
-              }, 
-              "category": {
-                "eng": "Color"
-              }, 
-              "destination": "546c368a-90ef-4145-8da6-20b8bb198b31", 
-              "uuid": "b8eddbd7-3c31-46bb-895c-543bcba447bc", 
-              "destination_type": "R"
-            }, 
-            {
-              "test": {
-                "test": "true", 
-                "type": "true"
-              }, 
-              "category": {
-                "eng": "Other"
-              }, 
-              "destination": "2be31f2e-e38c-42da-8626-7b668f5c2bcb", 
-              "uuid": "806cdd98-5104-4ebe-9ffc-4c884973ca5f", 
-              "destination_type": "A"
+              "destination_uuid": "c89414cf-7c07-42ce-9135-86a5a036f651",
+              "uuid": "84c87179-28d1-49f7-8961-d3268ad8fe6c"
             }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_message", 
-          "label": "kind",
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 154, 
-          "x": 278, 
-          "config": {}
-        }, 
+          ],
+          "uuid": "2be31f2e-e38c-42da-8626-7b668f5c2bcb"
+        },
         {
-          "uuid": "546c368a-90ef-4145-8da6-20b8bb198b31", 
-          "webhook_action": null, 
-          "rules": [
+          "exits": [
             {
-              "test": {
-                "type": "subflow",
-                "exit_type": "completed"
-              }, 
-              "category": {
-                "eng": "Complete"
-              }, 
-              "destination": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6", 
-              "uuid": "d163cfa4-5c75-4735-a0e0-d5a662001f80", 
-              "destination_type": "A"
+              "destination_uuid": "546c368a-90ef-4145-8da6-20b8bb198b31",
+              "uuid": "b8eddbd7-3c31-46bb-895c-543bcba447bc"
             },
             {
-              "test": {
-                "type": "subflow",
-                "exit_type": "expired"
-              },
-              "category": {
-                "eng": "Expired"
-              },
-              "destination": "12345678-6dde-47ae-84e5-40383bafb0d6",
-              "uuid": "12345678-5c75-4735-a0e0-d5a662001f80",
-              "destination_type": "A"
+              "destination_uuid": "2be31f2e-e38c-42da-8626-7b668f5c2bcb",
+              "uuid": "806cdd98-5104-4ebe-9ffc-4c884973ca5f"
             }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "subflow", 
-          "label": "Subflow", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 272, 
-          "x": 248, 
-          "config": {
-            "flow": {
-              "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93",
-              "name": "Child Flow"
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "color"
+                ],
+                "category_uuid": "76e924db-430d-4f63-a1e3-89e8164d4f6d",
+                "type": "has_any_word",
+                "uuid": "709dcfd4-964b-45a3-b5ab-65ea81d91204"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "b8eddbd7-3c31-46bb-895c-543bcba447bc",
+                "name": "Color",
+                "uuid": "76e924db-430d-4f63-a1e3-89e8164d4f6d"
+              },
+              {
+                "exit_uuid": "806cdd98-5104-4ebe-9ffc-4c884973ca5f",
+                "name": "Other",
+                "uuid": "ba484c88-74b8-49e4-9712-1ae7ddea304c"
+              }
+            ],
+            "default_category_uuid": "ba484c88-74b8-49e4-9712-1ae7ddea304c",
+            "operand": "@input",
+            "result_name": "kind",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
             }
-          }
+          },
+          "uuid": "c89414cf-7c07-42ce-9135-86a5a036f651"
+        },
+        {
+          "actions": [
+            {
+              "flow": {
+                "name": "Child Flow",
+                "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93"
+              },
+              "type": "enter_flow",
+              "uuid": "b036137a-911c-4d0d-9860-d5bb79f86b48"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6",
+              "uuid": "d163cfa4-5c75-4735-a0e0-d5a662001f80"
+            },
+            {
+              "destination_uuid": "12345678-6dde-47ae-84e5-40383bafb0d6",
+              "uuid": "12345678-5c75-4735-a0e0-d5a662001f80"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "completed"
+                ],
+                "category_uuid": "eafa919d-af6f-4751-8114-15d8e2ab493c",
+                "type": "has_only_text",
+                "uuid": "b68c630e-9e35-4581-abb6-d565c1a97117"
+              },
+              {
+                "arguments": [
+                  "expired"
+                ],
+                "category_uuid": "4598a831-0e3b-41aa-b70f-6fb767c09c95",
+                "type": "has_only_text",
+                "uuid": "06310f0b-525a-41a8-800e-0330c06ef266"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "d163cfa4-5c75-4735-a0e0-d5a662001f80",
+                "name": "Complete",
+                "uuid": "eafa919d-af6f-4751-8114-15d8e2ab493c"
+              },
+              {
+                "exit_uuid": "12345678-5c75-4735-a0e0-d5a662001f80",
+                "name": "Expired",
+                "uuid": "4598a831-0e3b-41aa-b70f-6fb767c09c95"
+              }
+            ],
+            "default_category_uuid": "",
+            "operand": "@child.status",
+            "result_name": "Subflow",
+            "type": "switch"
+          },
+          "uuid": "546c368a-90ef-4145-8da6-20b8bb198b31"
+        },
+        {
+          "actions": [
+            {
+              "text": "@results.subflow.category_localized: You picked @child.results.color.category_localized.",
+              "type": "send_msg",
+              "uuid": "c3de6a75-ebda-4d86-a684-fb7f82001cc3"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "c89414cf-7c07-42ce-9135-86a5a036f651",
+              "uuid": "75e8d012-14e9-47fa-843d-30f84e552c4d"
+            }
+          ],
+          "uuid": "4dd51bcf-6dde-47ae-84e5-40383bafb0d6"
+        },
+        {
+          "actions": [
+            {
+              "text": "You expired out of the subflow",
+              "type": "send_msg",
+              "uuid": "05942a7a-65ea-4c6a-8654-0b6f1990cca3"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "cb8561c7-f9d7-4e00-81f6-921213124b71"
+            }
+          ],
+          "uuid": "12345678-6dde-47ae-84e5-40383bafb0d6"
         }
-      ], 
-      "metadata": {
-        "expires": 10080, 
-        "revision": 24, 
-        "uuid": "7c1dee9b-af4c-407b-a269-5553e59149e1", 
-        "name": "Parent Flow", 
-        "saved_on": "2016-04-26T23:13:32.368766Z"
-      }
-    }, 
+      ],
+      "revision": 24,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "7c1dee9b-af4c-407b-a269-5553e59149e1"
+    },
     {
-      "base_language": "eng", 
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "8d80451e-f457-4438-9f91-75b3232d1826": {
+            "position": {
+              "left": 730,
+              "top": 160
+            },
+            "type": "execute_actions"
+          },
+          "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "fc561730-70f8-4426-b3c7-da237e88331e": {
+            "position": {
+              "left": 254,
+              "top": 110
+            },
+            "type": "wait_for_response"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Child Flow",
+      "nodes": [
         {
-          "y": 0, 
-          "x": 100, 
-          "destination": "fc561730-70f8-4426-b3c7-da237e88331e", 
-          "uuid": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb", 
           "actions": [
             {
-              "msg": {
-                "eng": "What @parent.kind do you like?"
-              }, 
-              "type": "reply"
+              "text": "What @parent.results.kind do you like?",
+              "type": "send_msg",
+              "uuid": "556b2f27-220e-4f53-9c86-b8f1f195bc28"
             }
-          ]
-        }, 
-        {
-          "y": 160, 
-          "x": 730, 
-          "destination": "fc561730-70f8-4426-b3c7-da237e88331e", 
-          "uuid": "8d80451e-f457-4438-9f91-75b3232d1826", 
-          "actions": [
+          ],
+          "exits": [
             {
-              "msg": {
-                "eng": "Try again."
-              }, 
-              "type": "reply"
+              "destination_uuid": "fc561730-70f8-4426-b3c7-da237e88331e",
+              "uuid": "02facd1f-b6c9-445a-a61f-54095e0605cc"
             }
-          ]
-        }
-      ], 
-      "version": 8, 
-      "flow_type": "F", 
-      "entry": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb", 
-      "rule_sets": [
+          ],
+          "uuid": "b7fe7de0-bb6f-4c11-8a4d-93ff2a1526eb"
+        },
         {
-          "uuid": "fc561730-70f8-4426-b3c7-da237e88331e", 
-          "webhook_action": null, 
-          "rules": [
+          "exits": [
             {
-              "test": {
-                "test": {
-                  "eng": "Red"
-                }, 
-                "type": "contains_any"
-              }, 
-              "category": {
-                "eng": "Red"
-              }, 
               "uuid": "8c25293a-5864-46b0-b61a-c9815ed03fdf"
-            }, 
+            },
             {
-              "test": {
-                "test": {
-                  "eng": "Green"
-                }, 
-                "type": "contains_any"
-              }, 
-              "category": {
-                "eng": "Green"
-              }, 
               "uuid": "e04e08b0-9f64-459f-b4d3-f301c5a825ff"
-            }, 
+            },
             {
-              "test": {
-                "test": {
-                  "eng": "Blue"
-                }, 
-                "type": "contains_any"
-              }, 
-              "category": {
-                "eng": "Blue"
-              }, 
               "uuid": "5cf35b6a-fe47-4ca4-bc59-9d9efb6348f1"
-            }, 
+            },
             {
-              "test": {
-                "test": "true", 
-                "type": "true"
-              }, 
-              "category": {
-                "eng": "Other"
-              }, 
-              "destination": "8d80451e-f457-4438-9f91-75b3232d1826", 
-              "uuid": "e2790305-7662-4118-b27c-21e3cfd95317", 
-              "destination_type": "A"
+              "destination_uuid": "8d80451e-f457-4438-9f91-75b3232d1826",
+              "uuid": "e2790305-7662-4118-b27c-21e3cfd95317"
             }
-          ], 
-          "webhook": null, 
-          "ruleset_type": "wait_message", 
-          "label": "Color", 
-          "operand": "@step.value", 
-          "finished_key": null, 
-          "response_type": "", 
-          "y": 110, 
-          "x": 254, 
-          "config": {}
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Red"
+                ],
+                "category_uuid": "7e0e9dbe-8105-4ed2-ab0a-bd0d3128ba60",
+                "type": "has_any_word",
+                "uuid": "4965a958-2579-4bd9-81b3-75f79c512f18"
+              },
+              {
+                "arguments": [
+                  "Green"
+                ],
+                "category_uuid": "df804591-9474-4138-b803-2ef676050c88",
+                "type": "has_any_word",
+                "uuid": "e6188cfe-f27b-428d-8d5d-b627aff01374"
+              },
+              {
+                "arguments": [
+                  "Blue"
+                ],
+                "category_uuid": "03de68c4-2a5d-4ee1-8fb2-3d1e551d5787",
+                "type": "has_any_word",
+                "uuid": "4e2087ed-5351-423c-b954-5a63be59c4f8"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "8c25293a-5864-46b0-b61a-c9815ed03fdf",
+                "name": "Red",
+                "uuid": "7e0e9dbe-8105-4ed2-ab0a-bd0d3128ba60"
+              },
+              {
+                "exit_uuid": "e04e08b0-9f64-459f-b4d3-f301c5a825ff",
+                "name": "Green",
+                "uuid": "df804591-9474-4138-b803-2ef676050c88"
+              },
+              {
+                "exit_uuid": "5cf35b6a-fe47-4ca4-bc59-9d9efb6348f1",
+                "name": "Blue",
+                "uuid": "03de68c4-2a5d-4ee1-8fb2-3d1e551d5787"
+              },
+              {
+                "exit_uuid": "e2790305-7662-4118-b27c-21e3cfd95317",
+                "name": "Other",
+                "uuid": "cbe1b428-207d-45e9-a43a-485640ba43cf"
+              }
+            ],
+            "default_category_uuid": "cbe1b428-207d-45e9-a43a-485640ba43cf",
+            "operand": "@input",
+            "result_name": "Color",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "fc561730-70f8-4426-b3c7-da237e88331e"
+        },
+        {
+          "actions": [
+            {
+              "text": "Try again.",
+              "type": "send_msg",
+              "uuid": "7944b409-6f1a-4e1e-b5a9-c566d102f8f0"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "fc561730-70f8-4426-b3c7-da237e88331e",
+              "uuid": "e1624670-7566-4380-b7c6-912a28ffe1ce"
+            }
+          ],
+          "uuid": "8d80451e-f457-4438-9f91-75b3232d1826"
         }
-      ], 
-      "metadata": {
-        "expires": 10080, 
-        "revision": 11, 
-        "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93", 
-        "name": "Child Flow", 
-        "saved_on": "2016-04-26T21:34:39.525175Z"
-      }
+      ],
+      "revision": 11,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93"
     }
-  ], 
+  ],
   "triggers": []
 }

--- a/media/test_flows/survey_campaign.json
+++ b/media/test_flows/survey_campaign.json
@@ -1,67 +1,78 @@
 {
-  "version": "11.4",
+  "version": "13",
   "site": "https://app.rapidpro.io",
   "flows": [
     {
-      "entry": "2618298e-fce9-4b3f-8152-118b06cb6d2b",
-      "action_sets": [
+      "_ui": {
+        "nodes": {
+          "0c70dfec-78b6-4210-9485-37806c5deebc": {
+            "position": {
+              "left": 85,
+              "top": 155
+            },
+            "type": "wait_for_response"
+          },
+          "2618298e-fce9-4b3f-8152-118b06cb6d2b": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 10080,
+      "language": "und",
+      "localization": {},
+      "name": "Survey One",
+      "nodes": [
         {
-          "uuid": "2618298e-fce9-4b3f-8152-118b06cb6d2b",
-          "x": 100,
-          "y": 0,
-          "destination": "0c70dfec-78b6-4210-9485-37806c5deebc",
           "actions": [
             {
-              "type": "reply",
-              "uuid": "7b3ba21e-e83b-4dcf-ba4b-7dea06485423",
-              "msg": {
-                "base": "Hi this is a survey. Which color is best? Red, Green, or Blue?"
-              },
-              "media": {},
-              "quick_replies": [],
-              "send_all": false
+              "text": "Hi this is a survey. Which color is best? Red, Green, or Blue?",
+              "type": "send_msg",
+              "uuid": "7b3ba21e-e83b-4dcf-ba4b-7dea06485423"
             }
           ],
-          "exit_uuid": "bd76d746-e0fc-43b0-a0c6-aef3015c7ba6"
-        }
-      ],
-      "rule_sets": [
-        {
-          "uuid": "0c70dfec-78b6-4210-9485-37806c5deebc",
-          "x": 85,
-          "y": 155,
-          "label": "Color",
-          "rules": [
+          "exits": [
             {
-              "uuid": "5a304369-c86d-40b9-8b81-43c74eaee994",
-              "category": {
-                "base": "All Responses"
-              },
-              "destination": null,
-              "destination_type": null,
-              "test": {
-                "type": "true"
-              },
-              "label": null
+              "destination_uuid": "0c70dfec-78b6-4210-9485-37806c5deebc",
+              "uuid": "bd76d746-e0fc-43b0-a0c6-aef3015c7ba6"
             }
           ],
-          "finished_key": null,
-          "ruleset_type": "wait_message",
-          "response_type": "",
-          "operand": "@step.value",
-          "config": {}
+          "uuid": "2618298e-fce9-4b3f-8152-118b06cb6d2b"
+        },
+        {
+          "exits": [
+            {
+              "uuid": "5a304369-c86d-40b9-8b81-43c74eaee994"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "5a304369-c86d-40b9-8b81-43c74eaee994",
+                "name": "All Responses",
+                "uuid": "306919ec-26fb-4fd0-8682-5cda92e037de"
+              }
+            ],
+            "default_category_uuid": "306919ec-26fb-4fd0-8682-5cda92e037de",
+            "operand": "@input",
+            "result_name": "Color",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "0c70dfec-78b6-4210-9485-37806c5deebc"
         }
       ],
-      "base_language": "base",
-      "flow_type": "F",
-      "version": "11.4",
-      "metadata": {
-        "name": "Survey One",
-        "saved_on": "2018-06-28T21:45:01.821820Z",
-        "revision": 4,
-        "uuid": "6d8250f9-3781-40f5-b76c-35fe2a2c9712",
-        "expires": 10080
-      }
+      "revision": 4,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "6d8250f9-3781-40f5-b76c-35fe2a2c9712"
     }
   ],
   "campaigns": [

--- a/media/test_flows/the_clinic.json
+++ b/media/test_flows/the_clinic.json
@@ -3,881 +3,1313 @@
     {
       "events": [
         {
-          "event_type": "F", 
+          "event_type": "F",
           "relative_to": {
-            "id": 1134, 
-            "key": "next_appointment", 
+            "key": "next_appointment",
             "label": "Next Appointment"
-          }, 
+          },
           "flow": {
-            "name": "Confirm Appointment", 
-            "id": 2806
-          }, 
-          "offset": -1, 
-          "delivery_hour": 10, 
-          "message": "", 
-          "id": 9955, 
-          "unit": "D"
-        }, 
+            "uuid": "4b2a34bb-2da8-49df-97d2-7347804dec92",
+            "name": "Confirm Appointment"
+          },
+          "offset": -1,
+          "delivery_hour": 10,
+          "message": "",
+          "unit": "D",
+          "uuid": "9bf9b59a-63a3-41f5-9288-8976a917c2c1"
+        },
         {
-          "event_type": "F", 
+          "event_type": "F",
           "relative_to": {
-            "id": 1134, 
-            "key": "next_appointment", 
+            "key": "next_appointment",
             "label": "Next Appointment"
-          }, 
+          },
           "flow": {
-            "name": "Appointment Followup", 
-            "id": 2807
-          }, 
-          "offset": 3, 
-          "delivery_hour": -1, 
-          "message": "", 
-          "id": 9956, 
-          "unit": "H"
-        }, 
+            "uuid": "fb505d32-93e3-4aad-b69a-7d3318131f78",
+            "name": "Appointment Followup"
+          },
+          "offset": 3,
+          "delivery_hour": -1,
+          "message": "",
+          "unit": "H",
+          "uuid": "f2d3578c-ba73-463f-86dc-9fb0a192cde8"
+        },
         {
-          "event_type": "F", 
+          "event_type": "F",
           "relative_to": {
-            "id": 1134, 
-            "key": "next_appointment", 
+            "key": "next_appointment",
             "label": "Next Appointment"
-          }, 
+          },
           "flow": {
-            "name": "Stop Notifications", 
-            "id": 2808
-          }, 
-          "offset": 45, 
-          "delivery_hour": -1, 
-          "message": "", 
-          "id": 9957, 
-          "unit": "M"
-        }, 
+            "uuid": "8f0ab307-2c36-4eaf-baf2-597af539a2c0",
+            "name": "Stop Notifications"
+          },
+          "offset": 45,
+          "delivery_hour": -1,
+          "message": "",
+          "unit": "M",
+          "uuid": "d21be313-8ed3-4d07-8ada-5ff9fa3f5722"
+        },
         {
-          "event_type": "F", 
+          "event_type": "F",
           "relative_to": {
-            "id": 1134, 
-            "key": "next_appointment", 
+            "key": "next_appointment",
             "label": "Next Appointment"
-          }, 
+          },
           "flow": {
-            "name": "Start Notifications", 
-            "id": 2809
-          }, 
-          "offset": -3, 
-          "delivery_hour": -1, 
-          "message": "", 
-          "id": 9958, 
-          "unit": "H"
-        }, 
+            "uuid": "eb0d5a69-756a-4c05-88eb-5e84fbd2dd9c",
+            "name": "Start Notifications"
+          },
+          "offset": -3,
+          "delivery_hour": -1,
+          "message": "",
+          "unit": "H",
+          "uuid": "c4ac7d43-31e8-4347-b968-bd55d13bfc10"
+        },
         {
-          "event_type": "M", 
+          "event_type": "M",
           "relative_to": {
-            "id": 1134, 
-            "key": "next_appointment", 
+            "key": "next_appointment",
             "label": "Next Appointment"
-          }, 
+          },
           "flow": {
-            "name": "Single Message",
-            "id": 2814
-          }, 
-          "offset": -1, 
-          "delivery_hour": -1, 
+            "uuid": "852d6534-e163-492a-b15e-55efe6f122cd",
+            "name": "Single Message"
+          },
+          "offset": -1,
+          "delivery_hour": -1,
           "message": "Hi there, just a quick reminder that you have an appointment at The Clinic at @(format_date(contact.next_appointment)). If you can't make it please call 1-888-THE-CLINIC.",
-          "id": 9959, 
-          "unit": "H"
-        }, 
+          "unit": "H",
+          "uuid": "ae854186-8e9e-4950-bb5e-338b80868067"
+        },
         {
-          "event_type": "M", 
+          "event_type": "M",
           "relative_to": {
-            "id": 1134, 
-            "key": "next_appointment", 
+            "key": "next_appointment",
             "label": "Next Appointment"
-          }, 
+          },
           "flow": {
-            "name": "Single Message",
-            "id": 2815
-          }, 
-          "offset": 1, 
-          "delivery_hour": -1, 
-          "message": "This is a second campaign message", 
-          "id": 9960, 
-          "unit": "H"
+            "uuid": "65a5507b-a3b0-4592-9ad4-ddd5f3e798fd",
+            "name": "Single Message"
+          },
+          "offset": 1,
+          "delivery_hour": -1,
+          "message": "This is a second campaign message",
+          "unit": "H",
+          "uuid": "56e8fcd7-e83c-49f8-81a8-f13939386667"
         }
-      ], 
+      ],
       "group": {
-        "name": "Pending Appointments", 
-        "id": 2308
-      }, 
-      "id": 405, 
+        "uuid": "efc9e6cd-7d50-4c56-9912-ff8bf1ba15ba",
+        "name": "Pending Appointments"
+      },
+      "uuid": "d285380b-057a-43bf-953f-81c5e25975d8",
       "name": "Appointment Schedule"
     }
-  ], 
-  "version": 3,
+  ],
+  "version": "13",
   "site": "http://rapidpro.io",
   "flows": [
     {
-      "definition": {
-        "entry": "276fb90d-1ac3-4e4c-b663-3fcd93c8bd20", 
-        "rule_sets": [], 
-        "action_sets": [
-          {
-            "y": 0, 
-            "x": 100, 
-            "destination": null, 
-            "uuid": "276fb90d-1ac3-4e4c-b663-3fcd93c8bd20", 
-            "actions": [
-              {
-                "msg": "I don't know what that means, try again.", 
-                "type": "reply"
-              }
-            ]
+      "_ui": {
+        "nodes": {
+          "276fb90d-1ac3-4e4c-b663-3fcd93c8bd20": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
           }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.200686Z", 
-        "metadata": {
-          "notes": []
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Catch All",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "I don't know what that means, try again.",
+              "type": "send_msg",
+              "uuid": "a06ad4ad-9d34-4211-81df-77a439238ac3"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "e72a4d0c-d085-4178-9c97-3579dbfc1ca6"
+            }
+          ],
+          "uuid": "276fb90d-1ac3-4e4c-b663-3fcd93c8bd20"
         }
-      }, 
-      "id": 2804, 
-      "flow_type": "F", 
-      "name": "Catch All"
-    }, 
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "198b20a2-c389-4cf6-8ccb-b45c959f3de1"
+    },
     {
-      "definition": {
-        "entry": "70e7ff3c-86af-4bb3-a70a-44907b493375", 
-        "rule_sets": [
-          {
-            "uuid": "3a662dd8-1760-409e-a315-30b3f00440b4", 
-            "webhook_action": null, 
-            "rules": [
-              {
-                "test": {
-                  "test": "@date.today|time_delta:'0'", 
-                  "type": "date_after"
-                }, 
-                "category": "After Today", 
-                "destination": "18a87b1d-2eaf-42eb-a937-2a31beb85f22", 
-                "uuid": "f8ee30d6-7430-4eb4-a217-0ffa2bf3e847"
-              }, 
-              {
-                "test": {
-                  "test": "true", 
-                  "type": "true"
-                }, 
-                "category": "Other", 
-                "destination": "f5a85f44-c01f-49bb-8894-194988a0831c", 
-                "uuid": "3cc636a0-e171-4da8-97a6-e12a4c34fb24"
+      "_ui": {
+        "nodes": {
+          "18a87b1d-2eaf-42eb-a937-2a31beb85f22": {
+            "position": {
+              "left": 206,
+              "top": 294
+            },
+            "type": "execute_actions"
+          },
+          "3a662dd8-1760-409e-a315-30b3f00440b4": {
+            "config": {
+              "cases": {
+                "2899adb3-522b-4d3c-bea6-8ffb05e25909": {
+                  "arguments": [
+                    "0"
+                  ]
+                }
               }
-            ], 
-            "webhook": null, 
-            "label": "Next Appointment", 
-            "operand": "@step.value", 
-            "finished_key": null, 
-            "response_type": "C", 
-            "y": 160, 
-            "x": 167
+            },
+            "position": {
+              "left": 167,
+              "top": 160
+            },
+            "type": "wait_for_response"
+          },
+          "70e7ff3c-86af-4bb3-a70a-44907b493375": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "f5a85f44-c01f-49bb-8894-194988a0831c": {
+            "position": {
+              "left": 431,
+              "top": 24
+            },
+            "type": "execute_actions"
           }
-        ], 
-        "action_sets": [
-          {
-            "y": 294, 
-            "x": 206, 
-            "destination": null, 
-            "uuid": "18a87b1d-2eaf-42eb-a937-2a31beb85f22", 
-            "actions": [
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Register Patient",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "Thanks for registering for SMS alerts for The Clinic. When is your appointment?",
+              "type": "send_msg",
+              "uuid": "6dec5265-b5ee-43fe-a840-d3fa6888dd62"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "3a662dd8-1760-409e-a315-30b3f00440b4",
+              "uuid": "dae7b3b0-eaab-486a-964c-62c21a0cb482"
+            }
+          ],
+          "uuid": "70e7ff3c-86af-4bb3-a70a-44907b493375"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry, I'm not sure what that means. Please try entering the date and time for your next appointment. e.g: 1/18/2013 2:30pm",
+              "type": "send_msg",
+              "uuid": "9183baf4-ce6f-4d89-9ad1-85efa9a23d65"
+            },
+            {
+              "labels": [
+                {
+                  "name": "Confused Rating",
+                  "uuid": "11b54361-4a22-4e5f-808a-b9f513185503"
+                }
+              ],
+              "type": "add_input_labels",
+              "uuid": "1e29bb31-8020-4e74-a520-947f4aadebce"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "3a662dd8-1760-409e-a315-30b3f00440b4",
+              "uuid": "5e5071b9-96cf-449f-ba26-c8bd3bff53ca"
+            }
+          ],
+          "uuid": "f5a85f44-c01f-49bb-8894-194988a0831c"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "18a87b1d-2eaf-42eb-a937-2a31beb85f22",
+              "uuid": "f8ee30d6-7430-4eb4-a217-0ffa2bf3e847"
+            },
+            {
+              "destination_uuid": "f5a85f44-c01f-49bb-8894-194988a0831c",
+              "uuid": "3cc636a0-e171-4da8-97a6-e12a4c34fb24"
+            }
+          ],
+          "router": {
+            "cases": [
               {
-                "msg": "Great, thanks for registering, we'll make sure to keep you in the loop as your appointment grows nearer.", 
-                "type": "reply"
-              }, 
-              {
-                "field": "next_appointment", 
-                "type": "save", 
-                "value": "@flow.next_appointment", 
-                "label": "Next Appointment"
-              }, 
-              {
-                "type": "add_group", 
-                "groups": [
-                  {
-                    "name": "Pending Appointments", 
-                    "id": 2308
-                  }
-                ]
-              }, 
-              {
-                "type": "flow", 
-                "name": "Triggered From Flow", 
-                "id": 2813
+                "arguments": [
+                  "@(datetime_add(today(), 0, \"D\"))"
+                ],
+                "category_uuid": "5eedfe1e-efd7-4834-a1f2-ca0bf3beb332",
+                "type": "has_date_gt",
+                "uuid": "2899adb3-522b-4d3c-bea6-8ffb05e25909"
               }
-            ]
-          }, 
-          {
-            "y": 24, 
-            "x": 431, 
-            "destination": "3a662dd8-1760-409e-a315-30b3f00440b4", 
-            "uuid": "f5a85f44-c01f-49bb-8894-194988a0831c", 
-            "actions": [
+            ],
+            "categories": [
               {
-                "msg": "Sorry, I'm not sure what that means. Please try entering the date and time for your next appointment. e.g: 1/18/2013 2:30pm", 
-                "type": "reply"
+                "exit_uuid": "f8ee30d6-7430-4eb4-a217-0ffa2bf3e847",
+                "name": "After Today",
+                "uuid": "5eedfe1e-efd7-4834-a1f2-ca0bf3beb332"
               },
               {
-                "labels": [
-                  {
-                    "name": "Confused Rating",
-                    "id": 196
-                  }
+                "exit_uuid": "3cc636a0-e171-4da8-97a6-e12a4c34fb24",
+                "name": "Other",
+                "uuid": "34ddb414-df56-4698-9079-8cd41f3be9fe"
+              }
+            ],
+            "default_category_uuid": "34ddb414-df56-4698-9079-8cd41f3be9fe",
+            "operand": "@input",
+            "result_name": "Next Appointment",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "3a662dd8-1760-409e-a315-30b3f00440b4"
+        },
+        {
+          "actions": [
+            {
+              "text": "Great, thanks for registering, we'll make sure to keep you in the loop as your appointment grows nearer.",
+              "type": "send_msg",
+              "uuid": "718dcefa-48cc-4cf4-8d93-332d16e700d2"
+            },
+            {
+              "field": {
+                "key": "next_appointment",
+                "name": "Next Appointment"
+              },
+              "type": "set_contact_field",
+              "uuid": "81bab53d-d6bd-4b96-98c4-6838d2df8c7d",
+              "value": "@results.next_appointment"
+            },
+            {
+              "groups": [
+                {
+                  "name": "Pending Appointments",
+                  "uuid": "efc9e6cd-7d50-4c56-9912-ff8bf1ba15ba"
+                }
+              ],
+              "type": "add_contact_groups",
+              "uuid": "8677221e-7cb5-4278-859e-5121858fe87d"
+            },
+            {
+              "flow": {
+                "name": "Triggered From Flow",
+                "uuid": "16f33155-9ef7-478f-8a05-365eb05d29f7"
+              },
+              "terminal": true,
+              "type": "enter_flow",
+              "uuid": "244bd2a1-aa6b-44c4-a302-14295b8829a2"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "e56afcec-ece9-4ce3-99be-c8228324fd08"
+            }
+          ],
+          "uuid": "18a87b1d-2eaf-42eb-a937-2a31beb85f22"
+        }
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "ad22ba89-68af-4e2d-9d06-13e0b61193d2"
+    },
+    {
+      "_ui": {
+        "nodes": {
+          "1c5043d4-1010-47e5-b90f-2d85370c680a": {
+            "position": {
+              "left": 653,
+              "top": 240
+            },
+            "type": "execute_actions"
+          },
+          "3112342a-0f24-45c4-8861-49204593559b": {
+            "position": {
+              "left": 25,
+              "top": 117
+            },
+            "type": "execute_actions"
+          },
+          "53d2c775-d64c-4d5e-b4dd-a29e15569b89": {
+            "config": {
+              "operand": {
+                "id": "next_appointment",
+                "type": "field"
+              }
+            },
+            "position": {
+              "left": 84,
+              "top": 0
+            },
+            "type": "split_by_contact_field"
+          },
+          "5819e334-bcba-4457-b4a9-0a840f1c0504": {
+            "position": {
+              "left": 295,
+              "top": 170
+            },
+            "type": "wait_for_response"
+          },
+          "81a28bd1-77af-465f-b1b9-d11333deb3ac": {
+            "position": {
+              "left": 126,
+              "top": 338
+            },
+            "type": "execute_actions"
+          },
+          "b3633acf-f7ac-467e-a902-eabe1be1e16e": {
+            "position": {
+              "left": 367,
+              "top": 280
+            },
+            "type": "execute_actions"
+          },
+          "b5ae11ff-e7d3-4dc4-a6de-a7ca6ada4229": {
+            "position": {
+              "left": 408,
+              "top": 14
+            },
+            "type": "execute_actions"
+          }
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Confirm Appointment",
+      "nodes": [
+        {
+          "exits": [
+            {
+              "destination_uuid": "3112342a-0f24-45c4-8861-49204593559b",
+              "uuid": "b8c907c7-a344-4093-b812-95f99fde6ce2"
+            },
+            {
+              "destination_uuid": "b5ae11ff-e7d3-4dc4-a6de-a7ca6ada4229",
+              "uuid": "a7756699-3f94-495a-8448-164765d8f7c4"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "category_uuid": "8c31f08a-d649-4e53-87c8-c0688ec4c149",
+                "type": "has_date",
+                "uuid": "62e81099-999c-4881-9a46-d36932750924"
+              }
+            ],
+            "categories": [
+              {
+                "exit_uuid": "b8c907c7-a344-4093-b812-95f99fde6ce2",
+                "name": "Has Appointment",
+                "uuid": "8c31f08a-d649-4e53-87c8-c0688ec4c149"
+              },
+              {
+                "exit_uuid": "a7756699-3f94-495a-8448-164765d8f7c4",
+                "name": "Other",
+                "uuid": "18dd2b53-b7de-4f18-9e11-6ddd5909487f"
+              }
+            ],
+            "default_category_uuid": "18dd2b53-b7de-4f18-9e11-6ddd5909487f",
+            "operand": "@fields.next_appointment",
+            "result_name": "Response 1",
+            "type": "switch"
+          },
+          "uuid": "53d2c775-d64c-4d5e-b4dd-a29e15569b89"
+        },
+        {
+          "actions": [
+            {
+              "text": "You don't have an appointment scheduled. Please contact 1-888-THE-CLINIC to schedule your next appointment.",
+              "type": "send_msg",
+              "uuid": "7403d6ab-1193-46bf-a145-872f2bf09cc8"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "674c714e-6943-41aa-9656-145bf8c7f288"
+            }
+          ],
+          "uuid": "b5ae11ff-e7d3-4dc4-a6de-a7ca6ada4229"
+        },
+        {
+          "actions": [
+            {
+              "text": "Your next appointment at The Clinic is @fields.next_appointment. Will you be  attending this appointment? Please reply with Yes or No to confirm.",
+              "type": "send_msg",
+              "uuid": "bde81910-d170-43b1-8c76-d1bf99eece9d"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "5819e334-bcba-4457-b4a9-0a840f1c0504",
+              "uuid": "1ccfe4c0-894d-453f-8803-199467e14a0a"
+            }
+          ],
+          "uuid": "3112342a-0f24-45c4-8861-49204593559b"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "81a28bd1-77af-465f-b1b9-d11333deb3ac",
+              "uuid": "aca46657-3347-403d-8994-bc8406eaccd5"
+            },
+            {
+              "destination_uuid": "b3633acf-f7ac-467e-a902-eabe1be1e16e",
+              "uuid": "030fd3a2-5e75-40ad-bd0b-dfdd4e72f2f6"
+            },
+            {
+              "destination_uuid": "1c5043d4-1010-47e5-b90f-2d85370c680a",
+              "uuid": "1f92a68a-6fd1-4d30-84a4-1bc7ac20f53f"
+            }
+          ],
+          "router": {
+            "cases": [
+              {
+                "arguments": [
+                  "Yes Y confirm"
                 ],
-                "type": "add_label"
-              }
-            ]
-          }, 
-          {
-            "y": 0, 
-            "x": 100, 
-            "destination": "3a662dd8-1760-409e-a315-30b3f00440b4", 
-            "uuid": "70e7ff3c-86af-4bb3-a70a-44907b493375", 
-            "actions": [
+                "category_uuid": "b10b2936-71cc-4755-bba2-1aaaa567a709",
+                "type": "has_any_word",
+                "uuid": "bc37715a-4290-4431-bae8-5e9b28d4b282"
+              },
               {
-                "msg": "Thanks for registering for SMS alerts for The Clinic. When is your appointment?", 
-                "type": "reply"
+                "arguments": [
+                  "No n"
+                ],
+                "category_uuid": "ee1f4260-290b-42c4-a8df-7f02295d9b8b",
+                "type": "has_any_word",
+                "uuid": "ee93425e-9704-4266-9967-9a6659879315"
               }
-            ]
-          }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.226957Z", 
-        "metadata": {
-          "notes": []
+            ],
+            "categories": [
+              {
+                "exit_uuid": "aca46657-3347-403d-8994-bc8406eaccd5",
+                "name": "Yes",
+                "uuid": "b10b2936-71cc-4755-bba2-1aaaa567a709"
+              },
+              {
+                "exit_uuid": "030fd3a2-5e75-40ad-bd0b-dfdd4e72f2f6",
+                "name": "No",
+                "uuid": "ee1f4260-290b-42c4-a8df-7f02295d9b8b"
+              },
+              {
+                "exit_uuid": "1f92a68a-6fd1-4d30-84a4-1bc7ac20f53f",
+                "name": "Other",
+                "uuid": "9ece200d-ef1a-493a-afc6-1491e484c948"
+              }
+            ],
+            "default_category_uuid": "9ece200d-ef1a-493a-afc6-1491e484c948",
+            "operand": "@input",
+            "result_name": "Confirmation",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "5819e334-bcba-4457-b4a9-0a840f1c0504"
+        },
+        {
+          "actions": [
+            {
+              "text": "I don't understand, please reply yes or no.",
+              "type": "send_msg",
+              "uuid": "fed215fa-d642-43b2-9379-8d609968e24d"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "5819e334-bcba-4457-b4a9-0a840f1c0504",
+              "uuid": "391c8196-ecc5-4a0d-850e-36934f20f762"
+            }
+          ],
+          "uuid": "1c5043d4-1010-47e5-b90f-2d85370c680a"
+        },
+        {
+          "actions": [
+            {
+              "text": "I'm sorry you are unable to attend. Please contact 1-888-THE-CLINIC to reschedule.",
+              "type": "send_msg",
+              "uuid": "686a13d7-9cab-4c36-84bf-122de394e92e"
+            },
+            {
+              "groups": [
+                {
+                  "name": "Pending Appointments",
+                  "uuid": "efc9e6cd-7d50-4c56-9912-ff8bf1ba15ba"
+                }
+              ],
+              "type": "remove_contact_groups",
+              "uuid": "a6a08439-3554-44b6-b943-5624fbc1a7d9"
+            },
+            {
+              "field": {
+                "key": "next_appointment",
+                "name": "Next Appointment"
+              },
+              "type": "set_contact_field",
+              "uuid": "890592ff-a441-4859-9c9a-8eb6b6cb9381",
+              "value": "None"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "581a28e0-e24b-41ce-9de1-024a108d0c06"
+            }
+          ],
+          "uuid": "b3633acf-f7ac-467e-a902-eabe1be1e16e"
+        },
+        {
+          "actions": [
+            {
+              "text": "Thanks, your appointment at The Clinic has been confirmed for @fields.next_appointment. See you then!",
+              "type": "send_msg",
+              "uuid": "e0425218-91f0-423b-a443-47b60dbb60dd"
+            },
+            {
+              "field": {
+                "key": "appointment_confirmed",
+                "name": "Appointment Confirmed"
+              },
+              "type": "set_contact_field",
+              "uuid": "2c42d319-4ad7-4c7c-bef8-1988ed3c5a63",
+              "value": "Confirmed"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "54ce1cd6-dd0e-4a4d-a358-c2d816e4b932"
+            }
+          ],
+          "uuid": "81a28bd1-77af-465f-b1b9-d11333deb3ac"
         }
-      }, 
-      "id": 2805, 
-      "flow_type": "F", 
-      "name": "Register Patient"
-    }, 
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "4b2a34bb-2da8-49df-97d2-7347804dec92"
+    },
     {
-      "definition": {
-        "entry": "53d2c775-d64c-4d5e-b4dd-a29e15569b89", 
-        "rule_sets": [
-          {
-            "uuid": "53d2c775-d64c-4d5e-b4dd-a29e15569b89", 
-            "webhook_action": null, 
-            "rules": [
-              {
-                "test": {
-                  "type": "date"
-                }, 
-                "category": "Has Appointment", 
-                "destination": "3112342a-0f24-45c4-8861-49204593559b", 
-                "uuid": "b8c907c7-a344-4093-b812-95f99fde6ce2"
-              }, 
-              {
-                "test": {
-                  "test": "true", 
-                  "type": "true"
-                }, 
-                "category": "Other", 
-                "destination": "b5ae11ff-e7d3-4dc4-a6de-a7ca6ada4229", 
-                "uuid": "a7756699-3f94-495a-8448-164765d8f7c4"
-              }
-            ], 
-            "webhook": null, 
-            "label": "Response 1", 
-            "operand": "@contact.next_appointment", 
-            "finished_key": null, 
-            "response_type": "C", 
-            "y": 0, 
-            "x": 84
-          }, 
-          {
-            "uuid": "5819e334-bcba-4457-b4a9-0a840f1c0504", 
-            "webhook_action": null, 
-            "rules": [
-              {
-                "test": {
-                  "test": "Yes Y confirm", 
-                  "type": "contains_any"
-                }, 
-                "category": "Yes", 
-                "destination": "81a28bd1-77af-465f-b1b9-d11333deb3ac", 
-                "uuid": "aca46657-3347-403d-8994-bc8406eaccd5"
-              }, 
-              {
-                "test": {
-                  "test": "No n", 
-                  "type": "contains_any"
-                }, 
-                "category": "No", 
-                "destination": "b3633acf-f7ac-467e-a902-eabe1be1e16e", 
-                "uuid": "030fd3a2-5e75-40ad-bd0b-dfdd4e72f2f6"
-              }, 
-              {
-                "test": {
-                  "test": "true", 
-                  "type": "true"
-                }, 
-                "category": "Other", 
-                "destination": "1c5043d4-1010-47e5-b90f-2d85370c680a", 
-                "uuid": "1f92a68a-6fd1-4d30-84a4-1bc7ac20f53f"
-              }
-            ], 
-            "webhook": null, 
-            "label": "Confirmation", 
-            "operand": "@step.value", 
-            "finished_key": null, 
-            "response_type": "C", 
-            "y": 170, 
-            "x": 295
+      "_ui": {
+        "nodes": {
+          "15a4e272-a689-41f6-9b8b-50c4d4923c15": {
+            "position": {
+              "left": 59,
+              "top": 903
+            },
+            "type": "wait_for_response"
+          },
+          "226e3ce8-765d-43ce-8e4c-3c10d2687364": {
+            "position": {
+              "left": 30,
+              "top": 462
+            },
+            "type": "execute_actions"
+          },
+          "40d8d356-d285-4e0c-b6ae-a47f8aff554e": {
+            "position": {
+              "left": 286,
+              "top": 532
+            },
+            "type": "wait_for_response"
+          },
+          "42719e07-7ee5-4c5a-8ec4-7f98026d2ef9": {
+            "position": {
+              "left": 232,
+              "top": 1001
+            },
+            "type": "execute_actions"
+          },
+          "51736b03-e53e-4ba1-b30b-455fc830668c": {
+            "position": {
+              "left": 740,
+              "top": 264
+            },
+            "type": "execute_actions"
+          },
+          "56293742-abdc-4ff6-b9dc-e828ed58313c": {
+            "position": {
+              "left": 465,
+              "top": 361
+            },
+            "type": "execute_actions"
+          },
+          "59a61d6f-75a9-49d8-9182-41de3ab26595": {
+            "position": {
+              "left": 723,
+              "top": 86
+            },
+            "type": "execute_actions"
+          },
+          "6f190d1a-b6c9-4533-95ed-83edf7d1603c": {
+            "position": {
+              "left": 415,
+              "top": 843
+            },
+            "type": "wait_for_response"
+          },
+          "8736f559-f236-4e15-bc02-29660b9a2081": {
+            "position": {
+              "left": 279,
+              "top": 663
+            },
+            "type": "execute_actions"
+          },
+          "d4251a10-0aa7-4feb-a743-9ccd2a75b225": {
+            "position": {
+              "left": 505,
+              "top": 638
+            },
+            "type": "execute_actions"
+          },
+          "ee5efdea-1f37-4c46-a414-31c29382c407": {
+            "position": {
+              "left": 66,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "ef24eadd-5f84-4dd7-be6f-96d4d7ef69e0": {
+            "position": {
+              "left": 56,
+              "top": 662
+            },
+            "type": "execute_actions"
+          },
+          "ff071c3f-1fdf-4559-ba8e-2c321dc26a93": {
+            "position": {
+              "left": 390,
+              "top": 253
+            },
+            "type": "wait_for_response"
           }
-        ], 
-        "action_sets": [
-          {
-            "y": 240, 
-            "x": 653, 
-            "destination": "5819e334-bcba-4457-b4a9-0a840f1c0504", 
-            "uuid": "1c5043d4-1010-47e5-b90f-2d85370c680a", 
-            "actions": [
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Appointment Followup",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "Thanks for choosing The Clinic. Your business is very important to us. To help us better serve you would you be interested in participating in a short survey?",
+              "type": "send_msg",
+              "uuid": "e088df30-2fec-41b2-8f39-62da43743a36"
+            },
+            {
+              "field": {
+                "key": "next_appointment",
+                "name": "Next Appointment"
+              },
+              "type": "set_contact_field",
+              "uuid": "658a6532-afb0-463f-9504-4461c11ff7f7",
+              "value": "None"
+            },
+            {
+              "field": {
+                "key": "appointment_confirmed",
+                "name": "Appointment Confirmed"
+              },
+              "type": "set_contact_field",
+              "uuid": "d379a63a-032e-4ac1-84ba-17fd7c7902ea",
+              "value": "None"
+            },
+            {
+              "groups": [
+                {
+                  "name": "Pending Appointments",
+                  "uuid": "efc9e6cd-7d50-4c56-9912-ff8bf1ba15ba"
+                }
+              ],
+              "type": "remove_contact_groups",
+              "uuid": "17676733-d592-4509-b4a4-76e63cf0deef"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "ff071c3f-1fdf-4559-ba8e-2c321dc26a93",
+              "uuid": "ae3549f8-89d0-420b-b28a-0b940d8ed299"
+            }
+          ],
+          "uuid": "ee5efdea-1f37-4c46-a414-31c29382c407"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry, I didn't understand that. Do you have time for a short survey? Please respond with either Yes or No. ",
+              "type": "send_msg",
+              "uuid": "c6beb8db-e9f0-42be-b902-787fce817fbd"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "ff071c3f-1fdf-4559-ba8e-2c321dc26a93",
+              "uuid": "2a568621-3d87-4f13-9299-13db47f6a1cc"
+            }
+          ],
+          "uuid": "59a61d6f-75a9-49d8-9182-41de3ab26595"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "226e3ce8-765d-43ce-8e4c-3c10d2687364",
+              "uuid": "c3dcf29a-b7c8-45ae-a4d8-2e5ad774c376"
+            },
+            {
+              "destination_uuid": "56293742-abdc-4ff6-b9dc-e828ed58313c",
+              "uuid": "814ad52f-e17c-4320-9a54-7433f21f7e17"
+            },
+            {
+              "destination_uuid": "59a61d6f-75a9-49d8-9182-41de3ab26595",
+              "uuid": "1d055623-7d54-411f-b24d-3ced5512f5b2"
+            }
+          ],
+          "router": {
+            "cases": [
               {
-                "msg": "I don't understand, please reply yes or no.", 
-                "type": "reply"
+                "arguments": [
+                  "Yes y sure"
+                ],
+                "category_uuid": "c2b69f01-04d5-422b-893c-a61f94fbb5b5",
+                "type": "has_any_word",
+                "uuid": "4433fb24-5143-458d-b15f-dcb218cad473"
+              },
+              {
+                "arguments": [
+                  "No n"
+                ],
+                "category_uuid": "a1e65620-4a1e-4234-968e-1aa080882a4d",
+                "type": "has_any_word",
+                "uuid": "3b6980f9-5c89-464a-bff7-58f75f1f4255"
               }
-            ]
-          }, 
-          {
-            "y": 280, 
-            "x": 367, 
-            "destination": null, 
-            "uuid": "b3633acf-f7ac-467e-a902-eabe1be1e16e", 
-            "actions": [
+            ],
+            "categories": [
               {
-                "msg": "I'm sorry you are unable to attend. Please contact 1-888-THE-CLINIC to reschedule.", 
-                "type": "reply"
-              }, 
+                "exit_uuid": "c3dcf29a-b7c8-45ae-a4d8-2e5ad774c376",
+                "name": "Yes",
+                "uuid": "c2b69f01-04d5-422b-893c-a61f94fbb5b5"
+              },
               {
-                "type": "del_group", 
-                "groups": [
-                  {
-                    "name": "Pending Appointments", 
-                    "id": 2308
-                  }
-                ]
-              }, 
+                "exit_uuid": "814ad52f-e17c-4320-9a54-7433f21f7e17",
+                "name": "No",
+                "uuid": "a1e65620-4a1e-4234-968e-1aa080882a4d"
+              },
               {
-                "field": "next_appointment", 
-                "type": "save", 
-                "value": "None", 
-                "label": "Next Appointment"
+                "exit_uuid": "1d055623-7d54-411f-b24d-3ced5512f5b2",
+                "name": "Other",
+                "uuid": "0c90a319-6411-45cf-a16b-b06db9e9f6ed"
               }
-            ]
-          }, 
-          {
-            "y": 117, 
-            "x": 25, 
-            "destination": "5819e334-bcba-4457-b4a9-0a840f1c0504", 
-            "uuid": "3112342a-0f24-45c4-8861-49204593559b", 
-            "actions": [
+            ],
+            "default_category_uuid": "0c90a319-6411-45cf-a16b-b06db9e9f6ed",
+            "operand": "@input",
+            "result_name": "Survey",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "ff071c3f-1fdf-4559-ba8e-2c321dc26a93"
+        },
+        {
+          "actions": [
+            {
+              "text": "Sorry, I'm not sure what that means. On a scale of 1 to 10, How likely are you to recommend The Clinic to your friends and family, 10 being very likely.",
+              "type": "send_msg",
+              "uuid": "20de5799-9494-44b1-b66c-1d985f0bd0b2"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "40d8d356-d285-4e0c-b6ae-a47f8aff554e",
+              "uuid": "fd716884-264e-45cb-a250-a5aac4addb84"
+            }
+          ],
+          "uuid": "51736b03-e53e-4ba1-b30b-455fc830668c"
+        },
+        {
+          "actions": [
+            {
+              "text": "Okay, maybe some other time. We hope you continue to choose The Clinic.",
+              "type": "send_msg",
+              "uuid": "094fdbd8-b909-492f-b5cf-a2e2a67fded1"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "7a679d7c-8c82-4fe0-b895-ba6649073aa1"
+            }
+          ],
+          "uuid": "56293742-abdc-4ff6-b9dc-e828ed58313c"
+        },
+        {
+          "actions": [
+            {
+              "text": "On a scale of 1 to 10, How likely are you to recommend The Clinic to your friends and family, 10 being very likely.",
+              "type": "send_msg",
+              "uuid": "f0ff1ab4-d890-4360-a2a7-33d827dc7d02"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "40d8d356-d285-4e0c-b6ae-a47f8aff554e",
+              "uuid": "f6674142-a9cb-4cc8-9c14-d25577fe255d"
+            }
+          ],
+          "uuid": "226e3ce8-765d-43ce-8e4c-3c10d2687364"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "ef24eadd-5f84-4dd7-be6f-96d4d7ef69e0",
+              "uuid": "4888b703-c47c-452e-b270-2b0e1763f6df"
+            },
+            {
+              "destination_uuid": "8736f559-f236-4e15-bc02-29660b9a2081",
+              "uuid": "3daa1c4e-04ad-4881-9e26-1235adf5a49b"
+            },
+            {
+              "destination_uuid": "d4251a10-0aa7-4feb-a743-9ccd2a75b225",
+              "uuid": "6169b8c5-1048-47b1-b24f-7433eff2c3c2"
+            },
+            {
+              "destination_uuid": "51736b03-e53e-4ba1-b30b-455fc830668c",
+              "uuid": "46708678-41be-459a-a92d-c0769c1b3eba"
+            }
+          ],
+          "router": {
+            "cases": [
               {
-                "msg": "Your next appointment at The Clinic is @contact.next_appointment. Will you be  attending this appointment? Please reply with Yes or No to confirm.", 
-                "type": "reply"
+                "arguments": [
+                  "1",
+                  "5"
+                ],
+                "category_uuid": "243cf55c-52b9-4e3e-aaec-31d866dbcb5a",
+                "type": "has_number_between",
+                "uuid": "c9d6b041-7e50-44d1-8d42-e69ce9c6bbbb"
+              },
+              {
+                "arguments": [
+                  "6",
+                  "8"
+                ],
+                "category_uuid": "0332420d-d7a4-4e8b-91fb-fd7c461854bb",
+                "type": "has_number_between",
+                "uuid": "a866a466-ddbe-446d-ac5e-193b5440a205"
+              },
+              {
+                "arguments": [
+                  "9",
+                  "10"
+                ],
+                "category_uuid": "a7ca08b4-c84d-492a-8ce3-3287256ef42d",
+                "type": "has_number_between",
+                "uuid": "d2f80cbc-f22f-4ce2-851a-e7e08d15075a"
               }
-            ]
-          }, 
-          {
-            "y": 338, 
-            "x": 126, 
-            "destination": null, 
-            "uuid": "81a28bd1-77af-465f-b1b9-d11333deb3ac", 
-            "actions": [
+            ],
+            "categories": [
               {
-                "msg": "Thanks, your appointment at The Clinic has been confirmed for @contact.next_appointment. See you then!", 
-                "type": "reply"
-              }, 
+                "exit_uuid": "4888b703-c47c-452e-b270-2b0e1763f6df",
+                "name": "Unlikely",
+                "uuid": "243cf55c-52b9-4e3e-aaec-31d866dbcb5a"
+              },
               {
-                "field": "appointment_confirmed", 
-                "type": "save", 
-                "value": "Confirmed", 
-                "label": "Appointment Confirmed"
+                "exit_uuid": "3daa1c4e-04ad-4881-9e26-1235adf5a49b",
+                "name": "Somewhat Likely",
+                "uuid": "0332420d-d7a4-4e8b-91fb-fd7c461854bb"
+              },
+              {
+                "exit_uuid": "6169b8c5-1048-47b1-b24f-7433eff2c3c2",
+                "name": "Very Likely",
+                "uuid": "a7ca08b4-c84d-492a-8ce3-3287256ef42d"
+              },
+              {
+                "exit_uuid": "46708678-41be-459a-a92d-c0769c1b3eba",
+                "name": "Other",
+                "uuid": "898f4fb8-b2b4-434d-8204-be250e9eccad"
               }
-            ]
-          }, 
-          {
-            "y": 14, 
-            "x": 408, 
-            "destination": null, 
-            "uuid": "b5ae11ff-e7d3-4dc4-a6de-a7ca6ada4229", 
-            "actions": [
+            ],
+            "default_category_uuid": "898f4fb8-b2b4-434d-8204-be250e9eccad",
+            "operand": "@input",
+            "result_name": "Rating",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "40d8d356-d285-4e0c-b6ae-a47f8aff554e"
+        },
+        {
+          "actions": [
+            {
+              "text": "That's wonderful. We are always striving to provide the best patient care possible. Can you share what part of your experience you were most pleased with?",
+              "type": "send_msg",
+              "uuid": "0f1da1f7-4c37-4814-b369-e21a6e978fe5"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "6f190d1a-b6c9-4533-95ed-83edf7d1603c",
+              "uuid": "dff19f27-dd05-4dec-ae6f-17fca4b5ecac"
+            }
+          ],
+          "uuid": "d4251a10-0aa7-4feb-a743-9ccd2a75b225"
+        },
+        {
+          "actions": [
+            {
+              "text": "Okay, so we obviously can do better. Can you tell us how we could have made your experience more pleasant?",
+              "type": "send_msg",
+              "uuid": "ee284124-bb53-4e29-8ddd-b84170947276"
+            },
+            {
+              "groups": [
+                {
+                  "name": "Unsatisfied Customers",
+                  "uuid": "cc6e1d94-8df5-4da7-857f-3b10904fa1ff"
+                }
+              ],
+              "type": "add_contact_groups",
+              "uuid": "71d421f3-146b-4a09-9910-6b65d62312d5"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "15a4e272-a689-41f6-9b8b-50c4d4923c15",
+              "uuid": "2ce8ee77-2087-4397-a00e-bc17031b3e36"
+            }
+          ],
+          "uuid": "ef24eadd-5f84-4dd7-be6f-96d4d7ef69e0"
+        },
+        {
+          "actions": [
+            {
+              "text": "That's great. Do you have any ideas or recommendations on ways we could improve your experience?",
+              "type": "send_msg",
+              "uuid": "c1543c65-aaaa-46f5-a330-151345bfe1ee"
+            }
+          ],
+          "exits": [
+            {
+              "destination_uuid": "15a4e272-a689-41f6-9b8b-50c4d4923c15",
+              "uuid": "60f14a7b-3f82-443a-89d3-b95b246acec9"
+            }
+          ],
+          "uuid": "8736f559-f236-4e15-bc02-29660b9a2081"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "42719e07-7ee5-4c5a-8ec4-7f98026d2ef9",
+              "uuid": "a748ef8c-20ab-4e71-9ce0-3edf5c4b0556"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
               {
-                "msg": "You don't have an appointment scheduled. Please contact 1-888-THE-CLINIC to schedule your next appointment.", 
-                "type": "reply"
+                "exit_uuid": "a748ef8c-20ab-4e71-9ce0-3edf5c4b0556",
+                "name": "All Responses",
+                "uuid": "4666dd11-aff9-4d97-881c-3e39798a0c66"
               }
-            ]
-          }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.253001Z", 
-        "metadata": {
-          "notes": []
+            ],
+            "default_category_uuid": "4666dd11-aff9-4d97-881c-3e39798a0c66",
+            "operand": "@input",
+            "result_name": "Doing Well",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "6f190d1a-b6c9-4533-95ed-83edf7d1603c"
+        },
+        {
+          "exits": [
+            {
+              "destination_uuid": "42719e07-7ee5-4c5a-8ec4-7f98026d2ef9",
+              "uuid": "0306b829-54b1-4457-8147-92670e5ee38a"
+            }
+          ],
+          "router": {
+            "cases": [],
+            "categories": [
+              {
+                "exit_uuid": "0306b829-54b1-4457-8147-92670e5ee38a",
+                "name": "All Responses",
+                "uuid": "bbe98dc7-1bce-41e6-804e-72d06dd8a846"
+              }
+            ],
+            "default_category_uuid": "bbe98dc7-1bce-41e6-804e-72d06dd8a846",
+            "operand": "@input",
+            "result_name": "Improvements",
+            "type": "switch",
+            "wait": {
+              "type": "msg"
+            }
+          },
+          "uuid": "15a4e272-a689-41f6-9b8b-50c4d4923c15"
+        },
+        {
+          "actions": [
+            {
+              "text": "Your feedback is extremely valuable to us. Thank you for helping us serve you better. We hope you continue to choose The Clinic.",
+              "type": "send_msg",
+              "uuid": "0b5986fc-b8c6-4b90-b4e9-ab426b381541"
+            },
+            {
+              "field": {
+                "key": "rating",
+                "name": "Rating"
+              },
+              "type": "set_contact_field",
+              "uuid": "9669e853-f529-4a96-b823-ff09aa39c6dc",
+              "value": "@results.rating "
+            },
+            {
+              "addresses": [
+                "feedback@theclinic.com"
+              ],
+              "body": "@results",
+              "subject": "Patient Feedback",
+              "type": "send_email",
+              "uuid": "c28b8ba6-7326-4026-b92f-b31a4a1d9fea"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "21f5e7ee-5cb3-4df0-a00e-ed808fb91a75"
+            }
+          ],
+          "uuid": "42719e07-7ee5-4c5a-8ec4-7f98026d2ef9"
         }
-      }, 
-      "id": 2806, 
-      "flow_type": "F", 
-      "name": "Confirm Appointment"
-    }, 
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "fb505d32-93e3-4aad-b69a-7d3318131f78"
+    },
     {
-      "definition": {
-        "entry": "ee5efdea-1f37-4c46-a414-31c29382c407", 
-        "rule_sets": [
-          {
-            "uuid": "ff071c3f-1fdf-4559-ba8e-2c321dc26a93", 
-            "webhook_action": null, 
-            "rules": [
-              {
-                "test": {
-                  "test": "Yes y sure", 
-                  "type": "contains_any"
-                }, 
-                "category": "Yes", 
-                "destination": "226e3ce8-765d-43ce-8e4c-3c10d2687364", 
-                "uuid": "c3dcf29a-b7c8-45ae-a4d8-2e5ad774c376"
-              }, 
-              {
-                "test": {
-                  "test": "No n", 
-                  "type": "contains_any"
-                }, 
-                "category": "No", 
-                "destination": "56293742-abdc-4ff6-b9dc-e828ed58313c", 
-                "uuid": "814ad52f-e17c-4320-9a54-7433f21f7e17"
-              }, 
-              {
-                "test": {
-                  "test": "true", 
-                  "type": "true"
-                }, 
-                "category": "Other", 
-                "destination": "59a61d6f-75a9-49d8-9182-41de3ab26595", 
-                "uuid": "1d055623-7d54-411f-b24d-3ced5512f5b2"
-              }
-            ], 
-            "webhook": null, 
-            "label": "Survey", 
-            "operand": "@step.value", 
-            "finished_key": null, 
-            "response_type": "C", 
-            "y": 253, 
-            "x": 390
-          }, 
-          {
-            "uuid": "40d8d356-d285-4e0c-b6ae-a47f8aff554e", 
-            "webhook_action": null, 
-            "rules": [
-              {
-                "test": {
-                  "max": "5", 
-                  "type": "between", 
-                  "min": "1"
-                }, 
-                "category": "Unlikely", 
-                "destination": "ef24eadd-5f84-4dd7-be6f-96d4d7ef69e0", 
-                "uuid": "4888b703-c47c-452e-b270-2b0e1763f6df"
-              }, 
-              {
-                "test": {
-                  "max": "8", 
-                  "type": "between", 
-                  "min": "6"
-                }, 
-                "category": "Somewhat Likely", 
-                "destination": "8736f559-f236-4e15-bc02-29660b9a2081", 
-                "uuid": "3daa1c4e-04ad-4881-9e26-1235adf5a49b"
-              }, 
-              {
-                "test": {
-                  "max": "10", 
-                  "type": "between", 
-                  "min": "9"
-                }, 
-                "category": "Very Likely", 
-                "destination": "d4251a10-0aa7-4feb-a743-9ccd2a75b225", 
-                "uuid": "6169b8c5-1048-47b1-b24f-7433eff2c3c2"
-              }, 
-              {
-                "test": {
-                  "test": "true", 
-                  "type": "true"
-                }, 
-                "category": "Other", 
-                "destination": "51736b03-e53e-4ba1-b30b-455fc830668c", 
-                "uuid": "46708678-41be-459a-a92d-c0769c1b3eba"
-              }
-            ], 
-            "webhook": null, 
-            "label": "Rating", 
-            "operand": "@step.value", 
-            "finished_key": null, 
-            "response_type": "C", 
-            "y": 532, 
-            "x": 286
-          }, 
-          {
-            "uuid": "6f190d1a-b6c9-4533-95ed-83edf7d1603c", 
-            "webhook_action": null, 
-            "rules": [
-              {
-                "test": {
-                  "test": "true", 
-                  "type": "true"
-                }, 
-                "category": "All Responses", 
-                "destination": "42719e07-7ee5-4c5a-8ec4-7f98026d2ef9", 
-                "uuid": "a748ef8c-20ab-4e71-9ce0-3edf5c4b0556"
-              }
-            ], 
-            "webhook": null, 
-            "label": "Doing Well", 
-            "operand": "@step.value", 
-            "finished_key": null, 
-            "response_type": "C", 
-            "y": 843, 
-            "x": 415
-          }, 
-          {
-            "uuid": "15a4e272-a689-41f6-9b8b-50c4d4923c15", 
-            "webhook_action": null, 
-            "rules": [
-              {
-                "test": {
-                  "test": "true", 
-                  "type": "true"
-                }, 
-                "category": "All Responses", 
-                "destination": "42719e07-7ee5-4c5a-8ec4-7f98026d2ef9", 
-                "uuid": "0306b829-54b1-4457-8147-92670e5ee38a"
-              }
-            ], 
-            "webhook": null, 
-            "label": "Improvements", 
-            "operand": "@step.value", 
-            "finished_key": null, 
-            "response_type": "C", 
-            "y": 903, 
-            "x": 59
+      "_ui": {
+        "nodes": {
+          "5a8a8088-4496-41c7-aedc-24a5d131e9d3": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
           }
-        ], 
-        "action_sets": [
-          {
-            "y": 264, 
-            "x": 740, 
-            "destination": "40d8d356-d285-4e0c-b6ae-a47f8aff554e", 
-            "uuid": "51736b03-e53e-4ba1-b30b-455fc830668c", 
-            "actions": [
-              {
-                "msg": "Sorry, I'm not sure what that means. On a scale of 1 to 10, How likely are you to recommend The Clinic to your friends and family, 10 being very likely.", 
-                "type": "reply"
-              }
-            ]
-          }, 
-          {
-            "y": 638, 
-            "x": 505, 
-            "destination": "6f190d1a-b6c9-4533-95ed-83edf7d1603c", 
-            "uuid": "d4251a10-0aa7-4feb-a743-9ccd2a75b225", 
-            "actions": [
-              {
-                "msg": "That's wonderful. We are always striving to provide the best patient care possible. Can you share what part of your experience you were most pleased with?", 
-                "type": "reply"
-              }
-            ]
-          }, 
-          {
-            "y": 361, 
-            "x": 465, 
-            "destination": null, 
-            "uuid": "56293742-abdc-4ff6-b9dc-e828ed58313c", 
-            "actions": [
-              {
-                "msg": "Okay, maybe some other time. We hope you continue to choose The Clinic.", 
-                "type": "reply"
-              }
-            ]
-          }, 
-          {
-            "y": 1001, 
-            "x": 232, 
-            "destination": null, 
-            "uuid": "42719e07-7ee5-4c5a-8ec4-7f98026d2ef9", 
-            "actions": [
-              {
-                "msg": "Your feedback is extremely valuable to us. Thank you for helping us serve you better. We hope you continue to choose The Clinic.", 
-                "type": "reply"
-              }, 
-              {
-                "field": "rating", 
-                "type": "save", 
-                "value": "@flow.rating ", 
-                "label": "Rating"
-              }, 
-              {
-                "msg": "@flow", 
-                "type": "email", 
-                "emails": [
-                  "feedback@theclinic.com"
-                ], 
-                "subject": "Patient Feedback"
-              }
-            ]
-          }, 
-          {
-            "y": 86, 
-            "x": 723, 
-            "destination": "ff071c3f-1fdf-4559-ba8e-2c321dc26a93", 
-            "uuid": "59a61d6f-75a9-49d8-9182-41de3ab26595", 
-            "actions": [
-              {
-                "msg": "Sorry, I didn't understand that. Do you have time for a short survey? Please respond with either Yes or No. ", 
-                "type": "reply"
-              }
-            ]
-          }, 
-          {
-            "y": 462, 
-            "x": 30, 
-            "destination": "40d8d356-d285-4e0c-b6ae-a47f8aff554e", 
-            "uuid": "226e3ce8-765d-43ce-8e4c-3c10d2687364", 
-            "actions": [
-              {
-                "msg": "On a scale of 1 to 10, How likely are you to recommend The Clinic to your friends and family, 10 being very likely.", 
-                "type": "reply"
-              }
-            ]
-          }, 
-          {
-            "y": 663, 
-            "x": 279, 
-            "destination": "15a4e272-a689-41f6-9b8b-50c4d4923c15", 
-            "uuid": "8736f559-f236-4e15-bc02-29660b9a2081", 
-            "actions": [
-              {
-                "msg": "That's great. Do you have any ideas or recommendations on ways we could improve your experience?", 
-                "type": "reply"
-              }
-            ]
-          }, 
-          {
-            "y": 0, 
-            "x": 66, 
-            "destination": "ff071c3f-1fdf-4559-ba8e-2c321dc26a93", 
-            "uuid": "ee5efdea-1f37-4c46-a414-31c29382c407", 
-            "actions": [
-              {
-                "msg": "Thanks for choosing The Clinic. Your business is very important to us. To help us better serve you would you be interested in participating in a short survey?", 
-                "type": "reply"
-              }, 
-              {
-                "field": "next_appointment", 
-                "type": "save", 
-                "value": "None", 
-                "label": "Next Appointment"
-              }, 
-              {
-                "field": "appointment_confirmed", 
-                "type": "save", 
-                "value": "None", 
-                "label": "Appointment Confirmed"
-              }, 
-              {
-                "type": "del_group", 
-                "groups": [
-                  {
-                    "name": "Pending Appointments", 
-                    "id": 2308
-                  }
-                ]
-              }
-            ]
-          }, 
-          {
-            "y": 662, 
-            "x": 56, 
-            "destination": "15a4e272-a689-41f6-9b8b-50c4d4923c15", 
-            "uuid": "ef24eadd-5f84-4dd7-be6f-96d4d7ef69e0", 
-            "actions": [
-              {
-                "msg": "Okay, so we obviously can do better. Can you tell us how we could have made your experience more pleasant?", 
-                "type": "reply"
-              }, 
-              {
-                "type": "add_group", 
-                "groups": [
-                  {
-                    "name": "Unsatisfied Customers", 
-                    "id": 2309
-                  }
-                ]
-              }
-            ]
-          }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.296226Z", 
-        "metadata": {
-          "notes": []
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Stop Notifications",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "groups": [
+                {
+                  "name": "Delay Notification",
+                  "uuid": "ee64972d-3c3b-4378-a115-68b6dcade0a0"
+                }
+              ],
+              "type": "remove_contact_groups",
+              "uuid": "f4262e50-8e4e-4df6-933f-3268cc2c3016"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "11bbcacc-f4a8-44b7-ad9d-30d1b7687a51"
+            }
+          ],
+          "uuid": "5a8a8088-4496-41c7-aedc-24a5d131e9d3"
         }
-      }, 
-      "id": 2807, 
-      "flow_type": "F", 
-      "name": "Appointment Followup"
-    }, 
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "8f0ab307-2c36-4eaf-baf2-597af539a2c0"
+    },
     {
-      "definition": {
-        "entry": "5a8a8088-4496-41c7-aedc-24a5d131e9d3", 
-        "rule_sets": [], 
-        "action_sets": [
-          {
-            "y": 0, 
-            "x": 100, 
-            "destination": null, 
-            "uuid": "5a8a8088-4496-41c7-aedc-24a5d131e9d3", 
-            "actions": [
-              {
-                "type": "del_group", 
-                "groups": [
-                  {
-                    "name": "Delay Notification", 
-                    "id": 2310
-                  }
-                ]
-              }
-            ]
+      "_ui": {
+        "nodes": {
+          "26678234-8a76-47a8-9ca7-e0b204765592": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
           }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.305278Z", 
-        "metadata": {
-          "notes": []
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Start Notifications",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "groups": [
+                {
+                  "name": "Delay Notification",
+                  "uuid": "ee64972d-3c3b-4378-a115-68b6dcade0a0"
+                }
+              ],
+              "type": "add_contact_groups",
+              "uuid": "6f3e1922-6577-4f83-baa7-d9a8eaa7a62e"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "691fe3e5-df11-4392-8f97-a1226fc7b30e"
+            }
+          ],
+          "uuid": "26678234-8a76-47a8-9ca7-e0b204765592"
         }
-      }, 
-      "id": 2808, 
-      "flow_type": "F", 
-      "name": "Stop Notifications"
-    }, 
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "eb0d5a69-756a-4c05-88eb-5e84fbd2dd9c"
+    },
     {
-      "definition": {
-        "entry": "26678234-8a76-47a8-9ca7-e0b204765592", 
-        "rule_sets": [], 
-        "action_sets": [
-          {
-            "y": 0, 
-            "x": 100, 
-            "destination": null, 
-            "uuid": "26678234-8a76-47a8-9ca7-e0b204765592", 
-            "actions": [
-              {
-                "type": "add_group", 
-                "groups": [
-                  {
-                    "name": "Delay Notification", 
-                    "id": 2310
-                  }
-                ]
-              }
-            ]
+      "_ui": {
+        "nodes": {
+          "43072a12-d007-43b8-8aca-96de332f5398": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
           }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.313646Z", 
-        "metadata": {
-          "notes": []
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Missed Call",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "Sorry, we missed your call.",
+              "type": "send_msg",
+              "uuid": "5569e889-2934-44f7-bf0f-7d595c846bea"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "77b02407-648d-4667-b0d9-35791e9991a8"
+            }
+          ],
+          "uuid": "43072a12-d007-43b8-8aca-96de332f5398"
         }
-      }, 
-      "id": 2809, 
-      "flow_type": "F", 
-      "name": "Start Notifications"
-    }, 
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "8d21a7da-dd20-4460-911e-ab579c7f55a3"
+    },
     {
-      "definition": {
-        "entry": "43072a12-d007-43b8-8aca-96de332f5398", 
-        "rule_sets": [], 
-        "action_sets": [
-          {
-            "y": 0, 
-            "x": 100, 
-            "destination": null, 
-            "uuid": "43072a12-d007-43b8-8aca-96de332f5398", 
-            "actions": [
-              {
-                "msg": "Sorry, we missed your call.", 
-                "type": "reply"
-              }
-            ]
+      "_ui": {
+        "nodes": {
+          "0ce3e457-5a9b-4b33-8593-22f878bd5470": {
+            "position": {
+              "left": 100,
+              "top": 0
+            },
+            "type": "execute_actions"
           }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.319977Z", 
-        "metadata": {
-          "notes": []
+        },
+        "stickies": {}
+      },
+      "expire_after_minutes": 0,
+      "language": "und",
+      "localization": {},
+      "name": "Triggered From Flow",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "text": "I was triggered from another flow",
+              "type": "send_msg",
+              "uuid": "818ef77f-1008-4fca-8ad9-8d3d92e28f10"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "508c3e1f-9e37-41c1-91e3-15c147a69125"
+            }
+          ],
+          "uuid": "0ce3e457-5a9b-4b33-8593-22f878bd5470"
         }
-      }, 
-      "id": 2810, 
-      "flow_type": "F", 
-      "name": "Missed Call"
-    }, 
-    {
-      "definition": {
-        "action_sets": [
-          {
-            "y": 0, 
-            "x": 100, 
-            "destination": null, 
-            "uuid": "0ce3e457-5a9b-4b33-8593-22f878bd5470", 
-            "actions": [
-              {
-                "msg": "I was triggered from another flow",
-                "type": "reply"
-              }
-            ]
-          }
-        ], 
-        "last_saved": "2014-10-29T21:40:47.326814Z", 
-        "entry": "0ce3e457-5a9b-4b33-8593-22f878bd5470", 
-        "rule_sets": [], 
-        "metadata": {}
-      }, 
-      "id": 2813, 
-      "flow_type": "F", 
-      "name": "Triggered From Flow"
+      ],
+      "revision": 0,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "16f33155-9ef7-478f-8a05-365eb05d29f7"
     }
-  ], 
+  ],
   "triggers": [
     {
       "flow": {
-        "name": "Catch All", 
-        "id": 2804
-      }, 
-      "groups": [], 
-      "keyword": null, 
+        "uuid": "198b20a2-c389-4cf6-8ccb-b45c959f3de1",
+        "name": "Catch All"
+      },
+      "groups": [],
+      "keyword": null,
       "trigger_type": "C"
-    }, 
+    },
     {
       "flow": {
-        "name": "Register Patient", 
-        "id": 2805
-      }, 
-      "groups": [], 
-      "keyword": "patient", 
+        "uuid": "ad22ba89-68af-4e2d-9d06-13e0b61193d2",
+        "name": "Register Patient"
+      },
+      "groups": [],
+      "keyword": "patient",
       "trigger_type": "K"
-    }, 
+    },
     {
       "flow": {
-        "name": "Confirm Appointment", 
-        "id": 2806
-      }, 
-      "groups": [], 
-      "keyword": "confirm", 
+        "uuid": "4b2a34bb-2da8-49df-97d2-7347804dec92",
+        "name": "Confirm Appointment"
+      },
+      "groups": [],
+      "keyword": "confirm",
       "trigger_type": "K"
-    }, 
+    },
     {
       "flow": {
-        "name": "Missed Call", 
-        "id": 2810
-      }, 
-      "groups": [], 
-      "keyword": null, 
+        "uuid": "8d21a7da-dd20-4460-911e-ab579c7f55a3",
+        "name": "Missed Call"
+      },
+      "groups": [],
+      "keyword": null,
       "trigger_type": "M"
     }
   ]

--- a/media/test_flows/whatsapp_template.json
+++ b/media/test_flows/whatsapp_template.json
@@ -2,40 +2,6 @@
   "version": "13",
   "flows": [
     {
-      "uuid": "c07d368e-fe1d-469d-b267-bca02d17c3e3",
-      "name": "Template Flow",
-      "spec_version": "13.0.0",
-      "language": "eng",
-      "type": "messaging",
-      "revision": 11,
-      "expire_after_minutes": 10080,
-      "localization": {},
-      "nodes": [
-        {
-          "uuid": "5bf98a89-d38d-40ba-8e5e-d54cad1777f1",
-          "actions": [
-            {
-              "attachments": [],
-              "text": "This is my test template message.",
-              "type": "send_msg",
-              "quick_replies": [],
-              "uuid": "b103d563-9320-40fe-8f96-c9d3fbe0262d",
-              "templating": {
-                "template": {
-                  "uuid": "f712e05c-bbed-40f1-b3d9-671bb9b60775",
-                  "name": "affirmation"
-                },
-                "variables": []
-              }
-            }
-          ],
-          "exits": [
-            {
-              "uuid": "29dd720b-00ed-4304-97b0-38c65bc38e30"
-            }
-          ]
-        }
-      ],
       "_ui": {
         "nodes": {
           "5bf98a89-d38d-40ba-8e5e-d54cad1777f1": {
@@ -46,7 +12,39 @@
             "type": "execute_actions"
           }
         }
-      }
+      },
+      "expire_after_minutes": 10080,
+      "language": "eng",
+      "localization": {},
+      "name": "Template Flow",
+      "nodes": [
+        {
+          "actions": [
+            {
+              "attachments": [],
+              "quick_replies": [],
+              "template": {
+                "name": "affirmation",
+                "uuid": "f712e05c-bbed-40f1-b3d9-671bb9b60775"
+              },
+              "template_variables": [],
+              "text": "This is my test template message.",
+              "type": "send_msg",
+              "uuid": "b103d563-9320-40fe-8f96-c9d3fbe0262d"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "29dd720b-00ed-4304-97b0-38c65bc38e30"
+            }
+          ],
+          "uuid": "5bf98a89-d38d-40ba-8e5e-d54cad1777f1"
+        }
+      ],
+      "revision": 11,
+      "spec_version": "14.4.0",
+      "type": "messaging",
+      "uuid": "c07d368e-fe1d-469d-b267-bca02d17c3e3"
     }
   ]
 }

--- a/temba/flows/legacy/migrations.py
+++ b/temba/flows/legacy/migrations.py
@@ -989,11 +989,11 @@ def migrate_export_to_version_9(exported_json, org, same_site=True):
 
         replace_with_uuid(ele, Contact.objects, contact_id_map)
 
-    def remap_channel(ele):
+    def remap_channel(ele):  # pragma: no cover
         from temba.channels.models import Channel
 
         channel_id = ele.get("channel")
-        if channel_id:  # pragma: no cover
+        if channel_id:
             channel = Channel.objects.filter(pk=channel_id).first()
             if channel:
                 ele["channel"] = channel.uuid
@@ -1029,10 +1029,10 @@ def migrate_export_to_version_9(exported_json, org, same_site=True):
             else:
                 del metadata["id"]  # pragma: no cover
 
-    for trigger in exported_json.get("triggers", []):
+    for trigger in exported_json.get("triggers", []):  # pragma: no cover
         if "flow" in trigger:
             remap_flow(trigger["flow"])
-        for group in trigger["groups"]:  # pragma: no cover
+        for group in trigger["groups"]:
             remap_group(group)
         remap_channel(trigger)
 
@@ -1162,7 +1162,7 @@ def migrate_to_version_6(json_flow, flow=None):
 
                 # convert our localized types
                 if rule["test"]["type"] in ("contains", "contains_any", "starts", "regex"):
-                    convert_to_dict(rule["test"], "test")
+                    convert_to_dict(rule["test"], "test")  # pragma: no cover
 
         for actionset in definition.get("action_sets"):
             for action in actionset.get("actions"):

--- a/temba/flows/management/commands/migrate_test_fixtures.py
+++ b/temba/flows/management/commands/migrate_test_fixtures.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         current = Version(Flow.CURRENT_SPEC_VERSION)
 
         for path in sorted(pathlib.Path("media/test_flows").rglob("*.json")):
-            rel = str(path)
+            rel = path.as_posix()
             if rel in SKIP or any(rel.startswith(d) for d in SKIP_DIRS):
                 continue
 
@@ -69,16 +69,22 @@ class Command(BaseCommand):
                 self.stdout.write(f"SKIP (already current): {rel}")
                 continue
 
-            version = Version(str(data["version"]))
-            self.stdout.write(f"MIGRATE {rel}: v{version} -> v{current}")
+            export_version = Version(str(data["version"]))
+            self.stdout.write(f"MIGRATE {rel}: export v{export_version} -> spec v{current}")
 
             try:
-                migrated = Flow.migrate_export(org, data, same_site=False, version=version)
+                migrated = Flow.migrate_export(org, data, same_site=False, version=export_version)
             except Exception as e:
                 self.stderr.write(f"  FAILED: {e}")
                 continue
 
             # keep the export envelope at the current export format - distinct from flow spec_version
             migrated["version"] = Org.CURRENT_EXPORT_VERSION
+
+            # strip the legacy "version" key from each migrated flow def - the migrated form uses
+            # "spec_version" only and Flow.migrate_definition treats the presence of "version" as
+            # an indicator of a legacy definition needing migration
+            for flow_def in migrated.get("flows", []):
+                flow_def.pop("version", None)
 
             path.write_text(json.dumps(migrated, indent=indent) + "\n")

--- a/temba/flows/management/commands/migrate_test_fixtures.py
+++ b/temba/flows/management/commands/migrate_test_fixtures.py
@@ -1,0 +1,84 @@
+"""
+Re-migrates flow test fixtures in media/test_flows/ to the current spec version.
+
+Used when bumping Flow.CURRENT_SPEC_VERSION so tests don't need to call mailroom's
+flow/migrate endpoint just to bring fixtures up to current spec.
+
+Skips fixtures used to test legacy migration behavior:
+  - media/test_flows/legacy/migrations/*  (inputs to FlowMigrationTest)
+  - media/test_flows/legacy/invalid/*     (intentionally invalid)
+  - media/test_flows/legacy/color_v11.json (tests legacy revision migration UI)
+  - media/test_flows/mixed_versions.json   (tests mixed-version import)
+"""
+
+import json
+import pathlib
+import re
+
+from packaging.version import Version
+
+from django.core.management.base import BaseCommand
+
+from temba.flows.models import Flow
+from temba.orgs.models import Org
+
+SKIP = {
+    "media/test_flows/legacy/color_v11.json",
+    "media/test_flows/mixed_versions.json",
+}
+SKIP_DIRS = {
+    "media/test_flows/legacy/migrations",
+    "media/test_flows/legacy/invalid",
+}
+
+
+def _detect_indent(text: str) -> int:
+    m = re.search(r"\n( +)\S", text)
+    return len(m.group(1)) if m else 2
+
+
+class Command(BaseCommand):
+    help = "Migrate flow test fixtures in media/test_flows/ to the current flow spec version"
+
+    def handle(self, *args, **options):
+        org = Org.objects.first()
+        if org is None:
+            self.stderr.write("No org found - need at least one org in the DB to run this")
+            return
+
+        current = Version(Flow.CURRENT_SPEC_VERSION)
+
+        for path in sorted(pathlib.Path("media/test_flows").rglob("*.json")):
+            rel = str(path)
+            if rel in SKIP or any(rel.startswith(d) for d in SKIP_DIRS):
+                continue
+
+            text = path.read_text()
+            indent = _detect_indent(text)
+            data = json.loads(text)
+
+            if "version" not in data:
+                self.stdout.write(f"SKIP (no version field): {rel}")
+                continue
+
+            # skip if all inner flows are already at the current spec version
+            inner_versions = [
+                Version(str(f.get("spec_version") or f.get("version") or "0")) for f in data.get("flows", [])
+            ]
+            if inner_versions and all(v >= current for v in inner_versions):
+                self.stdout.write(f"SKIP (already current): {rel}")
+                continue
+
+            version = Version(str(data["version"]))
+            self.stdout.write(f"MIGRATE {rel}: v{version} -> v{current}")
+
+            try:
+                migrated = Flow.migrate_export(org, data, same_site=False, version=version)
+            except Exception as e:
+                self.stderr.write(f"  FAILED: {e}")
+                continue
+
+            # keep the export envelope at the current export format - distinct from flow spec_version
+            migrated["version"] = Org.CURRENT_EXPORT_VERSION
+
+            path.write_text(json.dumps(migrated, indent=indent) + "\n")

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from functools import wraps
 from unittest.mock import call, patch
 
+from packaging.version import Version
+
 from django.conf import settings
 from django.db import connection
 from django.utils import timezone
@@ -14,7 +16,7 @@ from temba import mailroom
 from temba.campaigns.models import CampaignEvent
 from temba.channels.models import ChannelEvent
 from temba.contacts.models import URN, Contact, ContactField, ContactGroup, ContactURN
-from temba.flows.models import FlowRun, FlowSession, FlowStart
+from temba.flows.models import Flow, FlowRun, FlowSession, FlowStart
 from temba.locations.models import AdminBoundary
 from temba.mailroom.client.client import MailroomClient
 from temba.mailroom.modifiers import Modifier
@@ -355,10 +357,6 @@ class TestClient(MailroomClient):
     def flow_migrate(self, definition: dict, to_version=None):
         # fast-path: if the definition is already at the target version, skip the HTTP call.
         # for older fixtures we fall through to real mailroom since we'd need to actually migrate.
-        from packaging.version import Version
-
-        from temba.flows.models import Flow
-
         if not to_version:
             to_version = Flow.CURRENT_SPEC_VERSION
 

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -352,6 +352,23 @@ class TestClient(MailroomClient):
         }
 
     @_client_method
+    def flow_migrate(self, definition: dict, to_version=None):
+        # fast-path: if the definition is already at the target version, skip the HTTP call.
+        # for older fixtures we fall through to real mailroom since we'd need to actually migrate.
+        from packaging.version import Version
+
+        from temba.flows.models import Flow
+
+        if not to_version:
+            to_version = Flow.CURRENT_SPEC_VERSION
+
+        current = definition.get("spec_version")
+        if current and Version(current) >= Version(to_version):
+            return definition
+
+        return super().flow_migrate(definition, to_version=to_version)
+
+    @_client_method
     def flow_interrupt(self, org, flow):
         pass
 


### PR DESCRIPTION
## Summary

Eliminates real-mailroom dependency on the `flow/migrate` endpoint for the bulk of flow-importing tests by:

1. **Adding `TestClient.flow_migrate`** with a fast-path: returns the input unchanged when it's already at the target spec, falls through to real mailroom otherwise.
2. **Pre-migrating 30 test fixtures** in `media/test_flows/` to current spec 14.4.0 via a new `migrate_test_fixtures` management command.

Together these mean: any test that imports a current-spec fixture no longer triggers a real HTTP call to mailroom's `flow/migrate`, even though `Flow.migrate_definition` still calls `flow_migrate` internally during import.

## Why both changes are needed

Either change alone is useless:
- **Mock without migrated fixtures**: every fixture has `spec_version` 13.x or older, so the fast-path never fires.
- **Migrated fixtures without mock**: `migrate_definition` still calls `flow_migrate` for every import; even an already-current definition triggers a real HTTP call.

## Fixtures NOT migrated

These exist to test migration behavior and must stay at their original versions:

- `media/test_flows/legacy/migrations/*` — inputs to `FlowMigrationTest`
- `media/test_flows/legacy/invalid/*` — intentionally invalid
- `media/test_flows/legacy/color_v11.json` — used by `test_revisions` to test legacy revision migration UI
- `media/test_flows/mixed_versions.json` — used by `test_import_mixed_flow_versions`

## Real mailroom still called for

The fall-through correctly routes these to real mailroom:

- `FlowMigrationTest` (34 tests in `temba/flows/legacy/tests.py`) — load legacy fixtures, expected
- `test_ensure_current_version` — deliberately rewinds spec to 13.0.0 to test migration
- Tests loading `legacy/color_v11.json`

## Verification

Verified by temporarily replacing the fall-through with `raise AssertionError` — only the cases above fired, all expected.

Ran `temba.flows`, `temba.orgs`, `temba.api`, `temba.contacts`, `temba.msgs`, `temba.triggers`, `temba.campaigns`, `temba.tickets` (533 tests). Zero new failures. All 66 pre-existing failures are local-environment `NoSuchBucket` S3 errors that affect unmodified tests equally; CI has working S3.

## Re-running the migration

When `Flow.CURRENT_SPEC_VERSION` next bumps:

```
python manage.py migrate_test_fixtures
```

The command is idempotent — it inspects each fixture's inner `spec_version` and skips ones already at current.

## Test plan

- [x] `temba.flows.legacy.tests.FlowMigrationTest` — 34 tests pass
- [x] Full `temba.flows`, `temba.orgs`, `temba.api`, `temba.contacts`, `temba.msgs`, `temba.triggers`, `temba.campaigns`, `temba.tickets` — no new failures
- [x] `code_check.py` passes
- [x] `migrate_test_fixtures` command is idempotent