### PR TITLE
Guard tests against reaching a live mailroom via the production client

### DIFF
--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -564,7 +564,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         flow.refresh_from_db()
         self.assertEqual("New Name", flow.name)
 
-    def test_list_views(self):
+    @mock_mailroom
+    def test_list_views(self, mr_mocks):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
 

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -503,6 +503,19 @@ class MailroomClientTest(TembaTest):
         )
         self.assertEqual({"org_id": self.org.id, "flow": flow_def, "is_import": False}, json.loads(call[1]["data"]))
 
+    @patch("requests.post")
+    def test_flow_interrupt(self, mock_post):
+        flow = Flow.create(self.org, self.admin, "Flow")
+
+        mock_post.return_value = MockJsonResponse(200, {"sessions": 3})
+        self.client.flow_interrupt(self.org, flow)
+
+        mock_post.assert_called_once_with(
+            "http://localhost:8090/mi/flow/interrupt",
+            headers={"User-Agent": "Temba", "Authorization": "Token sesame"},
+            json={"org_id": self.org.id, "flow_id": flow.id},
+        )
+
     def test_flow_migrate(self):
         flow_def = {"nodes": [{"val": Decimal("1.23")}]}
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -44,6 +44,7 @@ from .mailroom import (
     create_broadcast,
     create_contact_locally,
     create_flowstart,
+    install_mailroom_guard,
     resolve_destination,
     update_field_locally,
 )
@@ -59,6 +60,9 @@ class TembaTest(SmartminTest):
 
     def setUp(self):
         super().setUp()
+
+        # fail loudly if a test reaches a live mailroom instead of mocking it
+        install_mailroom_guard(self)
 
         self.superuser = User.objects.create_user("super@user.com", self.default_password, is_superuser=True)
 

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -4,8 +4,9 @@ from collections import defaultdict
 from dataclasses import asdict
 from decimal import Decimal
 from functools import wraps
-from unittest.mock import call, patch
+from unittest.mock import NonCallableMock, call, patch
 
+import requests
 from packaging.version import Version
 
 from django.conf import settings
@@ -33,6 +34,38 @@ event_units = {
     CampaignEvent.UNIT_DAYS: "days",
     CampaignEvent.UNIT_WEEKS: "weeks",
 }
+
+# endpoints still allowed to reach a live mailroom during tests. these exercise goflow logic (flow migration and
+# dependency inspection) that we don't reimplement in TestClient, so the tests that need them talk to a real
+# mailroom for now - everything else must be faked via @mock_mailroom or mocked at the transport.
+LIVE_TEST_ENDPOINTS = {"flow/migrate", "flow/inspect", "flow/clone"}
+
+_real_mailroom_request = MailroomClient._request
+
+
+def _guarded_mailroom_request(self, endpoint, payload=None, files=None, post=True, encode_json=False):
+    # a patched transport (e.g. patch("requests.post")) means no real network call happens - that's how the
+    # MailroomClient's own request-construction tests work, so allow it
+    transport = requests.post if post else requests.get
+    mocked = isinstance(transport, NonCallableMock)
+
+    assert endpoint in LIVE_TEST_ENDPOINTS or mocked, (
+        f"test reached live mailroom endpoint /mi/{endpoint}; decorate the test with @mock_mailroom "
+        f"(adding a TestClient fake if needed) or mock the call"
+    )
+    return _real_mailroom_request(self, endpoint, payload=payload, files=files, post=post, encode_json=encode_json)
+
+
+def install_mailroom_guard(test):
+    """
+    Makes any un-mocked call to a live mailroom fail loudly. Patches MailroomClient._request, which covers both
+    the production client and the TestClient used by @mock_mailroom (TestClient fakes most endpoints above this
+    layer, so only un-faked ones reach here).
+    """
+
+    patcher = patch.object(MailroomClient, "_request", _guarded_mailroom_request)
+    patcher.start()
+    test.addCleanup(patcher.stop)
 
 
 def mock_inspect_query(org, query: str, fields=None) -> mailroom.QueryMetadata:
@@ -159,23 +192,10 @@ def _client_method(func):
 
 
 class TestClient(MailroomClient):
-    # endpoints that TestClient intentionally proxies to a real mailroom rather than faking. flow/migrate is
-    # still real because fixtures below the current spec version need actually migrating (see flow_migrate).
-    ALLOWED_LIVE_ENDPOINTS = {"flow/migrate"}
-
     def __init__(self, mocks: Mocks):
         self.mocks = mocks
 
         super().__init__(settings.MAILROOM_URL, settings.MAILROOM_AUTH_TOKEN)
-
-    def _request(self, endpoint, *args, **kwargs):
-        # reaching the real HTTP client means an endpoint isn't faked above and the test is silently
-        # depending on a live mailroom - fail loudly instead so it gets a fake or an explicit mock
-        assert endpoint in self.ALLOWED_LIVE_ENDPOINTS, (
-            f"test reached un-mocked mailroom endpoint /mi/{endpoint} via the real client; "
-            f"add a fake to TestClient or mock the call"
-        )
-        return super()._request(endpoint, *args, **kwargs)
 
     @_client_method
     def android_event(self, org, channel, phone: str, event_type: str, extra: dict, occurred_on):

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -35,24 +35,35 @@ event_units = {
     CampaignEvent.UNIT_WEEKS: "weeks",
 }
 
-# endpoints still allowed to reach a live mailroom during tests. these exercise goflow logic (flow migration and
-# dependency inspection) that we don't reimplement in TestClient, so the tests that need them talk to a real
-# mailroom for now - everything else must be faked via @mock_mailroom or mocked at the transport.
+# endpoints still allowed to reach a live mailroom during tests. these exercise goflow logic (flow migration,
+# dependency inspection and cloning) that isn't faithfully reimplemented in TestClient, so production-client
+# callers - undecorated tests using get_flow()/import_file() - still talk to a real mailroom for now. @mock_mailroom
+# tests don't reach here for these: TestClient's stubs intercept them above _request.
 LIVE_TEST_ENDPOINTS = {"flow/migrate", "flow/inspect", "flow/clone"}
 
 _real_mailroom_request = MailroomClient._request
 
 
+class LiveMailroomError(BaseException):
+    """
+    Raised when a test reaches a live mailroom instead of mocking it. Deliberately subclasses BaseException, not
+    Exception, so that application code wrapping mailroom calls in `except Exception` (e.g. smartmin action
+    handlers) can't swallow it and mask the violation.
+    """
+
+
 def _guarded_mailroom_request(self, endpoint, payload=None, files=None, post=True, encode_json=False):
     # a patched transport (e.g. patch("requests.post")) means no real network call happens - that's how the
-    # MailroomClient's own request-construction tests work, so allow it
+    # MailroomClient's own request-construction tests work, so allow it. this only detects Mock-based patches;
+    # patch("requests.post", new=<plain callable>) would slip past, but that form isn't used against requests here.
     transport = requests.post if post else requests.get
     mocked = isinstance(transport, NonCallableMock)
 
-    assert endpoint in LIVE_TEST_ENDPOINTS or mocked, (
-        f"test reached live mailroom endpoint /mi/{endpoint}; decorate the test with @mock_mailroom "
-        f"(adding a TestClient fake if needed) or mock the call"
-    )
+    if not (endpoint in LIVE_TEST_ENDPOINTS or mocked):
+        raise LiveMailroomError(
+            f"test reached live mailroom endpoint /mi/{endpoint}; decorate the test with @mock_mailroom "
+            f"(adding a TestClient fake if needed) or mock the call"
+        )
     return _real_mailroom_request(self, endpoint, payload=payload, files=files, post=post, encode_json=encode_json)
 
 


### PR DESCRIPTION
## Problem
The previous guard ([#6686](https://github.com/nyaruka/rapidpro/pull/6686)) lived on `TestClient`, so it only caught un-mocked endpoints reached **under `@mock_mailroom`**. Tests that use the **production** `MailroomClient` (no decorator) could still silently hit a live mailroom — e.g. `get_flow()`/`import_file()` in an undecorated test calls `flow_migrate`/`flow_clone`/`flow_inspect` for real.

## Change
Move the guard down to `MailroomClient._request` (installed in `TembaTest.setUp`), so it covers **both** the production client and `TestClient`. Any call to a non-whitelisted endpoint whose transport (`requests.post`/`get`) isn't mocked now raises a clear error.

`flow/migrate`, `flow/inspect` and `flow/clone` are whitelisted for now — they exercise goflow logic (migration, dependency inspection, cloning) that we don't reimplement in `TestClient`, the same family as the deferred flow-migration question.

## Status: draft / WIP
This intentionally surfaces the remaining tests that reach other endpoints via the prod client (e.g. `flow/interrupt` from a flow-archive test that forgot `@mock_mailroom`). Those are real test bugs to fix by adding `@mock_mailroom`, not endpoints to whitelist. CI will enumerate the full list; I'll fix them in follow-up commits until green.