### PR TITLE
Simplify Infobip and SignalWire claim forms

### DIFF
--- a/temba/channels/types/infobip/tests.py
+++ b/temba/channels/types/infobip/tests.py
@@ -24,15 +24,20 @@ class InfobipTypeTest(TembaTest):
         post_data["country"] = "NI"
         post_data["number"] = "250788123123"
         post_data["api_key"] = "12345"
-        post_data["base_url"] = "https://api.infobip.com"
 
+        # reject anything that isn't a plain subdomain label
+        post_data["subdomain"] = "https://xxxxx.api.infobip.com"
+        response = self.client.post(url, post_data)
+        self.assertFormError(response.context["form"], "subdomain", "Enter a valid subdomain.")
+
+        post_data["subdomain"] = "abcde"
         response = self.client.post(url, post_data)
 
         channel = Channel.objects.get()
 
         self.assertEqual("NI", channel.country)
         self.assertEqual(post_data["api_key"], channel.config["api_key"])
-        self.assertEqual(post_data["base_url"], channel.config["base_url"])
+        self.assertEqual("https://abcde.api.infobip.com", channel.config["base_url"])
         self.assertEqual("+250788123123", channel.address)
         self.assertEqual("IB", channel.channel_type)
 
@@ -53,7 +58,7 @@ class InfobipTypeTest(TembaTest):
         post_data["country"] = "NI"
         post_data["number"] = "20050"
         post_data["api_key"] = "12345"
-        post_data["base_url"] = "https://api.infobip.com"
+        post_data["subdomain"] = "abcde"
 
         response = self.client.post(url, post_data)
 
@@ -61,6 +66,6 @@ class InfobipTypeTest(TembaTest):
 
         self.assertEqual("NI", channel.country)
         self.assertEqual(post_data["api_key"], channel.config["api_key"])
-        self.assertEqual(post_data["base_url"], channel.config["base_url"])
+        self.assertEqual("https://abcde.api.infobip.com", channel.config["base_url"])
         self.assertEqual("20050", channel.address)
         self.assertEqual("IB", channel.channel_type)

--- a/temba/channels/types/infobip/views.py
+++ b/temba/channels/types/infobip/views.py
@@ -34,6 +34,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         )
         subdomain = forms.CharField(
             required=True,
+            max_length=63,
             label=_("Infobip API subdomain"),
             help_text=_(
                 "The subdomain of your Infobip API base URL. For example, if your base URL is "

--- a/temba/channels/types/infobip/views.py
+++ b/temba/channels/types/infobip/views.py
@@ -1,3 +1,5 @@
+import re
+
 import phonenumbers
 from smartmin.views import SmartFormView
 
@@ -8,6 +10,8 @@ from temba.channels.views import ALL_COUNTRIES, ClaimViewMixin
 from temba.utils.fields import SelectWidget
 
 from ...models import Channel
+
+SUBDOMAIN_RE = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$")
 
 
 class ClaimView(ClaimViewMixin, SmartFormView):
@@ -28,13 +32,20 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             label=_("Infobip API Key"),
             help_text=_("The API Key"),
         )
-        base_url = forms.CharField(
+        subdomain = forms.CharField(
             required=True,
-            label=_("Infobip API base URL"),
+            label=_("Infobip API subdomain"),
             help_text=_(
-                "To see your base URL, log in to the Infobip API Resource hub with your Infobip credentials. Once logged in, on all pages you should see your base URL in this format: https://xxxxx.api.infobip.com "
+                "The subdomain of your Infobip API base URL. For example, if your base URL is "
+                "https://xxxxx.api.infobip.com, enter xxxxx. You can find this in the Infobip API Resource hub."
             ),
         )
+
+        def clean_subdomain(self):
+            value = self.cleaned_data["subdomain"].strip().lower()
+            if not SUBDOMAIN_RE.match(value):
+                raise forms.ValidationError(_("Enter a valid subdomain."))
+            return value
 
         def clean_number(self):
             number = self.data["number"]
@@ -62,11 +73,11 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         number = form.cleaned_data.get("number")
         title = f"Infobip: {number}"
         api_key = form.cleaned_data.get("api_key")
-        base_url = form.cleaned_data.get("base_url")
+        subdomain = form.cleaned_data.get("subdomain")
         country = form.cleaned_data.get("country")
         config = {
             Channel.CONFIG_API_KEY: api_key,
-            Channel.CONFIG_BASE_URL: base_url,
+            Channel.CONFIG_BASE_URL: f"https://{subdomain}.api.infobip.com",
             Channel.CONFIG_CALLBACK_DOMAIN: org.get_brand_domain(),
         }
 

--- a/temba/channels/types/signalwire/tests.py
+++ b/temba/channels/types/signalwire/tests.py
@@ -32,9 +32,15 @@ class SignalWireTest(TembaTest):
 
         post_data["country"] = "US"
         post_data["number"] = "2065551212"
-        post_data["domain"] = "temba.signalwire.com"
+        post_data["space"] = "temba"
         post_data["project_key"] = "key123"
         post_data["api_token"] = "token123"
+
+        # reject anything that isn't a plain space name
+        post_data["space"] = "temba.signalwire.com"
+        response = self.client.post(url, post_data)
+        self.assertFormError(response.context["form"], "space", "Enter a valid space name.")
+        post_data["space"] = "temba"
 
         # try once with an error
         with patch("requests.get") as mock_get:

--- a/temba/channels/types/signalwire/views.py
+++ b/temba/channels/types/signalwire/views.py
@@ -1,3 +1,5 @@
+import re
+
 import phonenumbers
 import requests
 from smartmin.views import SmartFormView
@@ -10,6 +12,8 @@ from temba.utils.fields import SelectWidget
 
 from ...models import Channel
 from ...views import ALL_COUNTRIES, ClaimViewMixin
+
+SPACE_RE = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$")
 
 
 class SignalWireClaimView(ClaimViewMixin, SmartFormView):
@@ -27,8 +31,10 @@ class SignalWireClaimView(ClaimViewMixin, SmartFormView):
             label=_("Number"),
             help_text=_("The phone number or short code you are connecting."),
         )
-        domain = forms.CharField(
-            max_length=1024, label=_("Domain"), help_text=_("The domain for your account ex: rapid.signalwire.com")
+        space = forms.CharField(
+            max_length=64,
+            label=_("Space"),
+            help_text=_("Your SignalWire Space name. For example, if your space is rapid.signalwire.com, enter rapid."),
         )
         project_key = forms.CharField(
             max_length=64,
@@ -41,12 +47,23 @@ class SignalWireClaimView(ClaimViewMixin, SmartFormView):
             help_text=_("The API token to use to authenticate ex: FPd199eb93e878f8a3tw9ttna313914tnauwy"),
         )
 
+        def clean_space(self):
+            value = self.cleaned_data["space"].strip().lower()
+            if not SPACE_RE.match(value):
+                raise forms.ValidationError(_("Enter a valid space name."))
+            return value
+
         def clean(self):
-            sid = self.cleaned_data["project_key"]
-            token = self.cleaned_data["api_token"]
-            domain = self.cleaned_data["domain"]
+            sid = self.cleaned_data.get("project_key")
+            token = self.cleaned_data.get("api_token")
+            space = self.cleaned_data.get("space")
             number = self.cleaned_data["number"]
             country = self.cleaned_data["country"]
+
+            if not space:
+                return self.cleaned_data
+
+            domain = f"{space}.signalwire.com"
 
             address = number
             if len(number) > 6:
@@ -83,7 +100,8 @@ class SignalWireClaimView(ClaimViewMixin, SmartFormView):
 
         country = data.get("country")
         number = data.get("number")
-        domain = data.get("domain")
+        space = data.get("space")
+        domain = f"{space}.signalwire.com"
         sid = data.get("project_key")
         token = data.get("api_token")
 

--- a/temba/channels/types/signalwire/views.py
+++ b/temba/channels/types/signalwire/views.py
@@ -32,7 +32,7 @@ class SignalWireClaimView(ClaimViewMixin, SmartFormView):
             help_text=_("The phone number or short code you are connecting."),
         )
         space = forms.CharField(
-            max_length=64,
+            max_length=63,
             label=_("Space"),
             help_text=_("Your SignalWire Space name. For example, if your space is rapid.signalwire.com, enter rapid."),
         )
@@ -57,10 +57,10 @@ class SignalWireClaimView(ClaimViewMixin, SmartFormView):
             sid = self.cleaned_data.get("project_key")
             token = self.cleaned_data.get("api_token")
             space = self.cleaned_data.get("space")
-            number = self.cleaned_data["number"]
-            country = self.cleaned_data["country"]
+            number = self.cleaned_data.get("number")
+            country = self.cleaned_data.get("country")
 
-            if not space:
+            if not (space and number and country):
                 return self.cleaned_data
 
             domain = f"{space}.signalwire.com"
@@ -84,7 +84,7 @@ class SignalWireClaimView(ClaimViewMixin, SmartFormView):
                         phone_sid = phone.get("sid", "")
                         break
             except Exception:
-                raise ValidationError("Unable to connect to SignalWire, please check your domain, key and token")
+                raise ValidationError("Unable to connect to SignalWire, please check your space, key and token")
 
             if phone_sid == "":
                 raise ValidationError(f"Unable to find phone with number {number} on your account")


### PR DESCRIPTION
## Summary
- Infobip claim form now asks for the API subdomain (e.g. `xxxxx`) instead of the full `https://xxxxx.api.infobip.com` URL.
- SignalWire claim form now asks for the Space name (e.g. `rapid`) instead of the full `rapid.signalwire.com` domain.
- Both forms still construct and save the full base URL in channel config, so courier and other consumers are unchanged.
- Both new fields are validated as plain DNS labels to prevent arbitrary URLs being entered.

## Test plan
- [x] Existing Infobip and SignalWire claim tests updated to post the new fields and assert the saved `base_url` is constructed correctly
- [x] Added cases that a non-label value (e.g. full URL) is rejected with a validation error
- [x] `manage.py test temba.channels.types.infobip temba.channels.types.signalwire` passes
- [x] `code_check.py` passes