### PR TITLE
Fake flow/clone in tests with a Python port of goflow's clone

### DIFF
--- a/temba/mailroom/tests/test_mocks.py
+++ b/temba/mailroom/tests/test_mocks.py
@@ -1,0 +1,62 @@
+import copy
+
+from django.test import SimpleTestCase
+
+from temba.tests.mailroom import clone_flow_definition
+
+
+class CloneFlowDefinitionTest(SimpleTestCase):
+    def test_clone_flow_definition(self):
+        # b9b... and c0c... are dependencies that resolve to other objects in the target org; everything else is
+        # the flow's own structure which should keep its UUIDs
+        mapping = {
+            "b9b11111-1111-1111-1111-111111111111": "d0d11111-1111-1111-1111-111111111111",
+            "c0c22222-2222-2222-2222-222222222222": "e1e22222-2222-2222-2222-222222222222",
+        }
+        definition = {
+            "uuid": "a0a00000-0000-0000-0000-000000000000",  # flow's own uuid - unmapped, stays
+            "name": "Test",
+            "nodes": [
+                {
+                    "uuid": "a1a00000-0000-0000-0000-000000000000",  # node uuid - unmapped, stays
+                    "actions": [
+                        {
+                            "type": "add_contact_groups",
+                            "uuid": "a2a00000-0000-0000-0000-000000000000",
+                            "groups": [{"uuid": "b9b11111-1111-1111-1111-111111111111", "name": "Doctors"}],  # dep
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "a3a00000-0000-0000-0000-000000000000",
+                            "destination_uuid": "a1a00000-0000-0000-0000-000000000000",  # *_uuid, unmapped, stays
+                        }
+                    ],
+                }
+            ],
+            "_ui": {
+                "c0c22222-2222-2222-2222-222222222222": {"position": {"left": 0, "top": 0}},  # dep uuid as a key
+                "a1a00000-0000-0000-0000-000000000000": {"position": {"left": 1, "top": 1}},  # node uuid key, stays
+            },
+            "field_refs": ["c0c22222-2222-2222-2222-222222222222", "not-a-uuid"],  # uuid string in a list
+        }
+        original = copy.deepcopy(definition)
+
+        cloned = clone_flow_definition(definition, mapping)
+
+        # dependency UUIDs are remapped: as a "uuid" property value...
+        self.assertEqual("d0d11111-1111-1111-1111-111111111111", cloned["nodes"][0]["actions"][0]["groups"][0]["uuid"])
+        # ...as a dict key (renamed)...
+        self.assertIn("e1e22222-2222-2222-2222-222222222222", cloned["_ui"])
+        self.assertNotIn("c0c22222-2222-2222-2222-222222222222", cloned["_ui"])
+        # ...and as a bare string in a list
+        self.assertEqual("e1e22222-2222-2222-2222-222222222222", cloned["field_refs"][0])
+
+        # the flow's own UUIDs and non-UUID values are left untouched
+        self.assertEqual("a0a00000-0000-0000-0000-000000000000", cloned["uuid"])
+        self.assertEqual("a1a00000-0000-0000-0000-000000000000", cloned["nodes"][0]["exits"][0]["destination_uuid"])
+        self.assertIn("a1a00000-0000-0000-0000-000000000000", cloned["_ui"])
+        self.assertEqual("not-a-uuid", cloned["field_refs"][1])
+
+        # the input definition is not mutated
+        self.assertEqual(original, definition)

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -61,7 +61,8 @@ def clone_flow_definition(definition: dict, dependency_mapping: dict) -> dict:
                 value = node[key]
                 if (key == "uuid" or key.endswith("_uuid")) and isinstance(value, str):
                     node[key] = dependency_mapping.get(value, value)
-                elif is_uuid(key) and key in dependency_mapping:
+                # test cheap O(1) membership before is_uuid()'s try/except, which runs on every key otherwise
+                elif key in dependency_mapping and is_uuid(key):
                     node[dependency_mapping[key]] = node.pop(key)
             for value in node.values():
                 remap(value)
@@ -69,7 +70,7 @@ def clone_flow_definition(definition: dict, dependency_mapping: dict) -> dict:
             for i, value in enumerate(node):
                 if isinstance(value, str) and is_uuid(value):
                     node[i] = dependency_mapping.get(value, value)
-                else:
+                elif isinstance(value, (dict, list)):
                     remap(value)
 
     clone = copy.deepcopy(definition)

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import re
 from collections import defaultdict
@@ -26,7 +27,7 @@ from temba.schedules.models import Schedule
 from temba.tests.dates import parse_datetime
 from temba.tickets.models import Ticket
 from temba.utils import json
-from temba.utils.uuid import uuid7
+from temba.utils.uuid import is_uuid, uuid7
 
 event_units = {
     CampaignEvent.UNIT_MINUTES: "minutes",
@@ -35,13 +36,45 @@ event_units = {
     CampaignEvent.UNIT_WEEKS: "weeks",
 }
 
-# endpoints still allowed to reach a live mailroom during tests. these exercise goflow logic (flow migration,
-# dependency inspection and cloning) that isn't faithfully reimplemented in TestClient, so production-client
-# callers - undecorated tests using get_flow()/import_file() - still talk to a real mailroom for now. @mock_mailroom
-# tests don't reach here for these: TestClient's stubs intercept them above _request.
-LIVE_TEST_ENDPOINTS = {"flow/migrate", "flow/inspect", "flow/clone"}
+# endpoints still allowed to reach a live mailroom during tests. these exercise goflow logic (flow migration and
+# dependency inspection) that isn't faithfully reimplemented in TestClient, so production-client callers -
+# undecorated tests using get_flow()/import_file() - still talk to a real mailroom for now. @mock_mailroom tests
+# don't reach here for these: TestClient's stubs intercept them above _request.
+LIVE_TEST_ENDPOINTS = {"flow/migrate", "flow/inspect"}
 
 _real_mailroom_request = MailroomClient._request
+
+
+def clone_flow_definition(definition: dict, dependency_mapping: dict) -> dict:
+    """
+    Python port of goflow's flow clone (flows/definition/migrations.Clone) for tests. It walks the definition and
+    remaps dependency UUIDs - in "uuid"/"*_uuid" properties, UUID-named keys, and UUID strings in arrays - using
+    the given mapping, so an imported flow references the objects resolved for the target org.
+
+    Unlike goflow it leaves the flow's own element UUIDs untouched rather than assigning fresh random ones: that
+    uniqueness step isn't needed in tests and stable UUIDs are much easier to assert against.
+    """
+
+    def remap(node):
+        if isinstance(node, dict):
+            for key in list(node.keys()):
+                value = node[key]
+                if (key == "uuid" or key.endswith("_uuid")) and isinstance(value, str):
+                    node[key] = dependency_mapping.get(value, value)
+                elif is_uuid(key) and key in dependency_mapping:
+                    node[dependency_mapping[key]] = node.pop(key)
+            for value in node.values():
+                remap(value)
+        elif isinstance(node, list):
+            for i, value in enumerate(node):
+                if isinstance(value, str) and is_uuid(value):
+                    node[i] = dependency_mapping.get(value, value)
+                else:
+                    remap(value)
+
+    clone = copy.deepcopy(definition)
+    remap(clone)
+    return clone
 
 
 class LiveMailroomError(BaseException):
@@ -54,12 +87,19 @@ class LiveMailroomError(BaseException):
 
 def _guarded_mailroom_request(self, endpoint, payload=None, files=None, post=True, encode_json=False):
     # a patched transport (e.g. patch("requests.post")) means no real network call happens - that's how the
-    # MailroomClient's own request-construction tests work, so allow it. this only detects Mock-based patches;
-    # patch("requests.post", new=<plain callable>) would slip past, but that form isn't used against requests here.
+    # MailroomClient's own request-construction tests work, so let those through to the real _request. this only
+    # detects Mock-based patches; patch("requests.post", new=<plain callable>) would slip past, but that form
+    # isn't used against requests here.
     transport = requests.post if post else requests.get
-    mocked = isinstance(transport, NonCallableMock)
+    if isinstance(transport, NonCallableMock):
+        return _real_mailroom_request(self, endpoint, payload=payload, files=files, post=post, encode_json=encode_json)
 
-    if not (endpoint in LIVE_TEST_ENDPOINTS or mocked):
+    # flow/clone is simple enough to reimplement in Python, so fake it for the production client used by
+    # undecorated import tests rather than reaching a live mailroom. unlike migrate/inspect it needs no goflow.
+    if endpoint == "flow/clone":
+        return clone_flow_definition(payload["flow"], payload["dependency_mapping"])
+
+    if endpoint not in LIVE_TEST_ENDPOINTS:
         raise LiveMailroomError(
             f"test reached live mailroom endpoint /mi/{endpoint}; decorate the test with @mock_mailroom "
             f"(adding a TestClient fake if needed) or mock the call"
@@ -393,8 +433,7 @@ class TestClient(MailroomClient):
 
     @_client_method
     def flow_clone(self, definition: dict, dependency_mapping):
-        # we replace UUIDs in production to ensure uniqueness but for tests it's nicer to know the UUIDs
-        return definition
+        return clone_flow_definition(definition, dependency_mapping)
 
     @_client_method
     def flow_inspect(self, org, definition: dict, is_import=False):


### PR DESCRIPTION
Removes `flow/clone` from the live-mailroom test whitelist (the smallest of the three remaining goflow endpoints).

## Why it was live
`flow_clone` (UUID remapping during flow import/copy) is called from `Flow.import_definition`. Undecorated import tests hit it on the **production client**, so it had to be whitelisted. We can't just decorate those tests with `@mock_mailroom` — the same import path also calls `flow_inspect` to compute the dependencies it must create, and faking that returns empty deps (the tests would pass vacuously). And the previous identity stub (`return definition`) doesn't remap dependency UUIDs, so imports into an org with existing objects fail to resolve dependencies.

## Change
Reimplement goflow's flow clone in Python — `clone_flow_definition` in `temba/tests/mailroom.py` — porting `flows/definition/migrations.Clone`: walk the definition and remap dependency UUIDs (in `uuid`/`*_uuid` properties, UUID-named keys, and UUID strings in arrays) via the supplied mapping. Unlike goflow it leaves the flow's own element UUIDs stable rather than assigning fresh random ones — that uniqueness step isn't needed in tests and stable UUIDs are far easier to assert against.

Both the guard (production-client path) and `TestClient.flow_clone` use it, so flow cloning never reaches a live mailroom. The guard's mocked-transport check now runs first so the client's own request-construction tests are unaffected.

`flow/migrate` and `flow/inspect` remain whitelisted.

## Validation
- `test_definitionexport` dependency tests (subflow/field/group dependency resolution) now pass with no live `flow/clone` calls (remaining failures there are pre-existing localstack/S3 env errors).
- Flow copy (`test_copy_view`) and the mailroom client construction tests still pass.
- No `flow/clone` left in the whitelist; the guard catches any regression.