### PR TITLE
Update @nyaruka/temba-components to 0.159.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.159.2",
+    "@nyaruka/temba-components": "0.159.3",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nyaruka/temba-components@0.159.2":
-  version "0.159.2"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.159.2.tgz#02ccf8b3ae360b669dd9302a7cf1deca75bc6c5d"
-  integrity sha512-3u+eqQCCAmy/xBLX/reoAFJlKgaSRWZjT0EPul0eLQitDB3vU7S6JMzY+FvO876/K7Q1l8joCRwHR30AqTmC3g==
+"@nyaruka/temba-components@0.159.3":
+  version "0.159.3"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.159.3.tgz#9ea404a76e08b6c4c62a1211701abb9173361fd0"
+  integrity sha512-JRDfOIBqQ13aUlbS4k//TK354CJv1vGYlXOCPBvB6go8EqWmAZXp3EpuHw0MoLAaYtx5v40dohLOHTjoCvaN8A==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.159.3](https://github.com/nyaruka/temba-components/compare/v0.159.2...v0.159.3)

- Render dynamic avatars for contacts in chat history [#1028](https://github.com/nyaruka/temba-components/pull/1028)
- Validate flow-editor field lengths and flow-type availability [#1026](https://github.com/nyaruka/temba-components/pull/1026)
- Serve temba-components editor.json via the dev server [#1025](https://github.com/nyaruka/temba-components/pull/1025)
- Enable expression completion for the open ticket note field [#1024](https://github.com/nyaruka/temba-components/pull/1024)
- Route message list navigation through the SPA [#1023](https://github.com/nyaruka/temba-components/pull/1023)