### PR TITLE
Fix two-way messaging in msg_console across containers

### DIFF
--- a/temba/msgs/management/commands/msg_console.py
+++ b/temba/msgs/management/commands/msg_console.py
@@ -14,6 +14,12 @@ COURIER_URL = os.environ.get("COURIER_URL", "http://localhost:8080")
 DEFAULT_ORG = "1"
 DEFAULT_URN = "tel:+250788123123"
 
+# Host courier uses to reach our send callback, and the port it listens on. Defaults let everything run on
+# localhost; when courier runs in another container, set CALLBACK_HOST to a name it can resolve (e.g. the
+# container running this command) so MT replies are delivered back here.
+DEFAULT_CALLBACK_HOST = os.environ.get("MSG_CONSOLE_CALLBACK_HOST") or None
+DEFAULT_PORT = int(os.environ.get("MSG_CONSOLE_PORT", "49999"))
+
 
 class Command(BaseCommand):  # pragma: no cover
     def add_arguments(self, parser):
@@ -28,6 +34,24 @@ class Command(BaseCommand):  # pragma: no cover
 
         parser.add_argument(
             "--urn", type=str, action="store", dest="urn", default=DEFAULT_URN, help="The URN to send messages from"
+        )
+
+        parser.add_argument(
+            "--callback-host",
+            type=str,
+            action="store",
+            dest="callback_host",
+            default=DEFAULT_CALLBACK_HOST,
+            help="Host courier uses to reach this console's send callback (default: this host's hostname)",
+        )
+
+        parser.add_argument(
+            "--port",
+            type=int,
+            action="store",
+            dest="port",
+            default=DEFAULT_PORT,
+            help="Port for this console's send callback server to listen on",
         )
 
     def handle(self, *args, **options):
@@ -45,7 +69,15 @@ class Command(BaseCommand):  # pragma: no cover
             raise CommandError(f"Unable to connect to courier at {COURIER_URL}")
 
         try:
-            self.messenger = Messenger.create(org, user, COURIER_URL, callback=self.response_callback, scheme=scheme)
+            self.messenger = Messenger.create(
+                org,
+                user,
+                COURIER_URL,
+                callback=self.response_callback,
+                scheme=scheme,
+                port=options["port"],
+                callback_host=options["callback_host"],
+            )
             self.stdout.write(f"✅ Messenger started at️ {Fore.CYAN}{self.messenger.server.base_url}{Fore.RESET}")
         except Exception as e:
             raise CommandError(f"Unable to start messenger: {str(e)}")

--- a/temba/tests/integration.py
+++ b/temba/tests/integration.py
@@ -1,4 +1,5 @@
 import json
+import socket
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 
@@ -18,6 +19,11 @@ class Messenger:
 
     mailroom -db="postgres://temba:temba@localhost:5432/temba?sslmode=disable" -valkey=valkey://localhost:6379/15
     courier -db="postgres://temba:temba@localhost:5432/temba?sslmode=disable" -valkey=valkey://localhost:6379/15 -spool-dir="."
+
+    Outgoing (MT) replies are delivered by courier POSTing to the channel's send URL, so that URL must be reachable
+    from wherever courier runs. When courier runs in a different container/host than this server, pass `callback_host`
+    as a name courier can resolve (e.g. the container name); it defaults to this host's hostname rather than
+    "localhost" so cross-container delivery works out of the box.
     """
 
     CHANNEL_NAME = "Testing"
@@ -31,8 +37,19 @@ class Messenger:
         self.callback = callback
 
     @classmethod
-    def create(cls, org, user, courier_url, callback, country="EC", scheme="tel", address="123456", port=49999):
-        server = cls.Server(port)
+    def create(
+        cls,
+        org,
+        user,
+        courier_url,
+        callback,
+        country="EC",
+        scheme="tel",
+        address="123456",
+        port=49999,
+        callback_host=None,
+    ):
+        server = cls.Server(port, callback_host or socket.gethostname())
 
         config = {
             Channel.CONFIG_SEND_URL: f"{server.base_url}/send",
@@ -84,9 +101,11 @@ class Messenger:
             self.channel.release(user=self.channel.created_by)
 
     class Server(HTTPServer):
-        def __init__(self, port):
-            HTTPServer.__init__(self, ("localhost", port), Messenger.Handler)
-            self.base_url = f"http://localhost:{port}"
+        def __init__(self, port, host):
+            # Bind on all interfaces (not just loopback) so courier can reach the send callback even when it runs
+            # in a different container; advertise `host` in base_url so the channel's send URL resolves from there.
+            HTTPServer.__init__(self, ("0.0.0.0", port), Messenger.Handler)
+            self.base_url = f"http://{host}:{port}"
             self.thread = Thread(target=self.serve_forever)
             self.thread.setDaemon(True)
             self.thread.start()


### PR DESCRIPTION
## Problem

Sending MO messages from `msg_console` worked, but MT replies never arrived when courier runs in a separate container from the console (e.g. the per-worktree dev setup).

The `Messenger` callback server bound to `localhost` and registered the EX "Testing" channel's send URL as `http://localhost:<port>/send`. MT replies are delivered by **courier** POSTing to that send URL — but from courier's container, `localhost` is courier itself, so the reply was dropped. MO worked only because it's an outbound POST from the console to courier.

## Fix

- `temba/tests/integration.py`: bind the callback server to `0.0.0.0` (reachable cross-container) and advertise a resolvable host in the send URL, defaulting to the host's hostname instead of `localhost`.
- `temba/msgs/management/commands/msg_console.py`: add `--callback-host`/`--port` options (and `MSG_CONSOLE_CALLBACK_HOST`/`MSG_CONSOLE_PORT` env vars) so the send URL can point at a host courier can reach.

## Testing

Verified end-to-end against an isolated per-worktree pair: MO `fav` → courier → mailroom (Favorites flow) → courier → callback printed the MT reply ("What is your favorite color?"). With the old `localhost` bind the same reply hit nothing.