### PR TITLE
Reorder webhook log columns to put URL first

### DIFF
--- a/templates/request_logs/httplog_webhooks.html
+++ b/templates/request_logs/httplog_webhooks.html
@@ -7,23 +7,16 @@
     <table class="list lined header scrolled" style="100%">
       <thead>
         <tr>
-          <th>{% trans "Flow" %}</th>
           <th>{% trans "URL" %}</th>
           <th style="width:100px;">{% trans "Status" %}</th>
           <th style="width:100px;">{% trans "Elapsed" %}</th>
+          <th>{% trans "Flow" %}</th>
           <th style="width:100px;" class="text-right">{% trans "Time" %}</th>
         </tr>
       </thead>
       <tbody>
         {% for obj in object_list %}
           <tr class="{% if obj.is_error %}warning{% endif %}">
-            <td class="clickable">
-              <a href="{% url "flows.flow_editor" obj.flow.uuid %}">
-                <temba-label type="flow" primary clickable>
-                  {{ obj.flow.name }}
-                </temba-label>
-              </a>
-            </td>
             <td class="clickable">
               <a href="{% url "request_logs.httplog_read" obj.id %}" class="linked">{{ obj.url|truncatechars:128 }}</a>
             </td>
@@ -36,6 +29,13 @@
               {% else %}
                 {{ "--" }}
               {% endif %}
+            </td>
+            <td class="clickable">
+              <a href="{% url "flows.flow_editor" obj.flow.uuid %}">
+                <temba-label type="flow" primary clickable>
+                  {{ obj.flow.name }}
+                </temba-label>
+              </a>
             </td>
             <td class="text-right whitespace-nowrap">{{ obj.created_on|datetime }}</td>
           </tr>


### PR DESCRIPTION
On the `/httplog/webhooks/` page, reorder the columns so the URL is the primary identifier and Flow is demoted to fourth.

New column order: **URL, Status, Elapsed, Flow, Time** (previously: Flow, URL, Status, Elapsed, Time).