### PR TITLE
Run gc.collect() after each export

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1,3 +1,4 @@
+import gc
 import itertools
 import logging
 import os
@@ -1512,6 +1513,8 @@ class Export(TembaUUIDMixin, models.Model):
             self.save(update_fields=("status", "num_records", "path", "modified_on"))
 
             ExportFinishedNotificationType.create(self)
+        finally:
+            gc.collect()
 
     @classmethod
     def get_unfinished(cls, org, export_type: str):

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -1,4 +1,3 @@
-import gc
 import itertools
 import logging
 import os
@@ -1513,8 +1512,6 @@ class Export(TembaUUIDMixin, models.Model):
             self.save(update_fields=("status", "num_records", "path", "modified_on"))
 
             ExportFinishedNotificationType.create(self)
-        finally:
-            gc.collect()
 
     @classmethod
     def get_unfinished(cls, org, export_type: str):

--- a/temba/orgs/tasks.py
+++ b/temba/orgs/tasks.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 from datetime import timedelta
 
@@ -32,7 +33,10 @@ def perform_export(export_id):
     """
     Perform an export
     """
-    Export.objects.select_related("org", "created_by").get(id=export_id).perform()
+    try:
+        Export.objects.select_related("org", "created_by").get(id=export_id).perform()
+    finally:
+        gc.collect()
 
 
 @shared_task


### PR DESCRIPTION
## Summary
- Adds a `gc.collect()` in a `finally` block at the end of `Export.perform()` so retained references from large exports (contacts, messages, results, tickets, definitions) are freed before the worker picks up its next job. This is a low-risk first step at addressing worker memory growth seen since the Python 3.14 upgrade.

## Test plan
- [ ] Run an export end-to-end and confirm it still completes successfully
- [ ] Monitor celery worker RSS over a sequence of exports