### PR TITLE
Fix flow start read modal for URN-only starts and split creator/date

### DIFF
--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -61,6 +61,10 @@ def format_urn(urn, org):
     if org and org.is_anon:
         return ContactURN.ANON_MASK_HTML
 
+    # urn can be a ContactURN instance or a raw URN string (e.g. FlowStart.urns)
+    if isinstance(urn, str):
+        return URN.format(urn, international=True)
+
     return urn.get_display(org=org, international=True)
 
 

--- a/temba/flows/tests/test_startcrudl.py
+++ b/temba/flows/tests/test_startcrudl.py
@@ -93,12 +93,12 @@ class FlowStartCRUDLTest(TembaTest, CRUDLTestMixin):
         # a manual start shows who started it and its recipients
         response = self.assertReadFetch(read1_url, [self.editor, self.admin], context_object=start1)
         self.assertContains(response, "Test Flow 1")
-        self.assertContains(response, "by admin@textit.com on")
+        self.assertContains(response, "admin@textit.com")
         self.assertContains(response, "Bob")
 
         # an API start shows its query, exclusions and params
         response = self.assertReadFetch(read2_url, [self.admin], context_object=start2)
-        self.assertContains(response, "by an API call on")
+        self.assertContains(response, "An API call")
         self.assertContains(response, "name ~ Bob")
         self.assertContains(response, "No recent runs")
         self.assertContains(response, "&quot;first_name&quot;: &quot;Ryan&quot;")
@@ -106,10 +106,16 @@ class FlowStartCRUDLTest(TembaTest, CRUDLTestMixin):
         # a Zapier start against a deleted flow still renders its group, exclusions and params
         response = self.assertReadFetch(read3_url, [self.admin], context_object=start3)
         self.assertContains(response, "A deleted flow")
-        self.assertContains(response, "by Zapier on")
+        self.assertContains(response, "Zapier")
         self.assertContains(response, "Testers")
         self.assertContains(response, "Not in a flow")
         self.assertContains(response, "&quot;event&quot;: &quot;signup&quot;")
+
+        # a start against raw URNs (e.g. from the API) renders its URN recipients
+        start4 = self.create_flowstart(flow1, self.admin, typ="A", urns=["tel:+15156686221"])
+        read4_url = reverse("flows.flowstart_read", args=[start4.uuid])
+        response = self.assertReadFetch(read4_url, [self.admin], context_object=start4)
+        self.assertContains(response, "+1 515-668-6221")
 
         # starts from other orgs aren't accessible
         other_flow = self.create_flow("Other Flow", org=self.org2)

--- a/templates/flows/flowstart_read.html
+++ b/templates/flows/flowstart_read.html
@@ -65,22 +65,20 @@
       {% endif %}
     </div>
     <div class="start-section">
-      <div class="start-label">{% trans "Started" %}</div>
+      <div class="start-label">{% trans "Started by" %}</div>
       <div>
         {% if object.start_type == "M" %}
-          {% blocktrans trimmed with user=object.created_by.email when=object.created_on|timedate %}
-            by {{ user }} on {{ when }}
-          {% endblocktrans %}
+          {{ object.created_by.email }}
         {% elif object.start_type == "Z" %}
-          {% blocktrans trimmed with when=object.created_on|timedate %}
-            by Zapier on {{ when }}
-          {% endblocktrans %}
+          {% trans "Zapier" %}
         {% else %}
-          {% blocktrans trimmed with when=object.created_on|timedate %}
-            by an API call on {{ when }}
-          {% endblocktrans %}
+          {% trans "An API call" %}
         {% endif %}
       </div>
+    </div>
+    <div class="start-section">
+      <div class="start-label">{% trans "Started" %}</div>
+      <div>{{ object.created_on|timedate }}</div>
     </div>
     {% if object.groups.all or object.contacts.all or object.urns or object.query %}
       <div class="start-section">


### PR DESCRIPTION
## Summary

Two fixes to the flow start read modal (the details modal added in the recent flow starts redesign):

### 1. Fix 500 on starts targeting raw URNs
Opening the modal for a flow start that targets raw URNs (e.g. an API start with `urns: ["tel:+15156686221"]`) returned a 500:

```
AttributeError: 'str' object has no attribute 'get_display'
```

`includes/recipients.html` renders each URN through the `format_urn` filter, which assumed a `ContactURN` instance and called `.get_display()` on it — but `FlowStart.urns` stores plain strings. This path was never exercised before because the only other callers of `recipients.html` (broadcasts, triggers) don't pass `urns`.

`format_urn` now formats a raw URN string via `URN.format(urn, international=True)` (the same helper `airtime` views use), while still handling `ContactURN` objects and anon-org masking.

### 2. Separate "Started by" from "Started"
The modal previously rendered a single combined line (`by <user> on <when>`). It's now split into:
- **Started by** — the user's email (manual), `Zapier`, or `An API call`
- **Started** — the time/date via the `timedate` display (a time when recent, a day when in the past)

## Testing
`FlowStartCRUDLTest.test_read` extended with a raw-URN start case (the reproduction of the 500) and updated for the split creator/date fields. Verified the test fails without the `format_urn` fix and passes with it.