### PR TITLE
Make Turn.io channel type available to all orgs

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -94,8 +94,6 @@ class ChannelType(metaclass=ABCMeta):
     category = None
     beta_only = False
 
-    org_feature = None  # org feature required to use this channel type
-
     unique_addresses = False
 
     # the courier handling URL, will be wired automatically for use in templates, but wired to a null handler
@@ -133,8 +131,7 @@ class ChannelType(metaclass=ABCMeta):
         Determines whether this channel type is available to the given user considering the region and when not considering region, e.g. check timezone
         """
 
-        org_feature_visible = self.org_feature is None or self.org_feature in org.features
-        region_ignore_visible = org_feature_visible and ((not self.beta_only) or user.is_beta)
+        region_ignore_visible = (not self.beta_only) or user.is_beta
         region_aware_visible = True
 
         if self.available_timezones is not None:
@@ -424,16 +421,6 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
         from .types import TYPES
 
         return TYPES.values()
-
-    @classmethod
-    def get_org_features_choices(cls):
-        from .types import TYPES
-
-        features = []
-        for channel_type in TYPES.values():
-            if channel_type.org_feature:
-                features.append((channel_type.org_feature, f"Channel: {channel_type.name}"))
-        return tuple(features)
 
     @property
     def type(self) -> ChannelType:

--- a/temba/channels/types/turn/tests.py
+++ b/temba/channels/types/turn/tests.py
@@ -27,12 +27,6 @@ class TurnTypeTest(CRUDLTestMixin, TembaTest):
         self.login(self.admin)
 
         response = self.client.get(reverse("channels.channel_claim"))
-        self.assertNotContains(response, url)
-
-        self.org.features += ["channels:TRN"]
-        self.org.save()
-
-        response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, url)
 
         response = self.client.get(url)

--- a/temba/channels/types/turn/type.py
+++ b/temba/channels/types/turn/type.py
@@ -30,7 +30,6 @@ class TurnType(ChannelType):
     code = "TRN"
     name = "Turn.io WhatsApp"
     category = ChannelType.Category.SOCIAL_MEDIA
-    org_feature = "channels:TRN"
 
     unique_addresses = True
 

--- a/temba/staff/views.py
+++ b/temba/staff/views.py
@@ -14,7 +14,6 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
-from temba.channels.models import Channel
 from temba.orgs.models import Org, OrgRole
 from temba.orgs.views import switch_to_org
 from temba.users.models import User
@@ -152,7 +151,7 @@ class OrgCRUDL(SmartCRUDL):
 
         class Form(forms.ModelForm):
             features = forms.MultipleChoiceField(
-                choices=Org.FEATURES_CHOICES + Channel.get_org_features_choices(),
+                choices=Org.FEATURES_CHOICES,
                 widget=SelectMultipleWidget(),
                 required=False,
             )


### PR DESCRIPTION
Removes the org feature requirement (`channels:TRN`) from the Turn.io WhatsApp channel type so that any org can claim it.

The feature choice disappears from the org update form automatically since those choices are derived from channel types. Orgs that already have the feature in their features list just carry a harmless unused value.