### PR TITLE
Remove auto_translate as an org feature flag

### DIFF
--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -16,7 +16,7 @@ from temba.contacts.models import URN
 from temba.flows.models import Flow, FlowLabel, FlowRun, FlowStart, FlowUserConflictException, ResultsExport
 from temba.mailroom.client.types import Exclusions
 from temba.orgs.integrations.dtone.type import DTOneType
-from temba.orgs.models import Export, Org
+from temba.orgs.models import Export
 from temba.templates.models import TemplateTranslation
 from temba.tests import CRUDLTestMixin, TembaTest, matchers, mock_mailroom
 from temba.tests.base import get_contact_search, override_brand
@@ -1117,35 +1117,34 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.client.get(reverse("flows.flow_editor", args=[flow.uuid]))
             self.assertEqual(features, set(json.loads(response.context["feature_filters"])))
 
+        # auto_translate is always available
+        assert_features({"auto_translate"})
+
         # add a resthook
         Resthook.objects.create(org=flow.org, created_by=self.admin, modified_by=self.admin)
-        assert_features({"resthook"})
+        assert_features({"auto_translate", "resthook"})
 
         # add an NLP classifier
         Classifier.objects.create(org=flow.org, config="", created_by=self.admin, modified_by=self.admin)
-        assert_features({"classifier", "resthook"})
+        assert_features({"auto_translate", "classifier", "resthook"})
 
         # add a DT One integration
         DTOneType().connect(flow.org, self.admin, "login", "token")
-        assert_features({"airtime", "classifier", "resthook"})
+        assert_features({"auto_translate", "airtime", "classifier", "resthook"})
 
         # change our channel to use a whatsapp scheme
         self.channel.schemes = [URN.WHATSAPP_SCHEME]
         self.channel.save()
-        assert_features({"whatsapp", "airtime", "classifier", "resthook"})
+        assert_features({"auto_translate", "whatsapp", "airtime", "classifier", "resthook"})
 
         # change our channel to use a facebook scheme
         self.channel.schemes = [URN.FACEBOOK_SCHEME]
         self.channel.save()
-        assert_features({"optins", "airtime", "classifier", "resthook"})
+        assert_features({"auto_translate", "optins", "airtime", "classifier", "resthook"})
 
         self.setUpLocations()
 
-        assert_features({"optins", "airtime", "classifier", "resthook", "locations"})
-
-        flow.org.features = [Org.FEATURE_AUTO_TRANSLATE]
-        flow.org.save(update_fields=("features",))
-        assert_features({"optins", "airtime", "classifier", "resthook", "locations", "auto_translate"})
+        assert_features({"auto_translate", "optins", "airtime", "classifier", "resthook", "locations"})
 
     @mock_mailroom
     def test_template_warnings(self, mr_mocks):

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -743,7 +743,7 @@ class FlowCRUDL(SmartCRUDL):
             return context
 
         def get_features(self, org) -> list:
-            features = []
+            features = ["auto_translate"]
 
             facebook_channel = org.get_channel(Channel.ROLE_SEND, scheme=URN.FACEBOOK_SCHEME)
             whatsapp_channel = org.get_channel(Channel.ROLE_SEND, scheme=URN.WHATSAPP_SCHEME)
@@ -760,8 +760,6 @@ class FlowCRUDL(SmartCRUDL):
                 features.append("resthook")
             if org.root_location_id:
                 features.append("locations")
-            if Org.FEATURE_AUTO_TRANSLATE in org.features:
-                features.append("auto_translate")
 
             return features
 

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -244,7 +244,6 @@ class Org(SmartModel):
     FEATURE_TEAMS = "teams"  # can create teams to organize agent users
     FEATURE_PROMETHEUS = "prometheus"  # can create a prometheus token to access metrics
     FEATURE_SHARED_CHANNELS = "shared_channels"  # can share channels between orgs
-    FEATURE_AUTO_TRANSLATE = "auto_translate"  # can auto translate flow content via AI models
     FEATURES_CHOICES = (
         (FEATURE_USERS, _("Users")),
         (FEATURE_NEW_ORGS, _("New Orgs")),
@@ -252,7 +251,6 @@ class Org(SmartModel):
         (FEATURE_TEAMS, _("Teams")),
         (FEATURE_PROMETHEUS, _("Prometheus")),
         (FEATURE_SHARED_CHANNELS, _("Shared Channels")),
-        (FEATURE_AUTO_TRANSLATE, _("Auto Translate")),
     )
 
     LIMIT_CHANNELS = "channels"


### PR DESCRIPTION
Auto translation in the flow editor is now available to all workspaces unconditionally rather than being gated by the `auto_translate` org feature.

## Changes

- Drop the `FEATURE_AUTO_TRANSLATE` constant and its `FEATURES_CHOICES` entry from `Org`.
- `FlowCRUDL.Editor.get_features` always seeds the editor feature list with `auto_translate` instead of checking `org.features`.
- Update `test_editor_feature_filters` to expect `auto_translate` in every assertion.

## Notes

No data migration is needed — the `features` array on existing orgs may still contain the string `"auto_translate"`, but nothing reads it anymore so it is harmless.