### PR TITLE
Prevent editing and deleting system LLMs

### DIFF
--- a/temba/ai/models.py
+++ b/temba/ai/models.py
@@ -112,6 +112,8 @@ class LLM(TembaModel, DependencyMixin):
         return mailroom.get_client().llm_translate(self, source, target, items)
 
     def release(self, user):
+        assert not (self.is_system and self.org.is_active), "can't release system LLMs"
+
         super().release(user)
 
         self.is_active = False

--- a/temba/ai/tests/test_llm.py
+++ b/temba/ai/tests/test_llm.py
@@ -22,6 +22,17 @@ class LLMTest(TembaTest):
         self.assertEqual(1, LLM.objects.filter(is_active=False).count())
         self.assertEqual(2, LLM.objects.count())
 
+    def test_release_system(self):
+        system = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "System", {})
+        system.is_system = True
+        system.save(update_fields=("is_system",))
+
+        with self.assertRaises(AssertionError):
+            system.release(self.admin)
+
+        system.refresh_from_db()
+        self.assertTrue(system.is_active)
+
     def test_is_available_to(self):
         # by default available to any user
         self.assertTrue(OpenAIType().is_available_to(self.org, self.admin))

--- a/temba/ai/tests/test_llmcrudl.py
+++ b/temba/ai/tests/test_llmcrudl.py
@@ -71,6 +71,13 @@ class LLMCRUDLTest(TembaTest, CRUDLTestMixin):
         self.openai.refresh_from_db()
         self.assertEqual(self.openai.name, "GPT-4-Turbo")
 
+        # system LLMs can't be edited
+        self.openai.is_system = True
+        self.openai.save(update_fields=("is_system",))
+
+        self.login(self.admin)
+        self.assertEqual(404, self.client.get(update_url).status_code)
+
     @mock_mailroom
     def test_translate(self, mr_mocks):
         translate_url = reverse("ai.llm_translate", args=[self.openai.uuid])
@@ -131,3 +138,14 @@ class LLMCRUDLTest(TembaTest, CRUDLTestMixin):
         self.flow.refresh_from_db()
         self.assertTrue(self.flow.has_issues)
         self.assertNotIn(self.openai, self.flow.llm_dependencies.all())
+
+        # system LLMs can't be deleted
+        system = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "System", {})
+        system.is_system = True
+        system.save(update_fields=("is_system",))
+
+        delete_url = reverse("ai.llm_delete", args=[system.uuid])
+
+        self.login(self.admin)
+        self.assertEqual(404, self.client.get(delete_url).status_code)
+        self.assertEqual(404, self.client.post(delete_url).status_code)

--- a/temba/orgs/views/base.py
+++ b/temba/orgs/views/base.py
@@ -411,6 +411,14 @@ class BaseDependencyDeleteModal(DependencyMixin, ModalFormMixin, OrgObjPermsMixi
         "trigger": _("these will be removed"),  # soft for flows
     }
 
+    def get_queryset(self, **kwargs):
+        qs = super().get_queryset(**kwargs)
+
+        if hasattr(self.model, "is_system"):
+            qs = qs.filter(is_system=False)
+
+        return qs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 

--- a/templates/ai/llm_list.html
+++ b/templates/ai/llm_list.html
@@ -20,7 +20,7 @@
   <table class="list lined scrolled">
     <tbody>
       {% for obj in object_list %}
-        <tr {% if org_perms.ai.llm_update %}onclick="showUpdateLLMModal('{{ obj.uuid }}')" class="hover-linked update"{% endif %}>
+        <tr {% if org_perms.ai.llm_update and not obj.is_system %}onclick="showUpdateLLMModal('{{ obj.uuid }}')" class="hover-linked update"{% endif %}>
           <td style="width: 32px">
             <temba-icon class="inline-block mr-1 align-middle" name="{{ obj.type.icon }}">
             </temba-icon>
@@ -46,11 +46,13 @@
           </td>
           {% if org_perms.ai.llm_delete %}
             <td class="w-10">
-              <temba-icon name="delete"
-                          clickable="true"
-                          style="--icon-color:#bbb"
-                          onclick="event.stopPropagation(); showDeleteLLMModal('{{ obj.uuid }}');">
-              </temba-icon>
+              {% if not obj.is_system %}
+                <temba-icon name="delete"
+                            clickable="true"
+                            style="--icon-color:#bbb"
+                            onclick="event.stopPropagation(); showDeleteLLMModal('{{ obj.uuid }}');">
+                </temba-icon>
+              {% endif %}
             </td>
           {% endif %}
         </tr>


### PR DESCRIPTION
## Summary

- Adds an assertion to `LLM.release()` so system LLMs can't be soft-deleted while their org is active (matching the pattern in `Topic.release()` / `Team.release()`).
- Extends `BaseDependencyDeleteModal.get_queryset()` to filter out `is_system=True` rows when the model has the field — mirrors the existing filter in `BaseDeleteModal` and `BaseUpdateView`. As a result the LLM Update and Delete URLs now 404 for system LLMs (and the same gap is closed for `ContactGroup` / `ContactField`, which also use this base).
- Hides the row click-to-edit handler and the delete icon for system LLMs in the LLM list template.

## Test plan

- [x] New unit test: `LLMTest.test_release_system` confirms `release()` raises and the LLM stays active
- [x] New CRUDL coverage in `test_update` and `test_delete` confirms both URLs return 404 for a system LLM
- [x] Existing `temba.ai.tests`, `temba.contacts.tests.test_groupcrudl`, and `temba.contacts.tests.test_field` still pass
- [x] `code_check.py` passes