### PR TITLE
Fake flow/inspect in tests so the suite needs no live mailroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
 
     env:
       node-version: '20'
-      mailroom-version: '26.1.126'
 
     services:
       valkey:
@@ -60,11 +59,6 @@ jobs:
           uv run python manage.py migrate
           uv run python manage.py migrate_dynamo --testing
           uv run python manage.py create_buckets --testing
-          # fetch, extract and start mailroom
-          wget https://github.com/${{ github.repository_owner }}/mailroom/releases/download/v${{ env.mailroom-version }}/mailroom_${{ env.mailroom-version }}_linux_amd64.tar.gz
-          tar -xvf mailroom_${{ env.mailroom-version }}_linux_amd64.tar.gz mailroom
-          # start mailroom with workers disabled so it serves the web API but doesn't pop any queued tasks
-          ./mailroom -db=postgres://temba:temba@postgres:5432/temba?sslmode=disable -workers-realtime=0 -workers-batch=0 -workers-throttled=0 -log-level=info > mailroom.log &
 
       - name: Run pre-test checks
         run: |
@@ -79,7 +73,3 @@ jobs:
 
       - name: Coverage report
         run: uv run coverage report -m --fail-under=100
-
-      - name: Mailroom log
-        if: failure()
-        run: cat mailroom.log

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1805,7 +1805,8 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertEqual(404, response.status_code)
 
-    def test_write_protection(self):
+    @mock_mailroom
+    def test_write_protection(self, mr_mocks):
         flow = self.get_flow("favorites_v13")
         flow_json = flow.get_definition()
         flow_json_copy = flow_json.copy()
@@ -1828,16 +1829,19 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         with self.assertRaises(FlowUserConflictException):
             flow.save_revision(self.admin, flow_json_copy)
 
-        # make flow definition invalid by creating a duplicate node UUID
+        # make flow definition invalid by creating a duplicate node UUID - goflow rejects it on inspect, which we
+        # don't reimplement in tests, so stub the validation failure mailroom would return
         mode0_uuid = flow_json["nodes"][0]["uuid"]
         flow_json["nodes"][1]["uuid"] = mode0_uuid
 
+        mr_mocks.exception(mailroom.FlowValidationException(f"node UUID {mode0_uuid} isn't unique"))
         with self.assertRaises(mailroom.FlowValidationException) as cm:
             flow.save_revision(self.admin, flow_json)
 
         self.assertEqual(f"node UUID {mode0_uuid} isn't unique", str(cm.exception))
 
         # check view converts exception to error response
+        mr_mocks.exception(mailroom.FlowValidationException(f"node UUID {mode0_uuid} isn't unique"))
         response = self.client.post(
             reverse("flows.flow_revisions", args=[flow.uuid]), data=flow_json, content_type="application/json"
         )

--- a/temba/mailroom/tests/test_mocks.py
+++ b/temba/mailroom/tests/test_mocks.py
@@ -2,7 +2,96 @@ import copy
 
 from django.test import SimpleTestCase
 
-from temba.tests.mailroom import clone_flow_definition
+from temba.tests.mailroom import clone_flow_definition, inspect_flow
+
+
+class InspectFlowTest(SimpleTestCase):
+    def test_inspect_flow(self):
+        definition = {
+            "uuid": "a0a00000-0000-0000-0000-000000000000",
+            "name": "Test",
+            "nodes": [
+                {
+                    "uuid": "n1n00000-0000-0000-0000-000000000000",
+                    "actions": [
+                        {
+                            "type": "add_contact_groups",
+                            "groups": [
+                                {"uuid": "b9b11111-1111-1111-1111-111111111111", "name": "Doctors"},
+                                {"uuid": "b9b11111-1111-1111-1111-111111111111", "name": "Doctors"},  # duplicate
+                            ],
+                        },
+                        {"type": "set_contact_field", "field": {"key": "gender", "name": "Gender"}},
+                        {"type": "enter_flow", "flow": {}},  # malformed ref with no uuid/key is ignored
+                        {"type": "set_run_result", "name": "Note", "category": "Approved"},
+                        {"type": "set_run_result", "name": "Bare"},  # no category
+                        {
+                            "type": "send_msg",
+                            "text": "you are @fields.age, @parent.fields.phone, @globals.org_name",
+                            "attachments": ["image:@fields.photo"],  # expression in a list
+                            "extra": {"note": "@fields.mood"},  # expression in a nested dict
+                        },
+                    ],
+                    "router": {"result_name": "Color", "categories": [{"name": "Red"}, {"name": "Other"}]},
+                },
+                {
+                    "uuid": "n2n00000-0000-0000-0000-000000000000",
+                    "router": {
+                        "operand": "@fields.region",
+                        "result_name": "Color",  # same key as node 1 - merges
+                        "categories": [{"name": "Blue"}, {"name": "Other"}],
+                        "cases": [
+                            {"type": "has_group", "arguments": ["c0c22222-2222-2222-2222-222222222222"]},  # no name
+                            {"type": "has_group", "arguments": ["c1c33333-3333-3333-3333-333333333333", "Testers"]},
+                            {"type": "has_any_word", "arguments": ["red"]},  # not a dependency
+                        ],
+                    },
+                },
+            ],
+        }
+        original = copy.deepcopy(definition)
+
+        info = inspect_flow(definition)
+
+        # dependencies: typed action/router refs plus field/global refs pulled from expressions, deduped
+        self.assertEqual(
+            [
+                ("group", "b9b11111-1111-1111-1111-111111111111", "Doctors"),
+                ("field", "gender", "Gender"),
+                ("field", "age", ""),
+                ("field", "phone", ""),  # parent.fields.phone still resolves to field key "phone"
+                ("global", "org_name", ""),
+                ("field", "photo", ""),
+                ("field", "mood", ""),
+                ("field", "region", ""),  # from the router operand, scanned before its cases
+                ("group", "c0c22222-2222-2222-2222-222222222222", ""),
+                ("group", "c1c33333-3333-3333-3333-333333333333", "Testers"),
+            ],
+            [(d["type"], d.get("uuid", d.get("key")), d["name"]) for d in info["dependencies"]],
+        )
+        self.assertTrue(all(d["missing"] is False for d in info["dependencies"]))
+
+        # results: save-result actions (in node order) then routers, merged by snakified key across nodes
+        self.assertEqual(
+            [
+                {"key": "note", "name": "Note", "categories": ["Approved"]},
+                {"key": "bare", "name": "Bare", "categories": []},
+                {"key": "color", "name": "Color", "categories": ["Red", "Other", "Blue"]},
+            ],
+            [{k: r[k] for k in ("key", "name", "categories")} for r in info["results"]],
+        )
+        # the Color result merges both nodes that save it
+        color = next(r for r in info["results"] if r["key"] == "color")
+        self.assertEqual(
+            ["n1n00000-0000-0000-0000-000000000000", "n2n00000-0000-0000-0000-000000000000"], color["node_uuids"]
+        )
+
+        # the rest of the analysis isn't reproduced
+        self.assertEqual([], info["issues"])
+        self.assertEqual([], info["parent_refs"])
+
+        # the input definition is not mutated
+        self.assertEqual(original, definition)
 
 
 class CloneFlowDefinitionTest(SimpleTestCase):

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -35,12 +35,11 @@ event_units = {
     CampaignEvent.UNIT_WEEKS: "weeks",
 }
 
-# endpoints still allowed to reach a live mailroom during tests. flow/inspect needs real goflow dependency/issue
-# analysis that we don't reimplement here, and is reached by undecorated import tests using the production client.
-# flow/migrate is NOT here: current-spec definitions skip the call via MailroomClient.flow_migrate's TESTING
-# fast-path, and tests that load/import a below-current-spec definition must stub it with mr_mocks.flow_migrate -
-# anything else reaching it raises (migration is goflow's job, not something we exercise here).
-LIVE_TEST_ENDPOINTS = {"flow/inspect"}
+# no endpoint is allowed to reach a live mailroom during tests. the two that undecorated tests reach via the
+# production client - flow/clone and flow/inspect - are faked below from the request payload; flow/migrate
+# either skips the call (current-spec definitions hit MailroomClient.flow_migrate's TESTING fast-path) or must
+# be stubbed with mr_mocks.flow_migrate. anything else reaching _request without a Mock transport raises.
+LIVE_TEST_ENDPOINTS = set()
 
 _real_mailroom_request = MailroomClient._request
 
@@ -78,6 +77,124 @@ def clone_flow_definition(definition: dict, dependency_mapping: dict) -> dict:
     return clone
 
 
+# maps the action property holding an asset reference to its goflow dependency type. "groups"/"labels" hold lists
+# of references, the rest hold a single reference object. mirrors the reference-typed fields on goflow's actions
+# (flows/actions/*.go); types not consumed by Flow.update_dependencies (e.g. classifier) are intentionally omitted.
+_INSPECT_ACTION_REFS = {
+    "groups": "group",
+    "labels": "label",
+    "field": "field",
+    "flow": "flow",
+    "channel": "channel",
+    "llm": "llm",
+    "optin": "optin",
+    "topic": "topic",
+    "template": "template",
+}
+
+# contact field and global references read out of expressions. goflow resolves a field key as the segment after a
+# "fields" lookup at any of its context paths (fields/contact.fields/parent.fields/child.fields/...), so the key
+# is always what follows "fields." regardless of prefix; "globals.x" is a global. see goflow inspect/templates.go.
+_INSPECT_EXPR_REFS = re.compile(r"\b(fields|globals)\.([a-zA-Z][a-zA-Z0-9_]*)")
+
+# matches goflow's utils.Snakify: collapse runs of non-(letter/digit/underscore) to "_", trim, lowercase.
+_INSPECT_SNAKE = re.compile(r"[^\w]+", re.UNICODE)
+
+
+def _snakify(text: str) -> str:
+    return _INSPECT_SNAKE.sub("_", text.strip()).lower()
+
+
+def inspect_flow(definition: dict) -> dict:
+    """
+    Pragmatic Python stand-in for goflow's flow inspection (flows/inspect), used to fake flow/inspect for the
+    production client during tests instead of reaching a live mailroom. It reproduces the two parts of the
+    analysis that rapidpro consumes or asserts on:
+
+      - dependencies: the typed asset references that goflow's actions/routers enumerate, plus the field/global
+        references in expressions (used by Flow.save_revision / Flow.import_definition to wire up dependencies)
+      - results: the result specs that save-result actions and routers produce (stored on the flow and exposed
+        via the API/editor)
+
+    It is deliberately not a full port: goflow's issue analysis, structural validation, counts and locals aren't
+    reproduced. A test that needs those uses @mock_mailroom and stubs mr_mocks.flow_inspect (or, for validation
+    errors, mr_mocks.exception). During tests mailroom inspects without session assets (flow_inspect omits org_id
+    when settings.TESTING), so every dependency is missing=False and no asset-availability issues fire - matching
+    the empty issues we return here.
+    """
+
+    deps = []
+    deps_seen = set()
+    results = []
+    results_by_key = {}
+
+    def add_dep(dep_type: str, *, uuid: str = None, key: str = None, name: str = ""):
+        identity = uuid if uuid is not None else key
+        if identity is None or (dep_type, identity) in deps_seen:
+            return
+        deps_seen.add((dep_type, identity))
+        ref = {"type": dep_type, "name": name or "", "missing": False}
+        ref["uuid" if uuid is not None else "key"] = identity
+        deps.append(ref)
+
+    def add_typed_ref(dep_type: str, ref):
+        if isinstance(ref, dict):
+            add_dep(dep_type, uuid=ref.get("uuid"), key=ref.get("key"), name=ref.get("name", ""))
+
+    def scan_expressions(value):
+        if isinstance(value, str):
+            for namespace, key in _INSPECT_EXPR_REFS.findall(value):
+                add_dep("field" if namespace == "fields" else "global", key=key.lower())
+        elif isinstance(value, list):
+            for item in value:
+                scan_expressions(item)
+        elif isinstance(value, dict):
+            for item in value.values():
+                scan_expressions(item)
+
+    def add_result(node_uuid: str, name: str, categories: list):
+        # merge by snakified key, accumulating categories and the nodes that save the result (as goflow does)
+        key = _snakify(name)
+        spec = results_by_key.get(key)
+        if spec is None:
+            spec = {"key": key, "name": name, "categories": list(categories), "node_uuids": [node_uuid]}
+            results_by_key[key] = spec
+            results.append(spec)
+        else:
+            for category in categories:
+                if category not in spec["categories"]:
+                    spec["categories"].append(category)
+            if node_uuid not in spec["node_uuids"]:
+                spec["node_uuids"].append(node_uuid)
+
+    for node in definition.get("nodes", []):
+        node_uuid = node.get("uuid")
+        for action in node.get("actions", []):
+            for prop, dep_type in _INSPECT_ACTION_REFS.items():
+                if prop in action:
+                    value = action[prop]
+                    refs = value if isinstance(value, list) else [value]
+                    for ref in refs:
+                        add_typed_ref(dep_type, ref)
+            if action.get("type") == "set_run_result":
+                category = action.get("category")
+                add_result(node_uuid, action["name"], [category] if category else [])
+            scan_expressions(action)
+
+        router = node.get("router")
+        if router:
+            scan_expressions(router.get("operand"))
+            # only a has_group router test produces a dependency: arguments are [group_uuid] or [group_uuid, name]
+            for case in router.get("cases", []):
+                if case.get("type") == "has_group" and case.get("arguments"):
+                    args = case["arguments"]
+                    add_dep("group", uuid=args[0], name=args[1] if len(args) > 1 else "")
+            if router.get("result_name"):
+                add_result(node_uuid, router["result_name"], [c["name"] for c in router.get("categories", [])])
+
+    return {"dependencies": deps, "issues": [], "results": results, "parent_refs": [], "counts": {}, "locals": []}
+
+
 class LiveMailroomError(BaseException):
     """
     Raised when a test reaches a live mailroom instead of mocking it. Deliberately subclasses BaseException, not
@@ -95,10 +212,13 @@ def _guarded_mailroom_request(self, endpoint, payload=None, files=None, post=Tru
     if isinstance(transport, NonCallableMock):
         return _real_mailroom_request(self, endpoint, payload=payload, files=files, post=post, encode_json=encode_json)
 
-    # flow/clone is simple enough to reimplement in Python, so fake it for the production client used by
-    # undecorated import tests rather than reaching a live mailroom. unlike migrate/inspect it needs no goflow.
+    # flow/clone and flow/inspect are reached by undecorated import/save tests via the production client; both are
+    # faked from the request payload (see clone_flow_definition / inspect_flow) rather than reaching a live
+    # mailroom. @mock_mailroom tests don't get here - TestClient overrides the high-level client methods.
     if endpoint == "flow/clone":
         return clone_flow_definition(payload["flow"], payload["dependency_mapping"])
+    if endpoint == "flow/inspect":
+        return inspect_flow(payload["flow"])
 
     if endpoint not in LIVE_TEST_ENDPOINTS:
         raise LiveMailroomError(

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -35,12 +35,6 @@ event_units = {
     CampaignEvent.UNIT_WEEKS: "weeks",
 }
 
-# no endpoint is allowed to reach a live mailroom during tests. the two that undecorated tests reach via the
-# production client - flow/clone and flow/inspect - are faked below from the request payload; flow/migrate
-# either skips the call (current-spec definitions hit MailroomClient.flow_migrate's TESTING fast-path) or must
-# be stubbed with mr_mocks.flow_migrate. anything else reaching _request without a Mock transport raises.
-LIVE_TEST_ENDPOINTS = set()
-
 _real_mailroom_request = MailroomClient._request
 
 
@@ -220,12 +214,11 @@ def _guarded_mailroom_request(self, endpoint, payload=None, files=None, post=Tru
     if endpoint == "flow/inspect":
         return inspect_flow(payload["flow"])
 
-    if endpoint not in LIVE_TEST_ENDPOINTS:
-        raise LiveMailroomError(
-            f"test reached live mailroom endpoint /mi/{endpoint}; decorate the test with @mock_mailroom "
-            f"(adding a TestClient fake if needed) or mock the call"
-        )
-    return _real_mailroom_request(self, endpoint, payload=payload, files=files, post=post, encode_json=encode_json)
+    # any other endpoint reaching here is an un-mocked live mailroom call - fail loudly
+    raise LiveMailroomError(
+        f"test reached live mailroom endpoint /mi/{endpoint}; decorate the test with @mock_mailroom "
+        f"(adding a TestClient fake if needed) or mock the call"
+    )
 
 
 def install_mailroom_guard(test):


### PR DESCRIPTION
## Summary

`flow/inspect` was the last mailroom endpoint that undecorated tests reached on a *live* mailroom (the sole remaining entry in the test guard's allowed-endpoints set). This removes it — and with it the whole live-mailroom mechanism: **the test suite no longer requires a running mailroom, and CI no longer downloads or runs one.**

Rather than mock `flow/inspect` per-test (fragile and circular for the dependency-resolution tests, which import multi-flow graphs and trigger many inspect calls), this reimplements the part of goflow's inspection that rapidpro actually consumes as a Python stand-in (`inspect_flow`), and fakes the endpoint from the request payload in the guard — exactly mirroring how `flow/clone` is already handled for undecorated tests.

`inspect_flow` reproduces:
- **dependencies** — the typed asset references that goflow's actions/routers enumerate (groups, labels, fields, flows, channels, llms, optins, topics, templates, plus `has_group` router cases), and the field/global references found in expressions
- **results** — the result specs that save-result actions and routers produce, merged by snakified key across nodes

It deliberately does **not** reproduce goflow's issue analysis, structural validation, counts or locals — those aren't asserted by undecorated tests except for one structural-validation case, which now stubs the failure via `@mock_mailroom` + `mr_mocks.exception`. Tests that need richer inspection results continue to use `@mock_mailroom` with `mr_mocks.flow_inspect`.

Because the fake runs only on the production-client path (the guard patches `MailroomClient._request`, which `@mock_mailroom`'s `TestClient` overrides above this layer), `@mock_mailroom` tests are entirely unaffected.

## Follow-on cleanups (second commit)

- The guard's allowed-endpoints set is now empty, so it's removed — any endpoint that isn't faked or served by a mock transport now fails loudly unconditionally.
- The CI workflow no longer fetches and starts the mailroom binary (no test reaches it), dropping the download, the background process and the mailroom-log step.

## Coverage tradeoff

The dependency- and result-resolution tests now exercise a Python approximation of goflow's analysis instead of the real engine. goflow's internals aren't tested in this repo regardless, so this matches the project's existing stance; the approximation is covered by a focused unit test and validated against the existing import/dependency tests.

## Testing

- Dependency tests (subflow, dependency graph, all dependency types, implicit/explicit field+group imports, missing-flow-dependency) pass against the extractor
- `flow.info["results"]` assertions (flow info, flows API) pass against the ported result extraction
- Added a focused unit test for `inspect_flow` covering typed refs, expression refs, `has_group` cases, result merging and dedup
- Full CI suite green (and the second commit proves it stays green with no mailroom running in CI)