### PR TITLE
Fix list-view UI nits across messages, login, and clickable pills

### DIFF
--- a/static/css/frame.css
+++ b/static/css/frame.css
@@ -24,6 +24,7 @@ body {
 /* inline attachment pills */
 .attachment {
   display: flex;
+  align-items: center;
   margin-right: 5px;
   font-size: 0;
   white-space: nowrap;
@@ -34,6 +35,7 @@ body {
   border: 0;
   color: #777;
   display: flex;
+  align-items: center;
   font-size: 12px;
   height: 18px;
   padding: 3px 8px;
@@ -45,8 +47,10 @@ body {
   background-color: #e0e0e0;
   border: 0;
   color: #666;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   font-size: 12px;
+  height: 18px;
   padding: 3px;
 }
 

--- a/templates/allauth/elements/field.html
+++ b/templates/allauth/elements/field.html
@@ -14,13 +14,7 @@
               {% if attrs.name %}name="{{ attrs.name }}"{% endif %}
               {% if attrs.id %}id="{{ attrs.id }}"{% endif %}
               {% if attrs.placeholder %}placeholder="{{ attrs.placeholder }}"{% endif %}>{% slot value %}{% endslot %}</textarea>
-  {% else %}
-    {% if attrs.type != "checkbox" and attrs.type != "radio" and attrs.type != "hidden" %}
-      <label for="{{ attrs.id }}">
-        {% slot label %}
-        {% endslot %}
-      </label>
-    {% endif %}
+  {% elif attrs.type == "checkbox" or attrs.type == "radio" or attrs.type == "hidden" %}
     <input {% if attrs.required %}required{% endif %}
            {% if attrs.disabled %}disabled{% endif %}
            {% if attrs.readonly %}readonly{% endif %}
@@ -37,6 +31,21 @@
         {% endslot %}
       </label>
     {% endif %}
+  {% else %}
+    <label for="{{ attrs.id }}">
+      {% slot label %}
+      {% endslot %}
+    </label>
+    <temba-textinput {% if attrs.required %}required{% endif %}
+                     {% if attrs.disabled %}disabled{% endif %}
+                     {% if attrs.readonly %}readonly{% endif %}
+                     {% if attrs.name %}name="{{ attrs.name }}"{% endif %}
+                     {% if attrs.id %}id="{{ attrs.id }}"{% endif %}
+                     {% if attrs.placeholder %}placeholder="{{ attrs.placeholder }}"{% endif %}
+                     {% if attrs.autocomplete %}autocomplete="{{ attrs.autocomplete }}"{% endif %}
+                     {% if attrs.value is not None %}value="{{ attrs.value }}"{% endif %}
+                     {% if attrs.type == "password" %}password="true"{% else %}type="{{ attrs.type }}"{% endif %}>
+    </temba-textinput>
   {% endif %}
   {% if slots.help_text %}
     <div class="help-text">

--- a/templates/flows/flow_list.html
+++ b/templates/flows/flow_list.html
@@ -99,7 +99,7 @@
   {{ block.super }}
   <script type="text/javascript">
     function handleRowClicked(event) {
-      if (event.target.tagName == "A" || event.target.tagName == "BUTTON") {
+      if (event.target.closest("a") || event.target.tagName == "BUTTON") {
         return;
       }
 

--- a/templates/msgs/msg_list.html
+++ b/templates/msgs/msg_list.html
@@ -123,9 +123,11 @@
         return;
       }
 
-      var row = event.target.closest("tr");
-      var uuid = row.getAttribute("data-sender-uuid");
+      if (event.target.closest("a")) {
+        return;
+      }
 
+      var row = event.target.closest("tr");
       goto(event, row);
     }
 

--- a/templates/msgs/tags/attachment.html
+++ b/templates/msgs/tags/attachment.html
@@ -49,11 +49,9 @@
 </div>
 {% endif %}
 {% if category != 'geo' and not thumb %}
-  <div>
-    <a href="{{ url }}" download="true" class="flex-grow attachment-download rounded-l-none button-light">
-      <temba-icon name="download" onclick="downloadFile(event, '{{ url }}')">
-      </temba-icon>
-    </a>
-  </div>
+  <a href="{{ url }}" download="true" class="attachment-download rounded-l-none button-light">
+    <temba-icon name="download" onclick="downloadFile(event, '{{ url }}')">
+    </temba-icon>
+  </a>
 {% endif %}
 </div>

--- a/templates/orgs/login/login.html
+++ b/templates/orgs/login/login.html
@@ -14,16 +14,16 @@
       {% if field == '__all__' %}<div class="alert alert-error my-4">{{ errors }}</div>{% endif %}
     {% endfor %}
     <div class="mt-4">
-      <input type="text"
-             name="username"
-             maxlength="254"
-             placeholder="{{ _("Email Address") |escapejs }}"
-             value="{% if form.username.value %}{{ form.username.value|escape }}{% endif %}"
-             class="input">
+      <temba-textinput name="username"
+                       maxlength="254"
+                       placeholder="{{ _("Email Address") |escape }}"
+                       value="{% if form.username.value %}{{ form.username.value|escape }}{% endif %}">
+      </temba-textinput>
     </div>
     {% if form.username.errors %}<div class="alert alert-error mt-4">{{ form.username.errors }}</div>{% endif %}
     <div class="mt-4">
-      <input type="password" name="password" placeholder="{{ _("Password") |escapejs }}" class="input">
+      <temba-textinput name="password" placeholder="{{ _("Password") |escape }}" password="true">
+      </temba-textinput>
     </div>
     {% if form.password.errors %}<div class="alert alert-error mt-4">{{ form.password.errors }}</div>{% endif %}
     <div class="mt-2 text-right">

--- a/templates/orgs/login/two_factor_verify.html
+++ b/templates/orgs/login/two_factor_verify.html
@@ -14,7 +14,8 @@
   <form method="post">
     {% csrf_token %}
     <div class="mt-4">
-      <input name="otp" maxlength="6" placeholder="{{ _("6-digit code") |escape }}" class="input">
+      <temba-textinput name="otp" maxlength="6" placeholder="{{ _("6-digit code") |escape }}">
+      </temba-textinput>
     </div>
     {% if form.otp.errors %}<div class="alert alert-error mt-4">{{ form.otp.errors }}</div>{% endif %}
     <div class="mt-2 text-right">

--- a/templates/triggers/trigger_list.html
+++ b/templates/triggers/trigger_list.html
@@ -106,6 +106,10 @@
         return;
       }
 
+      if (event.target.closest("a")) {
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
       var modal = document.querySelector("#update-trigger");


### PR DESCRIPTION
## Summary
- Align the inline attachment download chip with its preview chip in the message list so they look like one joined pill.
- Standardize login, signup, and 2FA verify inputs on `<temba-textinput>` (via `templates/allauth/elements/field.html` and the legacy `orgs/login` templates) so they match the rest of the app.
- Stop the row `onclick` from swallowing clicks on label/flow/channel/group pills in the message, flow, and trigger list pages — those clicks now navigate via the link's own href.

## Test plan
- [ ] Inbox/Flow/Archive message lists: attachment chips render as one aligned pill; clicking a label or flow pill navigates to that label/flow.
- [ ] Flow list: clicking a label pill on a row navigates to the label filter, not the flow editor.
- [ ] Trigger list: clicking a channel, group, or flow pill navigates correctly instead of opening the trigger update modal.
- [ ] Login, signup, 2FA verify, and confirm-access pages render inputs in the temba-textinput style.