### PR TITLE
Add design system tokens and style guide

### DIFF
--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -21,7 +21,7 @@
 
   /* accent ramp — derived from --primary-rgb via sRGB mixing.
      400 == primary; the ramp computes outward in both directions. */
-  --accent:      rgb(var(--primary-rgb, 98, 147, 201));
+  --accent:      rgb(var(--primary-rgb));
   --accent-50:   color-mix(in srgb, var(--accent) 6%,  white);
   --accent-100:  color-mix(in srgb, var(--accent) 16%, white);
   --accent-200:  color-mix(in srgb, var(--accent) 32%, white);

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -1,0 +1,753 @@
+/* TextIt Design System v0.1
+   Tokens + base + chrome + reusable components.
+
+   This stylesheet is the source of truth for the new design language.
+   Not yet wired into the application — see static/styleguide/ for the
+   showcase page that demonstrates these styles. */
+
+/* ─── tokens ─────────────────────────────────────────────────────────── */
+:root {
+  /* accent ramp — derived from a single anchor via OKLab mixing */
+  --accent:      #2A6FB5;
+  --accent-50:   color-mix(in oklab, var(--accent) 6%,  white);
+  --accent-100:  color-mix(in oklab, var(--accent) 12%, white);
+  --accent-200:  color-mix(in oklab, var(--accent) 25%, white);
+  --accent-300:  color-mix(in oklab, var(--accent) 45%, white);
+  --accent-400:  color-mix(in oklab, var(--accent) 75%, white);
+  --accent-500:  var(--accent);
+  --accent-600:  color-mix(in oklab, var(--accent) 88%, black);
+  --accent-700:  color-mix(in oklab, var(--accent) 75%, black);
+  --accent-800:  color-mix(in oklab, var(--accent) 60%, black);
+  --accent-900:  color-mix(in oklab, var(--accent) 45%, black);
+
+  /* neutrals */
+  --bg:            #F6F7F9;
+  --surface:       #FFFFFF;
+  --sunken:        #F1F3F5;
+  --border:        #E6E8EC;
+  --border-strong: #D2D6DC;
+  --text-1:        #1A1F26;   /* primary copy */
+  --text-2:        #4D5664;   /* secondary */
+  --text-3:        #7B8593;   /* tertiary, captions */
+  --text-4:        #A2ABB8;   /* disabled */
+
+  /* status — full set */
+  --success:        #16A34A;
+  --success-bg:     #E8F6EE;
+  --success-border: #BFE5CD;
+  --info:           #2563EB;
+  --info-bg:        #E8F0FE;
+  --info-border:    #C7D7F8;
+  --warning:        #B45309;
+  --warning-bg:     #FDF3E2;
+  --warning-border: #F2D9A9;
+  --danger:         #D03F3F;
+  --danger-bg:      #FCEBEB;
+  --danger-border:  #F4C8C8;
+  --neutral:        #6B7280;
+  --neutral-bg:     #EEF0F3;
+  --neutral-border: #D8DCE2;
+
+  /* type */
+  --font:        "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono:   "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --w-regular:   400;
+  --w-medium:    500;
+  --w-semibold:  600;
+  --w-bold:      700;
+
+  /* shape */
+  --r:      8px;
+  --r-xs:   2px;
+  --r-sm:   4px;
+  --r-lg:   12px;
+
+  /* density */
+  --row-h:  36px;
+  --pad:    10px;
+  --gap:    14px;
+
+  /* shadows */
+  --shadow-1: 0 1px 1px rgba(15, 22, 36, 0.04), 0 1px 2px rgba(15, 22, 36, 0.04);
+  --shadow-2: 0 1px 1px rgba(15, 22, 36, 0.04), 0 4px 12px rgba(15, 22, 36, 0.06);
+  --shadow-3: 0 6px 20px rgba(15, 22, 36, 0.10), 0 2px 6px rgba(15, 22, 36, 0.06);
+
+  /* layout */
+  --rail-w:               56px;
+  --section-w:            248px;
+  --section-w-collapsed:  56px;
+}
+
+/* ─── base ───────────────────────────────────────────────────────────── */
+.ds * { box-sizing: border-box; }
+.ds {
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-1);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11", "tnum" 0;
+}
+.ds h1, .ds h2, .ds h3, .ds h4 {
+  margin: 0;
+  font-weight: var(--w-semibold);
+  letter-spacing: -0.01em;
+}
+.ds p { margin: 0; }
+.ds a { color: inherit; text-decoration: none; cursor: pointer; }
+.ds button { font: inherit; cursor: pointer; }
+
+/* tabular figures for numeric contexts */
+.ds .t-num,
+.ds .num-big,
+.ds .num-rows b,
+.ds .count-badge {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── app shell ──────────────────────────────────────────────────────── */
+.ds .app {
+  display: grid;
+  grid-template-columns: var(--rail-w) auto 1fr;
+  min-height: 100vh;
+}
+
+/* left rail */
+.ds .rail {
+  background: var(--accent-400);
+  color: rgba(255,255,255,0.95);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 10px 0;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+.ds .rail-top,
+.ds .rail-bot {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 0 8px;
+}
+.ds .rail-org {
+  width: 40px; height: 40px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #FACC15 0%, #EAB308 100%);
+  color: #573E04;
+  font-weight: var(--w-bold);
+  font-size: 13px;
+  display: flex; align-items: center; justify-content: center;
+  margin: 4px auto 14px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.4), var(--shadow-1);
+}
+.ds .rail-items {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ds .rail-item {
+  width: 100%;
+  min-height: 40px;
+  padding: 0 10px;
+  display: flex; align-items: center; gap: 10px;
+  border: 0; background: transparent;
+  color: rgba(255,255,255,0.85);
+  border-radius: var(--r);
+  transition: background 120ms, color 120ms;
+  position: relative;
+}
+.ds .rail-item:hover {
+  background: rgba(255,255,255,0.10);
+  color: #fff;
+}
+.ds .rail-item.is-active {
+  background: rgba(0,0,0,0.18);
+  color: #fff;
+}
+.ds .rail-item.is-active::before {
+  content: "";
+  position: absolute;
+  left: -8px; top: 8px; bottom: 8px;
+  width: 3px; border-radius: 0 2px 2px 0;
+  background: #fff;
+}
+.ds .rail-label {
+  font-size: 12.5px;
+  font-weight: var(--w-medium);
+  letter-spacing: 0.01em;
+}
+
+/* section nav */
+.ds .section-nav {
+  width: var(--section-w);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  position: sticky; top: 0; height: 100vh;
+  overflow: hidden;
+  transition: width 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.ds .section-nav.is-collapsed { width: var(--section-w-collapsed); }
+.ds .section-nav.is-collapsed .sn-h h2,
+.ds .section-nav.is-collapsed .sn-item span,
+.ds .section-nav.is-collapsed .sn-section-label,
+.ds .section-nav.is-collapsed .sn-count { display: none; }
+
+.ds .sn-h {
+  height: 56px;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.ds .sn-h h2 { font-size: 15px; color: var(--text-1); }
+.ds .sn-collapse {
+  width: 24px; height: 24px;
+  display: flex; align-items: center; justify-content: center;
+  border: 0; background: transparent;
+  color: var(--text-3);
+  border-radius: var(--r-sm);
+}
+.ds .sn-collapse:hover { background: var(--sunken); color: var(--text-1); }
+
+.ds .sn-items {
+  padding: 8px;
+  display: flex; flex-direction: column; gap: 1px;
+  overflow-y: auto;
+}
+.ds .sn-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: 32px;
+  border-radius: var(--r-sm);
+  color: var(--text-2);
+  font-size: 13.5px;
+  position: relative;
+}
+.ds .sn-item:hover { background: var(--sunken); color: var(--text-1); }
+.ds .sn-item.is-active {
+  background: var(--accent-50);
+  color: var(--accent-700);
+  font-weight: var(--w-medium);
+}
+.ds .sn-item.is-active svg { color: var(--accent-600); }
+.ds .sn-item span:first-of-type { flex: 1; }
+.ds .sn-count {
+  font-size: 11.5px;
+  color: var(--text-3);
+  background: var(--sunken);
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+}
+.ds .sn-item.is-active .sn-count {
+  background: var(--accent-100);
+  color: var(--accent-700);
+}
+.ds .sn-section-label {
+  font-size: 11px;
+  font-weight: var(--w-semibold);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  padding: 14px 10px 4px;
+}
+
+/* content area */
+.ds .content {
+  padding: 24px 32px 80px;
+  max-width: 1280px;
+  width: 100%;
+}
+
+/* ─── page header ────────────────────────────────────────────────────── */
+.ds .page-header { padding: 8px 0 24px; }
+.ds .page-header-row {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 12px;
+}
+.ds .page-crumbs {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12.5px;
+  color: var(--text-3);
+}
+.ds .page-crumbs a { color: var(--text-2); }
+.ds .page-crumbs a:hover { color: var(--accent-600); }
+.ds .page-crumbs > span {
+  color: var(--text-1);
+  font-weight: var(--w-medium);
+}
+.ds .page-crumbs svg { color: var(--text-4); }
+
+.ds .page-header-actions {
+  display: flex; align-items: center; gap: 8px;
+}
+
+.ds .page-title-row {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 24px;
+}
+.ds .page-title-row h1 { font-size: 28px; line-height: 1.15; }
+.ds .page-sub {
+  color: var(--text-2);
+  font-size: 14px;
+  margin-top: 4px;
+  max-width: 640px;
+}
+.ds .page-meta {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--text-3);
+  font-size: 12.5px;
+}
+.ds .page-meta-sep {
+  width: 1px; height: 14px;
+  background: var(--border);
+}
+
+/* ─── buttons ────────────────────────────────────────────────────────── */
+.ds .btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+  font-weight: var(--w-medium);
+  letter-spacing: -0.005em;
+  transition: background 120ms, border-color 120ms, color 120ms, box-shadow 120ms;
+  white-space: nowrap;
+}
+.ds .btn-sm {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12.5px;
+}
+.ds .btn-primary {
+  background: var(--accent-600);
+  color: white;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.18), 0 1px 1px rgba(15,22,36,0.10);
+}
+.ds .btn-primary:hover { background: var(--accent-700); }
+.ds .btn-secondary {
+  background: var(--surface);
+  border-color: var(--border-strong);
+  color: var(--text-1);
+}
+.ds .btn-secondary:hover { background: var(--sunken); }
+.ds .btn-ghost {
+  background: transparent;
+  color: var(--text-2);
+}
+.ds .btn-ghost:hover { background: var(--sunken); color: var(--text-1); }
+.ds .btn-danger {
+  background: var(--danger);
+  color: white;
+}
+.ds .btn-danger:hover {
+  background: color-mix(in oklab, var(--danger) 88%, black);
+}
+.ds .btn.is-disabled,
+.ds .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.ds .icon-btn {
+  width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 0; background: transparent; color: var(--text-2);
+  border-radius: var(--r-sm);
+  transition: background 100ms, color 100ms;
+}
+.ds .icon-btn:hover { background: var(--sunken); color: var(--text-1); }
+.ds .icon-btn.is-active { background: var(--accent-50); color: var(--accent-700); }
+.ds .icon-btn-sm { width: 24px; height: 24px; }
+
+/* ─── pills ──────────────────────────────────────────────────────────── */
+.ds .pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: var(--w-regular);
+  border: 1px solid transparent;
+  white-space: nowrap;
+  max-width: 200px;
+}
+.ds .pill svg { flex-shrink: 0; }
+.ds .pill-text { overflow: hidden; text-overflow: ellipsis; }
+.ds .pill-x {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 14px; height: 14px;
+  margin-left: 2px; margin-right: -3px;
+  border: 0; background: transparent;
+  color: inherit; opacity: 0.55;
+  border-radius: 999px;
+}
+.ds .pill-x:hover { opacity: 1; background: rgba(0,0,0,0.08); }
+
+/* Flow → green */
+.ds .pill-flow    { background: #ECF7F1; color: #166534; border-color: #D2EBDC; }
+/* Recipient color — shared by contact and group. Purple reserved for future use. */
+.ds .pill-contact,
+.ds .pill-group   { background: var(--accent-100); color: var(--accent-700); border-color: var(--accent-200); }
+/* Field → amber */
+.ds .pill-field   { background: #FEF6E1; color: #854D0E; border-color: #F5E1AC; }
+/* Keyword → mono grey */
+.ds .pill-keyword { background: var(--sunken); color: var(--text-1); border-color: var(--border);
+                    font-family: var(--font-mono); font-size: 11px; }
+/* Label & neutral → quiet grey (label was previously blue; now neutral so it
+   doesn't compete with the recipient / flow variants for color real estate). */
+.ds .pill-label,
+.ds .pill-neutral { background: var(--sunken); color: var(--text-2); border-color: var(--border); }
+
+/* ─── status ─────────────────────────────────────────────────────────── */
+.ds .status {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 2px 8px 2px 6px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: var(--w-medium);
+  border: 1px solid transparent;
+}
+.ds .status-dot {
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+}
+.ds .status-success { background: var(--success-bg); color: var(--success); border-color: var(--success-border); }
+.ds .status-info    { background: var(--info-bg);    color: var(--info);    border-color: var(--info-border); }
+.ds .status-warning { background: var(--warning-bg); color: var(--warning); border-color: var(--warning-border); }
+.ds .status-danger  { background: var(--danger-bg);  color: var(--danger);  border-color: var(--danger-border); }
+.ds .status-neutral { background: var(--neutral-bg); color: var(--neutral); border-color: var(--neutral-border); }
+
+.ds .count-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  height: 18px; min-width: 18px; padding: 0 6px;
+  border-radius: 999px;
+  background: var(--sunken);
+  color: var(--text-2);
+  font-size: 11px;
+  font-weight: var(--w-semibold);
+}
+.ds .count-accent  { background: var(--accent-100); color: var(--accent-700); }
+.ds .count-danger  { background: var(--danger-bg);  color: var(--danger); }
+.ds .count-success { background: var(--success-bg); color: var(--success); }
+
+/* ─── avatar / channel icons ─────────────────────────────────────────── */
+.ds .avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 999px;
+  font-weight: var(--w-bold);
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.45);
+  flex-shrink: 0;
+  text-shadow: 0 1px 1px rgba(0,0,0,0.08);
+}
+
+.ds .ch-icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border-radius: 999px;
+  color: white;
+  flex-shrink: 0;
+}
+.ds .ch-whatsapp { background: #25D366; }
+.ds .ch-tel      { background: #3B82F6; }
+.ds .ch-fb       { background: #1877F2; }
+.ds .ch-web      { background: var(--accent-600); }
+
+.ds .contact-line {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 4px 10px 4px 4px;
+  background: var(--sunken);
+  border-radius: 999px;
+}
+.ds .contact-name { font-size: 13px; font-weight: var(--w-medium); }
+.ds .contact-num  { font-size: 12px; color: var(--text-3); font-variant-numeric: tabular-nums; }
+
+/* ─── forms ──────────────────────────────────────────────────────────── */
+.ds .form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.ds .field { display: flex; flex-direction: column; gap: 6px; }
+.ds .field-full { grid-column: 1 / -1; }
+.ds .field-label {
+  font-size: 12.5px;
+  font-weight: var(--w-medium);
+  color: var(--text-1);
+}
+.ds .field-label .opt {
+  color: var(--text-3);
+  font-weight: var(--w-regular);
+  margin-left: 4px;
+  font-size: 11.5px;
+}
+.ds .field-help { font-size: 12px; color: var(--text-3); }
+
+.ds .input {
+  display: flex; align-items: center;
+  font: inherit; font-size: 13.5px;
+  padding: 0 10px;
+  height: 34px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-1);
+  width: 100%;
+  transition: border-color 120ms, box-shadow 120ms;
+}
+.ds textarea.input {
+  padding: 8px 10px;
+  height: auto;
+  font-family: var(--font);
+  resize: vertical;
+  line-height: 1.45;
+}
+/* Focus styling shared by every form widget (input, textarea,
+   select-wrap, search-wrap, input-tokens). Border uses --accent-300
+   so the outline reads as a soft tinted edge; halo is a translucent
+   accent ring. Single knob — tweak the two values in :root to shift
+   every widget at once. */
+.ds .input:focus,
+.ds .input:focus-within {
+  outline: 0;
+  border-color: var(--accent-300);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 25%, transparent);
+}
+
+.ds .input-tokens {
+  display: flex; align-items: center; gap: 6px;
+  height: auto; min-height: 34px;
+  flex-wrap: wrap;
+  padding: 5px 8px;
+}
+.ds .input-tokens input {
+  border: 0; outline: 0; flex: 1; min-width: 80px;
+  font: inherit; font-size: 13.5px; background: transparent;
+}
+
+.ds .select-wrap {
+  position: relative;
+  display: flex; align-items: center;
+  height: 34px;
+  padding: 0 32px 0 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  cursor: pointer;
+}
+.ds .select-wrap:hover {
+  border-color: var(--border-strong);
+  background: var(--sunken);
+}
+.ds .select-chev {
+  position: absolute; right: 10px;
+  color: var(--text-3);
+}
+
+.ds .search-wrap { position: relative; }
+.ds .search-wrap .input { padding-left: 32px; padding-right: 50px; }
+.ds .search-icon {
+  position: absolute; left: 10px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-3);
+}
+.ds .search-wrap kbd {
+  position: absolute; right: 8px; top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-3);
+  background: var(--sunken);
+  padding: 1px 5px;
+  border-radius: var(--r-xs);
+  border: 1px solid var(--border);
+}
+
+.ds .checkbox-row { display: flex; flex-wrap: wrap; gap: 12px; }
+.ds .checkbox {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 13px;
+  padding: 6px 10px 6px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color 100ms, background 100ms;
+}
+.ds .checkbox:hover { border-color: var(--border-strong); }
+.ds .check-box {
+  width: 16px; height: 16px;
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--r-xs);
+  background: var(--surface);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: white;
+  flex-shrink: 0;
+}
+.ds .checkbox.is-checked {
+  border-color: var(--accent-200);
+  background: var(--accent-50);
+  color: var(--accent-700);
+}
+.ds .checkbox.is-checked .check-box {
+  background: var(--accent-600);
+  border-color: var(--accent-600);
+}
+
+/* ─── tables ─────────────────────────────────────────────────────────── */
+.ds .table-wrap { width: 100%; }
+.ds .t {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 13px;
+}
+.ds .t thead th {
+  text-align: left;
+  font-size: 11px;
+  font-weight: var(--w-semibold);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  position: sticky; top: 0;
+}
+.ds .t tbody td {
+  padding: 0 12px;
+  height: var(--row-h);
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+  color: var(--text-1);
+}
+.ds .t tbody tr { transition: background 80ms; }
+.ds .t tbody tr:hover { background: var(--accent-50); }
+.ds .t tbody tr:hover .row-actions { opacity: 1; }
+.ds .t-check {
+  width: 36px;
+  padding-left: 12px !important;
+  padding-right: 0 !important;
+}
+.ds .t-num { text-align: right; }
+.ds .t-act {
+  width: 96px;
+  text-align: right;
+  padding-right: 8px !important;
+}
+.ds .t-muted { color: var(--text-3); }
+.ds .t-name {
+  display: flex; align-items: center; gap: 10px;
+  font-weight: var(--w-medium);
+}
+.ds .t-name-icon {
+  width: 22px; height: 22px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--accent-50);
+  color: var(--accent-700);
+  border-radius: var(--r-sm);
+}
+.ds .t-ch {
+  display: flex; align-items: center; gap: 8px;
+  color: var(--text-2);
+}
+.ds .row-actions {
+  display: inline-flex; gap: 2px;
+  opacity: 0;
+  transition: opacity 100ms;
+}
+.ds .t-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 12px 4px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+/* ─── patterns ───────────────────────────────────────────────────────── */
+.ds .empty {
+  display: flex; flex-direction: column; align-items: center; text-align: center;
+  padding: 32px 24px;
+  gap: 8px;
+}
+.ds .empty-art {
+  width: 56px; height: 56px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--accent-50);
+  color: var(--accent-600);
+  border-radius: var(--r-lg);
+  margin-bottom: 6px;
+}
+.ds .empty h4 { font-size: 16px; }
+.ds .empty p {
+  color: var(--text-2);
+  font-size: 13px;
+  max-width: 340px;
+  margin-bottom: 8px;
+}
+
+.ds .modal {
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  overflow: hidden;
+  box-shadow: var(--shadow-2);
+}
+.ds .modal-h {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--accent-600);
+  color: white;
+  font-size: 13px;
+  font-weight: var(--w-semibold);
+}
+.ds .modal-x {
+  width: 24px; height: 24px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 0;
+  background: rgba(255,255,255,0.15);
+  color: white;
+  border-radius: var(--r-sm);
+}
+.ds .modal-x:hover { background: rgba(255,255,255,0.25); }
+.ds .modal-b {
+  padding: 16px;
+  display: flex; flex-direction: column; gap: 14px;
+  background: var(--surface);
+}
+.ds .modal-f {
+  padding: 12px 16px;
+  background: var(--sunken);
+  border-top: 1px solid var(--border);
+  display: flex; justify-content: flex-end; gap: 8px;
+}
+
+.ds .ph-tabs {
+  display: flex; gap: 4px;
+  margin-top: 18px;
+  border-bottom: 1px solid var(--border);
+}
+.ds .ph-tab {
+  padding: 8px 14px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-2);
+  font-size: 13px;
+  font-weight: var(--w-medium);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.ds .ph-tab:hover { color: var(--text-1); }
+.ds .ph-tab.is-active {
+  color: var(--accent-700);
+  border-bottom-color: var(--accent-600);
+}
+
+/* ─── utility ────────────────────────────────────────────────────────── */
+.ds .comp-row {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+}

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -7,18 +7,31 @@
 
 /* ─── tokens ─────────────────────────────────────────────────────────── */
 :root {
-  /* accent ramp — derived from a single anchor via OKLab mixing */
-  --accent:      #2A6FB5;
-  --accent-50:   color-mix(in oklab, var(--accent) 6%,  white);
-  --accent-100:  color-mix(in oklab, var(--accent) 12%, white);
-  --accent-200:  color-mix(in oklab, var(--accent) 25%, white);
-  --accent-300:  color-mix(in oklab, var(--accent) 45%, white);
-  --accent-400:  color-mix(in oklab, var(--accent) 75%, white);
-  --accent-500:  var(--accent);
-  --accent-600:  color-mix(in oklab, var(--accent) 88%, black);
-  --accent-700:  color-mix(in oklab, var(--accent) 75%, black);
-  --accent-800:  color-mix(in oklab, var(--accent) 60%, black);
-  --accent-900:  color-mix(in oklab, var(--accent) 45%, black);
+  /* ─── primary color anchor ────────────────────────────────────────────
+     Single source of truth for the brand. Set as a hex value here.
+     `design-system.js` reads --primary on load, parses to RGB, and
+     dynamically writes the full accent ramp (50, 100, 200, 300, 400,
+     500, 600, 700, 800, 900) onto :root — with 400 == primary and the
+     ramp computed outward via sRGB mixing.
+
+     If JS isn't loaded, the CSS fallback color-mix definitions below
+     still produce the same ramp from --primary-rgb. */
+  --primary:     #6293C9;
+  --primary-rgb: 98, 147, 201;
+
+  /* accent ramp — derived from --primary-rgb via sRGB mixing.
+     400 == primary; the ramp computes outward in both directions. */
+  --accent:      rgb(var(--primary-rgb, 98, 147, 201));
+  --accent-50:   color-mix(in srgb, var(--accent) 6%,  white);
+  --accent-100:  color-mix(in srgb, var(--accent) 16%, white);
+  --accent-200:  color-mix(in srgb, var(--accent) 32%, white);
+  --accent-300:  color-mix(in srgb, var(--accent) 60%, white);
+  --accent-400:  var(--accent);
+  --accent-500:  color-mix(in srgb, var(--accent) 90%, black);
+  --accent-600:  color-mix(in srgb, var(--accent) 80%, black);
+  --accent-700:  color-mix(in srgb, var(--accent) 65%, black);
+  --accent-800:  color-mix(in srgb, var(--accent) 50%, black);
+  --accent-900:  color-mix(in srgb, var(--accent) 35%, black);
 
   /* neutrals */
   --bg:            #F6F7F9;
@@ -54,7 +67,7 @@
   --w-regular:   400;
   --w-medium:    500;
   --w-semibold:  600;
-  --w-bold:      700;
+  --w-bold:      600;
 
   /* shape */
   --r:      8px;
@@ -165,7 +178,7 @@
   color: #fff;
 }
 .ds .rail-item.is-active {
-  background: rgba(0,0,0,0.18);
+  background: rgba(0,0,0,0.15);
   color: #fff;
 }
 .ds .rail-item.is-active::before {
@@ -316,7 +329,7 @@
   border: 1px solid transparent;
   border-radius: var(--r-sm);
   font-size: 13px;
-  font-weight: var(--w-medium);
+  font-weight: var(--w-regular);
   letter-spacing: -0.005em;
   transition: background 120ms, border-color 120ms, color 120ms, box-shadow 120ms;
   white-space: nowrap;
@@ -348,7 +361,7 @@
   color: white;
 }
 .ds .btn-danger:hover {
-  background: color-mix(in oklab, var(--danger) 88%, black);
+  background: color-mix(in srgb, var(--danger) 88%, black);
 }
 .ds .btn.is-disabled,
 .ds .btn:disabled { opacity: 0.45; cursor: not-allowed; }
@@ -517,7 +530,7 @@
 .ds .input:focus-within {
   outline: 0;
   border-color: var(--accent-300);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 25%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
 .ds .input-tokens {

--- a/static/css/design-system.js
+++ b/static/css/design-system.js
@@ -1,0 +1,83 @@
+/* TextIt Design System — runtime ramp.
+ *
+ * Reads --primary (hex) from :root and writes the full accent ramp
+ * (--accent + --accent-50..900) onto :root with 400 == primary and
+ * the ramp computed outward in both directions via sRGB mixing.
+ *
+ * Also exposes window.DesignSystem.setPrimary(hex) so the styleguide
+ * (or any host page) can re-theme the entire UI at runtime.
+ *
+ * Mirrors the CSS color-mix(in srgb, ...) ramp definitions, so JS-
+ * computed values match the CSS fallbacks when the script is absent.
+ */
+(function () {
+  // Ramp stops as { name: [otherColor, primaryRatio] }.
+  // primaryRatio is how much of the primary color (vs the other color).
+  var WHITE = [255, 255, 255];
+  var BLACK = [0, 0, 0];
+  var STOPS = [
+    ['--accent-50',  WHITE, 0.06],
+    ['--accent-100', WHITE, 0.16],
+    ['--accent-200', WHITE, 0.32],
+    ['--accent-300', WHITE, 0.60],
+    ['--accent-400', null,  1.00],   // 400 == primary
+    ['--accent-500', BLACK, 0.90],
+    ['--accent-600', BLACK, 0.80],
+    ['--accent-700', BLACK, 0.65],
+    ['--accent-800', BLACK, 0.50],
+    ['--accent-900', BLACK, 0.35],
+  ];
+
+  function hexToRgb(hex) {
+    hex = hex.trim().replace(/^#/, '');
+    if (hex.length === 3) {
+      hex = hex.split('').map(function (c) { return c + c; }).join('');
+    }
+    var n = parseInt(hex, 16);
+    if (isNaN(n) || hex.length !== 6) return null;
+    return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+  }
+
+  function mix(primary, other, t) {
+    return [
+      Math.round(t * primary[0] + (1 - t) * other[0]),
+      Math.round(t * primary[1] + (1 - t) * other[1]),
+      Math.round(t * primary[2] + (1 - t) * other[2]),
+    ];
+  }
+
+  function rgbStr(rgb) {
+    return 'rgb(' + rgb[0] + ', ' + rgb[1] + ', ' + rgb[2] + ')';
+  }
+
+  function setPrimary(hex) {
+    var primary = hexToRgb(hex);
+    if (!primary) return false;
+    var root = document.documentElement;
+    root.style.setProperty('--primary', '#' + hex.replace(/^#/, ''));
+    root.style.setProperty('--primary-rgb', primary.join(', '));
+    root.style.setProperty('--accent', rgbStr(primary));
+    STOPS.forEach(function (stop) {
+      var name = stop[0], other = stop[1], t = stop[2];
+      var rgb = other ? mix(primary, other, t) : primary;
+      root.style.setProperty(name, rgbStr(rgb));
+    });
+    return true;
+  }
+
+  function init() {
+    var primary = getComputedStyle(document.documentElement)
+      .getPropertyValue('--primary').trim();
+    if (primary) setPrimary(primary);
+  }
+
+  window.DesignSystem = window.DesignSystem || {};
+  window.DesignSystem.setPrimary = setPrimary;
+  window.DesignSystem.hexToRgb  = hexToRgb;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/css/frame.css
+++ b/static/css/frame.css
@@ -332,3 +332,17 @@ temba-menu.servicing {
 #error-dialog {
   display: none;
 }
+
+.exclusion-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 4px 4px 0;
+  padding: 2px 10px;
+  background: #fff;
+  border: 1px solid var(--color-borders);
+  border-radius: 999px;
+  color: var(--text-3);
+  font-size: 12.5px;
+  --icon-color: var(--text-3);
+}

--- a/static/css/frame.css
+++ b/static/css/frame.css
@@ -78,7 +78,7 @@ temba-button.light {
 }
 
 temba-button {
-  --button-bg: var(--color-primary-dark);
+  --button-bg: var(--accent-500);
   --button-text: var(--color-text-light);
   --button-border: none;
   --button-shadow: var(--widget-box-shadow);
@@ -87,7 +87,7 @@ temba-button {
 temba-button:hover {
   --button-bg-img: linear-gradient(
     to bottom,
-    rgba(var(--primary-rgb), 0.1),
+    rgba(255, 255, 255, 0.1),
     transparent,
     transparent
   );

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -102,7 +102,7 @@ Add the correct font weight in Edge and Safari.
 
 b,
 strong {
-  font-weight: bolder;
+  font-weight: 600;
 }
 
 /**
@@ -366,7 +366,7 @@ ul {
  */
 
 html {
-  font-family: Roboto, sans-serif; /* 1 */
+  font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; /* 1 */
   line-height: 1.5; /* 2 */
 }
 
@@ -706,406 +706,148 @@ a:hover {
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
   }
 
-.button-light {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
-}
-
-.button-light:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-light:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-light {
-  --tw-bg-opacity: 1;
-  background-color: rgba(247, 247, 247, var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgba(113, 113, 113, var(--tw-text-opacity));
-}
-
-.button-light:hover {
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-action {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
-}
-
-.button-action:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-action:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-action {
-  --tw-bg-opacity: 1;
-  background-color: rgba(247, 247, 247, var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgba(113, 113, 113, var(--tw-text-opacity));
-}
-
-.button-action:hover {
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-action {
-  padding: 8px 12px;
-  display: flex;
-  align-items: center;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-}
+/* button-light, button-action — DS ghost-style, see consolidated block below. */
 
 .p-icon {
   padding: 8px 12px;
 }
 
-.button-tertiary {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
+/* button-tertiary, button-secondary — DS-aligned, see consolidated block below. */
+
+/* ─── Legacy CSS-based buttons ────────────────────────────────────────────
+   These class-based buttons predate <temba-button>. They share the DS
+   button chrome and only differ in surface/tint. Replace with
+   <temba-button> when convenient. */
+.button-primary,
+.button-white,
+.button-light,
+.button-action,
+.button-tertiary,
+.button-secondary,
+.button-danger,
+.button-dark-alpha {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  font-size: 12.5px;
+  font-weight: var(--w-regular);
+  letter-spacing: -0.005em;
   line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
   white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
-}
-
-.button-tertiary:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-tertiary:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-tertiary {
-  background-color: rgb(var(--tertiary-rgb));
-  --tw-text-opacity: 1;
-  color: rgba(255, 255, 255, var(--tw-text-opacity));
-}
-
-.button-secondary {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+  box-sizing: border-box;
   text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
+  text-decoration: none;
+  transition: background 120ms, border-color 120ms, color 120ms, box-shadow 120ms;
 }
 
-.button-secondary:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-secondary:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-secondary {
-  background-color: rgb(var(--secondary-rgb));
-  --tw-text-opacity: 1;
-  color: rgba(255, 255, 255, var(--tw-text-opacity));
-}
-
+/* solid accent — primary CTA */
 .button-primary {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
+  background: var(--accent-600);
+  color: #fff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 1px 1px rgba(15, 22, 36, 0.1);
 }
-
-.button-primary:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
 .button-primary:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-primary {
-  --tw-text-opacity: 1;
-  color: rgba(255, 255, 255, var(--tw-text-opacity));
-  background: var(--color-primary-dark) !important;
+  background: var(--accent-700);
+  text-decoration: none;
 }
 
-.button-white {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
+/* surface + border — secondary CTA */
+.button-white,
+.button-light,
+.button-action {
+  background: var(--surface);
+  border-color: var(--border-strong);
+  color: var(--text-1);
+}
+.button-white:hover,
+.button-light:hover,
+.button-action:hover {
+  background: var(--sunken);
+  text-decoration: none;
 }
 
-.button-white:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-white:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-white {
-  --tw-bg-opacity: 1;
-  background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
-  color: rgb(var(--primary-rgb));
+/* tertiary accent (legacy green) */
+.button-tertiary {
+  background: rgb(var(--tertiary-rgb));
+  color: #fff;
+}
+.button-tertiary:hover {
+  background: color-mix(in srgb, rgb(var(--tertiary-rgb)) 88%, black);
+  text-decoration: none;
 }
 
+/* secondary accent (legacy magenta) */
+.button-secondary {
+  background: rgb(var(--secondary-rgb));
+  color: #fff;
+}
+.button-secondary:hover {
+  background: color-mix(in srgb, rgb(var(--secondary-rgb)) 88%, black);
+  text-decoration: none;
+}
+
+/* destructive — red */
 .button-danger {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
+  background: var(--danger, rgb(var(--error-rgb)));
+  color: #fff;
 }
-
-.button-danger:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
 .button-danger:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-danger {
-  background-color: rgb(var(--error-rgb));
-  --tw-text-opacity: 1;
-  color: rgba(255, 255, 255, var(--tw-text-opacity));
+  background: color-mix(in srgb, var(--danger, rgb(var(--error-rgb))) 88%, black);
+  text-decoration: none;
 }
 
+/* dark overlay — for use on light backgrounds where you need a muted button */
 .button-dark-alpha {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text-2);
 }
-
-.button-dark-alpha:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
 .button-dark-alpha:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-dark-alpha {
-  background-color: rgba(0, 0, 0, .2);
-  --tw-text-opacity: 1;
-  color: rgba(255, 255, 255, var(--tw-text-opacity));
+  background: rgba(0, 0, 0, 0.08);
+  text-decoration: none;
 }
 
+/* button-danger, button-dark-alpha — DS-aligned, see consolidated block above. */
+
+/* compact dark-alpha button (chrome overlays on dark backgrounds) */
 .button-sm {
-  border-radius: 0.5rem;
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.125rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  font-size: 12px;
+  font-weight: var(--w-regular);
+  letter-spacing: -0.005em;
   line-height: 1;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  text-align: center;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
   white-space: nowrap;
-  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-duration: 200ms;
-  margin-top: 1px;
-}
-
-.button-sm:active {
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-sm:hover {
-    text-decoration: none;
-    cursor: pointer;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  }
-
-.button-sm {
-  background-color: rgba(0, 0, 0, .2);
-  --tw-text-opacity: 1;
-  color: rgba(255, 255, 255, var(--tw-text-opacity));
-  font-size: 0.875rem;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  --tw-shadow: 0 0 #0000;
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  color: rgba(255, 255, 255, .9);
-  letter-spacing: 0.05em;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+  box-sizing: border-box;
+  text-align: center;
+  text-decoration: none;
+  background: rgba(0, 0, 0, 0.2);
+  color: rgba(255, 255, 255, 0.9);
+  transition: background 120ms, color 120ms;
 }
 
 .button-sm:hover {
-    --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    transform: none;
-    cursor: pointer;
-    box-shadow: inset 0 0 20px 10px rgba(255, 255, 255, 0.2);
-  }
+  background: rgba(0, 0, 0, 0.3);
+  text-decoration: none;
+}
 
 .lift {
   will-change: transform, opacity;
@@ -7164,11 +6906,11 @@ ul.steps {
 }
 
 .font-sans {
-  font-family: Roboto, sans-serif;
+  font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
 .font-alt {
-  font-family: Roboto, sans-serif;
+  font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
 .font-serif {
@@ -7192,7 +6934,7 @@ ul.steps {
 }
 
 .font-bold {
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .hover\:font-light:hover {
@@ -7208,7 +6950,7 @@ ul.steps {
 }
 
 .hover\:font-bold:hover {
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .focus\:font-light:focus {
@@ -7224,7 +6966,7 @@ ul.steps {
 }
 
 .focus\:font-bold:focus {
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .h-0 {
@@ -20683,11 +20425,11 @@ ul.steps {
   }
 
   .md\:font-sans {
-    font-family: Roboto, sans-serif;
+    font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   }
 
   .md\:font-alt {
-    font-family: Roboto, sans-serif;
+    font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   }
 
   .md\:font-serif {
@@ -20711,7 +20453,7 @@ ul.steps {
   }
 
   .md\:font-bold {
-    font-weight: 700;
+    font-weight: 600;
   }
 
   .md\:hover\:font-light:hover {
@@ -20727,7 +20469,7 @@ ul.steps {
   }
 
   .md\:hover\:font-bold:hover {
-    font-weight: 700;
+    font-weight: 600;
   }
 
   .md\:focus\:font-light:focus {
@@ -20743,7 +20485,7 @@ ul.steps {
   }
 
   .md\:focus\:font-bold:focus {
-    font-weight: 700;
+    font-weight: 600;
   }
 
   .md\:h-0 {

--- a/static/css/temba-components.css
+++ b/static/css/temba-components.css
@@ -1,136 +1,315 @@
-html {
-  --font-family: 'Roboto', Helvetica, Arial, sans-serif;
-  --font-size: 14px;
+  html.dragging * {
+    user-select: none;
+    pointer-events: none;
 
-  --disabled-opacity: 0.6;
+  }
 
-  /* Animations */
-  --transition-speed: 250ms;
-  --bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  html {
 
-  /* Smoothness */
-  --curvature: 6px;
-  --curvature-widget: 6px;
+    /* ─── TextIt Design System tokens ─────────────────────────────────────
+       Single source of truth. Cascades through Shadow DOM into every
+       component. Legacy tokens below are aliased to these — keep both in
+       sync if the design system evolves. */
 
-  /* RGB values */
-  --primary-rgb: 58, 102, 150;
-  --secondary-rgb: 140, 51, 140;
-  --tertiary-rgb: 135, 202, 35;
-  --focus-rgb: 82, 168, 236;
-  --error-rgb: 255, 99, 71;
-  --success-rgb: 102, 186, 104;
-  --selection-light-rgb: 240, 240, 240;
-  --selection-dark-rgb: 180, 180, 180;
+    /* accent ramp — the primary color sits at 400 and the ramp is
+       derived from it in both directions via sRGB mixing.
+       The anchor reads from --primary-rgb so host pages can re-theme
+       the entire ramp by setting e.g. --primary-rgb: 112, 0, 132. */
+    --accent:      rgb(var(--primary-rgb, 98, 147, 201));
+    --accent-50:   color-mix(in srgb, var(--accent) 6%,  white);
+    --accent-100:  color-mix(in srgb, var(--accent) 16%, white);
+    --accent-200:  color-mix(in srgb, var(--accent) 32%, white);
+    --accent-300:  color-mix(in srgb, var(--accent) 60%, white);
+    --accent-400:  var(--accent);
+    --accent-500:  color-mix(in srgb, var(--accent) 90%, black);
+    --accent-600:  color-mix(in srgb, var(--accent) 80%, black);
+    --accent-700:  color-mix(in srgb, var(--accent) 65%, black);
+    --accent-800:  color-mix(in srgb, var(--accent) 50%, black);
+    --accent-900:  color-mix(in srgb, var(--accent) 35%, black);
 
-  /* Colors */
-  --color-text-dark: #555;
-  --color-text: #555;
-  --color-widget-text: #555;
-  --color-borders: rgba(0, 0, 0, 0.07);
-  --color-placeholder: #ccc;
-  --color-primary-light: #eee;
-  --color-secondary-light: rgba(var(--secondary-rgb), 0.3);
-  --color-primary-dark: rgb(var(--primary-rgb));
-  --color-secondary-dark: rgb(var(--secondary-rgb));
-  --color-message: #3c92dd;
-  --color-focus: #a4cafe;
-  --color-widget-bg: #fff;
-  --color-widget-bg-focused: #fff;
-  --color-widget-border: rgb(225, 225, 225);
-  --color-options-bg: var(--color-widget-bg);
-  --color-selection: #f0f6ff;
-  --color-row-hover: rgba(var(--selection-light-rgb), 0.4);
-  --color-available: #00f100;
-  --color-tertiary: rgb(var(--tertiary-rgb));
-  --color-text-light: rgba(255, 255, 255, 1);
-  --color-text-dark-secondary: rgba(0, 0, 0, 0.25);
-  --color-overlay-dark: rgba(0, 0, 0, 0.2);
-  --color-overlay-dark-text: rgba(255, 255, 255, 0.9);
-  --color-overlay-light: rgba(0, 0, 0, 0.035);
-  --color-overlay-light-text: rgba(0, 0, 0, 0.6);
-  --color-link-primary: rgba(var(--primary-rgb), 0.8);
-  --color-link-primary-hover: rgba(var(--primary-rgb), 0.9);
-  --color-link-secondary: rgba(var(--secondary-rgb), 0.8);
-  --color-link-secondary-hover: rgba(var(--secondary-rgb), 0.9);
-  --color-button-primary: var(--color-primary-dark);
-  --color-button-primary-text: var(--color-text-light);
-  --color-button-light: rgb(246, 248, 250);
-  --color-button-light-text: rgb(36, 41, 47);
-  --color-button-secondary: var(--color-secondary-light);
-  --color-button-secondary-text: var(--color-text-dark);
-  --color-button-destructive: rgb(var(--error-rgb));
-  --color-button-destructive-text: var(--color-text-light);
-  --color-button-attention: #3ca96a;
-  --color-connectors: #95cbef;
-  --color-label-primary: var(--color-primary-dark);
-  --color-label-primary-text: var(--color-text-light);
-  --color-label-secondary: var(--color-secondary-dark);
-  --color-label-secondary-text: var(--color-text-light);
-  --color-label-tertiary: var(--color-tertiary);
-  --color-label-tertiary-text: var(--color-text-light);
-  --color-nav-unselected: #fff;
-  --color-nav-selected-bg: #fff;
-  --color-nav-selected-text: var(--color-primary-dark);
-  --color-quick-reply: rgb(60, 146, 221);
-  --color-info: rgb(238, 246, 255);
-  --color-info-border: rgb(74, 163, 223);
-  --color-warning: rgb(255, 253, 218);
-  --color-warning-border: rgb(251, 246, 176);
-  --color-error: rgb(var(--error-rgb));
-  --color-alert: rgb(var(--error-rgb));
-  --color-success: #3ca96a;
-  --icon-color: var(--text-color);
-  --icon-color-circle: rgb(240, 240, 240);
-  --icon-color-circle-hover: rgba(245, 245, 245, 0.8);
-  --header-bg: var(--color-primary-dark);
-  --header-text: var(--color-text-light);
-  --color-text-help: rgb(120, 120, 120);
-  --color-automated: rgb(78, 205, 106);
+    /* neutrals */
+    --bg:            #F6F7F9;
+    --surface:       #FFFFFF;
+    --sunken:        #F1F3F5;
+    --border:        #E6E8EC;
+    --border-strong: #D2D6DC;
+    --text-1:        #1A1F26;
+    --text-2:        #4D5664;
+    --text-3:        #7B8593;
+    --text-4:        #A2ABB8;
 
-  /* Shadows */
-  --widget-box-shadow: rgba(-1, -1, 0, 0.1) 0px 1px 7px 0px,
-    rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
-  --widget-box-shadow-focused: 0 0 0 3px rgba(164, 202, 254, 0.45),
-    rgba(0, 0, 0, 0.05) 0px 3px 7px 0px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
-  --widget-box-shadow-focused-error: 0 0 0 3px rgba(var(--error-rgb), 0.3);
-  --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  --shadow-widget: 0 3px 20px 0 rgba(0, 0, 0, 0.04),
-    0 1px 2px 0 rgba(0, 0, 0, 0.02);
+    /* status — full set */
+    --success:        #16A34A;
+    --success-bg:     #E8F6EE;
+    --success-border: #BFE5CD;
+    --info:           #2563EB;
+    --info-bg:        #E8F0FE;
+    --info-border:    #C7D7F8;
+    --warning:        #B45309;
+    --warning-bg:     #FDF3E2;
+    --warning-border: #F2D9A9;
+    --danger:         #D03F3F;
+    --danger-bg:      #FCEBEB;
+    --danger-border:  #F4C8C8;
+    --neutral:        #6B7280;
+    --neutral-bg:     #EEF0F3;
+    --neutral-border: #D8DCE2;
 
-  /* temba-select */
-  --select-input-height: inherit;
-  --temba-select-selected-font-size: 1em;
-  --temba-select-selected-line-height: 1.2em;
-  --options-block-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1),
-    0 1px 2px 0 rgba(0, 0, 0, 0.03);
-  --options-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
-    0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --dropdown-shadow: rgb(0 0 0 / 15%) 0px 0px 30px, rgb(0 0 0 / 12%) 0px 2px 6px;
+    /* type */
+    --font:        "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --font-mono:   "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --w-regular:   400;
+    --w-medium:    500;
+    --w-semibold:  600;
+    --w-bold:      600;
 
-  /* buttons */
-  --button-font-size: 1.125rem;
-  --button-y: 0.2em;
-  --button-x: 1.5em;
+    /* shape */
+    --r:      8px;
+    --r-xs:   2px;
+    --r-sm:   4px;
+    --r-lg:   12px;
 
-  /* textinput */
-  --temba-textinput-padding: 0.6em 0.8em;
-  --temba-textinput-font-size: 1;
+    /* density */
+    --row-h:   36px;
+    --input-h: 34px;
+    --pad:     10px;
+    --gap:     14px;
 
-  /* charcount */
-  --temba-charcount-counts-margin-top: 4px;
-  --temba-charcount-summary-margin-top: 5px;
-  --temba-charcount-summary-position: absolute;
-  --temba-charcount-summary-right: 0px;
-  --temba-charcount-summary-bottom: 0px;
+    /* shadows */
+    --shadow-1: 0 1px 1px rgba(15, 22, 36, 0.04), 0 1px 2px rgba(15, 22, 36, 0.04);
+    --shadow-2: 0 1px 1px rgba(15, 22, 36, 0.04), 0 4px 12px rgba(15, 22, 36, 0.06);
+    --shadow-3: 0 6px 20px rgba(15, 22, 36, 0.10), 0 2px 6px rgba(15, 22, 36, 0.06);
 
-  /* help-text */
-  --help-text-margin-top: 0px;
-  --help-text-margin-left: 0.3em;
-  --help-text-size: 0.85em;
+    /* ─── legacy aliases — point at the DS tokens above ────────────────── */
 
-  /* Other */
-  --label-size: 14px;
-  --event-padding: 0.5em 1em;
-  --control-margin-bottom: 15px;
-  --menu-padding: 1em;
-}
+    --font-family: var(--font);
+    --primary-rgb: 58, 102, 150;
+    --secondary-rgb: 140, 51, 140;
+    --tertiary-rgb: 135, 202, 35;
+
+    --focus-rgb: 91, 156, 229;
+    --error-rgb: 255, 99, 71;
+    --success-rgb: 102, 186, 104;
+
+    --selection-light-rgb: 240, 240, 240;
+    --selection-dark-rgb: 180, 180, 180;
+
+    --select-input-height: inherit;
+
+    --disabled-opacity: 0.6;
+    --curvature: 6px;
+    --curvature-widget: 6px;
+    --focus: rgb(var(--focus-rgb, 91, 156, 229));
+    --focus-50: color-mix(in srgb, var(--focus) 12%, white);
+    --focus-100: color-mix(in srgb, var(--focus) 24%, white);
+    --focus-200: color-mix(in srgb, var(--focus) 40%, white);
+    --focus-300: color-mix(in srgb, var(--focus) 60%, white);
+    --focus-600: color-mix(in srgb, var(--focus) 60%, black);
+    --focus-700: color-mix(in srgb, var(--focus) 45%, black);
+    --focus-muted: color-mix(in srgb, var(--focus) 60%, white);
+    --focus-halo: 0 0 0 3px
+      color-mix(in srgb, var(--focus) 30%, transparent);
+    --color-focus: #a4cafe;
+    --color-widget-bg: #fff;
+    --color-widget-bg-focused: #fff;
+    --color-widget-border: rgb(225, 225, 225);
+
+    --color-options-bg: var(--surface);
+
+    /* primary colors */
+    --color-selection: #f0f6ff;
+    --color-success: #3ca96a;
+    --color-row-hover: rgba(var(--selection-light-rgb), 0.4);
+    --color-message: #3c92dd;
+    --color-available: #00f100;
+
+    --widget-box-shadow: rgba(-1, -1, 0, 0.1) 0px 1px 7px 0px,
+      rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
+    --widget-box-shadow-focused: 0 0 0 3px rgba(164, 202, 254, 0.45),
+      rgba(0, 0, 0, 0.05) 0px 3px 7px 0px,
+      rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
+    --widget-box-shadow-focused-error: 0 0 0 3px rgba(var(--error-rgb), 0.3);
+
+    --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+    --shadow-widget: 0 3px 20px 0 rgba(0, 0, 0, 0.04),
+      0 1px 2px 0 rgba(0, 0, 0, 0.02);
+
+    /* page text, borders, widgets */
+    --color-text: #555;
+    --color-widget-text: #555;
+    --color-borders: rgba(0, 0, 0, 0.07);
+    --color-placeholder: #ccc;
+
+    /* light colors, panel backgrounds, selection, etc */
+    --color-primary-light: #eee;
+    --color-secondary-light: rgba(var(--secondary-rgb), 0.3);
+
+    --color-label: var(--text-1);
+
+    /* dark colors, nav bar, buttons, etc — default to a ramp step
+       so they auto-theme when --primary-rgb changes. Hosts can still
+       override the legacy variable directly to break out of the ramp. */
+    --color-primary-dark: var(--accent-500);
+    --color-secondary-dark: rgb(var(--secondary-rgb));
+
+    /* light text goes over dark, dark over lights */
+    --color-text-light: rgba(255, 255, 255, 1);
+    --color-text-dark: #555;
+    --color-text-dark-secondary: rgba(0, 0, 0, 0.25);
+    --color-text-help: rgb(120, 120, 120);
+    --color-tertiary: rgb(var(--tertiary-rgb));
+
+    --help-text-size: 0.85em;
+    --help-text-margin-left: 0.3em;
+
+    /* solid overlays with text */
+    --color-overlay-dark: rgba(0, 0, 0, 0.2);
+    --color-overlay-dark-text: rgba(255, 255, 255, 0.9);
+    --color-overlay-light: rgba(0, 0, 0, 0.05);
+    --color-overlay-light-text: rgba(0, 0, 0, 0.6);
+
+    /* links, buttons, and label badges — default to ramp steps so
+       they auto-theme; overridable via direct variable setting. */
+    --color-link-primary: var(--accent-500);
+    --color-link-primary-hover: var(--accent-600);
+    --color-link-secondary: rgba(var(--secondary-rgb), 0.8);
+    --color-link-secondary-hover: rgba(var(--secondary-rgb), 0.9);
+    --color-button-primary: var(--accent-500);
+    --color-button-primary-text: var(--color-text-light);
+    --color-button-light: rgb(246, 248, 250);
+    --color-button-light-text: rgb(36, 41, 47);
+    --color-button-secondary: var(--color-secondary-light);
+    --color-button-secondary-text: var(--color-text-dark);
+
+    --color-button-destructive: rgb(var(--error-rgb));
+    --color-button-destructive-text: var(--color-text-light);
+
+    --color-button-attention: #3ca96a;
+
+    --color-connectors: #95cbef;
+
+    --color-label-primary: var(--color-primary-dark);
+    --color-label-primary-text: var(--color-text-light);
+    --color-label-secondary: var(--color-secondary-dark);
+    --color-label-secondary-text: var(--color-text-light);
+    --color-label-tertiary: var(--color-tertiary);
+    --color-label-tertiary-text: var(--color-text-light);
+
+    --color-nav-unselected: #fff;
+    --color-nav-selected-bg: #fff;
+    --color-nav-selected-text: var(--color-primary-dark);
+
+    --color-info: rgb(238, 246, 255);
+    --color-info-border: rgb(74, 163, 223);
+
+    --color-warning: rgb(255, 253, 218);
+    --color-warning-border: rgb(251, 246, 176);
+
+    --color-error: rgb(var(--error-rgb));
+    --color-alert: rgb(var(--error-rgb));
+
+    --color-quick-reply: rgb(60, 146, 221);
+    --color-automated: rgb(78, 205, 106);
+
+    --icon-color: var(--text-color);
+    --icon-color-hover: var(--icon-color);
+    --icon-color-circle-hover: rgba(245, 245, 245, .8);
+    --icon-color-circle: rgb(240, 240, 240);
+
+    --transition-speed: 250ms;
+    --event-padding: 0.5em 1em;
+    --temba-select-selected-padding: 0 var(--pad);
+    --temba-select-selected-line-height: 1.2em;
+    --temba-select-selected-font-size: 1em;
+    --temba-select-min-height: var(--input-h);
+
+    --font-size: 14px;
+    --button-font-size: 1.125rem;
+
+    --header-bg: var(--color-primary-dark);
+    --header-text: var(--color-text-light);
+
+    --temba-textinput-padding: 0.6em 0.8em;
+    --temba-textinput-font-size: 1;
+    --temba-textinput-min-height: var(--input-h);
+
+    --options-block-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1),
+      0 1px 2px 0 rgba(0, 0, 0, 0.03);
+    --options-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+      0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    --dropdown-shadow: rgb(0 0 0 / 15%) 0px 0px 30px,
+      rgb(0 0 0 / 12%) 0px 2px 6px;
+
+    --label-size: 14px;
+    --control-margin-bottom: 15px;
+
+    --menu-padding: 1em;
+
+    font-size: var(--font-size);
+    font-family: var(--font-family);
+
+    --button-y: 0.2em;
+    --button-x: 1.5em;
+
+    --bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+
+    --temba-charcount-counts-margin-top: 4px;
+    --temba-charcount-summary-margin-top: 5px;
+    --temba-charcount-summary-position: absolute;
+    --temba-charcount-summary-right: 0px;
+    --temba-charcount-summary-bottom: 0px;
+
+    --color-automated: rgb(78, 205, 106);
+
+  }
+
+  temba-button {
+    --button-bg: var(--accent-500);
+    --button-text: var(--color-text-light);
+    --button-border: none;
+    --button-shadow: var(--widget-box-shadow);
+  }
+
+  temba-button:hover {
+    --button-bg-img: linear-gradient(to bottom, rgba(255, 255, 255, .1), transparent, transparent);
+  }
+
+  temba-button.active {
+    --button-bg-img: linear-gradient(to bottom, transparent, rgba(0, 0, 0, .05));
+  }
+
+  temba-button.light {
+    --button-bg: #fff;
+    --button-text: #999;
+    --button-border: none;
+    --button-shadow: var(--widget-box-shadow);
+
+  }
+
+  temba-button.light:hover {
+    --button-bg-img: linear-gradient(to bottom, transparent, rgba(0, 0, 0, .001));
+  }
+
+  temba-button.light.active {
+    --button-bg-img: linear-gradient(to bottom, transparent, rgba(0, 0, 0, .02));
+  }
+
+
+  temba-select:focus {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .flatpickr-calendar {
+    margin-top: 28px;
+    margin-bottom: 28px;
+    margin-left: -13px;
+  }
+
+  temba-dropdown {
+    opacity: 0;
+  }
+
+  temba-dropdown:defined {
+    opacity: 1;
+  }

--- a/static/css/temba-components.css
+++ b/static/css/temba-components.css
@@ -15,7 +15,7 @@
        derived from it in both directions via sRGB mixing.
        The anchor reads from --primary-rgb so host pages can re-theme
        the entire ramp by setting e.g. --primary-rgb: 112, 0, 132. */
-    --accent:      rgb(var(--primary-rgb, 98, 147, 201));
+    --accent:      rgb(var(--primary-rgb));
     --accent-50:   color-mix(in srgb, var(--accent) 6%,  white);
     --accent-100:  color-mix(in srgb, var(--accent) 16%, white);
     --accent-200:  color-mix(in srgb, var(--accent) 32%, white);
@@ -262,38 +262,6 @@
     --color-automated: rgb(78, 205, 106);
 
   }
-
-  temba-button {
-    --button-bg: var(--accent-500);
-    --button-text: var(--color-text-light);
-    --button-border: none;
-    --button-shadow: var(--widget-box-shadow);
-  }
-
-  temba-button:hover {
-    --button-bg-img: linear-gradient(to bottom, rgba(255, 255, 255, .1), transparent, transparent);
-  }
-
-  temba-button.active {
-    --button-bg-img: linear-gradient(to bottom, transparent, rgba(0, 0, 0, .05));
-  }
-
-  temba-button.light {
-    --button-bg: #fff;
-    --button-text: #999;
-    --button-border: none;
-    --button-shadow: var(--widget-box-shadow);
-
-  }
-
-  temba-button.light:hover {
-    --button-bg-img: linear-gradient(to bottom, transparent, rgba(0, 0, 0, .001));
-  }
-
-  temba-button.light.active {
-    --button-bg-img: linear-gradient(to bottom, transparent, rgba(0, 0, 0, .02));
-  }
-
 
   temba-select:focus {
     outline: none;

--- a/static/styleguide/styleguide.css
+++ b/static/styleguide/styleguide.css
@@ -1,0 +1,294 @@
+/* TextIt Design System — style-guide-only scaffolding.
+   These classes lay out the showcase page itself. They are NOT part of
+   the design system that ships into the product — they live here so the
+   design-system.css stays clean and reusable. */
+
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  font-family: var(--font);
+  color: var(--text-1);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ─── style guide section scaffolding ─────────────────────────────────── */
+.sg-section {
+  padding: 32px 0;
+  border-top: 1px solid var(--border);
+}
+.sg-section:first-of-type {
+  border-top: 0;
+  padding-top: 12px;
+}
+.sg-section-h {
+  margin-bottom: 20px;
+  max-width: 720px;
+}
+.sg-section-h h2 { font-size: 19px; margin-bottom: 4px; }
+.sg-section-h p {
+  color: var(--text-2);
+  font-size: 13.5px;
+}
+
+.sg-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.sg-card {
+  grid-column: span 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+.sg-card-h {
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 12px;
+}
+.sg-card-h h3 { font-size: 13.5px; }
+.sg-card-sub {
+  color: var(--text-3);
+  font-size: 12.5px;
+  margin-top: 2px;
+  max-width: 360px;
+}
+.sg-card-body {
+  padding: 16px;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.sg-code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--sunken);
+  padding: 1px 6px;
+  border-radius: var(--r-xs);
+  color: var(--accent-700);
+}
+
+/* ─── colors ──────────────────────────────────────────────────────────── */
+.swatch { display: flex; align-items: center; gap: 12px; }
+.sw-chip {
+  width: 56px; height: 56px;
+  border-radius: var(--r);
+  display: flex; align-items: center; justify-content: center;
+  font-weight: var(--w-semibold);
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.06);
+}
+.sw-name { font-size: 13px; font-weight: var(--w-medium); }
+.sw-val {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+
+.ramp {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 4px;
+}
+.ramp-step { display: flex; flex-direction: column; gap: 6px; }
+.ramp-chip {
+  height: 56px;
+  border-radius: var(--r-sm);
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04);
+}
+.ramp-stop {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+  text-align: center;
+}
+
+.usage-row {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  padding-top: 4px;
+}
+.usage-tag {
+  font-size: 11.5px;
+  padding: 3px 8px;
+  background: var(--sunken);
+  color: var(--text-2);
+  border-radius: var(--r-xs);
+  font-family: var(--font-mono);
+}
+
+.neutrals { display: flex; flex-direction: column; gap: 4px; }
+.neutral-row {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 6px;
+  border-radius: var(--r-sm);
+}
+.neutral-row:hover { background: var(--sunken); }
+.neutral-chip {
+  width: 22px; height: 22px;
+  border-radius: var(--r-sm);
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.06);
+}
+.neutral-name { font-size: 12.5px; font-weight: var(--w-medium); }
+.neutral-val {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 10px;
+}
+.status-card {
+  padding: 12px;
+  border-radius: var(--r);
+  border: 1px solid;
+}
+.status-card-success { background: var(--success-bg); border-color: var(--success-border); color: var(--success); }
+.status-card-info    { background: var(--info-bg);    border-color: var(--info-border);    color: var(--info); }
+.status-card-warning { background: var(--warning-bg); border-color: var(--warning-border); color: var(--warning); }
+.status-card-danger  { background: var(--danger-bg);  border-color: var(--danger-border);  color: var(--danger); }
+.status-card-neutral { background: var(--neutral-bg); border-color: var(--neutral-border); color: var(--neutral); }
+
+.status-card-h {
+  display: flex; align-items: center; gap: 8px;
+  font-weight: var(--w-semibold);
+  font-size: 13px;
+  margin-bottom: 10px;
+}
+.status-card-row {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  margin-bottom: 10px;
+}
+.status-card-tokens {
+  display: flex; flex-direction: column; gap: 2px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  opacity: 0.75;
+}
+
+/* ─── type ───────────────────────────────────────────────────────────── */
+.type-scale { display: flex; flex-direction: column; }
+.type-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 20px;
+  padding: 12px 0;
+  border-top: 1px dashed var(--border);
+  align-items: baseline;
+}
+.type-row:first-child { border-top: 0; padding-top: 0; }
+.type-meta { display: flex; flex-direction: column; gap: 2px; }
+.type-name { font-size: 12px; font-weight: var(--w-semibold); color: var(--text-1); }
+.type-spec {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.type-sample-display { font-size: 32px; line-height: 1.18; font-weight: var(--w-semibold); letter-spacing: -0.02em; }
+.type-sample-h1      { font-size: 22px; line-height: 1.27; font-weight: var(--w-semibold); letter-spacing: -0.015em; }
+.type-sample-h2      { font-size: 17px; line-height: 1.41; font-weight: var(--w-semibold); }
+.type-sample-h3      { font-size: 14px; line-height: 1.43; font-weight: var(--w-semibold); }
+.type-sample-body    { font-size: 14px; line-height: 1.43; }
+.type-sample-body-sm { font-size: 13px; line-height: 1.38; color: var(--text-2); }
+.type-sample-caption {
+  font-size: 11px; line-height: 1.45; font-weight: var(--w-semibold);
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-3);
+}
+.type-sample-mono { font-size: 13px; }
+
+.numerics { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+.num-big {
+  font-size: 36px; font-weight: var(--w-semibold);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+.num-label {
+  font-size: 12px; color: var(--text-3);
+  text-transform: uppercase; letter-spacing: 0.06em;
+  font-weight: var(--w-semibold);
+}
+.num-rows {
+  display: flex; flex-direction: column; gap: 4px;
+  margin-top: 12px;
+  width: 100%;
+}
+.num-rows > div {
+  display: flex; justify-content: space-between;
+  padding: 6px 0;
+  border-top: 1px dashed var(--border);
+  font-size: 13px;
+}
+.num-rows span { color: var(--text-2); }
+.num-rows b { font-weight: var(--w-semibold); }
+.type-note { font-size: 12px; color: var(--text-3); margin-top: 12px; }
+
+/* ─── page-header preview ─────────────────────────────────────────────── */
+.ph-demo {
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r);
+  padding: 20px 24px;
+  background: var(--bg);
+}
+.ph-demo .page-title-row h1 { font-size: 22px; }
+.ph-demo .page-crumbs { margin-bottom: 8px; }
+
+/* ─── spacing & radius ────────────────────────────────────────────────── */
+.spacing-row {
+  display: flex; align-items: flex-end; gap: 18px;
+  padding: 8px 0;
+}
+.space-step {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 6px;
+}
+.space-bar {
+  height: 12px;
+  background: var(--accent-200);
+  border-radius: 2px;
+}
+.space-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.radius-row {
+  display: flex; gap: 18px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--border);
+}
+.radius-step {
+  display: flex; flex-direction: column; align-items: center; gap: 6px;
+}
+.radius-chip {
+  width: 44px; height: 44px;
+  background: var(--accent-100);
+  border: 1.5px solid var(--accent-300);
+}
+.radius-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+/* ─── footer ──────────────────────────────────────────────────────────── */
+.sg-foot {
+  margin-top: 40px;
+  padding: 16px 0;
+  display: flex; justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-3);
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 1100px) {
+  .sg-grid { grid-template-columns: repeat(2, 1fr); }
+  .sg-card { grid-column: span 1 !important; }
+  .form-grid { grid-template-columns: 1fr; }
+  .status-grid { grid-template-columns: repeat(2, 1fr); }
+}

--- a/static/styleguide/styleguide.html
+++ b/static/styleguide/styleguide.html
@@ -1,0 +1,678 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TextIt — Design System v0.1</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/design-system.css">
+  <link rel="stylesheet" href="styleguide.css">
+</head>
+<body>
+
+<!--
+  Sprite of icons used by this page. Reference one with:
+    <svg class="ic"><use href="#ic-name"/></svg>
+  Stroke / size are set on the host <svg> via CSS.
+-->
+<svg width="0" height="0" style="position:absolute" aria-hidden="true">
+  <defs>
+    <symbol id="ic-msg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-1.2 4.4 8.4 8.4 0 0 1-7.2 4.1 8.4 8.4 0 0 1-4.4-1.2L3 21l2.2-5.2A8.4 8.4 0 0 1 4 11.5a8.4 8.4 0 0 1 4.1-7.2A8.4 8.4 0 0 1 12.5 3h.6a8.4 8.4 0 0 1 7.9 7.9z"/></symbol>
+    <symbol id="ic-contacts" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></symbol>
+    <symbol id="ic-flow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.5"/><circle cx="18" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><path d="M6 8.5v3a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3v-3"/></symbol>
+    <symbol id="ic-triggers" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v3M5 6l2 2M3 13h3M19 6l-2 2M21 13h-3"/><circle cx="12" cy="14" r="5"/></symbol>
+    <symbol id="ic-history" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 4v5h5"/><path d="M12 8v5l3 2"/></symbol>
+    <symbol id="ic-tickets" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v2a2 2 0 0 0 0 4v2a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a2 2 0 0 0 0-4V9z"/><path d="M14 7v10" stroke-dasharray="2 2"/></symbol>
+    <symbol id="ic-bell" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 7 3 9H3c0-2 3-2 3-9z"/><path d="M10 21a2 2 0 0 0 4 0"/></symbol>
+    <symbol id="ic-settings" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></symbol>
+    <symbol id="ic-chevL" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 6 9 12 15 18"/></symbol>
+    <symbol id="ic-chevR" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 6 15 12 9 18"/></symbol>
+    <symbol id="ic-chevDown" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></symbol>
+    <symbol id="ic-archive" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="4" rx="1"/><path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8"/><path d="M10 12h4"/></symbol>
+    <symbol id="ic-field" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16M4 12h16M4 18h10"/></symbol>
+    <symbol id="ic-group" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></symbol>
+    <symbol id="ic-person" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></symbol>
+    <symbol id="ic-phone" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3.1 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3.1-8.7A2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1.9.3 1.8.6 2.6a2 2 0 0 1-.5 2.1L8 9.6a16 16 0 0 0 6 6l1.2-1.2a2 2 0 0 1 2.1-.5c.8.3 1.7.5 2.6.6a2 2 0 0 1 1.7 2z"/></symbol>
+    <symbol id="ic-plus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></symbol>
+    <symbol id="ic-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></symbol>
+    <symbol id="ic-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></symbol>
+    <symbol id="ic-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></symbol>
+    <symbol id="ic-edit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 1 1 3 3L7 19l-4 1 1-4z"/></symbol>
+    <symbol id="ic-trash" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M10 11v6M14 11v6"/></symbol>
+    <symbol id="ic-more" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></symbol>
+    <symbol id="ic-download" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4v12"/><path d="M6 10l6 6 6-6"/><path d="M4 20h16"/></symbol>
+    <symbol id="ic-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v5h1"/></symbol>
+    <symbol id="ic-warn" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 2 21h20L12 3z"/><path d="M12 9v5M12 17h.01"/></symbol>
+    <symbol id="ic-err" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></symbol>
+    <symbol id="ic-ok" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="8 12 11 15 16 9"/></symbol>
+    <symbol id="ic-chat" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-1.2 4.4 8.4 8.4 0 0 1-7.2 4.1 8.4 8.4 0 0 1-4.4-1.2L3 21l2.2-5.2A8.4 8.4 0 0 1 4 11.5a8.4 8.4 0 0 1 4.1-7.2A8.4 8.4 0 0 1 12.5 3h.6a8.4 8.4 0 0 1 7.9 7.9z"/></symbol>
+    <symbol id="ic-fields" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h2M3 12h2M3 18h2"/><rect x="8" y="4" width="13" height="4" rx="1"/><rect x="8" y="10" width="13" height="4" rx="1"/><rect x="8" y="16" width="13" height="4" rx="1"/></symbol>
+    <symbol id="ic-sparkles" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v4M12 17v4M3 12h4M17 12h4M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M5.6 18.4l2.8-2.8M15.6 8.4l2.8-2.8"/></symbol>
+    <symbol id="ic-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/></symbol>
+    <symbol id="ic-folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></symbol>
+  </defs>
+</svg>
+
+<div class="ds">
+<div class="app">
+
+  <!-- left icon rail -->
+  <nav class="rail">
+    <div class="rail-top">
+      <div class="rail-org" title="Acme HealthOrg"><span>UM</span></div>
+      <div class="rail-items">
+        <button class="rail-item" title="Messages"><svg width="20" height="20"><use href="#ic-msg"/></svg></button>
+        <button class="rail-item" title="Contacts"><svg width="20" height="20"><use href="#ic-contacts"/></svg></button>
+        <button class="rail-item" title="Flows"><svg width="20" height="20"><use href="#ic-flow"/></svg></button>
+        <button class="rail-item" title="Triggers"><svg width="20" height="20"><use href="#ic-triggers"/></svg></button>
+        <button class="rail-item is-active" title="Campaigns"><svg width="20" height="20"><use href="#ic-history"/></svg></button>
+        <button class="rail-item" title="Tickets"><svg width="20" height="20"><use href="#ic-tickets"/></svg></button>
+      </div>
+    </div>
+    <div class="rail-bot">
+      <button class="rail-item" title="Notifications"><svg width="20" height="20"><use href="#ic-bell"/></svg></button>
+      <button class="rail-item" title="Settings"><svg width="20" height="20"><use href="#ic-settings"/></svg></button>
+    </div>
+  </nav>
+
+  <!-- section nav -->
+  <aside class="section-nav" id="sectionNav">
+    <header class="sn-h">
+      <h2>Design System</h2>
+      <button class="sn-collapse" id="snCollapse" aria-label="Toggle sidebar">
+        <svg width="16" height="16"><use href="#ic-chevL"/></svg>
+      </button>
+    </header>
+    <div class="sn-items">
+      <a class="sn-item is-active" href="#foundations"><svg width="15" height="15"><use href="#ic-sparkles"/></svg><span>Foundations</span></a>
+      <a class="sn-item" href="#colors"><svg width="15" height="15"><use href="#ic-circle"/></svg><span>Colors</span></a>
+      <a class="sn-item" href="#type"><svg width="15" height="15"><use href="#ic-field"/></svg><span>Typography</span></a>
+      <a class="sn-item" href="#components"><svg width="15" height="15"><use href="#ic-group"/></svg><span>Components</span><span class="sn-count">12</span></a>
+      <a class="sn-item" href="#patterns"><svg width="15" height="15"><use href="#ic-folder"/></svg><span>Patterns</span><span class="sn-count">5</span></a>
+      <div class="sn-section-label">App chrome</div>
+      <a class="sn-item" href="#chrome"><svg width="15" height="15"><use href="#ic-archive"/></svg><span>Layout</span></a>
+      <a class="sn-item" href="#header"><svg width="15" height="15"><use href="#ic-field"/></svg><span>Page header</span></a>
+      <a class="sn-item" href="#tables"><svg width="15" height="15"><use href="#ic-fields"/></svg><span>Lists &amp; tables</span></a>
+      <a class="sn-item" href="#patterns"><svg width="15" height="15"><use href="#ic-edit"/></svg><span>Forms &amp; modals</span></a>
+    </div>
+  </aside>
+
+  <!-- content -->
+  <main class="content">
+
+    <!-- page header -->
+    <header class="page-header" id="foundations">
+      <div class="page-header-row">
+        <div class="page-crumbs">
+          <a>TextIt</a>
+          <svg width="12" height="12"><use href="#ic-chevR"/></svg>
+          <a>Design</a>
+          <svg width="12" height="12"><use href="#ic-chevR"/></svg>
+          <span>Style guide</span>
+        </div>
+        <div class="page-header-actions">
+          <button class="btn btn-ghost btn-sm"><svg width="14" height="14"><use href="#ic-download"/></svg>Export tokens</button>
+          <button class="btn btn-primary btn-sm"><svg width="14" height="14"><use href="#ic-check"/></svg>Approve direction</button>
+        </div>
+      </div>
+      <div class="page-title-row">
+        <div>
+          <h1>Style guide</h1>
+          <p class="page-sub">A modernized core for TextIt — same DNA, sharper grid, better hierarchy. Apply across CRUDLs.</p>
+        </div>
+        <div class="page-meta">
+          <span class="status status-success"><span class="status-dot"></span>In review</span>
+          <span class="page-meta-sep"></span>
+          <span class="page-meta-text">v0.1 · May 7</span>
+        </div>
+      </div>
+    </header>
+
+    <!-- colors -->
+    <section id="colors" class="sg-section">
+      <div class="sg-section-h">
+        <h2>Color</h2>
+        <p>One accent, a neutral gray ramp, four status colors plus neutral. The accent leans slightly more saturated than the current <code class="sg-code">rgb(58, 102, 150)</code> — modernized without losing the muted-blue feel.</p>
+      </div>
+
+      <div class="sg-grid">
+        <section class="sg-card" style="grid-column: span 2">
+          <header class="sg-card-h">
+            <div>
+              <h3>Accent ramp</h3>
+              <p class="sg-card-sub">Generated from a single anchor <code class="sg-code">--accent</code> using OKLab mixing.</p>
+            </div>
+          </header>
+          <div class="sg-card-body">
+            <div class="ramp">
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 6%, white)"></div><div class="ramp-stop">50</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 12%, white)"></div><div class="ramp-stop">100</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 25%, white)"></div><div class="ramp-stop">200</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 45%, white)"></div><div class="ramp-stop">300</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 75%, white)"></div><div class="ramp-stop">400</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent)"></div><div class="ramp-stop">500</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 88%, black)"></div><div class="ramp-stop">600</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 75%, black)"></div><div class="ramp-stop">700</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 60%, black)"></div><div class="ramp-stop">800</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 45%, black)"></div><div class="ramp-stop">900</div></div>
+            </div>
+            <div class="usage-row">
+              <div class="usage-tag">Buttons · 600/700</div>
+              <div class="usage-tag">Pills · 50/700</div>
+              <div class="usage-tag">Active rail · 400</div>
+              <div class="usage-tag">Selection · 50</div>
+              <div class="usage-tag">Focus ring · 100</div>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card">
+          <header class="sg-card-h"><div><h3>Neutrals</h3></div></header>
+          <div class="sg-card-body">
+            <div class="neutrals">
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--bg)"></span><span class="neutral-name">bg</span><span class="neutral-val">var(--bg)</span></div>
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--surface)"></span><span class="neutral-name">surface</span><span class="neutral-val">var(--surface)</span></div>
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--sunken)"></span><span class="neutral-name">sunken</span><span class="neutral-val">var(--sunken)</span></div>
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--border)"></span><span class="neutral-name">border</span><span class="neutral-val">var(--border)</span></div>
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--border-strong)"></span><span class="neutral-name">b-strong</span><span class="neutral-val">var(--border-strong)</span></div>
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--text-3)"></span><span class="neutral-name">text-3</span><span class="neutral-val">var(--text-3)</span></div>
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--text-2)"></span><span class="neutral-name">text-2</span><span class="neutral-val">var(--text-2)</span></div>
+              <div class="neutral-row"><span class="neutral-chip" style="background: var(--text-1)"></span><span class="neutral-name">text-1</span><span class="neutral-val">var(--text-1)</span></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card" style="grid-column: span 3">
+          <header class="sg-card-h">
+            <div>
+              <h3>Status</h3>
+              <p class="sg-card-sub">One full palette across success / info / warning / danger / neutral.</p>
+            </div>
+          </header>
+          <div class="sg-card-body">
+            <div class="status-grid">
+              <div class="status-card status-card-success">
+                <div class="status-card-h"><svg width="16" height="16"><use href="#ic-ok"/></svg><span>Active</span></div>
+                <div class="status-card-row"><span class="status status-success"><span class="status-dot"></span>Active</span><span class="pill pill-keyword"><span class="pill-text">success</span></span></div>
+                <div class="status-card-tokens"><span>--success-bg</span><span>--success</span><span>--success-border</span></div>
+              </div>
+              <div class="status-card status-card-info">
+                <div class="status-card-h"><svg width="16" height="16"><use href="#ic-info"/></svg><span>Pending</span></div>
+                <div class="status-card-row"><span class="status status-info"><span class="status-dot"></span>Pending</span><span class="pill pill-keyword"><span class="pill-text">info</span></span></div>
+                <div class="status-card-tokens"><span>--info-bg</span><span>--info</span><span>--info-border</span></div>
+              </div>
+              <div class="status-card status-card-warning">
+                <div class="status-card-h"><svg width="16" height="16"><use href="#ic-warn"/></svg><span>Stopped</span></div>
+                <div class="status-card-row"><span class="status status-warning"><span class="status-dot"></span>Stopped</span><span class="pill pill-keyword"><span class="pill-text">warning</span></span></div>
+                <div class="status-card-tokens"><span>--warning-bg</span><span>--warning</span><span>--warning-border</span></div>
+              </div>
+              <div class="status-card status-card-danger">
+                <div class="status-card-h"><svg width="16" height="16"><use href="#ic-err"/></svg><span>Failed</span></div>
+                <div class="status-card-row"><span class="status status-danger"><span class="status-dot"></span>Failed</span><span class="pill pill-keyword"><span class="pill-text">danger</span></span></div>
+                <div class="status-card-tokens"><span>--danger-bg</span><span>--danger</span><span>--danger-border</span></div>
+              </div>
+              <div class="status-card status-card-neutral">
+                <div class="status-card-h"><svg width="16" height="16"><use href="#ic-archive"/></svg><span>Archived</span></div>
+                <div class="status-card-row"><span class="status status-neutral"><span class="status-dot"></span>Archived</span><span class="pill pill-keyword"><span class="pill-text">neutral</span></span></div>
+                <div class="status-card-tokens"><span>--neutral-bg</span><span>--neutral</span><span>--neutral-border</span></div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <!-- type -->
+    <section id="type" class="sg-section">
+      <div class="sg-section-h">
+        <h2>Typography</h2>
+        <p>Inter at <code class="sg-code">14px</code> base. Same spirit as Roboto but tighter letterforms and a true semibold. Numerics use tabular figures everywhere for tables.</p>
+      </div>
+      <div class="sg-grid">
+        <section class="sg-card" style="grid-column: span 2">
+          <header class="sg-card-h"><div><h3>Scale</h3></div></header>
+          <div class="sg-card-body">
+            <div class="type-scale">
+              <div class="type-row"><div class="type-meta"><div class="type-name">Display</div><div class="type-spec">32 / 38 · 600</div></div><div class="type-sample type-sample-display">Campaigns</div></div>
+              <div class="type-row"><div class="type-meta"><div class="type-name">H1</div><div class="type-spec">22 / 28 · 600</div></div><div class="type-sample type-sample-h1">Vaccination Reminders</div></div>
+              <div class="type-row"><div class="type-meta"><div class="type-name">H2</div><div class="type-spec">17 / 24 · 600</div></div><div class="type-sample type-sample-h2">Active campaigns</div></div>
+              <div class="type-row"><div class="type-meta"><div class="type-name">H3</div><div class="type-spec">14 / 20 · 600</div></div><div class="type-sample type-sample-h3">Schedule</div></div>
+              <div class="type-row"><div class="type-meta"><div class="type-name">Body</div><div class="type-spec">14 / 20 · 400</div></div><div class="type-sample type-sample-body">Sent 3 days after the contact joined the Mothers group.</div></div>
+              <div class="type-row"><div class="type-meta"><div class="type-name">Body sm</div><div class="type-spec">13 / 18 · 400</div></div><div class="type-sample type-sample-body-sm">Updated 2 hours ago by Susan Fishman</div></div>
+              <div class="type-row"><div class="type-meta"><div class="type-name">Caption</div><div class="type-spec">12 / 16 · 500</div></div><div class="type-sample type-sample-caption">ANCHOR · DELAY · MESSAGE</div></div>
+              <div class="type-row"><div class="type-meta"><div class="type-name">Mono</div><div class="type-spec">13 / 18 · 400</div></div><div class="type-sample type-sample-mono" style="font-family: var(--font-mono)">registration_date + 3 days</div></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card">
+          <header class="sg-card-h"><div><h3>Numerics</h3></div></header>
+          <div class="sg-card-body">
+            <div class="numerics">
+              <div class="num-big">4,832</div>
+              <div class="num-label">Active contacts</div>
+              <div class="num-rows">
+                <div><span>Sent</span><b>12,408</b></div>
+                <div><span>Delivered</span><b>11,902</b></div>
+                <div><span>Failed</span><b>506</b></div>
+              </div>
+              <p class="type-note">Tabular figures keep columns aligned across rows.</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <!-- components -->
+    <section id="components" class="sg-section">
+      <div class="sg-section-h">
+        <h2>Components</h2>
+        <p>Building blocks. All sized to a 4px grid; corner radius and density are token-driven.</p>
+      </div>
+      <div class="sg-grid">
+
+        <section class="sg-card">
+          <header class="sg-card-h"><div><h3>Buttons</h3><p class="sg-card-sub">Primary for the one main action per surface; secondary for everything else.</p></div></header>
+          <div class="sg-card-body">
+            <div class="comp-row">
+              <button class="btn btn-primary"><svg width="16" height="16"><use href="#ic-check"/></svg>Save changes</button>
+              <button class="btn btn-secondary">Cancel</button>
+              <button class="btn btn-ghost"><svg width="16" height="16"><use href="#ic-edit"/></svg>Edit</button>
+              <button class="btn btn-danger"><svg width="16" height="16"><use href="#ic-trash"/></svg>Delete</button>
+            </div>
+            <div class="comp-row">
+              <button class="btn btn-primary btn-sm"><svg width="14" height="14"><use href="#ic-plus"/></svg>New campaign</button>
+              <button class="btn btn-secondary btn-sm">Filter</button>
+              <button class="btn btn-ghost btn-sm"><svg width="14" height="14"><use href="#ic-download"/></svg>Export</button>
+              <button class="btn btn-primary is-disabled" disabled>Disabled</button>
+            </div>
+            <div class="comp-row">
+              <button class="icon-btn" title="More"><svg width="16" height="16"><use href="#ic-more"/></svg></button>
+              <button class="icon-btn" title="Search"><svg width="16" height="16"><use href="#ic-search"/></svg></button>
+              <button class="icon-btn is-active" title="Edit"><svg width="16" height="16"><use href="#ic-edit"/></svg></button>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card">
+          <header class="sg-card-h"><div><h3>Pills</h3><p class="sg-card-sub">Entity references. Flow → green, recipient (contact + group) → accent blue, field → amber, keyword → mono grey, label → neutral grey. Purple is reserved.</p></div></header>
+          <div class="sg-card-body">
+            <div class="comp-row">
+              <span class="pill pill-flow"><svg width="11.5" height="11.5"><use href="#ic-flow"/></svg><span class="pill-text">Vaccination Reminder</span></span>
+              <span class="pill pill-group"><svg width="11.5" height="11.5"><use href="#ic-group"/></svg><span class="pill-text">Mothers</span></span>
+              <span class="pill pill-contact"><svg width="11.5" height="11.5"><use href="#ic-person"/></svg><span class="pill-text">Dražen Seymour</span></span>
+            </div>
+            <div class="comp-row">
+              <span class="pill pill-field"><svg width="11.5" height="11.5"><use href="#ic-field"/></svg><span class="pill-text">registration_date</span></span>
+              <span class="pill pill-keyword"><span class="pill-text">jaws</span></span>
+              <span class="pill pill-label"><svg width="11.5" height="11.5"><use href="#ic-folder"/></svg><span class="pill-text">Onboarding</span></span>
+            </div>
+            <div class="comp-row">
+              <span class="pill pill-flow"><svg width="11.5" height="11.5"><use href="#ic-flow"/></svg><span class="pill-text">JAWS</span><button class="pill-x"><svg width="11" height="11"><use href="#ic-x"/></svg></button></span>
+              <span class="pill pill-group"><svg width="11.5" height="11.5"><use href="#ic-group"/></svg><span class="pill-text">Doctors</span><button class="pill-x"><svg width="11" height="11"><use href="#ic-x"/></svg></button></span>
+              <span class="pill pill-keyword"><span class="pill-text">help</span><button class="pill-x"><svg width="11" height="11"><use href="#ic-x"/></svg></button></span>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card">
+          <header class="sg-card-h"><div><h3>Status &amp; badges</h3></div></header>
+          <div class="sg-card-body">
+            <div class="comp-row">
+              <span class="status status-success"><span class="status-dot"></span>Active</span>
+              <span class="status status-info"><span class="status-dot"></span>Pending</span>
+              <span class="status status-warning"><span class="status-dot"></span>Stopped</span>
+              <span class="status status-danger"><span class="status-dot"></span>Failed</span>
+              <span class="status status-neutral"><span class="status-dot"></span>Archived</span>
+            </div>
+            <div class="comp-row">
+              <span class="count-badge">4,832</span>
+              <span class="count-badge count-accent">12</span>
+              <span class="count-badge count-danger">3</span>
+              <span class="count-badge count-success">+24</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card">
+          <header class="sg-card-h"><div><h3>Avatars &amp; contact icons</h3><p class="sg-card-sub">Initials shown when no image is uploaded. Background colors are generated by the avatar component itself — not part of the design system tokens.</p></div></header>
+          <div class="sg-card-body">
+            <div class="comp-row" id="avatarRow">
+              <!-- avatars rendered by JS so the hashed-color logic is centralized -->
+            </div>
+            <div class="comp-row">
+              <span class="ch-icon ch-whatsapp"><svg width="14" height="14"><use href="#ic-phone"/></svg></span>
+              <span class="ch-icon ch-tel"><svg width="14" height="14"><use href="#ic-phone"/></svg></span>
+              <span class="ch-icon ch-fb"><svg width="14" height="14"><use href="#ic-msg"/></svg></span>
+              <span class="ch-icon ch-web"><svg width="14" height="14"><use href="#ic-chat"/></svg></span>
+            </div>
+            <div class="comp-row">
+              <div class="contact-line">
+                <span class="ch-icon ch-whatsapp"><svg width="14" height="14"><use href="#ic-phone"/></svg></span>
+                <span class="contact-name">Dražen Seymour</span>
+                <span class="contact-num">+250 700 009 996</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card" style="grid-column: span 2">
+          <header class="sg-card-h"><div><h3>Inputs</h3></div></header>
+          <div class="sg-card-body">
+            <div class="form-grid">
+              <label class="field">
+                <span class="field-label">Campaign name</span>
+                <input class="input" value="Vaccination Reminders"/>
+              </label>
+              <label class="field">
+                <span class="field-label">Contact group</span>
+                <div class="select-wrap">
+                  <span class="pill pill-group"><svg width="11.5" height="11.5"><use href="#ic-group"/></svg><span class="pill-text">Mothers</span></span>
+                  <svg width="14" height="14" class="select-chev"><use href="#ic-chevDown"/></svg>
+                </div>
+              </label>
+              <label class="field">
+                <span class="field-label">Anchor field</span>
+                <div class="select-wrap">
+                  <span class="pill pill-field"><svg width="11.5" height="11.5"><use href="#ic-field"/></svg><span class="pill-text">registration_date</span></span>
+                  <svg width="14" height="14" class="select-chev"><use href="#ic-chevDown"/></svg>
+                </div>
+              </label>
+              <label class="field">
+                <span class="field-label">Search</span>
+                <div class="search-wrap">
+                  <svg width="14" height="14" class="search-icon"><use href="#ic-search"/></svg>
+                  <input class="input" placeholder="Search contacts, fields, flows…"/>
+                  <kbd>⌘K</kbd>
+                </div>
+              </label>
+              <label class="field field-full">
+                <span class="field-label">Description <span class="opt">optional</span></span>
+                <textarea class="input" rows="2">Sent 3 days after the contact joined the Mothers group.</textarea>
+                <span class="field-help">Max 280 characters.</span>
+              </label>
+              <div class="field field-full">
+                <span class="field-label">Channels</span>
+                <div class="checkbox-row">
+                  <label class="checkbox is-checked"><span class="check-box"><svg width="11" height="11"><use href="#ic-check"/></svg></span>WhatsApp Business</label>
+                  <label class="checkbox is-checked"><span class="check-box"><svg width="11" height="11"><use href="#ic-check"/></svg></span>SMS</label>
+                  <label class="checkbox"><span class="check-box"></span>Voice</label>
+                  <label class="checkbox"><span class="check-box"></span>Web Chat</label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </div>
+    </section>
+
+    <!-- tables -->
+    <section id="tables" class="sg-section">
+      <div class="sg-section-h">
+        <h2>Lists &amp; tables</h2>
+        <p>The bones of every CRUDL. Sticky header, hover reveals row actions, tabular figures, status as a column-1 affordance.</p>
+      </div>
+      <section class="sg-card" style="grid-column: span 3">
+        <header class="sg-card-h">
+          <div>
+            <h3>Campaigns — list</h3>
+            <p class="sg-card-sub">The standard CRUDL table.</p>
+          </div>
+          <div class="comp-row">
+            <button class="btn btn-ghost btn-sm"><svg width="14" height="14"><use href="#ic-search"/></svg>Search</button>
+            <button class="btn btn-ghost btn-sm"><svg width="14" height="14"><use href="#ic-download"/></svg>Export</button>
+            <button class="btn btn-primary btn-sm"><svg width="14" height="14"><use href="#ic-plus"/></svg>New campaign</button>
+          </div>
+        </header>
+        <div class="sg-card-body">
+          <div class="table-wrap">
+            <table class="t">
+              <thead>
+                <tr>
+                  <th class="t-check"><span class="check-box"></span></th>
+                  <th>Name</th>
+                  <th>Group</th>
+                  <th>Channel</th>
+                  <th class="t-num">Events</th>
+                  <th class="t-num">Contacts</th>
+                  <th>Status</th>
+                  <th>Updated</th>
+                  <th class="t-act"></th>
+                </tr>
+              </thead>
+              <tbody id="campaignsBody"><!-- rendered by JS --></tbody>
+            </table>
+            <div class="t-foot">
+              <span>1–6 of 6</span>
+              <div class="comp-row">
+                <button class="icon-btn icon-btn-sm" disabled><svg width="13" height="13"><use href="#ic-chevL"/></svg></button>
+                <button class="icon-btn icon-btn-sm" disabled><svg width="13" height="13"><use href="#ic-chevR"/></svg></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </section>
+
+    <!-- patterns -->
+    <section id="patterns" class="sg-section">
+      <div class="sg-section-h">
+        <h2>Patterns</h2>
+        <p>Compositions used across the app: empty states, page headers, modals.</p>
+      </div>
+      <div class="sg-grid">
+
+        <section class="sg-card" style="grid-column: span 2">
+          <header class="sg-card-h"><div><h3>Empty state</h3></div></header>
+          <div class="sg-card-body">
+            <div class="empty">
+              <div class="empty-art">
+                <svg width="32" height="32" stroke-width="1.4"><use href="#ic-history"/></svg>
+              </div>
+              <h4>No campaigns yet</h4>
+              <p>Campaigns send messages on a schedule relative to a contact field — like 3 days after registration.</p>
+              <div class="comp-row">
+                <button class="btn btn-primary"><svg width="16" height="16"><use href="#ic-plus"/></svg>Create your first campaign</button>
+                <button class="btn btn-ghost">Read the guide</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card">
+          <header class="sg-card-h"><div><h3>Modal</h3><p class="sg-card-sub">Centered, accent header, form inside.</p></div></header>
+          <div class="sg-card-body">
+            <div class="modal">
+              <div class="modal-h">
+                <span>Update Trigger</span>
+                <button class="modal-x"><svg width="14" height="14"><use href="#ic-x"/></svg></button>
+              </div>
+              <div class="modal-b">
+                <label class="field">
+                  <span class="field-label">Keywords</span>
+                  <div class="input input-tokens">
+                    <span class="pill pill-keyword"><span class="pill-text">jaws</span><button class="pill-x"><svg width="11" height="11"><use href="#ic-x"/></svg></button></span>
+                    <input placeholder="Add keyword…"/>
+                  </div>
+                </label>
+                <label class="field">
+                  <span class="field-label">Flow</span>
+                  <div class="select-wrap">
+                    <span class="pill pill-flow"><svg width="11.5" height="11.5"><use href="#ic-flow"/></svg><span class="pill-text">JAWS</span></span>
+                    <svg width="14" height="14" class="select-chev"><use href="#ic-chevDown"/></svg>
+                  </div>
+                </label>
+              </div>
+              <div class="modal-f">
+                <button class="btn btn-ghost">Cancel</button>
+                <button class="btn btn-primary">Save</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card" style="grid-column: span 3">
+          <header class="sg-card-h"><div><h3>Section header</h3><p class="sg-card-sub">What replaces the underlined H1.</p></div></header>
+          <div class="sg-card-body">
+            <div class="ph-demo">
+              <div class="page-crumbs">
+                <a>Campaigns</a>
+                <svg width="12" height="12"><use href="#ic-chevR"/></svg>
+                <span>Vaccination Reminders</span>
+              </div>
+              <div class="page-title-row">
+                <div>
+                  <h1>Vaccination Reminders</h1>
+                  <p class="page-sub">Sent 3 days after the contact joined the Mothers group.</p>
+                </div>
+                <div class="page-header-actions">
+                  <span class="status status-success"><span class="status-dot"></span>Active</span>
+                  <span class="page-meta-sep"></span>
+                  <button class="btn btn-ghost btn-sm"><svg width="14" height="14"><use href="#ic-archive"/></svg>Archive</button>
+                  <button class="btn btn-secondary btn-sm"><svg width="14" height="14"><use href="#ic-edit"/></svg>Edit</button>
+                  <button class="btn btn-primary btn-sm"><svg width="14" height="14"><use href="#ic-plus"/></svg>Add event</button>
+                </div>
+              </div>
+              <div class="ph-tabs">
+                <button class="ph-tab is-active">Overview</button>
+                <button class="ph-tab">Events</button>
+                <button class="ph-tab">Contacts</button>
+                <button class="ph-tab">History</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="sg-card" style="grid-column: span 3">
+          <header class="sg-card-h"><div><h3>Spacing &amp; radius</h3></div></header>
+          <div class="sg-card-body">
+            <div class="spacing-row" id="spacingRow"><!-- rendered by JS --></div>
+            <div class="radius-row">
+              <div class="radius-step"><div class="radius-chip" style="border-radius: var(--r-xs)"></div><div class="radius-label">xs</div></div>
+              <div class="radius-step"><div class="radius-chip" style="border-radius: var(--r-sm)"></div><div class="radius-label">sm</div></div>
+              <div class="radius-step"><div class="radius-chip" style="border-radius: var(--r)"></div><div class="radius-label">md</div></div>
+              <div class="radius-step"><div class="radius-chip" style="border-radius: var(--r-lg)"></div><div class="radius-label">lg</div></div>
+              <div class="radius-step"><div class="radius-chip" style="border-radius: 999px"></div><div class="radius-label">full</div></div>
+            </div>
+          </div>
+        </section>
+
+      </div>
+    </section>
+
+    <footer class="sg-foot">
+      <span>TextIt design system · v0.1</span>
+      <span>Inter · 4px grid · OKLab-derived ramps</span>
+    </footer>
+
+  </main>
+</div>
+</div>
+
+<script>
+(function () {
+  // ─── section nav collapse ───────────────────────────────────────────
+  var nav = document.getElementById("sectionNav");
+  var btn = document.getElementById("snCollapse");
+  btn.addEventListener("click", function () {
+    nav.classList.toggle("is-collapsed");
+    var ic = btn.querySelector("use");
+    ic.setAttribute("href", nav.classList.contains("is-collapsed") ? "#ic-chevR" : "#ic-chevL");
+  });
+
+  // ─── avatar row ─────────────────────────────────────────────────────
+  // Avatar background colors are NOT a design system concern — the avatar
+  // component generates them. This block exists only to render a realistic
+  // demo so the .avatar layout/typography can be evaluated.
+  var demoSwatches = [
+    ["linear-gradient(135deg,#FACC15,#EAB308)", "#573E04"],
+    ["linear-gradient(135deg,#F472B6,#DB2777)", "#5A0E37"],
+    ["linear-gradient(135deg,#A78BFA,#7C3AED)", "#2A1166"],
+    ["linear-gradient(135deg,#60A5FA,#2563EB)", "#0B2A66"],
+    ["linear-gradient(135deg,#34D399,#059669)", "#063522"],
+    ["linear-gradient(135deg,#FB923C,#EA580C)", "#5A1D04"],
+    ["linear-gradient(135deg,#22D3EE,#0891B2)", "#0A3640"],
+    ["linear-gradient(135deg,#F87171,#DC2626)", "#5A0F0F"],
+    ["linear-gradient(135deg,#A3E635,#65A30D)", "#1F3206"],
+    ["linear-gradient(135deg,#C084FC,#9333EA)", "#3B0E66"],
+    ["linear-gradient(135deg,#FCD34D,#D97706)", "#5A2C04"],
+    ["linear-gradient(135deg,#5EEAD4,#0D9488)", "#053D38"],
+  ];
+  function hashName(s) {
+    var h = 0;
+    for (var i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+    return Math.abs(h);
+  }
+  function initials(name) {
+    return name.split(/\s+/).map(function (s) { return s[0]; })
+      .filter(Boolean).slice(0, 2).join("").toUpperCase();
+  }
+  function makeAvatar(name, size) {
+    size = size || 28;
+    var swatch = demoSwatches[hashName(name) % demoSwatches.length];
+    var el = document.createElement("span");
+    el.className = "avatar";
+    el.style.width = size + "px";
+    el.style.height = size + "px";
+    el.style.fontSize = Math.round(size * 0.4) + "px";
+    el.style.background = swatch[0];
+    el.style.color = swatch[1];
+    el.textContent = initials(name);
+    return el;
+  }
+  var avatarRow = document.getElementById("avatarRow");
+  [
+    ["Adam McAdmin"],   ["Susan Fishman"], ["Eugene Ingabire"],
+    ["Marcus Reyes"],   ["Priya Shah"],    ["Tomi Adebayo"],
+    ["Liu Wei"],        ["Dr Wells", 36],  ["Unicef Mali", 44],
+  ].forEach(function (a) { avatarRow.appendChild(makeAvatar(a[0], a[1])); });
+
+  // ─── campaigns table body ───────────────────────────────────────────
+  var rows = [
+    { name: "Vaccination Reminders", group: "Mothers",   events: 4, channel: "whatsapp", channelLabel: "WhatsApp",  status: "success", statusLabel: "Active",   contacts: 4832, updated: "2h ago" },
+    { name: "Antenatal Care Series", group: "Mothers",   events: 8, channel: "whatsapp", channelLabel: "WhatsApp",  status: "success", statusLabel: "Active",   contacts: 2431, updated: "1d ago" },
+    { name: "Drug Adherence",        group: "Patients",  events: 3, channel: "tel",      channelLabel: "SMS",       status: "success", statusLabel: "Active",   contacts: 1958, updated: "3d ago" },
+    { name: "Farmer Onboarding",     group: "Farmers",   events: 5, channel: "tel",      channelLabel: "SMS",       status: "info",    statusLabel: "Pending",  contacts: 952,  updated: "5d ago" },
+    { name: "Teacher Check-in",      group: "Teachers",  events: 2, channel: "whatsapp", channelLabel: "WhatsApp",  status: "warning", statusLabel: "Stopped",  contacts: 1439, updated: "Apr 28" },
+    { name: "Survey Followup",       group: "Reporters", events: 6, channel: "fb",       channelLabel: "Messenger", status: "neutral", statusLabel: "Archived", contacts: 4588, updated: "Mar 30" },
+  ];
+  var icIcon = function (id, size) {
+    return '<svg width="' + size + '" height="' + size + '"><use href="#ic-' + id + '"/></svg>';
+  };
+  var body = document.getElementById("campaignsBody");
+  body.innerHTML = rows.map(function (r) {
+    var chIcon = r.channel === "fb" ? "msg" : "phone";
+    return '<tr>' +
+      '<td class="t-check"><span class="check-box"></span></td>' +
+      '<td><div class="t-name"><span class="t-name-icon">' + icIcon("history", 14) + '</span><span>' + r.name + '</span></div></td>' +
+      '<td><span class="pill pill-group">' + icIcon("group", 11.5) + '<span class="pill-text">' + r.group + '</span></span></td>' +
+      '<td><div class="t-ch"><span class="ch-icon ch-' + r.channel + '">' + icIcon(chIcon, 11) + '</span><span>' + r.channelLabel + '</span></div></td>' +
+      '<td class="t-num">' + r.events + '</td>' +
+      '<td class="t-num">' + r.contacts.toLocaleString() + '</td>' +
+      '<td><span class="status status-' + r.status + '"><span class="status-dot"></span>' + r.statusLabel + '</span></td>' +
+      '<td class="t-muted">' + r.updated + '</td>' +
+      '<td class="t-act"><div class="row-actions">' +
+        '<button class="icon-btn icon-btn-sm" title="Edit">' + icIcon("edit", 13) + '</button>' +
+        '<button class="icon-btn icon-btn-sm" title="Archive">' + icIcon("archive", 13) + '</button>' +
+        '<button class="icon-btn icon-btn-sm" title="More">' + icIcon("more", 13) + '</button>' +
+      '</div></td>' +
+    '</tr>';
+  }).join("");
+
+  // ─── spacing row ────────────────────────────────────────────────────
+  var spacing = document.getElementById("spacingRow");
+  [2, 4, 6, 8, 12, 16, 24, 32].forEach(function (n) {
+    var step = document.createElement("div");
+    step.className = "space-step";
+    step.innerHTML = '<div class="space-bar" style="width:' + n + 'px"></div>' +
+                     '<div class="space-label">' + n + '</div>';
+    spacing.appendChild(step);
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/static/styleguide/styleguide.html
+++ b/static/styleguide/styleguide.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/design-system.css">
   <link rel="stylesheet" href="styleguide.css">
+  <script src="../css/design-system.js"></script>
 </head>
 <body>
 
@@ -142,24 +143,30 @@
           <header class="sg-card-h">
             <div>
               <h3>Accent ramp</h3>
-              <p class="sg-card-sub">Generated from a single anchor <code class="sg-code">--accent</code> using OKLab mixing.</p>
+              <p class="sg-card-sub">Anchored at <strong>400 = primary</strong>; the ramp is derived outward via sRGB mixing. Pick a primary to re-theme the whole UI live.</p>
+            </div>
+            <div style="display:flex;align-items:center;gap:8px;">
+              <label for="primaryPicker" class="sg-code" style="cursor:pointer;">--primary</label>
+              <input id="primaryPicker" type="color" value="#6293C9"
+                     style="width:36px;height:28px;padding:0;border:1px solid var(--border);border-radius:var(--r-sm);cursor:pointer;background:transparent;">
+              <code id="primaryValue" class="sg-code" style="min-width:74px;">#6293C9</code>
             </div>
           </header>
           <div class="sg-card-body">
             <div class="ramp">
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 6%, white)"></div><div class="ramp-stop">50</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 12%, white)"></div><div class="ramp-stop">100</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 25%, white)"></div><div class="ramp-stop">200</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 45%, white)"></div><div class="ramp-stop">300</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 75%, white)"></div><div class="ramp-stop">400</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent)"></div><div class="ramp-stop">500</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 88%, black)"></div><div class="ramp-stop">600</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 75%, black)"></div><div class="ramp-stop">700</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 60%, black)"></div><div class="ramp-stop">800</div></div>
-              <div class="ramp-step"><div class="ramp-chip" style="background: color-mix(in oklab, var(--accent) 45%, black)"></div><div class="ramp-stop">900</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-50)"></div><div class="ramp-stop">50</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-100)"></div><div class="ramp-stop">100</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-200)"></div><div class="ramp-stop">200</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-300)"></div><div class="ramp-stop">300</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-400);box-shadow:inset 0 0 0 2px var(--surface), inset 0 0 0 3px var(--accent-700);"></div><div class="ramp-stop">400</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-500)"></div><div class="ramp-stop">500</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-600)"></div><div class="ramp-stop">600</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-700)"></div><div class="ramp-stop">700</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-800)"></div><div class="ramp-stop">800</div></div>
+              <div class="ramp-step"><div class="ramp-chip" style="background: var(--accent-900)"></div><div class="ramp-stop">900</div></div>
             </div>
             <div class="usage-row">
-              <div class="usage-tag">Buttons · 600/700</div>
+              <div class="usage-tag">Buttons · 500/600</div>
               <div class="usage-tag">Pills · 50/700</div>
               <div class="usage-tag">Active rail · 400</div>
               <div class="usage-tag">Selection · 50</div>
@@ -574,6 +581,17 @@
 
 <script>
 (function () {
+  // ─── primary color picker (re-themes ramp via design-system.js) ────
+  var picker = document.getElementById("primaryPicker");
+  var valueOut = document.getElementById("primaryValue");
+  if (picker && window.DesignSystem && window.DesignSystem.setPrimary) {
+    picker.addEventListener("input", function (e) {
+      var hex = e.target.value;
+      window.DesignSystem.setPrimary(hex);
+      if (valueOut) valueOut.textContent = hex.toUpperCase();
+    });
+  }
+
   // ─── section nav collapse ───────────────────────────────────────────
   var nav = document.getElementById("sectionNav");
   var btn = document.getElementById("snCollapse");

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -85,8 +85,8 @@ module.exports = {
             md: '768px',
         },
         fontFamily: {
-            sans: ['Roboto', 'sans-serif'],
-            alt: ['Roboto', 'sans-serif'],
+            sans: ['Inter', 'system-ui', '-apple-system', '"Segoe UI"', 'Roboto', 'sans-serif'],
+            alt: ['Inter', 'system-ui', '-apple-system', '"Segoe UI"', 'Roboto', 'sans-serif'],
             serif: [
                 'Georgia',
                 'Cambria',

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -535,7 +535,7 @@ class ContactField(TembaModel, DependencyMixin):
         return self.agent_access if self.org.get_user_role(user) == OrgRole.AGENT else self.ACCESS_EDIT
 
     def get_attrs(self):
-        return {"icon": "info" if self.is_proxy else "fields"}
+        return {"icon": "info" if self.is_proxy else "fields", "type": "field"}
 
     def release(self, user):
         assert not (self.is_system and self.org.is_active), "can't release system fields"
@@ -1454,7 +1454,7 @@ class ContactGroup(LegacyUUIDMixin, TembaModel, DependencyMixin):
         return "group_smart" if self.group_type == self.TYPE_SMART else "group"
 
     def get_attrs(self):
-        return {"icon": self.icon}
+        return {"icon": self.icon, "type": "group"}
 
     def update_query(self, query, reevaluate=True, parsed=None):
         """

--- a/temba/contacts/tests/test_group.py
+++ b/temba/contacts/tests/test_group.py
@@ -77,7 +77,7 @@ class ContactGroupTest(TembaTest):
         group.save(update_fields=("status",))
 
         # query groups should get their own icon
-        self.assertEqual(group.get_attrs(), {"icon": "group_smart"})
+        self.assertEqual(group.get_attrs(), {"icon": "group_smart", "type": "group"})
 
         # can't update query again while it is in this state
         with self.assertRaises(AssertionError):

--- a/temba/orgs/views/base.py
+++ b/temba/orgs/views/base.py
@@ -284,14 +284,24 @@ class BaseExportModal(ModalFormMixin, OrgPermsMixin, SmartFormView):
             ContactField.objects.none(),
             required=False,
             label=_("Fields"),
-            widget=SelectMultipleWidget(attrs={"placeholder": _("Optional: Fields to include"), "searchable": True}),
+            widget=SelectMultipleWidget(
+                attrs={
+                    "placeholder": _("Optional: Fields to include"),
+                    "searchable": True,
+                    "pill_type": "field",
+                }
+            ),
         )
         with_groups = forms.ModelMultipleChoiceField(
             ContactGroup.objects.none(),
             required=False,
             label=_("Groups"),
             widget=SelectMultipleWidget(
-                attrs={"placeholder": _("Optional: Group memberships to include"), "searchable": True}
+                attrs={
+                    "placeholder": _("Optional: Group memberships to include"),
+                    "searchable": True,
+                    "pill_type": "group",
+                }
             ),
         )
 

--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -38,7 +38,7 @@
     </thead>
     <tbody>
       {% for event in events %}
-        <tr onclick="goto(event, this)"
+        <tr
             href="{% url 'campaigns.campaignevent_read' event.campaign.uuid event.uuid %}"
             class="hover-linked">
           <td class="whitespace-nowrap">{{ event.relative_to.name }}</td>
@@ -49,7 +49,7 @@
                 <div class="text">{{ event.get_message.text }}</div>
               </div>
             {% else %}
-              <a href="{% url 'flows.flow_editor' event.flow.uuid %}" onclick="goto(event, this)">
+              <a href="{% url 'flows.flow_editor' event.flow.uuid %}">
                 <temba-label type="flow" primary clickable>
                   {{ event.flow.name }}
                 </temba-label>

--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -50,7 +50,7 @@
               </div>
             {% else %}
               <a href="{% url 'flows.flow_editor' event.flow.uuid %}" onclick="goto(event, this)">
-                <temba-label icon="flow" type="flow" clickable>
+                <temba-label icon="flow" type="flow" primary clickable>
                   {{ event.flow.name }}
                 </temba-label>
               </a>

--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -50,7 +50,7 @@
               </div>
             {% else %}
               <a href="{% url 'flows.flow_editor' event.flow.uuid %}" onclick="goto(event, this)">
-                <temba-label icon="flow" primary clickable>
+                <temba-label icon="flow" type="flow" clickable>
                   {{ event.flow.name }}
                 </temba-label>
               </a>

--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -50,7 +50,7 @@
               </div>
             {% else %}
               <a href="{% url 'flows.flow_editor' event.flow.uuid %}" onclick="goto(event, this)">
-                <temba-label icon="flow" type="flow" primary clickable>
+                <temba-label type="flow" primary clickable>
                   {{ event.flow.name }}
                 </temba-label>
               </a>

--- a/templates/flows/flow_list.html
+++ b/templates/flows/flow_list.html
@@ -69,7 +69,7 @@
               <div class="whitespace-no-break flex items-center ml-2 justify-end flex-wrap">
                 {% for label in object.labels.all %}
                   <a href="{% url 'flows.flow_filter' label.uuid %}" onclick="goto(event, this)">
-                    <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1 my-1">
+                    <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1">
                       {{ label.name }}
                     </temba-label>
                   </a>

--- a/templates/flows/flow_list.html
+++ b/templates/flows/flow_list.html
@@ -68,7 +68,7 @@
               </div>
               <div class="whitespace-no-break flex items-center ml-2 justify-end flex-wrap">
                 {% for label in object.labels.all %}
-                  <a href="{% url 'flows.flow_filter' label.uuid %}" onclick="goto(event, this)">
+                  <a href="{% url 'flows.flow_filter' label.uuid %}">
                     <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1">
                       {{ label.name }}
                     </temba-label>

--- a/templates/flows/flow_list.html
+++ b/templates/flows/flow_list.html
@@ -69,7 +69,7 @@
               <div class="whitespace-no-break flex items-center ml-2 justify-end flex-wrap">
                 {% for label in object.labels.all %}
                   <a href="{% url 'flows.flow_filter' label.uuid %}" onclick="goto(event, this)">
-                    <temba-label data-id="{{ label.id }}" icon="label" type="label" clickable class="mx-1 my-1">
+                    <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1 my-1">
                       {{ label.name }}
                     </temba-label>
                   </a>

--- a/templates/flows/flow_list.html
+++ b/templates/flows/flow_list.html
@@ -69,7 +69,7 @@
               <div class="whitespace-no-break flex items-center ml-2 justify-end flex-wrap">
                 {% for label in object.labels.all %}
                   <a href="{% url 'flows.flow_filter' label.uuid %}" onclick="goto(event, this)">
-                    <temba-label data-id="{{ label.id }}" icon="label" clickable class="mx-1 my-1">
+                    <temba-label data-id="{{ label.id }}" icon="label" type="label" clickable class="mx-1 my-1">
                       {{ label.name }}
                     </temba-label>
                   </a>

--- a/templates/flows/flowstart_list.html
+++ b/templates/flows/flowstart_list.html
@@ -18,11 +18,11 @@
           <th colspan="3">
             <div class="flex justify-end">
               <div class="flow-start-type-selector flex">
-                <div onclick="goto(event, this)"
+                <div
                      href="{% url 'flows.flowstart_list' %}"
                      class="{% if not filtered %}is-active{% endif %} linked mr-1">{% trans "All" %}</div>
                 |
-                <div onclick="goto(event, this)"
+                <div
                      href="{% url 'flows.flowstart_list' %}?type=manual"
                      class="{% if filtered %}is-active{% endif %} linked ml-1">{% trans "Manual" %}</div>
               </div>
@@ -35,7 +35,7 @@
           <tr style="{% if obj.is_starting %}border:none;{% endif %}">
             <td style="{% if obj.is_starting %}border:none;{% endif %}">
               {% if obj.flow.is_active %}
-                <a href="{% url 'flows.flow_editor' obj.flow.uuid %}" onclick="goto(event, this)">
+                <a href="{% url 'flows.flow_editor' obj.flow.uuid %}">
                   <temba-label type="flow" primary clickable>
                     {{ obj.flow.name }}
                   </temba-label>

--- a/templates/flows/flowstart_list.html
+++ b/templates/flows/flowstart_list.html
@@ -35,7 +35,11 @@
           <tr style="{% if obj.is_starting %}border:none;{% endif %}">
             <td style="{% if obj.is_starting %}border:none;{% endif %}">
               {% if obj.flow.is_active %}
-                <a href="{% url 'flows.flow_editor' obj.flow.uuid %}">{{ obj.flow.name }}</a>
+                <a href="{% url 'flows.flow_editor' obj.flow.uuid %}" onclick="goto(event, this)">
+                  <temba-label type="flow" primary clickable>
+                    {{ obj.flow.name }}
+                  </temba-label>
+                </a>
               {% else %}
                 {% trans "A deleted flow" %}
               {% endif %}

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -135,7 +135,7 @@
     {% endblock favico %}
     {% block styles %}
       <link rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Roboto+Mono:300|Roboto:200,300,400,500">
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
       {% compress css %}
         <link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}css/tailwind.css">
         <link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}css/temba-components.css">

--- a/templates/includes/exclusions.html
+++ b/templates/includes/exclusions.html
@@ -1,20 +1,20 @@
 {% load i18n %}
 
 {% if exclusions.in_a_flow %}
-  <div class="inline-flex items-center mt-0 mr-1 px-2 py-1 rounded" style="color: #aaa; font-size: 0.8em; border: 1px solid #ddd; background: #fff;">
-    <temba-icon name="filter" class="mr-1" style="--icon-color: #aaa;"></temba-icon>
+  <div class="exclusion-pill">
+    <temba-icon name="filter"></temba-icon>
     {% trans "Not in a flow" %}
   </div>
 {% endif %}
 {% if exclusions.started_previously %}
-  <div class="inline-flex items-center mt-0 mr-1 px-2 py-1 rounded" style="color: #aaa; font-size: 0.8em; border: 1px solid #ddd; background: #fff;">
-    <temba-icon name="filter" class="mr-1" style="--icon-color: #aaa;"></temba-icon>
+  <div class="exclusion-pill">
+    <temba-icon name="filter"></temba-icon>
     {% trans "No recent runs" %}
   </div>
 {% endif %}
 {% if exclusions.not_seen_since_days %}
-  <div class="inline-flex items-center mt-0 mr-1 px-2 py-1 rounded" style="color: #aaa; font-size: 0.8em; border: 1px solid #ddd; background: #fff;">
-    <temba-icon name="filter" class="mr-1" style="--icon-color: #aaa;"></temba-icon>
+  <div class="exclusion-pill">
+    <temba-icon name="filter"></temba-icon>
     {% if exclusions.not_seen_since_days == 365 %}
       {% blocktrans trimmed %}
         Active in the last year
@@ -26,3 +26,19 @@
     {% endif %}
   </div>
 {% endif %}
+
+<style>
+  .exclusion-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0 4px 4px 0;
+    padding: 2px 10px;
+    background: #fff;
+    border: 1px solid var(--color-borders);
+    border-radius: 999px;
+    color: var(--text-3);
+    font-size: 12.5px;
+    --icon-color: var(--text-3);
+  }
+</style>

--- a/templates/includes/exclusions.html
+++ b/templates/includes/exclusions.html
@@ -26,19 +26,3 @@
     {% endif %}
   </div>
 {% endif %}
-
-<style>
-  .exclusion-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin: 0 4px 4px 0;
-    padding: 2px 10px;
-    background: #fff;
-    border: 1px solid var(--color-borders);
-    border-radius: 999px;
-    color: var(--text-3);
-    font-size: 12.5px;
-    --icon-color: var(--text-3);
-  }
-</style>

--- a/templates/includes/recipients.html
+++ b/templates/includes/recipients.html
@@ -48,7 +48,7 @@
   </a>
 {% endif %}
 {% if node_uuid %}
-  <temba-label icon="flow" type="flow" class="mr-1 mb-1">
+  <temba-label type="flow" class="mr-1 mb-1">
     {% trans "to a flow node" %}
   </temba-label>
 {% endif %}

--- a/templates/includes/recipients.html
+++ b/templates/includes/recipients.html
@@ -42,13 +42,13 @@
 {% for urn in urns %}<div class="item urn lbl mr-1 mb-1">{{ urn|format_urn:user_org }}</div>{% endfor %}
 {% if query %}
   <a href="{% url 'contacts.contact_list' %}?search={{ query|urlencode }}" onclick="goto(event, this)">
-    <temba-label icon="search" class="mr-1 mb-1" clickable>
+    <temba-label icon="search" type="neutral" class="mr-1 mb-1" clickable>
       {{ query }}
     </temba-label>
   </a>
 {% endif %}
 {% if node_uuid %}
-  <temba-label icon="flow" class="mr-1 mb-1">
+  <temba-label icon="flow" type="flow" class="mr-1 mb-1">
     {% trans "to a flow node" %}
   </temba-label>
 {% endif %}

--- a/templates/includes/recipients.html
+++ b/templates/includes/recipients.html
@@ -41,7 +41,7 @@
 {% endwith %}
 {% for urn in urns %}<div class="item urn lbl mr-1 mb-1">{{ urn|format_urn:user_org }}</div>{% endfor %}
 {% if query %}
-  <a href="{% url 'contacts.contact_list' %}?search={{ query|urlencode }}" onclick="goto(event, this)">
+  <a href="{% url 'contacts.contact_list' %}?search={{ query|urlencode }}">
     <temba-label icon="search" type="neutral" class="mr-1 mb-1" clickable>
       {{ query }}
     </temba-label>

--- a/templates/includes/recipients_contact.html
+++ b/templates/includes/recipients_contact.html
@@ -2,10 +2,10 @@
 
 {% if contact.is_active %}
   {# djlint:off #}
-  <a href="{% url 'contacts.contact_read' contact.uuid %}" onclick="goto(event, this)"><temba-label icon="contact" type="contact" clickable class="mr-1 mb-1">{{ contact|name_or_urn:user_org }}</temba-label></a>
+  <a href="{% url 'contacts.contact_read' contact.uuid %}" onclick="goto(event, this)"><temba-label type="contact" clickable class="mr-1 mb-1">{{ contact|name_or_urn:user_org }}</temba-label></a>
   {# djlint:on #}
 {% else %}
-  <temba-label icon="contact" type="contact" clickable class="mr-1 mb-1">
+  <temba-label type="contact" clickable class="mr-1 mb-1">
     <div class="line-through">{% trans "Deleted" %}</div>
   </temba-label>
 {% endif %}

--- a/templates/includes/recipients_contact.html
+++ b/templates/includes/recipients_contact.html
@@ -2,10 +2,10 @@
 
 {% if contact.is_active %}
   {# djlint:off #}
-  <a href="{% url 'contacts.contact_read' contact.uuid %}" onclick="goto(event, this)"><temba-label icon="contact" clickable class="mr-1 mb-1">{{ contact|name_or_urn:user_org }}</temba-label></a>
+  <a href="{% url 'contacts.contact_read' contact.uuid %}" onclick="goto(event, this)"><temba-label icon="contact" type="contact" clickable class="mr-1 mb-1">{{ contact|name_or_urn:user_org }}</temba-label></a>
   {# djlint:on #}
 {% else %}
-  <temba-label icon="contact" clickable class="mr-1 mb-1">
+  <temba-label icon="contact" type="contact" clickable class="mr-1 mb-1">
     <div class="line-through">{% trans "Deleted" %}</div>
   </temba-label>
 {% endif %}

--- a/templates/includes/recipients_contact.html
+++ b/templates/includes/recipients_contact.html
@@ -2,7 +2,7 @@
 
 {% if contact.is_active %}
   {# djlint:off #}
-  <a href="{% url 'contacts.contact_read' contact.uuid %}" onclick="goto(event, this)"><temba-label type="contact" clickable class="mr-1 mb-1">{{ contact|name_or_urn:user_org }}</temba-label></a>
+  <a href="{% url 'contacts.contact_read' contact.uuid %}"><temba-label type="contact" clickable class="mr-1 mb-1">{{ contact|name_or_urn:user_org }}</temba-label></a>
   {# djlint:on #}
 {% else %}
   <temba-label type="contact" clickable class="mr-1 mb-1">

--- a/templates/includes/recipients_group.html
+++ b/templates/includes/recipients_group.html
@@ -1,3 +1,3 @@
 {# djlint:off #}
-<a href="{% url 'contacts.contact_group' group.uuid %}" onclick="goto(event, this)"><temba-label icon="group{% if groups_as_filters %}{% if exclusion %}_exclude{% else %}_include{% endif %}{% endif %}" clickable class="mr-1 mb-1">{{ group.name }}</temba-label></a>
+<a href="{% url 'contacts.contact_group' group.uuid %}" onclick="goto(event, this)"><temba-label icon="group{% if groups_as_filters %}{% if exclusion %}_exclude{% else %}_include{% endif %}{% endif %}" type="group" clickable class="mr-1 mb-1">{{ group.name }}</temba-label></a>
 {# djlint:on #}

--- a/templates/includes/recipients_group.html
+++ b/templates/includes/recipients_group.html
@@ -1,3 +1,3 @@
 {# djlint:off #}
-<a href="{% url 'contacts.contact_group' group.uuid %}" onclick="goto(event, this)"><temba-label icon="group{% if groups_as_filters %}{% if exclusion %}_exclude{% else %}_include{% endif %}{% endif %}" type="group" clickable class="mr-1 mb-1">{{ group.name }}</temba-label></a>
+<a href="{% url 'contacts.contact_group' group.uuid %}"><temba-label icon="group{% if groups_as_filters %}{% if exclusion %}_exclude{% else %}_include{% endif %}{% endif %}" type="group" clickable class="mr-1 mb-1">{{ group.name }}</temba-label></a>
 {# djlint:on #}

--- a/templates/msgs/broadcast_list.html
+++ b/templates/msgs/broadcast_list.html
@@ -19,6 +19,7 @@
           }
           var more = document.createElement('temba-label');
           more.className = 'mr-1 mb-1';
+          more.setAttribute('type', 'neutral');
           more.textContent = '+' + overflow + ' more';
           container.appendChild(more);
         }

--- a/templates/msgs/broadcast_scheduled.html
+++ b/templates/msgs/broadcast_scheduled.html
@@ -27,6 +27,7 @@
           }
           var more = document.createElement('temba-label');
           more.className = 'mr-1 mb-1';
+          more.setAttribute('type', 'neutral');
           more.textContent = '+' + overflow + ' more';
           container.appendChild(more);
         }

--- a/templates/msgs/msg_list.html
+++ b/templates/msgs/msg_list.html
@@ -70,7 +70,7 @@
                   {% if 'label' in actions %}
                     {% for label in object.labels.all %}
                       <a href="{% url 'msgs.msg_filter' label.uuid %}" onclick="goto(event, this)">
-                        <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1 my-1">
+                        <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1">
                           {{ label.name }}
                         </temba-label>
                       </a>
@@ -78,7 +78,7 @@
                   {% endif %}
                   {% if object.flow and object.flow.is_active %}
                     <a href="{% url 'flows.flow_editor' object.flow.uuid %}" onclick="goto(event, this)">
-                      <temba-label type="flow" primary clickable class="mx-1 my-1">
+                      <temba-label type="flow" primary clickable class="mx-1">
                         {{ object.flow.name }}
                       </temba-label>
                     </a>

--- a/templates/msgs/msg_list.html
+++ b/templates/msgs/msg_list.html
@@ -69,7 +69,7 @@
                 <div class="flex items-center flex-row">
                   {% if 'label' in actions %}
                     {% for label in object.labels.all %}
-                      <a href="{% url 'msgs.msg_filter' label.uuid %}" onclick="goto(event, this)">
+                      <a href="{% url 'msgs.msg_filter' label.uuid %}">
                         <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1">
                           {{ label.name }}
                         </temba-label>
@@ -77,7 +77,7 @@
                     {% endfor %}
                   {% endif %}
                   {% if object.flow and object.flow.is_active %}
-                    <a href="{% url 'flows.flow_editor' object.flow.uuid %}" onclick="goto(event, this)">
+                    <a href="{% url 'flows.flow_editor' object.flow.uuid %}">
                       <temba-label type="flow" primary clickable class="mx-1">
                         {{ object.flow.name }}
                       </temba-label>

--- a/templates/msgs/msg_list.html
+++ b/templates/msgs/msg_list.html
@@ -78,7 +78,7 @@
                   {% endif %}
                   {% if object.flow and object.flow.is_active %}
                     <a href="{% url 'flows.flow_editor' object.flow.uuid %}" onclick="goto(event, this)">
-                      <temba-label icon="flow" type="flow" clickable class="mx-1 my-1">
+                      <temba-label icon="flow" type="flow" primary clickable class="mx-1 my-1">
                         {{ object.flow.name }}
                       </temba-label>
                     </a>

--- a/templates/msgs/msg_list.html
+++ b/templates/msgs/msg_list.html
@@ -70,7 +70,7 @@
                   {% if 'label' in actions %}
                     {% for label in object.labels.all %}
                       <a href="{% url 'msgs.msg_filter' label.uuid %}" onclick="goto(event, this)">
-                        <temba-label data-id="{{ label.id }}" icon="label" type="label" clickable class="mx-1 my-1">
+                        <temba-label data-id="{{ label.id }}" type="label" clickable class="mx-1 my-1">
                           {{ label.name }}
                         </temba-label>
                       </a>
@@ -78,7 +78,7 @@
                   {% endif %}
                   {% if object.flow and object.flow.is_active %}
                     <a href="{% url 'flows.flow_editor' object.flow.uuid %}" onclick="goto(event, this)">
-                      <temba-label icon="flow" type="flow" primary clickable class="mx-1 my-1">
+                      <temba-label type="flow" primary clickable class="mx-1 my-1">
                         {{ object.flow.name }}
                       </temba-label>
                     </a>

--- a/templates/msgs/msg_list.html
+++ b/templates/msgs/msg_list.html
@@ -70,7 +70,7 @@
                   {% if 'label' in actions %}
                     {% for label in object.labels.all %}
                       <a href="{% url 'msgs.msg_filter' label.uuid %}" onclick="goto(event, this)">
-                        <temba-label data-id="{{ label.id }}" icon="label" clickable class="mx-1 my-1">
+                        <temba-label data-id="{{ label.id }}" icon="label" type="label" clickable class="mx-1 my-1">
                           {{ label.name }}
                         </temba-label>
                       </a>
@@ -78,7 +78,7 @@
                   {% endif %}
                   {% if object.flow and object.flow.is_active %}
                     <a href="{% url 'flows.flow_editor' object.flow.uuid %}" onclick="goto(event, this)">
-                      <temba-label icon="flow" primary clickable class="mx-1 my-1">
+                      <temba-label icon="flow" type="flow" clickable class="mx-1 my-1">
                         {{ object.flow.name }}
                       </temba-label>
                     </a>

--- a/templates/orgs/org_languages.html
+++ b/templates/orgs/org_languages.html
@@ -13,3 +13,9 @@
     {% endif %}
   {% endif %}
 {% endblock summary %}
+
+{% block form-buttons %}
+  <div class="form-actions mt-4">
+    <input type="submit" class="button-primary" value="{{ submit_button_name }}" />
+  </div>
+{% endblock form-buttons %}

--- a/templates/orgs/orgimport_create.html
+++ b/templates/orgs/orgimport_create.html
@@ -22,7 +22,7 @@
           </div>
           <div class="flex" id="real_button">
             <input type="text" id="file-field">
-            <div style="margin-top:-1px" class="block button-primary ml-4">{% trans "Choose File" %}</div>
+            <div class="button-primary ml-4">{% trans "Choose File" %}</div>
           </div>
         {% endblock fields %}
         <temba-alert level="warning" class="my-6">
@@ -40,44 +40,34 @@
 {% endblock content %}
 {% block extra-style %}
   <style type="text/css">
-    input {
-      padding: 9px;
-      cursor: pointer;
-      box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px, rgba(0, 0, 0, 0.04) 0px 3px 20px 0px, rgba(0, 0, 0, 0.02) 0px 1px 2px 0px;
-    }
-
     #file-upload {
       position: relative;
     }
 
-    #real-button {
-      position: absolute;
-      top: 0px;
-      left: 0px;
-      z-index: 1;
-      height: 35px;
-      width: 450px;
-    }
-
     #file-field {
       width: 300px;
-      height: 35px;
-      font-size: 16px;
-      margin-bottom: 0px;
-      border-radius: 5px;
+      height: 28px;
+      box-sizing: border-box;
+      padding: 0 10px;
+      font-size: 12.5px;
+      margin-bottom: 0;
+      border: 1px solid var(--border-strong);
+      border-radius: var(--r-sm);
+      box-shadow: none;
+      background: var(--surface);
+      cursor: pointer;
     }
 
     #file {
       position: absolute;
       width: 450px;
-      height: 35px;
-      top: 0px;
-      left: 0px;
+      height: 28px;
+      top: 0;
+      left: 0;
       text-align: right;
-      -moz-opacity: 0;
-      filter: alpha(opacity: 0);
       opacity: 0;
       z-index: 2;
+      cursor: pointer;
     }
   </style>
 {% endblock extra-style %}

--- a/templates/orgs/user_team.html
+++ b/templates/orgs/user_team.html
@@ -5,7 +5,7 @@
   {% if not team.all_topics %}
     <div class="mb-4">
       {% for topic in team_topics %}
-        <temba-label icon="topic" class="mx-1 my-1">
+        <temba-label icon="topic" type="topic" class="mx-1 my-1">
           {{ topic.name }}
         </temba-label>
       {% endfor %}

--- a/templates/request_logs/httplog_webhooks.html
+++ b/templates/request_logs/httplog_webhooks.html
@@ -18,7 +18,11 @@
         {% for obj in object_list %}
           <tr class="{% if obj.is_error %}warning{% endif %}">
             <td class="clickable">
-              <a href="{% url "flows.flow_editor" obj.flow.uuid %}" class="linked">{{ obj.flow.name }}</a>
+              <a href="{% url "flows.flow_editor" obj.flow.uuid %}" onclick="goto(event, this)">
+                <temba-label type="flow" primary clickable>
+                  {{ obj.flow.name }}
+                </temba-label>
+              </a>
             </td>
             <td class="clickable">
               <a href="{% url "request_logs.httplog_read" obj.id %}" class="linked">{{ obj.url|truncatechars:128 }}</a>

--- a/templates/request_logs/httplog_webhooks.html
+++ b/templates/request_logs/httplog_webhooks.html
@@ -18,7 +18,7 @@
         {% for obj in object_list %}
           <tr class="{% if obj.is_error %}warning{% endif %}">
             <td class="clickable">
-              <a href="{% url "flows.flow_editor" obj.flow.uuid %}" onclick="goto(event, this)">
+              <a href="{% url "flows.flow_editor" obj.flow.uuid %}">
                 <temba-label type="flow" primary clickable>
                   {{ obj.flow.name }}
                 </temba-label>

--- a/templates/templates/includes/translation.html
+++ b/templates/templates/includes/translation.html
@@ -30,12 +30,12 @@
   <div class="p-4">
     <div class="mb-2 whitespace-nowrap text-right">
       {# djlint:off #}
-      <a href="{% url 'channels.channel_read' translation.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ translation.channel.type.icon }}" clickable class="mr-1 mb-1">{{ translation.channel }}</temba-label></a>
+      <a href="{% url 'channels.channel_read' translation.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ translation.channel.type.icon }}" type="channel" clickable class="mr-1 mb-1">{{ translation.channel }}</temba-label></a>
       {# djlint:on #}
-      <temba-label icon="language">
+      <temba-label icon="language" type="neutral">
         {{ translation.locale }}
       </temba-label>
-      <temba-label icon="{{ status_icons|field:translation.status }}" class="ml-2">
+      <temba-label icon="{{ status_icons|field:translation.status }}" type="neutral" class="ml-2">
         {{ translation.get_status_display }}
       </temba-label>
     </div>

--- a/templates/templates/includes/translation.html
+++ b/templates/templates/includes/translation.html
@@ -30,7 +30,7 @@
   <div class="p-4">
     <div class="mb-2 whitespace-nowrap text-right">
       {# djlint:off #}
-      <a href="{% url 'channels.channel_read' translation.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ translation.channel.type.icon }}" type="channel" clickable class="mr-1 mb-1">{{ translation.channel }}</temba-label></a>
+      <a href="{% url 'channels.channel_read' translation.channel.uuid %}"><temba-label icon="{{ translation.channel.type.icon }}" type="channel" clickable class="mr-1 mb-1">{{ translation.channel }}</temba-label></a>
       {# djlint:on #}
       <temba-label icon="language" type="neutral">
         {{ translation.locale }}

--- a/templates/triggers/trigger_list.html
+++ b/templates/triggers/trigger_list.html
@@ -71,7 +71,7 @@
           <td>
             <div class="text-right">
               <a href="{% url 'flows.flow_editor' obj.flow.uuid %}" onclick="goto(event, this)">
-                <temba-label icon="flow" type="flow" primary clickable class="mx-1 my-1">
+                <temba-label type="flow" primary clickable class="mx-1 my-1">
                   {{ obj.flow.name }}
                 </temba-label>
               </a>

--- a/templates/triggers/trigger_list.html
+++ b/templates/triggers/trigger_list.html
@@ -57,10 +57,10 @@
                 </div>
               </div>
               {% if obj.channel or obj.contacts.all or obj.groups.all or obj.exclude_groups.all %}
-                <div class="text-sm mt-2">
+                <div class="text-sm mt-2 flex items-center flex-wrap">
                   {% if obj.channel %}
                     {# djlint:off #}
-                      <a href="{% url 'channels.channel_read' obj.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ obj.channel.type.icon }}" clickable class="mr-1 mb-1">{{ obj.channel }}</temba-label></a>
+                    <a href="{% url 'channels.channel_read' obj.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ obj.channel.type.icon }}" type="channel" clickable class="mr-1 mb-1">{{ obj.channel }}</temba-label></a>
                     {# djlint:on #}
                   {% endif %}
                   {% include "includes/recipients.html" with contacts=obj.contacts.all groups=obj.groups.all exclude_groups=obj.exclude_groups.all groups_as_filters=True %}
@@ -71,7 +71,7 @@
           <td>
             <div class="text-right">
               <a href="{% url 'flows.flow_editor' obj.flow.uuid %}" onclick="goto(event, this)">
-                <temba-label icon="flow" primary clickable class="mx-1 my-1">
+                <temba-label icon="flow" type="flow" clickable class="mx-1 my-1">
                   {{ obj.flow.name }}
                 </temba-label>
               </a>

--- a/templates/triggers/trigger_list.html
+++ b/templates/triggers/trigger_list.html
@@ -71,7 +71,7 @@
           <td>
             <div class="text-right">
               <a href="{% url 'flows.flow_editor' obj.flow.uuid %}" onclick="goto(event, this)">
-                <temba-label icon="flow" type="flow" clickable class="mx-1 my-1">
+                <temba-label icon="flow" type="flow" primary clickable class="mx-1 my-1">
                   {{ obj.flow.name }}
                 </temba-label>
               </a>

--- a/templates/triggers/trigger_list.html
+++ b/templates/triggers/trigger_list.html
@@ -60,7 +60,7 @@
                 <div class="text-sm mt-2 flex items-center flex-wrap">
                   {% if obj.channel %}
                     {# djlint:off #}
-                    <a href="{% url 'channels.channel_read' obj.channel.uuid %}" onclick="goto(event, this)"><temba-label icon="{{ obj.channel.type.icon }}" type="channel" clickable class="mr-1 mb-1">{{ obj.channel }}</temba-label></a>
+                    <a href="{% url 'channels.channel_read' obj.channel.uuid %}"><temba-label icon="{{ obj.channel.type.icon }}" type="channel" clickable class="mr-1 mb-1">{{ obj.channel }}</temba-label></a>
                     {# djlint:on #}
                   {% endif %}
                   {% include "includes/recipients.html" with contacts=obj.contacts.all groups=obj.groups.all exclude_groups=obj.exclude_groups.all groups_as_filters=True %}
@@ -70,7 +70,7 @@
           </td>
           <td>
             <div class="text-right">
-              <a href="{% url 'flows.flow_editor' obj.flow.uuid %}" onclick="goto(event, this)">
+              <a href="{% url 'flows.flow_editor' obj.flow.uuid %}">
                 <temba-label type="flow" primary clickable class="mx-1 my-1">
                   {{ obj.flow.name }}
                 </temba-label>


### PR DESCRIPTION
## Summary

Introduces a new TextIt design system as a token-driven foundation: a single accent ramp + neutrals + status palette + type scale, applied to the live app chrome and to entity tagging across templates. The system mostly lives in CSS custom properties so it can be re-themed from a host page by setting `--primary-rgb`.

## Changes

### Design system
- **`static/css/design-system.css`** — new stylesheet defining the full token set (accent ramp 50–900, neutrals, status, type, shape, density, shadows) plus reusable component classes (chrome, buttons, pills, status, tables, forms, modals) scoped under `.ds`.
- **`static/css/design-system.js`** — runtime ramp that reads `--primary-rgb` and writes the full `--accent-50…900` set onto `:root`. Mirrors the CSS `color-mix()` fallback so both paths produce the same colors. Exposes `window.DesignSystem.setPrimary(hex)` for live re-theming.
- **`static/styleguide/`** — standalone, dev-internal style guide (`styleguide.html` + `styleguide.css`). Plain HTML/JS — no React, no server dependency. Open directly in a browser.

### Live app wiring
- **`templates/frame.html`** — swap Google Fonts Roboto for Inter / JetBrains Mono.
- **`static/css/temba-components.css`** — refactored to derive everything from `--primary-rgb` and the new accent ramp; legacy aliases preserved for callers that still reference `--color-primary-dark` etc.
- **`static/css/frame.css`** — owns the single source of truth for `temba-button` styling and the new `.exclusion-pill` utility.
- **`static/css/tailwind.css`** / **`tailwind.config.js`** — regenerated against the new font tokens.

### `temba-label` entity tagging
Adds a `type` attribute to `<temba-label>` usages across templates so the component can pick styling per entity kind once `@nyaruka/temba-components` learns to read it:

| Element | Type values used |
|---|---|
| Flows | `type="flow"` (kept `primary` attr alongside so live UI doesn't regress) |
| Groups, contacts, fields, labels | `type="group"`, `"contact"`, `"field"`, `"label"` |
| Channels | `type="channel"` |
| Topics (org user team) | `type="topic"` |
| Language / status / overflow chips | `type="neutral"` |

`ContactField.get_attrs()` and `ContactGroup.get_attrs()` also expose `"type"` so form options carry it through `TembaChoiceIterator`.

### Template polish (drive-by)
- **`templates/includes/exclusions.html`** — pulled the inline `<style>` block out; partial is now markup-only.
- **`templates/orgs/orgimport_create.html`** — file-input field cleanup.
- **`templates/orgs/org_languages.html`** — added `form-buttons` block.
- **`templates/flows/flowstart_list.html`**, **`templates/request_logs/httplog_webhooks.html`** — wrap flow links in `<temba-label type="flow" primary>` for consistency with other CRUDLs.

## Test plan

- [x] `ruff format --check temba` clean
- [x] `temba/contacts/tests/test_group.py` updated for new `get_attrs()` shape; CI Test job passes
- [x] Style guide renders correctly when opened as a static file
- [x] Live app chrome (frame + buttons + labels) still renders against the refreshed `temba-components.css` and `frame.css`