### PR TITLE
Use full name instead of first name in user chat ref

### DIFF
--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -543,7 +543,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                         "urn": "tel:+250781111111",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_user": {"uuid": str(self.editor.uuid), "name": "Ed", "avatar": None},
+                    "_user": {"uuid": str(self.editor.uuid), "name": "Ed McEdits", "avatar": None},
                 }
             },
             response.json(),
@@ -584,7 +584,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                         "urn": "tel:+250781111111",
                         "channel": {"uuid": str(self.channel.uuid), "name": "Test Channel"},
                     },
-                    "_user": {"uuid": str(self.editor.uuid), "name": "Ed", "avatar": None},
+                    "_user": {"uuid": str(self.editor.uuid), "name": "Ed McEdits", "avatar": None},
                 }
             },
             response.json(),

--- a/temba/users/models.py
+++ b/temba/users/models.py
@@ -199,7 +199,7 @@ class User(TembaUUIDMixin, AbstractBaseUser, PermissionsMixin):
         return {"uuid": str(self.uuid), "name": self.name}
 
     def as_chat_ref(self) -> dict:
-        return {"uuid": str(self.uuid), "name": self.first_name, "avatar": self.avatar.url if self.avatar else None}
+        return {"uuid": str(self.uuid), "name": self.name, "avatar": self.avatar.url if self.avatar else None}
 
     def fetch_avatar(self, url: str):  # pragma: no cover
         # fetch the avatar from the url and store it locally


### PR DESCRIPTION
Updates `User.as_chat_ref()` to return the user's full `name` instead of just their `first_name`, so chat references display the complete name. Test expectations updated accordingly.