### PR TITLE
Remove dead MailroomClient.version() method

### DIFF
--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -46,9 +46,6 @@ class MailroomClient:
         if auth_token:
             self.headers["Authorization"] = "Token " + auth_token
 
-    def version(self):
-        return self._request("", post=False).get("version")
-
     def android_event(self, org, channel, phone: str, event_type: str, extra: dict, occurred_on):
         return self._request(
             "android/event",

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -32,13 +32,6 @@ class MailroomClientTest(TembaTest):
 
         self.client = MailroomClient("http://localhost:8090", "sesame")
 
-    def test_version(self):
-        with patch("requests.get") as mock_get:
-            mock_get.return_value = MockJsonResponse(200, {"version": "5.3.4"})
-            version = self.client.version()
-
-        self.assertEqual("5.3.4", version)
-
     @patch("requests.post")
     def test_android_event(self, mock_post):
         mock_post.return_value = MockJsonResponse(200, {"id": 12345})


### PR DESCRIPTION
## What

Removes the unused `MailroomClient.version()` method and its test.

## Why

`version()` issued its request through the client's normal `_request()` path, which builds every URL under the `/mi/` internal route prefix. With an empty endpoint that resolves to `GET {base_url}/mi/` — but the version field is only returned by the health handler served at each HTTP listener's **root** (`/`) as a per-instance liveness probe, not as one of the `/mi/*` internal routes. There is no route at `/mi/`, so the call always 404'd and `_request()` raised. The method could never succeed against a real server and had no callers.

The breakage went unnoticed because its only test mocked `requests.get` to return a version payload directly, so the broken URL was never exercised.

## Changes

- Delete `version()` from `temba/mailroom/client/client.py`
- Delete `test_version` from `temba/mailroom/client/tests.py`

## Verification

- Grepped the repo for callers (`.version()`, `get_client().version`, etc.) — none outside the deleted test; the test mailroom client doesn't override `version` either.
- `temba.mailroom.client` test suite passes (aside from 3 pre-existing environment-only errors that require a reachable mailroom service and also fail on `main`).
- `ruff check` and `ruff format --check` pass on both files; no now-unused imports.