### PR TITLE
Expose LLM roles on internal API and rename role constants

### DIFF
--- a/temba/ai/models.py
+++ b/temba/ai/models.py
@@ -57,9 +57,10 @@ class LLM(TembaModel, DependencyMixin):
     A language model that can be used for AI tasks
     """
 
-    ROLE_TRANSLATION = "T"
-    ROLE_FLOWS = "F"
-    DEFAULT_ROLES = ROLE_TRANSLATION + ROLE_FLOWS
+    ROLE_EDITING = "T"
+    ROLE_ENGINE = "F"
+    ROLE_NAMES = {ROLE_EDITING: "editing", ROLE_ENGINE: "engine"}
+    DEFAULT_ROLES = ROLE_EDITING + ROLE_ENGINE
 
     org = models.ForeignKey(Org, related_name="llms", on_delete=models.PROTECT)
     llm_type = models.CharField(max_length=16)

--- a/temba/api/internal/serializers.py
+++ b/temba/api/internal/serializers.py
@@ -16,10 +16,14 @@ class ModelAsJsonSerializer(serializers.BaseSerializer):
 
 class LLMReadSerializer(serializers.ModelSerializer):
     type = serializers.CharField(source="llm_type")
+    roles = serializers.SerializerMethodField()
+
+    def get_roles(self, obj):
+        return [LLM.ROLE_NAMES[r] for r in obj.roles]
 
     class Meta:
         model = LLM
-        fields = ("uuid", "name", "type")
+        fields = ("uuid", "name", "type", "roles")
 
 
 class LocationReadSerializer(serializers.ModelSerializer):

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -324,7 +324,7 @@ class EndpointsTest(APITestMixin, TembaTest):
     def test_llms(self):
         endpoint_url = reverse("api.internal.llms") + ".json"
 
-        openai = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {})
+        openai = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {}, roles=LLM.ROLE_EDITING)
         anthropic = LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Claude", {})
         deleted = LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Deleted", {})
         deleted.release(self.admin)
@@ -344,16 +344,19 @@ class EndpointsTest(APITestMixin, TembaTest):
                     "uuid": str(anthropic.uuid),
                     "name": "Claude",
                     "type": "anthropic",
+                    "roles": ["editing", "engine"],
                 },
                 {
                     "uuid": str(openai.uuid),
                     "name": "GPT-4",
                     "type": "openai",
+                    "roles": ["editing"],
                 },
                 {
                     "uuid": str(system.uuid),
                     "name": "System",
                     "type": "openai",
+                    "roles": ["editing", "engine"],
                 },
             ],
         )


### PR DESCRIPTION
## Summary

- Renames Python role constants `ROLE_TRANSLATION` → `ROLE_EDITING` and `ROLE_FLOWS` → `ROLE_ENGINE`. The DB char codes (`T`/`F`) are unchanged, so no migration is needed.
- Adds a `ROLE_NAMES` mapping (`T → editing`, `F → engine`).
- Internal `/api/internal/llms` endpoint now returns a `roles` field, e.g. `{"uuid": "...", "name": "GPT-4", "type": "openai", "roles": ["editing", "engine"]}`.

Companion PRs in goflow and mailroom rename the long names (`translation`/`flows` → `editing`/`engine`) in the asset format and SQL mapping. Those can ship later — this PR doesn't depend on them since the DB chars don't change.

Note: `textit` imports `LLM.ROLE_TRANSLATION`, so it needs a sister rename PR before this merges.

## Test plan

- [x] `temba.api.internal` and `temba.ai` tests pass