### PR TITLE
Add websockets API with a connection-proxy endpoint for realtime messaging

### DIFF
--- a/temba/api/__init__.py
+++ b/temba/api/__init__.py
@@ -1,0 +1,1 @@
+from .checks import *  # noqa

--- a/temba/api/checks.py
+++ b/temba/api/checks.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.core.checks import Error, register
+
+
+@register()
+def websockets_auth_secret(app_configs, **kwargs):
+    errors = []
+
+    if not settings.WEBSOCKETS_AUTH_SECRET:
+        errors.append(
+            Error(
+                "WEBSOCKETS_AUTH_SECRET is not set.",
+                hint="Set WEBSOCKETS_AUTH_SECRET in Django settings to the shared secret configured on the "
+                "realtime messaging server. The websockets API refuses requests without it.",
+            )
+        )
+
+    return errors

--- a/temba/api/urls.py
+++ b/temba/api/urls.py
@@ -8,5 +8,6 @@ urlpatterns = APITokenCRUDL().as_urlpatterns()
 urlpatterns += [
     re_path(r"^api/$", RedirectView.as_view(pattern_name="api.v2.root", permanent=False), name="api"),
     re_path(r"^api/internal/", include("temba.api.internal.urls")),
+    re_path(r"^api/websockets/", include("temba.api.websockets.urls")),
     re_path(r"^api/v2/", include("temba.api.v2.urls")),
 ]

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,25 +1,32 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.urls import reverse
 
+from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
 from temba.tests import TembaTest
 
+SECRET = "topsecret"
 
+
+@override_settings(WEBSOCKETS_AUTH_SECRET=SECRET)
 class EndpointsTest(APITestMixin, TembaTest):
-    @override_settings(WEBSOCKETS_AUTH_SECRET=None)
+    def post(self, *, client=None, secret=SECRET):
+        headers = {"HTTP_X_WEBSOCKETS_SECRET": secret} if secret is not None else {}
+        return (client or self.client).post(
+            reverse("api.websockets.connect"), {}, content_type="application/json", **headers
+        )
+
     def test_connect(self):
         endpoint_url = reverse("api.websockets.connect")
 
-        def post(client=None):
-            return (client or self.client).post(endpoint_url, {}, content_type="application/json")
-
         # GET isn't supported - this endpoint only answers the realtime server's connect POST
         self.login(self.admin)
-        self.assertEqual(405, self.client.get(endpoint_url).status_code)
+        self.assertEqual(405, self.client.get(endpoint_url, HTTP_X_WEBSOCKETS_SECRET=SECRET).status_code)
 
         # an authenticated user gets subscribed to their own channel plus their current workspace's channel
         self.login(self.admin)
-        response = post()
+        response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual(
             {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}", f"org:{self.org.id}"]}},
@@ -28,7 +35,7 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         # the workspace channel is scoped to the current org - a user on a different workspace gets that org's channel
         self.login(self.admin2, choose_org=self.org2)
-        response = post()
+        response = self.post()
         self.assertEqual(
             {"result": {"user": str(self.admin2.id), "channels": [f"user:{self.admin2.id}", f"org:{self.org2.id}"]}},
             response.json(),
@@ -39,14 +46,14 @@ class EndpointsTest(APITestMixin, TembaTest):
         session = self.client.session
         del session["org_id"]
         session.save()
-        response = post()
+        response = self.post()
         self.assertEqual(
             {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}"]}}, response.json()
         )
 
         # an unauthenticated request is told to disconnect
         self.client.logout()
-        response = post()
+        response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
 
@@ -56,34 +63,33 @@ class EndpointsTest(APITestMixin, TembaTest):
         session = csrf_client.session
         session["org_id"] = self.org.id
         session.save()
-        response = post(csrf_client)
+        response = self.post(client=csrf_client)
         self.assertEqual(200, response.status_code)
         self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
 
-    @override_settings(WEBSOCKETS_AUTH_SECRET="sesame")
-    def test_connect_with_secret(self):
-        endpoint_url = reverse("api.websockets.connect")
+    def test_secret(self):
         self.login(self.admin)
 
-        # the correct shared secret is accepted
-        response = self.client.post(
-            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
-        )
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
-
         # a wrong secret is rejected for the whole API, even for an authenticated user
-        response = self.client.post(endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="open")
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(403, self.post(secret="open").status_code)
 
         # a missing secret is rejected
-        response = self.client.post(endpoint_url, {}, content_type="application/json")
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(403, self.post(secret=None).status_code)
 
         # a correct secret doesn't bypass session auth - a browser with no session is still told to disconnect
         self.client.logout()
-        response = self.client.post(
-            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
-        )
+        response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+    @override_settings(WEBSOCKETS_AUTH_SECRET=None)
+    def test_secret_required(self):
+        # the system check flags a deployment that hasn't configured the secret
+        errors = websockets_auth_secret(None)
+        self.assertEqual(1, len(errors))
+        self.assertEqual("WEBSOCKETS_AUTH_SECRET is not set.", errors[0].msg)
+
+        # and the API fails closed at request time for the bare wsgi path where system checks don't run
+        self.login(self.admin)
+        with self.assertRaises(ImproperlyConfigured):
+            self.post()

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -78,3 +78,11 @@ class EndpointsTest(APITestMixin, TembaTest):
         # a missing secret is rejected
         response = self.client.post(endpoint_url, {}, content_type="application/json")
         self.assertEqual(403, response.status_code)
+
+        # a correct secret doesn't bypass session auth - a browser with no session is still told to disconnect
+        self.client.logout()
+        response = self.client.post(
+            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,0 +1,80 @@
+from django.test import override_settings
+from django.urls import reverse
+
+from temba.api.tests.mixins import APITestMixin
+from temba.tests import TembaTest
+
+
+class EndpointsTest(APITestMixin, TembaTest):
+    def test_connect(self):
+        endpoint_url = reverse("api.websockets.connect")
+
+        def post(client=None):
+            return (client or self.client).post(endpoint_url, {}, content_type="application/json")
+
+        # GET isn't supported - this endpoint only answers the realtime server's connect POST
+        self.login(self.admin)
+        self.assertEqual(405, self.client.get(endpoint_url).status_code)
+
+        # an authenticated user gets subscribed to their own channel plus their current workspace's channel
+        self.login(self.admin)
+        response = post()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}", f"org:{self.org.id}"]}},
+            response.json(),
+        )
+
+        # the workspace channel is scoped to the current org - a user on a different workspace gets that org's channel
+        self.login(self.admin2, choose_org=self.org2)
+        response = post()
+        self.assertEqual(
+            {"result": {"user": str(self.admin2.id), "channels": [f"user:{self.admin2.id}", f"org:{self.org2.id}"]}},
+            response.json(),
+        )
+
+        # with no current workspace, only the user channel is returned
+        self.login(self.admin)
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        response = post()
+        self.assertEqual(
+            {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}"]}}, response.json()
+        )
+
+        # an unauthenticated request is told to disconnect
+        self.client.logout()
+        response = post()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+        # because it's a server-to-server POST with no CSRF token, it still works when CSRF checks are enforced
+        csrf_client = self.client_class(enforce_csrf_checks=True)
+        csrf_client.login(username=self.admin.email, password=self.default_password)
+        session = csrf_client.session
+        session["org_id"] = self.org.id
+        session.save()
+        response = post(csrf_client)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
+
+    @override_settings(WEBSOCKETS_AUTH_SECRET="sesame")
+    def test_connect_with_secret(self):
+        endpoint_url = reverse("api.websockets.connect")
+        self.login(self.admin)
+
+        # the correct shared secret is accepted
+        response = self.client.post(
+            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
+
+        # a wrong secret is rejected for the whole API, even for an authenticated user
+        response = self.client.post(endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="open")
+        self.assertEqual(403, response.status_code)
+
+        # a missing secret is rejected
+        response = self.client.post(endpoint_url, {}, content_type="application/json")
+        self.assertEqual(403, response.status_code)

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -6,6 +6,7 @@ from temba.tests import TembaTest
 
 
 class EndpointsTest(APITestMixin, TembaTest):
+    @override_settings(WEBSOCKETS_AUTH_SECRET=None)
     def test_connect(self):
         endpoint_url = reverse("api.websockets.connect")
 

--- a/temba/api/websockets/urls.py
+++ b/temba/api/websockets/urls.py
@@ -1,0 +1,7 @@
+from django.urls import re_path
+
+from .views import ConnectEndpoint
+
+urlpatterns = [
+    re_path(r"^connect$", ConnectEndpoint.as_view(), name="api.websockets.connect"),
+]

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.crypto import constant_time_compare
 
 from ..support import APISessionAuthentication
@@ -36,14 +37,15 @@ class WebSocketsSessionAuthentication(APISessionAuthentication):
 class HasWebSocketsSecret(BasePermission):
     """
     Gates the whole websockets API on a shared secret known only to the realtime server, compared in constant time
-    against the ``WEBSOCKETS_AUTH_SECRET`` setting. Only enforced when that setting is non-empty, so local development
-    and tests work without it.
+    against the ``WEBSOCKETS_AUTH_SECRET`` setting. The secret is required: a system check (see ``temba.api.checks``)
+    catches a missing one at deploy time, and this fails closed at request time for the bare wsgi path where system
+    checks don't run - so a misconfigured deployment can never silently accept any forwarded session cookie.
     """
 
     def has_permission(self, request, view):
         secret = settings.WEBSOCKETS_AUTH_SECRET
         if not secret:
-            return True
+            raise ImproperlyConfigured("WEBSOCKETS_AUTH_SECRET must be set to use the websockets API")
 
         return constant_time_compare(request.headers.get("X-Websockets-Secret", ""), secret)
 

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -41,7 +41,7 @@ class HasWebSocketsSecret(BasePermission):
     """
 
     def has_permission(self, request, view):
-        secret = getattr(settings, "WEBSOCKETS_AUTH_SECRET", None)
+        secret = settings.WEBSOCKETS_AUTH_SECRET
         if not secret:
             return True
 

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -1,0 +1,82 @@
+"""
+Endpoints called by the realtime messaging server that fronts browser WebSockets - server-to-server, never by
+browsers directly.
+
+Unlike the rest of the internal API (``/api/internal/``), which is called by the editor running in the user's
+browser and so *must* be reachable from the public internet, every endpoint here is only ever called by the
+realtime messaging server from inside our own network. That means this API can be made truly internal: serve
+``/api/websockets/`` only on an internal-only network path (e.g. behind an internal load balancer) and refuse it
+at the public edge, so it's never exposed to the internet at all. The shared-secret header enforced by
+``HasWebSocketsSecret`` is defense-in-depth on top of that network isolation - it lets us reject anything that
+isn't the realtime server even if the path is ever reachable - but the secret is not a substitute for keeping the
+API off the public internet.
+"""
+
+from rest_framework.permissions import BasePermission
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from django.conf import settings
+from django.utils.crypto import constant_time_compare
+
+from ..support import APISessionAuthentication
+
+
+class WebSocketsSessionAuthentication(APISessionAuthentication):
+    """
+    Session auth for the server-to-server proxy calls. The realtime server forwards the browser's session cookie but
+    can't present a CSRF token, so we no-op the CSRF check. Identity still comes from the real, signed session cookie.
+    """
+
+    def enforce_csrf(self, request):
+        return
+
+
+class HasWebSocketsSecret(BasePermission):
+    """
+    Gates the whole websockets API on a shared secret known only to the realtime server, compared in constant time
+    against the ``WEBSOCKETS_AUTH_SECRET`` setting. Only enforced when that setting is non-empty, so local development
+    and tests work without it.
+    """
+
+    def has_permission(self, request, view):
+        secret = getattr(settings, "WEBSOCKETS_AUTH_SECRET", None)
+        if not secret:
+            return True
+
+        return constant_time_compare(request.headers.get("X-Websockets-Secret", ""), secret)
+
+
+class BaseEndpoint(APIView):
+    """
+    Base class for all websockets API endpoints.
+    """
+
+    authentication_classes = (WebSocketsSessionAuthentication,)
+    permission_classes = (HasWebSocketsSecret,)
+    renderer_classes = (JSONRenderer,)
+
+
+class ConnectEndpoint(BaseEndpoint):
+    """
+    Connection proxy called by the realtime messaging server when a browser opens a WebSocket. The browser connects
+    with no auth token; the realtime server forwards the browser's session cookie to us and we resolve the user plus
+    their current workspace, returning the connection result - the user id and the server-side channels the connection
+    should be subscribed to.
+
+    Channels use integer DB ids (not UUIDs) because the services that publish to them key off the same ids; the
+    ``user`` and ``org`` namespaces are configured on the realtime server. If there's no authenticated session we
+    return a disconnect instruction instead so the realtime server closes the connection.
+    """
+
+    def post(self, request, *args, **kwargs):
+        user = request.user
+        if not user.is_authenticated:
+            return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
+
+        channels = [f"user:{user.id}"]
+        if request.org:
+            channels.append(f"org:{request.org.id}")
+
+        return Response({"result": {"user": str(user.id), "channels": channels}})

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -30,6 +30,11 @@ MAILROOM_URL = os.environ.get("MAILROOM_URL", "http://localhost:8091")
 MAILROOM_AUTH_TOKEN = os.environ.get("MAILROOM_AUTH_TOKEN")
 
 # -----------------------------------------------------------------------------------
+# WebSockets - shared secret for the realtime messaging server (must match its config)
+# -----------------------------------------------------------------------------------
+WEBSOCKETS_AUTH_SECRET = "topsecret"
+
+# -----------------------------------------------------------------------------------
 # In development, add in extra logging for exceptions and the debug toolbar
 # -----------------------------------------------------------------------------------
 MIDDLEWARE = ("temba.middleware.ExceptionMiddleware",) + MIDDLEWARE

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -852,6 +852,13 @@ MAILROOM_URL = None
 MAILROOM_AUTH_TOKEN = None
 
 # -----------------------------------------------------------------------------------
+# WebSockets (realtime messaging server)
+# -----------------------------------------------------------------------------------
+
+# optional shared secret which, when set, the websockets API requires in the X-Websockets-Secret header
+WEBSOCKETS_AUTH_SECRET = None
+
+# -----------------------------------------------------------------------------------
 # Data Model
 # -----------------------------------------------------------------------------------
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -855,7 +855,8 @@ MAILROOM_AUTH_TOKEN = None
 # WebSockets (realtime messaging server)
 # -----------------------------------------------------------------------------------
 
-# optional shared secret which, when set, the websockets API requires in the X-Websockets-Secret header
+# shared secret the websockets API requires in the X-Websockets-Secret header; required (see temba.api.checks) and
+# left unset here so each deployment must configure it
 WEBSOCKETS_AUTH_SECRET = None
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Adds a small `websockets` API that backs the connection proxy of a realtime messaging server fronting browser WebSockets.

## Background

A realtime messaging server can front browser WebSockets. Browsers open a WebSocket with no auth token; the server's "connect proxy" forwards the browser's `Cookie` header to a backend HTTP endpoint, which authenticates the user from their Django session and returns who they are plus which server-side channels to subscribe them to. This PR implements that backend.

## Why a new API rather than another `/api/internal/` endpoint

The existing internal API (`/api/internal/`) is called by the editor running in the user's **browser**, so it must be reachable from the public internet. This connect proxy is the opposite: it's only ever called by the realtime messaging server, **server-to-server**, from inside our own network. Two consequences:

- It introduces a **new auth mechanism** (a shared-secret header) that the rest of the internal API doesn't use.
- It can be made **truly internal** — served only on an internal-only network path and refused at the public edge — unlike the browser-facing internal API.

So it lives in its own `temba/api/websockets/` app, mounted at `^api/websockets/`, whose base class applies the new auth uniformly. The choice of realtime server is an implementation detail and isn't named in the code.

## What's here

`POST /api/websockets/connect`:

- Resolves the user from the forwarded session cookie and their current workspace (`request.org`).
- On success returns the connection result subscribing the connection to `user:<user.id>` and, when there's a current workspace, `org:<org.id>`. Channels use integer DB ids since the services that publish to them key off the same ids; the `user`/`org` namespaces are configured on the realtime server.
- When not authenticated, returns a disconnect instruction `{"disconnect": {"code": 4401, "reason": "unauthorized"}}` so the realtime server closes the connection.

### Auth

- **Session, CSRF-relaxed**: a small `SessionAuthentication` subclass no-ops the CSRF check, since this is a server-to-server POST with no CSRF token. Identity still comes from the real signed session cookie.
- **Shared secret (whole API)**: a permission class compares the `X-Websockets-Secret` header (constant-time) against the `WEBSOCKETS_AUTH_SECRET` setting; missing/wrong → 403. Only enforced when the setting is non-empty, so dev/tests work without it. It's defense-in-depth on top of network isolation, not a replacement for it — see the module docstring in [views.py](temba/api/websockets/views.py).

## Tests

`temba/api/websockets/tests.py` covers: authenticated → `result` with the correct user and channels (with and without a current workspace); the workspace channel scoped per org; unauthenticated → `disconnect`; a CSRF-enforcing client still succeeds; GET → 405; and the secret accept (200) / wrong (403) / missing (403) paths. `code_check.py` (migrations, ruff format, ruff) passes.
