### PR TITLE
Use request host for Telegram channel webhook callback domain

### DIFF
--- a/temba/channels/types/telegram/tests.py
+++ b/temba/channels/types/telegram/tests.py
@@ -55,14 +55,17 @@ class TelegramTypeTest(TembaTest):
         ]
         mock_post.return_value = MockResponse(200, '{"ok": true, "result": "SUCCESS"}')
 
-        response = self.client.post(url, {"auth_token": "184875172:BAEKbsOKAL23CXufXG4ksNV7Dq7e_1qi3j8"})
+        response = self.client.post(
+            url, {"auth_token": "184875172:BAEKbsOKAL23CXufXG4ksNV7Dq7e_1qi3j8"}, HTTP_HOST="tunnel.example.com"
+        )
         channel = Channel.objects.get(address="rapidbot")
         self.assertEqual(channel.channel_type, "TG")
         self.assertEqual(
             channel.config,
             {
                 "auth_token": "184875172:BAEKbsOKAL23CXufXG4ksNV7Dq7e_1qi3j8",
-                "callback_domain": channel.callback_domain,
+                # callback domain comes from the host the claim page was accessed on, not the brand domain
+                "callback_domain": "tunnel.example.com",
             },
         )
 

--- a/temba/channels/types/telegram/views.py
+++ b/temba/channels/types/telegram/views.py
@@ -43,7 +43,9 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         channel_config = {
             Channel.CONFIG_AUTH_TOKEN: auth_token,
-            Channel.CONFIG_CALLBACK_DOMAIN: org.get_brand_domain(),
+            # use the host the claim page was served on (e.g. a dev tunnel) rather than the brand domain, so the
+            # webhook we register with Telegram points back at a host that can actually reach this instance
+            Channel.CONFIG_CALLBACK_DOMAIN: self.request.get_host(),
         }
 
         self.object = Channel.create(


### PR DESCRIPTION
## Summary

When claiming a Telegram channel, the webhook callback domain was hardcoded to `org.get_brand_domain()` (a static value from settings). If the admin reaches the claim page on a different host — most commonly a public dev tunnel — the `setWebhook` call registers a URL Telegram can't actually use to reach this instance. This change sources the callback domain from the host the claim page was served on instead.

## Changes

- **`temba/channels/types/telegram/views.py`** — `ClaimView.form_valid` now stores `self.request.get_host()` as `CONFIG_CALLBACK_DOMAIN` instead of `org.get_brand_domain()`. This value flows through unchanged to `Channel.callback_domain`, which `TelegramType.activate()` uses (prefixed with `https://`) when calling Telegram's `setWebhook`. Added a comment explaining the deliberate divergence from other channel types.
- **`temba/channels/types/telegram/tests.py`** — `test_claim` now posts with `HTTP_HOST="tunnel.example.com"` and asserts the stored `callback_domain` matches that host, replacing the previous self-referential (tautological) assertion.

## Review notes

A pre-PR review raised two points, both resolved without further code change:

- **Port in `get_host()`** — `get_host()` can include a port. Kept as-is: this faithfully reflects "use the URL I'm accessing," public tunnels serve on 443 with no explicit port, and stripping would break a legitimate `:8443` tunnel (a port Telegram accepts).
- **Host-header trust** — `get_host()` is gated by `ALLOWED_HOSTS`. Verified that production server settings build `ALLOWED_HOSTS` from a fixed `DOMAINS` list (no wildcard), so this is not exploitable in production; the permissive `["*"]` exists only in local/dev settings, which is the intended tunnel scenario.

Scope was intentionally limited to Telegram. Other webhook-registering channel types (Viber, SignalWire, Bandwidth, Twilio, Vonage, Plivo, Dialog360, etc.) still use the brand domain and could get the same treatment later, but are out of scope here.

## Test plan

- [ ] `temba.channels.types.telegram.tests.TelegramTypeTest.test_claim` passes (asserts callback domain is taken from the request host)
- [ ] `ruff format` / `ruff check` clean on changed files (verified locally)

> Note: the Django test suite could not be executed in this environment (settings/DB not available here) — please run `TelegramTypeTest` in the devcontainer to confirm.