### PR TITLE
Remove redundant user:email and user:password notification types

### DIFF
--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -14,12 +14,7 @@ from temba.notifications.incidents.builtin import (
 )
 from temba.notifications.models import Notification
 from temba.notifications.tasks import send_notification_emails, trim_notifications
-from temba.notifications.types.builtin import (
-    ExportFinishedNotificationType,
-    InvitationAcceptedNotificationType,
-    UserEmailNotificationType,
-    UserPasswordNotificationType,
-)
+from temba.notifications.types.builtin import ExportFinishedNotificationType, InvitationAcceptedNotificationType
 from temba.orgs.models import Invitation, ItemCount, OrgRole
 from temba.tests import TembaTest, matchers
 from temba.tickets.models import TicketExport
@@ -344,48 +339,6 @@ class NotificationTest(TembaTest):
 
         recipients = set(mail.outbox[0].recipients()).union(mail.outbox[1].recipients())
         self.assertEqual({self.admin.email, self.editor.email}, recipients)
-
-    def test_user_email(self):
-        UserEmailNotificationType.create(self.org, self.editor, "prevaddr@trileet.com")
-
-        self.assert_notifications(
-            expected_json={
-                "type": "user:email",
-                "created_on": matchers.ISODatetime(),
-                "is_seen": True,
-            },
-            expected_target=None,
-            expected_users={self.editor},
-            email=True,
-        )
-
-        send_notification_emails()
-
-        self.assertEqual(1, len(mail.outbox))
-        self.assertEqual("[Nyaruka] Your email has been changed", mail.outbox[0].subject)
-        self.assertEqual(["prevaddr@trileet.com"], mail.outbox[0].recipients())  # previous address
-        self.assertIn("Your email has been changed to editor@textit.com", mail.outbox[0].body)  # new address
-
-    def test_user_password(self):
-        UserPasswordNotificationType.create(self.org, self.editor)
-
-        self.assert_notifications(
-            expected_json={
-                "type": "user:password",
-                "created_on": matchers.ISODatetime(),
-                "is_seen": True,
-            },
-            expected_target=None,
-            expected_users={self.editor},
-            email=True,
-        )
-
-        send_notification_emails()
-
-        self.assertEqual(1, len(mail.outbox))
-        self.assertEqual("[Nyaruka] Your password has been changed", mail.outbox[0].subject)
-        self.assertEqual(["editor@textit.com"], mail.outbox[0].recipients())
-        self.assertIn("Your password has been changed.", mail.outbox[0].body)
 
     def test_invitation_accepted(self):
         invitation = Invitation.create(self.org, self.admin, "bob@textit.com", OrgRole.ADMINISTRATOR)

--- a/temba/notifications/types/__init__.py
+++ b/temba/notifications/types/__init__.py
@@ -5,8 +5,6 @@ from .builtin import (
     InvitationAcceptedNotificationType,
     TicketActivityNotificationType,
     TicketsOpenedNotificationType,
-    UserEmailNotificationType,
-    UserPasswordNotificationType,
 )
 
 TYPES = {}
@@ -29,5 +27,3 @@ register_notification_type(IncidentStartedNotificationType())
 register_notification_type(InvitationAcceptedNotificationType())
 register_notification_type(TicketsOpenedNotificationType())
 register_notification_type(TicketActivityNotificationType())
-register_notification_type(UserEmailNotificationType())
-register_notification_type(UserPasswordNotificationType())

--- a/temba/notifications/types/builtin.py
+++ b/temba/notifications/types/builtin.py
@@ -119,61 +119,6 @@ class TicketActivityNotificationType(NotificationType):
         return "/ticket/mine/"
 
 
-class UserEmailNotificationType(NotificationType):
-    """
-    Notification that a user's email has been changed.
-    """
-
-    slug = "user:email"
-
-    @classmethod
-    def create(cls, org, user, prev_email: str):
-        Notification.create_all(
-            org,
-            cls.slug,
-            scope=str(user.id),
-            users=[user],
-            medium=Notification.MEDIUM_EMAIL,
-            email_address=prev_email,
-        )
-
-    def get_target_url(self, notification) -> str:
-        pass
-
-    def get_email_subject(self, notification) -> str:
-        return _("Your email has been changed")
-
-    def get_email_template(self, notification) -> str:
-        return "notifications/email/user_email"
-
-
-class UserPasswordNotificationType(NotificationType):
-    """
-    Notification that a user's password has been changed.
-    """
-
-    slug = "user:password"
-
-    @classmethod
-    def create(cls, org, user):
-        Notification.create_all(
-            org,
-            cls.slug,
-            scope=str(user.id),
-            users=[user],
-            medium=Notification.MEDIUM_EMAIL,
-        )
-
-    def get_target_url(self, notification) -> str:
-        pass
-
-    def get_email_subject(self, notification) -> str:
-        return _("Your password has been changed")
-
-    def get_email_template(self, notification) -> str:
-        return "notifications/email/user_password"
-
-
 class InvitationAcceptedNotificationType(NotificationType):
     """
     Notification that a user accepted an invitation to join the workspace.

--- a/templates/notifications/email/user_email.html
+++ b/templates/notifications/email/user_email.html
@@ -1,9 +1,0 @@
-{% extends "notifications/email/base.html" %}
-{% load i18n %}
-
-{% block notification-body %}
-  <p>
-    {% blocktrans with email=notification.user.email %}Your email has been changed to <b>{{ email }}</b>.{% endblocktrans %}
-  </p>
-  <p>{% trans "If you did not make that change, please get in touch with support." %}</p>
-{% endblock notification-body %}

--- a/templates/notifications/email/user_email.txt
+++ b/templates/notifications/email/user_email.txt
@@ -1,8 +1,0 @@
-{% extends "notifications/email/base.txt" %}
-{% load i18n %}
-
-{% block notification-body %}
-{% blocktrans with email=notification.user.email %}Your email has been changed to {{ email }}.{% endblocktrans %}
-
-{% trans "If you did not make that change, please get in touch with support." %}
-{% endblock notification-body %}

--- a/templates/notifications/email/user_password.html
+++ b/templates/notifications/email/user_password.html
@@ -1,7 +1,0 @@
-{% extends "notifications/email/base.html" %}
-{% load i18n %}
-
-{% block notification-body %}
-  <p>{% trans "Your password has been changed." %}</p>
-  <p>{% trans "If you did not make that change, please get in touch with support." %}</p>
-{% endblock notification-body %}

--- a/templates/notifications/email/user_password.txt
+++ b/templates/notifications/email/user_password.txt
@@ -1,8 +1,0 @@
-{% extends "notifications/email/base.txt" %}
-{% load i18n %}
-
-{% block notification-body %}
-{% trans "Your password has been changed." %}
-
-{% trans "If you did not make that change, please get in touch with support." %}
-{% endblock notification-body %}


### PR DESCRIPTION
## Summary

Removes the `user:email` and `user:password` notification types, which fired when a user's email address or password changed. These are now redundant: account email-address and password changes are handled by **django-allauth**, which sends its own notification emails when `ACCOUNT_EMAIL_NOTIFICATIONS = True` (currently set). Those emails render the project's branded `account/email/email_changed` and `account/email/password_changed` templates via the custom account adapter.

The two notification types had **no production call sites** — their `.create()` classmethods were only ever invoked from tests.

## Changes

- Remove `UserEmailNotificationType` and `UserPasswordNotificationType` from `temba/notifications/types/builtin.py`
- Remove their imports and `register_notification_type(...)` calls in `temba/notifications/types/__init__.py`
- Delete the `notifications/email/user_email.*` and `notifications/email/user_password.*` email templates
- Remove the corresponding tests in `temba/notifications/tests/test_notification.py`

## No migration needed

`Notification.notification_type` is a plain `CharField` (no DB-level choices/enum), so removing the Python types produces no schema change — `manage.py makemigrations --check` reports no changes. These types were never created in production, so there are no existing `notifications_notification` rows to clean up.

## Verification

- `manage.py test temba.notifications` — passes (21 tests)
- `ruff format --check temba` and `ruff check temba` — clean
- `manage.py makemigrations --check` — no changes detected