### PR TITLE
Publish locally-created UI notifications to realtime sockets via mailroom

### DIFF
--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -373,6 +373,13 @@ class MailroomClient:
             },
         )
 
+    def notification_publish(self, org, notifications: list[dict]):
+        """
+        Publishes already-created notifications to their users' realtime sockets. Each item is
+        {"user_id": int, "data": dict} where data is the notification's rendered JSON.
+        """
+        return self._request("notification/publish", {"org_id": org.id, "notifications": notifications})
+
     def org_deindex(self, org):
         return self._request("org/deindex", {"org_id": org.id})
 

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -931,6 +931,20 @@ class MailroomClientTest(TembaTest):
         )
 
     @patch("requests.post")
+    def test_notification_publish(self, mock_post):
+        mock_post.return_value = MockJsonResponse(200, {})
+        notifications = [{"user_id": self.admin.id, "data": {"type": "export:finished"}}]
+        response = self.client.notification_publish(self.org, notifications)
+
+        self.assertEqual({}, response)
+
+        mock_post.assert_called_once_with(
+            "http://localhost:8090/mi/notification/publish",
+            headers={"User-Agent": "Temba", "Authorization": "Token sesame"},
+            json={"org_id": self.org.id, "notifications": notifications},
+        )
+
+    @patch("requests.post")
     def test_org_deindex(self, mock_post):
         mock_post.return_value = MockJsonResponse(200, {})
         response = self.client.org_deindex(self.org)

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -2,7 +2,7 @@ import logging
 from abc import abstractmethod
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
@@ -198,13 +198,14 @@ class Notification(models.Model):
         medium: str = MEDIUM_UI,
         **kwargs,
     ):
+        created = []
         for user in users:
             # send email if notification type supports it and user's email is verified
             email_status = cls.EMAIL_STATUS_NONE
             if cls.MEDIUM_EMAIL in medium:
                 email_status = cls.EMAIL_STATUS_PENDING if user.is_verified() else cls.EMAIL_STATUS_UNVERIFIED
 
-            cls.objects.get_or_create(
+            notification, is_new = cls.objects.get_or_create(
                 org=org,
                 notification_type=notification_type,
                 scope=scope,
@@ -214,6 +215,30 @@ class Notification(models.Model):
                 email_status=email_status,
                 defaults=kwargs,
             )
+
+            # UI notifications are delivered live over the user's realtime socket; collect the newly created ones so
+            # they can be published once the surrounding transaction commits
+            if is_new and cls.MEDIUM_UI in medium:
+                created.append(notification)
+
+        if created:
+            transaction.on_commit(lambda: cls._publish(org, created))
+
+    @classmethod
+    def _publish(cls, org, notifications):
+        """
+        Best-effort realtime delivery of newly created UI notifications to their users' sockets, via mailroom - which
+        owns the socket addressing, subscriber-presence check and centrifugo publish, so those have one implementation
+        for both the notifications mailroom creates and the ones we create here. A failure must not fail the creating
+        operation: the notifications are already persisted and will still show on the next page load.
+        """
+        from temba.mailroom import get_client
+
+        items = [{"user_id": n.user_id, "data": n.as_json()} for n in notifications]
+        try:
+            get_client().notification_publish(org, items)
+        except Exception:
+            logger.exception("error publishing notifications to mailroom")
 
     def send_email(self):
         subject = self.type.get_email_subject(self)

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -406,6 +406,19 @@ class NotificationTest(TembaTest):
 
         self.assertTrue(self.editor.notifications.filter(export=export2).exists())
 
+        # a type that fans out to multiple users is published as a single batched call with one entry per user
+        self.org.add_user(self.editor, OrgRole.ADMINISTRATOR)  # so the incident notifies both admin and editor
+        before = len(mr_mocks.calls["notification_publish"])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ChannelDisconnectedIncidentType.get_or_create(channel=self.channel)
+
+        new_calls = mr_mocks.calls["notification_publish"][before:]
+        self.assertEqual(1, len(new_calls))  # one batched publish, not one per user
+        org_arg, items = new_calls[0].args
+        self.assertEqual(self.org, org_arg)
+        self.assertEqual({self.admin.id, self.editor.id}, {item["user_id"] for item in items})
+
     def test_channel_disconnected(self):
         self.org.add_user(self.editor, OrgRole.ADMINISTRATOR)  # upgrade editor to administrator
 

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+from unittest.mock import call
 
 from django.core import mail
 from django.urls import reverse
@@ -17,6 +18,7 @@ from temba.notifications.tasks import send_notification_emails, trim_notificatio
 from temba.notifications.types.builtin import ExportFinishedNotificationType, InvitationAcceptedNotificationType
 from temba.orgs.models import Invitation, ItemCount, OrgRole
 from temba.tests import TembaTest, matchers
+from temba.tests.mailroom import mock_mailroom
 from temba.tickets.models import TicketExport
 
 
@@ -364,6 +366,35 @@ class NotificationTest(TembaTest):
         self.assertEqual("[Nyaruka] New user joined your workspace", mail.outbox[0].subject)
         self.assertEqual(["admin@textit.com"], mail.outbox[0].recipients())  # only the other admins
         self.assertIn("User bob@textit.com accepted an invitation to join your workspace.", mail.outbox[0].body)
+
+    @mock_mailroom
+    def test_realtime_publish(self, mr_mocks):
+        # UI notifications are published to mailroom for realtime delivery once the transaction commits
+        export = ContactExport.create(self.org, self.editor)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ExportFinishedNotificationType.create(export)
+
+        notification = self.editor.notifications.get(export=export)
+        self.assertEqual(
+            [call(self.org, [{"user_id": self.editor.id, "data": notification.as_json()}])],
+            mr_mocks.calls["notification_publish"],
+        )
+
+        # email-only notifications are never published (no UI medium, nothing to deliver live)
+        invitation = Invitation.create(self.org, self.admin, "bob@textit.com", OrgRole.ADMINISTRATOR)
+        user = self.create_user("bob@textit.com")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            InvitationAcceptedNotificationType.create(invitation, user)
+
+        self.assertEqual(1, len(mr_mocks.calls["notification_publish"]))
+
+        # a duplicate (already-unseen) notification isn't re-created, so nothing new is published
+        with self.captureOnCommitCallbacks(execute=True):
+            ExportFinishedNotificationType.create(export)
+
+        self.assertEqual(1, len(mr_mocks.calls["notification_publish"]))
 
     def test_channel_disconnected(self):
         self.org.add_user(self.editor, OrgRole.ADMINISTRATOR)  # upgrade editor to administrator

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -396,6 +396,16 @@ class NotificationTest(TembaTest):
 
         self.assertEqual(1, len(mr_mocks.calls["notification_publish"]))
 
+        # publishing is best-effort: a mailroom failure is logged, not raised, and the notification is still created
+        export2 = ContactExport.create(self.org, self.editor)
+        mr_mocks.exception(ConnectionError("mailroom unreachable"))
+
+        with self.assertLogs("temba.notifications.models", level="ERROR"):
+            with self.captureOnCommitCallbacks(execute=True):
+                ExportFinishedNotificationType.create(export2)
+
+        self.assertTrue(self.editor.notifications.filter(export=export2).exists())
+
     def test_channel_disconnected(self):
         self.org.add_user(self.editor, OrgRole.ADMINISTRATOR)  # upgrade editor to administrator
 

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -694,6 +694,10 @@ class TestClient(MailroomClient):
         }
 
     @_client_method
+    def notification_publish(self, org, notifications: list[dict]):
+        return {}
+
+    @_client_method
     def org_deindex(self, org):
         return {}
 


### PR DESCRIPTION
## What

UI notifications created here (finished exports, locally-detected incidents) are now delivered live to a user's realtime notification socket, instead of only appearing on the next page load.

## Why

`Notification.create_all` only persisted rows to the database. The notifications mailroom creates get published to the user's `notifications:<org>:<user>` socket for live delivery, but the ones we create ourselves didn't — so they lagged until the next fetch/page load.

## How

- `Notification.create_all` collects the newly created UI-medium notifications and, via `transaction.on_commit`, hands their rendered `as_json()` to mailroom's `notification/publish` endpoint.
- Mailroom owns the socket addressing, subscriber-presence check and centrifugo publish, so there's a single implementation for both the notifications it creates and the ones created here; we just pass the pre-rendered payload.
- Delivery is best-effort: a failure is logged and never fails the creating operation, since the notification is already persisted.
- Adds `MailroomClient.notification_publish` and a `TestClient` fake.

## Notes for reviewers

- Depends on the mailroom `POST /mi/notification/publish` endpoint (nyaruka/mailroom#1110, merged).
- Email-only notification types (e.g. `invitation:accepted`) have no UI medium, so nothing is published for them.
- Deferring to `on_commit` mirrors mailroom's own publish-after-commit behaviour and avoids publishing a notification whose transaction later rolls back.
- New test `NotificationTest.test_realtime_publish` covers the publish call + payload, that email-only types don't publish, and that a deduped (already-unseen) notification doesn't re-publish.