### PR TITLE
Authorize notifications channel subscriptions via the subscribe proxy

### DIFF
--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -25,11 +25,12 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertIsInstance(expire_at, int)
         self.assertGreater(expire_at, int(timezone.now().timestamp()))
 
-    def assertConnect(self, response, *, user, channels, meta):
+    def assertConnect(self, response, *, user, meta):
         self.assertEqual(200, response.status_code)
         result = response.json()["result"]
         self.assertExpiry(result.pop("expire_at"))
-        self.assertEqual({"user": str(user.uuid), "channels": channels, "meta": meta}, result)
+        # connect attaches no server-side channels - the browser subscribes to what it wants itself
+        self.assertEqual({"user": str(user.uuid), "channels": [], "meta": meta}, result)
 
     def test_connect(self):
         endpoint_url = reverse("api.websockets.connect")
@@ -38,13 +39,12 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.login(self.admin)
         self.assertEqual(405, self.client.get(endpoint_url, HTTP_X_WEBSOCKETS_SECRET=SECRET).status_code)
 
-        # an authenticated user is subscribed to their notifications channel for their current workspace (scoped by
-        # both org uuid and user uuid), and their identity is attached to the connection meta
+        # an authenticated user gets no server-side channels (the browser subscribes to its own notifications and any
+        # history channels itself), but their identity is attached to the connection meta
         self.login(self.admin)
         self.assertConnect(
             self.post("api.websockets.connect"),
             user=self.admin,
-            channels=[f"notifications:{self.org.uuid}:{self.admin.uuid}"],
             meta={
                 "user_id": self.admin.id,
                 "user_uuid": str(self.admin.uuid),
@@ -53,12 +53,11 @@ class EndpointsTest(APITestMixin, TembaTest):
             },
         )
 
-        # scoped per (org, user) - a different user in a different workspace gets their own channel and meta
+        # meta is scoped per (org, user) - a different user in a different workspace gets their own identity
         self.login(self.admin2, choose_org=self.org2)
         self.assertConnect(
             self.post("api.websockets.connect"),
             user=self.admin2,
-            channels=[f"notifications:{self.org2.uuid}:{self.admin2.uuid}"],
             meta={
                 "user_id": self.admin2.id,
                 "user_uuid": str(self.admin2.uuid),
@@ -91,7 +90,6 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertConnect(
             self.post("api.websockets.connect", client=csrf_client),
             user=self.admin,
-            channels=[f"notifications:{self.org.uuid}:{self.admin.uuid}"],
             meta={
                 "user_id": self.admin.id,
                 "user_uuid": str(self.admin.uuid),
@@ -165,9 +163,6 @@ class EndpointsTest(APITestMixin, TembaTest):
         assertForbidden(f"history:{contact.uuid}:{ticket.uuid}:extra")  # too many segments
         assertForbidden("history")  # too few segments
         assertForbidden(f"presence:{contact.uuid}")  # unknown namespace
-        assertForbidden(
-            f"notifications:{self.org.uuid}:{self.admin.uuid}"
-        )  # server-side namespace, never via this proxy
 
         # an inactive contact is denied
         contact.is_active = False
@@ -187,6 +182,41 @@ class EndpointsTest(APITestMixin, TembaTest):
         response = subscribe(f"history:{contact.uuid}")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
+
+    def test_subscribe_notifications(self):
+        def subscribe(channel, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+
+        def assertAllowed(channel):
+            response = subscribe(channel)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        def assertForbidden(channel):
+            response = subscribe(channel)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+
+        self.login(self.admin)
+
+        # a user may watch their own notifications channel for their current workspace
+        assertAllowed(f"notifications:{self.org.uuid}:{self.admin.uuid}")
+
+        # but not another user's, even in the same workspace
+        assertForbidden(f"notifications:{self.org.uuid}:{self.editor.uuid}")
+
+        # nor their own notifications in a workspace that isn't their current one
+        assertForbidden(f"notifications:{self.org2.uuid}:{self.admin.uuid}")
+
+        # malformed: too few or too many segments
+        assertForbidden(f"notifications:{self.org.uuid}")
+        assertForbidden(f"notifications:{self.org.uuid}:{self.admin.uuid}:extra")
+
+        # a user with no current workspace is forbidden (request.org is None)
+        session = self.client.session
+        del session["org_id"]
+        session.save()
+        assertForbidden(f"notifications:{self.org.uuid}:{self.admin.uuid}")
 
     def test_subscribe_ticket_topic_access(self):
         # an agent restricted to a team's topics can only watch the history of tickets they're allowed to view - the

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -93,8 +93,9 @@ class ConnectEndpoint(BaseEndpoint):
 
     On success the result carries:
       * ``user`` - the user identifier (uuid);
-      * ``channels`` - the server-side channels to subscribe the connection to: a single
-        ``notifications:<org-uuid>:<user-uuid>`` for the user's current workspace;
+      * ``channels`` - empty: there are no server-side channels. The browser subscribes to everything it wants - its
+        own ``notifications:<org-uuid>:<user-uuid>`` channel and any contact/ticket ``history`` channels - through the
+        subscribe proxy, which authorizes each one against the live session;
       * ``meta`` - the user's identity (uuids and ids) attached to the connection so the subscription-authorization
         proxies can act on it without re-reading the session; ``meta`` is server-side only and never sent to the browser;
       * ``expire_at`` - when the realtime server should next call the refresh proxy to re-validate the connection.
@@ -110,10 +111,9 @@ class ConnectEndpoint(BaseEndpoint):
 
         org = request.org
         meta = {"user_id": user.id, "user_uuid": str(user.uuid), "org_id": org.id, "org_uuid": str(org.uuid)}
-        channels = [f"notifications:{org.uuid}:{user.uuid}"]
 
         return Response(
-            {"result": {"user": str(user.uuid), "channels": channels, "meta": meta, "expire_at": self.expire_at()}}
+            {"result": {"user": str(user.uuid), "channels": [], "meta": meta, "expire_at": self.expire_at()}}
         )
 
 
@@ -156,10 +156,21 @@ class SubscriptionEndpoint(BaseEndpoint):
 
         namespace, *parts = channel.split(":")
 
+        if namespace == "notifications":
+            return self._notifications_allowed(request, parts)
         if namespace == "history":
             return self._history_allowed(request, parts)
 
         return False
+
+    def _notifications_allowed(self, request, parts: list) -> bool:
+        """
+        ``notifications:<org-uuid>:<user-uuid>`` - a user's own notifications in their current workspace. There's
+        nothing to look up: a user may watch exactly the channel scoped to their current org and their own uuid, so we
+        just match the requested segments against the live session rather than touching the database. Any other shape -
+        a different user, a different workspace, or the wrong number of segments - simply fails the equality check.
+        """
+        return parts == [str(request.org.uuid), str(request.user.uuid)]
 
     def _history_allowed(self, request, parts: list) -> bool:
         """


### PR DESCRIPTION
## What

Make the per-user `notifications:<org-uuid>:<user-uuid>` channel a **client subscription** (authorized through the subscribe proxy) instead of a server-side channel attached at connect.

## Why

Centrifugo channels here come in two flavours:

- **server-side** — listed in the `connect` result, auto-subscribed by the realtime server. These never hit the `subscribe`/`sub_refresh` proxies, so there's no natural place to record subscription presence.
- **client** (`history:`) — the browser subscribes explicitly, so they flow through `subscribe`/`sub_refresh`, get authorized against the live session, and record presence in the `socket-subs:` valkey index for free.

The notifications channel was server-side, so to track its presence (needed so a publisher can skip publishing when nobody's connected) it would have required a parallel presence mechanism driven off the connection lifecycle, with its own longer TTL and re-arm logic. Treating it as a client subscription instead reuses the history path verbatim — one uniform presence mechanism, finer granularity (60s window / 150s TTL), and authorization re-checked on every `sub_refresh`. Nothing downstream depends on the server-side channel yet (the browser-side Centrifugo client isn't built), so this is the cheapest time to change it.

## How

- `connect` no longer attaches a server-side channel — it returns `channels: []`. It still authenticates and attaches `meta`.
- `is_allowed` gains a `notifications` namespace branch. Authorization is a pure session match — a user may subscribe to exactly `notifications:<current-org-uuid>:<own-user-uuid>` — so it needs no database query. Any other user, workspace, or segment count is denied.
- Presence falls out of the existing `record_subscription` call on `subscribe`/`sub_refresh`, writing the same `socket-subs:<channel>` key the history channels use.

The publisher contract is therefore unchanged: `EXISTS socket-subs:notifications:<org-uuid>:<user-uuid>` before publishing.

## Notes for reviewers

- The (future) browser client must subscribe to its own `notifications:<org-uuid>:<user-uuid>` channel — it already needs explicit subscribe logic for `history:`, so this is marginal.
- Workspace switching is handled naturally: the client re-subscribes to the new workspace's channel; the old one's `sub_refresh` is denied (org no longer matches) and lapses.

## Testing

- `test_connect` updated — `connect` returns no server-side channels.
- Added `test_subscribe_notifications` — own channel allowed; another user, another workspace, malformed segments, and no-current-workspace all denied.
- All websockets tests pass; ruff format/lint clean; no model changes (no migration).