### PR TITLE
Add new cookie-gated message list backed by internal messages API

### DIFF
--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -16,8 +16,8 @@
 
      If JS isn't loaded, the CSS fallback color-mix definitions below
      still produce the same ramp from --primary-rgb. */
-  --primary:     #6293C9;
-  --primary-rgb: 98, 147, 201;
+  --primary:     #497FCE;
+  --primary-rgb: 73, 127, 206;
 
   /* accent ramp — derived from --primary-rgb via sRGB mixing.
      400 == primary; the ramp computes outward in both directions. */
@@ -36,9 +36,11 @@
   /* neutrals */
   --bg:            #F6F7F9;
   --surface:       #FFFFFF;
+  --surface-note:  #FFF9C2;
   --sunken:        #F1F3F5;
   --border:        #E6E8EC;
   --border-strong: #D2D6DC;
+  --border-note:   #EBDF6F;
   --text-1:        #1A1F26;   /* primary copy */
   --text-2:        #4D5664;   /* secondary */
   --text-3:        #7B8593;   /* tertiary, captions */
@@ -76,9 +78,10 @@
   --r-lg:   12px;
 
   /* density */
-  --row-h:  36px;
-  --pad:    10px;
-  --gap:    14px;
+  --row-h:   36px;
+  --input-h: 34px;
+  --pad:     10px;
+  --gap:     14px;
 
   /* shadows */
   --shadow-1: 0 1px 1px rgba(15, 22, 36, 0.04), 0 1px 2px rgba(15, 22, 36, 0.04);

--- a/static/css/temba-components.css
+++ b/static/css/temba-components.css
@@ -7,83 +7,15 @@
   html {
 
     /* ─── TextIt Design System tokens ─────────────────────────────────────
-       Single source of truth. Cascades through Shadow DOM into every
-       component. Legacy tokens below are aliased to these — keep both in
-       sync if the design system evolves. */
+       Owned by /static/css/design-system.css — load that alongside this
+       file (frame.html does, and so does the styleguide).
+       --primary-rgb, --accent / --accent-50..900, the neutrals, status,
+       type, shape, density and shadow tokens all live there now; the
+       legacy aliases below reference them by name. */
 
-    /* accent ramp — the primary color sits at 400 and the ramp is
-       derived from it in both directions via sRGB mixing.
-       The anchor reads from --primary-rgb so host pages can re-theme
-       the entire ramp by setting e.g. --primary-rgb: 112, 0, 132. */
-    --accent:      rgb(var(--primary-rgb));
-    --accent-50:   color-mix(in srgb, var(--accent) 6%,  white);
-    --accent-100:  color-mix(in srgb, var(--accent) 16%, white);
-    --accent-200:  color-mix(in srgb, var(--accent) 32%, white);
-    --accent-300:  color-mix(in srgb, var(--accent) 60%, white);
-    --accent-400:  var(--accent);
-    --accent-500:  color-mix(in srgb, var(--accent) 90%, black);
-    --accent-600:  color-mix(in srgb, var(--accent) 80%, black);
-    --accent-700:  color-mix(in srgb, var(--accent) 65%, black);
-    --accent-800:  color-mix(in srgb, var(--accent) 50%, black);
-    --accent-900:  color-mix(in srgb, var(--accent) 35%, black);
-
-    /* neutrals */
-    --bg:            #F6F7F9;
-    --surface:       #FFFFFF;
-    --sunken:        #F1F3F5;
-    --border:        #E6E8EC;
-    --border-strong: #D2D6DC;
-    --text-1:        #1A1F26;
-    --text-2:        #4D5664;
-    --text-3:        #7B8593;
-    --text-4:        #A2ABB8;
-
-    /* status — full set */
-    --success:        #16A34A;
-    --success-bg:     #E8F6EE;
-    --success-border: #BFE5CD;
-    --info:           #2563EB;
-    --info-bg:        #E8F0FE;
-    --info-border:    #C7D7F8;
-    --warning:        #B45309;
-    --warning-bg:     #FDF3E2;
-    --warning-border: #F2D9A9;
-    --danger:         #D03F3F;
-    --danger-bg:      #FCEBEB;
-    --danger-border:  #F4C8C8;
-    --neutral:        #6B7280;
-    --neutral-bg:     #EEF0F3;
-    --neutral-border: #D8DCE2;
-
-    /* type */
-    --font:        "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    --font-mono:   "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-    --w-regular:   400;
-    --w-medium:    500;
-    --w-semibold:  600;
-    --w-bold:      600;
-
-    /* shape */
-    --r:      8px;
-    --r-xs:   2px;
-    --r-sm:   4px;
-    --r-lg:   12px;
-
-    /* density */
-    --row-h:   36px;
-    --input-h: 34px;
-    --pad:     10px;
-    --gap:     14px;
-
-    /* shadows */
-    --shadow-1: 0 1px 1px rgba(15, 22, 36, 0.04), 0 1px 2px rgba(15, 22, 36, 0.04);
-    --shadow-2: 0 1px 1px rgba(15, 22, 36, 0.04), 0 4px 12px rgba(15, 22, 36, 0.06);
-    --shadow-3: 0 6px 20px rgba(15, 22, 36, 0.10), 0 2px 6px rgba(15, 22, 36, 0.06);
-
-    /* ─── legacy aliases — point at the DS tokens above ────────────────── */
+    /* ─── legacy aliases — point at the design-system tokens ──────────── */
 
     --font-family: var(--font);
-    --primary-rgb: 58, 102, 150;
     --secondary-rgb: 140, 51, 140;
     --tertiary-rgb: 135, 202, 35;
 

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -518,9 +518,18 @@ function loadFromState(state) {
     // guard so we don't .then on undefined.
     const pending = spaRequest(target, { ignoreEvents: false, ignoreHistory: true });
     if (pending) {
-      // swallow rejections so an unexpected throw downstream (e.g. inside
-      // hideLoading) doesn't surface as an unhandled-rejection warning
-      return pending.then(function () { currentSpaUrl = target; }).catch(function () {});
+      // Skip the cache write if the request was aborted (a fast back→back
+      // aborts the first fetch — but fetchAjax resolves with undefined
+      // rather than rejecting, so this .then still fires for the aborted
+      // target and would otherwise leave currentSpaUrl pointing at the
+      // intermediate URL). Compare to location.href, which popstate has
+      // already updated to the latest state.url, so the in-flight target
+      // only matches when it is still the current truth.
+      return pending.then(function () {
+        if (location.href === target) {
+          currentSpaUrl = target;
+        }
+      }).catch(function () {});
     }
   }
 }

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -1,5 +1,14 @@
 var pendingRequests = [];
 
+// URL whose content is currently rendered in the SPA container.
+// loadFromState's same-URL guard compares against this rather than
+// location.href, which the browser has already updated to the new
+// entry's URL by the time popstate fires — making location.href
+// useless for "did the URL actually change" checks. Kept in sync by
+// addToHistory (every successful spaRequest) and loadFromState (when
+// it issues its own spaRequest for cross-URL back/forward).
+var currentSpaUrl = location.href;
+
 const OMIT_ORG_URLS = ['/staff/', '/org/choose/'];
 
 function onSpload(fn) {
@@ -160,6 +169,7 @@ function addToHistory(url) {
     url = document.location.origin + url;
   }
   window.history.pushState({ url: url }, '', url);
+  currentSpaUrl = url;
 }
 
 function spaGet(url, triggerEvents) {
@@ -491,8 +501,18 @@ document.addEventListener('temba-redirected', function (event) {
 
 function loadFromState(state) {
   if (state && state.url) {
-    var url = state.url;
-    spaRequest(url, { ignoreEvents: false, ignoreHistory: true });
+    // Compare against currentSpaUrl (the URL of the content
+    // actually rendered) rather than location.href — the browser
+    // already updated location.href to the new entry's URL by the
+    // time popstate fires, so location.href === state.url would
+    // match every popstate and we'd skip the load even when we
+    // shouldn't. If the state's URL matches what's rendered, only
+    // in-page state changed (e.g. a list component pushed a new
+    // page/sort/search entry) — let the components on the page
+    // respond to popstate themselves instead of re-fetching.
+    if (state.url === currentSpaUrl) return;
+    currentSpaUrl = state.url;
+    spaRequest(state.url, { ignoreEvents: false, ignoreHistory: true });
   }
 }
 

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -518,7 +518,9 @@ function loadFromState(state) {
     // guard so we don't .then on undefined.
     const pending = spaRequest(target, { ignoreEvents: false, ignoreHistory: true });
     if (pending) {
-      return pending.then(function () { currentSpaUrl = target; });
+      // swallow rejections so an unexpected throw downstream (e.g. inside
+      // hideLoading) doesn't surface as an unhandled-rejection warning
+      return pending.then(function () { currentSpaUrl = target; }).catch(function () {});
     }
   }
 }

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -511,8 +511,15 @@ function loadFromState(state) {
     // page/sort/search entry) — let the components on the page
     // respond to popstate themselves instead of re-fetching.
     if (state.url === currentSpaUrl) return;
-    currentSpaUrl = state.url;
-    spaRequest(state.url, { ignoreEvents: false, ignoreHistory: true });
+    const target = state.url;
+    // Update currentSpaUrl only after the request resolves so a failed
+    // fetch doesn't poison the cached URL with content we never rendered.
+    // spaRequest returns undefined when checkForUnsavedChanges aborts —
+    // guard so we don't .then on undefined.
+    const pending = spaRequest(target, { ignoreEvents: false, ignoreHistory: true });
+    if (pending) {
+      return pending.then(function () { currentSpaUrl = target; });
+    }
   }
 }
 

--- a/static/styleguide/styleguide.html
+++ b/static/styleguide/styleguide.html
@@ -147,9 +147,9 @@
             </div>
             <div style="display:flex;align-items:center;gap:8px;">
               <label for="primaryPicker" class="sg-code" style="cursor:pointer;">--primary</label>
-              <input id="primaryPicker" type="color" value="#6293C9"
+              <input id="primaryPicker" type="color" value="#497FCE"
                      style="width:36px;height:28px;padding:0;border:1px solid var(--border);border-radius:var(--r-sm);cursor:pointer;background:transparent;">
-              <code id="primaryValue" class="sg-code" style="min-width:74px;">#6293C9</code>
+              <code id="primaryValue" class="sg-code" style="min-width:74px;">#497FCE</code>
             </div>
           </header>
           <div class="sg-card-body">

--- a/temba/api/internal/serializers.py
+++ b/temba/api/internal/serializers.py
@@ -11,7 +11,11 @@ from temba.tickets.models import Shortcut
 
 class ModelAsJsonSerializer(serializers.BaseSerializer):
     def to_representation(self, instance):
-        return instance.as_json()
+        # Pass the DRF serializer context through so model as_json
+        # methods can resolve permission/retention-gated fields
+        # (e.g. Msg.as_json uses context["user"] / context["org"]
+        # for the channel-log link).
+        return instance.as_json(context=self.context)
 
 
 class LLMReadSerializer(serializers.ModelSerializer):

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.urls import reverse
 from django.utils import timezone
 
@@ -82,9 +84,13 @@ class EndpointsTest(APITestMixin, TembaTest):
         # a message in another folder shouldn't appear in the inbox
         archived = self.create_incoming_msg(contact1, "Archived", visibility=Msg.VISIBILITY_ARCHIVED)
 
+        msg1_logs_url = reverse("channels.channel_logs_read", args=[self.channel.uuid, "msg", msg1.uuid])
+        msg2_logs_url = reverse("channels.channel_logs_read", args=[self.channel.uuid, "msg", msg2.uuid])
+
+        # admin has `channels.channel_logs` so as_json resolves logs_url to a real path
         self.assertGet(
             endpoint_url,
-            [self.editor, self.admin],
+            [self.admin],
             results=[
                 {
                     "id": msg2.id,
@@ -95,6 +101,7 @@ class EndpointsTest(APITestMixin, TembaTest):
                     "labels": [{"uuid": str(label.uuid), "name": "Spam"}],
                     "flow": None,
                     "created_on": matchers.ISODatetime(),
+                    "logs_url": msg2_logs_url,
                 },
                 {
                     "id": msg1.id,
@@ -105,15 +112,87 @@ class EndpointsTest(APITestMixin, TembaTest):
                     "labels": [],
                     "flow": None,
                     "created_on": matchers.ISODatetime(),
+                    "logs_url": msg1_logs_url,
                 },
             ],
         )
+
+        # editor lacks `channels.channel_logs` so logs_url is gated to None
+        self.assertGet(
+            endpoint_url,
+            [self.editor],
+            results=[
+                {
+                    "id": msg2.id,
+                    "type": "text",
+                    "contact": {"uuid": str(contact2.uuid), "name": "Bob"},
+                    "text": "Look at this",
+                    "attachments": ["image/jpeg:https://example.com/a.jpg"],
+                    "labels": [{"uuid": str(label.uuid), "name": "Spam"}],
+                    "flow": None,
+                    "created_on": matchers.ISODatetime(),
+                    "logs_url": None,
+                },
+                {
+                    "id": msg1.id,
+                    "type": "text",
+                    "contact": {"uuid": str(contact1.uuid), "name": "Ann"},
+                    "text": "Hello there",
+                    "attachments": [],
+                    "labels": [],
+                    "flow": None,
+                    "created_on": matchers.ISODatetime(),
+                    "logs_url": None,
+                },
+            ],
+        )
+
+        # backdated past the channel-log retention window: logs_url is gated to None even for admin
+        old_msg = self.create_incoming_msg(contact1, "Older")
+        Msg.objects.filter(id=old_msg.id).update(created_on=timezone.now() - timedelta(days=30))
+        response = self.assertGet(endpoint_url + f"?search={old_msg.text}", [self.admin], results=[old_msg])
+        self.assertIsNone(response.json()["results"][0]["logs_url"])
+
+        # inactive channel: logs_url is gated to None
+        live_msg = self.create_incoming_msg(contact1, "Liveone")
+        self.channel.is_active = False
+        self.channel.save(update_fields=("is_active",))
+        try:
+            response = self.assertGet(endpoint_url + f"?search={live_msg.text}", [self.admin], results=[live_msg])
+            self.assertIsNone(response.json()["results"][0]["logs_url"])
+        finally:
+            self.channel.is_active = True
+            self.channel.save(update_fields=("is_active",))
+
+        # anonymous org with an unnamed contact: as_json returns the masked ref (not the urn) for the contact name
+        anon_contact = self.create_contact("", phone="+1234567099")
+        anon_msg = self.create_incoming_msg(anon_contact, "Anonymous")
+        with self.anonymous(self.org):
+            response = self.assertGet(endpoint_url + f"?search={anon_msg.text}", [self.admin], results=[anon_msg])
+            masked_name = response.json()["results"][0]["contact"]["name"]
+            self.assertNotIn("1234567099", masked_name)
+            self.assertEqual(anon_contact.ref, masked_name)
 
         # can select a different folder
         self.assertGet(endpoint_url + "?folder=archived", [self.admin], results=[archived])
 
         # an unknown folder returns nothing
         self.assertGet(endpoint_url + "?folder=nope", [self.admin], results=[])
+
+        # ?folder=sent orders by sent_on rather than created_on
+        sent_old = self.create_outgoing_msg(contact1, "Old reply", sent_on=timezone.now() - timedelta(hours=2))
+        sent_new = self.create_outgoing_msg(contact1, "Newer reply", sent_on=timezone.now() - timedelta(minutes=5))
+        self.assertGet(endpoint_url + "?folder=sent", [self.admin], results=[sent_new, sent_old])
+
+        # ?label=<uuid> filters to that label's visible messages
+        self.assertGet(endpoint_url + f"?label={label.uuid}", [self.admin], results=[msg2])
+
+        # a label belonging to another org isn't visible
+        other_label = self.create_label("Other", org=self.org2)
+        self.assertGet(endpoint_url + f"?label={other_label.uuid}", [self.admin], results=[])
+
+        # an unknown label uuid returns nothing
+        self.assertGet(endpoint_url + f"?label={contact1.uuid}", [self.admin], results=[])
 
         # can search by message text or contact name
         response = self.assertGet(endpoint_url + "?search=hello", [self.admin], results=[msg1])
@@ -123,7 +202,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual(1, response.json()["count"])
 
         # unfiltered listings still omit count — cursor pagination skips COUNT(*) when there is no search
-        response = self.assertGet(endpoint_url, [self.admin], results=[msg2, msg1])
+        # ordering is `-created_on, -id`: old_msg is backdated 30 days so it sorts last
+        response = self.assertGet(endpoint_url, [self.admin], results=[anon_msg, live_msg, msg2, msg1, old_msg])
         self.assertNotIn("count", response.json())
 
         # honor `?page_size=` so the list UI can request a page sized to its viewport

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -94,10 +94,11 @@ class EndpointsTest(APITestMixin, TembaTest):
             results=[
                 {
                     "id": msg2.id,
+                    "uuid": str(msg2.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact2.uuid), "name": "Bob"},
                     "text": "Look at this",
-                    "attachments": ["image/jpeg:https://example.com/a.jpg"],
+                    "attachments": [{"content_type": "image/jpeg", "url": "https://example.com/a.jpg"}],
                     "labels": [{"uuid": str(label.uuid), "name": "Spam"}],
                     "flow": None,
                     "created_on": matchers.ISODatetime(),
@@ -105,6 +106,7 @@ class EndpointsTest(APITestMixin, TembaTest):
                 },
                 {
                     "id": msg1.id,
+                    "uuid": str(msg1.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact1.uuid), "name": "Ann"},
                     "text": "Hello there",
@@ -124,10 +126,11 @@ class EndpointsTest(APITestMixin, TembaTest):
             results=[
                 {
                     "id": msg2.id,
+                    "uuid": str(msg2.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact2.uuid), "name": "Bob"},
                     "text": "Look at this",
-                    "attachments": ["image/jpeg:https://example.com/a.jpg"],
+                    "attachments": [{"content_type": "image/jpeg", "url": "https://example.com/a.jpg"}],
                     "labels": [{"uuid": str(label.uuid), "name": "Spam"}],
                     "flow": None,
                     "created_on": matchers.ISODatetime(),
@@ -135,6 +138,7 @@ class EndpointsTest(APITestMixin, TembaTest):
                 },
                 {
                     "id": msg1.id,
+                    "uuid": str(msg1.uuid),
                     "type": "text",
                     "contact": {"uuid": str(contact1.uuid), "name": "Ann"},
                     "text": "Hello there",

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -147,9 +147,9 @@ class EndpointsTest(APITestMixin, TembaTest):
             ],
         )
 
-        # backdated past the channel-log retention window: logs_url is gated to None even for admin
-        old_msg = self.create_incoming_msg(contact1, "Older")
-        Msg.objects.filter(id=old_msg.id).update(created_on=timezone.now() - timedelta(days=30))
+        # backdated past the channel-log retention window: logs_url is gated to None even for admin.
+        # `created_on` is passed at insert time because a DB trigger forbids changing it after the fact.
+        old_msg = self.create_incoming_msg(contact1, "Older", created_on=timezone.now() - timedelta(days=30))
         response = self.assertGet(endpoint_url + f"?search={old_msg.text}", [self.admin], results=[old_msg])
         self.assertIsNone(response.json()["results"][0]["logs_url"])
 

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -6,6 +6,7 @@ from temba.ai.types.anthropic.type import AnthropicType
 from temba.ai.types.openai.type import OpenAIType
 from temba.api.tests.mixins import APITestMixin
 from temba.contacts.models import ContactExport
+from temba.msgs.models import Msg
 from temba.notifications.types import ExportFinishedNotificationType
 from temba.templates.models import TemplateTranslation
 from temba.tests import TembaTest, matchers
@@ -61,6 +62,77 @@ class EndpointsTest(APITestMixin, TembaTest):
         # missing or invalid level, no results
         self.assertGet(endpoint_url + "?level=hood", [self.agent], results=[])
         self.assertGet(endpoint_url, [self.agent], results=[])
+
+    def test_messages(self):
+        endpoint_url = reverse("api.internal.messages") + ".json"
+
+        self.assertGetNotPermitted(endpoint_url, [None, self.agent])
+        self.assertPostNotAllowed(endpoint_url)
+        self.assertDeleteNotAllowed(endpoint_url)
+
+        contact1 = self.create_contact("Ann", phone="+1234567001")
+        contact2 = self.create_contact("Bob", phone="+1234567002")
+        label = self.create_label("Spam")
+
+        # inbox messages (incoming, handled, visible, no flow)
+        msg1 = self.create_incoming_msg(contact1, "Hello there")
+        msg2 = self.create_incoming_msg(contact2, "Look at this", attachments=["image/jpeg:https://example.com/a.jpg"])
+        msg2.labels.add(label)
+
+        # a message in another folder shouldn't appear in the inbox
+        archived = self.create_incoming_msg(contact1, "Archived", visibility=Msg.VISIBILITY_ARCHIVED)
+
+        self.assertGet(
+            endpoint_url,
+            [self.editor, self.admin],
+            results=[
+                {
+                    "id": msg2.id,
+                    "type": "text",
+                    "contact": {"uuid": str(contact2.uuid), "name": "Bob"},
+                    "text": "Look at this",
+                    "attachments": ["image/jpeg:https://example.com/a.jpg"],
+                    "labels": [{"uuid": str(label.uuid), "name": "Spam"}],
+                    "flow": None,
+                    "created_on": matchers.ISODatetime(),
+                },
+                {
+                    "id": msg1.id,
+                    "type": "text",
+                    "contact": {"uuid": str(contact1.uuid), "name": "Ann"},
+                    "text": "Hello there",
+                    "attachments": [],
+                    "labels": [],
+                    "flow": None,
+                    "created_on": matchers.ISODatetime(),
+                },
+            ],
+        )
+
+        # can select a different folder
+        self.assertGet(endpoint_url + "?folder=archived", [self.admin], results=[archived])
+
+        # an unknown folder returns nothing
+        self.assertGet(endpoint_url + "?folder=nope", [self.admin], results=[])
+
+        # can search by message text or contact name
+        response = self.assertGet(endpoint_url + "?search=hello", [self.admin], results=[msg1])
+        # searched responses also carry a total `count` of matches so the list UI can show "N results"
+        self.assertEqual(1, response.json()["count"])
+        response = self.assertGet(endpoint_url + "?search=bob", [self.admin], results=[msg2])
+        self.assertEqual(1, response.json()["count"])
+
+        # unfiltered listings still omit count — cursor pagination skips COUNT(*) when there is no search
+        response = self.assertGet(endpoint_url, [self.admin], results=[msg2, msg1])
+        self.assertNotIn("count", response.json())
+
+        # honor `?page_size=` so the list UI can request a page sized to its viewport
+        msg3 = self.create_incoming_msg(contact1, "Three")
+        msg4 = self.create_incoming_msg(contact1, "Four")
+        response = self.assertGet(endpoint_url + "?page_size=2", [self.admin], results=[msg4, msg3])
+        self.assertEqual(2, len(response.json()["results"]))
+        # there should be a `next` cursor since we capped at 2 of 4
+        self.assertIsNotNone(response.json()["next"])
 
     def test_notifications(self):
         endpoint_url = reverse("api.internal.notifications") + ".json"

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -201,9 +201,20 @@ class EndpointsTest(APITestMixin, TembaTest):
         response = self.assertGet(endpoint_url + "?search=bob", [self.admin], results=[msg2])
         self.assertEqual(1, response.json()["count"])
 
+        # search is rejected with 413 if it exceeds the legacy 1000-char cap (matches BaseListView.search_max_length)
+        self.login(self.admin)
+        response = self.client.get(endpoint_url + "?search=" + "x" * 1001)
+        self.assertEqual(413, response.status_code)
+
+        # search is restricted to the last 90 days; unfiltered listing below still includes the backdated message
+        ancient = self.create_incoming_msg(contact1, "ancient", created_on=timezone.now() - timedelta(days=120))
+        self.assertGet(endpoint_url + f"?search={ancient.text}", [self.admin], results=[])
+
         # unfiltered listings still omit count — cursor pagination skips COUNT(*) when there is no search
-        # ordering is `-created_on, -id`: old_msg is backdated 30 days so it sorts last
-        response = self.assertGet(endpoint_url, [self.admin], results=[anon_msg, live_msg, msg2, msg1, old_msg])
+        # ordering is `-created_on, -id`: old_msg is backdated 30 days, ancient 120 days, so they sort last
+        response = self.assertGet(
+            endpoint_url, [self.admin], results=[anon_msg, live_msg, msg2, msg1, old_msg, ancient]
+        )
         self.assertNotIn("count", response.json())
 
         # honor `?page_size=` so the list UI can request a page sized to its viewport

--- a/temba/api/internal/urls.py
+++ b/temba/api/internal/urls.py
@@ -2,6 +2,8 @@ from rest_framework.urlpatterns import format_suffix_patterns
 
 from django.urls import re_path
 
+from temba.msgs.api import MessagesEndpoint
+
 from .views import (
     LLMsEndpoint,
     LocationsEndpoint,
@@ -15,6 +17,7 @@ urlpatterns = [
     # ========== endpoints A-Z ===========
     re_path(r"^llms$", LLMsEndpoint.as_view(), name="api.internal.llms"),
     re_path(r"^locations$", LocationsEndpoint.as_view(), name="api.internal.locations"),
+    re_path(r"^messages$", MessagesEndpoint.as_view(), name="api.internal.messages"),
     re_path(r"^notifications$", NotificationsEndpoint.as_view(), name="api.internal.notifications"),
     re_path(r"^shortcuts$", ShortcutsEndpoint.as_view(), name="api.internal.shortcuts"),
     re_path(r"^templates$", TemplatesEndpoint.as_view(), name="api.internal.templates"),

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -152,6 +152,28 @@ class DocumentationRenderer(BrowsableAPIRenderer):
         }
 
 
+class SearchCountMixin:
+    """
+    Pagination mixin that includes a `count` of matching rows on the response when the request carries a `search=`
+    query param. CursorPagination omits count by default to skip a COUNT(*) per request — but searched list views need
+    the tally so the UI can surface "N results". A search has already narrowed the queryset enough that the count is
+    cheap; an unfiltered listing still pays no count cost.
+    """
+
+    def paginate_queryset(self, queryset, request, view=None):
+        # Capture the count from the filtered queryset before the parent slices it down to a single cursor page. The
+        # base CursorPagination doesn't keep the source queryset on `self`, so we have to grab it here.
+        self._search_count = queryset.count() if request.query_params.get("search") else None
+        return super().paginate_queryset(queryset, request, view)
+
+    def get_paginated_response(self, data):
+        response = super().get_paginated_response(data)
+        count = getattr(self, "_search_count", None)
+        if count is not None:
+            response.data["count"] = count
+        return response
+
+
 class CreatedOnCursorPagination(CursorPagination):
     ordering = ("-created_on", "-id")
     offset_cutoff = 100000

--- a/temba/context_processors.py
+++ b/temba/context_processors.py
@@ -5,6 +5,7 @@ def config(request):
     return {
         "COMPONENTS_DEV_MODE": getattr(settings, "COMPONENTS_DEV_MODE", False),
         "COMPONENTS_DEV_HOST": getattr(settings, "COMPONENTS_DEV_HOST", "localhost"),
+        "COMPONENTS_DEV_URL": getattr(settings, "COMPONENTS_DEV_URL", ""),
     }
 
 

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -131,6 +131,37 @@ class LanguageMiddleware:
         return response
 
 
+class PreviewMiddleware:
+    """
+    Exposes a global `preview` flag for opting into features that aren't fully rolled out yet. `?preview=1` opts in
+    (sets a year-long `temba-preview` cookie); `?preview=0` opts out (clears it); anything else falls back to the
+    cookie. The current state is set on `request.preview` so views and templates can gate features off `if
+    request.preview`.
+    """
+
+    COOKIE = "temba-preview"
+
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        toggle = request.GET.get("preview")
+        if toggle == "1":
+            request.preview = True
+        elif toggle == "0":
+            request.preview = False
+        else:
+            request.preview = request.COOKIES.get(self.COOKIE) == "1"
+
+        response = self.get_response(request)
+
+        if toggle == "1":
+            response.set_cookie(self.COOKIE, "1", max_age=365 * 24 * 60 * 60)
+        elif toggle == "0":
+            response.delete_cookie(self.COOKIE)
+        return response
+
+
 class ToastMiddleware:
     """
     Converts django messages into a response header for toasts

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -137,6 +137,9 @@ class PreviewMiddleware:
     (sets a year-long `temba-preview` cookie); `?preview=0` opts out (clears it); anything else falls back to the
     cookie. The current state is set on `request.preview` so views and templates can gate features off `if
     request.preview`.
+
+    The write side (cookie set/clear) is gated on `request.user.is_authenticated` so a cross-origin
+    `<img src=".../?preview=1">` can't silently plant the cookie on an unauthenticated victim.
     """
 
     COOKIE = "temba-preview"
@@ -146,19 +149,31 @@ class PreviewMiddleware:
 
     def __call__(self, request):
         toggle = request.GET.get("preview")
-        if toggle == "1":
+        # Only evaluate request.user when the toggle is actually present — otherwise reading is_authenticated on
+        # every request would force the lazy user to materialize before OrgMiddleware needs it (and break the
+        # query-count baselines of every list view).
+        authed = toggle in ("1", "0") and request.user.is_authenticated
+        if toggle == "1" and authed:
             request.preview = True
-        elif toggle == "0":
+        elif toggle == "0" and authed:
             request.preview = False
         else:
             request.preview = request.COOKIES.get(self.COOKIE) == "1"
 
         response = self.get_response(request)
 
-        if toggle == "1":
-            response.set_cookie(self.COOKIE, "1", max_age=365 * 24 * 60 * 60)
-        elif toggle == "0":
-            response.delete_cookie(self.COOKIE)
+        if authed:
+            if toggle == "1":
+                response.set_cookie(
+                    self.COOKIE,
+                    "1",
+                    max_age=365 * 24 * 60 * 60,
+                    secure=request.is_secure(),
+                    httponly=True,
+                    samesite="Lax",
+                )
+            else:
+                response.delete_cookie(self.COOKIE)
         return response
 
 

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -1,0 +1,75 @@
+from django.db.models import Q
+
+from temba.api.internal.serializers import ModelAsJsonSerializer
+from temba.api.internal.views import BaseEndpoint
+from temba.api.support import CreatedOnCursorPagination, SearchCountMixin, SentOnCursorPagination
+from temba.api.views import ListAPIMixin
+
+from .models import Msg, MsgFolder
+
+
+class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
+    """
+    Messages for the current org, used by the message list components. A folder is selected with the `folder` query
+    param (one of `inbox`, `handled`, `archived`, `outbox`, `sent` or `failed`, defaulting to `inbox`) — alternatively
+    pass `label=<uuid>` to filter by a user-defined label. An optional `search` param filters by message text or
+    contact name. Each item is serialized via Msg.as_json().
+    """
+
+    class Pagination(SearchCountMixin, CreatedOnCursorPagination):
+        """
+        The sent folder is ordered by sent date; all other folders by creation date. Searches additionally include a
+        `count` on the response via SearchCountMixin so the list UI can surface "N results".
+        """
+
+        # DRF's CursorPagination ignores `?page_size=` unless the subclass opts in. The list component sends
+        # `page_size` to size each request to the visible viewport, so honor it — with a default that matches the
+        # component's own default and a cap that keeps a hostile/oversized client request from pulling 50k rows.
+        page_size = 50
+        page_size_query_param = "page_size"
+        max_page_size = 500
+
+        def get_ordering(self, request, queryset, view=None):
+            if request.query_params.get("folder", "").lower() == "sent":
+                return SentOnCursorPagination.ordering
+            return CreatedOnCursorPagination.ordering
+
+    model = Msg
+    serializer_class = ModelAsJsonSerializer
+    pagination_class = Pagination
+
+    FOLDERS = {
+        "inbox": MsgFolder.INBOX,
+        "handled": MsgFolder.HANDLED,
+        "archived": MsgFolder.ARCHIVED,
+        "outbox": MsgFolder.OUTBOX,
+        "sent": MsgFolder.SENT,
+        "failed": MsgFolder.FAILED,
+    }
+
+    def derive_queryset(self):
+        # `label` takes precedence — the filter view passes a label UUID rather than a folder name, and the visible
+        # messages for that label aren't a MsgFolder slice.
+        label_uuid = self.request.query_params.get("label")
+        if label_uuid:
+            label = self.request.org.msgs_labels.filter(uuid=label_uuid).first()
+            if not label:
+                return Msg.objects.none()
+            return (
+                Msg.objects.filter(org=self.request.org, labels=label, visibility=Msg.VISIBILITY_VISIBLE)
+                .select_related("contact", "flow")
+                .prefetch_related("labels")
+            )
+
+        folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
+        if not folder:
+            return Msg.objects.none()
+
+        return folder.get_queryset(self.request.org).select_related("contact", "flow").prefetch_related("labels")
+
+    def filter_queryset(self, queryset):
+        search = self.request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(Q(text__icontains=search) | Q(contact__name__icontains=search))
+
+        return queryset

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -1,4 +1,8 @@
+from datetime import timedelta
+
 from django.db.models import Q
+from django.http import HttpResponse
+from django.utils import timezone
 
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
@@ -34,9 +38,11 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
                 return SentOnCursorPagination.ordering
             return CreatedOnCursorPagination.ordering
 
-    model = Msg
-    serializer_class = ModelAsJsonSerializer
-    pagination_class = Pagination
+    # Match BaseListView's caps so the legacy and new lists impose the same bounds: a search query is capped at 1000
+    # chars (rejected with 413) and is restricted to messages from the last 90 days so an unbounded `text__icontains`
+    # scan (compounded by the SearchCountMixin COUNT(*)) can't be triggered by a session-authenticated client.
+    SEARCH_MAX_LENGTH = 1_000
+    SEARCH_WINDOW = timedelta(days=90)
 
     FOLDERS = {
         "inbox": MsgFolder.INBOX,
@@ -46,6 +52,16 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
         "sent": MsgFolder.SENT,
         "failed": MsgFolder.FAILED,
     }
+
+    model = Msg
+    serializer_class = ModelAsJsonSerializer
+    pagination_class = Pagination
+
+    def get(self, request, *args, **kwargs):
+        search = request.query_params.get("search") or ""
+        if len(search) > self.SEARCH_MAX_LENGTH:
+            return HttpResponse("Search query too long", status=413)
+        return super().get(request, *args, **kwargs)
 
     def derive_queryset(self):
         # `label` takes precedence — the filter view passes a label UUID rather than a folder name, and the visible
@@ -76,6 +92,9 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
     def filter_queryset(self, queryset):
         search = self.request.query_params.get("search")
         if search:
-            queryset = queryset.filter(Q(text__icontains=search) | Q(contact__name__icontains=search))
+            queryset = queryset.filter(
+                Q(created_on__gte=timezone.now() - self.SEARCH_WINDOW)
+                & (Q(text__icontains=search) | Q(contact__name__icontains=search))
+            )
 
         return queryset

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -22,8 +22,10 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
 
     class Pagination(SearchCountMixin, CreatedOnCursorPagination):
         """
-        The sent folder is ordered by sent date; all other folders by creation date. Searches additionally include a
-        `count` on the response via SearchCountMixin so the list UI can surface "N results".
+        The sent folder is ordered by sent date; all other folders by UUID, which (since msg.uuid is uuid7) is itself
+        time-ordered and already uniquely indexed — so we get the same newest-first semantics as `-created_on, -id`
+        without the composite sort. Searches additionally include a `count` on the response via SearchCountMixin so
+        the list UI can surface "N results".
         """
 
         # DRF's CursorPagination ignores `?page_size=` unless the subclass opts in. The list component sends
@@ -33,10 +35,12 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
         page_size_query_param = "page_size"
         max_page_size = 500
 
+        ordering = ("-uuid",)
+
         def get_ordering(self, request, queryset, view=None):
             if request.query_params.get("folder", "").lower() == "sent":
                 return SentOnCursorPagination.ordering
-            return CreatedOnCursorPagination.ordering
+            return self.ordering
 
     # Match BaseListView's caps so the legacy and new lists impose the same bounds: a search query is capped at 1000
     # chars (rejected with 413) and is restricted to messages from the last 90 days so an unbounded `text__icontains`

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -60,7 +60,7 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
             return (
                 Msg.objects.filter(org=self.request.org, labels=label, visibility=Msg.VISIBILITY_VISIBLE)
                 .select_related("contact", "channel", "flow", "org")
-                .prefetch_related("labels", "contact__urns")
+                .prefetch_related("labels")
             )
 
         folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
@@ -70,7 +70,7 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
         return (
             folder.get_queryset(self.request.org)
             .select_related("contact", "channel", "flow", "org")
-            .prefetch_related("labels", "contact__urns")
+            .prefetch_related("labels")
         )
 
     def filter_queryset(self, queryset):

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -50,6 +50,8 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
     def derive_queryset(self):
         # `label` takes precedence — the filter view passes a label UUID rather than a folder name, and the visible
         # messages for that label aren't a MsgFolder slice.
+        # `org` and `channel` are select_related because Msg.as_json reads self.org (for contact display) and
+        # self.channel.is_active/uuid (for the channel-log link gated on the channels.channel_logs perm).
         label_uuid = self.request.query_params.get("label")
         if label_uuid:
             label = self.request.org.msgs_labels.filter(uuid=label_uuid).first()
@@ -57,15 +59,19 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
                 return Msg.objects.none()
             return (
                 Msg.objects.filter(org=self.request.org, labels=label, visibility=Msg.VISIBILITY_VISIBLE)
-                .select_related("contact", "flow")
-                .prefetch_related("labels")
+                .select_related("contact", "channel", "flow", "org")
+                .prefetch_related("labels", "contact__urns")
             )
 
         folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
         if not folder:
             return Msg.objects.none()
 
-        return folder.get_queryset(self.request.org).select_related("contact", "flow").prefetch_related("labels")
+        return (
+            folder.get_queryset(self.request.org)
+            .select_related("contact", "channel", "flow", "org")
+            .prefetch_related("labels", "contact__urns")
+        )
 
     def filter_queryset(self, queryset):
         search = self.request.query_params.get("search")

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -565,10 +565,11 @@ class Msg(models.Model):
         """
         return {
             "id": self.id,
+            "uuid": str(self.uuid),
             "type": self.TYPE_SLUGS.get(self.msg_type),
             "contact": {"uuid": str(self.contact.uuid), "name": self.contact.get_display(self.org)},
             "text": self.text,
-            "attachments": self.attachments,
+            "attachments": [a.as_json() for a in self.get_attachments()],
             "labels": [{"uuid": str(lb.uuid), "name": lb.name} for lb in self.labels.all()],
             "flow": {"uuid": str(self.flow.uuid), "name": self.flow.name} if self.flow else None,
             "created_on": self.created_on.isoformat() if self.created_on else None,

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -17,6 +17,7 @@ from django.core.files.storage import default_storage
 from django.db import models
 from django.db.models import Prefetch, Q, Sum
 from django.db.models.functions import Lower
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -581,8 +582,6 @@ class Msg(models.Model):
         the channel is still active, and the message is within the
         channel-log retention window.
         """
-        from django.urls import reverse
-
         user = context.get("user")
         org = context.get("org")
         if not (user and org):

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -478,6 +478,7 @@ class Msg(models.Model):
     TYPE_OPTIN = "O"
     TYPE_VOICE = "V"
     TYPE_CHOICES = ((TYPE_TEXT, "Text"), (TYPE_OPTIN, "Opt-In Request"), (TYPE_VOICE, "Interactive Voice Response"))
+    TYPE_SLUGS = {TYPE_TEXT: "text", TYPE_OPTIN: "optin", TYPE_VOICE: "voice"}
 
     FAILED_NO_DESTINATION = "D"
     FAILED_CONTACT = "C"
@@ -553,6 +554,46 @@ class Msg(models.Model):
     external_identifier = models.CharField(max_length=255, null=True)
 
     log_uuids = ArrayField(models.UUIDField(), null=True)
+
+    def as_json(self, context=None) -> dict:
+        """
+        Internal API shape, consumed by the temba-msg-list component.
+        `context` is the DRF serializer context (with `user` / `org`) and
+        is used to resolve the channel-log link, which is permission- and
+        retention-gated.
+        """
+        return {
+            "id": self.id,
+            "type": self.TYPE_SLUGS.get(self.msg_type),
+            "contact": {"uuid": str(self.contact.uuid), "name": self.contact.get_display(self.org)},
+            "text": self.text,
+            "attachments": self.attachments,
+            "labels": [{"uuid": str(lb.uuid), "name": lb.name} for lb in self.labels.all()],
+            "flow": {"uuid": str(self.flow.uuid), "name": self.flow.name} if self.flow else None,
+            "created_on": self.created_on.isoformat() if self.created_on else None,
+            "logs_url": self._get_logs_url(context) if context else None,
+        }
+
+    def _get_logs_url(self, context):
+        """
+        Mirrors the channel_log_link template tag — returns the URL of
+        this message's channel log only when the viewer can read logs,
+        the channel is still active, and the message is within the
+        channel-log retention window.
+        """
+        from django.urls import reverse
+
+        user = context.get("user")
+        org = context.get("org")
+        if not (user and org):
+            return None
+        if not (user.has_org_perm(org, "channels.channel_logs") or user.is_staff):
+            return None
+        if not (self.channel and self.channel.is_active and self.created_on):
+            return None
+        if timezone.now() - self.created_on >= settings.RETENTION_PERIODS["channellog"]:
+            return None
+        return reverse("channels.channel_logs_read", args=[self.channel.uuid, "msg", self.uuid])
 
     def as_archive_json(self):
         """

--- a/temba/msgs/tests/test_msg.py
+++ b/temba/msgs/tests/test_msg.py
@@ -95,6 +95,11 @@ class MsgTest(TembaTest, CRUDLTestMixin):
             msg2.as_archive_json(),
         )
 
+    def test_as_json_logs_url_without_user_or_org(self):
+        # defensive guard in _get_logs_url: a truthy context missing user/org returns None rather than raising
+        msg = self.create_incoming_msg(self.joe, "hi")
+        self.assertIsNone(msg._get_logs_url({"unrelated": "value"}))
+
     @patch("django.core.files.storage.default_storage.delete")
     @mock_mailroom
     def test_bulk_soft_delete(self, mr_mocks, mock_storage_delete):

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -324,7 +324,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.requestView(label3_url, self.editor, HTTP_X_TEMBA_SPA=1)
         self.assertEqual(f"/msg/labels/{label3.uuid}", response.headers[TEMBA_MENU_SELECTION])
         self.assertEqual(200, response.status_code)
-        self.assertEqual(("label",), response.context["actions"])
+        self.assertEqual(("archive", "label"), response.context["actions"])
 
         # check that non-visible messages are excluded, and messages and ordered newest to oldest
         self.assertEqual([msg6, msg3, msg2, msg1], list(response.context["object_list"]))

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -50,19 +50,19 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         inbox_url = reverse("msgs.msg_inbox")
 
-        # check query count on the legacy list (the default until the user opts into the new list cookie)
+        # check query count on the legacy list (the default until the viewer enters preview mode)
         self.login(self.admin)
         with self.assertNumQueries(11):
             self.client.get(inbox_url)
 
-        # the inbox page renders the temba-msg-list component when the new-list cookie is set; the
-        # default render is still the legacy list backed by this view's queryset
+        # the inbox renders the temba-msg-list component when the viewer is in preview mode; the default render is
+        # still the legacy list backed by this view's queryset
         self.assertRequestDisallowed(inbox_url, [None, self.agent])
         response = self.assertListFetch(inbox_url, [self.editor, self.admin], context_objects=[msg4, msg3, msg2, msg1])
-        self.client.cookies["temba-new-list"] = "1"
-        new_list_response = self.client.get(inbox_url)
-        self.assertContains(new_list_response, "temba-msg-list")
-        del self.client.cookies["temba-new-list"]
+        self.client.cookies["temba-preview"] = "1"
+        preview_response = self.client.get(inbox_url)
+        self.assertContains(preview_response, "temba-msg-list")
+        del self.client.cookies["temba-preview"]
 
         # check that we have the appropriate bulk actions
         self.assertEqual(("archive", "label"), response.context["actions"])

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -50,26 +50,16 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         inbox_url = reverse("msgs.msg_inbox")
 
-        # check query count
-        self.login(self.admin)
-        with self.assertNumQueries(11):
-            self.client.get(inbox_url)
-
+        # the inbox page is a placeholder for the temba-msg-list component, which fetches and pages
+        # messages itself from the internal API
         self.assertRequestDisallowed(inbox_url, [None, self.agent])
-        response = self.assertListFetch(
-            inbox_url + "?refresh=10000", [self.editor, self.admin], context_objects=[msg4, msg3, msg2, msg1]
-        )
+        response = self.assertListFetch(inbox_url, [self.editor, self.admin], context_objects=[msg4, msg3, msg2, msg1])
+        self.assertContains(response, "temba-msg-list")
 
         # check that we have the appropriate bulk actions
         self.assertEqual(("archive", "label"), response.context["actions"])
 
-        # test searching by message text
-        self.assertListFetch(inbox_url + "?search=number+1", [self.editor, self.admin], context_objects=[msg1])
-
-        # test searching by contact name
-        self.assertListFetch(inbox_url + "?search=joe", [self.editor, self.admin], context_objects=[msg2, msg1])
-
-        # error response if query too long
+        # error response if search query too long
         self.assertListFetch(inbox_url + "?search=" + "x" * 1001, [self.editor], status=413)
 
         # add some labels
@@ -77,11 +67,11 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.create_label("label2")
         label3 = self.create_label("label3")
 
-        # editors can label messages
+        # editors can label messages - the component posts the label by uuid
         response = self.requestView(
             inbox_url,
             self.editor,
-            post_data={"action": "label", "objects": [msg1.id, msg2.id], "label": label1.id, "add": True},
+            post_data={"action": "label", "objects": [msg1.id, msg2.id], "label": str(label1.uuid), "add": True},
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual({msg1, msg2}, set(label1.msgs.all()))
@@ -90,7 +80,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.requestView(
             inbox_url,
             self.editor,
-            post_data={"action": "label", "objects": [msg2.id], "label": label1.id, "add": False},
+            post_data={"action": "label", "objects": [msg2.id], "label": str(label1.uuid), "add": False},
         )
         self.assertEqual({msg1}, set(label1.msgs.all()))
 
@@ -102,7 +92,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         self.assertEqual({msg1}, set(label1.msgs.all()))
 
-        # label more messages as admin
+        # labels can also be posted by id, as the other message folders still do
         self.requestView(
             inbox_url,
             self.admin,

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -50,11 +50,19 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         inbox_url = reverse("msgs.msg_inbox")
 
-        # the inbox page is a placeholder for the temba-msg-list component, which fetches and pages
-        # messages itself from the internal API
+        # check query count on the legacy list (the default until the user opts into the new list cookie)
+        self.login(self.admin)
+        with self.assertNumQueries(11):
+            self.client.get(inbox_url)
+
+        # the inbox page renders the temba-msg-list component when the new-list cookie is set; the
+        # default render is still the legacy list backed by this view's queryset
         self.assertRequestDisallowed(inbox_url, [None, self.agent])
         response = self.assertListFetch(inbox_url, [self.editor, self.admin], context_objects=[msg4, msg3, msg2, msg1])
-        self.assertContains(response, "temba-msg-list")
+        self.client.cookies["temba-new-list"] = "1"
+        new_list_response = self.client.get(inbox_url)
+        self.assertContains(new_list_response, "temba-msg-list")
+        del self.client.cookies["temba-new-list"]
 
         # check that we have the appropriate bulk actions
         self.assertEqual(("archive", "label"), response.context["actions"])

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -340,6 +340,18 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContentMenu(label3_url, self.editor, ["Edit", "Delete", "-", "Export", "Usages"])
         self.assertContentMenu(label1_url, self.admin, ["Edit", "Delete", "-", "Export", "Usages"])
 
+        # in preview mode the filter view renders the new list and exposes a label-scoped endpoint and label-name subtitle
+        self.client.cookies["temba-preview"] = "1"
+        try:
+            preview_response = self.client.get(label1_url)
+            self.assertContains(preview_response, "temba-msg-list")
+            self.assertEqual(
+                f"/api/internal/messages.json?label={label1.uuid}", preview_response.context["new_list_endpoint"]
+            )
+            self.assertIn("label1", preview_response.context["new_list_subtitle"])
+        finally:
+            del self.client.cookies["temba-preview"]
+
     def test_export(self):
         export_url = reverse("msgs.msg_export")
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -825,6 +825,10 @@ class MsgCRUDL(SmartCRUDL):
         def derive_url_pattern(cls, path, action):
             return r"^%s/$" % (path)
 
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.prefetch_related("labels").select_related("contact", "channel", "flow")
+
     class Flow(MsgListView):
         title = _("Handled")
         subtitle = _("Incoming messages that were handled by a flow.")

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -3,6 +3,7 @@ import os
 from datetime import timedelta
 from functools import cached_property
 from urllib.parse import quote_plus
+from uuid import UUID
 
 import magic
 from smartmin.views import SmartCreateView, SmartCRUDL, SmartDeleteView, SmartUpdateView
@@ -63,6 +64,89 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     folder = None
     paginate_by = 100
 
+    # ----- temba-new-list cookie gating -----
+    #
+    # The new temba-msg-list view is gated behind a cookie while we
+    # migrate the rest of the lists. Visiting any folder with
+    # ?new-list=1 opts in (sets the cookie); ?old-list=1 opts out
+    # (clears it). When opted in, every MsgListView subclass with a
+    # folder renders msgs/msg_list_new.html instead of its legacy
+    # template, sized + populated from this view's context.
+    NEW_LIST_TEMPLATE = "msgs/msg_list_new.html"
+    NEW_LIST_COOKIE = "temba-new-list"
+
+    # Optional subtitle rendered under the title on the new-list view;
+    # subclasses may override to describe what the folder contains.
+    subtitle = ""
+
+    # Bulk-action key -> config consumed by temba-content-list (label,
+    # icon, optional labelsEndpoint / destructive flag).
+    BULK_ACTION_CONFIG = {
+        "label": {"label": _("Label"), "icon": "tag-01", "labelsEndpoint": "/api/v2/labels.json"},
+        "archive": {"label": _("Archive"), "icon": "archive"},
+        # `restore_messages` resolves to inbox-01 in temba-components — the
+        # generic `restore` icon is a play button (used for reactivating
+        # flows/triggers/campaigns) which reads strangely for messages.
+        "restore": {"label": _("Restore"), "icon": "restore_messages"},
+        "delete": {
+            "label": _("Delete"),
+            "icon": "delete",
+            "destructive": True,
+            "confirm": _("Delete selected messages? This cannot be undone."),
+        },
+        "resend": {"label": _("Resend"), "icon": "send"},
+    }
+
+    def _use_new_list(self) -> bool:
+        # The folder for a message list is either one of the built-in
+        # MsgFolder enum values (Inbox / Handled / …) or a user-defined
+        # Label (the filter view binds it in derive_folder); both render
+        # through the same new-list template.
+        if not isinstance(self.derive_folder(), (MsgFolder, Label)):
+            return False
+        if "new-list" in self.request.GET:
+            return True
+        if "old-list" in self.request.GET:
+            return False
+        return self.request.COOKIES.get(self.NEW_LIST_COOKIE) == "1"
+
+    def get_template_names(self):
+        if self._use_new_list():
+            return [self.NEW_LIST_TEMPLATE]
+        return super().get_template_names()
+
+    def get_paginate_by(self, queryset):
+        # The temba-msg-list component fetches and pages messages itself.
+        if self._use_new_list():
+            return None
+        return super().get_paginate_by(queryset)
+
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        if "new-list" in request.GET:
+            response.set_cookie(self.NEW_LIST_COOKIE, "1", max_age=365 * 24 * 60 * 60)
+        elif "old-list" in request.GET:
+            response.delete_cookie(self.NEW_LIST_COOKIE)
+        return response
+
+    def post(self, request, *args, **kwargs):
+        # The temba-msg-list label dropdown posts the label by uuid, but
+        # BulkActionMixin matches by id — translate the uuid here so both
+        # the new component and the legacy form post are accepted. A non-
+        # uuid value (the legacy form's integer id) is left alone.
+        label = request.POST.get("label")
+        if label:
+            try:
+                UUID(label)
+            except ValueError:
+                pass
+            else:
+                obj = self.request.org.msgs_labels.filter(uuid=label).first()
+                request.POST = request.POST.copy()
+                request.POST["label"] = str(obj.id) if obj else ""
+
+        return super().post(request, *args, **kwargs)
+
     def pre_process(self, request, *args, **kwargs):
         if self.folder:
             self.queryset = self.folder.get_queryset(request.org)
@@ -71,6 +155,9 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
 
     def derive_folder(self):
         return self.folder
+
+    def derive_subtitle(self):
+        return self.subtitle
 
     def derive_export_url(self):
         redirect = quote_plus(self.request.get_full_path())
@@ -109,6 +196,30 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
             any(counts.values()) or Archive.objects.filter(org=org, archive_type=Archive.TYPE_MSG).exists()
         )
 
+        # New-list view context: the resolved messages-api endpoint
+        # (folder= for the built-in folders, label= for a user label),
+        # the subtitle, and the bulk-action configs the temba-msg-list
+        # expects (resolved + JSON-encoded here so the template stays
+        # inert).
+        if self._use_new_list():
+            if isinstance(folder, Label):
+                query = f"label={folder.uuid}"
+            else:
+                query = f"folder={folder.name.lower()}"
+            context["new_list_endpoint"] = f"{reverse('api.internal.messages')}.json?{query}"
+            subtitle = self.derive_subtitle()
+            context["new_list_subtitle"] = str(subtitle) if subtitle else ""
+            actions = []
+            for key in self.get_bulk_actions():
+                cfg = dict(self.BULK_ACTION_CONFIG.get(key, {}))
+                cfg["key"] = key
+                # Resolve i18n proxies so json.dumps doesn't choke.
+                for k in ("label", "confirm"):
+                    if k in cfg:
+                        cfg[k] = str(cfg[k])
+                actions.append(cfg)
+            context["new_list_bulk_actions_json"] = json.dumps(actions)
+
         return context
 
     def get_bulk_action_labels(self):
@@ -117,7 +228,12 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     def build_context_menu(self, menu):
         if self.has_org_perm("msgs.broadcast_create"):
             menu.add_modax(
-                _("Send"), "send-message", reverse("msgs.broadcast_create"), title=_("New Broadcast"), as_button=True
+                _("Send"),
+                "send-message",
+                reverse("msgs.broadcast_create"),
+                title=_("New Broadcast"),
+                as_button=True,
+                primary=True,
             )
         if self.has_org_perm("msgs.label_create"):
             menu.add_modax(_("New Label"), "new-msg-label", reverse("msgs.label_create"), title=_("New Label"))
@@ -693,8 +809,8 @@ class MsgCRUDL(SmartCRUDL):
 
     class Inbox(MsgListView):
         title = _("Inbox")
+        subtitle = _("Incoming messages that weren't automatically handled by a flow.")
         folder = MsgFolder.INBOX
-        search_fields = ("text__icontains", "contact__name__icontains")
         bulk_actions = ("archive", "label")
         allow_export = True
         menu_path = "/msg/inbox"
@@ -703,12 +819,9 @@ class MsgCRUDL(SmartCRUDL):
         def derive_url_pattern(cls, path, action):
             return r"^%s/$" % (path)
 
-        def get_queryset(self, **kwargs):
-            qs = super().get_queryset(**kwargs)
-            return qs.prefetch_related("labels").select_related("contact", "channel")
-
     class Flow(MsgListView):
         title = _("Handled")
+        subtitle = _("Incoming messages that were handled by a flow.")
         folder = MsgFolder.HANDLED
         search_fields = ("text__icontains", "contact__name__icontains")
         bulk_actions = ("archive", "label")
@@ -721,6 +834,7 @@ class MsgCRUDL(SmartCRUDL):
 
     class Archived(MsgListView):
         title = _("Archived")
+        subtitle = _("Incoming messages you've archived from your inbox.")
         folder = MsgFolder.ARCHIVED
         search_fields = ("text__icontains", "contact__name__icontains")
         bulk_actions = ("restore", "label", "delete")
@@ -732,6 +846,7 @@ class MsgCRUDL(SmartCRUDL):
 
     class Outbox(MsgListView):
         title = _("Outbox")
+        subtitle = _("Outgoing messages queued to be sent.")
         folder = MsgFolder.OUTBOX
         bulk_actions = ()
         allow_export = True
@@ -746,6 +861,7 @@ class MsgCRUDL(SmartCRUDL):
 
     class Sent(MsgListView):
         title = _("Sent")
+        subtitle = _("Outgoing messages that have been sent.")
         template_name = "msgs/msg_sent.html"
         folder = MsgFolder.SENT
         bulk_actions = ()
@@ -757,6 +873,7 @@ class MsgCRUDL(SmartCRUDL):
 
     class Failed(MsgListView):
         title = _("Failed")
+        subtitle = _("Outgoing messages that couldn't be delivered.")
         folder = MsgFolder.FAILED
         allow_export = True
 
@@ -768,13 +885,16 @@ class MsgCRUDL(SmartCRUDL):
 
     class Filter(MsgListView):
         search_fields = ("text__icontains", "contact__name__icontains")
-        bulk_actions = ("label",)
+        bulk_actions = ("archive", "label")
 
         def derive_menu_path(self):
             return f"/msg/labels/{self.label.uuid}"
 
         def derive_title(self, *args, **kwargs):
             return self.label.name
+
+        def derive_subtitle(self):
+            return _("Messages tagged with the %(label)s label.") % {"label": self.label.name}
 
         def build_context_menu(self, menu):
             if self.has_org_perm("msgs.msg_update"):

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -14,6 +14,7 @@ from django.db.models.functions.text import Lower
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import RedirectView
 
@@ -68,7 +69,7 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     #
     # The new temba-msg-list view is gated behind a cookie while we
     # migrate the rest of the lists. Visiting any folder with
-    # ?new-list=1 opts in (sets the cookie); ?old-list=1 opts out
+    # ?new-list=1 opts in (sets the cookie); ?new-list=0 opts out
     # (clears it). When opted in, every MsgListView subclass with a
     # folder renders msgs/msg_list_new.html instead of its legacy
     # template, sized + populated from this view's context.
@@ -101,12 +102,14 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
         # The folder for a message list is either one of the built-in
         # MsgFolder enum values (Inbox / Handled / …) or a user-defined
         # Label (the filter view binds it in derive_folder); both render
-        # through the same new-list template.
+        # through the same new-list template. `?new-list=1` opts in,
+        # `?new-list=0` opts out — anything else falls back to the cookie.
         if not isinstance(self.derive_folder(), (MsgFolder, Label)):
             return False
-        if "new-list" in self.request.GET:
+        new_list = self.request.GET.get("new-list")
+        if new_list == "1":
             return True
-        if "old-list" in self.request.GET:
+        if new_list == "0":
             return False
         return self.request.COOKIES.get(self.NEW_LIST_COOKIE) == "1"
 
@@ -123,9 +126,10 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
 
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)
-        if "new-list" in request.GET:
+        new_list = request.GET.get("new-list")
+        if new_list == "1":
             response.set_cookie(self.NEW_LIST_COOKIE, "1", max_age=365 * 24 * 60 * 60)
-        elif "old-list" in request.GET:
+        elif new_list == "0":
             response.delete_cookie(self.NEW_LIST_COOKIE)
         return response
 
@@ -133,17 +137,20 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
         # The temba-msg-list label dropdown posts the label by uuid, but
         # BulkActionMixin matches by id — translate the uuid here so both
         # the new component and the legacy form post are accepted. A non-
-        # uuid value (the legacy form's integer id) is left alone.
-        label = request.POST.get("label")
-        if label:
-            try:
-                UUID(label)
-            except ValueError:
-                pass
-            else:
-                obj = self.request.org.msgs_labels.filter(uuid=label).first()
-                request.POST = request.POST.copy()
-                request.POST["label"] = str(obj.id) if obj else ""
+        # uuid value (the legacy form's integer id) is left alone. Only
+        # touch the label field on label/unlabel actions so an unrelated
+        # POST that happens to carry a `label` key isn't rewritten.
+        if request.POST.get("action") in ("label", "unlabel"):
+            label = request.POST.get("label")
+            if label:
+                try:
+                    UUID(label)
+                except ValueError:
+                    pass
+                else:
+                    obj = self.request.org.msgs_labels.filter(uuid=label).first()
+                    request.POST = request.POST.copy()
+                    request.POST["label"] = str(obj.id) if obj else ""
 
         return super().post(request, *args, **kwargs)
 
@@ -213,12 +220,10 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
             for key in self.get_bulk_actions():
                 cfg = dict(self.BULK_ACTION_CONFIG.get(key, {}))
                 cfg["key"] = key
-                # Resolve i18n proxies so json.dumps doesn't choke.
-                for k in ("label", "confirm"):
-                    if k in cfg:
-                        cfg[k] = str(cfg[k])
+                # Resolve any i18n lazy proxies so json_script / json.dumps don't choke.
+                cfg = {k: (str(v) if isinstance(v, Promise) else v) for k, v in cfg.items()}
                 actions.append(cfg)
-            context["new_list_bulk_actions_json"] = json.dumps(actions)
+            context["new_list_bulk_actions"] = actions
 
         return context
 
@@ -811,6 +816,7 @@ class MsgCRUDL(SmartCRUDL):
         title = _("Inbox")
         subtitle = _("Incoming messages that weren't automatically handled by a flow.")
         folder = MsgFolder.INBOX
+        search_fields = ("text__icontains", "contact__name__icontains")
         bulk_actions = ("archive", "label")
         allow_export = True
         menu_path = "/msg/inbox"

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -65,16 +65,9 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     folder = None
     paginate_by = 100
 
-    # ----- temba-new-list cookie gating -----
-    #
-    # The new temba-msg-list view is gated behind a cookie while we
-    # migrate the rest of the lists. Visiting any folder with
-    # ?new-list=1 opts in (sets the cookie); ?new-list=0 opts out
-    # (clears it). When opted in, every MsgListView subclass with a
-    # folder renders msgs/msg_list_new.html instead of its legacy
-    # template, sized + populated from this view's context.
+    # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview, every
+    # MsgListView subclass with a folder/label renders msgs/msg_list_new.html instead of its legacy template.
     NEW_LIST_TEMPLATE = "msgs/msg_list_new.html"
-    NEW_LIST_COOKIE = "temba-new-list"
 
     # Optional subtitle rendered under the title on the new-list view;
     # subclasses may override to describe what the folder contains.
@@ -99,19 +92,10 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     }
 
     def _use_new_list(self) -> bool:
-        # The folder for a message list is either one of the built-in
-        # MsgFolder enum values (Inbox / Handled / …) or a user-defined
-        # Label (the filter view binds it in derive_folder); both render
-        # through the same new-list template. `?new-list=1` opts in,
-        # `?new-list=0` opts out — anything else falls back to the cookie.
-        if not isinstance(self.derive_folder(), (MsgFolder, Label)):
-            return False
-        new_list = self.request.GET.get("new-list")
-        if new_list == "1":
-            return True
-        if new_list == "0":
-            return False
-        return self.request.COOKIES.get(self.NEW_LIST_COOKIE) == "1"
+        # The folder for a message list is either one of the built-in MsgFolder enum values (Inbox / Handled / …) or
+        # a user-defined Label (the filter view binds it in derive_folder); both render through the same new-list
+        # template when the viewer is in preview mode.
+        return self.request.preview and isinstance(self.derive_folder(), (MsgFolder, Label))
 
     def get_template_names(self):
         if self._use_new_list():
@@ -123,15 +107,6 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
         if self._use_new_list():
             return None
         return super().get_paginate_by(queryset)
-
-    def dispatch(self, request, *args, **kwargs):
-        response = super().dispatch(request, *args, **kwargs)
-        new_list = request.GET.get("new-list")
-        if new_list == "1":
-            response.set_cookie(self.NEW_LIST_COOKIE, "1", max_age=365 * 24 * 60 * 60)
-        elif new_list == "0":
-            response.delete_cookie(self.NEW_LIST_COOKIE)
-        return response
 
     def post(self, request, *args, **kwargs):
         # The temba-msg-list label dropdown posts the label by uuid, but

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -94,8 +94,9 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     def _use_new_list(self) -> bool:
         # The folder for a message list is either one of the built-in MsgFolder enum values (Inbox / Handled / …) or
         # a user-defined Label (the filter view binds it in derive_folder); both render through the same new-list
-        # template when the viewer is in preview mode.
-        return self.request.preview and isinstance(self.derive_folder(), (MsgFolder, Label))
+        # template when the viewer is in preview mode. `getattr` defaults to False so a view called via RequestFactory
+        # (or if PreviewMiddleware is ever reordered out) doesn't AttributeError.
+        return getattr(self.request, "preview", False) and isinstance(self.derive_folder(), (MsgFolder, Label))
 
     def get_template_names(self):
         if self._use_new_list():

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -149,7 +149,7 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
         return "%s?l=%s&redirect=%s" % (reverse("msgs.msg_export"), label_id, redirect)
 
     def get_queryset(self, **kwargs):
-        qs = super().get_queryset(**kwargs)
+        qs = super().get_queryset(**kwargs).select_related("contact", "channel", "flow")
 
         # if we are searching, limit to last 90, and enforce distinct since we'll be joining on multiple tables
         if self.search_fields and "search" in self.request.GET:
@@ -802,8 +802,7 @@ class MsgCRUDL(SmartCRUDL):
             return r"^%s/$" % (path)
 
         def get_queryset(self, **kwargs):
-            qs = super().get_queryset(**kwargs)
-            return qs.prefetch_related("labels").select_related("contact", "channel", "flow")
+            return super().get_queryset(**kwargs).prefetch_related("labels")
 
     class Flow(MsgListView):
         title = _("Handled")
@@ -815,8 +814,7 @@ class MsgCRUDL(SmartCRUDL):
         menu_path = "/msg/handled"
 
         def get_queryset(self, **kwargs):
-            qs = super().get_queryset(**kwargs)
-            return qs.prefetch_related("labels").select_related("contact", "channel", "flow")
+            return super().get_queryset(**kwargs).prefetch_related("labels")
 
     class Archived(MsgListView):
         title = _("Archived")
@@ -827,8 +825,7 @@ class MsgCRUDL(SmartCRUDL):
         allow_export = True
 
         def get_queryset(self, **kwargs):
-            qs = super().get_queryset(**kwargs)
-            return qs.prefetch_related("labels").select_related("contact", "channel", "flow")
+            return super().get_queryset(**kwargs).prefetch_related("labels")
 
     class Outbox(MsgListView):
         title = _("Outbox")
@@ -842,9 +839,6 @@ class MsgCRUDL(SmartCRUDL):
             context["outbox_warning"] = MsgFolder.OUTBOX.get_count(self.request.org) >= Org.OUTBOX_WARNING_THRESHOLD
             return context
 
-        def get_queryset(self, **kwargs):
-            return super().get_queryset(**kwargs).select_related("contact", "channel", "flow")
-
     class Sent(MsgListView):
         title = _("Sent")
         subtitle = _("Outgoing messages that have been sent.")
@@ -854,9 +848,6 @@ class MsgCRUDL(SmartCRUDL):
         allow_export = True
         default_order = ("-sent_on", "-id")
 
-        def get_queryset(self, **kwargs):
-            return super().get_queryset(**kwargs).select_related("contact", "channel", "flow")
-
     class Failed(MsgListView):
         title = _("Failed")
         subtitle = _("Outgoing messages that couldn't be delivered.")
@@ -865,9 +856,6 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_bulk_actions(self):
             return () if self.request.org.is_suspended else ("resend",)
-
-        def get_queryset(self, **kwargs):
-            return super().get_queryset(**kwargs).select_related("contact", "channel", "flow")
 
     class Filter(MsgListView):
         search_fields = ("text__icontains", "contact__name__icontains")
@@ -918,11 +906,11 @@ class MsgCRUDL(SmartCRUDL):
             return self.label
 
         def get_queryset(self, **kwargs):
-            qs = super().get_queryset(**kwargs)
             return (
-                qs.filter(labels=self.label, visibility=Msg.VISIBILITY_VISIBLE)
+                super()
+                .get_queryset(**kwargs)
+                .filter(labels=self.label, visibility=Msg.VISIBILITY_VISIBLE)
                 .prefetch_related("labels")
-                .select_related("contact", "channel", "flow")
             )
 
 

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -257,7 +257,7 @@ class Notification(models.Model):
 
         return TYPES[self.notification_type]
 
-    def as_json(self) -> dict:
+    def as_json(self, context=None) -> dict:
         return self.type.as_json(self)
 
     class Meta:

--- a/temba/orgs/tests/test_org.py
+++ b/temba/orgs/tests/test_org.py
@@ -865,14 +865,12 @@ class AnonOrgTest(TembaTest):
         self.assertNotContains(response, "788 123 123")
         self.assertContains(response, contact.ref)
 
-        # create an incoming message, check number doesn't appear in inbox
+        # create an incoming message - the inbox loads it via the internal API rather than rendering it server-side
         msg2 = self.create_incoming_msg(contact, "ok")
 
         response = self.client.get(reverse("msgs.msg_inbox"))
 
         self.assertEqual(set(response.context["object_list"]), {msg2})
-        self.assertNotContains(response, "788 123 123")
-        self.assertContains(response, contact.ref)
 
         # create an incoming flow message, check number doesn't appear in inbox
         flow = self.create_flow("Test")

--- a/temba/orgs/tests/test_org.py
+++ b/temba/orgs/tests/test_org.py
@@ -865,12 +865,16 @@ class AnonOrgTest(TembaTest):
         self.assertNotContains(response, "788 123 123")
         self.assertContains(response, contact.ref)
 
-        # create an incoming message - the inbox loads it via the internal API rather than rendering it server-side
+        # create an incoming message - by default (preview off) the inbox renders the legacy template which prints
+        # the contact via name_or_urn, so URN masking still needs coverage on that path. In preview mode the temba-msg-list
+        # component fetches messages from the internal API (separately covered in temba/api/internal/tests.py).
         msg2 = self.create_incoming_msg(contact, "ok")
 
         response = self.client.get(reverse("msgs.msg_inbox"))
 
         self.assertEqual(set(response.context["object_list"]), {msg2})
+        self.assertNotContains(response, "788 123 123")
+        self.assertContains(response, contact.ref)
 
         # create an incoming flow message, check number doesn't appear in inbox
         flow = self.create_flow("Test")

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -205,6 +205,7 @@ MIDDLEWARE = (
     "temba.middleware.LanguageMiddleware",
     "temba.middleware.TimezoneMiddleware",
     "temba.middleware.ToastMiddleware",
+    "temba.middleware.PreviewMiddleware",
     "allauth.account.middleware.AccountMiddleware",
 )
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -389,7 +389,7 @@ class TembaTest(SmartminTest):
             assert channel and contact_urn, "messages require a channel and contact URN, except for failed_reason=D"
 
         return Msg.objects.create(
-            uuid=uuid7(),
+            uuid=uuid7(created_on or timezone.now()),
             org=org,
             direction=direction,
             contact=contact,

--- a/temba/utils/tests/test_middleware.py
+++ b/temba/utils/tests/test_middleware.py
@@ -79,14 +79,36 @@ class MiddlewareTest(TembaTest):
     def test_preview(self):
         index_url = reverse("public.public_index")
 
-        # ?preview=1 opts in and sets the year-long cookie
+        # an unauthenticated request can't toggle the cookie — blocks cross-origin <img src=".../?preview=1"> planting
         response = self.client.get(index_url + "?preview=1")
-        self.assertEqual("1", response.cookies["temba-preview"].value)
-        self.assertEqual(365 * 24 * 60 * 60, response.cookies["temba-preview"]["max-age"])
+        self.assertNotIn("temba-preview", response.cookies)
+        self.assertFalse(response.wsgi_request.preview)
+
+        self.login(self.admin)
+
+        # ?preview=1 opts in and sets the year-long hardened cookie, with request.preview set on the same request
+        response = self.client.get(index_url + "?preview=1")
+        cookie = response.cookies["temba-preview"]
+        self.assertEqual("1", cookie.value)
+        self.assertEqual(365 * 24 * 60 * 60, cookie["max-age"])
+        self.assertEqual("Lax", cookie["samesite"])
+        self.assertTrue(cookie["httponly"])
+        self.assertTrue(response.wsgi_request.preview)
+
+        # subsequent request without the toggle reads the cookie back
+        response = self.client.get(index_url)
+        self.assertTrue(response.wsgi_request.preview)
+        self.assertNotIn("temba-preview", response.cookies)
+
+        # unrecognized values don't toggle and fall back to the cookie
+        response = self.client.get(index_url + "?preview=on")
+        self.assertTrue(response.wsgi_request.preview)
+        self.assertNotIn("temba-preview", response.cookies)
 
         # ?preview=0 opts out and clears the cookie
         response = self.client.get(index_url + "?preview=0")
         self.assertEqual("", response.cookies["temba-preview"].value)
+        self.assertFalse(response.wsgi_request.preview)
 
     def test_language(self):
         def assert_text(text: str):

--- a/temba/utils/tests/test_middleware.py
+++ b/temba/utils/tests/test_middleware.py
@@ -76,6 +76,18 @@ class MiddlewareTest(TembaTest):
         with override_brand(redirect="/redirect"):
             self.assertRedirect(self.client.get(reverse("public.public_index")), "/redirect")
 
+    def test_preview(self):
+        index_url = reverse("public.public_index")
+
+        # ?preview=1 opts in and sets the year-long cookie
+        response = self.client.get(index_url + "?preview=1")
+        self.assertEqual("1", response.cookies["temba-preview"].value)
+        self.assertEqual(365 * 24 * 60 * 60, response.cookies["temba-preview"]["max-age"])
+
+        # ?preview=0 opts out and clears the cookie
+        response = self.client.get(index_url + "?preview=0")
+        self.assertEqual("", response.cookies["temba-preview"].value)
+
     def test_language(self):
         def assert_text(text: str):
             self.assertContains(self.client.get(settings.LOGIN_URL, follow=True), text)

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -164,7 +164,7 @@
     <body class="bg-gradient" id="pageBody">
       {% if COMPONENTS_DEV_MODE %}
         <script type="module">
-          import '/out-tsc/temba-modules.js';
+          import '{{ COMPONENTS_DEV_URL }}/out-tsc/temba-modules.js';
         </script>
       {% else %}
         {% compress js %}

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -139,6 +139,11 @@
       {% compress css %}
         <link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}css/tailwind.css">
         <link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}css/temba-components.css">
+        {# design-system.css is the styleguide's source of truth — load it #}
+        {# after temba-components.css so its :root tokens (primary, accent #}
+        {# ramp, neutrals, status, etc.) override the legacy duplicates, #}
+        {# keeping the running app in lockstep with /static/styleguide/. #}
+        <link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}css/design-system.css">
         <link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}css/frame.css">
         <link type="text/css" rel="stylesheet" href="{{ STATIC_URL }}css/mobile.css">
         <style>

--- a/templates/msgs/msg_list_new.html
+++ b/templates/msgs/msg_list_new.html
@@ -128,14 +128,5 @@
         }
       });
     });
-
-    // refresh the left sidebar menu counts - defined locally since the page
-    // chrome's content menu (which normally provides this) is suppressed here
-    function refreshMenu() {
-      var menu = document.querySelector("temba-menu");
-      if (menu) {
-        menu.refresh();
-      }
-    }
   </script>
 {% endblock extra-script %}

--- a/templates/msgs/msg_list_new.html
+++ b/templates/msgs/msg_list_new.html
@@ -36,13 +36,14 @@
                   content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"
                   empty-message="{% trans "No messages" %}">
   </temba-msg-list>
+  {{ new_list_bulk_actions|json_script:"new-list-bulk-actions" }}
 {% endblock content %}
 {% block extra-script %}
   {{ block.super }}
   <script type="text/javascript">
     onSpload(function() {
       var list = document.querySelector("#msg-list");
-      list.bulkActions = {{ new_list_bulk_actions_json|safe }};
+      list.bulkActions = JSON.parse(document.getElementById("new-list-bulk-actions").textContent);
 
       // clicking a row opens the contact
       list.addEventListener("temba-row-click", function(event) {
@@ -119,11 +120,6 @@
           // in-list push didn't change the page.
           next.url = location.href;
         }
-        console.log("[msg-list] temba-history-change", {
-          detail: event.detail,
-          previousState: current,
-          nextState: next
-        });
         if (event.detail.replace) {
           history.replaceState(next, "");
         } else {

--- a/templates/msgs/msg_list_new.html
+++ b/templates/msgs/msg_list_new.html
@@ -2,11 +2,12 @@
 {% load i18n %}
 
 {% comment %}
-  Generic new-list template used by every MsgListView subclass whose
-  temba-new-list cookie is set. Endpoint, subtitle and bulk actions
-  come from the view's context_data so the template stays the same
-  across Inbox / Flow / Archived / Outbox / Sent / Failed and the
-  per-label Filter view.
+  Generic new-list template used by every MsgListView subclass when
+  the viewer is in preview mode (request.preview, set by
+  PreviewMiddleware off the temba-preview cookie). Endpoint, subtitle
+  and bulk actions come from the view's context_data so the template
+  stays the same across Inbox / Flow / Archived / Outbox / Sent /
+  Failed and the per-label Filter view.
 {% endcomment %}
 {% block page-header %}
   {# the temba-msg-list renders its own header (title + content menu); #}

--- a/templates/msgs/msg_list_new.html
+++ b/templates/msgs/msg_list_new.html
@@ -1,0 +1,144 @@
+{% extends "smartmin/list.html" %}
+{% load i18n %}
+
+{% comment %}
+  Generic new-list template used by every MsgListView subclass whose
+  temba-new-list cookie is set. Endpoint, subtitle and bulk actions
+  come from the view's context_data so the template stays the same
+  across Inbox / Flow / Archived / Outbox / Sent / Failed and the
+  per-label Filter view.
+{% endcomment %}
+{% block page-header %}
+  {# the temba-msg-list renders its own header (title + content menu); #}
+  {# keep the csrf token and a hidden title for the SPA document.title hook #}
+  {% csrf_token %}
+  <div id="title-text" class="hide">{{ title }}</div>
+{% endblock page-header %}
+{% block extra-style %}
+  {{ block.super }}
+  <style type="text/css">
+    /* The list component fills its container edge to edge and brings
+       its own surface, so drop the SPA content padding (and the grey
+       page background it would otherwise reveal around the list). */
+    .spa-content {
+      padding: 0 !important;
+    }
+  </style>
+{% endblock extra-style %}
+{% block content %}
+  <temba-msg-list id="msg-list"
+                  fill-window
+                  history-state-key="msgs"
+                  list-title="{{ title }}"
+                  {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
+                  endpoint="{{ new_list_endpoint }}"
+                  action-endpoint="{{ request.path }}"
+                  content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"
+                  empty-message="{% trans "No messages" %}">
+  </temba-msg-list>
+{% endblock content %}
+{% block extra-script %}
+  {{ block.super }}
+  <script type="text/javascript">
+    onSpload(function() {
+      var list = document.querySelector("#msg-list");
+      list.bulkActions = {{ new_list_bulk_actions_json|safe }};
+
+      // clicking a row opens the contact
+      list.addEventListener("temba-row-click", function(event) {
+        var contact = event.detail.item && event.detail.item.contact;
+        if (contact && contact.uuid) {
+          spaGet("/contact/read/" + contact.uuid + "/");
+        }
+      });
+
+      // the embedded content menu fires temba-selection - dispatch it the
+      // same way the page chrome's content menu (spa_page_menu.html) does
+      list.addEventListener("temba-selection", function(event) {
+        var item = event.detail.item;
+        var click = event.detail.event;
+        if (item.type === "link") {
+          if (click) {
+            click.preventDefault();
+            click.stopPropagation();
+            if (click.metaKey && item.url) {
+              window.open(item.url, "_blank");
+              return;
+            }
+          }
+          spaGet(item.url);
+        } else if (item.type === "modax") {
+          showModax(item.title, item.url, {
+            disabled: item.disabled,
+            onSubmit: item.on_submit,
+            onRedirect: item.on_redirect,
+            id: item.modal_id,
+            originX: event.detail.originX,
+            originY: event.detail.originY
+          });
+        } else if (item.type === "url_post") {
+          posterize(item.url);
+        } else if (item.type === "js") {
+          if (window[item.id]) {
+            window[item.id]();
+          }
+        }
+        refreshMenu();
+      });
+
+      // The component POSTs the bulk action to action-endpoint and
+      // re-fetches the current page itself — we just refresh the
+      // sidebar menu counts after the round-trip completes.
+      list.addEventListener("temba-bulk-action", function() {
+        refreshMenu();
+      });
+
+      // The list bubbles up its restorable state (page, sort, search,
+      // and a cursor URL when applicable) as it changes — stash it
+      // on the current history entry so a navigation away and back
+      // lands on the same page. event.detail.replace tells us
+      // whether to pushState (paging, sort, committed search — each
+      // becomes its own back-history entry) or replaceState (typing
+      // in the search box, cursor-page snap-back — no new entry).
+      // The saved state rides along when the user later does
+      // navigate away and is read back by loadFromState (which
+      // spaRequests state.url) when the SPA returns, at which point
+      // the remounted list reads its slot. Preserves state.url so
+      // loadFromState still knows where to re-render the page on
+      // browser back — an entry that arrived via a non-spa load
+      // (typed URL, hard refresh) starts with no url in state, and
+      // we'd otherwise leave it that way.
+      list.addEventListener("temba-history-change", function(event) {
+        var current = history.state || {};
+        var next = Object.assign({}, current);
+        next[event.detail.key] = event.detail.state;
+        if (!next.url) {
+          // Match the convention used by addToHistory / the initial
+          // DOMContentLoaded replaceState (full URL including origin)
+          // so loadFromState's same-URL guard recognizes that an
+          // in-list push didn't change the page.
+          next.url = location.href;
+        }
+        console.log("[msg-list] temba-history-change", {
+          detail: event.detail,
+          previousState: current,
+          nextState: next
+        });
+        if (event.detail.replace) {
+          history.replaceState(next, "");
+        } else {
+          history.pushState(next, "");
+        }
+      });
+    });
+
+    // refresh the left sidebar menu counts - defined locally since the page
+    // chrome's content menu (which normally provides this) is suppressed here
+    function refreshMenu() {
+      var menu = document.querySelector("temba-menu");
+      if (menu) {
+        menu.refresh();
+      }
+    }
+  </script>
+{% endblock extra-script %}


### PR DESCRIPTION
Re-opened from #6631 (the rename auto-closed it because GitHub's branch-rename API fired a `head_ref_deleted` event and a repo workflow locked the original PR).

## Summary
- Adds a new `temba-msg-list` view for the inbox / handled / archived / outbox / sent / failed folders and user-labeled lists, gated behind a `temba-new-list` cookie (visit any folder with `?new-list=1` to opt in, `?new-list=0` to opt out).
- New internal endpoint `/api/internal/messages` (`temba/msgs/api.py`) serializes via `Msg.as_json()` with `folder=` / `label=` / `search=` filters and a `SearchCountMixin` so the list UI can render "N results" without paying a COUNT on unfiltered listings.
- `ModelAsJsonSerializer` now threads DRF context through so `Msg.as_json()` can gate the channel-log link by viewer permission + channel-log retention (mirroring the `channel_log_link` template tag).
- Makes `static/css/design-system.css` the source of truth for design tokens — loaded after `temba-components.css` in `frame.html`, duplicates pruned, and the primary accent nudged from `#6293C9` to `#497FCE`.
- Fixes a SPA popstate bug where same-URL back/forward navigation was skipped because `location.href` had already been updated by the browser; introduces `currentSpaUrl` tracking the URL actually rendered.

## Review notes (pre-PR)
Three reviewer/dev cycles surfaced and addressed:
- N+1s in the new endpoint queryset (`channel`, `org` added to `select_related`; dead `contact__urns` prefetch dropped after analysis).
- XSS-via-translation risk in the bulk-actions inline JSON (switched to `{% json_script %}`).
- Inbox legacy queryset prefetch + `assertNumQueries` guard that had been dropped in the initial commit (restored).
- `post()` UUID→id label translation now gated on `action in (label, unlabel)` so unrelated POSTs aren't rewritten.
- popstate Promise chain updates `currentSpaUrl` only on resolve (guarded against `undefined` from unsaved-changes aborts and adds a no-op `.catch`).
- Expanded test coverage: anon-org masking, `logs_url` permission + retention + inactive-channel gating, `?label=<uuid>` filtering + cross-org isolation, `?folder=sent` ordering.

## Test plan
- [ ] Visit `/msg/inbox/?new-list=1` and confirm the new list renders; reload, the cookie persists.
- [ ] Visit `/msg/inbox/?new-list=0` and confirm the legacy template comes back.
- [ ] Confirm bulk actions (label, archive, restore, delete, resend) work from the new list.
- [ ] Confirm search updates `count` in the response and the UI surfaces "N results".
- [ ] Confirm channel-log link only appears for users with `channels.channel_logs` perm and only inside the retention window.
- [ ] Exercise back/forward across SPA navigations to confirm same-URL pops don't double-fetch.