### PR TITLE
Fix campaign read row navigation and render field as pill

### DIFF
--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -38,10 +38,14 @@
     </thead>
     <tbody>
       {% for event in events %}
-        <tr onclick="goto(event, this)"
+        <tr onclick="handleRowClicked(event)"
             href="{% url 'campaigns.campaignevent_read' event.campaign.uuid event.uuid %}"
             class="hover-linked">
-          <td class="whitespace-nowrap">{{ event.relative_to.name }}</td>
+          <td class="whitespace-nowrap">
+            <a href="{% url 'contacts.contactfield_list' %}">
+              <temba-label type="field" clickable>{{ event.relative_to.name }}</temba-label>
+            </a>
+          </td>
           <td class="whitespace-nowrap">{{ event.offset_display }}</td>
           <td class="w-full">
             {% if event.event_type == 'M' %}
@@ -72,3 +76,14 @@
     </tbody>
   </table>
 {% endblock content %}
+{% block extra-script %}
+  {{ block.super }}
+  <script type="text/javascript">
+    function handleRowClicked(event) {
+      if (event.target.closest("a")) {
+        return;
+      }
+      goto(event, event.target.closest("tr"));
+    }
+  </script>
+{% endblock extra-script %}

--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -38,7 +38,7 @@
     </thead>
     <tbody>
       {% for event in events %}
-        <tr
+        <tr onclick="goto(event, this)"
             href="{% url 'campaigns.campaignevent_read' event.campaign.uuid event.uuid %}"
             class="hover-linked">
           <td class="whitespace-nowrap">{{ event.relative_to.name }}</td>

--- a/templates/flows/flowstart_list.html
+++ b/templates/flows/flowstart_list.html
@@ -18,11 +18,11 @@
           <th colspan="3">
             <div class="flex justify-end">
               <div class="flow-start-type-selector flex">
-                <div
+                <div onclick="goto(event, this)"
                      href="{% url 'flows.flowstart_list' %}"
                      class="{% if not filtered %}is-active{% endif %} linked mr-1">{% trans "All" %}</div>
                 |
-                <div
+                <div onclick="goto(event, this)"
                      href="{% url 'flows.flowstart_list' %}?type=manual"
                      class="{% if filtered %}is-active{% endif %} linked ml-1">{% trans "Manual" %}</div>
               </div>


### PR DESCRIPTION
## Summary
Commit 971ad8e dropped `onclick="goto(event, this)"` from several templates assuming the new SPA click handler in [frame.js](static/js/frame.js) covered them, but that handler only fires on `<a>` elements. Anything else that relied on `goto` reading its own `href` silently stopped navigating.

Changes:
- **Campaign read** — Switch the event row to the `handleRowClicked` helper used in [msg_list.html](templates/msgs/msg_list.html). Clicks on the inner field / flow anchor pills bubble to the general SPA click handler (so each pill navigates to its own page), while bare row clicks call `goto` and open the campaign event read page. Also renders `event.relative_to` as a `temba-label type="field"` design-system pill linking to the contact fields list.
- **Flow start list** — Restore `onclick="goto(event, this)"` on the "All" / "Manual" `<div>` filter buttons.

The remaining `<a>`-tag changes in 971ad8e were correctly handled by the general SPA click handler and stay as-is.

## Test plan
- [ ] On the campaign read page, click the field pill and confirm it opens the contact fields list.
- [ ] Click the flow pill and confirm it opens the flow editor.
- [ ] Click anywhere else on the event row and confirm it opens the campaign event read page.
- [ ] On the flow start list page, click the "All" and "Manual" filter chips and confirm they filter.