### PR TITLE
Upgrade to elasticsearch 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "openai>=1.66.3,<2.0.0",
     "anthropic>=0.54.0,<1.0.0",
     "fido2>=2.0.0,<3.0.0",
-    "elasticsearch>=8.17.0,<9.0.0"
+    "elasticsearch>=9.0.0,<10.0.0"
 ]
 
 [project.urls]

--- a/temba/utils/management/commands/create_es_index.py
+++ b/temba/utils/management/commands/create_es_index.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
     def _create_template(self, client, name: str, schema: dict):
         """Creates an index template using the Elasticsearch API."""
 
-        client.indices.put_index_template(name=name, body=schema)
+        client.indices.put_index_template(name=name, **schema)
 
         opts = schema["template"]["settings"]["index"]
         self.stdout.write(
@@ -66,7 +66,7 @@ class Command(BaseCommand):
     def _create_index(self, client, name: str, schema: dict, alias: str = None):
         """Creates a regular index using the Elasticsearch API."""
 
-        client.indices.create(index=name, body=schema)
+        client.indices.create(index=name, **schema)
 
         opts = schema["settings"]["index"]
         self.stdout.write(
@@ -85,5 +85,5 @@ class Command(BaseCommand):
             except Exception:
                 pass  # alias doesn't exist yet
 
-            client.indices.update_aliases(body={"actions": actions})
+            client.indices.update_aliases(actions=actions)
             self.stdout.write(f" > added alias {alias} -> {name}")

--- a/uv.lock
+++ b/uv.lock
@@ -657,29 +657,32 @@ wheels = [
 
 [[package]]
 name = "elastic-transport"
-version = "8.17.1"
+version = "9.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
+    { name = "sniffio" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/54/d498a766ac8fa475f931da85a154666cc81a70f8eb4a780bc8e4e934e9ac/elastic_transport-8.17.1.tar.gz", hash = "sha256:5edef32ac864dca8e2f0a613ef63491ee8d6b8cfb52881fa7313ba9290cac6d2", size = 73425, upload-time = "2025-03-13T07:28:30.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/0a/a92140b666afdcb9862a16e4d80873b3c887c1b7e3f17e945fc3460edf1b/elastic_transport-9.2.1.tar.gz", hash = "sha256:97d9abd638ba8aa90faa4ca1bf1a18bde0fe2088fbc8757f2eb7b299f205773d", size = 77403, upload-time = "2025-12-23T11:54:12.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/cd/b71d5bc74cde7fc6fd9b2ff9389890f45d9762cbbbf81dc5e51fd7588c4a/elastic_transport-8.17.1-py3-none-any.whl", hash = "sha256:192718f498f1d10c5e9aa8b9cf32aed405e469a7f0e9d6a8923431dbb2c59fb8", size = 64969, upload-time = "2025-03-13T07:28:29.031Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e6/a42b600ae8b808371f740381f6c32050cad93f870d36cc697b8b7006bf7c/elastic_transport-9.2.1-py3-none-any.whl", hash = "sha256:39e1a25e486af34ce7aa1bc9005d1c736f1b6fb04c9b64ea0604ded5a61fc1d4", size = 65327, upload-time = "2025-12-23T11:54:11.681Z" },
 ]
 
 [[package]]
 name = "elasticsearch"
-version = "8.19.3"
+version = "9.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "elastic-transport" },
     { name = "python-dateutil" },
+    { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/79/365e306017a9fcfbbefab1a3b588d2404bea8806b36766ff0f886509a20e/elasticsearch-8.19.3.tar.gz", hash = "sha256:e84dd618a220cac25b962790085045dd27ac72e01c0a5d81bd29a2d47a71f03f", size = 800298, upload-time = "2025-12-23T12:56:00.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/15/283459c9299d412ffa2aaab69b082857631c519233f5491d6c567e3320ca/elasticsearch-9.3.0.tar.gz", hash = "sha256:f76e149c0a22d5ccbba58bdc30c9f51cf894231b359ef4fd7e839b558b59f856", size = 893538, upload-time = "2026-02-03T20:26:38.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/0f/ac126833c385b06166d41c486e4911f58ad7791fd1a53dd6e0b8d16ff214/elasticsearch-8.19.3-py3-none-any.whl", hash = "sha256:fe1db2555811192e8a1be78b01234d0a49d32b185ea7eeeb6f059331dee32838", size = 952820, upload-time = "2025-12-23T12:55:56.796Z" },
+    { url = "https://files.pythonhosted.org/packages/05/37/3a196f8918743f2104cb66b1f56218079ecac6e128c061de7df7f4faef02/elasticsearch-9.3.0-py3-none-any.whl", hash = "sha256:67bd2bb4f0800f58c2847d29cd57d6e7bf5bc273483b4f17421f93e75ba09f39", size = 979405, upload-time = "2026-02-03T20:26:34.552Z" },
 ]
 
 [[package]]
@@ -1608,7 +1611,7 @@ requires-dist = [
     { name = "django-timezone-field", specifier = "~=6.1.0" },
     { name = "django-valkey", specifier = ">=0.2.1,<0.3.0" },
     { name = "djangorestframework", specifier = "~=3.16.0" },
-    { name = "elasticsearch", specifier = ">=8.17.0,<9.0.0" },
+    { name = "elasticsearch", specifier = ">=9.0.0,<10.0.0" },
     { name = "ffmpeg-python", specifier = "~=0.2.0" },
     { name = "fido2", specifier = ">=2.0.0,<3.0.0" },
     { name = "geojson", specifier = "~=2.5.0" },


### PR DESCRIPTION
Bumps the `elasticsearch` python client from 8.x to 9.x and updates `create_es_index` to use the modern keyword-argument API.

## Changes

- `pyproject.toml`: `elasticsearch>=9.0.0,<10.0.0`
- `uv.lock`: `elasticsearch 8.19.3 → 9.3.0`, `elastic-transport 8.17.1 → 9.2.1`
- `temba/utils/management/commands/create_es_index.py`: replace deprecated `body=` kwarg on `indices.put_index_template`, `indices.create`, and `indices.update_aliases` with the modern keyword form (`**schema` / `actions=actions`). The `body=` kwarg has been deprecated since 8.0 and emits warnings under 9.x.

## Notes

Per upstream, the python client 9.x requires Elasticsearch server 9.x. Deployed clusters need to be on 9.x before this change ships. Verified locally against Elasticsearch 9.3.3.

## Verification

- `temba.utils.tests.test_elastic` — 3/3 pass
- `manage.py create_es_index messages` and `... contacts` succeed against a live ES 9.3.3 server
- `code_check.py` (makemigrations + ruff format + ruff check) clean