### PR TITLE
Include first_name and last_name in user chat refs

### DIFF
--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -540,7 +540,13 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                         "urn": "tel:+250781111111",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_user": {"uuid": str(self.editor.uuid), "name": "Ed", "avatar": None},
+                    "_user": {
+                        "uuid": str(self.editor.uuid),
+                        "name": "Ed",
+                        "first_name": "Ed",
+                        "last_name": "McEdits",
+                        "avatar": None,
+                    },
                 }
             },
             response.json(),
@@ -581,7 +587,13 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                         "urn": "tel:+250781111111",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_user": {"uuid": str(self.editor.uuid), "name": "Ed", "avatar": None},
+                    "_user": {
+                        "uuid": str(self.editor.uuid),
+                        "name": "Ed",
+                        "first_name": "Ed",
+                        "last_name": "McEdits",
+                        "avatar": None,
+                    },
                 }
             },
             response.json(),

--- a/temba/mailroom/tests/test_event.py
+++ b/temba/mailroom/tests/test_event.py
@@ -184,7 +184,13 @@ class EventTest(TembaTest):
                     "type": "contact_language_changed",
                     "created_on": "2025-08-06T19:46:39.778889794Z",
                     "language": "spa",
-                    "_user": {"uuid": str(self.admin.uuid), "name": "Andy", "avatar": None},  # refreshed
+                    "_user": {
+                        "uuid": str(self.admin.uuid),
+                        "name": "Andy",
+                        "first_name": "Andy",
+                        "last_name": "",
+                        "avatar": None,
+                    },  # refreshed
                 },
             ],
         )

--- a/temba/users/models.py
+++ b/temba/users/models.py
@@ -199,7 +199,13 @@ class User(TembaUUIDMixin, AbstractBaseUser, PermissionsMixin):
         return {"uuid": str(self.uuid), "name": self.name}
 
     def as_chat_ref(self) -> dict:
-        return {"uuid": str(self.uuid), "name": self.first_name, "avatar": self.avatar.url if self.avatar else None}
+        return {
+            "uuid": str(self.uuid),
+            "name": self.first_name,
+            "first_name": self.first_name,
+            "last_name": self.last_name,
+            "avatar": self.avatar.url if self.avatar else None,
+        }
 
     def fetch_avatar(self, url: str):  # pragma: no cover
         # fetch the avatar from the url and store it locally

--- a/temba/users/tests/test_user.py
+++ b/temba/users/tests/test_user.py
@@ -17,6 +17,16 @@ class UserTest(TembaTest):
         self.assertFalse(user.is_alpha)
         self.assertFalse(user.is_beta)
         self.assertEqual({"uuid": str(user.uuid), "name": "Jim McFlow"}, user.as_engine_ref())
+        self.assertEqual(
+            {
+                "uuid": str(user.uuid),
+                "name": "Jim",
+                "first_name": "Jim",
+                "last_name": "McFlow",
+                "avatar": None,
+            },
+            user.as_chat_ref(),
+        )
         self.assertEqual([self.org, self.org2], list(user.get_orgs().order_by("id")))
         self.assertFalse(user.is_verified())
         self.assertEqual(0, user.emailaddress_set.count())


### PR DESCRIPTION
Extends `User.as_chat_ref()` to include `first_name` and `last_name` alongside the existing `name` and `avatar` fields. Updates the corresponding user and mailroom event tests to cover the expanded payload.