### PR TITLE
Fix flow revision changes backfill migration

### DIFF
--- a/temba/flows/changes.py
+++ b/temba/flows/changes.py
@@ -5,8 +5,9 @@ _METADATA_FIELDS = ("name", "type", "expire_after_minutes")
 _STICKY_LAYOUT_FIELDS = ("position", "width", "height")
 
 # Top-level fields rewritten on every save or otherwise not part of the meaningful
-# definition — excluded when checking for "did anything change at all?"
-_SYSTEM_FIELDS = ("uuid", "revision", "spec_version")
+# definition — excluded when checking for "did anything change at all?". spec_version
+# isn't here because a spec_version diff is recorded as "spec" before the catch-all runs.
+_SYSTEM_FIELDS = ("uuid", "revision")
 
 
 def compute_changes(old: dict, new: dict) -> dict:

--- a/temba/flows/changes.py
+++ b/temba/flows/changes.py
@@ -22,12 +22,14 @@ def compute_changes(old: dict, new: dict) -> dict:
         stickies   — stickies added, removed, or content-edited
         metadata   — flow-level fields changed (name, type, expire_after_minutes, base_language)
         localization:<lang> — translations changed for that language
-        spec       — flow's spec version was bumped (added by Flow.save_revision, not here,
-                     since prior revisions are migrated forward before diffing)
+        spec       — flow's spec version was bumped
         other      — any difference not captured by the categories above; a safety net so
                      an empty tag list reliably means "nothing changed"
     """
     tags = set()
+
+    if old.get("spec_version") != new.get("spec_version"):
+        tags.add("spec")
 
     if old.get("language") != new.get("language"):
         tags.add("metadata")

--- a/temba/flows/migrations/0402_backfill_flowrevision_changes.py
+++ b/temba/flows/migrations/0402_backfill_flowrevision_changes.py
@@ -3,7 +3,7 @@ import logging
 
 from packaging.version import InvalidVersion, Version
 
-from django.db import connection, migrations
+from django.db import migrations
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,10 @@ def _tag_node_diff(old: dict, new: dict, tags: set) -> None:  # pragma: no cover
 
 
 def backfill_flowrevision_changes(apps, schema_editor):  # pragma: no cover
+    from django.db import connection as default_connection
+
     FlowRevision = apps.get_model("flows", "FlowRevision")
+    connection = schema_editor.connection if schema_editor is not None else default_connection
 
     # iterate flows that still have any null-changes revision, paged by flow_id
     flow_ids_qs = (
@@ -155,8 +158,15 @@ def backfill_flowrevision_changes(apps, schema_editor):  # pragma: no cover
                     prev_def = None
                     continue
 
+                if not def_text:
+                    # null/empty definition — log and reset the chain so the next
+                    # revision isn't diffed against a missing prior
+                    logger.warning("empty definition for revision %d, skipping", rev_id)
+                    prev_def = None
+                    continue
+
                 try:
-                    definition = json.loads(def_text) if def_text else None
+                    definition = json.loads(def_text)
                 except json.JSONDecodeError:
                     # corrupt definition JSON — log and reset the chain so the next
                     # revision isn't diffed against a missing prior

--- a/temba/flows/migrations/0402_backfill_flowrevision_changes.py
+++ b/temba/flows/migrations/0402_backfill_flowrevision_changes.py
@@ -1,9 +1,8 @@
-import json
 import logging
 
 from packaging.version import InvalidVersion, Version
 
-from django.db import connection as default_connection, migrations
+from django.db import migrations
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +111,6 @@ def _tag_node_diff(old: dict, new: dict, tags: set) -> None:  # pragma: no cover
 
 def backfill_flowrevision_changes(apps, schema_editor):  # pragma: no cover
     FlowRevision = apps.get_model("flows", "FlowRevision")
-    connection = schema_editor.connection if schema_editor is not None else default_connection
 
     # iterate flows that still have any null-changes revision, paged by flow_id
     flow_ids_qs = (
@@ -132,65 +130,39 @@ def backfill_flowrevision_changes(apps, schema_editor):  # pragma: no cover
             break
 
         for flow_id in flow_ids:
-            # fetch raw rows directly so a single revision with malformed JSON in
-            # its definition column doesn't fail the whole batch via the ORM's
-            # eager from_db_value decoding
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT id, definition, spec_version, changes FROM flows_flowrevision "
-                    "WHERE flow_id = %s ORDER BY revision, id",
-                    [flow_id],
-                )
-                rows = cursor.fetchall()
+            # load the whole flow's revisions; flows have bounded revision counts
+            # (trim keeps recent + dailies), and a single bulk_update at the end
+            # avoids interleaving writes with a server-side cursor
+            revs = list(
+                FlowRevision.objects.filter(flow_id=flow_id)
+                .order_by("revision", "id")
+                .only("id", "definition", "spec_version", "changes")
+            )
 
             prev_def = None
             updates = []
 
-            for rev_id, def_text, spec_version, existing_changes in rows:
+            for rev in revs:
                 try:
-                    spec_ok = Version(spec_version) >= MIN_SPEC
+                    spec_ok = Version(rev.spec_version) >= MIN_SPEC
                 except InvalidVersion:
                     spec_ok = False
 
-                if not spec_ok:
-                    prev_def = None
-                    continue
-
-                if not def_text:
-                    # null/empty definition — log and reset the chain so the next
-                    # revision isn't diffed against a missing prior
-                    logger.warning("empty definition for revision %d, skipping", rev_id)
-                    prev_def = None
-                    continue
-
-                try:
-                    definition = json.loads(def_text)
-                except json.JSONDecodeError:
-                    # corrupt definition JSON — log and reset the chain so the next
-                    # revision isn't diffed against a missing prior
-                    logger.warning("could not decode definition for revision %d, skipping", rev_id, exc_info=True)
-                    prev_def = None
-                    continue
-
-                if not isinstance(definition, dict):
-                    # valid JSON but not a flow definition (e.g. a bare list/number) —
-                    # reset the chain so we don't propagate a non-dict prev_def
-                    logger.warning("non-dict definition for revision %d, skipping", rev_id)
-                    prev_def = None
-                    continue
-
-                if prev_def is not None and not existing_changes:
+                if spec_ok and prev_def is not None and not rev.changes:
                     try:
-                        changes = compute_changes(prev_def, definition)
+                        rev.changes = compute_changes(prev_def, rev.definition)
                     except Exception:
                         # malformed definition (e.g. nodes/actions missing uuid) — leave
                         # changes as null and keep going so one bad row doesn't block
                         # the rest of the backfill
-                        logger.warning("could not compute changes for revision %d", rev_id, exc_info=True)
+                        logger.warning("could not compute changes for revision %d", rev.id, exc_info=True)
                     else:
-                        updates.append(FlowRevision(id=rev_id, changes=changes))
+                        updates.append(rev)
 
-                prev_def = definition
+                # only carry forward a definition compute_changes can read; this also
+                # ensures the first 13.x revision after a pre-13 history isn't diffed
+                # against an incompatible prior shape
+                prev_def = rev.definition if spec_ok else None
 
             if updates:
                 FlowRevision.objects.bulk_update(updates, ["changes"])

--- a/temba/flows/migrations/0402_backfill_flowrevision_changes.py
+++ b/temba/flows/migrations/0402_backfill_flowrevision_changes.py
@@ -3,7 +3,7 @@ import logging
 
 from packaging.version import InvalidVersion, Version
 
-from django.db import migrations
+from django.db import connection as default_connection, migrations
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ MIN_SPEC = Version("13.0.0")
 
 _METADATA_FIELDS = ("name", "type", "expire_after_minutes")
 _STICKY_LAYOUT_FIELDS = ("position", "width", "height")
-_SYSTEM_FIELDS = ("uuid", "revision", "spec_version")
+_SYSTEM_FIELDS = ("uuid", "revision")
 
 
 def compute_changes(old: dict, new: dict) -> dict:  # pragma: no cover
@@ -111,8 +111,6 @@ def _tag_node_diff(old: dict, new: dict, tags: set) -> None:  # pragma: no cover
 
 
 def backfill_flowrevision_changes(apps, schema_editor):  # pragma: no cover
-    from django.db import connection as default_connection
-
     FlowRevision = apps.get_model("flows", "FlowRevision")
     connection = schema_editor.connection if schema_editor is not None else default_connection
 
@@ -171,6 +169,13 @@ def backfill_flowrevision_changes(apps, schema_editor):  # pragma: no cover
                     # corrupt definition JSON — log and reset the chain so the next
                     # revision isn't diffed against a missing prior
                     logger.warning("could not decode definition for revision %d, skipping", rev_id, exc_info=True)
+                    prev_def = None
+                    continue
+
+                if not isinstance(definition, dict):
+                    # valid JSON but not a flow definition (e.g. a bare list/number) —
+                    # reset the chain so we don't propagate a non-dict prev_def
+                    logger.warning("non-dict definition for revision %d, skipping", rev_id)
                     prev_def = None
                     continue
 

--- a/temba/flows/migrations/0402_backfill_flowrevision_changes.py
+++ b/temba/flows/migrations/0402_backfill_flowrevision_changes.py
@@ -1,8 +1,9 @@
+import json
 import logging
 
 from packaging.version import InvalidVersion, Version
 
-from django.db import migrations
+from django.db import connection, migrations
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,9 @@ _SYSTEM_FIELDS = ("uuid", "revision", "spec_version")
 
 def compute_changes(old: dict, new: dict) -> dict:  # pragma: no cover
     tags = set()
+
+    if old.get("spec_version") != new.get("spec_version"):
+        tags.add("spec")
 
     if old.get("language") != new.get("language"):
         tags.add("metadata")
@@ -127,39 +131,51 @@ def backfill_flowrevision_changes(apps, schema_editor):  # pragma: no cover
             break
 
         for flow_id in flow_ids:
-            # load the whole flow's revisions; flows have bounded revision counts
-            # (trim keeps recent + dailies), and a single bulk_update at the end
-            # avoids interleaving writes with a server-side cursor
-            revs = list(
-                FlowRevision.objects.filter(flow_id=flow_id)
-                .order_by("revision", "id")
-                .only("id", "definition", "spec_version", "changes")
-            )
+            # fetch raw rows directly so a single revision with malformed JSON in
+            # its definition column doesn't fail the whole batch via the ORM's
+            # eager from_db_value decoding
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT id, definition, spec_version, changes FROM flows_flowrevision "
+                    "WHERE flow_id = %s ORDER BY revision, id",
+                    [flow_id],
+                )
+                rows = cursor.fetchall()
 
             prev_def = None
             updates = []
 
-            for rev in revs:
+            for rev_id, def_text, spec_version, existing_changes in rows:
                 try:
-                    spec_ok = Version(rev.spec_version) >= MIN_SPEC
+                    spec_ok = Version(spec_version) >= MIN_SPEC
                 except InvalidVersion:
                     spec_ok = False
 
-                if spec_ok and prev_def is not None and not rev.changes:
+                if not spec_ok:
+                    prev_def = None
+                    continue
+
+                try:
+                    definition = json.loads(def_text) if def_text else None
+                except json.JSONDecodeError:
+                    # corrupt definition JSON — log and reset the chain so the next
+                    # revision isn't diffed against a missing prior
+                    logger.warning("could not decode definition for revision %d, skipping", rev_id, exc_info=True)
+                    prev_def = None
+                    continue
+
+                if prev_def is not None and not existing_changes:
                     try:
-                        rev.changes = compute_changes(prev_def, rev.definition)
+                        changes = compute_changes(prev_def, definition)
                     except Exception:
                         # malformed definition (e.g. nodes/actions missing uuid) — leave
                         # changes as null and keep going so one bad row doesn't block
                         # the rest of the backfill
-                        logger.warning("could not compute changes for revision %d", rev.id, exc_info=True)
+                        logger.warning("could not compute changes for revision %d", rev_id, exc_info=True)
                     else:
-                        updates.append(rev)
+                        updates.append(FlowRevision(id=rev_id, changes=changes))
 
-                # only carry forward a definition compute_changes can read; this also
-                # ensures the first 13.x revision after a pre-13 history isn't diffed
-                # against an incompatible prior shape
-                prev_def = rev.definition if spec_ok else None
+                prev_def = definition
 
             if updates:
                 FlowRevision.objects.bulk_update(updates, ["changes"])

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -721,24 +721,21 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
         changes = None
         if current_revision:
             prior_def = current_revision.definition
-            spec_changed = current_revision.spec_version != Flow.CURRENT_SPEC_VERSION
-            if spec_changed:
+            if current_revision.spec_version != Flow.CURRENT_SPEC_VERSION:
                 # migrate the prior forward so the schemas align; accepting that name/expire
                 # then come from the live flow (get_migrated_definition rewrites them) — fine
                 # because cross-spec saves are rare and not where metadata diffs matter
                 try:
                     prior_def = current_revision.get_migrated_definition()
+                    # get_migrated_definition rewrites spec_version to CURRENT, but we
+                    # want compute_changes to see the original spec so it can tag "spec"
+                    prior_def[Flow.DEFINITION_SPEC_VERSION] = current_revision.spec_version
                 except Exception:
                     # don't block a valid save just because the legacy migration failed
                     logger.warning("could not migrate prior revision for flow %s", self.uuid, exc_info=True)
                     prior_def = None
             if prior_def is not None:
                 changes = compute_changes(prior_def, definition)
-                # a spec migration is itself a real change worth recording, even when
-                # the migration is content-equivalent — get_migrated_definition aligns
-                # the schemas so compute_changes can't see the spec bump on its own
-                if spec_changed:
-                    changes = {"tags": sorted(set(changes["tags"]) | {"spec"})}
 
         # if the definition is unchanged from the current revision, don't create a
         # new one — author-only changes shouldn't produce revision churn

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -708,11 +708,14 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
         else:
             revision = 1
 
-        # update metadata from database object
+        # update metadata from database object; normalize spec_version to CURRENT
+        # since that's what we persist on the new revision row, so the saved row
+        # and the diff input agree
         definition[Flow.DEFINITION_UUID] = self.uuid
         definition[Flow.DEFINITION_NAME] = self.name
         definition[Flow.DEFINITION_REVISION] = revision
         definition[Flow.DEFINITION_EXPIRE_AFTER_MINUTES] = self.expires_after_minutes
+        definition[Flow.DEFINITION_SPEC_VERSION] = Flow.CURRENT_SPEC_VERSION
 
         # diff against prior revision so we can skip no-op saves and later collapse
         # like-for-like edits; done outside the transaction below because

--- a/temba/flows/tests/test_changes.py
+++ b/temba/flows/tests/test_changes.py
@@ -179,11 +179,14 @@ class ComputeChangesTest(TembaTest):
         )
 
     def test_other_catch_all(self):
-        # system fields (uuid/revision/spec_version) are stripped before the catch-all
-        # check so they don't fire false positives on every save
+        # uuid/revision are stripped before the catch-all check so they don't fire
+        # false positives on every save; spec_version differences are recorded as "spec"
         old = _flow(uuid="11111111-1111-1111-1111-111111111111", revision=1, spec_version="13.0.0")
-        new = _flow(uuid="22222222-2222-2222-2222-222222222222", revision=2, spec_version="13.1.0")
+        new = _flow(uuid="22222222-2222-2222-2222-222222222222", revision=2, spec_version="13.0.0")
         self.assertEqual([], _tags(old, new))
+
+        # spec_version bump on its own is a recorded change
+        self.assertEqual(["spec"], _tags(_flow(spec_version="13.0.0"), _flow(spec_version="13.1.0")))
 
         # an unanticipated top-level field difference produces "other" so the empty
         # tag list remains a reliable signal that nothing changed


### PR DESCRIPTION
## Summary

Fixes a production failure of the `flows.0402_backfill_flowrevision_changes` data migration on revisions with malformed JSON in their `definition` text column, and moves "spec" tag detection into `compute_changes` itself so spec-only revisions (those created by goflow flow migrations) get tagged correctly.

## Changes

**`temba/flows/changes.py`**
- `compute_changes` now adds the `"spec"` tag whenever `old["spec_version"] != new["spec_version"]`. Callers no longer need to layer this in.
- Dropped `"spec_version"` from `_SYSTEM_FIELDS` since it's unreachable in the catch-all (a spec diff guarantees `tags` is non-empty).

**`temba/flows/models.py` (`Flow.save_revision`)**
- Normalizes `definition[Flow.DEFINITION_SPEC_VERSION] = Flow.CURRENT_SPEC_VERSION` near the top so the diff input matches the row we persist.
- After `get_migrated_definition()` rewrites `prior_def["spec_version"]` to CURRENT, the original is restored on `prior_def` so `compute_changes` can see the bump.
- Removed the now-redundant `tags |= {"spec"}` post-merge.

**`temba/flows/migrations/0402_backfill_flowrevision_changes.py`**
- Replaced the ORM `.filter(...).only(...)` load with a raw `SELECT ... FROM flows_flowrevision` via `schema_editor.connection`, so a single corrupt-JSON row doesn't fail the entire batch in `JSONAsTextField.from_db_value`.
- Each `definition` text is parsed individually; `JSONDecodeError`, null/empty `def_text`, and non-dict JSON each log a warning and reset the diff chain (so the next row isn't compared against a missing/bogus prior).
- Inlined `compute_changes` mirrors the production version (adds `"spec"` tag, same `_SYSTEM_FIELDS`).
- `apply_manual()` still works — falls back to the default connection when `schema_editor` is `None`.

**`temba/flows/tests/test_changes.py`**
- Updated `test_other_catch_all` for the new `"spec"` behavior; added an explicit assertion that a spec_version bump alone produces `["spec"]`.

## Behavior examples

| Old vs New definition                                 | Before this PR        | After this PR  |
|-------------------------------------------------------|-----------------------|----------------|
| Only `spec_version` changes (e.g. 13.0.0 → 13.1.0)    | `[]` (silent)         | `["spec"]`     |
| `spec_version` changes + a node edit                  | `["actions"]`         | `["actions","spec"]` |
| Backfill encounters a revision with corrupt JSON      | Whole flow's batch fails, migration aborts | Logs warning, skips that row, continues |
| Backfill encounters null/empty or non-dict definition | Silent skip, may propagate | Logs warning, resets chain |

## Test plan

- [x] `temba.flows.tests.test_changes` passes in CI
- [x] Full Test job passes in CI (both shards)
- [ ] Run migration in staging against a flow with a known corrupt-JSON revision; confirm warning is logged and migration completes