### PR TITLE
Update @nyaruka/temba-components to 0.159.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.159.4",
+    "@nyaruka/temba-components": "0.159.6",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nyaruka/temba-components@0.159.4":
-  version "0.159.4"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.159.4.tgz#e95452ca6726f09d77332df26359faac25395e9c"
-  integrity sha512-mKR/LXJrM/7xQtuaWVMbx/EJwDteJBWsxS1i20U3u9csdJDNKDrbfIkowEQ6r1Q2LfPrvtPTKid8Hyd5jRTQcw==
+"@nyaruka/temba-components@0.159.6":
+  version "0.159.6"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.159.6.tgz#06b085ec92338e64714754ad841055bb514d5951"
+  integrity sha512-gmSEU2oQI4TMe9LL3JhcLuAc4d9kYvEgEHcUti1hVdr5RcFpy8LiyUwJ7/7UR7W0zqRaTyXu3qcMJEvzdd4+sA==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.159.6](https://github.com/nyaruka/temba-components/compare/v0.159.4...v0.159.6)

- Promote a fully-translated language to a flow's default [#1033](https://github.com/nyaruka/temba-components/pull/1033)
- Add label-create affordance to ContentList label dropdown [#1031](https://github.com/nyaruka/temba-components/pull/1031)
- Fix empty contact fields tab from definition/data load race [#1032](https://github.com/nyaruka/temba-components/pull/1032)
- Refine flow list: inline type icons, drop status column, sparkline fixtures [#1030](https://github.com/nyaruka/temba-components/pull/1030)