### PR TITLE
Remove unused React references from static config and CSS

### DIFF
--- a/static/css/frame.css
+++ b/static/css/frame.css
@@ -50,13 +50,6 @@ body {
   padding: 3px;
 }
 
-.ReactModalPortal p {
-  margin-block-end: 14px;
-  margin-block-start: 10px;
-  margin-inline-end: 0px;
-  margin-inline-start: 0px;
-}
-
 .hide {
   display: none;
 }

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -135,8 +135,6 @@ STATICFILES_DIRS = (
     os.path.join(PROJECT_DIR, "../media"),
     os.path.join(PROJECT_DIR, "../node_modules/@nyaruka/temba-components/dist/static"),
     os.path.join(PROJECT_DIR, "../node_modules"),
-    os.path.join(PROJECT_DIR, "../node_modules/react/umd"),
-    os.path.join(PROJECT_DIR, "../node_modules/react-dom/umd"),
 )
 STATIC_ROOT = os.path.join(PROJECT_DIR, "../sitestatic")
 STATIC_URL = "/sitestatic/"


### PR DESCRIPTION
## Summary
- React is no longer used in this project, but `STATICFILES_DIRS` still pointed at `node_modules/react/umd` and `node_modules/react-dom/umd` (paths that don't even exist since react/react-dom aren't in `package.json`).
- Also drops a stale `.ReactModalPortal p` rule from `static/css/frame.css`.

## Test plan
- [ ] `collectstatic` runs without warnings about missing react/react-dom directories