### PR TITLE
Add subscribe and sub_refresh proxy endpoints to websockets API

### DIFF
--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,6 +1,3 @@
-from datetime import datetime, timezone as tzone
-from unittest.mock import patch
-
 from django_valkey import get_valkey_connection
 
 from django.test import override_settings
@@ -9,7 +6,7 @@ from django.utils import timezone
 
 from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
-from temba.api.websockets.views import SUBSCRIPTION_TTL, SUBSCRIPTION_WINDOW
+from temba.api.websockets.views import SUBSCRIPTION_TTL
 from temba.tests import TembaTest
 from temba.utils.uuid import uuid4
 
@@ -233,52 +230,35 @@ class EndpointsTest(APITestMixin, TembaTest):
     def test_subscription_index(self):
         contact = self.create_contact("Ann", phone="+1234", org=self.org)
         channel = f"history:{contact.uuid}"
-        key = f"subs:{channel}"
+        key = f"socket-subs:{channel}"
 
         r = get_valkey_connection()
         r.delete(key)
 
         self.login(self.admin)
 
-        # subscribe records the connection in the per-channel sorted set, scored by its expiry
-        t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=tzone.utc)
-        with patch("django.utils.timezone.now", return_value=t0):
-            response = self.post("api.websockets.subscribe", {"channel": channel, "client": "conn-1"})
+        # a denied subscription records nothing
+        denied = f"history:{uuid4()}"
+        denied_key = f"socket-subs:{denied}"
+        r.delete(denied_key)
+        response = self.post("api.websockets.subscribe", {"channel": denied, "client": "conn-1"})
         self.assertEqual(200, response.status_code)
-        self.assertEqual(int(t0.timestamp()) + SUBSCRIPTION_WINDOW, response.json()["result"]["expire_at"])
-        self.assertEqual([b"conn-1"], r.zrange(key, 0, -1))
-        score0 = r.zscore(key, "conn-1")
-        self.assertEqual(int(t0.timestamp()) + SUBSCRIPTION_TTL, int(score0))
+        self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+        self.assertEqual(0, r.exists(denied_key))
 
-        # the key has a TTL backstop so a channel nothing re-arms eventually vanishes
+        # subscribe sets a per-channel presence flag with a TTL backstop
+        response = self.post("api.websockets.subscribe", {"channel": channel, "client": "conn-1"})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(b"1", r.get(key))
         self.assertGreater(r.ttl(key), 0)
         self.assertLessEqual(r.ttl(key), SUBSCRIPTION_TTL)
 
-        # an already-expired member from a dead connection
-        r.zadd(key, {"dead-conn": int(t0.timestamp()) - 1})
-
-        # sub_refresh later re-arms the entry with a later expiry and lazily prunes the dead one
-        t1 = datetime(2024, 1, 1, 12, 0, 30, tzinfo=tzone.utc)
-        with patch("django.utils.timezone.now", return_value=t1):
-            response = self.post("api.websockets.sub_refresh", {"channel": channel, "client": "conn-1"})
+        # sub_refresh re-arms the key's TTL - after it has aged, a refresh sets it back toward the full TTL
+        r.expire(key, 5)
+        self.assertLessEqual(r.ttl(key), 5)
+        response = self.post("api.websockets.sub_refresh", {"channel": channel, "client": "conn-1"})
         self.assertEqual(200, response.status_code)
-        self.assertEqual(int(t1.timestamp()) + SUBSCRIPTION_WINDOW, response.json()["result"]["expire_at"])
-
-        score1 = r.zscore(key, "conn-1")
-        self.assertEqual(int(t1.timestamp()) + SUBSCRIPTION_TTL, int(score1))
-        self.assertGreater(score1, score0)
-        self.assertEqual([b"conn-1"], r.zrange(key, 0, -1))  # dead-conn was pruned
-
-        # a second connection to the same channel coexists - the set tracks every subscriber, not just the latest
-        with patch("django.utils.timezone.now", return_value=t1):
-            response = self.post("api.websockets.subscribe", {"channel": channel, "client": "conn-2"})
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({b"conn-1", b"conn-2"}, set(r.zrange(key, 0, -1)))
-
-        # an empty connection id isn't indexed (no blank member added)
-        response = self.post("api.websockets.subscribe", {"channel": channel, "client": ""})
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({b"conn-1", b"conn-2"}, set(r.zrange(key, 0, -1)))
+        self.assertGreater(r.ttl(key), 5)
 
     def test_secret(self):
         self.login(self.admin)

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -268,6 +268,17 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertGreater(score1, score0)
         self.assertEqual([b"conn-1"], r.zrange(key, 0, -1))  # dead-conn was pruned
 
+        # a second connection to the same channel coexists - the set tracks every subscriber, not just the latest
+        with patch("django.utils.timezone.now", return_value=t1):
+            response = self.post("api.websockets.subscribe", {"channel": channel, "client": "conn-2"})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({b"conn-1", b"conn-2"}, set(r.zrange(key, 0, -1)))
+
+        # an empty connection id isn't indexed (no blank member added)
+        response = self.post("api.websockets.subscribe", {"channel": channel, "client": ""})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({b"conn-1", b"conn-2"}, set(r.zrange(key, 0, -1)))
+
     def test_secret(self):
         self.login(self.admin)
 

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -1,19 +1,26 @@
+from datetime import datetime, timezone as tzone
+from unittest.mock import patch
+
+from django_valkey import get_valkey_connection
+
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
+from temba.api.websockets.views import SUBSCRIPTION_TTL, SUBSCRIPTION_WINDOW
 from temba.tests import TembaTest
+from temba.utils.uuid import uuid4
 
 SECRET = "topsecret"
 
 
 @override_settings(WEBSOCKETS_AUTH_SECRET=SECRET)
 class EndpointsTest(APITestMixin, TembaTest):
-    def post(self, name, *, client=None, secret=SECRET):
+    def post(self, name, data=None, *, client=None, secret=SECRET):
         headers = {"HTTP_X_WEBSOCKETS_SECRET": secret} if secret is not None else {}
-        return (client or self.client).post(reverse(name), {}, content_type="application/json", **headers)
+        return (client or self.client).post(reverse(name), data or {}, content_type="application/json", **headers)
 
     def assertExpiry(self, expire_at):
         self.assertIsInstance(expire_at, int)
@@ -114,6 +121,152 @@ class EndpointsTest(APITestMixin, TembaTest):
         response = self.post("api.websockets.refresh")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"result": {"expired": True}}, response.json())
+
+    def test_subscribe(self):
+        contact = self.create_contact("Ann", phone="+1234", org=self.org)
+        ticket = self.create_ticket(contact)
+
+        # a second contact + ticket in the same workspace, to prove a ticket must belong to the named contact
+        contact2 = self.create_contact("Cat", phone="+1236", org=self.org)
+        ticket2 = self.create_ticket(contact2)
+
+        # a contact + ticket in another workspace
+        other = self.create_contact("Bob", phone="+1235", org=self.org2)
+        other_ticket = self.create_ticket(other)
+
+        def subscribe(channel, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+
+        self.login(self.admin)
+
+        # allowed: a contact's history in the current workspace
+        response = subscribe(f"history:{contact.uuid}")
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
+
+        # allowed: a ticket's history for that contact
+        response = subscribe(f"history:{contact.uuid}:{ticket.uuid}")
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
+
+        def assertForbidden(channel):
+            response = subscribe(channel)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+
+        assertForbidden(f"history:{other.uuid}")  # contact in another workspace
+        assertForbidden(f"history:{uuid4()}")  # contact not found
+        assertForbidden(f"history:{contact.uuid}:{uuid4()}")  # ticket not found for the contact
+        assertForbidden(f"history:{contact.uuid}:{ticket2.uuid}")  # ticket belongs to a different contact, same org
+        assertForbidden(f"history:{contact.uuid}:{other_ticket.uuid}")  # ticket in another workspace
+        assertForbidden(f"history:{other.uuid}:{other_ticket.uuid}")  # both in another workspace
+        assertForbidden("history:not-a-uuid")  # malformed contact uuid
+        assertForbidden(f"history:{contact.uuid}:not-a-uuid")  # malformed ticket uuid
+        assertForbidden(f"history:{contact.uuid}:{ticket.uuid}:extra")  # too many segments
+        assertForbidden("history")  # too few segments
+        assertForbidden(f"presence:{contact.uuid}")  # unknown namespace
+        assertForbidden(
+            f"notifications:{self.org.uuid}:{self.admin.uuid}"
+        )  # server-side namespace, never via this proxy
+
+        # an inactive contact is denied
+        contact.is_active = False
+        contact.save(update_fields=("is_active",))
+        assertForbidden(f"history:{contact.uuid}")
+        contact.is_active = True
+        contact.save(update_fields=("is_active",))
+
+        # a user with no current workspace is forbidden
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        assertForbidden(f"history:{contact.uuid}")
+
+        # an unauthenticated request is told to disconnect
+        self.client.logout()
+        response = subscribe(f"history:{contact.uuid}")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+    def test_sub_refresh(self):
+        contact = self.create_contact("Ann", phone="+1234", org=self.org)
+        channel = f"history:{contact.uuid}"
+
+        def sub_refresh(ch=channel, client="conn-1"):
+            return self.post("api.websockets.sub_refresh", {"channel": ch, "client": client})
+
+        # still authorized -> the subscription is extended
+        self.login(self.admin)
+        response = sub_refresh()
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
+
+        # a channel the user may no longer access -> let the subscription expire
+        response = sub_refresh(f"history:{uuid4()}")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+        # access revoked since subscribe (contact deactivated) -> expired
+        contact.is_active = False
+        contact.save(update_fields=("is_active",))
+        response = sub_refresh()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+        contact.is_active = True
+        contact.save(update_fields=("is_active",))
+
+        # losing the current workspace -> expired
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        response = sub_refresh()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+        # no session at all -> expired (sub_refresh never disconnects)
+        self.client.logout()
+        response = sub_refresh()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+    def test_subscription_index(self):
+        contact = self.create_contact("Ann", phone="+1234", org=self.org)
+        channel = f"history:{contact.uuid}"
+        key = f"subs:{channel}"
+
+        r = get_valkey_connection()
+        r.delete(key)
+
+        self.login(self.admin)
+
+        # subscribe records the connection in the per-channel sorted set, scored by its expiry
+        t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=tzone.utc)
+        with patch("django.utils.timezone.now", return_value=t0):
+            response = self.post("api.websockets.subscribe", {"channel": channel, "client": "conn-1"})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(int(t0.timestamp()) + SUBSCRIPTION_WINDOW, response.json()["result"]["expire_at"])
+        self.assertEqual([b"conn-1"], r.zrange(key, 0, -1))
+        score0 = r.zscore(key, "conn-1")
+        self.assertEqual(int(t0.timestamp()) + SUBSCRIPTION_TTL, int(score0))
+
+        # the key has a TTL backstop so a channel nothing re-arms eventually vanishes
+        self.assertGreater(r.ttl(key), 0)
+        self.assertLessEqual(r.ttl(key), SUBSCRIPTION_TTL)
+
+        # an already-expired member from a dead connection
+        r.zadd(key, {"dead-conn": int(t0.timestamp()) - 1})
+
+        # sub_refresh later re-arms the entry with a later expiry and lazily prunes the dead one
+        t1 = datetime(2024, 1, 1, 12, 0, 30, tzinfo=tzone.utc)
+        with patch("django.utils.timezone.now", return_value=t1):
+            response = self.post("api.websockets.sub_refresh", {"channel": channel, "client": "conn-1"})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(int(t1.timestamp()) + SUBSCRIPTION_WINDOW, response.json()["result"]["expire_at"])
+
+        score1 = r.zscore(key, "conn-1")
+        self.assertEqual(int(t1.timestamp()) + SUBSCRIPTION_TTL, int(score1))
+        self.assertGreater(score1, score0)
+        self.assertEqual([b"conn-1"], r.zrange(key, 0, -1))  # dead-conn was pruned
 
     def test_secret(self):
         self.login(self.admin)

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -160,6 +160,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         assertForbidden(f"history:{contact.uuid}:{ticket2.uuid}")  # ticket belongs to a different contact, same org
         assertForbidden(f"history:{contact.uuid}:{other_ticket.uuid}")  # ticket in another workspace
         assertForbidden(f"history:{other.uuid}:{other_ticket.uuid}")  # both in another workspace
+        assertForbidden({"not": "a string"})  # non-string channel is a clean deny, not a 500
         assertForbidden("history:not-a-uuid")  # malformed contact uuid
         assertForbidden(f"history:{contact.uuid}:not-a-uuid")  # malformed ticket uuid
         assertForbidden(f"history:{contact.uuid}:{ticket.uuid}:extra")  # too many segments

--- a/temba/api/websockets/urls.py
+++ b/temba/api/websockets/urls.py
@@ -1,8 +1,10 @@
 from django.urls import re_path
 
-from .views import ConnectEndpoint, RefreshEndpoint
+from .views import ConnectEndpoint, RefreshEndpoint, SubRefreshEndpoint, SubscribeEndpoint
 
 urlpatterns = [
     re_path(r"^connect$", ConnectEndpoint.as_view(), name="api.websockets.connect"),
     re_path(r"^refresh$", RefreshEndpoint.as_view(), name="api.websockets.refresh"),
+    re_path(r"^subscribe$", SubscribeEndpoint.as_view(), name="api.websockets.subscribe"),
+    re_path(r"^sub_refresh$", SubRefreshEndpoint.as_view(), name="api.websockets.sub_refresh"),
 ]

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -35,14 +35,16 @@ from ..support import APISessionAuthentication
 # how long (seconds) a connection stays valid before the realtime server must re-validate it via the refresh proxy
 CONNECTION_TTL = 5 * 60
 
-# how long (seconds) a channel subscription stays authorized before the realtime server must re-check it via the
-# sub_refresh proxy. A short window keeps the subscription index reasonably fresh without re-checking too often.
+# how far ahead (seconds) we set a subscription's expire_at, scheduling the realtime server to call sub_refresh before
+# it lapses so we can re-authorize.
 SUBSCRIPTION_WINDOW = 60
 
-# how long (seconds) an entry lives in the valkey subscription index. Comfortably larger than SUBSCRIPTION_WINDOW so an
-# entry survives until the next sub_refresh re-arms it; if refreshes stop (e.g. a dead connection that we never get an
-# unsubscribe for) the entry simply ages out, which is how the index garbage-collects itself.
-SUBSCRIPTION_TTL = 90
+# how long (seconds) a channel's presence key survives without a refresh. It must comfortably exceed SUBSCRIPTION_WINDOW
+# plus the realtime server's refresh delay: the server drives sub_refresh from the expire_at we return (one window),
+# but refresh requests can be delayed up to ~1 minute, so consecutive refreshes can be ~SUBSCRIPTION_WINDOW + 60s apart.
+# 150s (60s window + ~60s delay + buffer) keeps the key alive across that gap while still expiring within a couple of
+# minutes once the last subscriber stops refreshing (there's no unsubscribe callback, so this TTL is the only GC).
+SUBSCRIPTION_TTL = 150
 
 
 class WebSocketsSessionAuthentication(APISessionAuthentication):
@@ -179,33 +181,26 @@ class SubscriptionEndpoint(BaseEndpoint):
 
         return Ticket.objects.filter(uuid=parts[1], contact=contact).exists()
 
-    def index_subscription(self, channel: str, client: str):
+    def record_subscription(self, channel: str):
         """
-        Record (or re-arm) a connection's subscription to a channel in the valkey index, so we can later answer
-        "what/who is subscribed to channel X". The index is a sorted set per channel (key ``subs:<channel>``) whose
-        members are connection ids scored by their expiry; the per-member score gives both lazy pruning and a fast read
-        of who's currently subscribed. Centrifugo OSS has no unsubscribe/disconnect proxy, so the TTL plus periodic
-        sub_refresh re-arming is the only reliable way to garbage-collect entries for connections that have gone away.
-        """
-        if not isinstance(client, str) or not client:  # nothing useful to index without a connection id
-            return
+        Mark a channel as having at least one active subscriber by (re)setting a per-channel presence key in valkey
+        with a TTL. We track presence only - whether a channel has any subscribers, not who or how many - because the
+        consuming service (which publishes a channel's events) only needs to know whether anyone is watching before it
+        bothers publishing, so one key per channel is all we keep. Every subscribe and sub_refresh re-sets the key, so
+        it stays present while some subscriber keeps refreshing and expires once the last one stops. The realtime
+        server has no unsubscribe or disconnect callback, so this TTL is the only garbage collection.
 
+        The key name (``socket-subs:<channel>``) and the presence-via-``EXISTS`` semantics are a contract shared with
+        the consuming service that reads it - keep them in sync.
+        """
         r = get_valkey_connection()
-        now = int(timezone.now().timestamp())
-        key = f"subs:{channel}"
-
-        pipe = r.pipeline()
-        pipe.zadd(key, {client: now + SUBSCRIPTION_TTL})
-        pipe.zremrangebyscore(key, 0, now)  # lazily drop members that have already expired
-        pipe.expire(key, SUBSCRIPTION_TTL)  # backstop so the key itself vanishes once nothing re-arms it
-        pipe.execute()
+        r.set(f"socket-subs:{channel}", "1", ex=SUBSCRIPTION_TTL)
 
 
 class SubscribeEndpoint(SubscriptionEndpoint):
     """
     Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a channel. The request
-    body carries the connection's ``client`` id and the requested ``channel``; we authorize that channel against the
-    live session.
+    body carries the requested ``channel``, which we authorize against the live session.
 
     An unauthenticated request is told to disconnect (its connection should never have got this far). Otherwise, if the
     user has a current workspace and may access the channel, we record the subscription and return an ``expire_at`` so
@@ -218,10 +213,9 @@ class SubscribeEndpoint(SubscriptionEndpoint):
             return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
 
         channel = request.data.get("channel", "")
-        client = request.data.get("client", "")
 
         if request.org and self.is_allowed(request, channel):
-            self.index_subscription(channel, client)
+            self.record_subscription(channel)
             return Response({"result": {"expire_at": self.subscription_expire_at()}})
 
         return Response({"error": {"code": 403, "message": "forbidden"}})
@@ -230,17 +224,16 @@ class SubscribeEndpoint(SubscriptionEndpoint):
 class SubRefreshEndpoint(SubscriptionEndpoint):
     """
     Sub refresh proxy called periodically by the realtime messaging server before a subscription's ``expire_at``. We
-    re-run the same authorization as subscribe (access may have been revoked since), and either re-arm the index entry
+    re-run the same authorization as subscribe (access may have been revoked since), and either re-arm the presence key
     and return a fresh ``expire_at`` or let the subscription expire. Only the ``result`` is acted on for refreshes, so
     every not-allowed case - including a session that's gone - is reported as expired rather than as a disconnect.
     """
 
     def post(self, request, *args, **kwargs):
         channel = request.data.get("channel", "")
-        client = request.data.get("client", "")
 
         if request.user.is_authenticated and request.org and self.is_allowed(request, channel):
-            self.index_subscription(channel, client)
+            self.record_subscription(channel)
             return Response({"result": {"expire_at": self.subscription_expire_at()}})
 
         return Response({"result": {"expired": True}})

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -149,6 +149,9 @@ class SubscriptionEndpoint(BaseEndpoint):
         are namespaced (``<namespace>:<...>``); this dispatches on the namespace so adding a new channel type later is
         a one-method change. Callers must have already established an authenticated user with a current workspace.
         """
+        if not isinstance(channel, str):  # malformed payload (e.g. a non-string channel) is just a denial, not a 500
+            return False
+
         namespace, *parts = channel.split(":")
 
         if namespace == "history":
@@ -183,6 +186,9 @@ class SubscriptionEndpoint(BaseEndpoint):
         of who's currently subscribed. Centrifugo OSS has no unsubscribe/disconnect proxy, so the TTL plus periodic
         sub_refresh re-arming is the only reliable way to garbage-collect entries for connections that have gone away.
         """
+        if not isinstance(client, str) or not client:  # nothing useful to index without a connection id
+            return
+
         r = get_valkey_connection()
         now = int(timezone.now().timestamp())
         key = f"subs:{channel}"

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -163,8 +163,9 @@ class SubscriptionEndpoint(BaseEndpoint):
         """
         ``history:<contact-uuid>`` (a contact's history) or ``history:<contact-uuid>:<ticket-uuid>`` (a ticket's
         history). The contact must belong to the workspace and be active; for the ticket form the ticket must in turn
-        belong to that contact and workspace. Every segment is validated as a uuid before it reaches a query, since the
-        uuid columns are ``UUIDField`` and would raise on a malformed value.
+        belong to that contact - and so to the same workspace, since a ticket always shares its contact's org. Every
+        segment is validated as a uuid before it reaches a query, since the uuid columns are ``UUIDField`` and would
+        raise on a malformed value.
         """
         if not (1 <= len(parts) <= 2) or not all(is_uuid(p) for p in parts):
             return False
@@ -176,7 +177,7 @@ class SubscriptionEndpoint(BaseEndpoint):
         if len(parts) == 1:
             return True
 
-        return Ticket.objects.filter(uuid=parts[1], org=org, contact=contact).exists()
+        return Ticket.objects.filter(uuid=parts[1], contact=contact).exists()
 
     def index_subscription(self, channel: str, client: str):
         """

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -17,6 +17,7 @@ isn't the realtime server even if the path is ever reachable - but the secret is
 API off the public internet.
 """
 
+from django_valkey import get_valkey_connection
 from rest_framework.permissions import BasePermission
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -26,10 +27,22 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 
+from temba.tickets.models import Ticket
+from temba.utils.uuid import is_uuid
+
 from ..support import APISessionAuthentication
 
 # how long (seconds) a connection stays valid before the realtime server must re-validate it via the refresh proxy
 CONNECTION_TTL = 5 * 60
+
+# how long (seconds) a channel subscription stays authorized before the realtime server must re-check it via the
+# sub_refresh proxy. A short window keeps the subscription index reasonably fresh without re-checking too often.
+SUBSCRIPTION_WINDOW = 60
+
+# how long (seconds) an entry lives in the valkey subscription index. Comfortably larger than SUBSCRIPTION_WINDOW so an
+# entry survives until the next sub_refresh re-arms it; if refreshes stop (e.g. a dead connection that we never get an
+# unsubscribe for) the entry simply ages out, which is how the index garbage-collects itself.
+SUBSCRIPTION_TTL = 90
 
 
 class WebSocketsSessionAuthentication(APISessionAuthentication):
@@ -116,3 +129,111 @@ class RefreshEndpoint(BaseEndpoint):
             return Response({"result": {"expired": True}})
 
         return Response({"result": {"expire_at": self.expire_at()}})
+
+
+class SubscriptionEndpoint(BaseEndpoint):
+    """
+    Base for the channel-subscription proxies (``subscribe`` and ``sub_refresh``). Both authorize a single
+    client-requested channel against the live Django session - ``request.user`` and ``request.org`` - and, when
+    allowed, record the subscription in a valkey index. The authorization deliberately reads the *current* workspace
+    rather than anything carried on the connection, so access that has been revoked since connect stops working here.
+    """
+
+    def subscription_expire_at(self) -> int:
+        """Unix time at which the realtime server should next re-check this subscription via the sub_refresh proxy."""
+        return int(timezone.now().timestamp()) + SUBSCRIPTION_WINDOW
+
+    def is_allowed(self, request, channel: str) -> bool:
+        """
+        Default-deny authorization of a client-requested channel for the current user's current workspace. Channels
+        are namespaced (``<namespace>:<...>``); this dispatches on the namespace so adding a new channel type later is
+        a one-method change. Callers must have already established an authenticated user with a current workspace.
+        """
+        namespace, *parts = channel.split(":")
+
+        if namespace == "history":
+            return self._history_allowed(request.org, parts)
+
+        return False
+
+    def _history_allowed(self, org, parts: list) -> bool:
+        """
+        ``history:<contact-uuid>`` (a contact's history) or ``history:<contact-uuid>:<ticket-uuid>`` (a ticket's
+        history). The contact must belong to the workspace and be active; for the ticket form the ticket must in turn
+        belong to that contact and workspace. Every segment is validated as a uuid before it reaches a query, since the
+        uuid columns are ``UUIDField`` and would raise on a malformed value.
+        """
+        if not (1 <= len(parts) <= 2) or not all(is_uuid(p) for p in parts):
+            return False
+
+        contact = org.contacts.filter(uuid=parts[0], is_active=True).first()
+        if not contact:
+            return False
+
+        if len(parts) == 1:
+            return True
+
+        return Ticket.objects.filter(uuid=parts[1], org=org, contact=contact).exists()
+
+    def index_subscription(self, channel: str, client: str):
+        """
+        Record (or re-arm) a connection's subscription to a channel in the valkey index, so we can later answer
+        "what/who is subscribed to channel X". The index is a sorted set per channel (key ``subs:<channel>``) whose
+        members are connection ids scored by their expiry; the per-member score gives both lazy pruning and a fast read
+        of who's currently subscribed. Centrifugo OSS has no unsubscribe/disconnect proxy, so the TTL plus periodic
+        sub_refresh re-arming is the only reliable way to garbage-collect entries for connections that have gone away.
+        """
+        r = get_valkey_connection()
+        now = int(timezone.now().timestamp())
+        key = f"subs:{channel}"
+
+        pipe = r.pipeline()
+        pipe.zadd(key, {client: now + SUBSCRIPTION_TTL})
+        pipe.zremrangebyscore(key, 0, now)  # lazily drop members that have already expired
+        pipe.expire(key, SUBSCRIPTION_TTL)  # backstop so the key itself vanishes once nothing re-arms it
+        pipe.execute()
+
+
+class SubscribeEndpoint(SubscriptionEndpoint):
+    """
+    Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a channel. The request
+    body carries the connection's ``client`` id and the requested ``channel``; we authorize that channel against the
+    live session.
+
+    An unauthenticated request is told to disconnect (its connection should never have got this far). Otherwise, if the
+    user has a current workspace and may access the channel, we record the subscription and return an ``expire_at`` so
+    the realtime server schedules a sub_refresh; anything else is refused with a forbidden error, which Centrifugo
+    surfaces to the browser as a failed subscribe without tearing down the whole connection.
+    """
+
+    def post(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
+
+        channel = request.data.get("channel", "")
+        client = request.data.get("client", "")
+
+        if request.org and self.is_allowed(request, channel):
+            self.index_subscription(channel, client)
+            return Response({"result": {"expire_at": self.subscription_expire_at()}})
+
+        return Response({"error": {"code": 403, "message": "forbidden"}})
+
+
+class SubRefreshEndpoint(SubscriptionEndpoint):
+    """
+    Sub refresh proxy called periodically by the realtime messaging server before a subscription's ``expire_at``. We
+    re-run the same authorization as subscribe (access may have been revoked since), and either re-arm the index entry
+    and return a fresh ``expire_at`` or let the subscription expire. Only the ``result`` is acted on for refreshes, so
+    every not-allowed case - including a session that's gone - is reported as expired rather than as a disconnect.
+    """
+
+    def post(self, request, *args, **kwargs):
+        channel = request.data.get("channel", "")
+        client = request.data.get("client", "")
+
+        if request.user.is_authenticated and request.org and self.is_allowed(request, channel):
+            self.index_subscription(channel, client)
+            return Response({"result": {"expire_at": self.subscription_expire_at()}})
+
+        return Response({"result": {"expired": True}})


### PR DESCRIPTION
Builds on the `connect`/`refresh` proxies added in #6677 (now merged to `main`).

Adds two channel-subscription proxy endpoints to the internal `websockets` API, for a Centrifugo real-time messaging server that fronts browser WebSockets. They share `BaseEndpoint` (session auth, the required secret gate, JSON rendering).

## Endpoints

- **`POST /api/websockets/subscribe`** — authorizes a client's request to subscribe to a channel against the *live* session (`request.user` + `request.org`). Unauthenticated → disconnect (`4401`); authorized → records the subscription and returns an `expire_at` so the server schedules a `sub_refresh`; anything else → `403 forbidden`.
- **`POST /api/websockets/sub_refresh`** — re-runs the same authorization periodically (access may have been revoked since subscribe), re-arming the presence key and returning a fresh `expire_at`, or letting the subscription expire (`{"result": {"expired": true}}`).

## Authorization

Default-deny allowlist over the `history` namespace:

- `history:<contact-uuid>` — allowed if the contact belongs to the current workspace and is active.
- `history:<contact-uuid>:<ticket-uuid>` — additionally requires the ticket to belong to that contact.

Every segment is validated as a uuid before it reaches a query. The dispatch lives in a single `is_allowed()` method so adding channel types later is a one-method change. Authorization reads the current workspace, never anything carried on the connection — that's the whole reason this lives here.

## Subscription index

A per-channel **presence key** in valkey (`socket-subs:<channel>` set with a TTL), matching the key name and semantics the consuming service reads (it checks whether a channel has any subscriber with `EXISTS` before bothering to publish that channel's events). Both proxies re-set the key on every subscribe/refresh, so it stays present while some subscriber keeps refreshing and expires once the last one stops. Since the messaging server (OSS) has no unsubscribe/disconnect callback, this TTL is the only garbage collection — it's set comfortably above the refresh window to survive the server's refresh delay.

## Tests

Covers allowed contact- and ticket-history; the full set of deny cases (other workspace, not found, ticket not belonging to the contact, malformed uuid, wrong arity, unknown namespace, non-string channel, inactive contact, no current workspace); unauthenticated → disconnect; and the presence key being written on an allowed subscribe (and not on a denied one) and its TTL re-armed on `sub_refresh`.