### PR TITLE
Add JSON endpoint to change a flow's base language

### DIFF
--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -12,12 +12,20 @@ from temba import mailroom
 from temba.api.models import Resthook
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import URN
-from temba.flows.models import Flow, FlowLabel, FlowRun, FlowStart, FlowUserConflictException, ResultsExport
+from temba.flows.models import (
+    Flow,
+    FlowLabel,
+    FlowRun,
+    FlowStart,
+    FlowUserConflictException,
+    FlowVersionConflictException,
+    ResultsExport,
+)
 from temba.mailroom.client.types import Exclusions
 from temba.orgs.integrations.dtone.type import DTOneType
 from temba.orgs.models import Export
 from temba.templates.models import TemplateTranslation
-from temba.tests import CRUDLTestMixin, TembaTest, matchers, mock_mailroom
+from temba.tests import CRUDLTestMixin, MockResponse, TembaTest, matchers, mock_mailroom
 from temba.tests.base import get_contact_search, override_brand
 from temba.tests.requests import MockJsonResponse
 from temba.triggers.models import Trigger
@@ -1853,6 +1861,10 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.admin)
 
+        # this endpoint is POST-only - a GET is not allowed (rather than 500ing on a missing template)
+        response = self.client.get(change_url)
+        self.assertEqual(405, response.status_code)
+
         # a missing or empty language is rejected
         response = self.client.post(change_url, {"language": ""}, content_type="application/json")
         self.assertEqual(400, response.status_code)
@@ -1891,6 +1903,47 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             },
             response.json(),
         )
+
+        # a request body that isn't valid JSON is rejected
+        response = self.client.post(change_url, data="not json", content_type="application/json")
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("Invalid request.", response.json()["description"])
+
+        # a version conflict whilst saving the new revision is converted to an error response
+        with patch("temba.flows.models.Flow.save_revision") as mock_save_revision:
+            mock_save_revision.side_effect = FlowVersionConflictException(13)
+            response = self.client.post(change_url, {"language": "ara"}, content_type="application/json")
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {
+                "status": "failure",
+                "description": "Your flow has been upgraded to the latest version. "
+                "In order to continue editing, please refresh your browser.",
+                "detail": None,
+            },
+            response.json(),
+        )
+
+        # a user conflict whilst saving the new revision is converted to an error response
+        with patch("temba.flows.models.Flow.save_revision") as mock_save_revision:
+            mock_save_revision.side_effect = FlowUserConflictException("Jim", None)
+            response = self.client.post(change_url, {"language": "ara"}, content_type="application/json")
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {
+                "status": "failure",
+                "description": "Jim is currently editing this Flow. "
+                "Your changes will not be saved until you refresh your browser.",
+                "detail": None,
+            },
+            response.json(),
+        )
+
+        # a failed request to mailroom is converted to an error response
+        mr_mocks.exception(mailroom.RequestException("", "", MockResponse(500, '{"error": "boom"}')))
+        response = self.client.post(change_url, {"language": "ara"}, content_type="application/json")
+        self.assertEqual(500, response.status_code)
+        self.assertEqual("Unable to change the flow's language.", response.json()["description"])
 
     def test_export_results(self):
         export_url = reverse("flows.flow_export_results")

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1844,27 +1844,38 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         flow = self.get_flow("favorites_v13")
 
-        change_url = reverse("flows.flow_change_language", args=[flow.id])
+        change_url = reverse("flows.flow_change_language", args=[flow.uuid])
 
-        self.assertUpdateSubmit(
-            change_url,
-            self.admin,
-            {"language": ""},
-            form_errors={"language": "This field is required."},
-            object_unchanged=flow,
-        )
+        # agents don't have permission to change the language
+        self.login(self.agent)
+        response = self.client.post(change_url, {"language": "spa"}, content_type="application/json")
+        self.assertLoginRedirect(response)
 
-        self.assertUpdateSubmit(
-            change_url,
-            self.admin,
-            {"language": "fra"},
-            form_errors={"language": "Not a valid language."},
-            object_unchanged=flow,
-        )
+        self.login(self.admin)
 
-        self.assertUpdateSubmit(change_url, self.admin, {"language": "spa"}, success_status=302)
+        # a missing or empty language is rejected
+        response = self.client.post(change_url, {"language": ""}, content_type="application/json")
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("Not a valid language.", response.json()["description"])
+
+        # a language that isn't one of the org's flow languages is rejected
+        response = self.client.post(change_url, {"language": "fra"}, content_type="application/json")
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("Not a valid language.", response.json()["description"])
+
+        # the flow's current base language is rejected
+        response = self.client.post(change_url, {"language": "eng"}, content_type="application/json")
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("Flow is already in this language.", response.json()["description"])
+
+        # changing to a valid language switches the base language and saves a new revision
+        response = self.client.post(change_url, {"language": "spa"}, content_type="application/json")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("success", response.json()["status"])
+        self.assertEqual(flow.revisions.order_by("-revision").first().revision, response.json()["revision"]["revision"])
 
         flow_def = flow.get_definition()
+        self.assertEqual("spa", flow_def["language"])
         self.assertIn("eng", flow_def["localization"])
         self.assertEqual("¿Cuál es tu color favorito?", flow_def["nodes"][0]["actions"][0]["text"])
 

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1879,6 +1879,19 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertIn("eng", flow_def["localization"])
         self.assertEqual("¿Cuál es tu color favorito?", flow_def["nodes"][0]["actions"][0]["text"])
 
+        # if mailroom rejects the resulting definition we return a failure response rather than a stack trace
+        mr_mocks.exception(mailroom.FlowValidationException("node isn't unique"))
+        response = self.client.post(change_url, {"language": "ara"}, content_type="application/json")
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {
+                "status": "failure",
+                "description": "Your flow failed validation. Please refresh your browser.",
+                "detail": "node isn't unique",
+            },
+            response.json(),
+        )
+
     def test_export_results(self):
         export_url = reverse("flows.flow_export_results")
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -810,7 +810,12 @@ class FlowCRUDL(SmartCRUDL):
         text is moved into the flow's localization and the target language's translations are promoted to be the base.
         """
 
-        permission = "flows.flow_update"
+        # matches the sibling editor endpoints (Revisions, Activity); editing the flow is enough to change its base
+        # language since an editor can already rewrite the whole definition via Revisions
+        permission = "flows.flow_editor"
+
+        # POST-only - a GET would otherwise try to render a non-existent template and 500
+        http_method_names = ["post"]
 
         @classmethod
         def derive_url_pattern(cls, path, action):
@@ -834,7 +839,7 @@ class FlowCRUDL(SmartCRUDL):
 
             try:
                 flow_def = mailroom.get_client().flow_change_language(flow.get_definition(), language)
-                revision, issues = flow.save_revision(request.user, flow_def)
+                revision, _issues = flow.save_revision(request.user, flow_def)
                 return JsonResponse({"status": "success", "revision": revision.as_json()})
 
             except mailroom.FlowValidationException as e:
@@ -860,6 +865,10 @@ class FlowCRUDL(SmartCRUDL):
                 return JsonResponse(
                     {"status": "failure", "description": _("Unable to change the flow's language.")}, status=500
                 )
+            except Exception:  # pragma: no cover
+                logger.error("Error changing flow base language", exc_info=True)
+                error = _("Your flow could not be saved. Please refresh your browser.")
+                detail = None
 
             return JsonResponse({"status": "failure", "description": error, "detail": detail}, status=400)
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -835,13 +835,33 @@ class FlowCRUDL(SmartCRUDL):
             try:
                 flow_def = mailroom.get_client().flow_change_language(flow.get_definition(), language)
                 revision, issues = flow.save_revision(request.user, flow_def)
+                return JsonResponse({"status": "success", "revision": revision.as_json()})
+
+            except mailroom.FlowValidationException as e:
+                error = _("Your flow failed validation. Please refresh your browser.")
+                detail = str(e)
+            except FlowVersionConflictException:
+                error = _(
+                    "Your flow has been upgraded to the latest version. "
+                    "In order to continue editing, please refresh your browser."
+                )
+                detail = None
+            except FlowUserConflictException as e:
+                error = (
+                    _(
+                        "%s is currently editing this Flow. "
+                        "Your changes will not be saved until you refresh your browser."
+                    )
+                    % e.other_user
+                )
+                detail = None
             except mailroom.RequestException:
                 logger.error("Mailroom request failed", exc_info=True)
                 return JsonResponse(
                     {"status": "failure", "description": _("Unable to change the flow's language.")}, status=500
                 )
 
-            return JsonResponse({"status": "success", "revision": revision.as_json()})
+            return JsonResponse({"status": "failure", "description": error, "detail": detail}, status=400)
 
     class ExportTranslation(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         class Form(forms.Form):

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -804,39 +804,44 @@ class FlowCRUDL(SmartCRUDL):
             if self.has_org_perm("orgs.org_export"):
                 menu.add_link(_("Export Definition"), f"{reverse('orgs.org_export')}?flow={obj.id}")
 
-    class ChangeLanguage(OrgObjPermsMixin, SmartUpdateView):
-        class Form(forms.Form):
-            language = forms.CharField(required=True)
-
-            def __init__(self, org, instance, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-
-                self.org = org
-
-            def clean_language(self):
-                data = self.cleaned_data["language"]
-                if data and data not in self.org.flow_languages:
-                    raise ValidationError(_("Not a valid language."))
-
-                return data
+    class ChangeLanguage(BaseReadView):
+        """
+        Used by the editor to switch a flow's base language to a fully translated language. The current base language
+        text is moved into the flow's localization and the target language's translations are promoted to be the base.
+        """
 
         permission = "flows.flow_update"
-        form_class = Form
-        success_url = "uuid@flows.flow_editor"
 
-        def get_form_kwargs(self):
-            kwargs = super().get_form_kwargs()
-            kwargs["org"] = self.request.org
-            return kwargs
+        @classmethod
+        def derive_url_pattern(cls, path, action):
+            return r"^%s/%s/(?P<uuid>[0-9a-f-]+)/$" % (path, action)
 
-        def form_valid(self, form):
-            flow_def = mailroom.get_client().flow_change_language(
-                self.object.get_definition(), form.cleaned_data["language"]
-            )
+        def post(self, request, *args, **kwargs):
+            flow = self.get_object()
 
-            self.object.save_revision(self.request.user, flow_def)
+            try:
+                language = json.loads(force_str(request.body)).get("language")
+            except Exception:
+                return JsonResponse({"status": "failure", "description": _("Invalid request.")}, status=400)
 
-            return HttpResponseRedirect(self.get_success_url())
+            if not language or language not in flow.org.flow_languages:
+                return JsonResponse({"status": "failure", "description": _("Not a valid language.")}, status=400)
+
+            if language == flow.base_language:
+                return JsonResponse(
+                    {"status": "failure", "description": _("Flow is already in this language.")}, status=400
+                )
+
+            try:
+                flow_def = mailroom.get_client().flow_change_language(flow.get_definition(), language)
+                revision, issues = flow.save_revision(request.user, flow_def)
+            except mailroom.RequestException:
+                logger.error("Mailroom request failed", exc_info=True)
+                return JsonResponse(
+                    {"status": "failure", "description": _("Unable to change the flow's language.")}, status=500
+                )
+
+            return JsonResponse({"status": "success", "revision": revision.as_json()})
 
     class ExportTranslation(ModalFormMixin, OrgObjPermsMixin, SmartUpdateView):
         class Form(forms.Form):

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -817,10 +817,6 @@ class FlowCRUDL(SmartCRUDL):
         # POST-only - a GET would otherwise try to render a non-existent template and 500
         http_method_names = ["post"]
 
-        @classmethod
-        def derive_url_pattern(cls, path, action):
-            return r"^%s/%s/(?P<uuid>[0-9a-f-]+)/$" % (path, action)
-
         def post(self, request, *args, **kwargs):
             flow = self.get_object()
 


### PR DESCRIPTION
## Summary

Adds a JSON endpoint the new flow editor calls to switch a flow's base/default language to a fully-translated language. The actual swap (moving the old base text into `localization` and promoting the target language's translations) is done by `mailroom.flow_change_language` (goflow) — this just exposes it to the editor and persists the result.

This repurposes the old, vestigial `FlowCRUDL.ChangeLanguage` form view (integer-pk keyed, returned a 302 redirect, referenced nowhere) into a UUID-keyed JSON endpoint, matching the sibling editor endpoints (`Revisions`, `Activity`).

## Changes

- **`temba/flows/views.py`** — `FlowCRUDL.ChangeLanguage` now extends `BaseReadView` with a UUID URL pattern and a JSON `POST`:
  - **POST-only** (`http_method_names = ["post"]`) so a stray GET returns a clean `405` instead of `500`ing on a non-existent read template.
  - Parses the request body, rejecting non-JSON with `400 {status, description: "Invalid request."}`.
  - Validates the target language is one of `org.flow_languages`; rejects empty/missing and the current base language (`400` + `{status, description}`).
  - Runs `mailroom.flow_change_language` on the latest definition and saves a revision; returns `{status: "success", revision: ...}`. The `issues` returned by `save_revision` is intentionally unused (the editor reloads on success).
  - Catches `FlowValidationException` / `FlowVersionConflictException` / `FlowUserConflictException` and returns the same `{status, description, detail}` `400` shape as `Revisions.post`; mailroom transport errors (`RequestException`) → `500`; a final `except Exception` catch-all (mirroring `Revisions.post`) keeps any unexpected error on the JSON contract instead of leaking a stack trace.
  - Permission **`flows.flow_editor`** (org-scoped via `BaseReadView`), matching the sibling editor endpoints — an editor can already rewrite the whole definition via `Revisions`, so editing rights are sufficient to flip the base language.
- **`temba/flows/tests/test_flowcrudl.py`** — `test_change_language` covers the JSON endpoint end-to-end: GET → 405, agent permission redirect, empty/invalid/same-language rejection, malformed-JSON body, the successful swap (base flips to `spa`, old base moves into localization), and every error branch — `FlowValidationException`, `FlowVersionConflictException`, `FlowUserConflictException` (→ 400 with the failure JSON), and a mailroom `RequestException` (→ 500). This brings `flows/views.py` back to 100% line coverage.

## Behavior

| Request | Response |
| --- | --- |
| `GET` | `405` (method not allowed) |
| `POST` body not JSON | `400 {status: failure, description: "Invalid request."}` |
| `POST {language: ""}` / unknown language | `400 {status: failure, description: "Not a valid language."}` |
| `POST` current base language | `400 {status: failure, description: "Flow is already in this language."}` |
| `POST` valid language | `200 {status: success, revision: {...}}` |
| definition fails validation | `400 {status: failure, description, detail}` |
| version / user edit conflict | `400 {status: failure, description, detail: null}` |
| mailroom transport error | `500 {status: failure, description: "Unable to change the flow's language."}` |

## Companion PR

This is the backend for **nyaruka/temba-components#1033** (the editor UI that calls this endpoint). Both must be deployed together; the editor gates the button on a 100%-translated language.

## Review notes

Addressed in review:
- The original `try` only caught `mailroom.RequestException`, but `save_revision` (via the wrapped `flow_inspect` mailroom call) can also raise `FlowValidationException` and the version/user conflict exceptions — which would otherwise escape as an uncaught `500` stack trace instead of the JSON contract. Now handled exactly like `Revisions.post`, with tests exercising each.
- Switched the permission from the stricter `flows.flow_update` to `flows.flow_editor` for consistency with the sibling editor endpoints.
- Restricted the endpoint to POST (GET previously rendered a missing template → 500).
- Added the `except Exception` catch-all so unexpected failures stay on the `{status, description}` contract.

## Test plan

- [x] `ruff format` + `ruff check` clean (line-length 120); no missing migrations.
- [x] `temba.flows.tests.test_flowcrudl.FlowCRUDLTest.test_change_language` green in CI (the suite makes real mailroom HTTP calls during fixture load, so it runs in CI rather than the local devcontainer).
- [x] `coverage report --fail-under=100` passes — `flows/views.py` back to 100%.