### PR TITLE
Add urn_path field to messages Elasticsearch index template

### DIFF
--- a/temba/utils/management/commands/data/es_messages.json
+++ b/temba/utils/management/commands/data/es_messages.json
@@ -49,6 +49,9 @@
                 "contact_uuid": {
                     "type": "keyword"
                 },
+                "urn_path": {
+                    "type": "keyword"
+                },
                 "text": {
                     "type": "text",
                     "analyzer": "msg_text"


### PR DESCRIPTION
## Summary

Mirrors [nyaruka/mailroom#1065](https://github.com/nyaruka/mailroom/pull/1065). Mailroom now writes a `urn_path` keyword field on every indexed message document so message search can eventually match against the URN a message was sent to or received from. This adds the corresponding mapping to the messages index template here so new monthly indexes accept the field.

Without this change, mailroom's writes of `urn_path` would be silently dropped on new indexes (template has `dynamic: false`).

## Deploy

Run `create_es_index messages` to put the updated template. New monthly indexes will pick up `urn_path` automatically. Existing monthly indexes were created without `urn_path` -- to backfill those, either reindex or `PUT _mapping` `urn_path` onto each existing month's index.

## Test plan

- [ ] Run `create_es_index messages` against a staging cluster and verify the new template has `urn_path` mapping
- [ ] Confirm mailroom indexing writes `urn_path` to a new monthly index