### PR TITLE
Swap order of When and Field columns on campaign read page

### DIFF
--- a/templates/campaigns/campaign_read.html
+++ b/templates/campaigns/campaign_read.html
@@ -30,8 +30,8 @@
   <table class="list lined">
     <thead>
       <tr>
-        <th>{% trans "Field" %}</th>
         <th>{% trans "When" %}</th>
+        <th>{% trans "Field" %}</th>
         <th></th>
         <th>{% trans "Contacts" %}</th>
       </tr>
@@ -41,12 +41,12 @@
         <tr onclick="handleRowClicked(event)"
             href="{% url 'campaigns.campaignevent_read' event.campaign.uuid event.uuid %}"
             class="hover-linked">
+          <td class="whitespace-nowrap">{{ event.offset_display }}</td>
           <td class="whitespace-nowrap">
             <a href="{% url 'contacts.contactfield_list' %}">
               <temba-label type="field" clickable>{{ event.relative_to.name }}</temba-label>
             </a>
           </td>
-          <td class="whitespace-nowrap">{{ event.offset_display }}</td>
           <td class="w-full">
             {% if event.event_type == 'M' %}
               <div class="message">


### PR DESCRIPTION
## Summary
- Put the offset/when column first and the field pill second on the campaign read page event list.

## Test plan
- [ ] Open a campaign read page and confirm the table header reads "When | Field | … | Contacts" and the rows match.