### PR TITLE
Trim flow revisions on save and keep the last 24h

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -781,8 +781,9 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
             self.update_dependencies(info["dependencies"])
 
-            # collapse older revisions inline so they don't pile up between cron runs
-            FlowRevision.trim_for_flow(self.id)
+        # collapse older revisions inline so they don't pile up between cron runs;
+        # done outside the save transaction so a trim failure can't roll back the save
+        FlowRevision.trim_for_flow(self.id)
 
         return revision, info["issues"]
 
@@ -1256,19 +1257,27 @@ class FlowRevision(models.Model):
 
             *to_delete, keeper = revs
 
-            tags = set((keeper.changes or {}).get("tags", []))
-            for rev in to_delete:
-                tags.update((rev.changes or {}).get("tags", []))
-            keeper.changes = {"tags": sorted(tags)}
+            update_fields = []
 
-            update_fields = ["changes"]
+            # only rewrite the keeper's changes when at least one revision in the group
+            # actually has changes recorded — preserves the legacy `None` signal (per
+            # the field comment, null means "don't try to collapse me") for groups that
+            # are entirely pre-changes
+            if any(rev.changes is not None for rev in (keeper, *to_delete)):
+                tags = set((keeper.changes or {}).get("tags", []))
+                for rev in to_delete:
+                    tags.update((rev.changes or {}).get("tags", []))
+                keeper.changes = {"tags": sorted(tags)}
+                update_fields.append("changes")
+
             if any(rev.created_by_id != keeper.created_by_id for rev in to_delete):
                 if system_user is None:
                     system_user = User.get_system_user()
                 keeper.created_by = system_user
                 update_fields.append("created_by")
 
-            keeper.save(update_fields=update_fields)
+            if update_fields:
+                keeper.save(update_fields=update_fields)
             deleted_ids.extend(rev.id for rev in to_delete)
 
         if not deleted_ids:

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1232,7 +1232,9 @@ class FlowRevision(models.Model):
         Our logic is:
          * always keep the last 25 revisions and everything from the past 24 hours
            (whichever covers more)
-         * for any revision beyond those, collapse to the last revision for that day
+         * for any revision beyond that cutoff, collapse to the last older revision
+           in each day-bucket (the day at the cutoff boundary is split — only the
+           pre-cutoff portion gets collapsed; the rest is in the keep window)
 
         The kept revision absorbs the `changes` of the deleted ones it replaces, so the
         recorded changes still describe everything that happened since the previous kept

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1263,39 +1263,42 @@ class FlowRevision(models.Model):
 
         system_user = None
         deleted_ids = []
-        for revs in by_date.values():
-            if len(revs) == 1:
-                continue
+        # the keeper updates and the deletes have to land together so a partial trim
+        # can't leave the day-bucket in a half-merged state
+        with transaction.atomic():
+            for revs in by_date.values():
+                if len(revs) == 1:
+                    continue
 
-            *to_delete, keeper = revs
+                *to_delete, keeper = revs
 
-            update_fields = []
+                update_fields = []
 
-            # only rewrite the keeper's changes when at least one revision in the group
-            # actually has changes recorded — preserves the legacy `None` signal (per
-            # the field comment, null means "don't try to collapse me") for groups that
-            # are entirely pre-changes
-            if any(rev.changes is not None for rev in (keeper, *to_delete)):
-                tags = set((keeper.changes or {}).get("tags", []))
-                for rev in to_delete:
-                    tags.update((rev.changes or {}).get("tags", []))
-                keeper.changes = {"tags": sorted(tags)}
-                update_fields.append("changes")
+                # only rewrite the keeper's changes when at least one revision in the group
+                # actually has changes recorded — preserves the legacy `None` signal (per
+                # the field comment, null means "don't try to collapse me") for groups that
+                # are entirely pre-changes
+                if any(rev.changes is not None for rev in (keeper, *to_delete)):
+                    tags = set((keeper.changes or {}).get("tags", []))
+                    for rev in to_delete:
+                        tags.update((rev.changes or {}).get("tags", []))
+                    keeper.changes = {"tags": sorted(tags)}
+                    update_fields.append("changes")
 
-            if any(rev.created_by_id != keeper.created_by_id for rev in to_delete):
-                if system_user is None:
-                    system_user = User.get_system_user()
-                keeper.created_by = system_user
-                update_fields.append("created_by")
+                if any(rev.created_by_id != keeper.created_by_id for rev in to_delete):
+                    if system_user is None:
+                        system_user = User.get_system_user()
+                    keeper.created_by = system_user
+                    update_fields.append("created_by")
 
-            if update_fields:
-                keeper.save(update_fields=update_fields)
-            deleted_ids.extend(rev.id for rev in to_delete)
+                if update_fields:
+                    keeper.save(update_fields=update_fields)
+                deleted_ids.extend(rev.id for rev in to_delete)
 
-        if not deleted_ids:
-            return 0
+            if not deleted_ids:
+                return 0
 
-        return FlowRevision.objects.filter(id__in=deleted_ids).delete()[0]
+            return FlowRevision.objects.filter(id__in=deleted_ids).delete()[0]
 
     @classmethod
     def validate_legacy_definition(cls, definition):

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -781,10 +781,9 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
             self.update_dependencies(info["dependencies"])
 
-        # collapse older revisions inline so they don't pile up between cron runs;
-        # done outside the save transaction (so a trim failure can't roll back the
-        # save) and best-effort (so a trim failure can't surface as a save failure
-        # to the caller — the cron task is still there as a safety net)
+        # cap the revision history inline so it doesn't pile up between cron runs;
+        # best-effort and outside the save transaction so a trim failure can neither
+        # roll back nor surface as a save failure (the cron task is the safety net)
         try:
             FlowRevision.trim_for_flow(self.id)
         except Exception:
@@ -1195,6 +1194,7 @@ class FlowRevision(models.Model):
     """
 
     LAST_TRIM_KEY = "temba:last_flow_revision_trim"
+    MAX_REVISIONS = 500
 
     flow = models.ForeignKey(Flow, on_delete=models.PROTECT, related_name="revisions")
     definition = JSONAsTextField(default=dict)
@@ -1202,7 +1202,7 @@ class FlowRevision(models.Model):
     revision = models.IntegerField()
 
     # categorized record of what changed since the previous revision; null for legacy
-    # revisions that pre-date this field, signalling "don't try to collapse me".
+    # revisions that pre-date this field.
     changes = models.JSONField(null=True, default=None)
 
     created_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT, related_name="revisions")
@@ -1227,78 +1227,17 @@ class FlowRevision(models.Model):
     @classmethod
     def trim_for_flow(cls, flow_id):
         """
-        Trims the revisions for the passed in flow.
-
-        Our logic is:
-         * always keep the last 25 revisions and everything from the past 24 hours
-           (whichever covers more)
-         * for any revision beyond that cutoff, collapse to the last older revision
-           in each day-bucket (the day at the cutoff boundary is split — only the
-           pre-cutoff portion gets collapsed; the rest is in the keep window)
-
-        The kept revision absorbs the `changes` of the deleted ones it replaces, so the
-        recorded changes still describe everything that happened since the previous kept
-        revision. If the absorbed revisions involved other authors, attribution falls
-        back to the system user since the kept revision now represents their work too.
+        Keeps the MAX_REVISIONS most recent revisions for this flow and deletes the rest.
 
         :param flow: the id of the flow to trim revisions for
         :return: the number of trimmed revisions
         """
-        # the cutoff is the earlier of "25th most recent revision" and "24 hours ago" —
-        # whichever covers more keeps more revisions safe from collapsing
-        rev_25 = FlowRevision.objects.filter(flow=flow_id).order_by("-created_on")[24:25]
-        day_ago = timezone.now() - timedelta(hours=24)
-        cutoff = min(rev_25[0].created_on, day_ago) if rev_25 else day_ago
-
-        # bucket older revisions by day in chronological order; only fetch the columns
-        # we actually look at — `definition` can be MB-sized and we never read it here
-        older = list(
-            FlowRevision.objects.filter(flow=flow_id, created_on__lt=cutoff)
-            .only("id", "created_on", "created_by_id", "changes")
-            .order_by("created_on")
+        keepers = list(
+            FlowRevision.objects.filter(flow=flow_id)
+            .order_by("-created_on", "-id")
+            .values_list("id", flat=True)[: cls.MAX_REVISIONS]
         )
-        by_date = defaultdict(list)
-        for rev in older:
-            by_date[rev.created_on.date()].append(rev)
-
-        system_user = None
-        deleted_ids = []
-        # the keeper updates and the deletes have to land together so a partial trim
-        # can't leave the day-bucket in a half-merged state
-        with transaction.atomic():
-            for revs in by_date.values():
-                if len(revs) == 1:
-                    continue
-
-                *to_delete, keeper = revs
-
-                update_fields = []
-
-                # only rewrite the keeper's changes when at least one revision in the group
-                # actually has changes recorded — preserves the legacy `None` signal (per
-                # the field comment, null means "don't try to collapse me") for groups that
-                # are entirely pre-changes
-                if any(rev.changes is not None for rev in (keeper, *to_delete)):
-                    tags = set((keeper.changes or {}).get("tags", []))
-                    for rev in to_delete:
-                        tags.update((rev.changes or {}).get("tags", []))
-                    keeper.changes = {"tags": sorted(tags)}
-                    update_fields.append("changes")
-
-                if any(rev.created_by_id != keeper.created_by_id for rev in to_delete):
-                    if system_user is None:
-                        system_user = User.get_system_user()
-                    keeper.created_by = system_user
-                    update_fields.append("created_by")
-
-                if update_fields:
-                    keeper.save(update_fields=update_fields)
-                deleted_ids.extend(rev.id for rev in to_delete)
-
-            if not deleted_ids:
-                return 0
-
-            return FlowRevision.objects.filter(id__in=deleted_ids).delete()[0]
+        return FlowRevision.objects.filter(flow=flow_id).exclude(id__in=keepers).delete()[0]
 
     @classmethod
     def validate_legacy_definition(cls, definition):

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -782,8 +782,13 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
             self.update_dependencies(info["dependencies"])
 
         # collapse older revisions inline so they don't pile up between cron runs;
-        # done outside the save transaction so a trim failure can't roll back the save
-        FlowRevision.trim_for_flow(self.id)
+        # done outside the save transaction (so a trim failure can't roll back the
+        # save) and best-effort (so a trim failure can't surface as a save failure
+        # to the caller — the cron task is still there as a safety net)
+        try:
+            FlowRevision.trim_for_flow(self.id)
+        except Exception:
+            logger.warning("failed to trim revisions for flow %s", self.uuid, exc_info=True)
 
         return revision, info["issues"]
 
@@ -1243,8 +1248,13 @@ class FlowRevision(models.Model):
         day_ago = timezone.now() - timedelta(hours=24)
         cutoff = min(rev_25[0].created_on, day_ago) if rev_25 else day_ago
 
-        # bucket older revisions by day in chronological order
-        older = list(FlowRevision.objects.filter(flow=flow_id, created_on__lt=cutoff).order_by("created_on"))
+        # bucket older revisions by day in chronological order; only fetch the columns
+        # we actually look at — `definition` can be MB-sized and we never read it here
+        older = list(
+            FlowRevision.objects.filter(flow=flow_id, created_on__lt=cutoff)
+            .only("id", "created_on", "created_by_id", "changes")
+            .order_by("created_on")
+        )
         by_date = defaultdict(list)
         for rev in older:
             by_date[rev.created_on.date()].append(rev)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -15,8 +15,8 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import OpClass
 from django.db import models, transaction
-from django.db.models import Max, Prefetch, Q, Sum
-from django.db.models.functions import Lower, TruncDate
+from django.db.models import Prefetch, Q, Sum
+from django.db.models.functions import Lower
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -781,6 +781,9 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
             self.update_dependencies(info["dependencies"])
 
+            # collapse older revisions inline so they don't pile up between cron runs
+            FlowRevision.trim_for_flow(self.id)
+
         return revision, info["issues"]
 
     @classmethod
@@ -1221,32 +1224,57 @@ class FlowRevision(models.Model):
         Trims the revisions for the passed in flow.
 
         Our logic is:
-         * always keep last 25 revisions
-         * for any revision beyond those, collapse to first revision for that day
+         * always keep the last 25 revisions and everything from the past 24 hours
+           (whichever covers more)
+         * for any revision beyond those, collapse to the last revision for that day
+
+        The kept revision absorbs the `changes` of the deleted ones it replaces, so the
+        recorded changes still describe everything that happened since the previous kept
+        revision. If the absorbed revisions involved other authors, attribution falls
+        back to the system user since the kept revision now represents their work too.
 
         :param flow: the id of the flow to trim revisions for
         :return: the number of trimmed revisions
         """
-        # find what date cutoff we will use for "25 most recent"
-        cutoff = FlowRevision.objects.filter(flow=flow_id).order_by("-created_on")[24:25]
+        # the cutoff is the earlier of "25th most recent revision" and "24 hours ago" —
+        # whichever covers more keeps more revisions safe from collapsing
+        rev_25 = FlowRevision.objects.filter(flow=flow_id).order_by("-created_on")[24:25]
+        day_ago = timezone.now() - timedelta(hours=24)
+        cutoff = min(rev_25[0].created_on, day_ago) if rev_25 else day_ago
 
-        # fewer than 25 revisions
-        if not cutoff:
+        # bucket older revisions by day in chronological order
+        older = list(FlowRevision.objects.filter(flow=flow_id, created_on__lt=cutoff).order_by("created_on"))
+        by_date = defaultdict(list)
+        for rev in older:
+            by_date[rev.created_on.date()].append(rev)
+
+        system_user = None
+        deleted_ids = []
+        for revs in by_date.values():
+            if len(revs) == 1:
+                continue
+
+            *to_delete, keeper = revs
+
+            tags = set((keeper.changes or {}).get("tags", []))
+            for rev in to_delete:
+                tags.update((rev.changes or {}).get("tags", []))
+            keeper.changes = {"tags": sorted(tags)}
+
+            update_fields = ["changes"]
+            if any(rev.created_by_id != keeper.created_by_id for rev in to_delete):
+                if system_user is None:
+                    system_user = User.get_system_user()
+                keeper.created_by = system_user
+                update_fields.append("created_by")
+
+            keeper.save(update_fields=update_fields)
+            deleted_ids.extend(rev.id for rev in to_delete)
+
+        if not deleted_ids:
             return 0
 
-        cutoff = cutoff[0].created_on
-
-        # find the ids of the first revision for each day starting at the cutoff
-        keepers = (
-            FlowRevision.objects.filter(flow=flow_id, created_on__lt=cutoff)
-            .annotate(created_date=TruncDate("created_on"))
-            .values("created_date")
-            .annotate(max_id=Max("id"))
-            .values_list("max_id", flat=True)
-        )
-
-        # delete the rest
-        return FlowRevision.objects.filter(flow=flow_id, created_on__lt=cutoff).exclude(id__in=keepers).delete()[0]
+        return FlowRevision.objects.filter(id__in=deleted_ids).delete()[0]
 
     @classmethod
     def validate_legacy_definition(cls, definition):

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -6,6 +6,7 @@ from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import ContactField, ContactGroup
 from temba.flows.models import (
     Flow,
+    FlowRevision,
     FlowRun,
     FlowStart,
     FlowStartCount,
@@ -277,6 +278,7 @@ class FlowTest(TembaTest, CRUDLTestMixin):
         ):
             rev_after_trim_fail, _ = flow.save_revision(self.admin, dict(latest_def))
         self.assertIsNotNone(rev_after_trim_fail)
+        self.assertTrue(FlowRevision.objects.filter(id=rev_after_trim_fail.id).exists())
 
         # can't save older spec version over newer
         definition = flow.revisions.order_by("id").last().definition

--- a/temba/flows/tests/test_flow.py
+++ b/temba/flows/tests/test_flow.py
@@ -266,6 +266,18 @@ class FlowTest(TembaTest, CRUDLTestMixin):
             rev3, _ = flow.save_revision(self.admin, dict(rev2.definition))
         self.assertIsNone(rev3.changes)
 
+        # a trim failure shouldn't surface as a save failure — the inline trim is
+        # best-effort housekeeping and the cron task is the safety net
+        flow.name = "Trim Test"
+        flow.save(update_fields=("name",))
+        latest_def = flow.revisions.order_by("id").last().definition
+        with patch(
+            "temba.flows.models.FlowRevision.trim_for_flow",
+            side_effect=RuntimeError("trim boom"),
+        ):
+            rev_after_trim_fail, _ = flow.save_revision(self.admin, dict(latest_def))
+        self.assertIsNotNone(rev_after_trim_fail)
+
         # can't save older spec version over newer
         definition = flow.revisions.order_by("id").last().definition
         definition["spec_version"] = Flow.FINAL_LEGACY_VERSION

--- a/temba/flows/tests/test_revision.py
+++ b/temba/flows/tests/test_revision.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from temba.flows.models import FlowRevision
 from temba.flows.tasks import trim_flow_revisions
+from temba.orgs.models import User
 from temba.tests import TembaTest
 
 
@@ -58,15 +59,26 @@ class FlowRevisionTest(TembaTest):
                 flow=flow1, definition=dict(), revision=revision, created_by=self.admin, created_on=created
             )
 
-        # then for 5 days prior, make a few more
+        # then for 5 days prior, make a few more — alternate authors and tag the changes so
+        # we can verify the trim merges changes and falls back to the system user when the
+        # absorbed revisions span multiple authors
+        day_keepers = []  # ids of the revisions we expect trim to keep on each prior day
         for i in range(5):
             created = created - timedelta(days=1)
-            for i in range(10):
+            for j in range(10):
                 revision -= 1
                 created = created - timedelta(minutes=1)
-                FlowRevision.objects.create(
-                    flow=flow1, definition=dict(), revision=revision, created_by=self.admin, created_on=created
+                rev = FlowRevision.objects.create(
+                    flow=flow1,
+                    definition=dict(),
+                    revision=revision,
+                    created_by=self.editor if j % 2 == 0 else self.admin,
+                    changes={"tags": [f"tag{j}"]},
+                    created_on=created,
                 )
+                # j=0 has the latest created_on within the day (loop walks back in time)
+                if j == 0:
+                    day_keepers.append(rev.id)
 
         # trim our flow revisions, should be left with original (today), 25 from yesterday, 1 per day for 5 days = 31
         self.assertEqual(76, FlowRevision.objects.filter(flow=flow1).count())
@@ -79,6 +91,16 @@ class FlowRevisionTest(TembaTest):
             .distinct("created_date")
             .count(),
         )
+
+        # the kept rev for each prior day should be the latest one (highest created_on),
+        # have absorbed every tag from the deleted siblings, and be attributed to the
+        # system user since the absorbed work spanned both admin and editor
+        system_user = User.get_system_user()
+        expected_tags = [f"tag{j}" for j in range(10)]
+        for keeper_id in day_keepers:
+            keeper = FlowRevision.objects.get(id=keeper_id)
+            self.assertEqual(expected_tags, keeper.changes["tags"])
+            self.assertEqual(system_user, keeper.created_by)
 
         # trim our clinic flow manually, should remain unchanged
         self.assertEqual(2, FlowRevision.objects.filter(flow=flow2).count())
@@ -94,3 +116,23 @@ class FlowRevisionTest(TembaTest):
         trim_flow_revisions()
         self.assertEqual(2, FlowRevision.objects.filter(flow=flow2).count())
         self.assertEqual(31, FlowRevision.objects.filter(flow=flow1).count())
+
+    def test_trim_revisions_keeps_last_24h(self):
+        # revisions from the last 24 hours are protected from collapsing even when there
+        # are well more than 25 of them
+        flow = self.create_flow("Flow 1")
+        FlowRevision.objects.filter(flow=flow).update(revision=100)
+
+        # 40 revisions all within the last 24h, spread across two calendar days
+        created = timezone.now() - timedelta(minutes=1)
+        revision = 100
+        for i in range(40):
+            revision -= 1
+            created = created - timedelta(minutes=30)
+            FlowRevision.objects.create(
+                flow=flow, definition=dict(), revision=revision, created_by=self.admin, created_on=created
+            )
+
+        self.assertEqual(41, FlowRevision.objects.filter(flow=flow).count())
+        self.assertEqual(0, FlowRevision.trim_for_flow(flow.id))
+        self.assertEqual(41, FlowRevision.objects.filter(flow=flow).count())

--- a/temba/flows/tests/test_revision.py
+++ b/temba/flows/tests/test_revision.py
@@ -5,8 +5,8 @@ from django.utils import timezone
 
 from temba.flows.models import FlowRevision
 from temba.flows.tasks import trim_flow_revisions
-from temba.orgs.models import User
 from temba.tests import TembaTest
+from temba.users.models import User
 
 
 class FlowRevisionTest(TembaTest):

--- a/temba/flows/tests/test_revision.py
+++ b/temba/flows/tests/test_revision.py
@@ -1,12 +1,10 @@
 from datetime import timedelta
 
-from django.db.models.functions import TruncDate
 from django.utils import timezone
 
 from temba.flows.models import FlowRevision
 from temba.flows.tasks import trim_flow_revisions
 from temba.tests import TembaTest
-from temba.users.models import User
 
 
 class FlowRevisionTest(TembaTest):
@@ -38,10 +36,7 @@ class FlowRevisionTest(TembaTest):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
 
-        revision = 100
-        FlowRevision.objects.all().update(revision=revision)
-
-        # create a single old clinic revision
+        # a small flow stays untouched
         FlowRevision.objects.create(
             flow=flow2,
             definition=dict(),
@@ -50,179 +45,31 @@ class FlowRevisionTest(TembaTest):
             created_by=self.admin,
         )
 
-        # make a bunch of revisions for flow 1 on the same day
-        created = timezone.now().replace(hour=6) - timedelta(days=1)
-        for i in range(25):
+        # build flow1 well past the cap
+        revision = FlowRevision.MAX_REVISIONS + 50
+        created = timezone.now()
+        for _ in range(FlowRevision.MAX_REVISIONS + 50):
             revision -= 1
             created = created - timedelta(minutes=1)
             FlowRevision.objects.create(
                 flow=flow1, definition=dict(), revision=revision, created_by=self.admin, created_on=created
             )
 
-        # then for 5 days prior, make a few more — alternate authors and tag the changes so
-        # we can verify the trim merges changes and falls back to the system user when the
-        # absorbed revisions span multiple authors
-        day_keepers = []  # ids of the revisions we expect trim to keep on each prior day
-        for i in range(5):
-            created = created - timedelta(days=1)
-            for j in range(10):
-                revision -= 1
-                created = created - timedelta(minutes=1)
-                rev = FlowRevision.objects.create(
-                    flow=flow1,
-                    definition=dict(),
-                    revision=revision,
-                    created_by=self.editor if j % 2 == 0 else self.admin,
-                    changes={"tags": [f"tag{j}"]},
-                    created_on=created,
-                )
-                # j=0 has the latest created_on within the day (loop walks back in time)
-                if j == 0:
-                    day_keepers.append(rev.id)
+        # +1 from the original revision created by create_flow
+        self.assertEqual(FlowRevision.MAX_REVISIONS + 51, FlowRevision.objects.filter(flow=flow1).count())
+        self.assertEqual(51, FlowRevision.trim(start))
+        self.assertEqual(FlowRevision.MAX_REVISIONS, FlowRevision.objects.filter(flow=flow1).count())
 
-        # trim our flow revisions, should be left with original (today), 25 from yesterday, 1 per day for 5 days = 31
-        self.assertEqual(76, FlowRevision.objects.filter(flow=flow1).count())
-        self.assertEqual(45, FlowRevision.trim(start))
-        self.assertEqual(31, FlowRevision.objects.filter(flow=flow1).count())
-        self.assertEqual(
-            7,
-            FlowRevision.objects.filter(flow=flow1)
-            .annotate(created_date=TruncDate("created_on"))
-            .distinct("created_date")
-            .count(),
-        )
-
-        # the kept rev for each prior day should be the latest one (highest created_on),
-        # have absorbed every tag from the deleted siblings, and be attributed to the
-        # system user since the absorbed work spanned both admin and editor
-        system_user = User.get_system_user()
-        expected_tags = [f"tag{j}" for j in range(10)]
-        for keeper_id in day_keepers:
-            keeper = FlowRevision.objects.get(id=keeper_id)
-            self.assertEqual(expected_tags, keeper.changes["tags"])
-            self.assertEqual(system_user, keeper.created_by)
-
-        # trim our clinic flow manually, should remain unchanged
+        # the small flow is unchanged
         self.assertEqual(2, FlowRevision.objects.filter(flow=flow2).count())
         self.assertEqual(0, FlowRevision.trim_for_flow(flow2.id))
         self.assertEqual(2, FlowRevision.objects.filter(flow=flow2).count())
 
-        # call our task
+        # task is idempotent
         trim_flow_revisions()
+        self.assertEqual(FlowRevision.MAX_REVISIONS, FlowRevision.objects.filter(flow=flow1).count())
         self.assertEqual(2, FlowRevision.objects.filter(flow=flow2).count())
-        self.assertEqual(31, FlowRevision.objects.filter(flow=flow1).count())
 
-        # call again (testing reading cache key)
         trim_flow_revisions()
+        self.assertEqual(FlowRevision.MAX_REVISIONS, FlowRevision.objects.filter(flow=flow1).count())
         self.assertEqual(2, FlowRevision.objects.filter(flow=flow2).count())
-        self.assertEqual(31, FlowRevision.objects.filter(flow=flow1).count())
-
-    def test_trim_revisions_keeps_last_24h(self):
-        # revisions from the last 24 hours are protected from collapsing even when there
-        # are well more than 25 of them
-        flow = self.create_flow("Flow 1")
-        FlowRevision.objects.filter(flow=flow).update(revision=100)
-
-        # 40 revisions all within the last 24h, spread across two calendar days
-        created = timezone.now() - timedelta(minutes=1)
-        revision = 100
-        for i in range(40):
-            revision -= 1
-            created = created - timedelta(minutes=30)
-            FlowRevision.objects.create(
-                flow=flow, definition=dict(), revision=revision, created_by=self.admin, created_on=created
-            )
-
-        self.assertEqual(41, FlowRevision.objects.filter(flow=flow).count())
-        self.assertEqual(0, FlowRevision.trim_for_flow(flow.id))
-        self.assertEqual(41, FlowRevision.objects.filter(flow=flow).count())
-
-    def test_trim_revisions_same_author_preserved(self):
-        # when every absorbed revision shares the keeper's author, attribution is
-        # preserved (the system-user fallback only fires for mixed authorship)
-        flow = self.create_flow("Flow 1")
-        FlowRevision.objects.filter(flow=flow).update(revision=100)
-
-        # three revisions on a single old day, all by the editor; anchor to noon UTC
-        # so the small window can't straddle UTC midnight regardless of when the
-        # test runs
-        old_day = (timezone.now() - timedelta(days=3)).replace(hour=12, minute=0, second=0, microsecond=0)
-        revision = 100
-        keeper_id = None
-        for j in range(3):
-            revision -= 1
-            rev = FlowRevision.objects.create(
-                flow=flow,
-                definition=dict(),
-                revision=revision,
-                created_by=self.editor,
-                changes={"tags": [f"tag{j}"]},
-                created_on=old_day - timedelta(minutes=10 * j),
-            )
-            # j=0 is the latest of the day and will be kept
-            if j == 0:
-                keeper_id = rev.id
-
-        # pad with 25 fresh revisions so the older day is outside the keep zone
-        recent = timezone.now() - timedelta(minutes=1)
-        for j in range(25):
-            revision -= 1
-            FlowRevision.objects.create(
-                flow=flow,
-                definition=dict(),
-                revision=revision,
-                created_by=self.admin,
-                created_on=recent - timedelta(minutes=j),
-            )
-
-        self.assertEqual(2, FlowRevision.trim_for_flow(flow.id))
-        keeper = FlowRevision.objects.get(id=keeper_id)
-        self.assertEqual(self.editor, keeper.created_by)
-        self.assertEqual(["tag0", "tag1", "tag2"], keeper.changes["tags"])
-
-    def test_trim_revisions_24h_cutoff_drives_trim(self):
-        # explicit "mixed" case: fewer than 25 recent revisions sit inside 24h, but
-        # additional revisions exist outside 24h and on the same calendar day as the
-        # 24h boundary — those older ones should still collapse, while everything in
-        # the 24h window is preserved
-        flow = self.create_flow("Flow 1")
-        FlowRevision.objects.filter(flow=flow).update(revision=100)
-
-        revision = 100
-
-        # 5 revisions inside the last 24h (well under 25, so the 24h cutoff wins
-        # over the rev-25 cutoff)
-        recent = timezone.now() - timedelta(minutes=1)
-        recent_ids = []
-        for j in range(5):
-            revision -= 1
-            rev = FlowRevision.objects.create(
-                flow=flow,
-                definition=dict(),
-                revision=revision,
-                created_by=self.admin,
-                created_on=recent - timedelta(minutes=j),
-            )
-            recent_ids.append(rev.id)
-
-        # 4 revisions on a day older than 24h ago — these should collapse to 1.
-        # Anchor to noon UTC so the small minute-level span can't span midnight.
-        old_day = (timezone.now() - timedelta(days=2)).replace(hour=12, minute=0, second=0, microsecond=0)
-        for j in range(4):
-            revision -= 1
-            FlowRevision.objects.create(
-                flow=flow,
-                definition=dict(),
-                revision=revision,
-                created_by=self.admin,
-                created_on=old_day - timedelta(minutes=j),
-            )
-
-        self.assertEqual(10, FlowRevision.objects.filter(flow=flow).count())
-        # 3 of the 4 old-day revisions get collapsed away
-        self.assertEqual(3, FlowRevision.trim_for_flow(flow.id))
-        # 5 recent + 1 collapsed old-day + 1 original from create_flow = 7
-        self.assertEqual(7, FlowRevision.objects.filter(flow=flow).count())
-        # every recent revision is still there
-        for rev_id in recent_ids:
-            self.assertTrue(FlowRevision.objects.filter(id=rev_id).exists())

--- a/temba/flows/tests/test_revision.py
+++ b/temba/flows/tests/test_revision.py
@@ -143,8 +143,10 @@ class FlowRevisionTest(TembaTest):
         flow = self.create_flow("Flow 1")
         FlowRevision.objects.filter(flow=flow).update(revision=100)
 
-        # three revisions on a single old day, all by the editor
-        old_day = timezone.now() - timedelta(days=3)
+        # three revisions on a single old day, all by the editor; anchor to noon UTC
+        # so the small window can't straddle UTC midnight regardless of when the
+        # test runs
+        old_day = (timezone.now() - timedelta(days=3)).replace(hour=12, minute=0, second=0, microsecond=0)
         revision = 100
         keeper_id = None
         for j in range(3):
@@ -203,8 +205,9 @@ class FlowRevisionTest(TembaTest):
             )
             recent_ids.append(rev.id)
 
-        # 4 revisions on a day older than 24h ago — these should collapse to 1
-        old_day = timezone.now() - timedelta(days=2)
+        # 4 revisions on a day older than 24h ago — these should collapse to 1.
+        # Anchor to noon UTC so the small minute-level span can't span midnight.
+        old_day = (timezone.now() - timedelta(days=2)).replace(hour=12, minute=0, second=0, microsecond=0)
         for j in range(4):
             revision -= 1
             FlowRevision.objects.create(

--- a/temba/flows/tests/test_revision.py
+++ b/temba/flows/tests/test_revision.py
@@ -136,3 +136,90 @@ class FlowRevisionTest(TembaTest):
         self.assertEqual(41, FlowRevision.objects.filter(flow=flow).count())
         self.assertEqual(0, FlowRevision.trim_for_flow(flow.id))
         self.assertEqual(41, FlowRevision.objects.filter(flow=flow).count())
+
+    def test_trim_revisions_same_author_preserved(self):
+        # when every absorbed revision shares the keeper's author, attribution is
+        # preserved (the system-user fallback only fires for mixed authorship)
+        flow = self.create_flow("Flow 1")
+        FlowRevision.objects.filter(flow=flow).update(revision=100)
+
+        # three revisions on a single old day, all by the editor
+        old_day = timezone.now() - timedelta(days=3)
+        revision = 100
+        keeper_id = None
+        for j in range(3):
+            revision -= 1
+            rev = FlowRevision.objects.create(
+                flow=flow,
+                definition=dict(),
+                revision=revision,
+                created_by=self.editor,
+                changes={"tags": [f"tag{j}"]},
+                created_on=old_day - timedelta(minutes=10 * j),
+            )
+            # j=0 is the latest of the day and will be kept
+            if j == 0:
+                keeper_id = rev.id
+
+        # pad with 25 fresh revisions so the older day is outside the keep zone
+        recent = timezone.now() - timedelta(minutes=1)
+        for j in range(25):
+            revision -= 1
+            FlowRevision.objects.create(
+                flow=flow,
+                definition=dict(),
+                revision=revision,
+                created_by=self.admin,
+                created_on=recent - timedelta(minutes=j),
+            )
+
+        self.assertEqual(2, FlowRevision.trim_for_flow(flow.id))
+        keeper = FlowRevision.objects.get(id=keeper_id)
+        self.assertEqual(self.editor, keeper.created_by)
+        self.assertEqual(["tag0", "tag1", "tag2"], keeper.changes["tags"])
+
+    def test_trim_revisions_24h_cutoff_drives_trim(self):
+        # explicit "mixed" case: fewer than 25 recent revisions sit inside 24h, but
+        # additional revisions exist outside 24h and on the same calendar day as the
+        # 24h boundary — those older ones should still collapse, while everything in
+        # the 24h window is preserved
+        flow = self.create_flow("Flow 1")
+        FlowRevision.objects.filter(flow=flow).update(revision=100)
+
+        revision = 100
+
+        # 5 revisions inside the last 24h (well under 25, so the 24h cutoff wins
+        # over the rev-25 cutoff)
+        recent = timezone.now() - timedelta(minutes=1)
+        recent_ids = []
+        for j in range(5):
+            revision -= 1
+            rev = FlowRevision.objects.create(
+                flow=flow,
+                definition=dict(),
+                revision=revision,
+                created_by=self.admin,
+                created_on=recent - timedelta(minutes=j),
+            )
+            recent_ids.append(rev.id)
+
+        # 4 revisions on a day older than 24h ago — these should collapse to 1
+        old_day = timezone.now() - timedelta(days=2)
+        for j in range(4):
+            revision -= 1
+            FlowRevision.objects.create(
+                flow=flow,
+                definition=dict(),
+                revision=revision,
+                created_by=self.admin,
+                created_on=old_day - timedelta(minutes=j),
+            )
+
+        self.assertEqual(10, FlowRevision.objects.filter(flow=flow).count())
+        # 3 of the 4 old-day revisions get collapsed away
+        self.assertEqual(3, FlowRevision.trim_for_flow(flow.id))
+        # 5 recent + 1 collapsed old-day + 1 original from create_flow = 7
+        self.assertEqual(7, FlowRevision.objects.filter(flow=flow).count())
+        # every recent revision is still there
+        for rev_id in recent_ids:
+            self.assertTrue(FlowRevision.objects.filter(id=rev_id).exists())

--- a/temba/users/adapter.py
+++ b/temba/users/adapter.py
@@ -17,8 +17,11 @@ from temba.utils.email.send import EmailSender
 
 class InviteAdapterMixin:
     def post_login(self, request, user, *, email_verification, signal_kwargs, email, signup, redirect_url):
-        # deferred to avoid pulling temba.orgs.views.* into module-load time, which
-        # races with the autoreloader's parallel imports under Python 3.14
+        # deferred so this module stays importable from allauth's startup
+        # `adapter_check`. Importing anything from `temba.orgs.views.*` at module
+        # scope runs `temba/orgs/views/__init__.py`, which star-imports the
+        # heavy `views.py`; under Python 3.14's stricter `_ModuleLock` deadlock
+        # detection that races with runserver's autoreloader and aborts startup.
         from temba.orgs.views.utils import switch_to_org
 
         # if we are working with an invite, mark it as accepted

--- a/temba/users/adapter.py
+++ b/temba/users/adapter.py
@@ -11,13 +11,16 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.models import Invitation
-from temba.orgs.views.views import switch_to_org
 from temba.users.models import User
 from temba.utils.email.send import EmailSender
 
 
 class InviteAdapterMixin:
     def post_login(self, request, user, *, email_verification, signal_kwargs, email, signup, redirect_url):
+        # deferred to avoid pulling temba.orgs.views.* into module-load time, which
+        # races with the autoreloader's parallel imports under Python 3.14
+        from temba.orgs.views.utils import switch_to_org
+
         # if we are working with an invite, mark it as accepted
         secret = request.session.pop("invite_secret", None)
         if secret:

--- a/temba/users/forms.py
+++ b/temba/users/forms.py
@@ -5,7 +5,6 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from temba.orgs.models import Invitation
-from temba.orgs.views.utils import switch_to_org
 from temba.users.models import User
 
 
@@ -51,6 +50,11 @@ class TembaSignupForm(InviteFormMixin, SignupForm):
         return super().clean_email()
 
     def save(self, request):
+        # deferred for the same reason as in temba/users/adapter.py — keep this
+        # module out of the orgs.views import chain so it stays safe to load
+        # from any startup-side path under Python 3.14
+        from temba.orgs.views.utils import switch_to_org
+
         # remove our invite from the session
         if "invite_secret" in request.session:
             del request.session["invite_secret"]


### PR DESCRIPTION
## Summary

Simplifies `FlowRevision.trim_for_flow` to keep the **500 most recent revisions** per flow and delete the rest, runs the trim inline at the end of every `Flow.save_revision`, and works around a Python 3.14 import-deadlock that surfaces during `runserver` autoreloader startup.

## Changes

### `temba/flows/models.py`
- `FlowRevision.MAX_REVISIONS = 500` is the new (only) trim policy. `trim_for_flow` keeps the 500 most-recent rows by `(created_on DESC, id DESC)` and deletes everything else for that flow — no day-bucketing, no change-tag merging, no author handling.
- `Flow.save_revision` now calls `trim_for_flow` inline at the end, **outside** the save transaction and wrapped in a try/except logging warning. Best-effort housekeeping that can't roll back or fail the save; the existing scheduled `trim_flow_revisions` cron task stays in place as a safety net.

### `temba/users/adapter.py`, `temba/users/forms.py`
- Defer `from temba.orgs.views.utils import switch_to_org` to inside the methods that use it. At module scope the import runs `temba/orgs/views/__init__.py` (which star-imports the heavy `views.py`); under Python 3.14's stricter `_ModuleLock` deadlock detection that races with the autoreloader and aborts startup. Deferring keeps both modules safe to load early.

### Tests
- `test_trim_revisions` rewritten to cover the simpler policy: build a flow with `MAX_REVISIONS + 50` revisions, assert trim returns 50 and leaves exactly `MAX_REVISIONS` rows, and assert a small flow is untouched plus the cron task is idempotent.
- New `test_save_revision` case verifying that a trim failure doesn't fail the save and that the new revision still persists.

## Behavior changes operators may notice

| Scenario | Before | After |
|---|---|---|
| Flow with 100 revisions over many months | All 100 kept | All 100 kept |
| Flow with 600 revisions | All 600 kept | Most-recent 500 kept |
| `Flow.save_revision` | Cron-only trim path | Also trims inline (cron stays as backup) |

## Test plan
- [x] `python manage.py test temba.flows.tests.test_revision` — passes
- [x] `python manage.py test temba.flows.tests.test_flow.FlowTest.test_save_revision` — passes
- [x] `runserver` starts cleanly under Python 3.14
- [x] CI green