### PR TITLE
Add typing indicator support to contact chat and msg console

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -831,6 +831,7 @@ class ChannelLog:
 
     LOG_TYPE_UNKNOWN = "unknown"
     LOG_TYPE_MSG_SEND = "msg_send"
+    LOG_TYPE_EVENT_SEND = "event_send"
     LOG_TYPE_MSG_STATUS = "msg_status"
     LOG_TYPE_MSG_RECEIVE = "msg_receive"
     LOG_TYPE_EVENT_RECEIVE = "event_receive"
@@ -847,6 +848,7 @@ class ChannelLog:
     LOG_TYPE_DISPLAY = {
         LOG_TYPE_UNKNOWN: _("Other Event"),
         LOG_TYPE_MSG_SEND: _("Message Send"),
+        LOG_TYPE_EVENT_SEND: _("Event Send"),
         LOG_TYPE_MSG_STATUS: _("Message Status"),
         LOG_TYPE_MSG_RECEIVE: _("Message Receive"),
         LOG_TYPE_EVENT_RECEIVE: _("Event Receive"),

--- a/temba/channels/types/external/type.py
+++ b/temba/channels/types/external/type.py
@@ -33,6 +33,7 @@ class ExternalType(ChannelType):
     CONFIG_SEND_BODY = "body"
     CONFIG_MT_RESPONSE_CHECK = "mt_response_check"
     CONFIG_CONTENT_TYPE = "content_type"
+    CONFIG_SEND_TYPING_URL = "send_typing_url"
 
     CONFIG_DEFAULT_SEND_BODY = (
         "uuid={{uuid}}&text={{text}}&to={{to}}&to_no_plus={{to_no_plus}}&from={{from}}&from_no_plus={{from_no_plus}}"

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import iso8601
 import phonenumbers
 import regex
+from django_valkey import get_valkey_connection
 from openpyxl import load_workbook
 from smartmin.models import SmartModel
 
@@ -648,6 +649,13 @@ class Contact(LegacyUUIDMixin, SmartModel):
         from temba.mailroom.events import Event
 
         return Event.get_by_contact(self, user, before=before, after=after, ticket=ticket, limit=limit)
+
+    def is_typing(self) -> bool:
+        """
+        Returns whether this contact is currently typing - a transient marker set by courier when a channel
+        reports the contact is typing.
+        """
+        return bool(get_valkey_connection().exists(f"typing:{self.uuid}"))
 
     def get_scheduled_broadcasts(self):
         return (

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -3,6 +3,7 @@ from unittest.mock import call, patch
 from urllib.parse import quote
 
 import iso8601
+from django_valkey import get_valkey_connection
 
 from django.conf import settings
 from django.urls import reverse
@@ -693,6 +694,18 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(404, response.status_code)
 
     @mock_mailroom
+    def test_chat_typing(self, mr_mocks):
+        contact = self.create_contact("Joe Blow", urns=["tel:+250781111111"])
+        chat_url = reverse("contacts.contact_chat", args=[contact.uuid])
+
+        self.login(self.editor)
+
+        response = self.client.post(chat_url, {"typing": True}, content_type="application/json")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, response.json())
+        self.assertEqual(call(self.org, contact), mr_mocks.calls["msg_typing"][-1])
+
+    @mock_mailroom
     def test_chat_reply_non_own_permission(self, mr_mocks):
         contact = self.create_contact("Joe Blow", urns=["tel:+250781111111"])
         ticket = self.create_ticket(contact)
@@ -805,7 +818,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # providing a after value fetches newer history
         response = self.client.get(chat_url + "?after=019a9299-1fa0-7124-82dc-716e856f293e")  # 2025-11-17T16:15
         self.assertEqual(200, response.status_code)
-        self.assertEqual({"events": [], "next": None}, response.json())
+        self.assertEqual({"events": [], "next": None, "typing": False}, response.json())
 
         # if there are less than a page of events, next is empty
         mock_get_by_contact.return_value = mock_events(
@@ -821,6 +834,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                     {"uuid": matchers.UUIDString(version=7), "type": "test", "created_on": "2025-11-17T16:00:00+00:00"},
                 ],
                 "next": None,
+                "typing": False,
             },
             response.json(),
         )
@@ -833,10 +847,18 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(chat_url + "?after=019a9299-1fa0-7124-82dc-716e856f293e")  # 2025-11-17T16:15
         self.assertEqual(200, response.status_code)
         self.assertEqual(
-            {"events": matchers.List(length=50), "next": matchers.UUIDString(version=7)},
+            {"events": matchers.List(length=50), "next": matchers.UUIDString(version=7), "typing": False},
             response.json(),
         )
         self.assertEqual(response.json()["events"][0]["uuid"], response.json()["next"])
+
+        # if courier has flagged the contact as currently typing, that's included in poll responses
+        mock_get_by_contact.return_value = []
+        get_valkey_connection().set(f"typing:{contact.uuid}", "1", ex=10)
+
+        response = self.client.get(chat_url + "?after=019a9299-1fa0-7124-82dc-716e856f293e")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"events": [], "next": None, "typing": True}, response.json())
 
     @mock_mailroom
     def test_chat_search(self, mr_mocks):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -508,12 +508,24 @@ class ContactCRUDL(SmartCRUDL):
                 # after value means UI is polling for new events
                 events = contact.get_history(request.user, after=after, ticket=ticket, limit=self.page_size + 1)
                 page, more = events[: self.page_size], events[self.page_size :]
-                return JsonResponse({"events": list(reversed(page)), "next": page[-1]["uuid"] if more else None})
+                return JsonResponse(
+                    {
+                        "events": list(reversed(page)),
+                        "next": page[-1]["uuid"] if more else None,
+                        "typing": contact.is_typing(),
+                    }
+                )
             else:
                 return JsonResponse({"error": "must specify before or after parameter"}, status=400)
 
         def post(self, request, *args, **kwargs):
             payload = json.loads(request.body)
+
+            # an indication that the user is typing rather than an actual message to send
+            if payload.get("typing"):
+                mailroom.get_client().msg_typing(request.org, self.get_object())
+                return JsonResponse({})
+
             text = payload.get("text", "")
             attachments = []
             ticket = None

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -367,6 +367,9 @@ class MailroomClient:
             },
         )
 
+    def msg_typing(self, org, contact):
+        return self._request("msg/typing", {"org_id": org.id, "contact_id": contact.id})
+
     def org_deindex(self, org):
         return self._request("org/deindex", {"org_id": org.id})
 

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -925,6 +925,20 @@ class MailroomClientTest(TembaTest):
         )
 
     @patch("requests.post")
+    def test_msg_typing(self, mock_post):
+        ann = self.create_contact("Ann", urns=["tel:+12340000001"])
+        mock_post.return_value = MockJsonResponse(200, {})
+        response = self.client.msg_typing(self.org, ann)
+
+        self.assertEqual({}, response)
+
+        mock_post.assert_called_once_with(
+            "http://localhost:8090/mi/msg/typing",
+            headers={"User-Agent": "Temba", "Authorization": "Token sesame"},
+            json={"org_id": self.org.id, "contact_id": ann.id},
+        )
+
+    @patch("requests.post")
     def test_org_deindex(self, mock_post):
         mock_post.return_value = MockJsonResponse(200, {})
         response = self.client.org_deindex(self.org)

--- a/temba/msgs/management/commands/msg_console.py
+++ b/temba/msgs/management/commands/msg_console.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import termios
+import threading
 import time
 import tty
 
@@ -20,6 +21,12 @@ DEFAULT_URN = "tel:+250788123123"
 
 # how often we send typing indicators while the user is typing (courier's marker lasts 10 seconds)
 TYPING_THROTTLE = 4
+
+# how long a received typing indicator stays visible, matching courier's marker TTL
+TYPING_DISPLAY = 10
+
+# animation frames for the typing indicator shown after the user's input
+TYPING_FRAMES = ["·  ", "·· ", "···", "   "]
 
 # Host courier uses to reach our send callback, and the port it listens on. Defaults let everything run on
 # localhost; when courier runs in another container, set CALLBACK_HOST to a name it can resolve (e.g. the
@@ -96,7 +103,13 @@ class Command(BaseCommand):  # pragma: no cover
 
         self.path = path
         self.buffer = []
-        self.last_typing = 0
+        self.last_typing = 0  # last time we sent a typing indicator
+        self.typing_until = 0  # when the typing indicator we're showing expires
+        self.frame = 0
+        self.reading = False
+        self.term_lock = threading.Lock()  # the input loop, callback server and animator all draw
+
+        threading.Thread(target=self.animate_typing, daemon=True).start()
 
         try:
             while True:
@@ -117,11 +130,12 @@ class Command(BaseCommand):  # pragma: no cover
         if not sys.stdin.isatty():
             return input(self.prompt)
 
-        print(self.prompt, end="", flush=True)
-
         fd = sys.stdin.fileno()
         old = termios.tcgetattr(fd)
         self.buffer = []
+        with self.term_lock:
+            self.reading = True
+            self.redraw_prompt()
         try:
             # unlike raw mode, cbreak leaves Ctrl+C working.. and TCSADRAIN doesn't discard anything
             # typed while the last message was sending
@@ -130,7 +144,9 @@ class Command(BaseCommand):  # pragma: no cover
             while True:
                 ch = sys.stdin.read(1)
                 if ch in ("\n", "\r"):
-                    print()
+                    with self.term_lock:
+                        self.reading = False
+                        print("\033[0K")  # erase any typing indicator to the right of the input
                     return "".join(self.buffer)
                 elif ch == "\x04":  # Ctrl+D quits like Ctrl+C
                     raise KeyboardInterrupt()
@@ -140,13 +156,16 @@ class Command(BaseCommand):  # pragma: no cover
                 elif ch in ("\x7f", "\x08"):  # backspace
                     if self.buffer:
                         self.buffer.pop()
-                        print("\b \b", end="", flush=True)
+                        with self.term_lock:
+                            self.redraw_prompt()
                 elif ch.isprintable():
                     self.buffer.append(ch)
-                    print(ch, end="", flush=True)
                     self.send_typing()
+                    with self.term_lock:
+                        self.redraw_prompt()
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old)
+            self.reading = False
             self.buffer = []
 
     def send_typing(self):
@@ -157,14 +176,46 @@ class Command(BaseCommand):  # pragma: no cover
             self.last_typing = time.time()
             self.messenger.typing(self.path)
 
-    def response_callback(self, data):
-        print("\033[2K\033[1G", end="")  # erase current line and move cursor to start of line
-        if data.get("type") == "typing":
-            print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {Fore.YELLOW}is typing…{Fore.RESET}")
-        else:
-            print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {data['text']}")
-        # reprint the prompt along with anything the user has typed so far
+    def redraw_prompt(self):
+        """
+        Redraws the prompt line: the prompt, the current input and an animated typing indicator if one
+        is active. Callers must hold the terminal lock.
+        """
+        print("\033[2K\033[1G", end="")
         print(self.prompt + "".join(self.buffer), end="", flush=True)
+
+        if time.time() < self.typing_until:
+            dots = TYPING_FRAMES[self.frame % len(TYPING_FRAMES)]
+            # draw the indicator after the input, then move the cursor back to the input
+            print(f"  {Fore.YELLOW}typing{dots}{Fore.RESET}\033[{8 + len(dots)}D", end="", flush=True)
+
+    def animate_typing(self):
+        """
+        Advances the typing indicator animation and clears it when it expires.
+        """
+        while True:
+            time.sleep(0.3)
+            with self.term_lock:
+                if not self.typing_until:
+                    continue
+                self.frame += 1
+                if time.time() >= self.typing_until:
+                    self.typing_until = 0
+                if self.reading:
+                    self.redraw_prompt()
+
+    def response_callback(self, data):
+        with self.term_lock:
+            print("\033[2K\033[1G", end="")  # erase current line and move cursor to start of line
+            if data.get("type") == "typing":
+                self.typing_until = time.time() + TYPING_DISPLAY
+            else:
+                # a message takes the place of any typing indicator
+                self.typing_until = 0
+                print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {data['text']}")
+            # reprint the prompt along with anything the user has typed so far
+            if self.reading:
+                self.redraw_prompt()
 
     def get_org(self, id_or_name):
         """

--- a/temba/msgs/management/commands/msg_console.py
+++ b/temba/msgs/management/commands/msg_console.py
@@ -190,7 +190,7 @@ class Command(BaseCommand):  # pragma: no cover
 
     def typing_line(self) -> str:
         dots = TYPING_FRAMES[self.frame % len(TYPING_FRAMES)]
-        return f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {Fore.YELLOW}typing{dots}{Fore.RESET}"
+        return f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {Fore.YELLOW}{dots}{Fore.RESET}"
 
     def show_typing_line(self):
         """

--- a/temba/msgs/management/commands/msg_console.py
+++ b/temba/msgs/management/commands/msg_console.py
@@ -84,13 +84,17 @@ class Command(BaseCommand):  # pragma: no cover
 
         self.stdout.write(
             f"\nSending messages to {Fore.CYAN}{org.name}{Fore.RESET} as {Fore.CYAN}{scheme}:{path}{Fore.RESET}. "
-            "Use Ctrl+C to quit."
+            f"Type {Fore.CYAN}/typing{Fore.RESET} to send a typing indicator. Use Ctrl+C to quit."
         )
 
         try:
             while True:
                 line = input(self.prompt)
                 if not line:
+                    continue
+
+                if line == "/typing":
+                    self.messenger.typing(path)
                     continue
 
                 self.messenger.incoming(path, line)
@@ -101,7 +105,10 @@ class Command(BaseCommand):  # pragma: no cover
 
     def response_callback(self, data):
         print("\033[2K\033[1G", end="")  # erase current line and move cursor to start of line
-        print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {data['text']}")
+        if data.get("type") == "typing":
+            print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {Fore.YELLOW}is typing…{Fore.RESET}")
+        else:
+            print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {data['text']}")
         print(self.prompt, end="", flush=True)
 
     def get_org(self, id_or_name):

--- a/temba/msgs/management/commands/msg_console.py
+++ b/temba/msgs/management/commands/msg_console.py
@@ -1,4 +1,8 @@
 import os
+import sys
+import termios
+import time
+import tty
 
 import requests
 from colorama import Fore, init as colorama_init
@@ -13,6 +17,9 @@ from temba.tests.integration import Messenger
 COURIER_URL = os.environ.get("COURIER_URL", "http://localhost:8080")
 DEFAULT_ORG = "1"
 DEFAULT_URN = "tel:+250788123123"
+
+# how often we send typing indicators while the user is typing (courier's marker lasts 10 seconds)
+TYPING_THROTTLE = 4
 
 # Host courier uses to reach our send callback, and the port it listens on. Defaults let everything run on
 # localhost; when courier runs in another container, set CALLBACK_HOST to a name it can resolve (e.g. the
@@ -84,17 +91,17 @@ class Command(BaseCommand):  # pragma: no cover
 
         self.stdout.write(
             f"\nSending messages to {Fore.CYAN}{org.name}{Fore.RESET} as {Fore.CYAN}{scheme}:{path}{Fore.RESET}. "
-            f"Type {Fore.CYAN}/typing{Fore.RESET} to send a typing indicator. Use Ctrl+C to quit."
+            "Typing indicators are sent as you type. Use Ctrl+C to quit."
         )
+
+        self.path = path
+        self.buffer = []
+        self.last_typing = 0
 
         try:
             while True:
-                line = input(self.prompt)
+                line = self.read_line()
                 if not line:
-                    continue
-
-                if line == "/typing":
-                    self.messenger.typing(path)
                     continue
 
                 self.messenger.incoming(path, line)
@@ -103,13 +110,61 @@ class Command(BaseCommand):  # pragma: no cover
             self.messenger.release(release_channel=False)
             self.stdout.write("🛑 Messenger stopped")
 
+    def read_line(self) -> str:
+        """
+        Like input() but reads a character at a time so we can send typing indicators as the user types.
+        """
+        if not sys.stdin.isatty():
+            return input(self.prompt)
+
+        print(self.prompt, end="", flush=True)
+
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        self.buffer = []
+        try:
+            # unlike raw mode, cbreak leaves Ctrl+C working.. and TCSADRAIN doesn't discard anything
+            # typed while the last message was sending
+            tty.setcbreak(fd, termios.TCSADRAIN)
+
+            while True:
+                ch = sys.stdin.read(1)
+                if ch in ("\n", "\r"):
+                    print()
+                    return "".join(self.buffer)
+                elif ch == "\x04":  # Ctrl+D quits like Ctrl+C
+                    raise KeyboardInterrupt()
+                elif ch == "\x1b":  # swallow escape sequences (e.g. arrow keys)
+                    if sys.stdin.read(1) == "[":
+                        sys.stdin.read(1)
+                elif ch in ("\x7f", "\x08"):  # backspace
+                    if self.buffer:
+                        self.buffer.pop()
+                        print("\b \b", end="", flush=True)
+                elif ch.isprintable():
+                    self.buffer.append(ch)
+                    print(ch, end="", flush=True)
+                    self.send_typing()
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+            self.buffer = []
+
+    def send_typing(self):
+        """
+        Sends a typing indicator if we haven't sent one recently.
+        """
+        if time.time() - self.last_typing >= TYPING_THROTTLE:
+            self.last_typing = time.time()
+            self.messenger.typing(self.path)
+
     def response_callback(self, data):
         print("\033[2K\033[1G", end="")  # erase current line and move cursor to start of line
         if data.get("type") == "typing":
             print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {Fore.YELLOW}is typing…{Fore.RESET}")
         else:
             print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {data['text']}")
-        print(self.prompt, end="", flush=True)
+        # reprint the prompt along with anything the user has typed so far
+        print(self.prompt + "".join(self.buffer), end="", flush=True)
 
     def get_org(self, id_or_name):
         """

--- a/temba/msgs/management/commands/msg_console.py
+++ b/temba/msgs/management/commands/msg_console.py
@@ -105,6 +105,7 @@ class Command(BaseCommand):  # pragma: no cover
         self.buffer = []
         self.last_typing = 0  # last time we sent a typing indicator
         self.typing_until = 0  # when the typing indicator we're showing expires
+        self.typing_shown = False  # whether the line above the prompt is currently the typing line
         self.frame = 0
         self.reading = False
         self.term_lock = threading.Lock()  # the input loop, callback server and animator all draw
@@ -146,7 +147,11 @@ class Command(BaseCommand):  # pragma: no cover
                 if ch in ("\n", "\r"):
                     with self.term_lock:
                         self.reading = False
-                        print("\033[0K")  # erase any typing indicator to the right of the input
+                        if self.typing_shown:
+                            # remove the typing line so it doesn't strand in the history - if still
+                            # active it redraws above the next prompt
+                            self.remove_typing_line()
+                        print()
                     return "".join(self.buffer)
                 elif ch == "\x04":  # Ctrl+D quits like Ctrl+C
                     raise KeyboardInterrupt()
@@ -178,44 +183,75 @@ class Command(BaseCommand):  # pragma: no cover
 
     def redraw_prompt(self):
         """
-        Redraws the prompt line: the prompt, the current input and an animated typing indicator if one
-        is active. Callers must hold the terminal lock.
+        Redraws the prompt line with the current input. Callers must hold the terminal lock.
         """
         print("\033[2K\033[1G", end="")
         print(self.prompt + "".join(self.buffer), end="", flush=True)
 
-        if time.time() < self.typing_until:
-            dots = TYPING_FRAMES[self.frame % len(TYPING_FRAMES)]
-            # draw the indicator after the input, then move the cursor back to the input
-            print(f"  {Fore.YELLOW}typing{dots}{Fore.RESET}\033[{8 + len(dots)}D", end="", flush=True)
+    def typing_line(self) -> str:
+        dots = TYPING_FRAMES[self.frame % len(TYPING_FRAMES)]
+        return f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {Fore.YELLOW}typing{dots}{Fore.RESET}"
+
+    def show_typing_line(self):
+        """
+        Inserts the typing line above the prompt, pushing the prompt down. Callers must hold the
+        terminal lock.
+        """
+        print("\033[2K\033[1G", end="")
+        print(self.typing_line())
+        self.typing_shown = True
+        self.redraw_prompt()
+
+    def remove_typing_line(self):
+        """
+        Removes the typing line above the prompt, pulling the prompt back up. Callers must hold the
+        terminal lock.
+        """
+        print("\033[2K\033[1G\033[1A", end="")
+        self.typing_shown = False
+        self.redraw_prompt()
 
     def animate_typing(self):
         """
-        Advances the typing indicator animation and clears it when it expires.
+        Shows, advances and expires the typing line above the prompt.
         """
         while True:
             time.sleep(0.3)
             with self.term_lock:
                 if not self.typing_until:
                     continue
-                self.frame += 1
                 if time.time() >= self.typing_until:
                     self.typing_until = 0
-                if self.reading:
-                    self.redraw_prompt()
+                if not self.reading:
+                    continue
+
+                if not self.typing_until:
+                    if self.typing_shown:
+                        self.remove_typing_line()
+                elif self.typing_shown:
+                    # redraw the typing line in place, preserving the cursor on the prompt line
+                    self.frame += 1
+                    print(f"\0337\033[1A\033[2K\033[1G{self.typing_line()}\0338", end="", flush=True)
+                else:
+                    self.show_typing_line()
 
     def response_callback(self, data):
         with self.term_lock:
-            print("\033[2K\033[1G", end="")  # erase current line and move cursor to start of line
             if data.get("type") == "typing":
                 self.typing_until = time.time() + TYPING_DISPLAY
+                if self.reading and not self.typing_shown:
+                    self.show_typing_line()
             else:
-                # a message takes the place of any typing indicator
                 self.typing_until = 0
+                print("\033[2K\033[1G", end="")  # erase current line and move cursor to start of line
+                if self.typing_shown:
+                    # the message takes the typing line's place
+                    print("\033[1A\033[2K\033[1G", end="")
+                    self.typing_shown = False
                 print(f"📠 {Fore.GREEN}{self.messenger.channel.address}{Fore.RESET}> {data['text']}")
-            # reprint the prompt along with anything the user has typed so far
-            if self.reading:
-                self.redraw_prompt()
+                # reprint the prompt along with anything the user has typed so far
+                if self.reading:
+                    self.redraw_prompt()
 
     def get_org(self, id_or_name):
         """

--- a/temba/tests/integration.py
+++ b/temba/tests/integration.py
@@ -56,6 +56,7 @@ class Messenger:
             ExternalType.CONFIG_SEND_METHOD: "POST",
             ExternalType.CONFIG_CONTENT_TYPE: "application/json",
             ExternalType.CONFIG_SEND_BODY: '{"text": "{{text}}"}',
+            ExternalType.CONFIG_SEND_TYPING_URL: f"{server.base_url}/typing",
         }
 
         channel = org.channels.filter(channel_type=ExternalType.code, name=cls.CHANNEL_NAME, is_active=True).first()
@@ -90,6 +91,16 @@ class Messenger:
 
         payload = response.json()
         return Msg.objects.get(uuid=payload["data"][0]["msg_uuid"])
+
+    def typing(self, sender):
+        """
+        Simulates the contact typing on their device.
+        """
+        webhook = f"{self.courier_url}/c/ex/{str(self.channel.uuid)}/typing"
+        response = requests.post(webhook, data={"from": sender})
+
+        if response.status_code != 200:
+            raise ValueError(f"courier returned non-200 response: {response.content}")
 
     def handle_outgoing(self, data):
         return self.callback(data) or "OK"

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -478,6 +478,10 @@ class TestClient(MailroomClient):
         }
 
     @_client_method
+    def msg_typing(self, org, contact):
+        return {}
+
+    @_client_method
     def org_deindex(self, org):
         return {}
 


### PR DESCRIPTION
* Chat POSTs with `{"typing": true}` are proxied to mailroom's new `msg/typing` endpoint
* Chat polling responses include whether the contact is currently typing (a transient valkey marker set by courier)
* The msg console sends typing indicators automatically as you type (reads input a character at a time in cbreak mode, throttled to one every 4s) and renders received typing indicators as an animated dots line above the prompt - replaced in place when the message arrives, expiring after courier's 10s marker TTL otherwise
* New `event_send` channel log type display name

Depends on nyaruka/mailroom#1097 (and a temba-components release including nyaruka/temba-components#1029 for the chat UI side).
