### PR TITLE
Stop legacy migration unit tests from incidentally hitting mailroom

### DIFF
--- a/temba/flows/legacy/tests.py
+++ b/temba/flows/legacy/tests.py
@@ -140,7 +140,7 @@ class FlowMigrationTest(TembaTest):
 
     @mock_mailroom
     def test_migrate_to_11_12(self, mr_mocks):
-        flow = self.load_flow("favorites")
+        flow = self.create_flow("Favorites")
         definition = {
             "entry": "79b4776b-a995-475d-ae06-1cab9af8a28e",
             "rule_sets": [],
@@ -233,7 +233,7 @@ class FlowMigrationTest(TembaTest):
         # removed the invalid reference
         self.assertEqual(len(migrated["action_sets"]), 2)
 
-        flow = self.load_flow("migrate_to_11_12")
+        flow = self.create_flow("Migrate 11.12")
         flow_json = self.load_flow_def("migrate_to_11_12")
         migrated = migrate_to_version_11_12(flow_json, flow)
 
@@ -242,7 +242,7 @@ class FlowMigrationTest(TembaTest):
 
     @mock_mailroom
     def test_migrate_to_11_12_with_one_node(self, mr_mocks):
-        flow = self.load_flow("migrate_to_11_12_one_node")
+        flow = self.create_flow("Migrate 11.12 One Node")
         flow_json = self.load_flow_def("migrate_to_11_12_one_node")
         migrated = migrate_to_version_11_12(flow_json, flow)
 
@@ -250,7 +250,7 @@ class FlowMigrationTest(TembaTest):
 
     @mock_mailroom
     def test_migrate_to_11_12_other_org_existing_flow(self, mr_mocks):
-        flow = self.load_flow("migrate_to_11_12_other_org", {"CHANNEL-UUID": str(self.channel.uuid)})
+        flow = self.create_flow("Migrate 11.12 Other Org")
         flow_json = self.load_flow_def("migrate_to_11_12_other_org", {"CHANNEL-UUID": str(self.channel.uuid)})
 
         # change ownership of the channel it's referencing
@@ -273,7 +273,7 @@ class FlowMigrationTest(TembaTest):
 
     @mock_mailroom
     def test_migrate_to_11_11(self, mr_mocks):
-        flow = self.load_flow("migrate_to_11_11")
+        flow = self.create_flow("Migrate 11.11")
         flow_json = self.load_flow_def("migrate_to_11_11")
 
         migrated = migrate_to_version_11_11(flow_json, flow)
@@ -656,7 +656,7 @@ class FlowMigrationTest(TembaTest):
         self.create_field("district", "District", ContactField.TYPE_DISTRICT)
         self.create_field("joined_on", "Joined On", ContactField.TYPE_DATETIME)
 
-        flow = self.load_flow("type_flow")
+        flow = self.create_flow("Type Flow")
         flow_def = self.load_flow_def("type_flow")
         migrated = migrate_to_version_11_0(flow_def, flow)
 
@@ -686,7 +686,7 @@ class FlowMigrationTest(TembaTest):
 
     @mock_mailroom
     def test_migrate_to_11_0_with_null_ruleset_label(self, mr_mocks):
-        flow = self.load_flow("migrate_to_11_0")
+        flow = self.create_flow("Migrate 11.0")
         definition = {
             "rule_sets": [
                 {
@@ -708,7 +708,7 @@ class FlowMigrationTest(TembaTest):
 
     @mock_mailroom
     def test_migrate_to_11_0_with_null_msg_text(self, mr_mocks):
-        flow = self.load_flow("migrate_to_11_0")
+        flow = self.create_flow("Migrate 11.0")
         definition = {
             "action_sets": [
                 {
@@ -726,7 +726,7 @@ class FlowMigrationTest(TembaTest):
 
     @mock_mailroom
     def test_migrate_to_11_0_with_broken_localization(self, mr_mocks):
-        flow = self.load_flow("migrate_to_11_0")
+        flow = self.create_flow("Migrate 11.0")
         flow_def = self.load_flow_def("migrate_to_11_0")
         migrated = migrate_to_version_11_0(flow_def, flow)
 
@@ -782,7 +782,7 @@ class FlowMigrationTest(TembaTest):
     @mock_mailroom
     def test_migrate_to_10(self, mr_mocks):
         # this is really just testing our rewriting of webhook rulesets
-        flow = self.load_flow("dual_webhook")
+        flow = self.create_flow("Dual Webhook")
         flow_def = self.load_flow_def("dual_webhook")
 
         # get our definition out


### PR DESCRIPTION
Follow-up to the flow-migrate work. `FlowMigrationTest` exercises the **Python** legacy migrations (`migrate_to_version_*`), but many tests obtained the `flow` *context* argument via `load_flow()` — which runs the full import pipeline and migrates the fixture all the way to the current spec, i.e. a live mailroom `flow/migrate` call that has nothing to do with the Python migration being asserted.

## Change
Swap those incidental `load_flow(...)` calls for `create_flow(...)`, which builds a context flow in the org **without** migrating (no mailroom). 10 call sites across the `migrate_to_version_*` tests.

## Kept `load_flow()` where the import is genuinely needed
- **Looks up org objects the import creates** — `test_migrate_to_11_6` (remaps group UUIDs via `get_group_by_name`), `test_migrate_to_11_12_channel_dependencies` (asserts `channel_dependencies`).
- **Multi-flow fixtures** — `test_migrate_to_11_9` (needs Valid1/Invalid1/Invalid2 flows).
- **Asserts the flow reaches current spec** — `test_migrate_bad_group_names`, `test_migrate_malformed_groups`, `test_migrate_malformed_single_message_flow`, `test_migrate_sample_flows`.

These genuinely use the migration pipeline (and the import's dependency creation), so they legitimately keep `flow/migrate` whitelisted.

## Verification
With `flow/migrate` removed from the guard whitelist, the swapped tests pass and only the 7 genuine import-pipeline tests trip it — no test fails for a non-mailroom reason. (One pre-existing env failure in `test_migrate_sample_flows`, `'eng' != 'und'`, reproduces on `main` and is unrelated.)

Net: ~9 needless live-mailroom round-trips removed from pure-Python migration unit tests; `flow/migrate` stays whitelisted but now only for tests that truly exercise the import/migration pipeline.