### PR TITLE
Include ticket lifecycle events from other tickets when fetching history for a ticket

### DIFF
--- a/temba/mailroom/events.py
+++ b/temba/mailroom/events.py
@@ -45,8 +45,9 @@ class Event:
     TYPE_TICKET_REOPENED = "ticket_reopened"
     TYPE_TICKET_TOPIC_CHANGED = "ticket_topic_changed"
 
-    basic_ticket_types = {TYPE_TICKET_CLOSED, TYPE_TICKET_OPENED, TYPE_TICKET_REOPENED}
-    all_ticket_types = basic_ticket_types | {TYPE_TICKET_ASSIGNED, TYPE_TICKET_NOTE_ADDED, TYPE_TICKET_TOPIC_CHANGED}
+    # per-ticket detail events which are only shown on the read page of the ticket they belong to, as opposed to the
+    # lifecycle events (opened/closed/reopened) which are shown everywhere
+    ticket_detail_types = {TYPE_TICKET_ASSIGNED, TYPE_TICKET_NOTE_ADDED, TYPE_TICKET_TOPIC_CHANGED}
 
     @classmethod
     def _from_item(cls, contact, item: dict) -> dict:
@@ -134,14 +135,10 @@ class Event:
 
     @classmethod
     def _include_event(cls, event, ticket_uuid) -> bool:
-        if event["type"] in cls.all_ticket_types:
-            if ticket_uuid:
-                # if we have a ticket this is for the ticket UI, so we want *all* events for *only* that ticket
-                event_ticket_uuid = event.get("ticket_uuid", event.get("ticket", {}).get("uuid"))
-                return event_ticket_uuid == str(ticket_uuid)
-            else:
-                # if not then this for the contact read page so only show ticket opened/closed/reopened events
-                return event["type"] in cls.basic_ticket_types
+        if event["type"] in cls.ticket_detail_types:
+            # detail events are only included when fetching for the ticket they belong to
+            event_ticket_uuid = event.get("ticket_uuid", event.get("ticket", {}).get("uuid"))
+            return bool(ticket_uuid) and event_ticket_uuid == str(ticket_uuid)
 
         return True
 

--- a/temba/mailroom/tests/test_event.py
+++ b/temba/mailroom/tests/test_event.py
@@ -370,7 +370,7 @@ class EventTest(TembaTest):
             for item in items:
                 writer.put_item(item)
 
-        # by default we only include basic ticket event types
+        # by default we only include ticket lifecycle event types
         self.assert_get_by_contact(
             contact,
             self.admin,
@@ -386,13 +386,14 @@ class EventTest(TembaTest):
             ],
         )
 
-        # if we specify ticket 1 then we get only events for that ticket
+        # if we specify ticket 1 then we also get detail events for that ticket (but not for ticket 2)
         self.assert_get_by_contact(
             contact,
             self.admin,
             before=UUID("019a9dc5-b384-7b2d-a1e1-a315a2ebe926"),  # in the future
             ticket=UUID("01994f4f-45ba-7f25-a785-b52e19b16c6b"),
             expected=[
+                "019a9336-9228-7f2e-bb18-26c5f392fec5",  # ticket_opened for ticket 2
                 "019a9336-9228-7d59-b7c2-25c3d7091357",
                 "019a9336-9228-7b7d-b068-89df0c04df2f",  # ticket_closed for ticket 1
                 "019a9336-9228-79a0-9f72-232125ced67d",
@@ -413,7 +414,9 @@ class EventTest(TembaTest):
                 "019a9336-9229-71c1-a6f9-695b374c13a3",  # ticket_note_added for ticket 2
                 "019a9336-9228-7f2e-bb18-26c5f392fec5",  # ticket_opened for ticket 2
                 "019a9336-9228-7d59-b7c2-25c3d7091357",
+                "019a9336-9228-7b7d-b068-89df0c04df2f",  # ticket_closed for ticket 1
                 "019a9336-9228-79a0-9f72-232125ced67d",
+                "019a9336-9228-75c8-8824-0dd4f9484be9",  # ticket_opened for ticket 1
                 "019a9336-9228-73e8-b4f5-3a2b42593bb0",
                 "019a9336-9228-71f0-becb-a56435927677",
             ],


### PR DESCRIPTION
When fetching contact history scoped to a ticket, ticket opened/closed/reopened events for *other* tickets were filtered out. This didn't match how mailroom routes realtime events, where lifecycle events go to the contact channel which the ticket view also subscribes to — so the realtime stream included them but a fetch didn't.

Now only the per-ticket detail events (assignee, note and topic changes) are filtered to the ticket being fetched, and lifecycle events are always included, making fetched history consistent with the realtime stream. The \`basic_ticket_types\`/\`all_ticket_types\` sets are replaced by a single \`ticket_detail_types\` set.