### PR TITLE
Drop seed-RNG reliance for mailroom_db spec entities and bulk group contacts

### DIFF
--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -283,10 +283,12 @@ class Command(BaseCommand):
 
         for u in spec["users"]:
             user = User.objects.create_user(
-                u["email"], USER_PASSWORD, first_name=u["first_name"], last_name=u["last_name"]
+                u["email"],
+                USER_PASSWORD,
+                uuid=u["uuid"],
+                first_name=u["first_name"],
+                last_name=u["last_name"],
             )
-            user.uuid = u["uuid"]
-            user.save(update_fields=("uuid",))
             team = org.teams.get(name=u["team"]) if u.get("team") else None
             org.add_user(user, OrgRole.from_code(u["role"]), team=team)
 
@@ -296,7 +298,8 @@ class Command(BaseCommand):
         self._log(f"Creating {len(spec['fields'])} fields... ")
 
         for f in spec["fields"]:
-            field = ContactField.objects.create(
+            ContactField.objects.create(
+                uuid=f["uuid"],
                 org=org,
                 key=f["key"],
                 name=f["name"],
@@ -306,8 +309,6 @@ class Command(BaseCommand):
                 created_by=user,
                 modified_by=user,
             )
-            field.uuid = f["uuid"]
-            field.save(update_fields=["uuid"])
 
         self._log(self.style.SUCCESS("OK") + "\n")
 
@@ -316,7 +317,13 @@ class Command(BaseCommand):
 
         for g in spec["globals"]:
             Global.objects.create(
-                org=org, key=g["key"], name=g["name"], value=g["value"], created_by=user, modified_by=user
+                uuid=g["uuid"],
+                org=org,
+                key=g["key"],
+                name=g["name"],
+                value=g["value"],
+                created_by=user,
+                modified_by=user,
             )
 
         self._log(self.style.SUCCESS("OK") + "\n")
@@ -456,7 +463,13 @@ class Command(BaseCommand):
         self._log(self.style.SUCCESS("OK") + "\n")
 
     def create_group_contacts(self, spec, org, user):
+        from temba.utils import uuid
+
         self._log("Generating group contacts...")
+
+        # use a local generator seeded by the org id so bulk contacts have stable UUIDs
+        # across regens and don't collide between orgs
+        gen = uuid.seeded_generator(org.id)
 
         for g in spec["groups"]:
             size = int(g.get("size", 0))
@@ -480,6 +493,8 @@ class Command(BaseCommand):
                             fields={},
                             groups=[],
                         )
+                        contact.uuid = str(gen())
+                        contact.save(update_fields=("uuid",))
 
                     contacts.append(contact)
 


### PR DESCRIPTION
Follow-up to [#6600](https://github.com/nyaruka/rapidpro/pull/6600).

That PR pinned user and campaign-event UUIDs in the spec but kept the existing two-step "create then overwrite" pattern (which deliberately preserved the seeded RNG consumption count). With users/events now spec-pinned, we can do the cleaner thing everywhere and stop relying on the global RNG for `mailroom_db`'s own creates.

## Changes

- `create_users` / `create_fields` / `create_globals`: pass `uuid=` directly to `create()` instead of the previous two-step pattern. The spec UUID is the only one ever stored, no wasted RNG consumption.
- `create_group_contacts`: the 120 Doctors / 10 Testers contacts had non-deterministic UUIDs because they came from mailroom (via `Contact.create` -> `contact_create` endpoint), and mailroom's seeded generator state at call time depends on cron firings, task processing, etc. They now get UUIDs from a local rapidpro-side seeded generator (seed=2345) instantiated once per command run and shared across orgs (so Org1's first doctor doesn't collide with Org2's first contact).

## What still uses the global seed

`uuid.default_generator = uuid.seeded_generator(1234)` is still patched for `org.initialize()` consumers (system fields/groups/topics created in rapidpro core). Mailroom's `testdb` constants reference those system entities, so they still need to be deterministic — but they're created entirely *before* mailroom_db's create_* methods, so mailroom_db changes can't shift them anymore.

## Test plan

- [ ] Regenerate the dump with this PR
- [ ] Verify the originally-pinned user / campaign-event UUIDs are unchanged (sanity check on spec pinning)
- [ ] Verify the 120 Doctors group contact UUIDs are stable across two consecutive regens
- [ ] Run mailroom's `go test ./...` on the new dump