### PR TITLE
Authorize ticket history subscriptions by team topic access

### DIFF
--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -7,7 +7,9 @@ from django.utils import timezone
 from temba.api.checks import websockets_auth_secret
 from temba.api.tests.mixins import APITestMixin
 from temba.api.websockets.views import SUBSCRIPTION_TTL
+from temba.orgs.models import OrgRole
 from temba.tests import TembaTest
+from temba.tickets.models import Team, Topic
 from temba.utils.uuid import uuid4
 
 SECRET = "topsecret"
@@ -185,6 +187,52 @@ class EndpointsTest(APITestMixin, TembaTest):
         response = subscribe(f"history:{contact.uuid}")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+    def test_subscribe_ticket_topic_access(self):
+        # an agent restricted to a team's topics can only watch the history of tickets they're allowed to view - the
+        # same scoping the ticketing UI applies, not just "the ticket exists for this contact"
+        sales = Topic.create(self.org, self.admin, "Sales")
+        support = Topic.create(self.org, self.admin, "Support")
+        sales_team = Team.create(self.org, self.admin, "Sales Team", topics=[sales])
+        self.org.add_user(self.agent, OrgRole.AGENT, team=sales_team)
+
+        contact = self.create_contact("Ann", phone="+1234", org=self.org)
+        sales_ticket = self.create_ticket(contact, topic=sales)
+        support_ticket = self.create_ticket(contact, topic=support)
+        assigned_ticket = self.create_ticket(contact, topic=support, assignee=self.agent)
+
+        def subscribe(channel, *, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+
+        def assertAllowed(channel):
+            response = subscribe(channel)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        def assertForbidden(channel):
+            response = subscribe(channel)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+
+        self.login(self.agent)
+
+        # the contact's own history is still allowed (not topic-scoped)
+        assertAllowed(f"history:{contact.uuid}")
+
+        # a ticket in the agent's team topic is allowed
+        assertAllowed(f"history:{contact.uuid}:{sales_ticket.uuid}")
+
+        # a ticket assigned to the agent is allowed even though its topic is outside their team
+        assertAllowed(f"history:{contact.uuid}:{assigned_ticket.uuid}")
+
+        # a ticket in a topic outside the agent's team and not assigned to them is forbidden
+        assertForbidden(f"history:{contact.uuid}:{support_ticket.uuid}")
+
+        # an admin (no team restriction) can watch any of the workspace's tickets
+        self.login(self.admin)
+        assertAllowed(f"history:{contact.uuid}:{sales_ticket.uuid}")
+        assertAllowed(f"history:{contact.uuid}:{support_ticket.uuid}")
+        assertAllowed(f"history:{contact.uuid}:{assigned_ticket.uuid}")
 
     def test_sub_refresh(self):
         contact = self.create_contact("Ann", phone="+1234", org=self.org)

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -214,6 +214,9 @@ class EndpointsTest(APITestMixin, TembaTest):
             self.assertEqual(200, response.status_code)
             self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
 
+        def sub_refresh(channel, *, client="conn-1"):
+            return self.post("api.websockets.sub_refresh", {"channel": channel, "client": client})
+
         self.login(self.agent)
 
         # the contact's own history is still allowed (not topic-scoped)
@@ -227,6 +230,17 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         # a ticket in a topic outside the agent's team and not assigned to them is forbidden
         assertForbidden(f"history:{contact.uuid}:{support_ticket.uuid}")
+
+        # sub_refresh applies the same topic scoping: a foreign-topic ticket the agent can't view expires rather than
+        # being re-armed, so losing access (or never having had it) tears the subscription down on the next refresh
+        response = sub_refresh(f"history:{contact.uuid}:{support_ticket.uuid}")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+        # while a ticket the agent can view is re-armed with a fresh expiry
+        response = sub_refresh(f"history:{contact.uuid}:{sales_ticket.uuid}")
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
 
         # an admin (no team restriction) can watch any of the workspace's tickets
         self.login(self.admin)

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -157,21 +157,24 @@ class SubscriptionEndpoint(BaseEndpoint):
         namespace, *parts = channel.split(":")
 
         if namespace == "history":
-            return self._history_allowed(request.org, parts)
+            return self._history_allowed(request, parts)
 
         return False
 
-    def _history_allowed(self, org, parts: list) -> bool:
+    def _history_allowed(self, request, parts: list) -> bool:
         """
         ``history:<contact-uuid>`` (a contact's history) or ``history:<contact-uuid>:<ticket-uuid>`` (a ticket's
-        history). The contact must belong to the workspace and be active; for the ticket form the ticket must in turn
-        belong to that contact - and so to the same workspace, since a ticket always shares its contact's org. Every
-        segment is validated as a uuid before it reaches a query, since the uuid columns are ``UUIDField`` and would
-        raise on a malformed value.
+        history). The contact must belong to the workspace and be active. For the ticket form the ticket must in turn
+        belong to that contact - and so to the same workspace, since a ticket always shares its contact's org - and the
+        user must actually be allowed to view it: an agent on a topic-restricted team can only see tickets in their
+        team's topics (plus any assigned to them), exactly as the ticketing UI scopes them, so we authorize through
+        ``Ticket.get_accessible`` rather than just checking the ticket exists. Every segment is validated as a uuid
+        before it reaches a query, since the uuid columns are ``UUIDField`` and would raise on a malformed value.
         """
         if not (1 <= len(parts) <= 2) or not all(is_uuid(p) for p in parts):
             return False
 
+        org = request.org
         contact = org.contacts.filter(uuid=parts[0], is_active=True).first()
         if not contact:
             return False
@@ -179,7 +182,7 @@ class SubscriptionEndpoint(BaseEndpoint):
         if len(parts) == 1:
             return True
 
-        return Ticket.objects.filter(uuid=parts[1], contact=contact).exists()
+        return Ticket.get_accessible(org, request.user).filter(uuid=parts[1], contact=contact).exists()
 
     def record_subscription(self, channel: str):
         """

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -85,17 +85,32 @@ class Topic(TembaModel, DependencyMixin):
         return cls.create(org, user, definition["name"])
 
     @classmethod
+    def get_restriction(cls, org, user):
+        """
+        Returns the topics the given user is restricted to in the org, or None if they can access all of the org's
+        topics. Staff and members whose team grants all topics are unrestricted; a member on a topic-limited team is
+        restricted to that team's topics; a user with no membership in the org can access nothing. This is the single
+        source of truth for team topic access, shared by everything that scopes topics or tickets to a user.
+        """
+        if user.is_staff:
+            return None
+
+        membership = org.get_membership(user)
+        if not membership:
+            return cls.objects.none()
+
+        if membership.team and not membership.team.all_topics:
+            return membership.team.topics.all()
+
+        return None
+
+    @classmethod
     def get_accessible(cls, org, user):
         """
         Gets the topics accessible to the given user in the given org.
         """
-
-        if not user.is_staff:
-            membership = org.get_membership(user)
-            if membership.team and not membership.team.all_topics:
-                return membership.team.topics.all()
-
-        return org.topics.filter(is_active=True)
+        restricted = cls.get_restriction(org, user)
+        return org.topics.filter(is_active=True) if restricted is None else restricted
 
     def release(self, user):
         assert not (self.is_system and self.org.is_active), "can't release system topics"
@@ -256,20 +271,14 @@ class Ticket(models.Model):
         Gets the tickets in the org that the given user is allowed to view. This mirrors what the ticketing UI exposes:
         the union of the Mine and All folders. Staff and users whose team grants all topics can view every ticket;
         an agent on a topic-restricted team can view tickets in their team's topics plus any assigned to them (they can
-        always see their own tickets even in topics they otherwise lack access to). A non-staff user with no membership
-        in the org can view nothing - we fail closed rather than exposing the whole workspace.
+        always see their own tickets even in topics they otherwise lack access to). A user with no membership in the org
+        can view nothing - we fail closed rather than exposing the whole workspace.
         """
         qs = org.tickets.all()
 
-        if user.is_staff:
-            return qs
-
-        membership = org.get_membership(user)
-        if not membership:
-            return qs.none()
-
-        if membership.team and not membership.team.all_topics:
-            qs = qs.filter(Q(assignee=user) | Q(topic__in=membership.team.topics.all()))
+        restricted = Topic.get_restriction(org, user)
+        if restricted is not None:
+            qs = qs.filter(Q(assignee=user) | Q(topic__in=restricted))
 
         return qs
 
@@ -337,10 +346,10 @@ class TicketFolder(metaclass=ABCMeta):
     def get_queryset(self, org, user, *, ordered: bool):
         qs = org.tickets.all()
 
-        if self.restrict_topics and not user.is_staff:
-            membership = org.get_membership(user)
-            if membership.team and not membership.team.all_topics:
-                qs = qs.filter(topic__in=list(membership.team.topics.all()))
+        if self.restrict_topics:
+            restricted = Topic.get_restriction(org, user)
+            if restricted is not None:
+                qs = qs.filter(topic__in=restricted)
 
         if ordered:
             qs = qs.order_by("-last_activity_on", "-id")

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -256,14 +256,20 @@ class Ticket(models.Model):
         Gets the tickets in the org that the given user is allowed to view. This mirrors what the ticketing UI exposes:
         the union of the Mine and All folders. Staff and users whose team grants all topics can view every ticket;
         an agent on a topic-restricted team can view tickets in their team's topics plus any assigned to them (they can
-        always see their own tickets even in topics they otherwise lack access to).
+        always see their own tickets even in topics they otherwise lack access to). A non-staff user with no membership
+        in the org can view nothing - we fail closed rather than exposing the whole workspace.
         """
         qs = org.tickets.all()
 
-        if not user.is_staff:
-            membership = org.get_membership(user)
-            if membership and membership.team and not membership.team.all_topics:
-                qs = qs.filter(Q(assignee=user) | Q(topic__in=membership.team.topics.all()))
+        if user.is_staff:
+            return qs
+
+        membership = org.get_membership(user)
+        if not membership:
+            return qs.none()
+
+        if membership.team and not membership.team.all_topics:
+            qs = qs.filter(Q(assignee=user) | Q(topic__in=membership.team.topics.all()))
 
         return qs
 

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -251,6 +251,23 @@ class Ticket(models.Model):
         return resp.get("changed_uuids", [])
 
     @classmethod
+    def get_accessible(cls, org, user):
+        """
+        Gets the tickets in the org that the given user is allowed to view. This mirrors what the ticketing UI exposes:
+        the union of the Mine and All folders. Staff and users whose team grants all topics can view every ticket;
+        an agent on a topic-restricted team can view tickets in their team's topics plus any assigned to them (they can
+        always see their own tickets even in topics they otherwise lack access to).
+        """
+        qs = org.tickets.all()
+
+        if not user.is_staff:
+            membership = org.get_membership(user)
+            if membership and membership.team and not membership.team.all_topics:
+                qs = qs.filter(Q(assignee=user) | Q(topic__in=membership.team.topics.all()))
+
+        return qs
+
+    @classmethod
     def get_assignee_count(cls, org, user, topics, status: str) -> int:
         """
         Gets the count of tickets assigned to the given user across the given topics and status.

--- a/temba/tickets/tests/test_ticket.py
+++ b/temba/tickets/tests/test_ticket.py
@@ -61,6 +61,29 @@ class TicketTest(TembaTest):
 
         self.assertEqual([call(self.org, self.admin, [ticket], via="ui")], mr_mocks.calls["ticket_reopen"])
 
+    def test_get_accessible(self):
+        sales = Topic.create(self.org, self.admin, "Sales")
+        support = Topic.create(self.org, self.admin, "Support")
+        sales_team = Team.create(self.org, self.admin, "Sales Team", topics=[sales])
+        agent2 = self.create_user("agent2@textit.com")
+        self.org.add_user(agent2, OrgRole.AGENT, team=sales_team)
+
+        contact = self.create_contact("Ann", urns=["twitter:annie"])
+        general_ticket = self.create_ticket(contact, topic=self.org.default_topic)
+        sales_ticket = self.create_ticket(contact, topic=sales)
+        support_ticket = self.create_ticket(contact, topic=support)
+        assigned_ticket = self.create_ticket(contact, topic=support, assignee=agent2)
+
+        all_tickets = {general_ticket, sales_ticket, support_ticket, assigned_ticket}
+
+        # staff, admins and agents on a team with all topics can view every ticket
+        self.assertEqual(all_tickets, set(Ticket.get_accessible(self.org, self.customer_support)))
+        self.assertEqual(all_tickets, set(Ticket.get_accessible(self.org, self.admin)))
+        self.assertEqual(all_tickets, set(Ticket.get_accessible(self.org, self.agent)))
+
+        # an agent on a topic-restricted team only sees tickets in their topics, plus any assigned to them
+        self.assertEqual({sales_ticket, assigned_ticket}, set(Ticket.get_accessible(self.org, agent2)))
+
     @mock_mailroom
     def test_counts(self, mr_mocks):
         general = self.org.default_topic

--- a/temba/tickets/tests/test_ticket.py
+++ b/temba/tickets/tests/test_ticket.py
@@ -84,6 +84,9 @@ class TicketTest(TembaTest):
         # an agent on a topic-restricted team only sees tickets in their topics, plus any assigned to them
         self.assertEqual({sales_ticket, assigned_ticket}, set(Ticket.get_accessible(self.org, agent2)))
 
+        # a non-staff user with no membership in the org sees nothing (fails closed)
+        self.assertEqual(set(), set(Ticket.get_accessible(self.org, self.admin2)))
+
     @mock_mailroom
     def test_counts(self, mr_mocks):
         general = self.org.default_topic


### PR DESCRIPTION
## What

The channel-subscription proxy that authorizes realtime `history:<contact-uuid>:<ticket-uuid>` subscriptions only checked that the ticket belonged to the named contact (and so to the workspace). It did not consider whether the requesting user was actually allowed to *view* that ticket.

For an agent on a topic-restricted team this is a gap: such a user could subscribe to the realtime history of a ticket in a topic outside their team — and so receive its events — simply by knowing the contact and ticket UUIDs, even though the ticketing UI would never let them open it.

## Changes

- Add `Ticket.get_accessible(org, user)` — a queryset of the tickets a user may view, mirroring what the ticketing UI exposes (the union of the Mine and All folders): staff and users whose team grants all topics see every ticket; an agent on a topic-restricted team sees tickets in their team's topics plus any assigned to them (they can always see their own tickets, even in topics they otherwise lack access to). This is the ticket-level analogue of the existing `Topic.get_accessible`.
- Authorize the ticket form of the `history` channel through `Ticket.get_accessible` instead of a bare existence check. Both `subscribe` and `sub_refresh` route through the same authorization, so a restricted user is denied at subscribe time and any later loss of access tears the subscription down on the next refresh.
- The contact-only form (`history:<contact-uuid>`) is unchanged.

## Notes for reviewers

- No schema changes (`get_accessible` is a new classmethod; `makemigrations --check` is clean).
- New tests cover the authorization at both the endpoint level (`test_subscribe_ticket_topic_access`) and the model level (`Ticket.get_accessible`): agent allowed for their team's topic, allowed for a ticket assigned to them in a foreign topic, forbidden for an unassigned foreign-topic ticket, and admin/staff unrestricted.