### PR TITLE
Use django.conf.settings; drop the implicit settings_local dev override

### DIFF
--- a/temba/public/sitemaps.py
+++ b/temba/public/sitemaps.py
@@ -1,7 +1,6 @@
+from django.conf import settings
 from django.contrib.sitemaps import Sitemap
 from django.urls import reverse
-
-from temba.settings import SITEMAP
 
 
 class PublicViewSitemap(Sitemap):
@@ -9,7 +8,7 @@ class PublicViewSitemap(Sitemap):
     changefreq = "daily"
 
     def items(self):
-        return SITEMAP
+        return settings.SITEMAP
 
     def location(self, item):
         return reverse(item)

--- a/temba/public/urls.py
+++ b/temba/public/urls.py
@@ -1,8 +1,7 @@
+from django.conf import settings
 from django.contrib.sitemaps.views import sitemap
 from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
-
-from temba.settings import DEBUG
 
 from .sitemaps import PublicViewSitemap
 from .views import Android, DemoGenerateCoupon, DemoOrderStatus, Forgetme, IndexView, Style, Welcome, WelcomeRedirect
@@ -20,5 +19,5 @@ urlpatterns = [
     re_path(r"^demo/coupon/$", csrf_exempt(DemoGenerateCoupon.as_view()), {}, "demo.generate_coupon"),
 ]
 
-if DEBUG:  # pragma: needs cover
+if settings.DEBUG:  # pragma: needs cover
     urlpatterns.append(re_path(r"^style/$", Style.as_view(), {}, "public.public_style"))

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timezone as tzone
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.utils import timezone
 
-from temba import settings
 from temba.msgs.models import Broadcast, Media
 from temba.tests import TembaTest
 from temba.utils.compose import compose_deserialize_attachments

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -57,12 +57,3 @@ warnings.filterwarnings(
 # Make our sitestatic URL be our static URL on development
 # -----------------------------------------------------------------------------------
 STATIC_URL = "/static/"
-
-# -----------------------------------------------------------------------------------
-# Optional local overrides — create temba/settings_local.py to override settings
-# without modifying this checked-in file. settings_local.py is gitignored.
-# -----------------------------------------------------------------------------------
-try:
-    from .settings_local import *  # noqa
-except ImportError:
-    pass


### PR DESCRIPTION
Two related settings-configuration cleanups, both pushing toward selecting/configuring settings explicitly via `DJANGO_SETTINGS_MODULE` rather than relying on the settings module's name or contents.

**1. Use `django.conf.settings` instead of importing the settings module by name**

A few modules read values straight from the settings module (`from temba.settings import ...` / `from temba import settings`) rather than through `django.conf.settings`. That bypasses `DJANGO_SETTINGS_MODULE` and forces the active settings to live at `temba/settings.py`, so configurations that point `DJANGO_SETTINGS_MODULE` at a different module don't work.

- `temba/public/urls.py` (`DEBUG`)
- `temba/public/sitemaps.py` (`SITEMAP`)
- `temba/schedules/tests.py` (`MEDIA_ROOT`)

**2. Drop the implicit `settings_local` override from the sample dev settings**

`temba/settings.py.dev` ended with a guarded `from .settings_local import *`. Local configuration should be done by pointing `DJANGO_SETTINGS_MODULE` at a custom settings module, rather than relying on an implicit import of a gitignored file. The import was optional (wrapped in `try/except ImportError`), so removing it is a no-op for any checkout without a `settings_local.py`.