### PR TITLE
Tweaks to FlowRevision

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -974,8 +974,7 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
         assert not self.is_active, "can't delete flow which hasn't been released"
 
-        for rev in self.revisions.all():
-            rev.release()
+        delete_in_batches(self.revisions.all())
 
         for trigger in self.triggers.all():
             trigger.delete()
@@ -1322,11 +1321,8 @@ class FlowRevision(models.Model):
             "created_on": self.created_on.isoformat(),
             "version": self.spec_version,
             "revision": self.revision,
-            "changes": self.changes,
+            "changes": self.changes or {},
         }
-
-    def release(self):
-        self.delete()
 
 
 class FlowActivityCount(BaseScopedCount):

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -773,7 +773,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
                     "id": revisions[1].id,
                     "version": "11.12",
                     "revision": 1,
-                    "changes": None,
+                    "changes": {},
                 },
             ],
             response.json()["results"],


### PR DESCRIPTION
## Summary
- `FlowRevision.as_json()` now returns `{}` instead of `None` for `changes` when the field is unset.
- Removed `FlowRevision.release()` since it only called `delete()`; `Flow.delete()` now uses `delete_in_batches` for revisions.
- Updated `test_revisions` assertion accordingly.