### PR TITLE
Update @nyaruka/temba-components to 0.161.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.160.1",
+    "@nyaruka/temba-components": "0.161.0",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nyaruka/temba-components@0.160.1":
-  version "0.160.1"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.160.1.tgz#a6d0c0394a3cc76d21e3f9054bbf85b9b8dcdbf5"
-  integrity sha512-IL6goD2NM1Gzy37UnT9WIl/VPNDKpMzSAFVkbHNdH+9BZcgdj/gpbjl/u2W7sfUEDSVHjszZu757Ts4/wLrIFQ==
+"@nyaruka/temba-components@0.161.0":
+  version "0.161.0"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.161.0.tgz#d56ff9ad41fe6baf2ab5bd64b6f66282c510be09"
+  integrity sha512-NSRjP0NF4qMQ1ylAkJeOXAxrJuD5e98Qz2TBJeIBuIyiQgcK7l8rzOF7WsQWyBuMjA7cNT8s3Vq/x7/MERCHyA==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.161.0](https://github.com/nyaruka/temba-components/compare/v0.160.1...v0.161.0)

- Support legacy webhooks by preserving result_name placement [#1035](https://github.com/nyaruka/temba-components/pull/1035)
- Flow list label chips link to the label view [#1036](https://github.com/nyaruka/temba-components/pull/1036)