### PR TITLE
Handle courier send callbacks concurrently in msg_console

### DIFF
--- a/temba/tests/integration.py
+++ b/temba/tests/integration.py
@@ -1,6 +1,6 @@
 import json
 import socket
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 
 import requests
@@ -100,11 +100,19 @@ class Messenger:
         if release_channel:
             self.channel.release(user=self.channel.created_by)
 
-    class Server(HTTPServer):
+    class Server(ThreadingHTTPServer):
+        # Courier sends MT replies from a pool of concurrent workers (its foreman defaults to 32 senders), so this
+        # server must handle requests concurrently. A single-threaded HTTPServer processes one send at a time and
+        # only backlogs a handful of pending connections, causing courier sends to be refused -> retried with
+        # backoff or eventually failed, which shows up as replies arriving delayed or not at all. ThreadingHTTPServer
+        # services each send on its own thread; daemon_threads lets those threads die on shutdown.
+        daemon_threads = True
+        request_queue_size = 64
+
         def __init__(self, port, host):
             # Bind on all interfaces (not just loopback) so courier can reach the send callback even when it runs
             # in a different container; advertise `host` in base_url so the channel's send URL resolves from there.
-            HTTPServer.__init__(self, ("0.0.0.0", port), Messenger.Handler)
+            ThreadingHTTPServer.__init__(self, ("0.0.0.0", port), Messenger.Handler)
             self.base_url = f"http://{host}:{port}"
             self.thread = Thread(target=self.serve_forever)
             self.thread.setDaemon(True)


### PR DESCRIPTION
## Problem

When using the `msg_console` management command, replies from courier sometimes come back **delayed or not at all**.

The reply path is: console posts an incoming message to courier → mailroom runs the flow and queues the outgoing (MT) reply → courier delivers it by POSTing to the console's local send callback server (`Messenger.Server` in `temba/tests/integration.py`) → that handler prints the reply.

The callback server was a plain single-threaded `HTTPServer`, which handles one request at a time with an accept backlog of only 5. Courier, however, sends from a pool of concurrent workers (its foreman defaults to `MaxWorkers: 32`). When more than a couple of replies are in flight, courier's parallel POSTs overflow the backlog and get connection-refused. Courier then marks those sends ERRORED and **retries with backoff** (delay), and after retries are exhausted marks them FAILED (**never arrives**) — exactly the reported symptom.

## Fix

Switch `Messenger.Server` from `HTTPServer` to `ThreadingHTTPServer` so each send is serviced on its own thread. Also set `daemon_threads = True` (so Ctrl+C still exits cleanly) and bump `request_queue_size` to 64 as defense-in-depth for connection bursts.

No change to `msg_console.py` itself — its `response_callback` just prints, which is safe to call from multiple threads.