### PR TITLE
Add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. Focus on:
+            - Correctness and likely bugs
+            - Security issues
+            - Performance concerns
+            - Test coverage gaps
+            - Adherence to existing project conventions
+
+            Use inline comments for specific issues and a top-level comment
+            for the overall summary. Keep it concise — skip nits and praise.
+          claude_args: '--model claude-opus-4-7 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'


### PR DESCRIPTION
## Summary
- Mirrors the workflow used in nyaruka/temba-components — runs `anthropics/claude-code-action@v1` on PR open/sync/reopen/ready_for_review and posts inline + summary review comments.
- Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret to be set (same secret name as in temba-components).

## Test plan
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` repo secret
- [ ] Confirm the action runs on this PR (or the next one) and posts a review