### PR TITLE
Hide system LLMs from list view

### DIFF
--- a/temba/ai/tests/test_llmcrudl.py
+++ b/temba/ai/tests/test_llmcrudl.py
@@ -22,6 +22,11 @@ class LLMCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_list(self):
         list_url = reverse("ai.llm_list")
 
+        # system LLMs should be hidden from the list
+        system = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "System", {})
+        system.is_system = True
+        system.save(update_fields=("is_system",))
+
         self.assertRequestDisallowed(list_url, [None, self.agent])
 
         response = self.assertListFetch(

--- a/temba/ai/views.py
+++ b/temba/ai/views.py
@@ -98,6 +98,9 @@ class LLMCRUDL(SmartCRUDL):
         menu_path = "settings/ai"
         default_order = (Lower("name"),)
 
+        def derive_queryset(self, **kwargs):
+            return super().derive_queryset(**kwargs).filter(is_system=False)
+
         def build_context_menu(self, menu):
             if self.has_org_perm("ai.llm_connect") and not self.is_limit_reached():
                 org = self.request.org

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -328,6 +328,9 @@ class EndpointsTest(APITestMixin, TembaTest):
         anthropic = LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Claude", {})
         deleted = LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Deleted", {})
         deleted.release(self.admin)
+        system = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "System", {})
+        system.is_system = True
+        system.save(update_fields=("is_system",))
 
         self.assertGetNotPermitted(endpoint_url, [None])
         self.assertPostNotAllowed(endpoint_url)
@@ -345,6 +348,11 @@ class EndpointsTest(APITestMixin, TembaTest):
                 {
                     "uuid": str(openai.uuid),
                     "name": "GPT-4",
+                    "type": "openai",
+                },
+                {
+                    "uuid": str(system.uuid),
+                    "name": "System",
                     "type": "openai",
                 },
             ],


### PR DESCRIPTION
Excludes LLMs with `is_system=True` from the AI list view (`ai.llm_list`), since they're not user-managed and shouldn't appear alongside connected models.

The internal API endpoint (`api.internal.llms`) intentionally still returns system LLMs — they need to be visible there for the rest of the app to use them.