### PR TITLE
Add contact event timeline (past and upcoming)

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -800,12 +800,22 @@ class Contact(LegacyUUIDMixin, SmartModel):
 
         future_full.sort(key=lambda e: e[0])
 
-        # past page: events strictly before the past cursor (defaults to now)
-        past_cutoff = iso8601.parse_date(before) if before else now
+        # past page: events strictly before the past cursor (defaults to now). a malformed cursor
+        # (e.g. a hand-crafted query param) is treated as absent rather than raising
+        past_cutoff = now
+        if before:
+            try:
+                past_cutoff = iso8601.parse_date(before)
+            except iso8601.ParseError:
+                pass
         past_window = [(w, e) for (w, e) in past_full if w < past_cutoff]
 
+        # sent broadcasts are loaded capped (past_limit + 1) so we can tell if there are more; the
+        # tie-break below tops this up if a tied group lands on the page boundary
+        sent_msg_ids = set()
         sent = self.msgs.filter(broadcast__isnull=False, created_on__lt=past_cutoff).order_by("-created_on")
         for msg in sent[: past_limit + 1]:
+            sent_msg_ids.add(msg.id)
             past_window.append(
                 (
                     msg.created_on,
@@ -826,11 +836,29 @@ class Contact(LegacyUUIDMixin, SmartModel):
             boundary = past_page[-1][0]
             while len(past_page) < len(past_window) and past_window[len(past_page)][0] == boundary:
                 past_page.append(past_window[len(past_page)])
-            has_more_past = len(past_window) > len(past_page)
 
-        # future page: events strictly after the future cursor (defaults to no cursor = from soonest)
+            # sent broadcasts were only loaded capped, so the in-memory window may not hold every
+            # broadcast tied at the boundary timestamp - fetch any not already included and append
+            # them so the strict `< boundary` next-page cursor can't skip a tied sibling
+            for msg in self.msgs.filter(broadcast__isnull=False, created_on=boundary).exclude(id__in=sent_msg_ids):
+                past_page.append(
+                    (
+                        msg.created_on,
+                        {"type": "sent_broadcast", "scheduled": msg.created_on.isoformat(), "message": msg.text},
+                    )
+                )
+
+            has_more_past = len(past_window) > len(past_page) or sent.filter(created_on__lt=boundary).exists()
+
+        # future page: events strictly after the future cursor (defaults to no cursor = from soonest).
+        # a malformed cursor is treated as absent rather than raising
+        after_dt = None
         if after is not None:
-            after_dt = iso8601.parse_date(after)
+            try:
+                after_dt = iso8601.parse_date(after)
+            except iso8601.ParseError:
+                pass
+        if after_dt is not None:
             future_window = [(w, e) for (w, e) in future_full if w > after_dt]
         else:
             future_window = future_full

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -668,7 +668,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
             .filter(Q(contacts__in=[self]) | Q(groups__in=self.groups.all()))
             .exclude(exclude_groups__in=self.groups.all())
             .distinct()
-            .select_related("schedule")
+            .select_related("schedule", "flow")
         )
 
     def _get_campaigns(self):
@@ -817,6 +817,17 @@ class Contact(LegacyUUIDMixin, SmartModel):
         has_more_past = len(past_window) > past_limit
         past_page = past_window[:past_limit]
 
+        # the next-page cursor is a bare timestamp and the next page filters strictly before it, so
+        # if the page boundary splits a group of events sharing the same timestamp, the un-shown
+        # siblings would be dropped. campaign-event times derived from anchor + offset (and snapped
+        # to delivery_hour) can collide, so extend the page to cover the whole tied group at the
+        # boundary - then the strict `< cursor` next page can't skip anything
+        if has_more_past:
+            boundary = past_page[-1][0]
+            while len(past_page) < len(past_window) and past_window[len(past_page)][0] == boundary:
+                past_page.append(past_window[len(past_page)])
+            has_more_past = len(past_window) > len(past_page)
+
         # future page: events strictly after the future cursor (defaults to no cursor = from soonest)
         if after is not None:
             after_dt = iso8601.parse_date(after)
@@ -826,6 +837,14 @@ class Contact(LegacyUUIDMixin, SmartModel):
 
         has_more_future = len(future_window) > future_limit
         future_page = future_window[:future_limit]
+
+        # same tie-break guard as the past page: the next-page cursor filters strictly after a bare
+        # timestamp, so extend the page to cover any tied group straddling the boundary
+        if has_more_future:
+            boundary = future_page[-1][0]
+            while len(future_page) < len(future_window) and future_window[len(future_page)][0] == boundary:
+                future_page.append(future_window[len(future_page)])
+            has_more_future = len(future_window) > len(future_page)
 
         return {
             "now": now.isoformat(),

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -651,7 +651,9 @@ class Contact(LegacyUUIDMixin, SmartModel):
 
     def get_scheduled_broadcasts(self):
         return (
-            self.org.broadcasts.filter(schedule__next_fire__gte=timezone.now(), is_active=True)
+            self.org.broadcasts.filter(
+                schedule__next_fire__gte=timezone.now(), schedule__is_paused=False, is_active=True
+            )
             .exclude(schedule=None)
             .filter(Q(contacts__in=[self]) | Q(groups__in=self.groups.all()))
             .distinct()
@@ -663,7 +665,10 @@ class Contact(LegacyUUIDMixin, SmartModel):
 
         return (
             self.org.triggers.filter(
-                trigger_type=Trigger.TYPE_SCHEDULE, schedule__next_fire__gte=timezone.now(), is_archived=False
+                trigger_type=Trigger.TYPE_SCHEDULE,
+                schedule__next_fire__gte=timezone.now(),
+                schedule__is_paused=False,
+                is_archived=False,
             )
             .filter(Q(contacts__in=[self]) | Q(groups__in=self.groups.all()))
             .exclude(exclude_groups__in=self.groups.all())
@@ -801,11 +806,12 @@ class Contact(LegacyUUIDMixin, SmartModel):
         future_full.sort(key=lambda e: e[0])
 
         # past page: events strictly before the past cursor (defaults to now). a malformed cursor
-        # (e.g. a hand-crafted query param) is treated as absent rather than raising
+        # (e.g. a hand-crafted query param) is treated as absent rather than raising, and the cursor
+        # is clamped to now so a future-dated cursor can't pull the entire (uncapped) past history
         past_cutoff = now
         if before:
             try:
-                past_cutoff = iso8601.parse_date(before)
+                past_cutoff = min(iso8601.parse_date(before), now)
             except iso8601.ParseError:
                 pass
         past_window = [(w, e) for (w, e) in past_full if w < past_cutoff]
@@ -836,6 +842,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
             boundary = past_page[-1][0]
             while len(past_page) < len(past_window) and past_window[len(past_page)][0] == boundary:
                 past_page.append(past_window[len(past_page)])
+            in_mem_end = len(past_page)  # entries beyond this come from the DB top-up below, not past_window
 
             # sent broadcasts were only loaded capped, so the in-memory window may not hold every
             # broadcast tied at the boundary timestamp - fetch any not already included and append
@@ -848,7 +855,9 @@ class Contact(LegacyUUIDMixin, SmartModel):
                     )
                 )
 
-            has_more_past = len(past_window) > len(past_page) or sent.filter(created_on__lt=boundary).exists()
+            # compare against the in-memory window end (not len(past_page)) - the DB top-up can push
+            # past_page past len(past_window) while older entries still remain to show on the next page
+            has_more_past = len(past_window) > in_mem_end or sent.filter(created_on__lt=boundary).exists()
 
         # future page: events strictly after the future cursor (defaults to no cursor = from soonest).
         # a malformed cursor is treated as absent rather than raising

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -19,6 +19,7 @@ from django.core.validators import validate_email
 from django.db import models, transaction
 from django.db.models import Count, F, Max, Q, Sum, Value
 from django.db.models.functions import Concat, Lower
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -670,61 +671,178 @@ class Contact(LegacyUUIDMixin, SmartModel):
             .select_related("schedule")
         )
 
-    def get_scheduled(self) -> list:
+    def _get_campaigns(self):
         """
-        Gets this contact's upcoming activity
+        Returns the active campaigns this contact is a member of (via group membership).
+        """
+        from temba.campaigns.models import Campaign
+
+        return list(
+            Campaign.objects.filter(org=self.org, is_archived=False, group__in=self.groups.all())
+            .prefetch_related("events", "events__flow", "events__relative_to")
+            .distinct()
+        )
+
+    def _get_campaign_events(self, campaigns) -> list:
+        """
+        Computes the times of all campaign events for the given campaigns (which should be the ones
+        this contact is currently a member of).
+
+        Each event's time is derived from the contact's anchor date field plus the event offset, so the
+        result is the campaign's prospective timeline relative to this contact - not a record of what
+        actually fired (a contact may have joined a campaign mid-way through). Returns a list of
+        (datetime, event-dict) tuples.
         """
         from temba.campaigns.models import CampaignEvent
 
-        def scope_to_event_id(scope: str) -> int:
-            # scope is "<eventid>:<fire_version>"
-            return int(scope.split(":")[0])
+        field_values = {}  # cache anchor field values by field id
+        results = []
+        for campaign in campaigns:
+            for event in campaign.events.all():
+                if not event.is_active:
+                    continue
 
-        fires = self.fires.filter(fire_type=ContactFire.TYPE_CAMPAIGN_EVENT)
-        event_ids = {scope_to_event_id(f.scope) for f in fires}
-        events = CampaignEvent.objects.filter(
-            campaign__org=self.org, campaign__is_archived=False, id__in=event_ids, is_active=True
-        )
-        events_by_id = {e.id: e for e in events}
+                field = event.relative_to
+                if field.id not in field_values:
+                    field_values[field.id] = self.get_field_value(field)
+                anchor = field_values[field.id]
+                if anchor is None:  # contact has no value for this event's anchor field
+                    continue
 
-        merged = []
-        for fire in fires:
-            event = events_by_id.get(scope_to_event_id(fire.scope))
-            if event and fire.scope == f"{event.id}:{event.fire_version}":
+                when = anchor + event.get_offset()
+                if event.delivery_hour >= 0 and event.unit in (CampaignEvent.UNIT_DAYS, CampaignEvent.UNIT_WEEKS):
+                    when = when.astimezone(self.org.timezone).replace(
+                        hour=event.delivery_hour, minute=0, second=0, microsecond=0
+                    )
+
                 obj = {
                     "type": "campaign_event",
-                    "scheduled": fire.fire_on.isoformat(),
-                    "repeat_period": None,
-                    "campaign": event.campaign.as_export_ref(),
+                    "scheduled": when.isoformat(),
+                    "campaign": {
+                        **campaign.as_export_ref(),
+                        "url": reverse("campaigns.campaign_read", args=[campaign.uuid]),
+                    },
+                    "url": reverse("campaigns.campaignevent_read", args=[campaign.uuid, event.uuid]),
                 }
                 if event.event_type == CampaignEvent.TYPE_FLOW:
-                    obj["flow"] = event.flow.as_export_ref()
+                    obj["flow"] = {
+                        **event.flow.as_export_ref(),
+                        "url": reverse("flows.flow_editor", args=[event.flow.uuid]),
+                    }
                 else:
                     obj["message"] = event.get_message(contact=self)["text"]
 
-                merged.append(obj)
+                results.append((when, obj))
 
+        return results
+
+    def get_events(self, *, before: str = None, after: str = None, past_limit: int = 5, future_limit: int = 10) -> dict:
+        """
+        Gets this contact's event timeline - a merged, time-ordered view of campaign events and
+        broadcasts, both upcoming and past.
+
+        By default we return up to `future_limit` upcoming events plus the most recent `past_limit`
+        past events. Passing the returned `next_before` cursor pages further back through past events
+        with no limit; passing `next_after` pages further forward through upcoming events. The
+        returned `future_count` is the total number of upcoming events (uncapped) so callers can
+        display an accurate badge.
+        """
+        now = timezone.now()
+        # upcoming events are capped at a year out across the board - projected
+        # repeating schedules stop at the horizon, and one-off events beyond
+        # the horizon are simply dropped
+        horizon = now + timedelta(days=365)
+        campaigns = self._get_campaigns()
+
+        # build the canonical future and past pools - we always compute both so that
+        # future_count is accurate regardless of which page is being requested
+        future_full = []
+        past_full = []
+
+        for when, event in self._get_campaign_events(campaigns):
+            if when < now:
+                past_full.append((when, event))
+            elif when <= horizon:
+                future_full.append((when, event))
+
+        # repeating schedules expand into multiple timeline entries within the
+        # one-year horizon so the user sees the cadence directly rather than a
+        # "Weekly" caption on a single dot
         for broadcast in self.get_scheduled_broadcasts():
-            merged.append(
-                {
-                    "type": "scheduled_broadcast",
-                    "scheduled": broadcast.schedule.next_fire.isoformat(),
-                    "repeat_period": broadcast.schedule.repeat_period,
-                    "message": broadcast.get_translation()["text"],
-                }
-            )
-
+            text = broadcast.get_translation()["text"]
+            for fire_time in broadcast.schedule.project_fires(horizon):
+                future_full.append(
+                    (
+                        fire_time,
+                        {
+                            "type": "scheduled_broadcast",
+                            "scheduled": fire_time.isoformat(),
+                            "message": text,
+                        },
+                    )
+                )
         for trigger in self.get_scheduled_triggers():
-            merged.append(
-                {
-                    "type": "scheduled_trigger",
-                    "scheduled": trigger.schedule.next_fire.isoformat(),
-                    "repeat_period": trigger.schedule.repeat_period,
-                    "flow": trigger.flow.as_export_ref(),
-                }
+            flow_ref = {
+                **trigger.flow.as_export_ref(),
+                "url": reverse("flows.flow_editor", args=[trigger.flow.uuid]),
+            }
+            for fire_time in trigger.schedule.project_fires(horizon):
+                future_full.append(
+                    (
+                        fire_time,
+                        {
+                            "type": "scheduled_trigger",
+                            "scheduled": fire_time.isoformat(),
+                            "flow": flow_ref,
+                        },
+                    )
+                )
+
+        future_full.sort(key=lambda e: e[0])
+
+        # past page: events strictly before the past cursor (defaults to now)
+        past_cutoff = iso8601.parse_date(before) if before else now
+        past_window = [(w, e) for (w, e) in past_full if w < past_cutoff]
+
+        sent = self.msgs.filter(broadcast__isnull=False, created_on__lt=past_cutoff).order_by("-created_on")
+        for msg in sent[: past_limit + 1]:
+            past_window.append(
+                (
+                    msg.created_on,
+                    {"type": "sent_broadcast", "scheduled": msg.created_on.isoformat(), "message": msg.text},
+                )
             )
 
-        return sorted(merged, key=lambda k: k["scheduled"])
+        past_window.sort(key=lambda e: e[0], reverse=True)
+        has_more_past = len(past_window) > past_limit
+        past_page = past_window[:past_limit]
+
+        # future page: events strictly after the future cursor (defaults to no cursor = from soonest)
+        if after is not None:
+            after_dt = iso8601.parse_date(after)
+            future_window = [(w, e) for (w, e) in future_full if w > after_dt]
+        else:
+            future_window = future_full
+
+        has_more_future = len(future_window) > future_limit
+        future_page = future_window[:future_limit]
+
+        return {
+            "now": now.isoformat(),
+            "campaigns": [
+                {
+                    "uuid": str(c.uuid),
+                    "name": c.name,
+                    "url": reverse("campaigns.campaign_read", args=[c.uuid]),
+                }
+                for c in campaigns
+            ],
+            "future_count": len(future_full),
+            "future": [event for _, event in future_page],
+            "past": [event for _, event in past_page],
+            "next_before": past_page[-1][0].isoformat() if has_more_past and past_page else None,
+            "next_after": future_page[-1][0].isoformat() if has_more_future and future_page else None,
+        }
 
     def get_field_serialized(self, field) -> str:
         """

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -741,9 +741,11 @@ class Contact(LegacyUUIDMixin, SmartModel):
 
         return results
 
-    def get_events(self, *, before: str = None, after: str = None, past_limit: int = 5, future_limit: int = 10) -> dict:
+    def get_timeline(
+        self, *, before: str = None, after: str = None, past_limit: int = 5, future_limit: int = 10
+    ) -> dict:
         """
-        Gets this contact's event timeline - a merged, time-ordered view of campaign events and
+        Gets this contact's timeline - a merged, time-ordered view of campaign events and
         broadcasts, both upcoming and past.
 
         By default we return up to `future_limit` upcoming events plus the most recent `past_limit`

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1248,6 +1248,46 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(3, response.json()["future_count"])
         self.assertEqual(1, len(response.json()["past"]))  # campaign event dropped, sent broadcast remains
 
+    def test_events_delivery_hour_snapping(self):
+        """A campaign event with a delivery_hour snaps its projected time to that hour in the org timezone."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        group = self.create_group("Members", contacts=[contact])
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
+        # joined a few days ago at an arbitrary time-of-day so we can confirm the projected time isn't
+        # just anchor + offset; the +20 day offset below still lands comfortably in the future
+        joined_at = timezone.now().replace(hour=3, minute=37, second=12, microsecond=0) - timedelta(days=5)
+        self.set_contact_field(contact, "joined", joined_at.isoformat())
+
+        # +20 day event with delivery_hour=9 (UNIT_DAYS) -> projected time snaps to 09:00 org-local
+        campaign = Campaign.create(self.org, self.admin, "Reminders", group)
+        CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign,
+            joined,
+            20,
+            unit="D",
+            delivery_hour=9,
+            translations={"eng": {"text": "Morning reminder"}},
+            base_language="eng",
+        )
+
+        response = self.requestView(events_url, self.admin)
+        future = response.json()["future"]
+        self.assertEqual(1, len(future))
+
+        scheduled = iso8601.parse_date(future[0]["scheduled"]).astimezone(self.org.timezone)
+        expected = (
+            (joined_at + timedelta(days=20))
+            .astimezone(self.org.timezone)
+            .replace(hour=9, minute=0, second=0, microsecond=0)
+        )
+        self.assertEqual(expected, scheduled)
+        self.assertEqual(9, scheduled.hour)
+        self.assertEqual(0, scheduled.minute)
+
     def test_events_pagination(self):
         contact = self.create_contact("Joe", phone="+1234567890")
         events_url = reverse("contacts.contact_events", args=[contact.uuid])
@@ -1399,9 +1439,27 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         scheduled = [e["scheduled"] for e in seen]
         # all seven events present, none dropped, none duplicated
         self.assertEqual(7, len(scheduled))
-        self.assertEqual(7, len(set(scheduled)) + 2)  # 3 tied share one timestamp -> 5 distinct
+        # the 3 tied events share one timestamp, the other 4 are distinct -> 5 distinct timestamps
+        self.assertEqual(5, len(set(scheduled)))
         # the three tied events all survive
         self.assertEqual(3, sum(1 for e in seen if e["message"].startswith("Tied")))
+
+    def test_events_malformed_cursor(self):
+        """A garbage before/after cursor is treated as absent and returns a normal 200, not a 500."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        # baseline response with no cursor (drop `now`, which is recomputed fresh per request)
+        expected = self.requestView(events_url, self.admin).json()
+        del expected["now"]
+
+        for param in ("before", "after"):
+            response = self.requestView(events_url + f"?{param}=garbage", self.admin)
+            self.assertEqual(200, response.status_code)
+            # an unparseable cursor falls back to the default (no cursor), matching the baseline
+            actual = response.json()
+            del actual["now"]
+            self.assertEqual(expected, actual)
 
     def test_events_repeating_projection(self):
         """A repeating scheduled broadcast expands into timeline entries within the one-year horizon."""

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1539,6 +1539,104 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(8, len(messages))
         self.assertEqual(set(f"Tied {i}" for i in range(8)), set(messages))
 
+    def test_events_excludes_paused_schedules(self):
+        """Scheduled broadcasts and triggers whose schedule is paused are excluded from the timeline."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        # a non-paused scheduled broadcast (future fire) - should appear in future
+        self.create_broadcast(
+            self.admin,
+            {"eng": {"text": "Active bcast"}},
+            contacts=[contact],
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=3), Schedule.REPEAT_NEVER),
+        )
+
+        # a paused scheduled broadcast (future fire) - should be excluded
+        paused_bcast = self.create_broadcast(
+            self.admin,
+            {"eng": {"text": "Paused bcast"}},
+            contacts=[contact],
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=4), Schedule.REPEAT_NEVER),
+        )
+        paused_bcast.schedule.is_paused = True
+        paused_bcast.schedule.save()
+
+        # a paused scheduled trigger - should be excluded
+        paused_trigger = Trigger.create(
+            self.org,
+            self.admin,
+            trigger_type=Trigger.TYPE_SCHEDULE,
+            flow=self.create_flow("Paused Flow"),
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=5), Schedule.REPEAT_NEVER),
+        )
+        paused_trigger.contacts.add(contact)
+        paused_trigger.schedule.is_paused = True
+        paused_trigger.schedule.save()
+
+        future = self.requestView(events_url, self.admin).json()["future"]
+        messages = [e.get("message") for e in future if e["type"] == "scheduled_broadcast"]
+        self.assertEqual(["Active bcast"], messages)  # non-paused broadcast present
+        self.assertNotIn("Paused bcast", messages)  # paused broadcast excluded
+        self.assertEqual([], [e for e in future if e["type"] == "scheduled_trigger"])  # paused trigger excluded
+
+    def test_events_more_past_not_dropped_with_tied_sent_broadcasts(self):
+        """Older past events aren't dropped when a full page of tied sent broadcasts straddles the boundary."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        group = self.create_group("Members", contacts=[contact])
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        tied_at = timezone.now() - timedelta(days=30)
+
+        # eight sent broadcasts ALL sharing one created_on (T = now - 30d). With past_limit=5 the first
+        # page loads only past_limit + 1 (=6) of them; the in-memory tie-break extends to all 6 loaded
+        # (the cap), then the supplemental DB query appends the other 2 tied siblings -> past_page holds 8.
+        for i in range(8):
+            bcast = self.create_broadcast(self.admin, {"eng": {"text": f"Tied {i}"}}, contacts=[contact])
+            bcast.msgs.all().delete()  # drop the auto-created now-dated msg
+            msg = self.create_outgoing_msg(contact, f"Tied {i}", created_on=tied_at)
+            msg.broadcast = bcast
+            msg.save(update_fields=("broadcast",))
+
+        # two OLDER past campaign message events at distinct times strictly older than T. The contact
+        # joined 100 days ago, so the +10d / +40d offsets project to now - 90d and now - 60d.
+        joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
+        joined_at = timezone.now() - timedelta(days=100)
+        self.set_contact_field(contact, "joined", joined_at.isoformat())
+        campaign = Campaign.create(self.org, self.admin, "Reminders", group)
+        for days in (10, 40):  # -> now - 90d and now - 60d, both older than the tied broadcasts at T
+            CampaignEvent.create_message_event(
+                self.org,
+                self.admin,
+                campaign,
+                joined,
+                days,
+                unit="D",
+                translations={"eng": {"text": f"Campaign +{days}d"}},
+                base_language="eng",
+            )
+
+        # the old code computed has_more_past as len(past_window)=8 > len(past_page)=8 -> False, so the
+        # first page's cursor was None and the 2 older campaign events were silently dropped. the fix
+        # compares against the in-memory window end (6) instead, so paging continues to the older events.
+        seen = []
+        before = None
+        for _ in range(20):  # generous cap to avoid an infinite loop on regression
+            url = events_url + (f"?before={quote(before)}" if before else "")
+            data = self.requestView(url, self.admin).json()
+            seen.extend(data["past"])
+            before = data["next_before"]
+            if not before:
+                break
+
+        messages = [e["message"] for e in seen]
+        # all 10 events surface across paging: 8 tied broadcasts + 2 older campaign events, no drops/dupes
+        self.assertEqual(10, len(messages))
+        self.assertEqual(set(messages), set([f"Tied {i}" for i in range(8)] + ["Campaign +10d", "Campaign +40d"]))
+        # the 2 older campaign events specifically must survive (the false-negative the fix addresses)
+        self.assertIn("Campaign +10d", messages)
+        self.assertIn("Campaign +40d", messages)
+
     def test_events_pagination_tied_future(self):
         """Upcoming events tied at the future page boundary are never split across the page boundary."""
         contact = self.create_contact("Joe", phone="+1234567890")

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1086,15 +1086,15 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             export.config,
         )
 
-    def test_events(self):
+    def test_timeline(self):
         contact1 = self.create_contact("Joe", phone="+1234567890")
         contact2 = self.create_contact("Frank", phone="+1204567802")
         farmers = self.create_group("Farmers", contacts=[contact1, contact2])
 
-        events_url = reverse("contacts.contact_events", args=[contact1.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact1.uuid])
 
-        self.assertRequestDisallowed(events_url, [None, self.agent, self.admin2])
-        response = self.assertReadFetch(events_url, [self.editor, self.admin])
+        self.assertRequestDisallowed(timeline_url, [None, self.agent, self.admin2])
+        response = self.assertReadFetch(timeline_url, [self.editor, self.admin])
         self.assertEqual([], response.json()["campaigns"])
         self.assertEqual([], response.json()["future"])
         self.assertEqual([], response.json()["past"])
@@ -1165,7 +1165,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         trigger3.contacts.add(contact1, contact2)
         trigger3.exclude_groups.add(farmers)
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         self.assertEqual(
             [
                 {
@@ -1243,16 +1243,16 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # events for archived campaigns shouldn't appear
         campaign.archive(self.admin)
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         self.assertEqual(3, len(response.json()["future"]))  # campaign event dropped
         self.assertEqual(3, response.json()["future_count"])
         self.assertEqual(1, len(response.json()["past"]))  # campaign event dropped, sent broadcast remains
 
-    def test_events_delivery_hour_snapping(self):
+    def test_timeline_delivery_hour_snapping(self):
         """A campaign event with a delivery_hour snaps its projected time to that hour in the org timezone."""
         contact = self.create_contact("Joe", phone="+1234567890")
         group = self.create_group("Members", contacts=[contact])
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
         # joined a few days ago at an arbitrary time-of-day so we can confirm the projected time isn't
@@ -1274,7 +1274,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             base_language="eng",
         )
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         future = response.json()["future"]
         self.assertEqual(1, len(future))
 
@@ -1288,11 +1288,11 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(9, scheduled.hour)
         self.assertEqual(0, scheduled.minute)
 
-    def test_events_inactive_and_missing_anchor(self):
+    def test_timeline_inactive_and_missing_anchor(self):
         """Inactive campaign events and events whose anchor field the contact lacks are omitted."""
         contact = self.create_contact("Joe", phone="+1234567890")
         group = self.create_group("Members", contacts=[contact])
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
         # a second datetime field that the contact has NO value for
@@ -1339,7 +1339,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         inactive.is_active = False
         inactive.save(update_fields=("is_active",))
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         future = response.json()["future"]
 
         # only the single visible event survives
@@ -1348,15 +1348,15 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(reverse("campaigns.campaignevent_read", args=[campaign.uuid, visible.uuid]), future[0]["url"])
         self.assertEqual("Visible", future[0]["message"])
 
-    def test_events_pagination(self):
+    def test_timeline_pagination(self):
         contact = self.create_contact("Joe", phone="+1234567890")
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         # send the contact more past broadcasts than fit on a single page
         for i in range(7):
             self.create_broadcast(self.admin, {"eng": {"text": f"Bcast {i}"}}, contacts=[contact])
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         self.assertEqual([], response.json()["future"])
         self.assertEqual(0, response.json()["future_count"])
         self.assertEqual(5, len(response.json()["past"]))
@@ -1364,7 +1364,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertIsNotNone(next_before)
 
         # paging back with the cursor returns the remaining older events
-        response = self.requestView(events_url + f"?before={quote(next_before)}", self.admin)
+        response = self.requestView(timeline_url + f"?before={quote(next_before)}", self.admin)
         self.assertEqual([], response.json()["future"])
         self.assertEqual(2, len(response.json()["past"]))
         self.assertIsNone(response.json()["next_before"])
@@ -1378,22 +1378,22 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                 schedule=Schedule.create(self.org, timezone.now() + timedelta(days=i + 1), Schedule.REPEAT_NEVER),
             )
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         self.assertEqual(10, len(response.json()["future"]))
         self.assertEqual(12, response.json()["future_count"])
         next_after = response.json()["next_after"]
         self.assertIsNotNone(next_after)
 
-        response = self.requestView(events_url + f"?after={quote(next_after)}", self.admin)
+        response = self.requestView(timeline_url + f"?after={quote(next_after)}", self.admin)
         self.assertEqual(2, len(response.json()["future"]))
         self.assertEqual(12, response.json()["future_count"])
         self.assertIsNone(response.json()["next_after"])
 
-    def test_events_pagination_mixed_past(self):
+    def test_timeline_pagination_mixed_past(self):
         """The past-page cursor pages correctly through a mix of campaign events and sent broadcasts."""
         contact = self.create_contact("Joe", phone="+1234567890")
         group = self.create_group("Members", contacts=[contact])
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         # contact joined 100 days ago - campaign offsets below all land in the past
         joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
@@ -1429,14 +1429,14 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             msg.save(update_fields=("broadcast",))
 
         # eight past events total, five per page -> first page has five, cursor set
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         first = response.json()["past"]
         self.assertEqual(5, len(first))
         next_before = response.json()["next_before"]
         self.assertIsNotNone(next_before)
 
         # second page returns the remaining three, no further cursor
-        response = self.requestView(events_url + f"?before={quote(next_before)}", self.admin)
+        response = self.requestView(timeline_url + f"?before={quote(next_before)}", self.admin)
         second = response.json()["past"]
         self.assertEqual(3, len(second))
         self.assertIsNone(response.json()["next_before"])
@@ -1448,11 +1448,11 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # and they remain in strict newest-first order across the boundary
         self.assertEqual(scheduled, sorted(scheduled, reverse=True))
 
-    def test_events_pagination_tied_timestamps(self):
+    def test_timeline_pagination_tied_timestamps(self):
         """Past events sharing an exact timestamp are never split across a page boundary."""
         contact = self.create_contact("Joe", phone="+1234567890")
         group = self.create_group("Members", contacts=[contact])
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
         joined_at = timezone.now() - timedelta(days=100)
@@ -1490,7 +1490,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         seen = []
         before = None
         for _ in range(10):  # generous cap to avoid an infinite loop on regression
-            url = events_url + (f"?before={quote(before)}" if before else "")
+            url = timeline_url + (f"?before={quote(before)}" if before else "")
             data = self.requestView(url, self.admin).json()
             seen.extend(data["past"])
             before = data["next_before"]
@@ -1505,10 +1505,10 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # the three tied events all survive
         self.assertEqual(3, sum(1 for e in seen if e["message"].startswith("Tied")))
 
-    def test_events_pagination_tied_sent_broadcasts(self):
+    def test_timeline_pagination_tied_sent_broadcasts(self):
         """Sent broadcasts tied at the page boundary beyond the capped load are recovered via the supplemental query."""
         contact = self.create_contact("Joe", phone="+1234567890")
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         base = timezone.now() - timedelta(days=30)
 
@@ -1527,7 +1527,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         seen = []
         before = None
         for _ in range(20):  # generous cap to avoid an infinite loop on regression
-            url = events_url + (f"?before={quote(before)}" if before else "")
+            url = timeline_url + (f"?before={quote(before)}" if before else "")
             data = self.requestView(url, self.admin).json()
             seen.extend(data["past"])
             before = data["next_before"]
@@ -1539,10 +1539,10 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(8, len(messages))
         self.assertEqual(set(f"Tied {i}" for i in range(8)), set(messages))
 
-    def test_events_excludes_paused_schedules(self):
+    def test_timeline_excludes_paused_schedules(self):
         """Scheduled broadcasts and triggers whose schedule is paused are excluded from the timeline."""
         contact = self.create_contact("Joe", phone="+1234567890")
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         # a non-paused scheduled broadcast (future fire) - should appear in future
         self.create_broadcast(
@@ -1574,17 +1574,17 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         paused_trigger.schedule.is_paused = True
         paused_trigger.schedule.save()
 
-        future = self.requestView(events_url, self.admin).json()["future"]
+        future = self.requestView(timeline_url, self.admin).json()["future"]
         messages = [e.get("message") for e in future if e["type"] == "scheduled_broadcast"]
         self.assertEqual(["Active bcast"], messages)  # non-paused broadcast present
         self.assertNotIn("Paused bcast", messages)  # paused broadcast excluded
         self.assertEqual([], [e for e in future if e["type"] == "scheduled_trigger"])  # paused trigger excluded
 
-    def test_events_more_past_not_dropped_with_tied_sent_broadcasts(self):
+    def test_timeline_more_past_not_dropped_with_tied_sent_broadcasts(self):
         """Older past events aren't dropped when a full page of tied sent broadcasts straddles the boundary."""
         contact = self.create_contact("Joe", phone="+1234567890")
         group = self.create_group("Members", contacts=[contact])
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         tied_at = timezone.now() - timedelta(days=30)
 
@@ -1622,7 +1622,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         seen = []
         before = None
         for _ in range(20):  # generous cap to avoid an infinite loop on regression
-            url = events_url + (f"?before={quote(before)}" if before else "")
+            url = timeline_url + (f"?before={quote(before)}" if before else "")
             data = self.requestView(url, self.admin).json()
             seen.extend(data["past"])
             before = data["next_before"]
@@ -1637,10 +1637,10 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertIn("Campaign +10d", messages)
         self.assertIn("Campaign +40d", messages)
 
-    def test_events_pagination_tied_future(self):
+    def test_timeline_pagination_tied_future(self):
         """Upcoming events tied at the future page boundary are never split across the page boundary."""
         contact = self.create_contact("Joe", phone="+1234567890")
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         # nine distinct upcoming scheduled broadcasts (days 1..9) plus a tied group of three sharing
         # one later start_time. soonest-first, the future_limit=10 boundary falls inside the tied group
@@ -1665,7 +1665,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         seen = []
         after = None
         for _ in range(20):  # generous cap to avoid an infinite loop on regression
-            url = events_url + (f"?after={quote(after)}" if after else "")
+            url = timeline_url + (f"?after={quote(after)}" if after else "")
             data = self.requestView(url, self.admin).json()
             seen.extend(data["future"])
             after = data["next_after"]
@@ -1679,27 +1679,27 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # the three tied events all survive
         self.assertEqual(3, sum(1 for m in messages if m.startswith("Tied")))
 
-    def test_events_malformed_cursor(self):
+    def test_timeline_malformed_cursor(self):
         """A garbage before/after cursor is treated as absent and returns a normal 200, not a 500."""
         contact = self.create_contact("Joe", phone="+1234567890")
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         # baseline response with no cursor (drop `now`, which is recomputed fresh per request)
-        expected = self.requestView(events_url, self.admin).json()
+        expected = self.requestView(timeline_url, self.admin).json()
         del expected["now"]
 
         for param in ("before", "after"):
-            response = self.requestView(events_url + f"?{param}=garbage", self.admin)
+            response = self.requestView(timeline_url + f"?{param}=garbage", self.admin)
             self.assertEqual(200, response.status_code)
             # an unparseable cursor falls back to the default (no cursor), matching the baseline
             actual = response.json()
             del actual["now"]
             self.assertEqual(expected, actual)
 
-    def test_events_repeating_projection(self):
+    def test_timeline_repeating_projection(self):
         """A repeating scheduled broadcast expands into timeline entries within the one-year horizon."""
         contact = self.create_contact("Joe", phone="+1234567890")
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         bcast = self.create_broadcast(
             self.admin,
@@ -1713,7 +1713,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             ),
         )
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
 
         # the weekly broadcast is projected forward through the one-year window -
         # 52 or 53 occurrences depending on calendar alignment, ten visible per page
@@ -1734,10 +1734,10 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         for earlier, later in zip(fires[1:], fires[2:]):
             self.assertEqual(timedelta(days=7), later - earlier)
 
-    def test_events_horizon_drops_distant_future(self):
+    def test_timeline_horizon_drops_distant_future(self):
         """A one-off scheduled event more than a year out is dropped from the timeline."""
         contact = self.create_contact("Joe", phone="+1234567890")
-        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+        timeline_url = reverse("contacts.contact_timeline", args=[contact.uuid])
 
         # one within the window, one well outside it
         self.create_broadcast(
@@ -1753,7 +1753,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             schedule=Schedule.create(self.org, timezone.now() + timedelta(days=400), Schedule.REPEAT_NEVER),
         )
 
-        response = self.requestView(events_url, self.admin)
+        response = self.requestView(timeline_url, self.admin)
         self.assertEqual(1, response.json()["future_count"])
         self.assertEqual(["Soon"], [e["message"] for e in response.json()["future"]])
 

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1288,6 +1288,66 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(9, scheduled.hour)
         self.assertEqual(0, scheduled.minute)
 
+    def test_events_inactive_and_missing_anchor(self):
+        """Inactive campaign events and events whose anchor field the contact lacks are omitted."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        group = self.create_group("Members", contacts=[contact])
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
+        # a second datetime field that the contact has NO value for
+        renewed = self.create_field("renewed", "Renewed On", value_type=ContactField.TYPE_DATETIME)
+        self.set_contact_field(contact, "joined", (timezone.now() - timedelta(days=5)).isoformat())
+
+        campaign = Campaign.create(self.org, self.admin, "Reminders", group)
+
+        # an active event anchored on a field the contact HAS -> appears
+        visible = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign,
+            joined,
+            20,
+            unit="D",
+            translations={"eng": {"text": "Visible"}},
+            base_language="eng",
+        )
+
+        # an active event anchored on a field the contact does NOT have -> omitted (line 710)
+        CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign,
+            renewed,
+            20,
+            unit="D",
+            translations={"eng": {"text": "No anchor"}},
+            base_language="eng",
+        )
+
+        # an inactive event on a field the contact has -> omitted (line 703)
+        inactive = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign,
+            joined,
+            25,
+            unit="D",
+            translations={"eng": {"text": "Inactive"}},
+            base_language="eng",
+        )
+        inactive.is_active = False
+        inactive.save(update_fields=("is_active",))
+
+        response = self.requestView(events_url, self.admin)
+        future = response.json()["future"]
+
+        # only the single visible event survives
+        self.assertEqual(1, len(future))
+        self.assertEqual(1, response.json()["future_count"])
+        self.assertEqual(reverse("campaigns.campaignevent_read", args=[campaign.uuid, visible.uuid]), future[0]["url"])
+        self.assertEqual("Visible", future[0]["message"])
+
     def test_events_pagination(self):
         contact = self.create_contact("Joe", phone="+1234567890")
         events_url = reverse("contacts.contact_events", args=[contact.uuid])
@@ -1398,22 +1458,12 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         joined_at = timezone.now() - timedelta(days=100)
         self.set_contact_field(contact, "joined", joined_at.isoformat())
 
-        # campaign with three events at the SAME offset -> three events at one identical timestamp,
-        # plus four more at distinct earlier offsets. The three tied events straddle the past_limit=5
-        # boundary, which would drop un-shown siblings without the tie-break guard.
+        # campaign with four newer events at distinct offsets, plus three events at one identical
+        # (older) offset. Newest-first, the page boundary (past_limit=5) falls inside the tied group:
+        # positions 5/6/7 are the three tied siblings, so without the tie-break guard the next-page
+        # `< cursor` filter would drop the un-shown siblings. This exercises the tie-break while loop.
         campaign = Campaign.create(self.org, self.admin, "Reminders", group)
-        for i in range(3):
-            CampaignEvent.create_message_event(
-                self.org,
-                self.admin,
-                campaign,
-                joined,
-                50,  # all +50 days -> identical time
-                unit="D",
-                translations={"eng": {"text": f"Tied {i}"}},
-                base_language="eng",
-            )
-        for days in (10, 20, 30, 40):
+        for days in (40, 50, 60, 70):  # distinct, all NEWER than the +30d tied group
             CampaignEvent.create_message_event(
                 self.org,
                 self.admin,
@@ -1422,6 +1472,17 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                 days,
                 unit="D",
                 translations={"eng": {"text": f"Distinct +{days}d"}},
+                base_language="eng",
+            )
+        for i in range(3):
+            CampaignEvent.create_message_event(
+                self.org,
+                self.admin,
+                campaign,
+                joined,
+                30,  # all +30 days -> identical time, older than the distinct ones above
+                unit="D",
+                translations={"eng": {"text": f"Tied {i}"}},
                 base_language="eng",
             )
 
@@ -1443,6 +1504,82 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(5, len(set(scheduled)))
         # the three tied events all survive
         self.assertEqual(3, sum(1 for e in seen if e["message"].startswith("Tied")))
+
+    def test_events_pagination_tied_sent_broadcasts(self):
+        """Sent broadcasts tied at the page boundary beyond the capped load are recovered via the supplemental query."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        base = timezone.now() - timedelta(days=30)
+
+        # eight sent broadcasts ALL sharing the exact same created_on. the past page loads only
+        # past_limit + 1 (=6) of them, so two tied siblings are left unloaded. the page boundary lands
+        # on this shared timestamp, and the supplemental tied-broadcast query must recover the two that
+        # the capped load missed - otherwise the strict `< cursor` next page would silently drop them.
+        for i in range(8):
+            bcast = self.create_broadcast(self.admin, {"eng": {"text": f"Tied {i}"}}, contacts=[contact])
+            bcast.msgs.all().delete()  # drop the auto-created now-dated msg
+            msg = self.create_outgoing_msg(contact, f"Tied {i}", created_on=base)
+            msg.broadcast = bcast
+            msg.save(update_fields=("broadcast",))
+
+        # walk every past page, collecting all events
+        seen = []
+        before = None
+        for _ in range(20):  # generous cap to avoid an infinite loop on regression
+            url = events_url + (f"?before={quote(before)}" if before else "")
+            data = self.requestView(url, self.admin).json()
+            seen.extend(data["past"])
+            before = data["next_before"]
+            if not before:
+                break
+
+        # all eight tied broadcasts survive paging, none dropped, none duplicated
+        messages = [e["message"] for e in seen]
+        self.assertEqual(8, len(messages))
+        self.assertEqual(set(f"Tied {i}" for i in range(8)), set(messages))
+
+    def test_events_pagination_tied_future(self):
+        """Upcoming events tied at the future page boundary are never split across the page boundary."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        # nine distinct upcoming scheduled broadcasts (days 1..9) plus a tied group of three sharing
+        # one later start_time. soonest-first, the future_limit=10 boundary falls inside the tied group
+        # (positions 10/11/12), so the tie-break while loop must extend the page to cover the whole group.
+        for i in range(9):
+            self.create_broadcast(
+                self.admin,
+                {"eng": {"text": f"Distinct {i}"}},
+                contacts=[contact],
+                schedule=Schedule.create(self.org, timezone.now() + timedelta(days=i + 1), Schedule.REPEAT_NEVER),
+            )
+        tied_start = timezone.now() + timedelta(days=20)
+        for i in range(3):
+            self.create_broadcast(
+                self.admin,
+                {"eng": {"text": f"Tied {i}"}},
+                contacts=[contact],
+                schedule=Schedule.create(self.org, tied_start, Schedule.REPEAT_NEVER),
+            )
+
+        # walk every future page, collecting all events
+        seen = []
+        after = None
+        for _ in range(20):  # generous cap to avoid an infinite loop on regression
+            url = events_url + (f"?after={quote(after)}" if after else "")
+            data = self.requestView(url, self.admin).json()
+            seen.extend(data["future"])
+            after = data["next_after"]
+            if not after:
+                break
+
+        messages = [e["message"] for e in seen]
+        # all twelve upcoming events present, none dropped, none duplicated
+        self.assertEqual(12, len(messages))
+        self.assertEqual(12, len(set(messages)))
+        # the three tied events all survive
+        self.assertEqual(3, sum(1 for m in messages if m.startswith("Tied")))
 
     def test_events_malformed_cursor(self):
         """A garbage before/after cursor is treated as absent and returns a normal 200, not a 500."""

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1289,6 +1289,120 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(12, response.json()["future_count"])
         self.assertIsNone(response.json()["next_after"])
 
+    def test_events_pagination_mixed_past(self):
+        """The past-page cursor pages correctly through a mix of campaign events and sent broadcasts."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        group = self.create_group("Members", contacts=[contact])
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        # contact joined 100 days ago - campaign offsets below all land in the past
+        joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
+        joined_at = timezone.now() - timedelta(days=100)
+        self.set_contact_field(contact, "joined", joined_at.isoformat())
+
+        # four past campaign message events at distinct offsets (-90, -80, -70, -60 days)
+        campaign = Campaign.create(self.org, self.admin, "Reminders", group)
+        for days in (10, 20, 30, 40):
+            CampaignEvent.create_message_event(
+                self.org,
+                self.admin,
+                campaign,
+                joined,
+                days,
+                unit="D",
+                translations={"eng": {"text": f"Campaign +{days}d"}},
+                base_language="eng",
+            )
+
+        # four sent broadcasts interleaved in time with the campaign events. created_on is
+        # immutable (DB trigger), so we set it at insert time on a fresh outgoing msg and then
+        # attach it to the broadcast (a non-created_on field update, which the trigger allows)
+        for i in range(4):
+            bcast = self.create_broadcast(self.admin, {"eng": {"text": f"Bcast {i}"}}, contacts=[contact])
+            bcast.msgs.all().delete()  # drop the auto-created now-dated msg
+            msg = self.create_outgoing_msg(
+                contact,
+                f"Bcast {i}",
+                created_on=joined_at + timedelta(days=15 + i * 10),  # -85, -75, -65, -55 days
+            )
+            msg.broadcast = bcast
+            msg.save(update_fields=("broadcast",))
+
+        # eight past events total, five per page -> first page has five, cursor set
+        response = self.requestView(events_url, self.admin)
+        first = response.json()["past"]
+        self.assertEqual(5, len(first))
+        next_before = response.json()["next_before"]
+        self.assertIsNotNone(next_before)
+
+        # second page returns the remaining three, no further cursor
+        response = self.requestView(events_url + f"?before={quote(next_before)}", self.admin)
+        second = response.json()["past"]
+        self.assertEqual(3, len(second))
+        self.assertIsNone(response.json()["next_before"])
+
+        # across both pages we see all eight events with no duplicates and no drops
+        scheduled = [e["scheduled"] for e in first] + [e["scheduled"] for e in second]
+        self.assertEqual(8, len(scheduled))
+        self.assertEqual(8, len(set(scheduled)))
+        # and they remain in strict newest-first order across the boundary
+        self.assertEqual(scheduled, sorted(scheduled, reverse=True))
+
+    def test_events_pagination_tied_timestamps(self):
+        """Past events sharing an exact timestamp are never split across a page boundary."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        group = self.create_group("Members", contacts=[contact])
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
+        joined_at = timezone.now() - timedelta(days=100)
+        self.set_contact_field(contact, "joined", joined_at.isoformat())
+
+        # campaign with three events at the SAME offset -> three events at one identical timestamp,
+        # plus four more at distinct earlier offsets. The three tied events straddle the past_limit=5
+        # boundary, which would drop un-shown siblings without the tie-break guard.
+        campaign = Campaign.create(self.org, self.admin, "Reminders", group)
+        for i in range(3):
+            CampaignEvent.create_message_event(
+                self.org,
+                self.admin,
+                campaign,
+                joined,
+                50,  # all +50 days -> identical time
+                unit="D",
+                translations={"eng": {"text": f"Tied {i}"}},
+                base_language="eng",
+            )
+        for days in (10, 20, 30, 40):
+            CampaignEvent.create_message_event(
+                self.org,
+                self.admin,
+                campaign,
+                joined,
+                days,
+                unit="D",
+                translations={"eng": {"text": f"Distinct +{days}d"}},
+                base_language="eng",
+            )
+
+        # walk every past page, collecting all events
+        seen = []
+        before = None
+        for _ in range(10):  # generous cap to avoid an infinite loop on regression
+            url = events_url + (f"?before={quote(before)}" if before else "")
+            data = self.requestView(url, self.admin).json()
+            seen.extend(data["past"])
+            before = data["next_before"]
+            if not before:
+                break
+
+        scheduled = [e["scheduled"] for e in seen]
+        # all seven events present, none dropped, none duplicated
+        self.assertEqual(7, len(scheduled))
+        self.assertEqual(7, len(set(scheduled)) + 2)  # 3 tied share one timestamp -> 5 distinct
+        # the three tied events all survive
+        self.assertEqual(3, sum(1 for e in seen if e["message"].startswith("Tied")))
+
     def test_events_repeating_projection(self):
         """A repeating scheduled broadcast expands into timeline entries within the one-year horizon."""
         contact = self.create_contact("Joe", phone="+1234567890")
@@ -1317,11 +1431,14 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             self.assertEqual("scheduled_broadcast", entry["type"])
             self.assertEqual("Weekly check-in", entry["message"])
 
-        # those occurrences are sorted oldest-first; the first matches the schedule's next_fire
-        # and successive entries are one week apart
+        # those occurrences are sorted oldest-first; the first matches the schedule's next_fire.
+        # because the schedule starts in the future, update_schedule sets next_fire to the raw
+        # start_time (not snapped to a Monday) and calculate_next_fire only snaps subsequent fires
+        # onto Mondays - so the first interval isn't necessarily 7 days, but every interval after
+        # the second occurrence is
         fires = [iso8601.parse_date(e["scheduled"]) for e in response.json()["future"]]
         self.assertEqual(bcast.schedule.next_fire.astimezone(tzone.utc), fires[0])
-        for earlier, later in zip(fires, fires[1:]):
+        for earlier, later in zip(fires[1:], fires[2:]):
             self.assertEqual(timedelta(days=7), later - earlier)
 
     def test_events_horizon_drops_distant_future(self):

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta, timezone as tzone
 from unittest.mock import call, patch
+from urllib.parse import quote
+
+import iso8601
 
 from django.conf import settings
 from django.urls import reverse
@@ -7,7 +10,7 @@ from django.utils import timezone
 
 from temba import mailroom
 from temba.campaigns.models import Campaign, CampaignEvent
-from temba.contacts.models import Contact, ContactExport, ContactField, ContactFire
+from temba.contacts.models import Contact, ContactExport, ContactField
 from temba.locations.models import AdminBoundary
 from temba.mailroom.client.types import Exclusions
 from temba.msgs.models import Media
@@ -1083,66 +1086,51 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             export.config,
         )
 
-    def test_scheduled(self):
+    def test_events(self):
         contact1 = self.create_contact("Joe", phone="+1234567890")
         contact2 = self.create_contact("Frank", phone="+1204567802")
         farmers = self.create_group("Farmers", contacts=[contact1, contact2])
 
-        schedule_url = reverse("contacts.contact_scheduled", args=[contact1.uuid])
+        events_url = reverse("contacts.contact_events", args=[contact1.uuid])
 
-        self.assertRequestDisallowed(schedule_url, [None, self.agent, self.admin2])
-        response = self.assertReadFetch(schedule_url, [self.editor, self.admin])
-        self.assertEqual({"results": []}, response.json())
+        self.assertRequestDisallowed(events_url, [None, self.agent, self.admin2])
+        response = self.assertReadFetch(events_url, [self.editor, self.admin])
+        self.assertEqual([], response.json()["campaigns"])
+        self.assertEqual([], response.json()["future"])
+        self.assertEqual([], response.json()["past"])
+        self.assertEqual(0, response.json()["future_count"])
+        self.assertIsNone(response.json()["next_before"])
+        self.assertIsNone(response.json()["next_after"])
 
-        # create a campaign and event fires for this contact
+        # create a campaign with a past and a future event, computed from the contact's join date
         campaign = Campaign.create(self.org, self.admin, "Reminders", farmers)
         joined = self.create_field("joined", "Joined On", value_type=ContactField.TYPE_DATETIME)
-        event2_flow = self.create_flow("Reminder Flow")
-        event1 = CampaignEvent.create_message_event(
+        flow = self.create_flow("Reminder Flow")
+        msg_event = CampaignEvent.create_message_event(
             self.org,
             self.admin,
             campaign,
             joined,
-            2,
+            3,
             unit="D",
             translations={"eng": {"text": "Hi"}},
             base_language="eng",
         )
-        event2 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, joined, 2, unit="D", flow=event2_flow)
-        # old fire version should not be displayed
-        ContactFire.objects.create(
-            org=self.org,
-            contact=contact1,
-            fire_type=ContactFire.TYPE_CAMPAIGN_EVENT,
-            scope=f"{event1.id}:{event1.fire_version}",  # old version
-            fire_on=timezone.now() + timedelta(days=2),
-        )
-        # update event
-        event1.fire_version += 1
-        event1.save()
-        fire1 = ContactFire.objects.create(
-            org=self.org,
-            contact=contact1,
-            fire_type=ContactFire.TYPE_CAMPAIGN_EVENT,
-            scope=f"{event1.id}:{event1.fire_version}",  # latest version
-            fire_on=timezone.now() + timedelta(days=2),
-        )
-        fire2 = ContactFire.objects.create(
-            org=self.org,
-            contact=contact1,
-            fire_type=ContactFire.TYPE_CAMPAIGN_EVENT,
-            scope=f"{event2.id}:{event2.fire_version}",
-            fire_on=timezone.now() + timedelta(days=5),
-        )
+        flow_event = CampaignEvent.create_flow_event(self.org, self.admin, campaign, joined, 20, unit="D", flow=flow)
 
-        # create scheduled and regular broadcasts which send to both groups
-        bcast1 = self.create_broadcast(
+        # contact joined 10 days ago, so the +3 day event is past and the +20 day event is upcoming
+        self.set_contact_field(contact1, "joined", (timezone.now() - timedelta(days=10)).isoformat())
+        joined_on = contact1.get_field_value(joined)
+
+        # create a scheduled broadcast and an already-sent broadcast
+        bcast = self.create_broadcast(
             self.admin,
             {"eng": {"text": "Hi again"}},
             contacts=[contact1, contact2],
-            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=3), Schedule.REPEAT_DAILY),
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=3), Schedule.REPEAT_NEVER),
         )
         self.create_broadcast(self.admin, {"eng": {"text": "Bye"}}, contacts=[contact1, contact2])  # not scheduled
+        sent_msg = contact1.msgs.get(broadcast__isnull=False)
 
         # create scheduled trigger which this contact is explicitly added to
         trigger1_flow = self.create_flow("Favorites 1")
@@ -1151,7 +1139,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             self.admin,
             trigger_type=Trigger.TYPE_SCHEDULE,
             flow=trigger1_flow,
-            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=4), Schedule.REPEAT_WEEKLY),
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=4), Schedule.REPEAT_NEVER),
         )
         trigger1.contacts.add(contact1, contact2)
 
@@ -1162,7 +1150,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             self.admin,
             trigger_type=Trigger.TYPE_SCHEDULE,
             flow=trigger2_flow,
-            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=6), Schedule.REPEAT_MONTHLY),
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=6), Schedule.REPEAT_NEVER),
         )
         trigger2.groups.add(farmers)
 
@@ -1172,57 +1160,192 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             self.admin,
             trigger_type=Trigger.TYPE_SCHEDULE,
             flow=self.create_flow("Favorites 3"),
-            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=4), Schedule.REPEAT_WEEKLY),
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=4), Schedule.REPEAT_NEVER),
         )
         trigger3.contacts.add(contact1, contact2)
         trigger3.exclude_groups.add(farmers)
 
-        response = self.requestView(schedule_url, self.admin)
+        response = self.requestView(events_url, self.admin)
         self.assertEqual(
-            {
-                "results": [
-                    {
-                        "type": "campaign_event",
-                        "scheduled": fire1.fire_on.isoformat(),
-                        "repeat_period": None,
-                        "campaign": {"uuid": str(campaign.uuid), "name": "Reminders"},
-                        "message": "Hi",
+            [
+                {
+                    "type": "scheduled_broadcast",
+                    "scheduled": bcast.schedule.next_fire.astimezone(tzone.utc).isoformat(),
+                    "message": "Hi again",
+                },
+                {
+                    "type": "scheduled_trigger",
+                    "scheduled": trigger1.schedule.next_fire.astimezone(tzone.utc).isoformat(),
+                    "flow": {
+                        "uuid": str(trigger1_flow.uuid),
+                        "name": "Favorites 1",
+                        "url": reverse("flows.flow_editor", args=[trigger1_flow.uuid]),
                     },
-                    {
-                        "type": "scheduled_broadcast",
-                        "scheduled": bcast1.schedule.next_fire.astimezone(tzone.utc).isoformat(),
-                        "repeat_period": "D",
-                        "message": "Hi again",
+                },
+                {
+                    "type": "scheduled_trigger",
+                    "scheduled": trigger2.schedule.next_fire.astimezone(tzone.utc).isoformat(),
+                    "flow": {
+                        "uuid": str(trigger2_flow.uuid),
+                        "name": "Favorites 2",
+                        "url": reverse("flows.flow_editor", args=[trigger2_flow.uuid]),
                     },
-                    {
-                        "type": "scheduled_trigger",
-                        "scheduled": trigger1.schedule.next_fire.astimezone(tzone.utc).isoformat(),
-                        "repeat_period": "W",
-                        "flow": {"uuid": str(trigger1_flow.uuid), "name": "Favorites 1"},
+                },
+                {
+                    "type": "campaign_event",
+                    "scheduled": (joined_on + timedelta(days=20)).isoformat(),
+                    "campaign": {
+                        "uuid": str(campaign.uuid),
+                        "name": "Reminders",
+                        "url": reverse("campaigns.campaign_read", args=[campaign.uuid]),
                     },
-                    {
-                        "type": "campaign_event",
-                        "scheduled": fire2.fire_on.isoformat(),
-                        "repeat_period": None,
-                        "campaign": {"uuid": str(campaign.uuid), "name": "Reminders"},
-                        "flow": {"uuid": str(event2_flow.uuid), "name": "Reminder Flow"},
+                    "url": reverse("campaigns.campaignevent_read", args=[campaign.uuid, flow_event.uuid]),
+                    "flow": {
+                        "uuid": str(flow.uuid),
+                        "name": "Reminder Flow",
+                        "url": reverse("flows.flow_editor", args=[flow.uuid]),
                     },
-                    {
-                        "type": "scheduled_trigger",
-                        "scheduled": trigger2.schedule.next_fire.astimezone(tzone.utc).isoformat(),
-                        "repeat_period": "M",
-                        "flow": {"uuid": str(trigger2_flow.uuid), "name": "Favorites 2"},
-                    },
-                ]
-            },
-            response.json(),
+                },
+            ],
+            response.json()["future"],
         )
+        self.assertEqual(
+            [
+                {"type": "sent_broadcast", "scheduled": sent_msg.created_on.isoformat(), "message": "Bye"},
+                {
+                    "type": "campaign_event",
+                    "scheduled": (joined_on + timedelta(days=3)).isoformat(),
+                    "campaign": {
+                        "uuid": str(campaign.uuid),
+                        "name": "Reminders",
+                        "url": reverse("campaigns.campaign_read", args=[campaign.uuid]),
+                    },
+                    "url": reverse("campaigns.campaignevent_read", args=[campaign.uuid, msg_event.uuid]),
+                    "message": "Hi",
+                },
+            ],
+            response.json()["past"],
+        )
+        self.assertEqual(
+            [
+                {
+                    "uuid": str(campaign.uuid),
+                    "name": "Reminders",
+                    "url": reverse("campaigns.campaign_read", args=[campaign.uuid]),
+                },
+            ],
+            response.json()["campaigns"],
+        )
+        self.assertEqual(4, response.json()["future_count"])
+        self.assertIsNone(response.json()["next_before"])
+        self.assertIsNone(response.json()["next_after"])
 
-        # fires for archived campaigns shouldn't appear
+        # events for archived campaigns shouldn't appear
         campaign.archive(self.admin)
 
-        response = self.requestView(schedule_url, self.admin)
-        self.assertEqual(3, len(response.json()["results"]))
+        response = self.requestView(events_url, self.admin)
+        self.assertEqual(3, len(response.json()["future"]))  # campaign event dropped
+        self.assertEqual(3, response.json()["future_count"])
+        self.assertEqual(1, len(response.json()["past"]))  # campaign event dropped, sent broadcast remains
+
+    def test_events_pagination(self):
+        contact = self.create_contact("Joe", phone="+1234567890")
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        # send the contact more past broadcasts than fit on a single page
+        for i in range(7):
+            self.create_broadcast(self.admin, {"eng": {"text": f"Bcast {i}"}}, contacts=[contact])
+
+        response = self.requestView(events_url, self.admin)
+        self.assertEqual([], response.json()["future"])
+        self.assertEqual(0, response.json()["future_count"])
+        self.assertEqual(5, len(response.json()["past"]))
+        next_before = response.json()["next_before"]
+        self.assertIsNotNone(next_before)
+
+        # paging back with the cursor returns the remaining older events
+        response = self.requestView(events_url + f"?before={quote(next_before)}", self.admin)
+        self.assertEqual([], response.json()["future"])
+        self.assertEqual(2, len(response.json()["past"]))
+        self.assertIsNone(response.json()["next_before"])
+
+        # and now stack up enough upcoming scheduled broadcasts to test forward paging
+        for i in range(12):
+            self.create_broadcast(
+                self.admin,
+                {"eng": {"text": f"Upcoming {i}"}},
+                contacts=[contact],
+                schedule=Schedule.create(self.org, timezone.now() + timedelta(days=i + 1), Schedule.REPEAT_NEVER),
+            )
+
+        response = self.requestView(events_url, self.admin)
+        self.assertEqual(10, len(response.json()["future"]))
+        self.assertEqual(12, response.json()["future_count"])
+        next_after = response.json()["next_after"]
+        self.assertIsNotNone(next_after)
+
+        response = self.requestView(events_url + f"?after={quote(next_after)}", self.admin)
+        self.assertEqual(2, len(response.json()["future"]))
+        self.assertEqual(12, response.json()["future_count"])
+        self.assertIsNone(response.json()["next_after"])
+
+    def test_events_repeating_projection(self):
+        """A repeating scheduled broadcast expands into timeline entries within the one-year horizon."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        bcast = self.create_broadcast(
+            self.admin,
+            {"eng": {"text": "Weekly check-in"}},
+            contacts=[contact],
+            schedule=Schedule.create(
+                self.org,
+                timezone.now() + timedelta(days=2),
+                Schedule.REPEAT_WEEKLY,
+                repeat_days_of_week="M",
+            ),
+        )
+
+        response = self.requestView(events_url, self.admin)
+
+        # the weekly broadcast is projected forward through the one-year window -
+        # 52 or 53 occurrences depending on calendar alignment, ten visible per page
+        self.assertIn(response.json()["future_count"], (52, 53))
+        self.assertEqual(10, len(response.json()["future"]))
+        self.assertIsNotNone(response.json()["next_after"])
+        for entry in response.json()["future"]:
+            self.assertEqual("scheduled_broadcast", entry["type"])
+            self.assertEqual("Weekly check-in", entry["message"])
+
+        # those occurrences are sorted oldest-first; the first matches the schedule's next_fire
+        # and successive entries are one week apart
+        fires = [iso8601.parse_date(e["scheduled"]) for e in response.json()["future"]]
+        self.assertEqual(bcast.schedule.next_fire.astimezone(tzone.utc), fires[0])
+        for earlier, later in zip(fires, fires[1:]):
+            self.assertEqual(timedelta(days=7), later - earlier)
+
+    def test_events_horizon_drops_distant_future(self):
+        """A one-off scheduled event more than a year out is dropped from the timeline."""
+        contact = self.create_contact("Joe", phone="+1234567890")
+        events_url = reverse("contacts.contact_events", args=[contact.uuid])
+
+        # one within the window, one well outside it
+        self.create_broadcast(
+            self.admin,
+            {"eng": {"text": "Soon"}},
+            contacts=[contact],
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=30), Schedule.REPEAT_NEVER),
+        )
+        self.create_broadcast(
+            self.admin,
+            {"eng": {"text": "Way out"}},
+            contacts=[contact],
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=400), Schedule.REPEAT_NEVER),
+        )
+
+        response = self.requestView(events_url, self.admin)
+        self.assertEqual(1, response.json()["future_count"])
+        self.assertEqual(["Soon"], [e["message"] for e in response.json()["future"]])
 
     @mock_mailroom
     def test_open_ticket(self, mr_mocks):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -177,7 +177,7 @@ class ContactCRUDL(SmartCRUDL):
         "export",
         "interrupt",
         "delete",
-        "scheduled",
+        "events",
         "chat",
         "chat_search",
     )
@@ -345,15 +345,19 @@ class ContactCRUDL(SmartCRUDL):
             context["msg_logs_after"] = (timezone.now() - settings.RETENTION_PERIODS["channellog"]).isoformat()
             return context
 
-    class Scheduled(BaseReadView):
+    class Events(BaseReadView):
         """
-        Merged list of upcoming activity (campaign event fires and scheduled broadcasts)
+        Timeline of campaign events and broadcasts for a contact, both upcoming and past. Pass a
+        `before` cursor (returned as `next_before`) to page further back through past events; pass
+        an `after` cursor (returned as `next_after`) to page further forward through upcoming events.
         """
 
         permission = "contacts.contact_read"
 
         def render_to_response(self, context, **response_kwargs):
-            return JsonResponse({"results": self.object.get_scheduled()})
+            before = self.request.GET.get("before") or None
+            after = self.request.GET.get("after") or None
+            return JsonResponse(self.object.get_events(before=before, after=after))
 
     class Chat(BaseReadView):
         """

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -177,7 +177,7 @@ class ContactCRUDL(SmartCRUDL):
         "export",
         "interrupt",
         "delete",
-        "events",
+        "timeline",
         "chat",
         "chat_search",
     )
@@ -345,7 +345,7 @@ class ContactCRUDL(SmartCRUDL):
             context["msg_logs_after"] = (timezone.now() - settings.RETENTION_PERIODS["channellog"]).isoformat()
             return context
 
-    class Events(BaseReadView):
+    class Timeline(BaseReadView):
         """
         Timeline of campaign events and broadcasts for a contact, both upcoming and past. Pass a
         `before` cursor (returned as `next_before`) to page further back through past events; pass
@@ -357,7 +357,7 @@ class ContactCRUDL(SmartCRUDL):
         def render_to_response(self, context, **response_kwargs):
             before = self.request.GET.get("before") or None
             after = self.request.GET.get("after") or None
-            return JsonResponse(self.object.get_events(before=before, after=after))
+            return JsonResponse(self.object.get_timeline(before=before, after=after))
 
     class Chat(BaseReadView):
         """

--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -122,6 +122,29 @@ class Schedule(models.Model):
 
             self.save()
 
+    def project_fires(self, horizon) -> list:
+        """
+        Projects future fires for this schedule from `next_fire` up to and including `horizon`. A
+        one-off schedule returns just `next_fire` (if before the horizon); a repeating schedule
+        iterates `calculate_next_fire` to build successive occurrences while they remain inside the
+        window. A safety cap guards against pathological schedules that fail to advance.
+        """
+
+        if self.next_fire is None or self.next_fire > horizon:
+            return []
+
+        fires = [self.next_fire]
+        if self.repeat_period == Schedule.REPEAT_NEVER:
+            return fires
+
+        safety_cap = 10_000
+        for _i in range(safety_cap - 1):
+            next_fire = self.calculate_next_fire(fires[-1])
+            if not next_fire or next_fire <= fires[-1] or next_fire > horizon:
+                break
+            fires.append(next_fire)
+        return fires
+
     def calculate_next_fire(self, now):
         """
         Get the next point in the future when our schedule should fire again. Note this should only be called to find

--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -137,6 +137,9 @@ class Schedule(models.Model):
         if self.repeat_period == Schedule.REPEAT_NEVER:
             return fires
 
+        # the safety cap guards against a pathological schedule that never advances past the horizon;
+        # if it's ever hit we silently return the truncated list rather than erroring (no real schedule
+        # repeats often enough to produce this many fires within a one-year window)
         safety_cap = 10_000
         for _i in range(safety_cap - 1):
             next_fire = self.calculate_next_fire(fires[-1])

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -8,6 +8,7 @@
 #     - a valkey instance listening on localhost
 # -----------------------------------------------------------------------------------
 
+import os
 import warnings
 
 from .settings_common import *  # noqa
@@ -18,6 +19,9 @@ DEBUG = True
 ALLOWED_HOSTS = ["*"]
 
 INTERNAL_IPS = ("127.0.0.1",)
+
+COMPONENTS_DEV_MODE = bool(os.environ.get("COMPONENTS_DEV_MODE"))
+COMPONENTS_DEV_URL = os.environ.get("COMPONENTS_DEV_URL", "")
 
 # -----------------------------------------------------------------------------------
 # Mailroom - localhost for dev, no auth token

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -114,8 +114,10 @@
 
       if (event.url) {
         spaGet(event.url);
-      } else if (event.type == "scheduled_broadcast" || event.type == "sent_broadcast") {
+      } else if (event.type == "scheduled_broadcast") {
         spaGet("{% url 'msgs.broadcast_scheduled' %}");
+      } else if (event.type == "sent_broadcast") {
+        spaGet("{% url 'msgs.broadcast_list' %}");
       } else if (event.type == "scheduled_trigger") {
         spaGet("{% url 'triggers.trigger_folder' 'schedule' %}");
       }

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -43,7 +43,7 @@
     <temba-tab icon="campaign" name="{{ _("Up Next") |escapejs }}">
       <div style="border-top-right-radius: var(--curvature)"
            class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
-        <temba-contact-events contact="{{ object.uuid }}" -temba-selection="handleEventClicked">
+        <temba-contact-events contact="{{ object.uuid }}" -temba-selection="handleTimelineClicked">
         </temba-contact-events>
       </div>
     </temba-tab>
@@ -85,10 +85,10 @@
     function handleContactRefreshed(evt) {
       var contact = evt.detail.data;
 
-      // if our contact refreshes, refresh the events timeline
-      var events = document.querySelector("temba-contact-events");
-      if (events) {
-        events.refresh();
+      // if our contact refreshes, refresh the timeline
+      var timeline = document.querySelector("temba-contact-events");
+      if (timeline) {
+        timeline.refresh();
       }
 
       var menu = document.querySelector("temba-menu");
@@ -109,7 +109,7 @@
       spaGet("/contact/?search=" + encodeURIComponent(evt.detail.key) + "+%3D+" + encodeURIComponent("\"" + evt.detail.value + "\""))
     }
 
-    function handleEventClicked(evt) {
+    function handleTimelineClicked(evt) {
       var event = evt.detail;
 
       if (event.url) {

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -41,7 +41,7 @@
       </div>
     </temba-tab>
     <temba-tab icon="campaign" name="{{ _("Next Up") |escapejs }}">
-      <div style="border-top-right-radius: var(--curvature)"
+      <div style="border-top-right-radius: var(--curvature); background: #fff"
            class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
         <temba-contact-timeline contact="{{ object.uuid }}" -temba-selection="handleTimelineClicked">
         </temba-contact-timeline>

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -43,8 +43,8 @@
     <temba-tab icon="campaign" name="{{ _("Up Next") |escapejs }}">
       <div style="border-top-right-radius: var(--curvature)"
            class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
-        <temba-contact-events contact="{{ object.uuid }}" -temba-selection="handleTimelineClicked">
-        </temba-contact-events>
+        <temba-contact-timeline contact="{{ object.uuid }}" -temba-selection="handleTimelineClicked">
+        </temba-contact-timeline>
       </div>
     </temba-tab>
     <temba-tab icon="notes" name="{{ _("Notepad") }}" activity>
@@ -86,7 +86,7 @@
       var contact = evt.detail.data;
 
       // if our contact refreshes, refresh the timeline
-      var timeline = document.querySelector("temba-contact-events");
+      var timeline = document.querySelector("temba-contact-timeline");
       if (timeline) {
         timeline.refresh();
       }

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -40,11 +40,11 @@
         </temba-contact-fields>
       </div>
     </temba-tab>
-    <temba-tab icon="campaign" name="{{ _("Next Up") |escapejs }}" hideEmpty hidden>
+    <temba-tab icon="campaign" name="{{ _("Up Next") |escapejs }}">
       <div style="border-top-right-radius: var(--curvature)"
            class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
-        <temba-contact-pending contact="{{ object.uuid }}" -temba-selection="handlePendingClicked">
-        </temba-contact-pending>
+        <temba-contact-events contact="{{ object.uuid }}" -temba-selection="handleEventClicked">
+        </temba-contact-events>
       </div>
     </temba-tab>
     <temba-tab icon="notes" name="{{ _("Notepad") }}" activity>
@@ -85,10 +85,10 @@
     function handleContactRefreshed(evt) {
       var contact = evt.detail.data;
 
-      // if our contact refreshes, refresh our pendingEvents
-      var pending = document.querySelector("temba-contact-pending");
-      if (pending) {
-        pending.refresh();
+      // if our contact refreshes, refresh the events timeline
+      var events = document.querySelector("temba-contact-events");
+      if (events) {
+        events.refresh();
       }
 
       var menu = document.querySelector("temba-menu");
@@ -109,14 +109,14 @@
       spaGet("/contact/?search=" + encodeURIComponent(evt.detail.key) + "+%3D+" + encodeURIComponent("\"" + evt.detail.value + "\""))
     }
 
-    function handlePendingClicked(evt) {
-      var pending = evt.detail;
+    function handleEventClicked(evt) {
+      var event = evt.detail;
 
-      if (pending.type == "campaign_event") {
-        spaGet("/campaign/read/" + pending.campaign.uuid + "/");
-      } else if (pending.type == "scheduled_broadcast") {
+      if (event.url) {
+        spaGet(event.url);
+      } else if (event.type == "scheduled_broadcast" || event.type == "sent_broadcast") {
         spaGet("{% url 'msgs.broadcast_scheduled' %}");
-      } else {
+      } else if (event.type == "scheduled_trigger") {
         spaGet("{% url 'triggers.trigger_folder' 'schedule' %}");
       }
     }

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -99,8 +99,11 @@
 
     function handleTabChanged() {
       var tab = document.querySelector("temba-tabs").index;
+      // keep the tab in the fetched url (not just the displayed one) so that navigating
+      // away and back re-fetches this page with ?tab= set and restores the active tab
+      // rather than defaulting to the first (Chat) tab
       window.history.replaceState({
-        url: "{% url 'contacts.contact_read' object.uuid %}",
+        url: "{% url 'contacts.contact_read' object.uuid %}?tab=" + tab,
         show: window.location.pathname + "?tab=" + tab
       }, "", "?tab=" + tab);
     }

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -40,9 +40,9 @@
         </temba-contact-fields>
       </div>
     </temba-tab>
-    <temba-tab icon="campaign" name="{{ _("Next Up") |escapejs }}">
+    <temba-tab icon="schedule" name="{{ _("Next Up") |escapejs }}">
       <div style="border-top-right-radius: var(--curvature); background: #fff"
-           class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
+           class="flex flex-grow flex-col py-8 px-4 overflow-y-auto">
         <temba-contact-timeline contact="{{ object.uuid }}" -temba-selection="handleTimelineClicked">
         </temba-contact-timeline>
       </div>

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -40,7 +40,7 @@
         </temba-contact-fields>
       </div>
     </temba-tab>
-    <temba-tab icon="campaign" name="{{ _("Up Next") |escapejs }}">
+    <temba-tab icon="campaign" name="{{ _("Next Up") |escapejs }}">
       <div style="border-top-right-radius: var(--curvature)"
            class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
         <temba-contact-timeline contact="{{ object.uuid }}" -temba-selection="handleTimelineClicked">


### PR DESCRIPTION
## Summary

Replaces the contact "Next Up" scheduled-activity list with a full **event timeline** on the contact read page — a merged, time-ordered view of campaign events, scheduled broadcasts, scheduled triggers, and past sent broadcasts, covering both upcoming and past activity with cursor-based paging.

## Changes

**`Contact.get_events()`** (replaces `get_scheduled()`) — `temba/contacts/models.py`
- Returns a merged timeline split into `future` / `past` pages plus an uncapped `future_count` so the badge stays accurate regardless of which page is requested.
- Campaign-event times are projected from the contact's anchor field value + event offset (with optional `delivery_hour` snapping in the org timezone) — the campaign's prospective timeline relative to this contact, not a record of past fires. Inactive events and events whose anchor field the contact has no value for are skipped.
- Repeating broadcasts/triggers expand into individual timeline entries within a one-year horizon (via `Schedule.project_fires`) so the cadence is shown directly; one-off events beyond the horizon are dropped.
- Past page interleaves sent broadcasts (`msgs` with a broadcast) with past campaign events.
- Cursor paging: `before` → `next_before` pages back through past events; `after` → `next_after` pages forward through upcoming events. The `before` cursor is clamped to `now`, and a malformed cursor is treated as absent rather than raising. Each event carries a `url` for navigation.

**`Schedule.project_fires(horizon)`** — `temba/schedules/models.py`
- Projects fire times from `next_fire` up to a horizon: one-off returns just `next_fire`; repeating iterates `calculate_next_fire` with a non-advancement guard and a safety cap (intentionally silent on the cap, documented inline).

**Scheduled querysets** — `temba/contacts/models.py`
- `get_scheduled_broadcasts()` / `get_scheduled_triggers()` now exclude paused schedules (`schedule__is_paused=False`), matching mailroom's `schedules_due` index, so a paused weekly schedule no longer projects ~52 phantom entries. Added `flow` to the triggers `select_related` (N+1).

**View + template**
- Renamed `ContactCRUDL.Scheduled` → `Events` (url `contacts.contact_events`), reading `before`/`after` query params.
- `contact_read.html` renders `<temba-contact-events>` (was `<temba-contact-pending>`) with a click handler that prefers `event.url`; `sent_broadcast` clicks route to the broadcasts list (`msgs.broadcast_list`) and `scheduled_broadcast` to the scheduled list.

**Dev settings** — `COMPONENTS_DEV_MODE` / `COMPONENTS_DEV_URL` now read from env in `settings.py.dev`.

## Tied-timestamp paging

The next-page cursor is a bare timestamp filtered strictly (`<` / `>`), so a tied group straddling a page boundary could drop or under-report events. Handled by:
- Extending each page in-memory to cover the whole tied group at the boundary.
- A supplemental query (`created_on=boundary`) to recover tied sent broadcasts the capped load missed.
- Computing `has_more_past` against the in-memory window end (not the inflated page length), so the DB top-up can't mask older campaign events that still remain.

## Review notes

Opened after 3 pre-PR review cycles; further hardened during land in response to automated review:
- **`has_more_past` false-negative**: DB-tied sent broadcasts could inflate the page past `len(past_window)` and hide older campaign events — now compares against `in_mem_end`.
- **Paused schedules** excluded from projection.
- **Cursor cap bypass**: `before` cursor clamped to `now` so it can't pull the entire uncapped past history.
- **Sent-broadcast deep-link** routed to the broadcasts list rather than the scheduled-broadcasts page.
- Repeating-projection test corrected (first fire of a future-dated repeating schedule is the raw `next_fire`); malformed-cursor 500 guarded; trigger.flow N+1 fixed.

## Test plan
- [x] `test_events` — base timeline (campaign events, broadcasts, triggers, sent)
- [x] `test_events_pagination` / `_mixed_past` / `_tied_timestamps` / `_tied_sent_broadcasts` / `_tied_future` — cursor round-trips and tied-boundary handling
- [x] `test_events_more_past_not_dropped_with_tied_sent_broadcasts` — `has_more_past` false-negative regression (fails on pre-fix code)
- [x] `test_events_excludes_paused_schedules` — paused broadcast/trigger excluded
- [x] `test_events_repeating_projection` / `_horizon_drops_distant_future` — one-year-horizon expansion and drop
- [x] `test_events_inactive_and_missing_anchor` — inactive event / missing anchor field skipped
- [x] `test_events_delivery_hour_snapping` — `delivery_hour` snapped to org timezone
- [x] `test_events_malformed_cursor` — garbage cursor returns 200, not 500
- [x] `code_check.py` clean (migrations, ruff format, ruff); CI green at 100% coverage