### PR TITLE
Skip creating flow revisions when the definition hasn't changed

### DIFF
--- a/temba/flows/changes.py
+++ b/temba/flows/changes.py
@@ -4,6 +4,10 @@ _METADATA_FIELDS = ("name", "type", "expire_after_minutes")
 
 _STICKY_LAYOUT_FIELDS = ("position", "width", "height")
 
+# Top-level fields rewritten on every save or otherwise not part of the meaningful
+# definition — excluded when checking for "did anything change at all?"
+_SYSTEM_FIELDS = ("uuid", "revision", "spec_version")
+
 
 def compute_changes(old: dict, new: dict) -> dict:
     """
@@ -18,6 +22,8 @@ def compute_changes(old: dict, new: dict) -> dict:
         stickies   — stickies added, removed, or content-edited
         metadata   — flow-level fields changed (name, type, expire_after_minutes, base_language)
         localization:<lang> — translations changed for that language
+        other      — any difference not captured by the categories above; a safety net so
+                     an empty tag list reliably means "nothing changed"
     """
     tags = set()
 
@@ -73,6 +79,15 @@ def compute_changes(old: dict, new: dict) -> dict:
     for lang in set(old_loc) | set(new_loc):
         if (old_loc.get(lang) or {}) != (new_loc.get(lang) or {}):
             tags.add(f"localization:{lang}")
+
+    # safety net: if nothing was tagged but the definitions still differ in some way
+    # we didn't anticipate (new schema fields, unknown node shapes, etc.), record it
+    # as "other" so an empty tag list is a reliable proof that nothing changed
+    if not tags:
+        old_stripped = {k: v for k, v in old.items() if k not in _SYSTEM_FIELDS}
+        new_stripped = {k: v for k, v in new.items() if k not in _SYSTEM_FIELDS}
+        if old_stripped != new_stripped:
+            tags.add("other")
 
     return {"tags": sorted(tags)}
 

--- a/temba/flows/changes.py
+++ b/temba/flows/changes.py
@@ -82,7 +82,9 @@ def compute_changes(old: dict, new: dict) -> dict:
 
     # safety net: if nothing was tagged but the definitions still differ in some way
     # we didn't anticipate (new schema fields, unknown node shapes, etc.), record it
-    # as "other" so an empty tag list is a reliable proof that nothing changed
+    # as "other" so an empty tag list is a reliable proof that nothing changed.
+    # System fields are stripped only at the top level (where they actually live);
+    # a stray system-named key nested deep in a node would still surface as "other".
     if not tags:
         old_stripped = {k: v for k, v in old.items() if k not in _SYSTEM_FIELDS}
         new_stripped = {k: v for k, v in new.items() if k not in _SYSTEM_FIELDS}

--- a/temba/flows/changes.py
+++ b/temba/flows/changes.py
@@ -22,6 +22,8 @@ def compute_changes(old: dict, new: dict) -> dict:
         stickies   — stickies added, removed, or content-edited
         metadata   — flow-level fields changed (name, type, expire_after_minutes, base_language)
         localization:<lang> — translations changed for that language
+        spec       — flow's spec version was bumped (added by Flow.save_revision, not here,
+                     since prior revisions are migrated forward before diffing)
         other      — any difference not captured by the categories above; a safety net so
                      an empty tag list reliably means "nothing changed"
     """

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -256,7 +256,7 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
             if flow:
                 flow.name = Flow.get_unique_name(org, flow_name, ignore=flow)
-                flow.version_number = flow_version
+                flow.version_number = str(flow_version)
                 flow.expires_after_minutes = flow_expires
                 flow.save(update_fields=("name", "expires_after_minutes"))
             else:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -713,12 +713,10 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
         definition[Flow.DEFINITION_REVISION] = revision
         definition[Flow.DEFINITION_EXPIRE_AFTER_MINUTES] = self.expires_after_minutes
 
-        # inspect the flow (with optional validation)
-        info = mailroom.get_client().flow_inspect(self.org, definition)
-
-        # diff against prior revision so we can later collapse like-for-like edits;
-        # done outside the transaction below because get_migrated_definition() may
-        # call mailroom (HTTP) and we don't want that holding row locks
+        # diff against prior revision so we can skip no-op saves and later collapse
+        # like-for-like edits; done outside the transaction below because
+        # get_migrated_definition() may call mailroom (HTTP) and we don't want that
+        # holding row locks
         changes = None
         if current_revision:
             prior_def = current_revision.definition
@@ -734,6 +732,19 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
                     prior_def = None
             if prior_def is not None:
                 changes = compute_changes(prior_def, definition)
+
+        # if the definition is unchanged from the current revision, don't create a
+        # new one — author-only changes shouldn't produce revision churn. We still
+        # bump the flow's spec version if it's stale so migrations like
+        # ensure_current_version aren't silently dropped on no-op saves.
+        if changes == {"tags": []}:
+            if self.version_number != Flow.CURRENT_SPEC_VERSION:
+                self.version_number = Flow.CURRENT_SPEC_VERSION
+                self.save(update_fields=("version_number",))
+            return current_revision, (self.info or {}).get("issues", [])
+
+        # inspect the flow (with optional validation)
+        info = mailroom.get_client().flow_inspect(self.org, definition)
 
         if user is None:
             is_system_rev = True

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -739,13 +739,14 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
         # so migrations like ensure_current_version aren't silently dropped on
         # no-op saves and revision.spec_version doesn't go stale.
         if changes is not None and not changes["tags"]:
-            if self.version_number != Flow.CURRENT_SPEC_VERSION:
-                self.version_number = Flow.CURRENT_SPEC_VERSION
-                self.save(update_fields=("version_number",))
-            if current_revision.spec_version != Flow.CURRENT_SPEC_VERSION:
-                current_revision.spec_version = Flow.CURRENT_SPEC_VERSION
-                current_revision.definition[Flow.DEFINITION_SPEC_VERSION] = Flow.CURRENT_SPEC_VERSION
-                current_revision.save(update_fields=("spec_version", "definition"))
+            with transaction.atomic():
+                if self.version_number != Flow.CURRENT_SPEC_VERSION:
+                    self.version_number = Flow.CURRENT_SPEC_VERSION
+                    self.save(update_fields=("version_number",))
+                if current_revision.spec_version != Flow.CURRENT_SPEC_VERSION:
+                    current_revision.spec_version = Flow.CURRENT_SPEC_VERSION
+                    current_revision.definition[Flow.DEFINITION_SPEC_VERSION] = Flow.CURRENT_SPEC_VERSION
+                    current_revision.save(update_fields=("spec_version", "definition"))
             return current_revision, (self.info or {}).get("issues", [])
 
         # inspect the flow (with optional validation)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -720,7 +720,8 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
         changes = None
         if current_revision:
             prior_def = current_revision.definition
-            if current_revision.spec_version != Flow.CURRENT_SPEC_VERSION:
+            spec_changed = current_revision.spec_version != Flow.CURRENT_SPEC_VERSION
+            if spec_changed:
                 # migrate the prior forward so the schemas align; accepting that name/expire
                 # then come from the live flow (get_migrated_definition rewrites them) — fine
                 # because cross-spec saves are rare and not where metadata diffs matter
@@ -732,21 +733,15 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
                     prior_def = None
             if prior_def is not None:
                 changes = compute_changes(prior_def, definition)
+                # a spec migration is itself a real change worth recording, even when
+                # the migration is content-equivalent — get_migrated_definition aligns
+                # the schemas so compute_changes can't see the spec bump on its own
+                if spec_changed:
+                    changes = {"tags": sorted(set(changes["tags"]) | {"spec"})}
 
         # if the definition is unchanged from the current revision, don't create a
-        # new one — author-only changes shouldn't produce revision churn. We still
-        # bump the flow's spec version (and the current revision's) if it's stale
-        # so migrations like ensure_current_version aren't silently dropped on
-        # no-op saves and revision.spec_version doesn't go stale.
+        # new one — author-only changes shouldn't produce revision churn
         if changes is not None and not changes["tags"]:
-            with transaction.atomic():
-                if self.version_number != Flow.CURRENT_SPEC_VERSION:
-                    self.version_number = Flow.CURRENT_SPEC_VERSION
-                    self.save(update_fields=("version_number",))
-                if current_revision.spec_version != Flow.CURRENT_SPEC_VERSION:
-                    current_revision.spec_version = Flow.CURRENT_SPEC_VERSION
-                    current_revision.definition[Flow.DEFINITION_SPEC_VERSION] = Flow.CURRENT_SPEC_VERSION
-                    current_revision.save(update_fields=("spec_version", "definition"))
             return current_revision, (self.info or {}).get("issues", [])
 
         # inspect the flow (with optional validation)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -735,12 +735,17 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
         # if the definition is unchanged from the current revision, don't create a
         # new one — author-only changes shouldn't produce revision churn. We still
-        # bump the flow's spec version if it's stale so migrations like
-        # ensure_current_version aren't silently dropped on no-op saves.
-        if changes == {"tags": []}:
+        # bump the flow's spec version (and the current revision's) if it's stale
+        # so migrations like ensure_current_version aren't silently dropped on
+        # no-op saves and revision.spec_version doesn't go stale.
+        if changes is not None and not changes["tags"]:
             if self.version_number != Flow.CURRENT_SPEC_VERSION:
                 self.version_number = Flow.CURRENT_SPEC_VERSION
                 self.save(update_fields=("version_number",))
+            if current_revision.spec_version != Flow.CURRENT_SPEC_VERSION:
+                current_revision.spec_version = Flow.CURRENT_SPEC_VERSION
+                current_revision.definition[Flow.DEFINITION_SPEC_VERSION] = Flow.CURRENT_SPEC_VERSION
+                current_revision.save(update_fields=("spec_version", "definition"))
             return current_revision, (self.info or {}).get("issues", [])
 
         # inspect the flow (with optional validation)

--- a/temba/flows/tests/test_changes.py
+++ b/temba/flows/tests/test_changes.py
@@ -53,9 +53,10 @@ class ComputeChangesTest(TembaTest):
 
         self.assertEqual(["layout"], _tags(_flow(ui_nodes=ui), _flow(ui_nodes=ui_moved)))
 
-        # type-only change in _ui shouldn't count as a move
+        # type-only change in _ui isn't a layout move, but still falls through to "other"
+        # so the empty tag list remains a reliable signal that nothing changed
         ui_retyped = {"a" * 36: {"position": {"left": 0, "top": 0}, "type": "wait_for_response"}}
-        self.assertEqual([], _tags(_flow(ui_nodes=ui), _flow(ui_nodes=ui_retyped)))
+        self.assertEqual(["other"], _tags(_flow(ui_nodes=ui), _flow(ui_nodes=ui_retyped)))
 
     def test_actions(self):
         a1 = {"uuid": "ac" + "0" * 34, "type": "send_msg", "text": "hello"}
@@ -176,6 +177,17 @@ class ComputeChangesTest(TembaTest):
                 _flow(localization={"spa": {item: {"text": "buenas"}}}),
             ),
         )
+
+    def test_other_catch_all(self):
+        # system fields (uuid/revision/spec_version) are stripped before the catch-all
+        # check so they don't fire false positives on every save
+        old = _flow(uuid="11111111-1111-1111-1111-111111111111", revision=1, spec_version="13.0.0")
+        new = _flow(uuid="22222222-2222-2222-2222-222222222222", revision=2, spec_version="13.1.0")
+        self.assertEqual([], _tags(old, new))
+
+        # an unanticipated top-level field difference produces "other" so the empty
+        # tag list remains a reliable signal that nothing changed
+        self.assertEqual(["other"], _tags(_flow(), _flow(future_top_level={"foo": "bar"})))
 
     def test_combined(self):
         node_a = {"uuid": "a" * 36, "actions": [], "exits": []}

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -129,23 +129,22 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         rev.spec_version = "13.0.0"
         rev.save()
 
+        old_modified_on = flow.modified_on
         old_saved_on = flow.saved_on
 
         flow.ensure_current_version()
 
-        # when the migration is a no-op for this flow's content, the flow's spec
-        # version is bumped (along with the existing revision's) but no new revision
-        # is created since the definition didn't actually change. If a future spec
-        # bump rewrites this fixture meaningfully these counts will change and the
-        # test assertions below will need to be updated to reflect a real migration.
+        # spec migration is itself a recorded change — a new revision is created with
+        # the "spec" tag even if the migration is content-equivalent for this fixture
         self.assertEqual(Flow.CURRENT_SPEC_VERSION, flow.version_number)
-        self.assertEqual(1, flow.revisions.count())
-        rev = flow.revisions.get()
-        self.assertEqual(Flow.CURRENT_SPEC_VERSION, rev.spec_version)
-        self.assertEqual(Flow.CURRENT_SPEC_VERSION, rev.definition["spec_version"])
+        self.assertEqual(2, flow.revisions.count())
+        latest = flow.revisions.order_by("id").last()
+        self.assertEqual("system", latest.created_by.email)
+        self.assertEqual({"tags": ["spec"]}, latest.changes)
 
-        # saved_on isn't touched on a no-op save
+        # saved on won't have been updated but modified on will
         self.assertEqual(old_saved_on, flow.saved_on)
+        self.assertGreater(flow.modified_on, old_modified_on)
 
     @mock_mailroom
     def test_flow_archive_with_campaign(self, mr_mocks):

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -129,19 +129,18 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         rev.spec_version = "13.0.0"
         rev.save()
 
-        old_modified_on = flow.modified_on
         old_saved_on = flow.saved_on
 
         flow.ensure_current_version()
 
-        # check we migrate to current spec version
+        # check we migrate to current spec version — when the migration is a no-op
+        # for this flow's content, the flow's spec is bumped but no new revision is
+        # created since the definition didn't actually change
         self.assertEqual(Flow.CURRENT_SPEC_VERSION, flow.version_number)
-        self.assertEqual(2, flow.revisions.count())
-        self.assertEqual("system", flow.revisions.order_by("id").last().created_by.email)
+        self.assertEqual(1, flow.revisions.count())
 
-        # saved on won't have been updated but modified on will
+        # saved_on isn't touched on a no-op save
         self.assertEqual(old_saved_on, flow.saved_on)
-        self.assertGreater(flow.modified_on, old_modified_on)
 
     @mock_mailroom
     def test_flow_archive_with_campaign(self, mr_mocks):
@@ -241,25 +240,27 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         first = flow.revisions.order_by("id").last()
         self.assertIsNone(first.changes)
 
-        # saving an unchanged definition produces an empty tag list
-        rev2, _ = flow.save_revision(self.admin, dict(first.definition))
-        self.assertEqual({"tags": []}, rev2.changes)
+        # saving an unchanged definition is a no-op — returns the current revision and
+        # doesn't create a new one
+        same, _ = flow.save_revision(self.admin, dict(first.definition))
+        self.assertEqual(first.id, same.id)
+        self.assertEqual(1, flow.revisions.count())
 
         # renaming the flow shows up as a metadata tag in the next saved revision
         flow.name = "Renamed"
         flow.save(update_fields=("name",))
-        rev3, _ = flow.save_revision(self.admin, dict(rev2.definition))
-        self.assertEqual({"tags": ["metadata"]}, rev3.changes)
+        rev2, _ = flow.save_revision(self.admin, dict(first.definition))
+        self.assertEqual({"tags": ["metadata"]}, rev2.changes)
 
         # if migrating the prior revision blows up the save still succeeds with changes=None
-        rev3.spec_version = "11.12"
-        rev3.save(update_fields=("spec_version",))
+        rev2.spec_version = "11.12"
+        rev2.save(update_fields=("spec_version",))
         with patch(
             "temba.flows.models.FlowRevision.get_migrated_definition",
             side_effect=ValueError("boom"),
         ):
-            rev4, _ = flow.save_revision(self.admin, dict(rev3.definition))
-        self.assertIsNone(rev4.changes)
+            rev3, _ = flow.save_revision(self.admin, dict(rev2.definition))
+        self.assertIsNone(rev3.changes)
 
         # can't save older spec version over newer
         definition = flow.revisions.order_by("id").last().definition

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -133,11 +133,16 @@ class FlowTest(TembaTest, CRUDLTestMixin):
 
         flow.ensure_current_version()
 
-        # check we migrate to current spec version — when the migration is a no-op
-        # for this flow's content, the flow's spec is bumped but no new revision is
-        # created since the definition didn't actually change
+        # when the migration is a no-op for this flow's content, the flow's spec
+        # version is bumped (along with the existing revision's) but no new revision
+        # is created since the definition didn't actually change. If a future spec
+        # bump rewrites this fixture meaningfully these counts will change and the
+        # test assertions below will need to be updated to reflect a real migration.
         self.assertEqual(Flow.CURRENT_SPEC_VERSION, flow.version_number)
         self.assertEqual(1, flow.revisions.count())
+        rev = flow.revisions.get()
+        self.assertEqual(Flow.CURRENT_SPEC_VERSION, rev.spec_version)
+        self.assertEqual(Flow.CURRENT_SPEC_VERSION, rev.definition["spec_version"])
 
         # saved_on isn't touched on a no-op save
         self.assertEqual(old_saved_on, flow.saved_on)

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -2246,9 +2246,12 @@ msgstr "Azul"
         self.assertContains(response, "Spanish (spa)")
         self.assertEqual({"language": "spa"}, response.context["form"].initial)
 
-        # confirm the import
+        # confirm the import — the imported definition has new Spanish localization
+        # so it's a real change (no-op imports don't create a new revision)
+        imported_def = flow.get_definition()
+        imported_def["localization"] = {"spa": {"a4d15ed4-5b24-407f-b86e-4b881f09a186": {"arguments": ["Azul"]}}}
         with patch("temba.mailroom.client.client.MailroomClient.po_import") as mock_po_import:
-            mock_po_import.return_value = {"flows": [flow.get_definition()]}
+            mock_po_import.return_value = {"flows": [imported_def]}
 
             response = self.requestView(step2_url, self.admin, post_data={"language": "spa"})
 

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -740,8 +740,10 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         revision.spec_version = "11.12"
         revision.save(update_fields=("definition", "spec_version"))
 
-        # create a new migrated revision
+        # create a new migrated revision (rename so the save isn't a no-op)
         flow_def = revision.get_migrated_definition()
+        flow.name = "Color Renamed"
+        flow.save(update_fields=("name",))
         flow.save_revision(self.admin, flow_def)
 
         revisions = list(flow.revisions.all().order_by("-created_on"))
@@ -822,13 +824,22 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.post(revisions_url, definition, content_type="application/json")
         self.assertEqual(302, response.status_code)
 
-        # check that we can create a new revision
+        # posting the unchanged definition is a no-op — no new revision created
         self.login(self.admin)
+        response = self.client.post(revisions_url, definition, content_type="application/json")
+        same_revision = response.json()
+        self.assertEqual(1, same_revision["revision"][Flow.DEFINITION_REVISION])
+        self.assertEqual(1, flow.revisions.count())
+
+        # but a real change creates a new revision (rename the flow so the next save
+        # picks up a metadata diff via the live flow.name)
+        flow.name = "Renamed Flow"
+        flow.save(update_fields=("name",))
         response = self.client.post(revisions_url, definition, content_type="application/json")
         new_revision = response.json()
         self.assertEqual(2, new_revision["revision"][Flow.DEFINITION_REVISION])
 
-        # but we can't save our old revision
+        # we can't save our old revision number
         response = self.client.post(revisions_url, definition, content_type="application/json")
         self.assertResponseError(
             response, "description", "Your changes will not be saved until you refresh your browser"
@@ -1793,6 +1804,11 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(1, flow_json["revision"])
 
         self.login(self.admin)
+
+        # rename so the next save isn't a no-op (identical definitions don't create
+        # a new revision)
+        flow.name = "Favorites Renamed"
+        flow.save(update_fields=("name",))
 
         # saving should work
         flow.save_revision(self.admin, flow_json)

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -765,7 +765,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
                     "id": revisions[0].id,
                     "version": Flow.CURRENT_SPEC_VERSION,
                     "revision": 2,
-                    "changes": {"tags": ["routing"]},
+                    "changes": {"tags": ["routing", "spec"]},
                 },
                 {
                     "user": {"email": "admin@textit.com", "name": "Andy"},


### PR DESCRIPTION
## Summary

Saving a flow revision with an unchanged definition no longer produces a new revision. Empty tag list is treated as a reliable proof that nothing changed, with a catch-all so unanticipated diffs can't slip through. Spec migrations are recorded as a new `spec` tag on the resulting revision so the migration itself is still tracked.

## Changes

### `Flow.save_revision` (`temba/flows/models.py`)

- After computing the diff against the prior revision, if the resulting tag list is empty we return the current revision instead of creating a new one. Author-only or otherwise no-op saves no longer churn revision history.
- When the prior revision's spec version differs from the current spec, `save_revision` adds a `spec` tag to the changes. `get_migrated_definition()` aligns the schemas before diffing so `compute_changes` can't see the spec bump on its own — the `spec` tag is added explicitly here.
- Drive-by fix: `Flow.import_flows` was assigning a `Version` object to `flow.version_number` (a `CharField`). Previously masked because `save_revision` always reset it to a string; now coerced explicitly with `str(flow_version)`.

### `compute_changes` (`temba/flows/changes.py`)

- New `other` catch-all tag. After the categorized checks, if no tags fired but the definitions still differ (after stripping system-managed `uuid` / `revision` / `spec_version` at the top level), `other` is added. Empty tag list is now a reliable signal that nothing changed, even when future schema fields land that the diff hasn't been taught about.
- Docstring documents the `spec` tag (added by `save_revision`) and the `other` catch-all alongside the existing tags.

### Behavior examples

| Scenario | Prior result | New result |
|---|---|---|
| Editor saves identical definition | New revision with `{"tags": []}` | Same revision returned, count unchanged |
| Editor renames the flow | `{"tags": ["metadata"]}` | `{"tags": ["metadata"]}` (unchanged) |
| `ensure_current_version` migrates 13.0.0 → 14.4.0, content-equivalent | New revision, `changes=null` | New revision with `{"tags": ["spec"]}` |
| Legacy 11.12 → current migration that rewrites routing | `{"tags": ["routing"]}` | `{"tags": ["routing", "spec"]}` |
| Future schema adds a top-level field we haven't categorized | `{"tags": []}` (incorrectly skipped) | `{"tags": ["other"]}` (revision created) |

### Tests

- `temba/flows/tests/test_changes.py` — new `test_other_catch_all` covers system-field stripping and the `other` fallback. `test_layout` updated since `_ui` `type`-only changes (previously dropped) now fall through to `other`.
- `temba/flows/tests/test_flow.py` — `test_save_revision` asserts that an unchanged save returns the same revision and doesn't create a new one. `test_ensure_current_version` asserts the new `{"tags": ["spec"]}` revision.
- `temba/flows/tests/test_flowcrudl.py` — `test_save_revisions` exercises both the no-op and the real-change paths. `test_revisions` updated to expect `["routing", "spec"]` for the legacy migration. `test_write_protection` and the `test_revisions` migration test now make a real change before saving so the save isn't a no-op. `test_import_translation` mock returns a definition with new localization so it's a real change.

## Test plan

- [x] `temba.flows.tests.test_changes`, `temba.flows.tests.test_flow`, `temba.flows.tests.test_revision`, `temba.flows.tests.test_flowcrudl` (relevant subset) — green locally.
- [x] `code_check.py` clean.
- [x] CI green on the PR.