### PR TITLE
Hide PO translation export/import menu items in flow editor

### DIFF
--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -806,17 +806,6 @@ class FlowCRUDL(SmartCRUDL):
             if self.has_org_perm("orgs.org_export"):
                 menu.add_link(_("Export Definition"), f"{reverse('orgs.org_export')}?flow={obj.id}")
 
-            # limit PO export/import to non-archived flows since mailroom doesn't know about archived flows
-            if not obj.is_archived:
-                menu.add_modax(
-                    _("Export Translation"),
-                    "export-translation",
-                    reverse("flows.flow_export_translation", args=[obj.id]),
-                )
-
-                if self.has_org_perm("flows.flow_update"):
-                    menu.add_link(_("Import Translation"), reverse("flows.flow_import_translation", args=[obj.id]))
-
     class ChangeLanguage(OrgObjPermsMixin, SmartUpdateView):
         class Form(forms.Form):
             language = forms.CharField(required=True)


### PR DESCRIPTION
## Summary

- Removes the **Export Translation** and **Import Translation** entries from the flow editor's context menu.
- The underlying views, URLs, and mailroom PO export/import client calls are untouched — direct links still work, and re-enabling is a trivial revert.

## Why

First step toward potentially removing PO file export/import as a feature. Hiding the menu items lets us gauge whether anyone notices or complains before committing to a full removal.

## Test plan

- [x] `test_views`, `test_menu`, and `test_export_and_download_translation` pass.
- [x] `ruff format` / `ruff check` clean.
- [ ] Manually confirm the two entries no longer appear in the flow editor's gear menu.