### PR TITLE
Stop sending deprecated user_id to mailroom's notification/publish endpoint

### DIFF
--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -376,8 +376,7 @@ class MailroomClient:
     def notification_publish(self, org, notifications: list[dict]):
         """
         Publishes already-created notifications to their users' realtime sockets. Each item is
-        {"user_uuid": str, "user_id": int, "data": dict} where data is the notification's rendered JSON and
-        user_id is deprecated.
+        {"user_uuid": str, "data": dict} where data is the notification's rendered JSON.
         """
         return self._request("notification/publish", {"org_id": org.id, "notifications": notifications})
 

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -933,9 +933,7 @@ class MailroomClientTest(TembaTest):
     @patch("requests.post")
     def test_notification_publish(self, mock_post):
         mock_post.return_value = MockJsonResponse(200, {})
-        notifications = [
-            {"user_uuid": str(self.admin.uuid), "user_id": self.admin.id, "data": {"type": "export:finished"}}
-        ]
+        notifications = [{"user_uuid": str(self.admin.uuid), "data": {"type": "export:finished"}}]
         response = self.client.notification_publish(self.org, notifications)
 
         self.assertEqual({}, response)

--- a/temba/notifications/models.py
+++ b/temba/notifications/models.py
@@ -236,11 +236,7 @@ class Notification(models.Model):
         """
         from temba.mailroom import get_client
 
-        items = [
-            # user_id is deprecated but still sent for mailroom versions that don't read user_uuid
-            {"user_uuid": str(n.user.uuid), "user_id": n.user_id, "data": n.as_json()}
-            for n in notifications
-        ]
+        items = [{"user_uuid": str(n.user.uuid), "data": n.as_json()} for n in notifications]
         try:
             get_client().notification_publish(org, items)
         except Exception:

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -380,7 +380,7 @@ class NotificationTest(TembaTest):
             [
                 call(
                     self.org,
-                    [{"user_uuid": str(self.editor.uuid), "user_id": self.editor.id, "data": notification.as_json()}],
+                    [{"user_uuid": str(self.editor.uuid), "data": notification.as_json()}],
                 )
             ],
             mr_mocks.calls["notification_publish"],


### PR DESCRIPTION
Mailroom now reads `user_uuid` from notification publish requests, so we no longer need to send the deprecated `user_id` field.