### PR TITLE
Update @nyaruka/temba-components to 0.158.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .envrc
 .devcontainer
 .direnv
+orca
+orca.yaml
 .commit
 .ruff_cache
 .vscode/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.157.1",
+    "@nyaruka/temba-components": "0.158.0",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nyaruka/temba-components@0.157.1":
-  version "0.157.1"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.157.1.tgz#46b894fc59bd4e049d805ee63f18818bb50c9be4"
-  integrity sha512-KKZjXSHiVFCo3qRP/xsWWC24tj9mS8+CJSmaHfKzEJU1u0TiL5Q5M8rm2M/8SubFM7N66TtUDlcMNRf9Z69YBQ==
+"@nyaruka/temba-components@0.158.0":
+  version "0.158.0"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.158.0.tgz#9bef6935158a1bf02a6406eaa6d98664ac712464"
+  integrity sha512-xtrdcAHfLw0RniIxpEJx39R1hmavm+PtC9K3RvaVbwpZNoKmxas50YbP0vJCIRTuoHGsXrUml9DG7MVisHjwSw==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.158.0](https://github.com/nyaruka/temba-components/compare/v0.157.1...v0.158.0)

- Adopt design system across contact panel, tabs, and field editor [#1011](https://github.com/nyaruka/temba-components/pull/1011)
- Stop pill clicks inside CanvasNodes from also opening the action editor [#1014](https://github.com/nyaruka/temba-components/pull/1014)
- Add orca setup hook for worktree initialization [#1013](https://github.com/nyaruka/temba-components/pull/1013)
- Show language names instead of codes in chat history events [#1010](https://github.com/nyaruka/temba-components/pull/1010)