### PR TITLE
Tidy contact and ticket detail layouts

### DIFF
--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -12,24 +12,22 @@
               collapses="true"
               class="flex-grow -mt-2">
     <temba-tab class="chat" icon="message" name="{{ _("Chat") |escapejs }}">
-      <div style="border-top-right-radius: var(--curvature);" class="flex flex-grow flex-col overflow-y-auto">
-        <temba-contact-chat contact="{{ object.uuid }}"
-                            monitor="true"
-                            avatar="{{ branding.logos.avatar }}"
-                            {% if object.last_seen_on %}showSearch{% endif %}
-                            {% if org_perms.contacts.contact_interrupt %}showInterrupt{% endif %}
-                            {% if org_perms.channels.channel_logs or request.user.is_staff %}showMessageLogsAfter="{{ msg_logs_after }}"{% endif %}
-                            -temba-interrupt="handleInterruptContact">
-        </temba-contact-chat>
-      </div>
+      <temba-contact-chat contact="{{ object.uuid }}"
+                          monitor="true"
+                          avatar="{{ branding.logos.avatar }}"
+                          {% if object.last_seen_on %}showSearch{% endif %}
+                          {% if org_perms.contacts.contact_interrupt %}showInterrupt{% endif %}
+                          {% if org_perms.channels.channel_logs or request.user.is_staff %}showMessageLogsAfter="{{ msg_logs_after }}"{% endif %}
+                          -temba-interrupt="handleInterruptContact">
+      </temba-contact-chat>
     </temba-tab>
     <temba-tab icon="info" name="{{ _("Details") |escapejs }}">
-      <temba-contact-details contact="{{ object.uuid }}" class="p-4 overflow-y-auto">
+      <temba-contact-details contact="{{ object.uuid }}" class="py-4 px-1 overflow-y-auto">
       </temba-contact-details>
     </temba-tab>
     <temba-tab icon="fields" name="{{ _("Fields") |escapejs }}">
       <div style="border-top-right-radius: var(--curvature)"
-           class="flex flex-grow flex-col p-4 overflow-y-auto">
+           class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
         <temba-contact-fields timezone="{{ object.org.timezone }}"
                               contact="{{ object.uuid }}"
                               -temba-button-clicked="handleFieldSearch">
@@ -44,17 +42,12 @@
     </temba-tab>
     <temba-tab icon="campaign" name="{{ _("Next Up") |escapejs }}" hideEmpty hidden>
       <div style="border-top-right-radius: var(--curvature)"
-           class="flex flex-grow flex-col p-4 overflow-y-auto">
+           class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
         <temba-contact-pending contact="{{ object.uuid }}" -temba-selection="handlePendingClicked">
         </temba-contact-pending>
       </div>
     </temba-tab>
-    <temba-tab icon="notes"
-               name="{{ _("Notepad") }}"
-               activity
-               activityColor="#ffbd00"
-               selectionBackground="#fff9c2"
-               borderColor="#ebdf6f">
+    <temba-tab icon="notes" name="{{ _("Notepad") }}" activity>
       <temba-contact-notepad contact="{{ object.uuid }}">
       </temba-contact-notepad>
     </temba-tab>

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -11,7 +11,7 @@
               index="{{ request.GET.tab }}"
               collapses="true"
               class="flex-grow -mt-2">
-    <temba-tab class="chat" icon="message" name="{{ _("Chat") |escapejs }}">
+    <temba-tab icon="message" name="{{ _("Chat") |escapejs }}">
       <temba-contact-chat contact="{{ object.uuid }}"
                           monitor="true"
                           avatar="{{ branding.logos.avatar }}"

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -701,7 +701,7 @@
           </temba-tab>
           <temba-tab icon="fields" name="{{ _("Fields") |escapejs }}">
             <div style="border-top-right-radius: var(--curvature)"
-                 class="flex flex-grow flex-col p-4 overflow-y-auto">
+                 class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
               <temba-contact-fields timezone="{{ object.org.timezone }}"
                                     -temba-button-clicked="handleFieldSearch"
                                     role="{{ request.role.code }}">

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -686,20 +686,18 @@
                     collapses="true"
                     class="flex-grow hidden">
           <temba-tab icon="message" name="{{ _("Chat") |escapejs }}">
-            <div style="border-top-right-radius: var(--curvature);" class="flex flex-grow flex-col overflow-y-auto">
-              <temba-contact-chat agent="{{ request.user.email }}"
-                                  style="opacity: 0"
-                                  monitor="true"
-                                  -temba-ticket-updated="handleTicketUpdated"
-                                  -temba-message-sent="handleMessageSent"
-                                  -temba-interrupt="handleInterruptContact"
-                                  {% if org_perms.contacts.contact_interrupt %}showInterrupt{% endif %}
-                                  {% if org_perms.channels.channel_logs or request.user.is_staff %}showMessageLogsAfter="{{ msg_logs_after }}"{% endif %}
-                                  {% if not can_assign %}disableAssign{% endif %}
-                                  {% if not can_reply_non_own %}disableReply{% endif %}
-                                  avatar="{{ branding.logos.avatar }}">
-              </temba-contact-chat>
-            </div>
+            <temba-contact-chat agent="{{ request.user.email }}"
+                                style="opacity: 0"
+                                monitor="true"
+                                -temba-ticket-updated="handleTicketUpdated"
+                                -temba-message-sent="handleMessageSent"
+                                -temba-interrupt="handleInterruptContact"
+                                {% if org_perms.contacts.contact_interrupt %}showInterrupt{% endif %}
+                                {% if org_perms.channels.channel_logs or request.user.is_staff %}showMessageLogsAfter="{{ msg_logs_after }}"{% endif %}
+                                {% if not can_assign %}disableAssign{% endif %}
+                                {% if not can_reply_non_own %}disableReply{% endif %}
+                                avatar="{{ branding.logos.avatar }}">
+            </temba-contact-chat>
           </temba-tab>
           <temba-tab icon="fields" name="{{ _("Fields") |escapejs }}">
             <div style="border-top-right-radius: var(--curvature)"
@@ -713,12 +711,7 @@
               </temba-contact-fields>
             </div>
           </temba-tab>
-          <temba-tab icon="notes"
-                     name="{{ _("Notepad") }}"
-                     activity
-                     activityColor="#ffbd00"
-                     selectionBackground="#fff9c2"
-                     borderColor="#ebdf6f">
+          <temba-tab icon="notes" name="{{ _("Notepad") }}" activity>
             <temba-contact-notepad contact="{{ object.uuid }}">
             </temba-contact-notepad>
           </temba-tab>


### PR DESCRIPTION
## Summary

Simplifies the tab layouts in the contact read view and the ticket detail pane: drops unnecessary wrapper `<div>`s around `<temba-contact-chat>`, aligns padding across the inner tab wrappers (`p-4` → `py-4 px-1`), and removes Notepad tab attribute overrides that are now defaults in `temba-components`.

## Changes

- `templates/contacts/contact_read.html`
  - Removed the wrapper `<div>` (with `border-top-right-radius` inline style and `flex flex-grow flex-col overflow-y-auto` classes) around `<temba-contact-chat>`; the component handles its own scroll/sizing.
  - Updated `<temba-contact-details>` and the Fields / Next Up tab wrappers from `p-4` to `py-4 px-1`.
  - Dropped the stale `class="chat"` on the Chat `<temba-tab>` (no remaining references).
  - Removed `activityColor`, `selectionBackground`, and `borderColor` overrides from the Notepad `<temba-tab>` (now defaults in `temba-components`).
- `templates/tickets/ticket_list.html`
  - Same wrapper removal around `<temba-contact-chat>`.
  - Updated the Fields tab wrapper from `p-4` to `py-4 px-1` to match the contact view.
  - Same Notepad attribute cleanup.

## Review notes

Pre-PR review caught one substantive inconsistency and one bit of dead markup:

- **Fields tab padding inconsistency** (🟡 Medium) — the ticket-side Fields tab kept `p-4` while the contact view moved to `py-4 px-1`. Fixed: both now use the new padding.
- **Stale `class="chat"`** (💡 Suggestion) — leftover from the now-removed wrapper. Confirmed no consumers in templates, static CSS, or the `temba-tab` component, then removed.
- A non-blocking observation about wrapper consolidation (the Chat tab dropped its wrapper but Fields/Next-Up still wrap their components) was noted but left as-is — needs component-author confirmation and is out of scope for this UI cleanup.

## Test plan

- [ ] Open a contact detail page; verify Chat tab renders/scrolls correctly and inherits the rounded-corner treatment from the component.
- [ ] Verify Details, Fields, and Next Up tabs render with the new horizontal padding.
- [ ] Open the ticket list view; verify the agent Chat tab and Fields tab render correctly and match the contact view's padding.
- [ ] Confirm the Notepad tab activity indicator still uses the expected yellow theming (now from component defaults).