### PR TITLE
Include user UUID when publishing notifications to mailroom

### DIFF
--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -376,7 +376,8 @@ class MailroomClient:
     def notification_publish(self, org, notifications: list[dict]):
         """
         Publishes already-created notifications to their users' realtime sockets. Each item is
-        {"user_id": int, "data": dict} where data is the notification's rendered JSON.
+        {"user_uuid": str, "user_id": int, "data": dict} where data is the notification's rendered JSON and
+        user_id is deprecated.
         """
         return self._request("notification/publish", {"org_id": org.id, "notifications": notifications})
 

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -933,7 +933,9 @@ class MailroomClientTest(TembaTest):
     @patch("requests.post")
     def test_notification_publish(self, mock_post):
         mock_post.return_value = MockJsonResponse(200, {})
-        notifications = [{"user_id": self.admin.id, "data": {"type": "export:finished"}}]
+        notifications = [
+            {"user_uuid": str(self.admin.uuid), "user_id": self.admin.id, "data": {"type": "export:finished"}}
+        ]
         response = self.client.notification_publish(self.org, notifications)
 
         self.assertEqual({}, response)

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -229,12 +229,18 @@ class Notification(models.Model):
         """
         Best-effort realtime delivery of newly created UI notifications to their users' sockets, via mailroom - which
         owns the socket addressing, subscriber-presence check and centrifugo publish, so those have one implementation
-        for both the notifications mailroom creates and the ones we create here. A failure must not fail the creating
-        operation: the notifications are already persisted and will still show on the next page load.
+        for both the notifications mailroom creates and the ones we create here. Users are identified by UUID because
+        that's what socket addressing uses, and because the user may not belong to the workspace (e.g. staff). A
+        failure must not fail the creating operation: the notifications are already persisted and will still show on
+        the next page load.
         """
         from temba.mailroom import get_client
 
-        items = [{"user_id": n.user_id, "data": n.as_json()} for n in notifications]
+        items = [
+            # user_id is deprecated but still sent for mailroom versions that don't read user_uuid
+            {"user_uuid": str(n.user.uuid), "user_id": n.user_id, "data": n.as_json()}
+            for n in notifications
+        ]
         try:
             get_client().notification_publish(org, items)
         except Exception:

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -377,7 +377,12 @@ class NotificationTest(TembaTest):
 
         notification = self.editor.notifications.get(export=export)
         self.assertEqual(
-            [call(self.org, [{"user_id": self.editor.id, "data": notification.as_json()}])],
+            [
+                call(
+                    self.org,
+                    [{"user_uuid": str(self.editor.uuid), "user_id": self.editor.id, "data": notification.as_json()}],
+                )
+            ],
             mr_mocks.calls["notification_publish"],
         )
 
@@ -417,7 +422,7 @@ class NotificationTest(TembaTest):
         self.assertEqual(1, len(new_calls))  # one batched publish, not one per user
         org_arg, items = new_calls[0].args
         self.assertEqual(self.org, org_arg)
-        self.assertEqual({self.admin.id, self.editor.id}, {item["user_id"] for item in items})
+        self.assertEqual({str(self.admin.uuid), str(self.editor.uuid)}, {item["user_uuid"] for item in items})
 
     def test_channel_disconnected(self):
         self.org.add_user(self.editor, OrgRole.ADMINISTRATOR)  # upgrade editor to administrator


### PR DESCRIPTION
Realtime notification sockets are addressed by user UUID, but the publish payload only carried the user's id, forcing mailroom to resolve it against the workspace's users. That lookup fails - and the notification is silently dropped, with an error logged - for users who aren't members of the workspace, e.g. staff who serviced it and ran an export there.

This sends `user_uuid` in each notification so mailroom can address the socket directly without any user lookup. `user_id` is still included (commented as deprecated) so older mailroom versions that only read it keep working regardless of deploy order; it can be dropped once those are gone.

Pairs with nyaruka/mailroom#1116, which makes the publish endpoint prefer `user_uuid` and fall back to `user_id`.