### PR TITLE
Mock the flow_change_language mailroom endpoint in tests

### DIFF
--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1880,12 +1880,25 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(400, response.status_code)
         self.assertEqual("Flow is already in this language.", response.json()["description"])
 
-        # changing to a valid language switches the base language and saves a new revision
+        # changing to a valid language switches the base language and saves a new revision. mailroom does the actual
+        # re-basing of the definition so we just mock the definition it returns.
+        changed_def = flow.get_definition()
+        changed_def["language"] = "spa"
+        changed_def["localization"]["eng"] = {}
+        changed_def["nodes"][0]["actions"][0]["text"] = "¿Cuál es tu color favorito?"
+        mr_mocks.flow_change_language(changed_def)
+
         response = self.client.post(change_url, {"language": "spa"}, content_type="application/json")
         self.assertEqual(200, response.status_code)
         self.assertEqual("success", response.json()["status"])
         self.assertEqual(flow.revisions.order_by("-revision").first().revision, response.json()["revision"]["revision"])
 
+        # the flow's current (base-language English) definition was sent to mailroom along with the target language
+        passed_def, passed_lang = mr_mocks.calls["flow_change_language"][-1].args
+        self.assertEqual("eng", passed_def["language"])
+        self.assertEqual("spa", passed_lang)
+
+        # the re-based definition mailroom returned is what we saved
         flow_def = flow.get_definition()
         self.assertEqual("spa", flow_def["language"])
         self.assertIn("eng", flow_def["localization"])
@@ -1910,6 +1923,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual("Invalid request.", response.json()["description"])
 
         # a version conflict whilst saving the new revision is converted to an error response
+        mr_mocks.flow_change_language(flow.get_definition())
         with patch("temba.flows.models.Flow.save_revision") as mock_save_revision:
             mock_save_revision.side_effect = FlowVersionConflictException(13)
             response = self.client.post(change_url, {"language": "ara"}, content_type="application/json")
@@ -1925,6 +1939,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
         # a user conflict whilst saving the new revision is converted to an error response
+        mr_mocks.flow_change_language(flow.get_definition())
         with patch("temba.flows.models.Flow.save_revision") as mock_save_revision:
             mock_save_revision.side_effect = FlowUserConflictException("Jim", None)
             response = self.client.post(change_url, {"language": "ara"}, content_type="application/json")

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -159,10 +159,23 @@ def _client_method(func):
 
 
 class TestClient(MailroomClient):
+    # endpoints that TestClient intentionally proxies to a real mailroom rather than faking. flow/migrate is
+    # still real because fixtures below the current spec version need actually migrating (see flow_migrate).
+    ALLOWED_LIVE_ENDPOINTS = {"flow/migrate"}
+
     def __init__(self, mocks: Mocks):
         self.mocks = mocks
 
         super().__init__(settings.MAILROOM_URL, settings.MAILROOM_AUTH_TOKEN)
+
+    def _request(self, endpoint, *args, **kwargs):
+        # reaching the real HTTP client means an endpoint isn't faked above and the test is silently
+        # depending on a live mailroom - fail loudly instead so it gets a fake or an explicit mock
+        assert endpoint in self.ALLOWED_LIVE_ENDPOINTS, (
+            f"test reached un-mocked mailroom endpoint /mi/{endpoint} via the real client; "
+            f"add a fake to TestClient or mock the call"
+        )
+        return super()._request(endpoint, *args, **kwargs)
 
     @_client_method
     def android_event(self, org, channel, phone: str, event_type: str, extra: dict, occurred_on):

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -61,6 +61,7 @@ class Mocks:
         self._contact_parse_query = {}
         self._contact_search = {}
         self._contact_urns = []
+        self._flow_change_language = []
         self._flow_inspect = []
         self._flow_start_preview = []
         self._llm_translate = []
@@ -96,6 +97,13 @@ class Mocks:
 
     def contact_urns(self, urns: dict):
         self._contact_urns.append(urns)
+
+    def flow_change_language(self, definition: dict):
+        """
+        Queues the re-based definition that mailroom should return for the next flow_change_language call.
+        """
+
+        self._flow_change_language.append(definition)
 
     def flow_inspect(self, *, dependencies=(), issues=(), results=(), parent_refs=(), counts=None, locals=None):
         self._flow_inspect.append(
@@ -333,6 +341,11 @@ class TestClient(MailroomClient):
                     results[i].contact_id = result
 
         return results
+
+    @_client_method
+    def flow_change_language(self, definition: dict, language):
+        assert self.mocks._flow_change_language, "missing flow_change_language mock"
+        return self.mocks._flow_change_language.pop(0)
 
     @_client_method
     def flow_clone(self, definition: dict, dependency_mapping):


### PR DESCRIPTION
Tests that change a flow's base language were hitting a **live mailroom** instance. `TestClient` (the in-test mailroom fake) reimplements each endpoint in Python, but `flow_change_language` was never overridden, so it fell through to the real `MailroomClient` and made an HTTP call to mailroom.

### Fake the endpoint
- `Mocks.flow_change_language(definition)` queues the re-based definition mailroom should return.
- `TestClient.flow_change_language` returns that queued value instead of calling the real endpoint.

`test_change_language` is rewritten to register the returned definition via the mock and assert the view's own responsibilities — that it passes the flow's current definition and target language to mailroom, saves the returned definition as a new revision, and handles the validation / version-conflict / user-conflict / request-failure error paths. The actual re-basing of the definition is mailroom's job and is already covered by the client unit test.

### Catch this class of bug going forward
`TestClient` inherited the real client's `_request`, so *any* endpoint it doesn't fake silently fell through to a live mailroom call — exactly how `flow_change_language` slipped through. `TestClient._request` now asserts the endpoint is in an explicit allow-set and otherwise raises a clear error pointing at the missing fake.

`flow/migrate` is the one whitelisted endpoint: fixtures below the current spec version still need real migration, so that's deferred to a separate change (either keeping fixtures at the current spec version, or faking migration).

After this, flow migration is the only endpoint in the test suite that still reaches a live mailroom.