### PR TITLE
Disable mailroom task processing in CI and mailroom_db dev command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           wget https://github.com/${{ github.repository_owner }}/mailroom/releases/download/v${{ env.mailroom-version }}/mailroom_${{ env.mailroom-version }}_linux_amd64.tar.gz
           tar -xvf mailroom_${{ env.mailroom-version }}_linux_amd64.tar.gz mailroom
           # start mailroom with workers disabled so it serves the web API but doesn't pop any queued tasks
-          ./mailroom -db=postgres://temba:temba@postgres:5432/temba?sslmode=disable -valkey=valkey://valkey:6379/15 -workers-realtime=0 -workers-batch=0 -workers-throttled=0 -log-level=info > mailroom.log &
+          ./mailroom -db=postgres://temba:temba@postgres:5432/temba?sslmode=disable -workers-realtime=0 -workers-batch=0 -workers-throttled=0 -log-level=info > mailroom.log &
 
       - name: Run pre-test checks
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     env:
       node-version: '20'
-      mailroom-version: '26.1.69'
+      mailroom-version: '26.1.109'
 
     services:
       valkey:
@@ -63,8 +63,8 @@ jobs:
           # fetch, extract and start mailroom
           wget https://github.com/${{ github.repository_owner }}/mailroom/releases/download/v${{ env.mailroom-version }}/mailroom_${{ env.mailroom-version }}_linux_amd64.tar.gz
           tar -xvf mailroom_${{ env.mailroom-version }}_linux_amd64.tar.gz mailroom
-          # start mailroom but use different valkey db so that it doesn't actually handle tasks
-          ./mailroom -db=postgres://temba:temba@postgres:5432/temba?sslmode=disable -valkey=valkey://valkey:6379/15 -log-level=info > mailroom.log &
+          # start mailroom with workers disabled so it serves the web API but doesn't pop any queued tasks
+          ./mailroom -db=postgres://temba:temba@postgres:5432/temba?sslmode=disable -valkey=valkey://valkey:6379/15 -workers-realtime=0 -workers-batch=0 -workers-throttled=0 -log-level=info > mailroom.log &
 
       - name: Run pre-test checks
         run: |

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -81,7 +81,7 @@ class Command(BaseCommand):
         self._log(self.style.SUCCESS("OK") + "\n")
 
         mr_cmd = f'go run ./cmd/mailroom --port={mr_port} -db="postgres://{db_user}:temba@localhost/{db_name}?sslmode=disable" --valkey="valkey://localhost:6379/15" --workers-realtime=0 --workers-batch=0 --workers-throttled=0 -uuid-seed=123'
-        input(f"\nPlease start mailroom:\n   % ./{mr_cmd}\n\nPress enter when ready.\n")
+        input(f"\nPlease start mailroom:\n   % {mr_cmd}\n\nPress enter when ready.\n")
 
         root_location = self.load_locations(locs_file)
 

--- a/temba/utils/management/commands/mailroom_db.py
+++ b/temba/utils/management/commands/mailroom_db.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
         superuser = User.objects.create_user("root", USER_PASSWORD, is_superuser=True)
         self._log(self.style.SUCCESS("OK") + "\n")
 
-        mr_cmd = f'go run ./cmd/mailroom --port={mr_port} -db="postgres://{db_user}:temba@localhost/{db_name}?sslmode=disable" --valkey="valkey://localhost:6379/15" -uuid-seed=123'
+        mr_cmd = f'go run ./cmd/mailroom --port={mr_port} -db="postgres://{db_user}:temba@localhost/{db_name}?sslmode=disable" --valkey="valkey://localhost:6379/15" --workers-realtime=0 --workers-batch=0 --workers-throttled=0 -uuid-seed=123'
         input(f"\nPlease start mailroom:\n   % ./{mr_cmd}\n\nPress enter when ready.\n")
 
         root_location = self.load_locations(locs_file)


### PR DESCRIPTION
## Summary

- Pass `--workers-realtime=0 --workers-batch=0 --workers-throttled=0` to mailroom in both:
  - `temba/utils/management/commands/mailroom_db.py` — the suggested command shown to the developer.
  - `.github/workflows/ci.yml` — the CI background mailroom that backs the test suite.
- Replaces the previous "use different valkey db so it doesn't actually handle tasks" hack in CI with explicit intent — the workers-disabled mailroom can safely share the same Valkey as the test runner.
- Bumps `mailroom-version` from `26.1.69` to `26.1.109` so the new flags are recognised.

Depends on [nyaruka/mailroom#1069](https://github.com/nyaruka/mailroom/pull/1069), which is merged but needs a v26.1.109 release before this PR's CI can pass.

## Test plan

- [ ] Cut mailroom v26.1.109 (or whichever next tag includes #1069) before merging
- [ ] CI green on this branch — confirms mailroom starts cleanly with workers=0 and the rapidpro test suite still passes
- [ ] Local: run `manage.py mailroom_db` and follow the printed command — confirm mailroom logs `foreman disabled, no workers configured` three times and serves the web API