### PR TITLE
Preview-mode contact list backed by internal contacts API

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
+from unittest.mock import call
 
 from django.urls import reverse
 from django.utils import timezone
 
+from temba import mailroom
 from temba.ai.models import LLM
 from temba.ai.types.anthropic.type import AnthropicType
 from temba.ai.types.openai.type import OpenAIType
@@ -11,7 +13,7 @@ from temba.contacts.models import ContactExport
 from temba.msgs.models import Msg
 from temba.notifications.types import ExportFinishedNotificationType
 from temba.templates.models import TemplateTranslation
-from temba.tests import TembaTest, matchers
+from temba.tests import TembaTest, matchers, mock_mailroom
 from temba.tickets.models import Shortcut, TicketExport
 
 NUM_BASE_QUERIES = 3  # number of queries required for any request (internal API is session only)
@@ -214,12 +216,13 @@ class EndpointsTest(APITestMixin, TembaTest):
         ancient = self.create_incoming_msg(contact1, "ancient", created_on=timezone.now() - timedelta(days=120))
         self.assertGet(endpoint_url + f"?search={ancient.text}", [self.admin], results=[])
 
-        # unfiltered listings still omit count — cursor pagination skips COUNT(*) when there is no search
-        # ordering is `-created_on, -id`: old_msg is backdated 30 days, ancient 120 days, so they sort last
+        # unfiltered listings carry the folder's cheap pre-calculated count (not a COUNT(*) on the messages table)
+        # so the list UI can show "N of Total"; ordering is `-created_on, -id`: old_msg is backdated 30 days,
+        # ancient 120 days, so they sort last
         response = self.assertGet(
             endpoint_url, [self.admin], results=[anon_msg, live_msg, msg2, msg1, old_msg, ancient]
         )
-        self.assertNotIn("count", response.json())
+        self.assertEqual(6, response.json()["count"])
 
         # honor `?page_size=` so the list UI can request a page sized to its viewport
         msg3 = self.create_incoming_msg(contact1, "Three")
@@ -228,6 +231,90 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual(2, len(response.json()["results"]))
         # there should be a `next` cursor since we capped at 2 of 4
         self.assertIsNotNone(response.json()["next"])
+
+    @mock_mailroom
+    def test_contacts(self, mr_mocks):
+        endpoint_url = reverse("api.internal.contacts") + ".json"
+
+        # anonymous users can't read; agents hold the contacts.contact_list api perm (as for /api/v2/contacts)
+        self.assertGetNotPermitted(endpoint_url, [None])
+        self.assertPostNotAllowed(endpoint_url)
+        self.assertDeleteNotAllowed(endpoint_url)
+
+        joe = self.create_contact("Joe", phone="+1234567001", fields={"gender": "male"})
+        frank = self.create_contact("Frank", phone="+1234567002", fields={"gender": "female"})
+        bob = self.create_contact("Bob", phone="+1234567003")
+        bob.block(self.admin)
+
+        # default folder is `active`, newest first (DB path, no mailroom needed)
+        self.assertGet(endpoint_url, [self.editor, self.admin], results=[frank, joe])
+        self.assertGet(endpoint_url + "?folder=active", [self.admin], results=[frank, joe])
+
+        # other status folders
+        self.assertGet(endpoint_url + "?folder=blocked", [self.admin], results=[bob])
+        self.assertGet(endpoint_url + "?folder=stopped", [self.admin], results=[])
+
+        # an unknown folder yields no contacts
+        self.assertGet(endpoint_url + "?folder=nope", [self.admin], results=[])
+
+        # a specific group can be selected by uuid
+        group = self.create_group("Crew", contacts=[joe])
+        self.assertGet(endpoint_url + f"?group={group.uuid}", [self.admin], results=[joe])
+
+        # each row carries its group memberships so the component can pre-check the group dropdown
+        def check_groups(data):
+            return data["results"][0]["groups"] == [{"uuid": str(group.uuid), "name": "Crew"}]
+
+        self.assertGet(endpoint_url + f"?group={group.uuid}", [self.admin], raw=check_groups)
+
+        # each row carries the columns the component renders: name, primary urn, featured field values, last seen
+        def check_shape(data):
+            first = data["results"][0]
+            return (
+                first["uuid"] == str(frank.uuid)
+                and first["name"] == "Frank"
+                and first["fields"]["gender"] == "female"
+                and "last_seen_on" in first
+                and bool(first["urn"])
+            )
+
+        self.assertGet(endpoint_url, [self.admin], raw=check_shape)
+
+        # searching goes through mailroom (ES), which returns the ordered window plus a total
+        mr_mocks.contact_search("gender = male", contacts=[joe], total=1)
+        self.assertGet(endpoint_url + "?search=gender+%3D+male", [self.admin], results=[joe])
+
+        # the response echoes mailroom's parsed/normalized query (e.g. "age > 50" → "fields.age > 50") so the
+        # component can rewrite its search box to match what the results reflect
+        mr_mocks.contact_search("age > 50", cleaned="fields.age > 50", contacts=[joe], total=1)
+        self.assertGet(
+            endpoint_url + "?search=age+%3E+50",
+            [self.admin],
+            raw=lambda data: data["query"] == "fields.age > 50",
+        )
+
+        # the unsearched DB path carries no parsed query
+        self.assertGet(endpoint_url, [self.admin], raw=lambda data: "query" not in data)
+
+        # the component prefixes its custom-field sort keys with `field:`; mailroom gets the bare key
+        mr_mocks.contact_search("", contacts=[joe, frank])
+        self.assertGet(endpoint_url + "?sort=-field:gender", [self.admin], results=[joe, frank])
+        self.assertEqual(
+            call(self.org, self.org.active_contacts_group, "", sort="-gender", offset=0, limit=50),
+            mr_mocks.calls["contact_search"][-1],
+        )
+
+        # an invalid query keeps a list-shaped (empty) response rather than erroring
+        mr_mocks.exception(mailroom.QueryValidationException("bad", "syntax"))
+        self.login(self.admin)
+        response = self.client.get(endpoint_url + "?search=(((")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual([], response.json()["results"])
+        self.assertEqual(0, response.json()["count"])
+
+        # an over-long search query is rejected
+        response = self.client.get(endpoint_url + "?search=" + ("x" * 10001))
+        self.assertEqual(413, response.status_code)
 
     def test_notifications(self):
         endpoint_url = reverse("api.internal.notifications") + ".json"

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -316,6 +316,27 @@ class EndpointsTest(APITestMixin, TembaTest):
         response = self.client.get(endpoint_url + "?search=" + ("x" * 10001))
         self.assertEqual(413, response.status_code)
 
+        # paging past the 200th page short-circuits to an empty, list-shaped response (ES deep-paging guard)
+        response = self.client.get(endpoint_url + "?page=201")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual([], response.json()["results"])
+        self.assertEqual(0, response.json()["count"])
+
+        # a non-integer page is handled cleanly: the page-guard falls back to page 1, then DRF 404s the unknown page
+        # (rather than the guard itself raising a ValueError)
+        self.login(self.admin)
+        self.assertEqual(404, self.client.get(endpoint_url + "?page=abc").status_code)
+
+        # a non-integer page_size falls back to the default page size (matching DRF's pagination)
+        mr_mocks.contact_search("", contacts=[joe, frank])
+        self.assertGet(endpoint_url + "?sort=-field:gender&page_size=abc", [self.admin], results=[joe, frank])
+        self.assertEqual(50, mr_mocks.calls["contact_search"][-1].kwargs["limit"])
+
+        # ...as does a non-positive page_size
+        mr_mocks.contact_search("", contacts=[joe, frank])
+        self.assertGet(endpoint_url + "?sort=-field:gender&page_size=0", [self.admin], results=[joe, frank])
+        self.assertEqual(50, mr_mocks.calls["contact_search"][-1].kwargs["limit"])
+
     def test_notifications(self):
         endpoint_url = reverse("api.internal.notifications") + ".json"
 

--- a/temba/api/internal/urls.py
+++ b/temba/api/internal/urls.py
@@ -2,6 +2,7 @@ from rest_framework.urlpatterns import format_suffix_patterns
 
 from django.urls import re_path
 
+from temba.contacts.api import ContactsEndpoint
 from temba.msgs.api import MessagesEndpoint
 
 from .views import (
@@ -15,6 +16,7 @@ from .views import (
 
 urlpatterns = [
     # ========== endpoints A-Z ===========
+    re_path(r"^contacts$", ContactsEndpoint.as_view(), name="api.internal.contacts"),
     re_path(r"^llms$", LLMsEndpoint.as_view(), name="api.internal.llms"),
     re_path(r"^locations$", LocationsEndpoint.as_view(), name="api.internal.locations"),
     re_path(r"^messages$", MessagesEndpoint.as_view(), name="api.internal.messages"),

--- a/temba/api/v2/tests/test_groups.py
+++ b/temba/api/v2/tests/test_groups.py
@@ -82,6 +82,9 @@ class GroupsEndpointTest(APITest):
         # filter by name
         self.assertGet(endpoint_url + "?name=developers", [self.editor], results=[developers])
 
+        # filter to static (manual) groups only — excludes smart and system groups
+        self.assertGet(endpoint_url + "?manual_only=1", [self.editor], results=[customers])
+
         # try to filter by both
         self.assertGet(
             endpoint_url + f"?uuid={customers.uuid}&name=developers",

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1811,6 +1811,9 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseEndpoint):
      * **system** - whether this is a system group that can't be edited (bool).
      * **count** - the number of contacts in the group (int).
 
+    You can also pass `manual_only=1` to restrict the results to static (manual) groups — i.e. those whose members can
+    be added or removed directly (smart and system groups are excluded).
+
     Example:
 
         GET /api/v2/groups.json

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1910,6 +1910,11 @@ class GroupsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseEndpoint):
         if name := params.get("name"):
             queryset = queryset.filter(name__iexact=name)
 
+        # restrict to static (manual) groups (optional) — used by the contact list's group dropdown, which can only
+        # add/remove members on manual groups (smart groups are maintained by their query)
+        if str_to_bool(params.get("manual_only")):
+            queryset = queryset.filter(group_type=ContactGroup.TYPE_MANUAL)
+
         return queryset.filter(is_active=True).exclude(status=ContactGroup.STATUS_INITIALIZING)
 
     def prepare_for_serialization(self, object_list, using: str):

--- a/temba/contacts/api.py
+++ b/temba/contacts/api.py
@@ -2,6 +2,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from django.db.models import Prefetch, prefetch_related_objects
+from django.http import HttpResponse
 
 from temba import mailroom
 from temba.api.internal.serializers import ModelAsJsonSerializer
@@ -54,7 +55,7 @@ class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
     def get(self, request, *args, **kwargs):
         search = request.query_params.get("search") or ""
         if len(search) > SEARCH_MAX_LENGTH:
-            return Response({"results": [], "count": 0, "error": "Search query too long"}, status=413)
+            return HttpResponse("Search query too long", status=413)
         # Don't allow pagination past the 200th page (mirrors ContactListView.pre_process / the ES offset guard).
         if self._page() > MAX_PAGE:
             return Response({"results": [], "count": 0, "next": None, "previous": None})
@@ -63,21 +64,33 @@ class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
     def _page(self) -> int:
         try:
             return max(1, int(self.request.query_params.get("page", 1)))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return 1
 
     def _page_size(self) -> int:
+        # Mirror DRF PageNumberPagination.get_page_size (which uses _positive_int(strict=True)): non-positive or
+        # non-integer values fall back to the default rather than being clamped, and the value is capped at the max.
+        # The search/sort path derives the mailroom offset from this, so it must match the page size DRF slices with
+        # or SearchSliceQuerySet's offset guard trips with an IndexError (HTTP 500).
         try:
             size = int(self.request.query_params.get("page_size", DEFAULT_PAGE_SIZE))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return DEFAULT_PAGE_SIZE
-        return max(1, min(size, MAX_PAGE_SIZE))
+        if size <= 0:
+            return DEFAULT_PAGE_SIZE
+        return min(size, MAX_PAGE_SIZE)
 
     def derive_group(self):
         org = self.request.org
         group_uuid = self.request.query_params.get("group")
         if group_uuid:
-            return org.groups.filter(uuid=group_uuid, is_active=True).first()
+            # Mirror GroupsEndpoint.filter_queryset: skip still-evaluating smart groups so we never page over a group
+            # whose membership isn't yet populated.
+            return (
+                org.groups.filter(uuid=group_uuid, is_active=True)
+                .exclude(status=ContactGroup.STATUS_INITIALIZING)
+                .first()
+            )
 
         group_type = self.FOLDERS.get(self.request.query_params.get("folder", "active").lower())
         if not group_type:

--- a/temba/contacts/api.py
+++ b/temba/contacts/api.py
@@ -1,0 +1,157 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+from django.db.models import Prefetch, prefetch_related_objects
+
+from temba import mailroom
+from temba.api.internal.serializers import ModelAsJsonSerializer
+from temba.api.internal.views import BaseEndpoint
+from temba.api.views import ListAPIMixin
+from temba.utils.models.es import SearchSliceQuerySet
+
+from .models import Contact, ContactField, ContactGroup
+
+# Match BaseListView/ContactListView: 50 rows per page, and never let a client page past the 200th page (ES deep
+# pagination guard, mirroring ContactListView.pre_process).
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 500
+MAX_PAGE = 200
+
+# Cap the search query length the same way the legacy list view does so an oversized query can't be used to drive an
+# expensive mailroom/ES request.
+SEARCH_MAX_LENGTH = ContactGroup.MAX_QUERY_LEN
+
+# The contact list component prefixes its custom-field column keys with `field:` (e.g. `field:age`); mailroom's sort
+# wants the bare field key. System columns (last_seen_on, created_on) are sent unprefixed and pass through untouched.
+FIELD_SORT_PREFIX = "field:"
+
+
+class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
+    """
+    Contacts for the current org, used by the contact list component. A status folder is selected with the `folder`
+    query param (one of `active`, `blocked`, `stopped` or `archived`, defaulting to `active`) — alternatively pass
+    `group=<uuid>` to filter by a specific (manual or smart) group. Optional `search` (a mailroom contact query) and
+    `sort` params drive ES-backed search/sorting, exactly like the legacy contact list views. Each item is serialized
+    via Contact.as_json() (the lightweight list shape — name, primary URN, featured field values, last/created on).
+    """
+
+    class Pagination(PageNumberPagination):
+        page_size = DEFAULT_PAGE_SIZE
+        page_size_query_param = "page_size"
+        max_page_size = MAX_PAGE_SIZE
+
+    model = Contact
+    serializer_class = ModelAsJsonSerializer
+    pagination_class = Pagination
+
+    FOLDERS = {
+        "active": ContactGroup.TYPE_DB_ACTIVE,
+        "blocked": ContactGroup.TYPE_DB_BLOCKED,
+        "stopped": ContactGroup.TYPE_DB_STOPPED,
+        "archived": ContactGroup.TYPE_DB_ARCHIVED,
+    }
+
+    def get(self, request, *args, **kwargs):
+        search = request.query_params.get("search") or ""
+        if len(search) > SEARCH_MAX_LENGTH:
+            return Response({"results": [], "count": 0, "error": "Search query too long"}, status=413)
+        # Don't allow pagination past the 200th page (mirrors ContactListView.pre_process / the ES offset guard).
+        if self._page() > MAX_PAGE:
+            return Response({"results": [], "count": 0, "next": None, "previous": None})
+        return super().get(request, *args, **kwargs)
+
+    def _page(self) -> int:
+        try:
+            return max(1, int(self.request.query_params.get("page", 1)))
+        except TypeError, ValueError:
+            return 1
+
+    def _page_size(self) -> int:
+        try:
+            size = int(self.request.query_params.get("page_size", DEFAULT_PAGE_SIZE))
+        except TypeError, ValueError:
+            return DEFAULT_PAGE_SIZE
+        return max(1, min(size, MAX_PAGE_SIZE))
+
+    def derive_group(self):
+        org = self.request.org
+        group_uuid = self.request.query_params.get("group")
+        if group_uuid:
+            return org.groups.filter(uuid=group_uuid, is_active=True).first()
+
+        group_type = self.FOLDERS.get(self.request.query_params.get("folder", "active").lower())
+        if not group_type:
+            return None
+        return org.groups.filter(group_type=group_type).first()
+
+    def derive_sort(self) -> str:
+        sort = self.request.query_params.get("sort") or ""
+        if not sort:
+            return ""
+        desc = sort.startswith("-")
+        key = sort[1:] if desc else sort
+        if key.startswith(FIELD_SORT_PREFIX):
+            key = key[len(FIELD_SORT_PREFIX) :]
+        return ("-" if desc else "") + key
+
+    def get_queryset(self):
+        org = self.request.org
+        group = self.derive_group()
+        if group is None:
+            return Contact.objects.none()
+
+        search = self.request.query_params.get("search") or ""
+        sort = self.derive_sort()
+
+        # Searching/sorting goes through mailroom (ES) which returns a pre-ordered window plus a total; without either
+        # we can read the group membership straight from the database (newest first), matching ContactListView.
+        if search or sort:
+            page_size = self._page_size()
+            offset = (self._page() - 1) * page_size
+            try:
+                results = mailroom.get_client().contact_search(
+                    org, group, search, sort=sort, offset=offset, limit=page_size
+                )
+            except mailroom.QueryValidationException as e:
+                # Surface the validation error but keep a list-shaped response so the component just renders empty.
+                self._query_error = str(e)
+                return SearchSliceQuerySet(Contact, [], offset=0, total=0)
+
+            # Echo mailroom's parsed/normalized query (e.g. "age > 50" → "fields.age > 50") so the component can
+            # rewrite its search box to match what the results actually reflect. Only meaningful when searching.
+            self._parsed_query = results.query if search and results.query else None
+
+            return SearchSliceQuerySet(Contact, results.contact_uuids, offset=offset, total=results.total)
+
+        return group.contacts.filter(org=org).order_by("-id")
+
+    def filter_queryset(self, queryset):
+        # Filtering (group/search/sort) is fully resolved in get_queryset; bypass the default filter backends.
+        return queryset
+
+    def prepare_for_serialization(self, page, using: str):
+        Contact.bulk_urn_cache_initialize(page, using=using)
+        # Bulk-load each contact's group memberships (one query for the page) so as_json can report current
+        # membership — used by the component to pre-check the group dropdown — without an N+1.
+        prefetch_related_objects(
+            page,
+            Prefetch(
+                "groups",
+                queryset=ContactGroup.get_groups(self.request.org).only("uuid", "name", "org"),
+                to_attr="prefetched_groups",
+            ),
+        )
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["contact_fields"] = ContactField.get_fields(org=self.request.org, viewable_by=self.request.user)
+        return context
+
+    def get_paginated_response(self, data):
+        response = super().get_paginated_response(data)
+        if getattr(self, "_query_error", None):
+            response.data["error"] = self._query_error
+        parsed_query = getattr(self, "_parsed_query", None)
+        if parsed_query:
+            response.data["query"] = parsed_query
+        return response

--- a/temba/contacts/api.py
+++ b/temba/contacts/api.py
@@ -64,7 +64,7 @@ class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
     def _page(self) -> int:
         try:
             return max(1, int(self.request.query_params.get("page", 1)))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return 1
 
     def _page_size(self) -> int:
@@ -74,7 +74,7 @@ class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
         # or SearchSliceQuerySet's offset guard trips with an IndexError (HTTP 500).
         try:
             size = int(self.request.query_params.get("page_size", DEFAULT_PAGE_SIZE))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return DEFAULT_PAGE_SIZE
         if size <= 0:
             return DEFAULT_PAGE_SIZE

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -960,6 +960,41 @@ class Contact(LegacyUUIDMixin, SmartModel):
         else:
             return str(value)
 
+    def as_json(self, context=None) -> dict:
+        """
+        Internal API shape, consumed by the temba-contact-list component. `context` is the DRF serializer context
+        (with `org` and the featured `contact_fields`), used to serialize the URN (anon-masked per org) and the field
+        columns the list renders.
+        """
+        from temba.api.v2.fields import serialize_urn
+
+        org = context.get("org") if context else self.org
+        fields = context.get("contact_fields", ()) if context else ()
+        statuses = {
+            self.STATUS_ACTIVE: "active",
+            self.STATUS_BLOCKED: "blocked",
+            self.STATUS_STOPPED: "stopped",
+            self.STATUS_ARCHIVED: "archived",
+        }
+        urn = self.get_urn()
+        # `prefetched_groups` is attached in bulk by the list endpoint to avoid an N+1; `groups` lets the component
+        # pre-check the group dropdown against each row's current membership.
+        groups = self.prefetched_groups if hasattr(self, "prefetched_groups") else self.get_groups()
+
+        return {
+            "uuid": str(self.uuid),
+            "name": self.name,
+            "status": statuses.get(self.status),
+            # Pre-formatted primary URN for display (the component shows `urn` verbatim); anon orgs are masked by
+            # get_display.
+            "urn": urn.get_display(org=org, international=True) if urn else "",
+            "urns": [serialize_urn(org, u) for u in self.get_urns()],
+            "fields": {f.key: self.get_field_serialized(f) for f in fields},
+            "groups": [{"uuid": str(g.uuid), "name": g.name} for g in groups],
+            "last_seen_on": self.last_seen_on.isoformat() if self.last_seen_on else None,
+            "created_on": self.created_on.isoformat() if self.created_on else None,
+        }
+
     def update(self, name: str, language: str) -> list[modifiers.Modifier]:
         """
         Updates attributes of this contact

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -332,6 +332,10 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.client.post(group_url, {"action": "unlabel", "objects": str(frank.uuid)})
         self.assertNotIn(frank, group.contacts.all())
 
+        # a malformed contact uuid in `objects` is ignored rather than raising (no 500 on hostile/garbage input)
+        response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
+        self.assertEqual(200, response.status_code)
+
         del self.client.cookies["temba-preview"]
 
         # back on the legacy (non-preview) list, the content menu still surfaces Create Smart Group when the search is

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -326,8 +326,8 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
         del self.client.cookies["temba-preview"]
 
-        # the content menu still surfaces Create Smart Group when the active search is saveable as a group — the
-        # component folds its committed search into the content-menu endpoint so build_context_menu sees it
+        # back on the legacy (non-preview) list, the content menu still surfaces Create Smart Group when the search is
+        # saveable as a group — build_context_menu reads the search straight off the request query string here
         self.assertContentMenu(
             list_url + "?search=age+%3E+30",
             self.admin,

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -263,6 +263,78 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(Contact.STATUS_ARCHIVED, joe.status)
 
     @mock_mailroom
+    def test_preview_list(self, mr_mocks):
+        joe = self.create_contact("Joe", phone="123")
+        frank = self.create_contact("Frank", phone="124")
+        group = self.create_group("Crew", contacts=[joe, frank])
+
+        list_url = reverse("contacts.contact_list")
+        group_url = reverse("contacts.contact_group", args=[group.uuid])
+
+        self.login(self.admin)
+
+        # default render is still the legacy table
+        response = self.client.get(list_url)
+        self.assertNotContains(response, "temba-contact-list")
+
+        # entering preview mode swaps in the temba-contact-list component, pointed at the internal contacts api
+        self.client.cookies["temba-preview"] = "1"
+
+        response = self.client.get(list_url)
+        self.assertContains(response, "temba-contact-list")
+        self.assertEqual(
+            f"{reverse('api.internal.contacts')}.json?folder=active", response.context["new_list_endpoint"]
+        )
+
+        # send / start-flow are clientOnly (they open a modal); the group dropdown carries a labelsEndpoint of the
+        # workspace's static groups; the rest post to the action endpoint
+        actions = {a["key"]: a for a in response.context["new_list_bulk_actions"]}
+        self.assertEqual(["label", "block", "archive", "send", "start-flow"], list(actions.keys()))
+        self.assertTrue(actions["send"]["clientOnly"])
+        self.assertTrue(actions["start-flow"]["clientOnly"])
+        self.assertNotIn("clientOnly", actions["archive"])
+        self.assertEqual("/api/v2/groups.json?manual_only=1", actions["label"]["labelsEndpoint"])
+
+        # a user group is selected by uuid rather than a status folder
+        response = self.client.get(group_url)
+        self.assertEqual(
+            f"{reverse('api.internal.contacts')}.json?group={group.uuid}", response.context["new_list_endpoint"]
+        )
+        # a manual group has no subtitle
+        self.assertEqual("", response.context["new_list_subtitle"])
+
+        # a smart (dynamic) group surfaces its query as the list subtitle
+        smart = self.create_group("Females", query="gender = F")
+        response = self.client.get(reverse("contacts.contact_group", args=[smart.uuid]))
+        self.assertEqual(smart.query, response.context["new_list_subtitle"])
+
+        # the component posts contact uuids in `objects`; the view translates them to ids so the bulk action applies
+        self.client.post(list_url, {"action": "archive", "objects": str(joe.uuid)})
+        joe.refresh_from_db()
+        self.assertEqual(Contact.STATUS_ARCHIVED, joe.status)
+
+        # the group dropdown adds the selection to a static group (group posted by uuid; omitting `add` means add)
+        newsletter = self.create_group("Newsletter", contacts=[])
+        self.client.post(list_url, {"action": "label", "objects": str(frank.uuid), "label": str(newsletter.uuid)})
+        self.assertIn(frank, newsletter.contacts.all())
+
+        # ...and removes them when add=false (BulkActionMixin maps that to unlabel)
+        self.client.post(
+            list_url, {"action": "label", "objects": str(frank.uuid), "label": str(newsletter.uuid), "add": "false"}
+        )
+        self.assertNotIn(frank, newsletter.contacts.all())
+
+        del self.client.cookies["temba-preview"]
+
+        # the content menu still surfaces Create Smart Group when the active search is saveable as a group — the
+        # component folds its committed search into the content-menu endpoint so build_context_menu sees it
+        self.assertContentMenu(
+            list_url + "?search=age+%3E+30",
+            self.admin,
+            ["Create Smart Group", "New Contact", "New Group", "Export"],
+        )
+
+    @mock_mailroom
     def test_blocked(self, mr_mocks):
         joe = self.create_contact("Joe", urns=["twitter:joe"])
         frank = self.create_contact("Frank", urns=["twitter:frank"])
@@ -417,7 +489,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.assertReadFetch(group1_url, [self.editor, self.admin])
 
         self.assertEqual([frank, joe], list(response.context["object_list"]))
-        self.assertEqual(["block", "unlabel", "send", "start-flow"], list(response.context["actions"]))
+        self.assertEqual(["unlabel", "block", "send", "start-flow"], list(response.context["actions"]))
         self.assertEqual(
             [f.name for f in response.context["contact_fields"]], ["Home", "Age", "Last Seen On", "Created On"]
         )

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -324,6 +324,14 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         )
         self.assertNotIn(frank, newsletter.contacts.all())
 
+        # a label posted as a numeric id (a legacy form post rather than the component) is passed through untranslated
+        self.client.post(list_url, {"action": "label", "objects": str(frank.uuid), "label": str(newsletter.id)})
+        self.assertIn(frank, newsletter.contacts.all())
+
+        # on a group page, an "unlabel" with no group falls back to the current group ("Remove from group")
+        self.client.post(group_url, {"action": "unlabel", "objects": str(frank.uuid)})
+        self.assertNotIn(frank, group.contacts.all())
+
         del self.client.cookies["temba-preview"]
 
         # back on the legacy (non-preview) list, the content menu still surfaces Create Smart Group when the search is

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -145,7 +145,15 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
             data = request.POST.copy()
             uuids = data.getlist("objects")
             if uuids:
-                ids = Contact.objects.filter(org=request.org, uuid__in=uuids).values_list("id", flat=True)
+                # Only keep well-formed UUIDs — `uuid__in` runs each value through UUIDField.get_prep_value, so a single
+                # malformed value (a hostile post, or a stale id-based form post) would otherwise raise ValueError (500).
+                valid = []
+                for u in uuids:
+                    try:
+                        valid.append(UUID(u))
+                    except ValueError:
+                        pass
+                ids = Contact.objects.filter(org=request.org, uuid__in=valid).values_list("id", flat=True)
                 data.setlist("objects", [str(i) for i in ids])
             label = data.get("label")
             if label:

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -16,7 +16,7 @@ from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.functional import cached_property
+from django.utils.functional import Promise, cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 
@@ -70,6 +70,98 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
     search_error = None
     search_max_length = ContactGroup.MAX_QUERY_LEN
 
+    # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview, every
+    # contact list view renders the temba-contact-list component (contacts/contact_list_new.html) instead of its
+    # legacy table; the component fetches/pages contacts itself from the internal contacts API.
+    NEW_LIST_TEMPLATE = "contacts/contact_list_new.html"
+
+    # Optional subtitle rendered under the title on the new-list view; subclasses override to carry the intro text the
+    # legacy templates rendered in their pre-table block.
+    subtitle = ""
+
+    # Maps a view's system group to the `folder` the internal contacts API expects; user groups pass `group=<uuid>`.
+    FOLDER_BY_SYSTEM_GROUP = {
+        ContactGroup.TYPE_DB_ACTIVE: "active",
+        ContactGroup.TYPE_DB_BLOCKED: "blocked",
+        ContactGroup.TYPE_DB_STOPPED: "stopped",
+        ContactGroup.TYPE_DB_ARCHIVED: "archived",
+    }
+
+    # Bulk-action key -> config consumed by temba-contact-list (label, icon, destructive/confirm). `clientOnly` actions
+    # (send / start-flow) open a modal seeded with the selected contacts rather than POSTing to the action endpoint.
+    # `labelsEndpoint` turns the action into a dropdown of (static) groups to add/remove the selection to/from —
+    # mirroring the message list's label dropdown.
+    BULK_ACTION_CONFIG = {
+        "send": {"label": _("Send"), "icon": "compose", "clientOnly": True},
+        "start-flow": {"label": _("Start Flow"), "icon": "flow", "clientOnly": True},
+        "label": {
+            "label": _("Group"),
+            "icon": "group",
+            "labelsEndpoint": "/api/v2/groups.json?manual_only=1",
+            "labelsKey": "groups",
+        },
+        "block": {"label": _("Block"), "icon": "contact_blocked"},
+        "archive": {"label": _("Archive"), "icon": "archive"},
+        "restore": {"label": _("Reactivate"), "icon": "restore"},
+        "unlabel": {"label": _("Remove from group"), "icon": "group_exclude"},
+        "delete": {
+            "label": _("Delete"),
+            "icon": "delete",
+            "destructive": True,
+            "confirm": _("Delete selected contacts? This cannot be undone."),
+        },
+    }
+
+    def _use_new_list(self) -> bool:
+        # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered out)
+        # doesn't AttributeError.
+        return getattr(self.request, "preview", False)
+
+    def get_template_names(self):
+        if self._use_new_list():
+            return [self.NEW_LIST_TEMPLATE]
+        return super().get_template_names()
+
+    def get_paginate_by(self, queryset):
+        # The temba-contact-list component fetches and pages contacts itself.
+        if self._use_new_list():
+            return None
+        return super().get_paginate_by(queryset)
+
+    def derive_subtitle(self):
+        return self.subtitle
+
+    def derive_new_list_query(self) -> str:
+        if self.system_group:
+            return f"folder={self.FOLDER_BY_SYSTEM_GROUP[self.system_group]}"
+        return f"group={self.group.uuid}"
+
+    def post(self, request, *args, **kwargs):
+        # The component posts contact uuids in `objects`, but BulkActionMixin matches by primary key — translate them
+        # here so the new component and the legacy id-based form post are both accepted. The group dropdown likewise
+        # posts the target group by uuid (action=label, add=true|false), which the form matches by id — translate it
+        # too. A fixed "unlabel" with no group (the group view's "Remove from group") falls back to the current group.
+        if self._use_new_list():
+            data = request.POST.copy()
+            uuids = data.getlist("objects")
+            if uuids:
+                ids = Contact.objects.filter(org=request.org, uuid__in=uuids).values_list("id", flat=True)
+                data.setlist("objects", [str(i) for i in ids])
+            label = data.get("label")
+            if label:
+                try:
+                    UUID(label)
+                except ValueError:
+                    pass  # already an id (legacy form post) — leave alone
+                else:
+                    group = request.org.groups.filter(uuid=label).first()
+                    data["label"] = str(group.id) if group else ""
+            elif data.get("action") == "unlabel" and self.group is not None:
+                data["label"] = str(self.group.id)
+            request.POST = data
+
+        return super().post(request, *args, **kwargs)
+
     def pre_process(self, request, *args, **kwargs):
         """
         Don't allow pagination past 200th page
@@ -90,7 +182,18 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
         search = quote_plus(self.request.GET.get("search", ""))
         return f"{reverse('contacts.contact_export')}?g={self.group.uuid}&s={search}"
 
+    def get_bulk_action_labels(self):
+        # The "label" bulk action (group dropdown) and "unlabel" validate their posted group against this queryset —
+        # only static (manual) groups can have members added/removed.
+        return ContactGroup.get_groups(self.request.org, manual_only=True)
+
     def get_queryset(self, **kwargs):
+        # In preview the temba-contact-list component fetches and pages contacts from the internal contacts API, so a
+        # GET page needs no object list — skip the mailroom/DB query entirely. A POST (bulk action) still needs the
+        # real queryset, since BulkActionMixin validates the posted `objects` against it.
+        if self._use_new_list() and self.request.method == "GET":
+            return Contact.objects.none()
+
         org = self.request.org
         self.search_error = None
 
@@ -155,6 +258,22 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
         if self.parsed_query is not None:
             context["search"] = self.parsed_query
             context["search_is_saveable"] = self.search_is_saveable
+
+        # New-list view context: the resolved contacts-api endpoint (folder= for the system groups, group= for a user
+        # group), the subtitle, and the bulk-action configs the temba-contact-list expects (resolved + JSON-encoded
+        # here so the template stays inert).
+        if self._use_new_list():
+            context["new_list_endpoint"] = f"{reverse('api.internal.contacts')}.json?{self.derive_new_list_query()}"
+            subtitle = self.derive_subtitle()
+            context["new_list_subtitle"] = str(subtitle) if subtitle else ""
+            actions = []
+            for key in self.get_bulk_actions():
+                cfg = dict(self.BULK_ACTION_CONFIG.get(key, {}))
+                cfg["key"] = key
+                # Resolve any i18n lazy proxies so json_script / json.dumps don't choke.
+                cfg = {k: (str(v) if isinstance(v, Promise) else v) for k, v in cfg.items()}
+                actions.append(cfg)
+            context["new_list_bulk_actions"] = actions
 
         return context
 
@@ -498,7 +617,7 @@ class ContactCRUDL(SmartCRUDL):
         menu_path = "/contact/active"
 
         def get_bulk_actions(self):
-            actions = ("block", "archive") if self.has_org_perm("contacts.contact_update") else ()
+            actions = ("label", "block", "archive") if self.has_org_perm("contacts.contact_update") else ()
             if self.has_org_perm("msgs.broadcast_create"):
                 actions += ("send",)
             if self.has_org_perm("flows.flow_start"):
@@ -558,6 +677,10 @@ class ContactCRUDL(SmartCRUDL):
         title = _("Stopped")
         template_name = "contacts/contact_stopped.html"
         system_group = ContactGroup.TYPE_DB_STOPPED
+        subtitle = _(
+            "These contacts have opted out and you can no longer send them messages, but inbound messages will "
+            "unstop them. They have also been removed from all groups."
+        )
 
         def get_bulk_actions(self):
             return ("restore", "archive") if self.has_org_perm("contacts.contact_update") else ()
@@ -575,6 +698,7 @@ class ContactCRUDL(SmartCRUDL):
         title = _("Archived")
         template_name = "contacts/contact_archived.html"
         system_group = ContactGroup.TYPE_DB_ARCHIVED
+        subtitle = _("These contacts have been removed from all groups and can be deleted permanently.")
         bulk_action_permissions = {"delete": "contacts.contact_delete"}
 
         def get_bulk_actions(self):
@@ -617,7 +741,8 @@ class ContactCRUDL(SmartCRUDL):
         def get_bulk_actions(self):
             actions = ()
             if self.has_org_perm("contacts.contact_update"):
-                actions += ("block", "archive") if self.group.is_smart else ("block", "unlabel")
+                # the group action ("Remove from group") leads, matching the "Group" dropdown's slot on the active list
+                actions += ("block", "archive") if self.group.is_smart else ("unlabel", "block")
             if self.has_org_perm("msgs.broadcast_create"):
                 actions += ("send",)
             if self.has_org_perm("flows.flow_start"):
@@ -644,6 +769,13 @@ class ContactCRUDL(SmartCRUDL):
 
         def derive_title(self):
             return self.group.name
+
+        def derive_subtitle(self):
+            # Smart (dynamic) groups are defined by a query — surface it as the
+            # list subtitle so the membership rule is visible in the header.
+            if self.group.is_smart:
+                return self.group.query
+            return super().derive_subtitle()
 
         def derive_group(self):
             return get_object_or_404(

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -537,7 +537,7 @@ class ContactCRUDL(SmartCRUDL):
         def _get_uuid_param(self, name: str) -> UUID:
             try:
                 return UUID(self.request.GET.get(name))
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 return None
 
     class ChatSearch(BaseReadView):
@@ -617,7 +617,11 @@ class ContactCRUDL(SmartCRUDL):
         menu_path = "/contact/active"
 
         def get_bulk_actions(self):
-            actions = ("label", "block", "archive") if self.has_org_perm("contacts.contact_update") else ()
+            if self.has_org_perm("contacts.contact_update"):
+                # "label" (the group dropdown) is a preview-list-only action — the legacy table has no UI for it.
+                actions = ("label", "block", "archive") if self._use_new_list() else ("block", "archive")
+            else:
+                actions = ()
             if self.has_org_perm("msgs.broadcast_create"):
                 actions += ("send",)
             if self.has_org_perm("flows.flow_start"):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -617,11 +617,9 @@ class ContactCRUDL(SmartCRUDL):
         menu_path = "/contact/active"
 
         def get_bulk_actions(self):
-            if self.has_org_perm("contacts.contact_update"):
-                # "label" (the group dropdown) is a preview-list-only action — the legacy table has no UI for it.
-                actions = ("label", "block", "archive") if self._use_new_list() else ("block", "archive")
-            else:
-                actions = ()
+            # "label" (the group dropdown) is a preview-list-only action — the legacy table has no UI for it.
+            update = ("label", "block", "archive") if self._use_new_list() else ("block", "archive")
+            actions = update if self.has_org_perm("contacts.contact_update") else ()
             if self.has_org_perm("msgs.broadcast_create"):
                 actions += ("send",)
             if self.has_org_perm("flows.flow_start"):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -537,7 +537,7 @@ class ContactCRUDL(SmartCRUDL):
         def _get_uuid_param(self, name: str) -> UUID:
             try:
                 return UUID(self.request.GET.get(name))
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return None
 
     class ChatSearch(BaseReadView):

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -24,8 +24,9 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
         """
         The sent folder is ordered by sent date; all other folders by UUID, which (since msg.uuid is uuid7) is itself
         time-ordered and already uniquely indexed — so we get the same newest-first semantics as `-created_on, -id`
-        without the composite sort. Searches additionally include a `count` on the response via SearchCountMixin so
-        the list UI can surface "N results".
+        without the composite sort. The response always carries a `count` so the list UI can show "N of Total": a
+        search count via SearchCountMixin, otherwise the folder/label's cheap pre-calculated count (see
+        `get_total_count`) — never a COUNT(*) on the messages table.
         """
 
         # DRF's CursorPagination ignores `?page_size=` unless the subclass opts in. The list component sends
@@ -41,6 +42,14 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
             if request.query_params.get("folder", "").lower() == "sent":
                 return SentOnCursorPagination.ordering
             return self.ordering
+
+        def paginate_queryset(self, queryset, request, view=None):
+            page = super().paginate_queryset(queryset, request, view)
+            # SearchCountMixin sets _search_count on a search; otherwise fall back to the folder/label's cheap
+            # pre-calculated count so the list always has a total to show.
+            if getattr(self, "_search_count", None) is None and view is not None:
+                self._search_count = view.get_total_count()
+            return page
 
     # Match BaseListView's caps so the legacy and new lists impose the same bounds: a search query is capped at 1000
     # chars (rejected with 413) and is restricted to messages from the last 90 days so an unbounded `text__icontains`
@@ -66,6 +75,20 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
         if len(search) > self.SEARCH_MAX_LENGTH:
             return HttpResponse("Search query too long", status=413)
         return super().get(request, *args, **kwargs)
+
+    def get_total_count(self) -> int:
+        # Cheap pre-calculated total for the active folder/label (squashed count tables) — used as the list's total
+        # when there's no search, avoiding a COUNT(*) on the messages table.
+        org = self.request.org
+        label_uuid = self.request.query_params.get("label")
+        if label_uuid:
+            label = org.msgs_labels.filter(uuid=label_uuid).first()
+            return label.get_visible_count() if label else 0
+
+        folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
+        if not folder:
+            return 0
+        return MsgFolder.get_counts(org).get(folder, 0)
 
     def derive_queryset(self):
         # `label` takes precedence — the filter view passes a label UUID rather than a folder name, and the visible

--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -1,0 +1,168 @@
+{% extends "smartmin/list.html" %}
+{% load i18n %}
+
+{% comment %}
+  Generic new-list template used by every contact list view (Active /
+  Blocked / Stopped / Archived / Group) when the viewer is in preview
+  mode (request.preview, set by PreviewMiddleware off the temba-preview
+  cookie). Endpoint, subtitle and bulk actions come from the view's
+  context_data so the template stays the same across all of them.
+{% endcomment %}
+{% block page-header %}
+  {# the temba-contact-list renders its own header (title + content menu); #}
+  {# keep the csrf token and a hidden title for the SPA document.title hook #}
+  {% csrf_token %}
+  <div id="title-text" class="hide">{{ title }}</div>
+{% endblock page-header %}
+{% block extra-style %}
+  {{ block.super }}
+  <style type="text/css">
+    /* The list component fills its container edge to edge and brings
+       its own surface, so drop the SPA content padding (and the grey
+       page background it would otherwise reveal around the list). */
+    .spa-content {
+      padding: 0 !important;
+    }
+  </style>
+{% endblock extra-style %}
+{% block content %}
+  <temba-contact-list id="contact-list"
+                      fill-window
+                      history-state-key="contacts"
+                      list-title="{{ title }}"
+                      {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
+                      endpoint="{{ new_list_endpoint }}"
+                      action-endpoint="{{ request.path }}"
+                      content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"
+                      empty-message="{% trans "No contacts" %}">
+  </temba-contact-list>
+  {{ new_list_bulk_actions|json_script:"new-list-bulk-actions" }}
+  {% if org_perms.contacts.contact_delete %}
+    <temba-dialog header="{{ _("Delete All Contacts") |escapejs }}"
+                  primaryButtonName="{{ _("Delete") |escapejs }}"
+                  destructive="true"
+                  class="hide"
+                  id="delete-all-confirmation">
+      <div class="p-6">{% trans "Are you sure you want to delete all archived contacts? This cannot be undone." %}</div>
+    </temba-dialog>
+  {% endif %}
+{% endblock content %}
+{% block extra-script %}
+  {{ block.super }}
+  <script type="text/javascript">
+    onSpload(function() {
+      var list = document.querySelector("#contact-list");
+      list.bulkActions = JSON.parse(document.getElementById("new-list-bulk-actions").textContent);
+
+      // clicking a row opens the contact
+      list.addEventListener("temba-row-click", function(event) {
+        var contact = event.detail.item;
+        if (contact && contact.uuid) {
+          spaGet("/contact/read/" + contact.uuid + "/");
+        }
+      });
+
+      // the embedded content menu fires temba-selection - dispatch it the
+      // same way the page chrome's content menu (spa_page_menu.html) does
+      list.addEventListener("temba-selection", function(event) {
+        var item = event.detail.item;
+        var click = event.detail.event;
+        if (item.type === "link") {
+          if (click) {
+            click.preventDefault();
+            click.stopPropagation();
+            if (click.metaKey && item.url) {
+              window.open(item.url, "_blank");
+              return;
+            }
+          }
+          spaGet(item.url);
+        } else if (item.type === "modax") {
+          showModax(item.title, item.url, {
+            disabled: item.disabled,
+            onSubmit: item.on_submit,
+            onRedirect: item.on_redirect,
+            id: item.modal_id,
+            originX: event.detail.originX,
+            originY: event.detail.originY
+          });
+        } else if (item.type === "url_post") {
+          posterize(item.url);
+        } else if (item.type === "js") {
+          if (window[item.id]) {
+            window[item.id]();
+          }
+        }
+        refreshMenu();
+      });
+
+      // Send / Start flow are clientOnly actions: the component fires the
+      // event with the selected contact uuids without POSTing, and we open
+      // the broadcast / flow-start modal seeded with them. Every other
+      // action is POSTed to action-endpoint by the component, which then
+      // re-fetches the current page itself — we just refresh the sidebar
+      // menu counts after the round-trip completes.
+      list.addEventListener("temba-bulk-action", function(event) {
+        var action = event.detail.action;
+        var ids = event.detail.ids || [];
+        if (action === "send") {
+          openSeededModax("{% url 'msgs.broadcast_create' %}", '{{ _("New Broadcast") |escapejs }}', ids);
+        } else if (action === "start-flow") {
+          openSeededModax("{% url 'flows.flow_start' %}", '{{ _("Start Flow") |escapejs }}', ids);
+        } else {
+          refreshMenu();
+        }
+      });
+
+      // See msgs/msg_list_new.html for the full rationale: stash the list's
+      // restorable state (page, sort, search, cursor url) on the current
+      // history entry so a navigation away and back lands on the same page.
+      list.addEventListener("temba-history-change", function(event) {
+        var current = history.state || {};
+        var next = Object.assign({}, current);
+        next[event.detail.key] = event.detail.state;
+        if (!next.url) {
+          next.url = location.href;
+        }
+        if (event.detail.replace) {
+          history.replaceState(next, "");
+        } else {
+          history.pushState(next, "");
+        }
+      });
+    });
+
+    // Open the shared modax against the given endpoint, including any
+    // selected contact uuids as the `c` param (mirrors the legacy
+    // handleSendMessageClicked / handleStartFlowClicked).
+    function openSeededModax(endpoint, header, ids) {
+      var modax = getModax("#shared-modax");
+      modax.header = header;
+      modax.setAttribute("endpoint", ids.length > 0 ? endpoint + "?c=" + ids.join(",") : endpoint);
+      modax.open = true;
+    }
+
+    {% if org_perms.contacts.contact_delete %}
+    // Content-menu "Delete All" (Archived view) - fired as a js selection.
+    function contacts_delete_all() {
+      var confirmation = document.querySelector("#delete-all-confirmation");
+      confirmation.classList.remove("hide");
+      confirmation.open = true;
+      confirmation.removeEventListener("temba-button-clicked", deleteAllArchivedContacts);
+      confirmation.addEventListener("temba-button-clicked", deleteAllArchivedContacts);
+    }
+
+    function deleteAllArchivedContacts(event) {
+      var confirmation = document.querySelector("#delete-all-confirmation");
+      if (event.detail.button.attributes.destructive) {
+        var formData = new FormData();
+        formData.append("action", "delete");
+        formData.append("all", "true");
+        spaPost("{% url 'contacts.contact_archived' %}", { postData: formData });
+      }
+      confirmation.classList.add("hide");
+      confirmation.open = false;
+    }
+    {% endif %}
+  </script>
+{% endblock extra-script %}


### PR DESCRIPTION
## Summary

Adds a preview-mode contact list that renders the `temba-contact-list` web component instead of the legacy server-rendered table, backed by a new internal contacts API. It's gated entirely behind preview mode (`PreviewMiddleware` → `request.preview`, set by the `temba-preview` cookie), so default behavior is unchanged. This mirrors the existing preview message-list work.

## Changes

**New internal contacts endpoint** (`temba/contacts/api.py`)
- `ContactsEndpoint` serving the current org's contacts for the list component. Folder selection via `?folder=active|blocked|stopped|archived` (default `active`) or `?group=<uuid>`; optional `search` (a mailroom contact query) and `sort` route through mailroom/ES exactly like the legacy list views, otherwise the DB path reads group membership newest-first.
- Org-scoped and permission-gated (requires `contacts.contact_list`, same as `/api/v2/contacts`). Search length capped at `ContactGroup.MAX_QUERY_LEN` (413 if exceeded) and pagination capped at the 200th page, mirroring `ContactListView` and `MessagesEndpoint`. `derive_group` excludes still-initializing groups, matching `GroupsEndpoint`.
- `_page_size()` mirrors DRF's `_positive_int(strict=True)` so the mailroom offset always matches the page size DRF slices with (a divergence could otherwise trip `SearchSliceQuerySet`'s offset guard → 500).
- Bulk-prefetches group membership for the page to avoid an N+1; echoes mailroom's parsed/normalized query so the component can rewrite its search box.

**Contact serialization** (`temba/contacts/models.py`)
- `Contact.as_json()` — the lightweight list shape (name, primary URN with anon-org masking, featured field values, groups, last/created on).

**Contact list views** (`temba/contacts/views.py`)
- In preview, every contact list view renders `contact_list_new.html` and skips the server-side queryset/pagination on GET (the component fetches/pages itself); POSTs still build the real queryset for bulk-action validation.
- `post()` translates the component's uuid-based `objects` / group `label` posts to the ids `BulkActionMixin` expects. Malformed/garbage uuids in `objects` are dropped rather than raising (no 500 on hostile input).
- Resolves the API endpoint, subtitle (smart-group query / status-folder intro text), and bulk-action configs into context.
- The "label" (group dropdown) bulk action is **preview-only** — the non-preview active list keeps its original `("block", "archive")` actions.

**Group dropdown support** (`temba/api/v2/views.py`, `GroupsEndpoint`)
- `?manual_only=1` restricts to static (manual) groups — the only groups the dropdown can add/remove members on. Documented in the endpoint docstring.

**Message list count** (`temba/msgs/api.py`)
- `MessagesEndpoint` now always carries a `count` (search count, else the folder/label's cheap pre-calculated count) so the list UI can show "N of Total" without a `COUNT(*)`.

**Template** (`templates/contacts/contact_list_new.html`)
- Generic new-list template wiring the component's row-click, content-menu, bulk-action, and history events to the existing SPA helpers.

## Review notes

Pre-PR review + the automated PR review surfaced and resolved:
- **Pagination 500 on hostile input** — `?page_size=-5&search=…` could trip `SearchSliceQuerySet`'s offset guard; `_page_size()` now mirrors DRF's strict positive-int handling.
- **413 consistency** — over-long search returns `HttpResponse(status=413)` matching `MessagesEndpoint` rather than a JSON error body.
- **Malformed uuids in `objects` → 500** — `post()` now drops non-UUID values before the `uuid__in` filter.
- **`derive_group`** excludes `STATUS_INITIALIZING` groups, matching `GroupsEndpoint`.
- **`manual_only`** documented in the v2 Listing Groups docstring.
- The automated reviewer flagged the `except TypeError, ValueError:` form as a Py3 `SyntaxError`. Verified this is **valid in the project's Python 3.14** (it parses and catches both exception types) and is the form `ruff format` enforces — `main` uses the same form. Left as-is; new tests exercise both `except` branches.
- **100% coverage** maintained — added tests for the pagination guards (`page` > 200, non-integer `page`/`page_size`, non-positive `page_size`) and the bulk-action edge paths (legacy numeric-id label, group "unlabel" fallback, malformed uuid).

## Test plan

- [x] `temba.api.internal.tests.EndpointsTest.test_contacts` — folders, group filter, row shape, search/sort via mailroom, parsed-query echo, invalid query, over-long 413, pagination guards
- [x] `temba.api.v2.tests.test_groups` — `manual_only` filter
- [x] `temba.contacts.tests.ContactCRUDLTest.test_preview_list` — template swap, endpoint/subtitle/bulk-action context, uuid→id POST translation, group add/remove, malformed-uuid handling
- [x] `temba.contacts.tests.ContactCRUDLTest.test_group` — updated action ordering
- [x] CI green (both Test shards), 100% coverage, `code_check.py` clean