### PR TITLE
Add websockets API with connect and refresh proxy endpoints for realtime messaging

### DIFF
--- a/temba/api/__init__.py
+++ b/temba/api/__init__.py
@@ -1,0 +1,1 @@
+from .checks import *  # noqa

--- a/temba/api/checks.py
+++ b/temba/api/checks.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.core.checks import Error, register
+
+
+@register()
+def websockets_auth_secret(app_configs, **kwargs):
+    errors = []
+
+    if not settings.WEBSOCKETS_AUTH_SECRET:
+        errors.append(
+            Error(
+                "WEBSOCKETS_AUTH_SECRET is not set.",
+                hint="Set WEBSOCKETS_AUTH_SECRET in Django settings to the shared secret configured on the "
+                "realtime messaging server. The websockets API refuses requests without it.",
+            )
+        )
+
+    return errors

--- a/temba/api/urls.py
+++ b/temba/api/urls.py
@@ -8,5 +8,6 @@ urlpatterns = APITokenCRUDL().as_urlpatterns()
 urlpatterns += [
     re_path(r"^api/$", RedirectView.as_view(pattern_name="api.v2.root", permanent=False), name="api"),
     re_path(r"^api/internal/", include("temba.api.internal.urls")),
+    re_path(r"^api/websockets/", include("temba.api.websockets.urls")),
     re_path(r"^api/v2/", include("temba.api.v2.urls")),
 ]

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -128,12 +127,8 @@ class EndpointsTest(APITestMixin, TembaTest):
 
     @override_settings(WEBSOCKETS_AUTH_SECRET=None)
     def test_secret_required(self):
-        # the system check flags a deployment that hasn't configured the secret
+        # the secret is required, enforced by a deploy-time system check (system checks run as part of migrate /
+        # runserver, so an unset secret fails the deploy before the API ever serves a request)
         errors = websockets_auth_secret(None)
         self.assertEqual(1, len(errors))
         self.assertEqual("WEBSOCKETS_AUTH_SECRET is not set.", errors[0].msg)
-
-        # and the API fails closed at request time for the bare wsgi path where system checks don't run
-        self.login(self.admin)
-        with self.assertRaises(ImproperlyConfigured):
-            self.post("api.websockets.connect")

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,25 +1,32 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.urls import reverse
 
+from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
 from temba.tests import TembaTest
 
+SECRET = "topsecret"
 
+
+@override_settings(WEBSOCKETS_AUTH_SECRET=SECRET)
 class EndpointsTest(APITestMixin, TembaTest):
-    @override_settings(WEBSOCKETS_AUTH_SECRET=None)
+    def post(self, *, client=None, secret=SECRET):
+        headers = {"HTTP_X_WEBSOCKETS_SECRET": secret} if secret is not None else {}
+        return (client or self.client).post(
+            reverse("api.websockets.connect"), {}, content_type="application/json", **headers
+        )
+
     def test_connect(self):
         endpoint_url = reverse("api.websockets.connect")
 
-        def post(client=None):
-            return (client or self.client).post(endpoint_url, {}, content_type="application/json")
-
         # GET isn't supported - this endpoint only answers the realtime server's connect POST
         self.login(self.admin)
-        self.assertEqual(405, self.client.get(endpoint_url).status_code)
+        self.assertEqual(405, self.client.get(endpoint_url, HTTP_X_WEBSOCKETS_SECRET=SECRET).status_code)
 
         # an authenticated user gets subscribed to their own channel plus their current workspace's channel
         self.login(self.admin)
-        response = post()
+        response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual(
             {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}", f"org:{self.org.id}"]}},
@@ -28,7 +35,7 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         # the workspace channel is scoped to the current org - a user on a different workspace gets that org's channel
         self.login(self.admin2, choose_org=self.org2)
-        response = post()
+        response = self.post()
         self.assertEqual(
             {"result": {"user": str(self.admin2.id), "channels": [f"user:{self.admin2.id}", f"org:{self.org2.id}"]}},
             response.json(),
@@ -39,14 +46,14 @@ class EndpointsTest(APITestMixin, TembaTest):
         session = self.client.session
         del session["org_id"]
         session.save()
-        response = post()
+        response = self.post()
         self.assertEqual(
             {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}"]}}, response.json()
         )
 
         # an unauthenticated request is told to disconnect
         self.client.logout()
-        response = post()
+        response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
 
@@ -56,34 +63,33 @@ class EndpointsTest(APITestMixin, TembaTest):
         session = csrf_client.session
         session["org_id"] = self.org.id
         session.save()
-        response = post(csrf_client)
+        response = self.post(client=csrf_client)
         self.assertEqual(200, response.status_code)
         self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
 
-    @override_settings(WEBSOCKETS_AUTH_SECRET="sesame")
-    def test_connect_with_secret(self):
-        endpoint_url = reverse("api.websockets.connect")
+    def test_secret(self):
         self.login(self.admin)
 
-        # the correct shared secret is accepted
-        response = self.client.post(
-            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
-        )
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
-
         # a wrong secret is rejected for the whole API, even for an authenticated user
-        response = self.client.post(endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="open")
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(403, self.post(secret="open").status_code)
 
         # a missing secret is rejected
-        response = self.client.post(endpoint_url, {}, content_type="application/json")
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(403, self.post(secret=None).status_code)
 
         # a correct secret doesn't bypass session auth - a browser with no session is still told to disconnect
         self.client.logout()
-        response = self.client.post(
-            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
-        )
+        response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+    @override_settings(WEBSOCKETS_AUTH_SECRET=None)
+    def test_secret_required(self):
+        # the system check flags a deployment that hasn't configured the secret
+        errors = websockets_auth_secret(None)
+        self.assertEqual(1, len(errors))
+        self.assertEqual("WEBSOCKETS_AUTH_SECRET is not set.", errors[0].msg)
+
+        # and the API fails closed at request time for the bare wsgi path where system checks don't run
+        self.login(self.admin)
+        with self.assertRaises(ImproperlyConfigured):
+            self.post()

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -78,3 +78,11 @@ class EndpointsTest(APITestMixin, TembaTest):
         # a missing secret is rejected
         response = self.client.post(endpoint_url, {}, content_type="application/json")
         self.assertEqual(403, response.status_code)
+
+        # a correct secret doesn't bypass session auth - a browser with no session is still told to disconnect
+        self.client.logout()
+        response = self.client.post(
+            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -24,31 +24,21 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.login(self.admin)
         self.assertEqual(405, self.client.get(endpoint_url, HTTP_X_WEBSOCKETS_SECRET=SECRET).status_code)
 
-        # an authenticated user gets subscribed to their own channel plus their current workspace's channel
+        # an authenticated user is subscribed to their own notifications channel, keyed by user uuid
         self.login(self.admin)
         response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual(
-            {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}", f"org:{self.org.id}"]}},
+            {"result": {"user": str(self.admin.uuid), "channels": [f"notifications:{self.admin.uuid}"]}},
             response.json(),
         )
 
-        # the workspace channel is scoped to the current org - a user on a different workspace gets that org's channel
-        self.login(self.admin2, choose_org=self.org2)
+        # the channel is per-user - a different user gets their own notifications channel (not workspace-scoped)
+        self.login(self.editor)
         response = self.post()
         self.assertEqual(
-            {"result": {"user": str(self.admin2.id), "channels": [f"user:{self.admin2.id}", f"org:{self.org2.id}"]}},
+            {"result": {"user": str(self.editor.uuid), "channels": [f"notifications:{self.editor.uuid}"]}},
             response.json(),
-        )
-
-        # with no current workspace, only the user channel is returned
-        self.login(self.admin)
-        session = self.client.session
-        del session["org_id"]
-        session.save()
-        response = self.post()
-        self.assertEqual(
-            {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}"]}}, response.json()
         )
 
         # an unauthenticated request is told to disconnect
@@ -60,12 +50,9 @@ class EndpointsTest(APITestMixin, TembaTest):
         # because it's a server-to-server POST with no CSRF token, it still works when CSRF checks are enforced
         csrf_client = self.client_class(enforce_csrf_checks=True)
         csrf_client.login(username=self.admin.email, password=self.default_password)
-        session = csrf_client.session
-        session["org_id"] = self.org.id
-        session.save()
         response = self.post(client=csrf_client)
         self.assertEqual(200, response.status_code)
-        self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
+        self.assertEqual(str(self.admin.uuid), response.json()["result"]["user"])
 
     def test_secret(self):
         self.login(self.admin)

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -61,17 +61,14 @@ class EndpointsTest(APITestMixin, TembaTest):
             },
         )
 
-        # a user with no current workspace gets no channels and no org in their meta
+        # a user with no current workspace can't connect for now - they're told to disconnect
         self.login(self.admin)
         session = self.client.session
         del session["org_id"]
         session.save()
-        self.assertConnect(
-            self.post("api.websockets.connect"),
-            user=self.admin,
-            channels=[],
-            meta={"user_id": self.admin.id, "user_uuid": str(self.admin.uuid)},
-        )
+        response = self.post("api.websockets.connect")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
 
         # an unauthenticated request is told to disconnect
         self.client.logout()

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -95,11 +95,19 @@ class EndpointsTest(APITestMixin, TembaTest):
         )
 
     def test_refresh(self):
-        # a still-authenticated connection is extended with a new expiry
+        # a still-authenticated connection with a current workspace is extended with a new expiry
         self.login(self.admin)
         response = self.post("api.websockets.refresh")
         self.assertEqual(200, response.status_code)
         self.assertExpiry(response.json()["result"]["expire_at"])
+
+        # losing the current workspace expires the connection (matches connect requiring one)
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        response = self.post("api.websockets.refresh")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
 
         # a connection whose session is gone is told it has expired, which tears the connection down
         self.client.logout()

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,0 +1,80 @@
+from django.test import override_settings
+from django.urls import reverse
+
+from temba.api.tests.mixins import APITestMixin
+from temba.tests import TembaTest
+
+
+class EndpointsTest(APITestMixin, TembaTest):
+    def test_connect(self):
+        endpoint_url = reverse("api.websockets.connect")
+
+        def post(client=None):
+            return (client or self.client).post(endpoint_url, {}, content_type="application/json")
+
+        # GET isn't supported - this endpoint only answers the realtime server's connect POST
+        self.login(self.admin)
+        self.assertEqual(405, self.client.get(endpoint_url).status_code)
+
+        # an authenticated user gets subscribed to their own channel plus their current workspace's channel
+        self.login(self.admin)
+        response = post()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}", f"org:{self.org.id}"]}},
+            response.json(),
+        )
+
+        # the workspace channel is scoped to the current org - a user on a different workspace gets that org's channel
+        self.login(self.admin2, choose_org=self.org2)
+        response = post()
+        self.assertEqual(
+            {"result": {"user": str(self.admin2.id), "channels": [f"user:{self.admin2.id}", f"org:{self.org2.id}"]}},
+            response.json(),
+        )
+
+        # with no current workspace, only the user channel is returned
+        self.login(self.admin)
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        response = post()
+        self.assertEqual(
+            {"result": {"user": str(self.admin.id), "channels": [f"user:{self.admin.id}"]}}, response.json()
+        )
+
+        # an unauthenticated request is told to disconnect
+        self.client.logout()
+        response = post()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+        # because it's a server-to-server POST with no CSRF token, it still works when CSRF checks are enforced
+        csrf_client = self.client_class(enforce_csrf_checks=True)
+        csrf_client.login(username=self.admin.email, password=self.default_password)
+        session = csrf_client.session
+        session["org_id"] = self.org.id
+        session.save()
+        response = post(csrf_client)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
+
+    @override_settings(WEBSOCKETS_AUTH_SECRET="sesame")
+    def test_connect_with_secret(self):
+        endpoint_url = reverse("api.websockets.connect")
+        self.login(self.admin)
+
+        # the correct shared secret is accepted
+        response = self.client.post(
+            endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="sesame"
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(str(self.admin.id), response.json()["result"]["user"])
+
+        # a wrong secret is rejected for the whole API, even for an authenticated user
+        response = self.client.post(endpoint_url, {}, content_type="application/json", HTTP_X_WEBSOCKETS_SECRET="open")
+        self.assertEqual(403, response.status_code)
+
+        # a missing secret is rejected
+        response = self.client.post(endpoint_url, {}, content_type="application/json")
+        self.assertEqual(403, response.status_code)

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,32 +1,30 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
 from temba.tests import TembaTest
-from temba.utils.uuid import uuid4
 
 SECRET = "topsecret"
-
-FORBIDDEN = {"error": {"code": 403, "message": "forbidden"}}
 
 
 @override_settings(WEBSOCKETS_AUTH_SECRET=SECRET)
 class EndpointsTest(APITestMixin, TembaTest):
-    def post(self, *, client=None, secret=SECRET):
+    def post(self, name, *, client=None, secret=SECRET):
         headers = {"HTTP_X_WEBSOCKETS_SECRET": secret} if secret is not None else {}
-        return (client or self.client).post(
-            reverse("api.websockets.connect"), {}, content_type="application/json", **headers
-        )
+        return (client or self.client).post(reverse(name), {}, content_type="application/json", **headers)
 
-    def subscribe(self, channel: str):
-        return self.client.post(
-            reverse("api.websockets.subscribe"),
-            {"channel": channel},
-            content_type="application/json",
-            HTTP_X_WEBSOCKETS_SECRET=SECRET,
-        )
+    def assertExpiry(self, expire_at):
+        self.assertIsInstance(expire_at, int)
+        self.assertGreater(expire_at, int(timezone.now().timestamp()))
+
+    def assertConnect(self, response, *, user, channels, meta):
+        self.assertEqual(200, response.status_code)
+        result = response.json()["result"]
+        self.assertExpiry(result.pop("expire_at"))
+        self.assertEqual({"user": str(user.uuid), "channels": channels, "meta": meta}, result)
 
     def test_connect(self):
         endpoint_url = reverse("api.websockets.connect")
@@ -35,45 +33,50 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.login(self.admin)
         self.assertEqual(405, self.client.get(endpoint_url, HTTP_X_WEBSOCKETS_SECRET=SECRET).status_code)
 
-        # an authenticated user is subscribed to their notifications channel for their current workspace, scoped by
-        # both org uuid and user uuid
+        # an authenticated user is subscribed to their notifications channel for their current workspace (scoped by
+        # both org uuid and user uuid), and their identity is attached to the connection meta
         self.login(self.admin)
-        response = self.post()
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(
-            {
-                "result": {
-                    "user": str(self.admin.uuid),
-                    "channels": [f"notifications:{self.org.uuid}:{self.admin.uuid}"],
-                }
+        self.assertConnect(
+            self.post("api.websockets.connect"),
+            user=self.admin,
+            channels=[f"notifications:{self.org.uuid}:{self.admin.uuid}"],
+            meta={
+                "user_id": self.admin.id,
+                "user_uuid": str(self.admin.uuid),
+                "org_id": self.org.id,
+                "org_uuid": str(self.org.uuid),
             },
-            response.json(),
         )
 
-        # the channel is scoped per (org, user) - a different user in a different workspace gets their own channel
+        # scoped per (org, user) - a different user in a different workspace gets their own channel and meta
         self.login(self.admin2, choose_org=self.org2)
-        response = self.post()
-        self.assertEqual(
-            {
-                "result": {
-                    "user": str(self.admin2.uuid),
-                    "channels": [f"notifications:{self.org2.uuid}:{self.admin2.uuid}"],
-                }
+        self.assertConnect(
+            self.post("api.websockets.connect"),
+            user=self.admin2,
+            channels=[f"notifications:{self.org2.uuid}:{self.admin2.uuid}"],
+            meta={
+                "user_id": self.admin2.id,
+                "user_uuid": str(self.admin2.uuid),
+                "org_id": self.org2.id,
+                "org_uuid": str(self.org2.uuid),
             },
-            response.json(),
         )
 
-        # a user with no current workspace gets no channels
+        # a user with no current workspace gets no channels and no org in their meta
         self.login(self.admin)
         session = self.client.session
         del session["org_id"]
         session.save()
-        response = self.post()
-        self.assertEqual({"result": {"user": str(self.admin.uuid), "channels": []}}, response.json())
+        self.assertConnect(
+            self.post("api.websockets.connect"),
+            user=self.admin,
+            channels=[],
+            meta={"user_id": self.admin.id, "user_uuid": str(self.admin.uuid)},
+        )
 
         # an unauthenticated request is told to disconnect
         self.client.logout()
-        response = self.post()
+        response = self.post("api.websockets.connect")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
 
@@ -83,71 +86,43 @@ class EndpointsTest(APITestMixin, TembaTest):
         session = csrf_client.session
         session["org_id"] = self.org.id
         session.save()
-        response = self.post(client=csrf_client)
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(
-            {
-                "result": {
-                    "user": str(self.admin.uuid),
-                    "channels": [f"notifications:{self.org.uuid}:{self.admin.uuid}"],
-                }
+        self.assertConnect(
+            self.post("api.websockets.connect", client=csrf_client),
+            user=self.admin,
+            channels=[f"notifications:{self.org.uuid}:{self.admin.uuid}"],
+            meta={
+                "user_id": self.admin.id,
+                "user_uuid": str(self.admin.uuid),
+                "org_id": self.org.id,
+                "org_uuid": str(self.org.uuid),
             },
-            response.json(),
         )
 
-    def test_subscribe(self):
-        contact = self.create_contact("Ann", phone="+1234567001")
-        other_org_contact = self.create_contact("Bob", phone="+1234567002", org=self.org2)
-
-        # an unauthenticated request is told to disconnect
-        response = self.subscribe(f"chat:{contact.uuid}")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
-
+    def test_refresh(self):
+        # a still-authenticated connection is extended with a new expiry
         self.login(self.admin)
-
-        # a contact in the user's current workspace is allowed
-        response = self.subscribe(f"chat:{contact.uuid}")
+        response = self.post("api.websockets.refresh")
         self.assertEqual(200, response.status_code)
-        self.assertEqual({"result": {}}, response.json())
+        self.assertExpiry(response.json()["result"]["expire_at"])
 
-        # a contact in another workspace is denied (not found when scoped to the current org)
-        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{other_org_contact.uuid}").json())
-
-        # a non-existent contact is denied
-        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{uuid4()}").json())
-
-        # a malformed contact uuid is denied (and doesn't error)
-        self.assertEqual(FORBIDDEN, self.subscribe("chat:not-a-uuid").json())
-
-        # an unrecognized namespace is denied (default deny)
-        self.assertEqual(FORBIDDEN, self.subscribe(f"secrets:{contact.uuid}").json())
-
-        # a released contact is denied
-        contact.is_active = False
-        contact.save(update_fields=("is_active",))
-        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{contact.uuid}").json())
-        contact.is_active = True
-        contact.save(update_fields=("is_active",))
-
-        # a user with no current workspace is denied
-        session = self.client.session
-        del session["org_id"]
-        session.save()
-        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{contact.uuid}").json())
+        # a connection whose session is gone is told it has expired, which tears the connection down
+        self.client.logout()
+        response = self.post("api.websockets.refresh")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
 
     def test_secret(self):
         self.login(self.admin)
 
         # a wrong secret is rejected for the whole API, even for an authenticated user
-        self.assertEqual(403, self.post(secret="open").status_code)
+        self.assertEqual(403, self.post("api.websockets.connect", secret="open").status_code)
 
         # a missing secret is rejected
-        self.assertEqual(403, self.post(secret=None).status_code)
+        self.assertEqual(403, self.post("api.websockets.connect", secret=None).status_code)
 
         # a correct secret doesn't bypass session auth - a browser with no session is still told to disconnect
         self.client.logout()
-        response = self.post()
+        response = self.post("api.websockets.connect")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
 
@@ -161,4 +136,4 @@ class EndpointsTest(APITestMixin, TembaTest):
         # and the API fails closed at request time for the bare wsgi path where system checks don't run
         self.login(self.admin)
         with self.assertRaises(ImproperlyConfigured):
-            self.post()
+            self.post("api.websockets.connect")

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -5,8 +5,11 @@ from django.urls import reverse
 from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
 from temba.tests import TembaTest
+from temba.utils.uuid import uuid4
 
 SECRET = "topsecret"
+
+FORBIDDEN = {"error": {"code": 403, "message": "forbidden"}}
 
 
 @override_settings(WEBSOCKETS_AUTH_SECRET=SECRET)
@@ -15,6 +18,14 @@ class EndpointsTest(APITestMixin, TembaTest):
         headers = {"HTTP_X_WEBSOCKETS_SECRET": secret} if secret is not None else {}
         return (client or self.client).post(
             reverse("api.websockets.connect"), {}, content_type="application/json", **headers
+        )
+
+    def subscribe(self, channel: str):
+        return self.client.post(
+            reverse("api.websockets.subscribe"),
+            {"channel": channel},
+            content_type="application/json",
+            HTTP_X_WEBSOCKETS_SECRET=SECRET,
         )
 
     def test_connect(self):
@@ -83,6 +94,47 @@ class EndpointsTest(APITestMixin, TembaTest):
             },
             response.json(),
         )
+
+    def test_subscribe(self):
+        contact = self.create_contact("Ann", phone="+1234567001")
+        other_org_contact = self.create_contact("Bob", phone="+1234567002", org=self.org2)
+
+        # an unauthenticated request is told to disconnect
+        response = self.subscribe(f"chat:{contact.uuid}")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+        self.login(self.admin)
+
+        # a contact in the user's current workspace is allowed
+        response = self.subscribe(f"chat:{contact.uuid}")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {}}, response.json())
+
+        # a contact in another workspace is denied (not found when scoped to the current org)
+        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{other_org_contact.uuid}").json())
+
+        # a non-existent contact is denied
+        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{uuid4()}").json())
+
+        # a malformed contact uuid is denied (and doesn't error)
+        self.assertEqual(FORBIDDEN, self.subscribe("chat:not-a-uuid").json())
+
+        # an unrecognized namespace is denied (default deny)
+        self.assertEqual(FORBIDDEN, self.subscribe(f"secrets:{contact.uuid}").json())
+
+        # a released contact is denied
+        contact.is_active = False
+        contact.save(update_fields=("is_active",))
+        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{contact.uuid}").json())
+        contact.is_active = True
+        contact.save(update_fields=("is_active",))
+
+        # a user with no current workspace is denied
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        self.assertEqual(FORBIDDEN, self.subscribe(f"chat:{contact.uuid}").json())
 
     def test_secret(self):
         self.login(self.admin)

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -6,6 +6,7 @@ from temba.tests import TembaTest
 
 
 class EndpointsTest(APITestMixin, TembaTest):
+    @override_settings(WEBSOCKETS_AUTH_SECRET=None)
     def test_connect(self):
         endpoint_url = reverse("api.websockets.connect")
 

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -24,22 +24,41 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.login(self.admin)
         self.assertEqual(405, self.client.get(endpoint_url, HTTP_X_WEBSOCKETS_SECRET=SECRET).status_code)
 
-        # an authenticated user is subscribed to their own notifications channel, keyed by user uuid
+        # an authenticated user is subscribed to their notifications channel for their current workspace, scoped by
+        # both org uuid and user uuid
         self.login(self.admin)
         response = self.post()
         self.assertEqual(200, response.status_code)
         self.assertEqual(
-            {"result": {"user": str(self.admin.uuid), "channels": [f"notifications:{self.admin.uuid}"]}},
+            {
+                "result": {
+                    "user": str(self.admin.uuid),
+                    "channels": [f"notifications:{self.org.uuid}:{self.admin.uuid}"],
+                }
+            },
             response.json(),
         )
 
-        # the channel is per-user - a different user gets their own notifications channel (not workspace-scoped)
-        self.login(self.editor)
+        # the channel is scoped per (org, user) - a different user in a different workspace gets their own channel
+        self.login(self.admin2, choose_org=self.org2)
         response = self.post()
         self.assertEqual(
-            {"result": {"user": str(self.editor.uuid), "channels": [f"notifications:{self.editor.uuid}"]}},
+            {
+                "result": {
+                    "user": str(self.admin2.uuid),
+                    "channels": [f"notifications:{self.org2.uuid}:{self.admin2.uuid}"],
+                }
+            },
             response.json(),
         )
+
+        # a user with no current workspace gets no channels
+        self.login(self.admin)
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        response = self.post()
+        self.assertEqual({"result": {"user": str(self.admin.uuid), "channels": []}}, response.json())
 
         # an unauthenticated request is told to disconnect
         self.client.logout()
@@ -50,9 +69,20 @@ class EndpointsTest(APITestMixin, TembaTest):
         # because it's a server-to-server POST with no CSRF token, it still works when CSRF checks are enforced
         csrf_client = self.client_class(enforce_csrf_checks=True)
         csrf_client.login(username=self.admin.email, password=self.default_password)
+        session = csrf_client.session
+        session["org_id"] = self.org.id
+        session.save()
         response = self.post(client=csrf_client)
         self.assertEqual(200, response.status_code)
-        self.assertEqual(str(self.admin.uuid), response.json()["result"]["user"])
+        self.assertEqual(
+            {
+                "result": {
+                    "user": str(self.admin.uuid),
+                    "channels": [f"notifications:{self.org.uuid}:{self.admin.uuid}"],
+                }
+            },
+            response.json(),
+        )
 
     def test_secret(self):
         self.login(self.admin)

--- a/temba/api/websockets/urls.py
+++ b/temba/api/websockets/urls.py
@@ -1,8 +1,8 @@
 from django.urls import re_path
 
-from .views import ConnectEndpoint, SubscribeEndpoint
+from .views import ConnectEndpoint, RefreshEndpoint
 
 urlpatterns = [
     re_path(r"^connect$", ConnectEndpoint.as_view(), name="api.websockets.connect"),
-    re_path(r"^subscribe$", SubscribeEndpoint.as_view(), name="api.websockets.subscribe"),
+    re_path(r"^refresh$", RefreshEndpoint.as_view(), name="api.websockets.refresh"),
 ]

--- a/temba/api/websockets/urls.py
+++ b/temba/api/websockets/urls.py
@@ -1,7 +1,8 @@
 from django.urls import re_path
 
-from .views import ConnectEndpoint
+from .views import ConnectEndpoint, SubscribeEndpoint
 
 urlpatterns = [
     re_path(r"^connect$", ConnectEndpoint.as_view(), name="api.websockets.connect"),
+    re_path(r"^subscribe$", SubscribeEndpoint.as_view(), name="api.websockets.subscribe"),
 ]

--- a/temba/api/websockets/urls.py
+++ b/temba/api/websockets/urls.py
@@ -1,0 +1,7 @@
+from django.urls import re_path
+
+from .views import ConnectEndpoint
+
+urlpatterns = [
+    re_path(r"^connect$", ConnectEndpoint.as_view(), name="api.websockets.connect"),
+]

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -2,6 +2,11 @@
 Endpoints called by the realtime messaging server that fronts browser WebSockets - server-to-server, never by
 browsers directly.
 
+These handle connection authentication and lifecycle: ``connect`` authenticates a new connection from the forwarded
+session cookie, and ``refresh`` periodically re-validates it. The connect result also attaches the user's identity to
+the connection's server-side ``meta``, so the proxies that authorize individual channel subscriptions (handled by
+another internal service) can act on that identity without re-reading the Django session.
+
 Unlike the rest of the internal API (``/api/internal/``), which is called by the editor running in the user's
 browser and so *must* be reachable from the public internet, every endpoint here is only ever called by the
 realtime messaging server from inside our own network. That means this API can be made truly internal: serve
@@ -19,11 +24,13 @@ from rest_framework.views import APIView
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 
-from temba.utils.uuid import is_uuid
-
 from ..support import APISessionAuthentication
+
+# how long (seconds) a connection stays valid before the realtime server must re-validate it via the refresh proxy
+CONNECTION_TTL = 5 * 60
 
 
 class WebSocketsSessionAuthentication(APISessionAuthentication):
@@ -61,17 +68,25 @@ class BaseEndpoint(APIView):
     permission_classes = (HasWebSocketsSecret,)
     renderer_classes = (JSONRenderer,)
 
+    def expire_at(self) -> int:
+        """Unix time at which the connection should next be re-validated by the refresh proxy."""
+        return int(timezone.now().timestamp()) + CONNECTION_TTL
+
 
 class ConnectEndpoint(BaseEndpoint):
     """
     Connection proxy called by the realtime messaging server when a browser opens a WebSocket. The browser connects
-    with no auth token; the realtime server forwards the browser's session cookie to us and we resolve the user,
-    returning the connection result - the user identifier and the server-side channels to subscribe the connection to.
+    with no auth token; the realtime server forwards the browser's session cookie and we resolve the user.
 
-    Notifications are scoped to a user within a workspace, so the connection is subscribed to a single channel for the
-    user's current workspace, ``notifications:<org-uuid>:<user-uuid>``; the ``notifications`` namespace is configured
-    on the realtime server. A user with no current workspace gets no channels. If there's no authenticated session we
-    return a disconnect instruction instead so the realtime server closes the connection.
+    The result carries:
+      * ``user`` - the user identifier (uuid);
+      * ``channels`` - the server-side channels to subscribe the connection to, a single
+        ``notifications:<org-uuid>:<user-uuid>`` for the user's current workspace (none if they have no current one);
+      * ``meta`` - the user's identity (uuids and ids) attached to the connection so the subscription-authorization
+        proxies can act on it without re-reading the session; ``meta`` is server-side only and never sent to the browser;
+      * ``expire_at`` - when the realtime server should next call the refresh proxy to re-validate the connection.
+
+    If there's no authenticated session we return a disconnect instruction so the realtime server closes the connection.
     """
 
     def post(self, request, *args, **kwargs):
@@ -79,39 +94,27 @@ class ConnectEndpoint(BaseEndpoint):
         if not user.is_authenticated:
             return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
 
+        meta = {"user_id": user.id, "user_uuid": str(user.uuid)}
         channels = []
         if request.org:
+            meta["org_id"] = request.org.id
+            meta["org_uuid"] = str(request.org.uuid)
             channels.append(f"notifications:{request.org.uuid}:{user.uuid}")
 
-        return Response({"result": {"user": str(user.uuid), "channels": channels}})
+        return Response(
+            {"result": {"user": str(user.uuid), "channels": channels, "meta": meta, "expire_at": self.expire_at()}}
+        )
 
 
-class SubscribeEndpoint(BaseEndpoint):
+class RefreshEndpoint(BaseEndpoint):
     """
-    Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a channel that needs
-    authorization (a namespace configured with a subscribe proxy on the realtime server). We resolve the user and their
-    current workspace from the forwarded session cookie and allow the subscription only if it's one we recognize and
-    the user has access to it in that workspace - everything else is denied.
-
-    The only client-subscribable channel for now is a contact's chat history, ``chat:<contact-uuid>``, allowed only
-    when the contact belongs to the user's current workspace. Access is always scoped to ``request.org``, so a channel
-    for a contact in another workspace simply isn't found and is denied.
+    Refresh proxy called periodically by the realtime messaging server before a connection's ``expire_at``. We re-check
+    that the forwarded session is still valid (the user is still logged in) and either extend the connection with a new
+    ``expire_at`` or let it expire - this is how a logout or session expiry eventually tears down the WebSocket.
     """
 
     def post(self, request, *args, **kwargs):
-        user = request.user
-        if not user.is_authenticated:
-            return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
+        if not request.user.is_authenticated:
+            return Response({"result": {"expired": True}})
 
-        if request.org and self.is_allowed(request, request.data.get("channel", "")):
-            return Response({"result": {}})
-
-        return Response({"error": {"code": 403, "message": "forbidden"}})
-
-    def is_allowed(self, request, channel: str) -> bool:
-        namespace, _, ref = channel.partition(":")
-
-        if namespace == "chat":  # chat history for a contact in the current workspace
-            return is_uuid(ref) and request.org.contacts.filter(uuid=ref, is_active=True).exists()
-
-        return False
+        return Response({"result": {"expire_at": self.expire_at()}})

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.crypto import constant_time_compare
 
 from ..support import APISessionAuthentication
@@ -36,14 +37,15 @@ class WebSocketsSessionAuthentication(APISessionAuthentication):
 class HasWebSocketsSecret(BasePermission):
     """
     Gates the whole websockets API on a shared secret known only to the realtime server, compared in constant time
-    against the ``WEBSOCKETS_AUTH_SECRET`` setting. Only enforced when that setting is non-empty, so local development
-    and tests work without it.
+    against the ``WEBSOCKETS_AUTH_SECRET`` setting. The secret is required: a system check (see ``temba.api.checks``)
+    catches a missing one at deploy time, and this fails closed at request time for the bare wsgi path where system
+    checks don't run - so a misconfigured deployment can never silently accept any forwarded session cookie.
     """
 
     def has_permission(self, request, view):
         secret = settings.WEBSOCKETS_AUTH_SECRET
         if not secret:
-            return True
+            raise ImproperlyConfigured("WEBSOCKETS_AUTH_SECRET must be set to use the websockets API")
 
         return constant_time_compare(request.headers.get("X-Websockets-Secret", ""), secret)
 

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -105,12 +105,14 @@ class ConnectEndpoint(BaseEndpoint):
 class RefreshEndpoint(BaseEndpoint):
     """
     Refresh proxy called periodically by the realtime messaging server before a connection's ``expire_at``. We re-check
-    that the forwarded session is still valid (the user is still logged in) and either extend the connection with a new
-    ``expire_at`` or let it expire - this is how a logout or session expiry eventually tears down the WebSocket.
+    that the connection is still valid - the user is still logged in and still has a current workspace, matching what
+    ``connect`` requires - and either extend it with a new ``expire_at`` or let it expire. This is how a logout, session
+    expiry, or losing access to the workspace eventually tears down the WebSocket.
     """
 
     def post(self, request, *args, **kwargs):
-        if not request.user.is_authenticated:
+        # mirror connect: a connection is only kept alive while it has an authenticated user with a current workspace
+        if not request.user.is_authenticated or not request.org:
             return Response({"result": {"expired": True}})
 
         return Response({"result": {"expire_at": self.expire_at()}})

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -63,13 +63,12 @@ class BaseEndpoint(APIView):
 class ConnectEndpoint(BaseEndpoint):
     """
     Connection proxy called by the realtime messaging server when a browser opens a WebSocket. The browser connects
-    with no auth token; the realtime server forwards the browser's session cookie to us and we resolve the user plus
-    their current workspace, returning the connection result - the user id and the server-side channels the connection
-    should be subscribed to.
+    with no auth token; the realtime server forwards the browser's session cookie to us and we resolve the user,
+    returning the connection result - the user identifier and the server-side channels to subscribe the connection to.
 
-    Channels use integer DB ids (not UUIDs) because the services that publish to them key off the same ids; the
-    ``user`` and ``org`` namespaces are configured on the realtime server. If there's no authenticated session we
-    return a disconnect instruction instead so the realtime server closes the connection.
+    For now the connection is subscribed to a single channel, ``notifications:<user-uuid>``; the ``notifications``
+    namespace is configured on the realtime server. If there's no authenticated session we return a disconnect
+    instruction instead so the realtime server closes the connection.
     """
 
     def post(self, request, *args, **kwargs):
@@ -77,8 +76,4 @@ class ConnectEndpoint(BaseEndpoint):
         if not user.is_authenticated:
             return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
 
-        channels = [f"user:{user.id}"]
-        if request.org:
-            channels.append(f"org:{request.org.id}")
-
-        return Response({"result": {"user": str(user.id), "channels": channels}})
+        return Response({"result": {"user": str(user.uuid), "channels": [f"notifications:{user.uuid}"]}})

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -21,6 +21,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.crypto import constant_time_compare
 
+from temba.utils.uuid import is_uuid
+
 from ..support import APISessionAuthentication
 
 
@@ -82,3 +84,34 @@ class ConnectEndpoint(BaseEndpoint):
             channels.append(f"notifications:{request.org.uuid}:{user.uuid}")
 
         return Response({"result": {"user": str(user.uuid), "channels": channels}})
+
+
+class SubscribeEndpoint(BaseEndpoint):
+    """
+    Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a channel that needs
+    authorization (a namespace configured with a subscribe proxy on the realtime server). We resolve the user and their
+    current workspace from the forwarded session cookie and allow the subscription only if it's one we recognize and
+    the user has access to it in that workspace - everything else is denied.
+
+    The only client-subscribable channel for now is a contact's chat history, ``chat:<contact-uuid>``, allowed only
+    when the contact belongs to the user's current workspace. Access is always scoped to ``request.org``, so a channel
+    for a contact in another workspace simply isn't found and is denied.
+    """
+
+    def post(self, request, *args, **kwargs):
+        user = request.user
+        if not user.is_authenticated:
+            return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
+
+        if request.org and self.is_allowed(request, request.data.get("channel", "")):
+            return Response({"result": {}})
+
+        return Response({"error": {"code": 403, "message": "forbidden"}})
+
+    def is_allowed(self, request, channel: str) -> bool:
+        namespace, _, ref = channel.partition(":")
+
+        if namespace == "chat":  # chat history for a contact in the current workspace
+            return is_uuid(ref) and request.org.contacts.filter(uuid=ref, is_active=True).exists()
+
+        return False

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -66,9 +66,10 @@ class ConnectEndpoint(BaseEndpoint):
     with no auth token; the realtime server forwards the browser's session cookie to us and we resolve the user,
     returning the connection result - the user identifier and the server-side channels to subscribe the connection to.
 
-    For now the connection is subscribed to a single channel, ``notifications:<user-uuid>``; the ``notifications``
-    namespace is configured on the realtime server. If there's no authenticated session we return a disconnect
-    instruction instead so the realtime server closes the connection.
+    Notifications are scoped to a user within a workspace, so the connection is subscribed to a single channel for the
+    user's current workspace, ``notifications:<org-uuid>:<user-uuid>``; the ``notifications`` namespace is configured
+    on the realtime server. A user with no current workspace gets no channels. If there's no authenticated session we
+    return a disconnect instruction instead so the realtime server closes the connection.
     """
 
     def post(self, request, *args, **kwargs):
@@ -76,4 +77,8 @@ class ConnectEndpoint(BaseEndpoint):
         if not user.is_authenticated:
             return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
 
-        return Response({"result": {"user": str(user.uuid), "channels": [f"notifications:{user.uuid}"]}})
+        channels = []
+        if request.org:
+            channels.append(f"notifications:{request.org.uuid}:{user.uuid}")
+
+        return Response({"result": {"user": str(user.uuid), "channels": channels}})

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -41,7 +41,7 @@ class HasWebSocketsSecret(BasePermission):
     """
 
     def has_permission(self, request, view):
-        secret = getattr(settings, "WEBSOCKETS_AUTH_SECRET", None)
+        secret = settings.WEBSOCKETS_AUTH_SECRET
         if not secret:
             return True
 

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -1,0 +1,82 @@
+"""
+Endpoints called by the realtime messaging server that fronts browser WebSockets - server-to-server, never by
+browsers directly.
+
+Unlike the rest of the internal API (``/api/internal/``), which is called by the editor running in the user's
+browser and so *must* be reachable from the public internet, every endpoint here is only ever called by the
+realtime messaging server from inside our own network. That means this API can be made truly internal: serve
+``/api/websockets/`` only on an internal-only network path (e.g. behind an internal load balancer) and refuse it
+at the public edge, so it's never exposed to the internet at all. The shared-secret header enforced by
+``HasWebSocketsSecret`` is defense-in-depth on top of that network isolation - it lets us reject anything that
+isn't the realtime server even if the path is ever reachable - but the secret is not a substitute for keeping the
+API off the public internet.
+"""
+
+from rest_framework.permissions import BasePermission
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from django.conf import settings
+from django.utils.crypto import constant_time_compare
+
+from ..support import APISessionAuthentication
+
+
+class WebSocketsSessionAuthentication(APISessionAuthentication):
+    """
+    Session auth for the server-to-server proxy calls. The realtime server forwards the browser's session cookie but
+    can't present a CSRF token, so we no-op the CSRF check. Identity still comes from the real, signed session cookie.
+    """
+
+    def enforce_csrf(self, request):
+        return
+
+
+class HasWebSocketsSecret(BasePermission):
+    """
+    Gates the whole websockets API on a shared secret known only to the realtime server, compared in constant time
+    against the ``WEBSOCKETS_AUTH_SECRET`` setting. Only enforced when that setting is non-empty, so local development
+    and tests work without it.
+    """
+
+    def has_permission(self, request, view):
+        secret = getattr(settings, "WEBSOCKETS_AUTH_SECRET", None)
+        if not secret:
+            return True
+
+        return constant_time_compare(request.headers.get("X-Websockets-Secret", ""), secret)
+
+
+class BaseEndpoint(APIView):
+    """
+    Base class for all websockets API endpoints.
+    """
+
+    authentication_classes = (WebSocketsSessionAuthentication,)
+    permission_classes = (HasWebSocketsSecret,)
+    renderer_classes = (JSONRenderer,)
+
+
+class ConnectEndpoint(BaseEndpoint):
+    """
+    Connection proxy called by the realtime messaging server when a browser opens a WebSocket. The browser connects
+    with no auth token; the realtime server forwards the browser's session cookie to us and we resolve the user plus
+    their current workspace, returning the connection result - the user id and the server-side channels the connection
+    should be subscribed to.
+
+    Channels use integer DB ids (not UUIDs) because the services that publish to them key off the same ids; the
+    ``user`` and ``org`` namespaces are configured on the realtime server. If there's no authenticated session we
+    return a disconnect instruction instead so the realtime server closes the connection.
+    """
+
+    def post(self, request, *args, **kwargs):
+        user = request.user
+        if not user.is_authenticated:
+            return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
+
+        channels = [f"user:{user.id}"]
+        if request.org:
+            channels.append(f"org:{request.org.id}")
+
+        return Response({"result": {"user": str(user.id), "channels": channels}})

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -73,28 +73,29 @@ class ConnectEndpoint(BaseEndpoint):
     Connection proxy called by the realtime messaging server when a browser opens a WebSocket. The browser connects
     with no auth token; the realtime server forwards the browser's session cookie and we resolve the user.
 
-    The result carries:
+    We currently require an authenticated user with a current workspace; if either is missing we return a disconnect
+    instruction so the realtime server closes the connection.
+
+    On success the result carries:
       * ``user`` - the user identifier (uuid);
-      * ``channels`` - the server-side channels to subscribe the connection to, a single
-        ``notifications:<org-uuid>:<user-uuid>`` for the user's current workspace (none if they have no current one);
+      * ``channels`` - the server-side channels to subscribe the connection to: a single
+        ``notifications:<org-uuid>:<user-uuid>`` for the user's current workspace;
       * ``meta`` - the user's identity (uuids and ids) attached to the connection so the subscription-authorization
         proxies can act on it without re-reading the session; ``meta`` is server-side only and never sent to the browser;
       * ``expire_at`` - when the realtime server should next call the refresh proxy to re-validate the connection.
-
-    If there's no authenticated session we return a disconnect instruction so the realtime server closes the connection.
     """
 
     def post(self, request, *args, **kwargs):
         user = request.user
-        if not user.is_authenticated:
+
+        # for now a connection requires an authenticated user with a current workspace. This could be reworked in
+        # future to also support anonymous connections - e.g. webchat - which have no Django user or workspace.
+        if not user.is_authenticated or not request.org:
             return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
 
-        meta = {"user_id": user.id, "user_uuid": str(user.uuid)}
-        channels = []
-        if request.org:
-            meta["org_id"] = request.org.id
-            meta["org_uuid"] = str(request.org.uuid)
-            channels.append(f"notifications:{request.org.uuid}:{user.uuid}")
+        org = request.org
+        meta = {"user_id": user.id, "user_uuid": str(user.uuid), "org_id": org.id, "org_uuid": str(org.uuid)}
+        channels = [f"notifications:{org.uuid}:{user.uuid}"]
 
         return Response(
             {"result": {"user": str(user.uuid), "channels": channels, "meta": meta, "expire_at": self.expire_at()}}

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -23,7 +23,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 
@@ -46,17 +45,13 @@ class WebSocketsSessionAuthentication(APISessionAuthentication):
 class HasWebSocketsSecret(BasePermission):
     """
     Gates the whole websockets API on a shared secret known only to the realtime server, compared in constant time
-    against the ``WEBSOCKETS_AUTH_SECRET`` setting. The secret is required: a system check (see ``temba.api.checks``)
-    catches a missing one at deploy time, and this fails closed at request time for the bare wsgi path where system
-    checks don't run - so a misconfigured deployment can never silently accept any forwarded session cookie.
+    against the ``WEBSOCKETS_AUTH_SECRET`` setting. The secret is required and enforced by a system check (see
+    ``temba.api.checks``) which fails the deploy if it's unset - and since system checks run as part of migrate /
+    runserver, the secret is always configured by the time the API serves a request.
     """
 
     def has_permission(self, request, view):
-        secret = settings.WEBSOCKETS_AUTH_SECRET
-        if not secret:
-            raise ImproperlyConfigured("WEBSOCKETS_AUTH_SECRET must be set to use the websockets API")
-
-        return constant_time_compare(request.headers.get("X-Websockets-Secret", ""), secret)
+        return constant_time_compare(request.headers.get("X-Websockets-Secret", ""), settings.WEBSOCKETS_AUTH_SECRET)
 
 
 class BaseEndpoint(APIView):

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -30,6 +30,11 @@ MAILROOM_URL = os.environ.get("MAILROOM_URL", "http://localhost:8091")
 MAILROOM_AUTH_TOKEN = os.environ.get("MAILROOM_AUTH_TOKEN")
 
 # -----------------------------------------------------------------------------------
+# WebSockets - shared secret for the realtime messaging server (must match its config)
+# -----------------------------------------------------------------------------------
+WEBSOCKETS_AUTH_SECRET = "topsecret"
+
+# -----------------------------------------------------------------------------------
 # In development, add in extra logging for exceptions and the debug toolbar
 # -----------------------------------------------------------------------------------
 MIDDLEWARE = ("temba.middleware.ExceptionMiddleware",) + MIDDLEWARE

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -852,6 +852,13 @@ MAILROOM_URL = None
 MAILROOM_AUTH_TOKEN = None
 
 # -----------------------------------------------------------------------------------
+# WebSockets (realtime messaging server)
+# -----------------------------------------------------------------------------------
+
+# optional shared secret which, when set, the websockets API requires in the X-Websockets-Secret header
+WEBSOCKETS_AUTH_SECRET = None
+
+# -----------------------------------------------------------------------------------
 # Data Model
 # -----------------------------------------------------------------------------------
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -855,7 +855,8 @@ MAILROOM_AUTH_TOKEN = None
 # WebSockets (realtime messaging server)
 # -----------------------------------------------------------------------------------
 
-# optional shared secret which, when set, the websockets API requires in the X-Websockets-Secret header
+# shared secret the websockets API requires in the X-Websockets-Secret header; required (see temba.api.checks) and
+# left unset here so each deployment must configure it
 WEBSOCKETS_AUTH_SECRET = None
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Adds a small `websockets` API that backs a realtime messaging server fronting browser WebSockets. These endpoints handle **connection authentication and lifecycle**; authorizing individual channel subscriptions is handled by a separate internal service (mailroom), to keep Django-session handling in the one place that has it natively.

## Background

A realtime messaging server can front browser WebSockets. Browsers open a WebSocket with no auth token; the server forwards the browser's `Cookie` header to backend "proxy" endpoints which authenticate the user from their Django session. This PR implements the connection-level proxies.

## Why a new API rather than more `/api/internal/` endpoints

The existing internal API (`/api/internal/`) is called by the editor running in the user's **browser**, so it must be reachable from the public internet. These proxies are the opposite: they're only ever called by the realtime messaging server, **server-to-server**, from inside our own network. So they live in their own `temba/api/websockets/` app (mounted at `^api/websockets/`) with a base class that applies a shared auth mechanism uniformly. Consequences:

- They use a **new auth mechanism** (a required shared-secret header) the rest of the internal API doesn't.
- They can be made **truly internal** — served only on an internal-only network path and refused at the public edge. See the module docstring in `temba/api/websockets/views.py`.

The choice of realtime server is an implementation detail and isn't named in the code.

## Endpoints

### `POST /api/websockets/connect` — connect proxy
Resolves the user from the forwarded session cookie and returns the connection result:

- `user` — the user identifier (uuid).
- `channels` — the server-side channels to subscribe the connection to: a single `notifications:<org-uuid>:<user-uuid>` for the user's current workspace.
- `meta` — the user's identity (`user_id`/`user_uuid`, `org_id`/`org_uuid`) attached to the connection. Centrifugo forwards this on subsequent proxy calls, so the subscription-authorization proxies can act on it without re-reading the Django session. **`meta` is server-side only and never sent to the browser**, so the integer ids in it don't leak.
- `expire_at` — when the realtime server should next call the refresh proxy.

A connection currently requires an authenticated user **with a current workspace**; if either is missing → `{"disconnect": {"code": 4401, "reason": "unauthorized"}}`. (This could be reworked later to support anonymous connections such as webchat, which have no Django user/workspace.) (4401 is a WebSocket close code in the application-defined 4000–4999 range mirroring HTTP 401, not an HTTP status.)

### `POST /api/websockets/refresh` — refresh proxy
Called periodically before a connection's `expire_at`. Re-checks the connection is still valid — the user is still logged in **and still has a current workspace** (matching what `connect` requires) — and either extends the connection (`{"result": {"expire_at": …}}`) or lets it expire (`{"result": {"expired": true}}`). This is how a logout, session expiry, or losing workspace access eventually tears down the WebSocket — the one place connection validity is re-evaluated.

## Subscription authorization lives in mailroom

Authorizing client-initiated channel subscriptions (e.g. a contact's chat history) is a pure DB check (`contact ∈ org`) that doesn't need the Django session — it can run off the identity in the connection `meta` set above. So the `subscribe`/`sub_refresh` proxies, plus the realtime subscription state (a valkey index), belong in mailroom alongside the eventual `publish`/`rpc` event proxies, rather than here. This split keeps each service to its strength: **rapidpro owns connection identity & lifecycle (connect/refresh); mailroom owns channel authorization & realtime state.** Mailroom never has to decode a Django session.

## Auth

- **Session, CSRF-relaxed**: a small `SessionAuthentication` subclass no-ops the CSRF check, since these are server-to-server POSTs with no CSRF token. Identity still comes from the real signed session cookie.
- **Shared secret (whole API, required)**: a permission class compares the `X-Websockets-Secret` header (constant-time) against the `WEBSOCKETS_AUTH_SECRET` setting. The secret is **required**, enforced by a Django **system check** that fails the deploy if it's unset — system checks run as part of `migrate`/`runserver`, so the secret is always configured by the time the API serves a request. Every deployment must set `WEBSOCKETS_AUTH_SECRET`; the dev value is in `settings.py.dev`.

All identifiers in channel names and the connect `user` field are **UUIDs**, not sequential DB ids — server-side channel names are echoed to the browser, so this avoids leaking enumerable ids.

## Deployment note

`connect` now returns `expire_at`, so the realtime server **must** be configured with a refresh proxy (and to forward connection meta) — otherwise connections would be force-closed at every expiry with nothing to renew them.

## Tests

`temba/api/websockets/tests.py` covers, for connect: authenticated → workspace-scoped notifications channel + identity meta + a future expiry, a different (org, user) pair, no-workspace → empty channels + org-less meta, unauthenticated → `disconnect`, and a CSRF-enforcing client still succeeding; for refresh: still-authenticated → new expiry, logged-out → `expired`; plus GET → 405 and the required-secret enforcement (system check + request-time fail-closed). `code_check.py` (migrations, ruff format, ruff) passes.



