### PR TITLE
Keep test flow fixtures at current spec and skip flow/migrate for them

### DIFF
--- a/media/test_flows/all_dependency_types.json
+++ b/media/test_flows/all_dependency_types.json
@@ -11,7 +11,7 @@
       "name": "New Child",
       "nodes": [],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "c866af22-8eff-41e5-9471-73c26c30f16b"
     },
@@ -154,7 +154,7 @@
         }
       ],
       "revision": 11,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "ee765ff2-96b0-440a-b108-393f613466bb"
     }

--- a/media/test_flows/background.json
+++ b/media/test_flows/background.json
@@ -47,7 +47,7 @@
         }
       ],
       "revision": 6,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging_background",
       "uuid": "1ff89517-5735-466b-be31-682b49521cbf"
     }

--- a/media/test_flows/cataclysm.json
+++ b/media/test_flows/cataclysm.json
@@ -213,7 +213,7 @@
         }
       ],
       "revision": 49,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "ef9603ff-3886-4e5e-8870-0f643b6098de"
     },
@@ -273,7 +273,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "d6dd96b1-d500-4c7a-9f9c-eae3f2a2a7c5"
     }

--- a/media/test_flows/color_v13.json
+++ b/media/test_flows/color_v13.json
@@ -188,7 +188,7 @@
                 }
             ],
             "revision": 1,
-            "spec_version": "14.4.0",
+            "spec_version": "14.4.1",
             "type": "messaging",
             "uuid": "ca45c8dd-d882-4f56-8522-1cdda67fd5b5"
         }

--- a/media/test_flows/dependencies.json
+++ b/media/test_flows/dependencies.json
@@ -385,7 +385,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "845f5a05-e92e-46fa-9444-cde06fb53ea0"
     },
@@ -538,7 +538,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "2b118e66-960f-4ba5-abb9-2b250916d4ff"
     }

--- a/media/test_flows/dependencies_v13.json
+++ b/media/test_flows/dependencies_v13.json
@@ -154,7 +154,7 @@
         }
       ],
       "revision": 6,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "f310f98f-abd7-42ce-92d5-fca1cb100e7a"
     },
@@ -700,7 +700,7 @@
         }
       ],
       "revision": 22,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "89894985-f68d-4a1b-b49e-4ea6dfc5e76a"
     }

--- a/media/test_flows/dependencies_voice.json
+++ b/media/test_flows/dependencies_voice.json
@@ -115,7 +115,7 @@
         }
       ],
       "revision": 22,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "voice",
       "uuid": "e05a2116-20b5-4641-833d-f7184a13ddd5"
     }

--- a/media/test_flows/favorites.json
+++ b/media/test_flows/favorites.json
@@ -395,7 +395,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "fb41a52c-ee56-4bd9-9849-5bf1e8a7633f"
     }

--- a/media/test_flows/favorites_v13.json
+++ b/media/test_flows/favorites_v13.json
@@ -403,7 +403,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "aef60b1e-14ab-4095-81ee-fce02b3e320d"
     }

--- a/media/test_flows/group_send_flow.json
+++ b/media/test_flows/group_send_flow.json
@@ -42,7 +42,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "92474cb5-7d9c-42a1-8953-5f81824a660d"
     }

--- a/media/test_flows/ivr.json
+++ b/media/test_flows/ivr.json
@@ -326,7 +326,7 @@
         }
       ],
       "revision": 25,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "voice",
       "uuid": "3d089d93-cbfe-408b-8d70-8c450cfc57b1"
     }

--- a/media/test_flows/mailroom/background.json
+++ b/media/test_flows/mailroom/background.json
@@ -47,7 +47,7 @@
         }
       ],
       "revision": 6,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging_background",
       "uuid": "1ff89517-5735-466b-be31-682b49521cbf"
     }

--- a/media/test_flows/mailroom/contact_surveyor.json
+++ b/media/test_flows/mailroom/contact_surveyor.json
@@ -311,7 +311,7 @@
         }
       ],
       "revision": 16,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging_offline",
       "uuid": "ed8cf8d4-a42c-4ce1-a7e3-44a2918e3cec"
     }

--- a/media/test_flows/mailroom/favorites_timeout.json
+++ b/media/test_flows/mailroom/favorites_timeout.json
@@ -430,7 +430,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "526a3278-3575-4d18-b5f7-84b79002e6ec"
     }

--- a/media/test_flows/mailroom/incoming_extra.json
+++ b/media/test_flows/mailroom/incoming_extra.json
@@ -42,7 +42,7 @@
         }
       ],
       "revision": 4,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "dc9a2be2-7706-4539-b9ef-4cbb42bce34e"
     }

--- a/media/test_flows/mailroom/ivr_flow.json
+++ b/media/test_flows/mailroom/ivr_flow.json
@@ -466,7 +466,7 @@
         }
       ],
       "revision": 7,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "voice",
       "uuid": "5fdf1652-f034-4265-ad14-eccc3019d6c7"
     }

--- a/media/test_flows/mailroom/parent_child_expiration.json
+++ b/media/test_flows/mailroom/parent_child_expiration.json
@@ -205,7 +205,7 @@
         }
       ],
       "revision": 33,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "2cdcd8d9-a210-4269-a0cd-f4a07cc4f68a"
     },
@@ -289,7 +289,7 @@
         }
       ],
       "revision": 12,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "c4dd3c3a-1c7c-4bb8-a8c4-11aaec1a4fea"
     }

--- a/media/test_flows/mailroom/pick_a_number.json
+++ b/media/test_flows/mailroom/pick_a_number.json
@@ -149,7 +149,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "dd034104-4a78-4aad-9beb-e9d79d8c84a9"
     }

--- a/media/test_flows/mailroom/send_all.json
+++ b/media/test_flows/mailroom/send_all.json
@@ -38,7 +38,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "4b8089fb-bb10-4cbc-800f-a0aa8bb21713"
     }

--- a/media/test_flows/mailroom/sms_form.json
+++ b/media/test_flows/mailroom/sms_form.json
@@ -344,7 +344,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "8b53d166-57c2-4943-8e93-a2b4077ec88e"
     }

--- a/media/test_flows/media_survey.json
+++ b/media/test_flows/media_survey.json
@@ -269,7 +269,7 @@
         }
       ],
       "revision": 169,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging_offline",
       "uuid": "9097ec00-3af0-4eef-988d-26c5094ce4ec"
     }

--- a/media/test_flows/new_mother.json
+++ b/media/test_flows/new_mother.json
@@ -70,7 +70,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "31c99659-e09f-4351-9c54-9d73f7fadc31"
     }

--- a/media/test_flows/parent_child_trigger.json
+++ b/media/test_flows/parent_child_trigger.json
@@ -103,7 +103,7 @@
         }
       ],
       "revision": 3,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "1ddf2d46-0cce-4c33-8049-9ebbbe28bb61"
     },
@@ -142,7 +142,7 @@
         }
       ],
       "revision": 1,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "c541b853-e33d-4fbb-8086-99e5d8ed6dc2"
     }

--- a/media/test_flows/parent_without_its_child.json
+++ b/media/test_flows/parent_without_its_child.json
@@ -79,7 +79,7 @@
         }
       ],
       "revision": 7,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "6228646f-6c67-4237-a2d9-6e2c6060e8cd"
     }

--- a/media/test_flows/rating_10.json
+++ b/media/test_flows/rating_10.json
@@ -145,7 +145,7 @@
         }
       ],
       "revision": 7,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "d6a23704-c558-40c0-b850-5102cf69896c"
     }

--- a/media/test_flows/subflow.json
+++ b/media/test_flows/subflow.json
@@ -224,7 +224,7 @@
         }
       ],
       "revision": 24,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "7c1dee9b-af4c-407b-a269-5553e59149e1"
     },
@@ -369,7 +369,7 @@
         }
       ],
       "revision": 11,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "8a2c48a7-0592-4863-85c1-6b32584d4a93"
     }

--- a/media/test_flows/survey_campaign.json
+++ b/media/test_flows/survey_campaign.json
@@ -70,7 +70,7 @@
         }
       ],
       "revision": 4,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "6d8250f9-3781-40f5-b76c-35fe2a2c9712"
     }

--- a/media/test_flows/the_clinic.json
+++ b/media/test_flows/the_clinic.json
@@ -145,7 +145,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "198b20a2-c389-4cf6-8ccb-b45c959f3de1"
     },
@@ -328,7 +328,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "ad22ba89-68af-4e2d-9d06-13e0b61193d2"
     },
@@ -604,7 +604,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "4b2a34bb-2da8-49df-97d2-7347804dec92"
     },
@@ -1104,7 +1104,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "fb505d32-93e3-4aad-b69a-7d3318131f78"
     },
@@ -1148,7 +1148,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "8f0ab307-2c36-4eaf-baf2-597af539a2c0"
     },
@@ -1192,7 +1192,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "eb0d5a69-756a-4c05-88eb-5e84fbd2dd9c"
     },
@@ -1231,7 +1231,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "8d21a7da-dd20-4460-911e-ab579c7f55a3"
     },
@@ -1270,7 +1270,7 @@
         }
       ],
       "revision": 0,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "16f33155-9ef7-478f-8a05-365eb05d29f7"
     }

--- a/media/test_flows/whatsapp_template.json
+++ b/media/test_flows/whatsapp_template.json
@@ -42,7 +42,7 @@
         }
       ],
       "revision": 11,
-      "spec_version": "14.4.0",
+      "spec_version": "14.4.1",
       "type": "messaging",
       "uuid": "c07d368e-fe1d-469d-b267-bca02d17c3e3"
     }

--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import asdict
 
 import requests
+from packaging.version import Version
 
 from django.conf import settings
 
@@ -202,6 +203,14 @@ class MailroomClient:
 
         if not to_version:  # pragma: no cover
             to_version = Flow.CURRENT_SPEC_VERSION
+
+        # in tests fixtures are kept at the current spec (see the migrate_test_fixtures command), so skip the HTTP
+        # round-trip when the definition is already at or beyond the target. in production we always defer to
+        # mailroom, which may apply newer patch migrations within the same version that this client isn't aware of.
+        if settings.TESTING:
+            current = definition.get("spec_version")
+            if current and Version(current) >= Version(to_version):
+                return definition
 
         return self._request("flow/migrate", {"flow": definition, "to_version": to_version}, encode_json=True)
 

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -8,7 +8,6 @@ from functools import wraps
 from unittest.mock import NonCallableMock, call, patch
 
 import requests
-from packaging.version import Version
 
 from django.conf import settings
 from django.db import connection
@@ -18,7 +17,7 @@ from temba import mailroom
 from temba.campaigns.models import CampaignEvent
 from temba.channels.models import ChannelEvent
 from temba.contacts.models import URN, Contact, ContactField, ContactGroup, ContactURN
-from temba.flows.models import Flow, FlowRun, FlowSession, FlowStart
+from temba.flows.models import FlowRun, FlowSession, FlowStart
 from temba.locations.models import AdminBoundary
 from temba.mailroom.client.client import MailroomClient
 from temba.mailroom.modifiers import Modifier
@@ -36,10 +35,12 @@ event_units = {
     CampaignEvent.UNIT_WEEKS: "weeks",
 }
 
-# endpoints still allowed to reach a live mailroom during tests. these exercise goflow logic (flow migration and
-# dependency inspection) that isn't faithfully reimplemented in TestClient, so production-client callers -
-# undecorated tests using get_flow()/import_file() - still talk to a real mailroom for now. @mock_mailroom tests
-# don't reach here for these: TestClient's stubs intercept them above _request.
+# endpoints still allowed to reach a live mailroom during tests, both reached by undecorated import tests using
+# the production client:
+#  - flow/inspect needs real goflow dependency/issue analysis we don't reimplement here
+#  - flow/migrate is only reached for fixtures below the current spec (the legacy-migration tests); current-spec
+#    fixtures skip the call via the fast-path in MailroomClient.flow_migrate
+# @mock_mailroom tests don't reach here for these - TestClient's stubs intercept above _request.
 LIVE_TEST_ENDPOINTS = {"flow/migrate", "flow/inspect"}
 
 _real_mailroom_request = MailroomClient._request
@@ -449,19 +450,6 @@ class TestClient(MailroomClient):
             "counts": {},
             "locals": [],
         }
-
-    @_client_method
-    def flow_migrate(self, definition: dict, to_version=None):
-        # fast-path: if the definition is already at the target version, skip the HTTP call.
-        # for older fixtures we fall through to real mailroom since we'd need to actually migrate.
-        if not to_version:
-            to_version = Flow.CURRENT_SPEC_VERSION
-
-        current = definition.get("spec_version")
-        if current and Version(current) >= Version(to_version):
-            return definition
-
-        return super().flow_migrate(definition, to_version=to_version)
 
     @_client_method
     def flow_interrupt(self, org, flow):


### PR DESCRIPTION
Shrinks the live-mailroom `flow/migrate` surface from "every flow import" to "only the intentional legacy-migration tests."

## Two parts

**1. Re-migrate fixtures to current spec.** Ran the existing `migrate_test_fixtures` command so fixtures track `Flow.CURRENT_SPEC_VERSION` again (they'd drifted to 14.4.0; current is 14.4.1). The 14.4.1 migration matched no fixture, so the diff is purely `spec_version` bumps across 29 files — zero content changes.

**2. Move the migrate fast-path to the real client, gated on `TESTING`.** Undecorated import tests use the production `MailroomClient`, which called `flow/migrate` even when a definition was already current. `MailroomClient.flow_migrate` now skips the round-trip when the definition is already at/beyond the target — **but only under `settings.TESTING`**.

   This gating is essential: in production rapidpro asks to migrate to *its* `CURRENT_SPEC_VERSION`, and mailroom may apply newer patch migrations within that version that this client doesn't know about. A prod-side short-circuit would silently strand definitions a patch behind. (`flow_inspect` already uses the same `settings.TESTING` pattern.)

   The now-redundant `TestClient.flow_migrate` override is removed (it inherits the real client's fast-path).

## Result
- Current-spec imports (decorated **and** undecorated) skip the live `flow/migrate` call.
- Only legacy-migration tests (importing sub-current fixtures) still reach it — so it stays whitelisted, now precisely justified.
- `flow/inspect` remains the other whitelisted endpoint (genuine goflow dependency analysis).

Verified: the fixtures-only commit was already CI-green (zero tests shift); with the short-circuit, undecorated dependency tests no longer trip `flow/migrate` while legacy-migration tests still do.