### PR TITLE
Standardize WhatsApp Graph API calls on v22.0 via a shared base URL c…

### DIFF
--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -10,7 +10,15 @@ from temba.contacts.models import URN
 from temba.request_logs.models import HTTPLog
 
 from ...models import ChannelType
-from .views import ClaimView, ClearSessionToken, Connect, RequestCode, SelectWABA, VerifyCode
+from .views import (
+    WHATSAPP_GRAPH_API_BASE,
+    ClaimView,
+    ClearSessionToken,
+    Connect,
+    RequestCode,
+    SelectWABA,
+    VerifyCode,
+)
 
 
 class WhatsAppType(ChannelType):
@@ -58,14 +66,14 @@ class WhatsAppType(ChannelType):
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
 
         # Subscribe to events
-        url = f"https://graph.facebook.com/v22.0/{waba_id}/subscribed_apps"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/{waba_id}/subscribed_apps"
         resp = requests.post(url, headers=headers)
 
         if resp.status_code != 200:  # pragma: no cover
             raise ValidationError(_("Unable to subscribe to app to WABA with ID %s" % waba_id))
 
         # register numbers
-        url = f"https://graph.facebook.com/v22.0/{channel.address}/register"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/{channel.address}/register"
         data = {"messaging_product": "whatsapp", "pin": wa_pin}
 
         resp = requests.post(url, data=data, headers=headers)
@@ -77,7 +85,7 @@ class WhatsAppType(ChannelType):
 
     def fetch_templates(self, channel) -> list:
         waba_id = channel.config["wa_waba_id"]
-        url = f"https://graph.facebook.com/v22.0/{waba_id}/message_templates"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/{waba_id}/message_templates"
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
         templates = []
 

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -21,8 +21,8 @@ from ...views import ClaimViewMixin
 
 logger = logging.getLogger(__name__)
 
-# base URL for all WhatsApp Cloud Graph API calls - bump the version here in one place
-GRAPH_API_BASE = "https://graph.facebook.com/v22.0"
+# base URL for all WhatsApp Cloud Graph API calls (also imported by type.py) - bump the version here in one place
+WHATSAPP_GRAPH_API_BASE = "https://graph.facebook.com/v22.0"
 
 # WhatsApp Cloud only requires the business_management OAuth scope at the top level; the
 # whatsapp_business_management and whatsapp_business_messaging permissions are granted as
@@ -55,7 +55,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         app_id = settings.FACEBOOK_APPLICATION_ID
         app_secret = settings.FACEBOOK_APPLICATION_SECRET
 
-        url = f"{GRAPH_API_BASE}/debug_token"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/debug_token"
         params = {"access_token": f"{app_id}|{app_secret}", "input_token": oauth_user_token}
 
         response = requests.get(url, params=params)
@@ -85,7 +85,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         target_waba = self.request.GET.get("waba_id", None)
 
-        url = f"{GRAPH_API_BASE}/{target_waba}"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/{target_waba}"
         params = {
             "access_token": oauth_user_token,
             "fields": "id,name,currency,message_template_namespace,owner_business_info,account_review_status,on_behalf_of_business_info,primary_funding_id,purchase_order_number,timezone_id",
@@ -98,7 +98,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             "on_behalf_of_business_info", target_waba_details.get("owner_business_info")
         ).get("id")
 
-        url = f"{GRAPH_API_BASE}/{target_waba}/phone_numbers"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/{target_waba}/phone_numbers"
         params = {"access_token": oauth_user_token}
         response = requests.get(url, params=params)
         response_json = response.json()
@@ -113,7 +113,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
                     waba_id=target_waba_details["id"],
                     currency=target_waba_details.get("currency", "USD"),
                     business_id=business_id,
-                    message_template_namespace=target_waba_details["message_template_namespace"],
+                    message_template_namespace=target_waba_details.get("message_template_namespace"),
                 )
             )
 
@@ -162,7 +162,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         }
 
         # assign system user to WABA
-        url = f"{GRAPH_API_BASE}/{waba_id}/assigned_users"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/{waba_id}/assigned_users"
         params = {"user": f"{settings.WHATSAPP_ADMIN_SYSTEM_USER_ID}", "tasks": ["MANAGE"]}
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
 
@@ -248,7 +248,7 @@ class SelectWABA(ChannelTypeMixin, OrgPermsMixin, SmartTemplateView):
         app_id = settings.FACEBOOK_APPLICATION_ID
         app_secret = settings.FACEBOOK_APPLICATION_SECRET
 
-        url = f"{GRAPH_API_BASE}/debug_token"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/debug_token"
         params = {"access_token": f"{app_id}|{app_secret}", "input_token": oauth_user_token}
 
         response = requests.get(url, params=params)
@@ -295,7 +295,7 @@ class RequestCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smar
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        phone_number_url = f"{GRAPH_API_BASE}/{self.object.address}"
+        phone_number_url = f"{WHATSAPP_GRAPH_API_BASE}/{self.object.address}"
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
         resp = requests.get(phone_number_url, headers=headers)
 
@@ -311,14 +311,14 @@ class RequestCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smar
 
         phone_number_id = channel.address
 
-        request_code_url = f"{GRAPH_API_BASE}/{phone_number_id}/request_code"
+        request_code_url = f"{WHATSAPP_GRAPH_API_BASE}/{phone_number_id}/request_code"
         params = {"code_method": "SMS", "language": "en_US"}
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
 
         resp = requests.post(request_code_url, params=params, headers=headers)
 
         if resp.status_code != 200:  # pragma: no cover
-            phone_number_url = f"{GRAPH_API_BASE}/{phone_number_id}"
+            phone_number_url = f"{WHATSAPP_GRAPH_API_BASE}/{phone_number_id}"
             resp = requests.get(phone_number_url, headers=headers)
 
             verified_status = False
@@ -363,7 +363,7 @@ class VerifyCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smart
         waba_id = channel.config.get("wa_waba_id")
         wa_pin = channel.config.get("wa_pin")
 
-        request_code_url = f"{GRAPH_API_BASE}/{phone_number_id}/verify_code"
+        request_code_url = f"{WHATSAPP_GRAPH_API_BASE}/{phone_number_id}/verify_code"
         params = {"code": f"{code}"}
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
 
@@ -373,7 +373,7 @@ class VerifyCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smart
             raise forms.ValidationError(_("Failed to verify phone number with code %s") % code)
 
         # register numbers
-        url = f"{GRAPH_API_BASE}/{channel.address}/register"
+        url = f"{WHATSAPP_GRAPH_API_BASE}/{channel.address}/register"
         data = {"messaging_product": "whatsapp", "pin": wa_pin}
 
         resp = requests.post(url, data=data, headers=headers)
@@ -411,13 +411,13 @@ class Connect(ChannelTypeMixin, OrgPermsMixin, SmartFormView):
                         + self.org.get_brand_domain()
                         + reverse("channels.types.whatsapp.connect"),
                     }
-                    token_url = f"{GRAPH_API_BASE}/oauth/access_token"
+                    token_url = f"{WHATSAPP_GRAPH_API_BASE}/oauth/access_token"
                     response = requests.post(token_url, json=token_request_data)
                     response_json = response.json()
                     if int(response.status_code / 100) == 2:
                         auth_token = response_json["access_token"]
 
-                url = f"{GRAPH_API_BASE}/debug_token"
+                url = f"{WHATSAPP_GRAPH_API_BASE}/debug_token"
                 params = {"access_token": f"{app_id}|{app_secret}", "input_token": auth_token}
 
                 response = requests.get(url, params=params)

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -21,6 +21,9 @@ from ...views import ClaimViewMixin
 
 logger = logging.getLogger(__name__)
 
+# base URL for all WhatsApp Cloud Graph API calls - bump the version here in one place
+GRAPH_API_BASE = "https://graph.facebook.com/v22.0"
+
 # WhatsApp Cloud only requires the business_management OAuth scope at the top level; the
 # whatsapp_business_management and whatsapp_business_messaging permissions are granted as
 # granular (per-WABA) scopes and so are not present in the token's top-level scopes list.
@@ -52,7 +55,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         app_id = settings.FACEBOOK_APPLICATION_ID
         app_secret = settings.FACEBOOK_APPLICATION_SECRET
 
-        url = "https://graph.facebook.com/v22.0/debug_token"
+        url = f"{GRAPH_API_BASE}/debug_token"
         params = {"access_token": f"{app_id}|{app_secret}", "input_token": oauth_user_token}
 
         response = requests.get(url, params=params)
@@ -82,7 +85,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
 
         target_waba = self.request.GET.get("waba_id", None)
 
-        url = f"https://graph.facebook.com/v18.0/{target_waba}"
+        url = f"{GRAPH_API_BASE}/{target_waba}"
         params = {
             "access_token": oauth_user_token,
             "fields": "id,name,currency,message_template_namespace,owner_business_info,account_review_status,on_behalf_of_business_info,primary_funding_id,purchase_order_number,timezone_id",
@@ -95,7 +98,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
             "on_behalf_of_business_info", target_waba_details.get("owner_business_info")
         ).get("id")
 
-        url = f"https://graph.facebook.com/v18.0/{target_waba}/phone_numbers"
+        url = f"{GRAPH_API_BASE}/{target_waba}/phone_numbers"
         params = {"access_token": oauth_user_token}
         response = requests.get(url, params=params)
         response_json = response.json()
@@ -159,7 +162,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         }
 
         # assign system user to WABA
-        url = f"https://graph.facebook.com/v22.0/{waba_id}/assigned_users"
+        url = f"{GRAPH_API_BASE}/{waba_id}/assigned_users"
         params = {"user": f"{settings.WHATSAPP_ADMIN_SYSTEM_USER_ID}", "tasks": ["MANAGE"]}
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
 
@@ -245,7 +248,7 @@ class SelectWABA(ChannelTypeMixin, OrgPermsMixin, SmartTemplateView):
         app_id = settings.FACEBOOK_APPLICATION_ID
         app_secret = settings.FACEBOOK_APPLICATION_SECRET
 
-        url = "https://graph.facebook.com/v18.0/debug_token"
+        url = f"{GRAPH_API_BASE}/debug_token"
         params = {"access_token": f"{app_id}|{app_secret}", "input_token": oauth_user_token}
 
         response = requests.get(url, params=params)
@@ -292,7 +295,7 @@ class RequestCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smar
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        phone_number_url = f"https://graph.facebook.com/v22.0/{self.object.address}"
+        phone_number_url = f"{GRAPH_API_BASE}/{self.object.address}"
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
         resp = requests.get(phone_number_url, headers=headers)
 
@@ -308,14 +311,14 @@ class RequestCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smar
 
         phone_number_id = channel.address
 
-        request_code_url = f"https://graph.facebook.com/v22.0/{phone_number_id}/request_code"
+        request_code_url = f"{GRAPH_API_BASE}/{phone_number_id}/request_code"
         params = {"code_method": "SMS", "language": "en_US"}
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
 
         resp = requests.post(request_code_url, params=params, headers=headers)
 
         if resp.status_code != 200:  # pragma: no cover
-            phone_number_url = f"https://graph.facebook.com/v22.0/{phone_number_id}"
+            phone_number_url = f"{GRAPH_API_BASE}/{phone_number_id}"
             resp = requests.get(phone_number_url, headers=headers)
 
             verified_status = False
@@ -360,7 +363,7 @@ class VerifyCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smart
         waba_id = channel.config.get("wa_waba_id")
         wa_pin = channel.config.get("wa_pin")
 
-        request_code_url = f"https://graph.facebook.com/v22.0/{phone_number_id}/verify_code"
+        request_code_url = f"{GRAPH_API_BASE}/{phone_number_id}/verify_code"
         params = {"code": f"{code}"}
         headers = {"Authorization": f"Bearer {settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN}"}
 
@@ -370,7 +373,7 @@ class VerifyCode(ChannelTypeMixin, OrgObjPermsMixin, SmartModelActionView, Smart
             raise forms.ValidationError(_("Failed to verify phone number with code %s") % code)
 
         # register numbers
-        url = f"https://graph.facebook.com/v22.0/{channel.address}/register"
+        url = f"{GRAPH_API_BASE}/{channel.address}/register"
         data = {"messaging_product": "whatsapp", "pin": wa_pin}
 
         resp = requests.post(url, data=data, headers=headers)
@@ -408,13 +411,13 @@ class Connect(ChannelTypeMixin, OrgPermsMixin, SmartFormView):
                         + self.org.get_brand_domain()
                         + reverse("channels.types.whatsapp.connect"),
                     }
-                    token_url = "https://graph.facebook.com/v22.0/oauth/access_token"
+                    token_url = f"{GRAPH_API_BASE}/oauth/access_token"
                     response = requests.post(token_url, json=token_request_data)
                     response_json = response.json()
                     if int(response.status_code / 100) == 2:
                         auth_token = response_json["access_token"]
 
-                url = "https://graph.facebook.com/v22.0/debug_token"
+                url = f"{GRAPH_API_BASE}/debug_token"
                 params = {"access_token": f"{app_id}|{app_secret}", "input_token": auth_token}
 
                 response = requests.get(url, params=params)


### PR DESCRIPTION
Standardizes all WhatsApp Cloud Graph API calls on a single `WHATSAPP_GRAPH_API_BASE` constant so the API version lives in one place (`views.py`, imported by `type.py`).

### ⚠️ Behavior change: Graph API version bump (v18.0 → v22.0)
Three calls were previously on **v18.0** and are now on **v22.0** (the rest of the code was already v22.0):

- `GET /{waba_id}` — WABA details (requests `message_template_namespace`, `on_behalf_of_business_info`, `purchase_order_number`, …)
- `GET /{waba_id}/phone_numbers`
- `GET /debug_token` (in `SelectWABA`)

This is a live API change against Meta, not a pure refactor. `message_template_namespace` access is now defensive (`.get()`) so a dropped field on v22.0 will not `KeyError` the claim flow, but the WABA-detail field list should still be sanity-checked against real Meta credentials.

### Refactor
- Extracted `WHATSAPP_GRAPH_API_BASE` and routed all 12 call sites in `views.py` plus the 3 in `type.py` through it.
- Existing tests already assert against `v22.0` URLs, so coverage stays green.