### PR TITLE
Allow dev settings overrides via gitignored settings_local.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules
 screenshots
 sitestatic
 temba/settings.py
+temba/settings_local.py
 manage.sh
 rp.sh
 

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -48,3 +48,12 @@ warnings.filterwarnings(
 # Make our sitestatic URL be our static URL on development
 # -----------------------------------------------------------------------------------
 STATIC_URL = "/static/"
+
+# -----------------------------------------------------------------------------------
+# Optional local overrides — create temba/settings_local.py to override settings
+# without modifying this checked-in file. settings_local.py is gitignored.
+# -----------------------------------------------------------------------------------
+try:
+    from .settings_local import *  # noqa
+except ImportError:
+    pass


### PR DESCRIPTION
Adds an optional `temba/settings_local.py` import at the bottom of `settings.py.dev` so per-worktree or per-developer dev overrides (e.g. a scoped test database name) can live in a gitignored file instead of mutating the checked-in settings.

The override file is added to `.gitignore`. If absent, the import is a no-op.