### PR TITLE
Remove obsolete auto_translate feature flag

### DIFF
--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1119,34 +1119,33 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.client.get(reverse("flows.flow_editor", args=[flow.uuid]))
             self.assertEqual(features, set(json.loads(response.context["feature_filters"])))
 
-        # auto_translate is always available
-        assert_features({"auto_translate"})
+        assert_features(set())
 
         # add a resthook
         Resthook.objects.create(org=flow.org, created_by=self.admin, modified_by=self.admin)
-        assert_features({"auto_translate", "resthook"})
+        assert_features({"resthook"})
 
         # add an NLP classifier
         Classifier.objects.create(org=flow.org, config="", created_by=self.admin, modified_by=self.admin)
-        assert_features({"auto_translate", "classifier", "resthook"})
+        assert_features({"classifier", "resthook"})
 
         # add a DT One integration
         DTOneType().connect(flow.org, self.admin, "login", "token")
-        assert_features({"auto_translate", "airtime", "classifier", "resthook"})
+        assert_features({"airtime", "classifier", "resthook"})
 
         # change our channel to use a whatsapp scheme
         self.channel.schemes = [URN.WHATSAPP_SCHEME]
         self.channel.save()
-        assert_features({"auto_translate", "whatsapp", "airtime", "classifier", "resthook"})
+        assert_features({"whatsapp", "airtime", "classifier", "resthook"})
 
         # change our channel to use a facebook scheme
         self.channel.schemes = [URN.FACEBOOK_SCHEME]
         self.channel.save()
-        assert_features({"auto_translate", "optins", "airtime", "classifier", "resthook"})
+        assert_features({"optins", "airtime", "classifier", "resthook"})
 
         self.setUpLocations()
 
-        assert_features({"auto_translate", "optins", "airtime", "classifier", "resthook", "locations"})
+        assert_features({"optins", "airtime", "classifier", "resthook", "locations"})
 
     @mock_mailroom
     def test_template_warnings(self, mr_mocks):

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -743,7 +743,7 @@ class FlowCRUDL(SmartCRUDL):
             return context
 
         def get_features(self, org) -> list:
-            features = ["auto_translate"]
+            features = []
 
             facebook_channel = org.get_channel(Channel.ROLE_SEND, scheme=URN.FACEBOOK_SCHEME)
             whatsapp_channel = org.get_channel(Channel.ROLE_SEND, scheme=URN.WHATSAPP_SCHEME)


### PR DESCRIPTION
## Summary
- temba-components 0.156.16 removed the `auto_translate` feature flag and always enables auto-translate, so it no longer needs to be advertised from the editor view.
- Drop `"auto_translate"` from `get_features` in `temba/flows/views.py` and from every `assert_features` call in `test_editor_feature_filters`.

## Test plan
- [ ] CI runs `temba/flows/tests/test_flowcrudl.py::FlowCRUDLTest::test_editor_feature_filters` and it passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BoFbYgpMySgx5pT4YMUq6)_