### PR TITLE
Use stable UUIDs for users and campaign events in mailroom_db spec

### DIFF
--- a/temba/utils/management/commands/data/mailroom_db.json
+++ b/temba/utils/management/commands/data/mailroom_db.json
@@ -10,18 +10,21 @@
             "sequence_start": 10000,
             "users": [
                 {
+                    "uuid": "ad9fdf9f-56ab-422a-b77d-e3ec26091a25",
                     "email": "admin1@textit.com",
                     "role": "A",
                     "first_name": "Andy",
                     "last_name": "Admin"
                 },
                 {
+                    "uuid": "ed84a3d7-92e4-4a8b-b01f-db11ff83bbb6",
                     "email": "editor1@textit.com",
                     "role": "E",
                     "first_name": "Ed",
                     "last_name": "McEditor"
                 },
                 {
+                    "uuid": "aee44553-ab35-482b-a4d4-6f000ec611ab",
                     "email": "agent1@textit.com",
                     "role": "T",
                     "first_name": "Ann",
@@ -335,6 +338,7 @@
                     "group": "Doctors",
                     "events": [
                         {
+                            "uuid": "3c8eca88-a5f8-4e27-96f4-e47f19cc0de8",
                             "flow": "Favorites",
                             "offset_field": "joined",
                             "offset": "5",
@@ -343,7 +347,7 @@
                             "start_mode": "I"
                         },
                         {
-                            "uuid": "3a92a964-3a8d-420b-9206-2cd9d884ac30",
+                            "uuid": "f2a3f8c5-e831-4df3-b046-8d8cdb90f178",
                             "base_language": "eng",
                             "translations": {
                                 "eng": {"text": "Hi @contact.name, it is time to consult with your patients."},
@@ -355,6 +359,7 @@
                             "start_mode": "P"
                         },
                         {
+                            "uuid": "552a7155-66bc-4323-aad0-8421f87a4e0c",
                             "flow": "Pick a Number",
                             "offset_field": "joined",
                             "offset": "1",
@@ -554,6 +559,7 @@
             "topics": [],
             "users": [
                 {
+                    "uuid": "a2afc5e7-e97b-45e5-9850-8896957fef54",
                     "email": "admin2@textit.com",
                     "role": "A",
                     "first_name": "",

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -285,6 +285,8 @@ class Command(BaseCommand):
             user = User.objects.create_user(
                 u["email"], USER_PASSWORD, first_name=u["first_name"], last_name=u["last_name"]
             )
+            user.uuid = u["uuid"]
+            user.save(update_fields=("uuid",))
             team = org.teams.get(name=u["team"]) if u.get("team") else None
             org.add_user(user, OrgRole.from_code(u["role"]), team=team)
 
@@ -372,7 +374,7 @@ class Command(BaseCommand):
 
                 if "flow" in e:
                     flow = Flow.objects.get(org=org, name=e["flow"])
-                    CampaignEvent.create_flow_event(
+                    event = CampaignEvent.create_flow_event(
                         org,
                         user,
                         campaign,
@@ -384,7 +386,7 @@ class Command(BaseCommand):
                         start_mode=e["start_mode"],
                     )
                 else:
-                    CampaignEvent.create_message_event(
+                    event = CampaignEvent.create_message_event(
                         org,
                         user,
                         campaign,
@@ -396,6 +398,8 @@ class Command(BaseCommand):
                         delivery_hour=e.get("delivery_hour", -1),
                         start_mode=e["start_mode"],
                     )
+                event.uuid = e["uuid"]
+                event.save(update_fields=("uuid",))
 
         # make events look like they've been scheduled
         CampaignEvent.objects.all().update(status=CampaignEvent.STATUS_READY, fire_version=1)


### PR DESCRIPTION
## Summary

Users and campaign events were the only top-level entities in the mailroom test DB spec without explicit UUIDs — they took whatever the seeded RNG (seed=1234) produced at the moment of creation. So any rapidpro change that shifted the default `uuid4` consumption count (a new model field with `default=uuid4`, an extra `create()` call inside `org.initialize()`, dict-iteration changes from a Python upgrade, etc.) would silently shift these UUIDs and break mailroom's hardcoded `testdb.*` constants on the next dump regen.

This pins them in `mailroom_db.json` to the values mailroom already expects ([`testsuite/testdb/constants.go`](https://github.com/nyaruka/mailroom/blob/main/testsuite/testdb/constants.go)) and assigns the spec UUID **after** the `create()` call (same pattern already used for fields, groups, contacts). Doing it post-create means the field default still fires once and consumes a UUID from the seeded RNG, so the consumption count is unchanged — every other UUID in the dump (flow node UUIDs, etc.) stays byte-identical to today's output.

## Test plan
- [ ] Run `mailroom_db` to regenerate the dump
- [ ] In mailroom, copy the new dump to `testsuite/testdata/postgres.dump` and run `go test -p=1 ./...`
- [ ] Verify `testsuite/testdb/constants.go` does **not** need updating (was the whole point)