### PR TITLE
Drop redundant inline-block from CSS-based buttons

### DIFF
--- a/templates/channels/types/whatsapp_legacy/config.html
+++ b/templates/channels/types/whatsapp_legacy/config.html
@@ -10,5 +10,5 @@
 <div class="mt-4">
   <a href="{% url 'channels.types.whatsapp_legacy.refresh' channel.uuid %}"
      onclick="handlePosterizeClick(event)"
-     class="button-primary inline-block mt-2 posterize">{% trans "Refresh Contacts" %}</a>
+     class="button-primary mt-2 posterize">{% trans "Refresh Contacts" %}</a>
 </div>

--- a/templates/public/public_style.html
+++ b/templates/public/public_style.html
@@ -321,7 +321,7 @@
     <div class="code">.lift</div>
     , but looks best when applied to things with a shadow.
     <div class="mt-2">
-      <div class="button-primary lift inline-block">Lifted Button</div>
+      <div class="button-primary lift">Lifted Button</div>
     </div>
     <div class="mt-2">
       <div class="card w-128 lift cursor-pointer">

--- a/templates/public/public_welcome.html
+++ b/templates/public/public_welcome.html
@@ -69,7 +69,7 @@
 
           {% endblocktrans %}
           <div class="mt-6">
-            <a href="{% url 'flows.flow_list' %}" onclick="goto(event)" class="button-light lift inline-block">{% trans "Create a Flow" %}</a>
+            <a href="{% url 'flows.flow_list' %}" onclick="goto(event)" class="button-light lift">{% trans "Create a Flow" %}</a>
           </div>
         </div>
       </div>
@@ -102,7 +102,7 @@
           <div class="mt-6">
             <div href="{% url 'channels.channel_claim' %}"
                  onclick="goto(event)"
-                 class="button-primary lift inline-block">{% trans "Add Number" %}</div>
+                 class="button-primary lift">{% trans "Add Number" %}</div>
           </div>
         </div>
       </div>
@@ -141,16 +141,16 @@
           {% endblocktrans %}
         </div>
         <div class="mt-6">
-          <a href="{% url 'contacts.contactimport_create' %}" class="button-primary lift inline-block mr-1 mb-1">{% trans "Import Contacts" %}</a>
+          <a href="{% url 'contacts.contactimport_create' %}" class="button-primary lift mr-1 mb-1">{% trans "Import Contacts" %}</a>
           <temba-modax endpoint="{% url 'contacts.contact_create' %}"
                        header="{{ _("Create Contact") |escapejs }}"
                        class="inline-block mb-1">
-            <div class="button-light lift inline-block mr-1">{% trans "Create Contact" %}</div>
+            <div class="button-light lift mr-1">{% trans "Create Contact" %}</div>
           </temba-modax>
           <temba-modax endpoint="{% url 'contacts.contactgroup_create' %}"
                        header="{{ _("Create Group") |escapejs }}"
                        class="inline-block mb-1">
-            <div class="button-light lift inline-block mr-1 mb-1">{% trans "Create Group" %}</div>
+            <div class="button-light lift mr-1 mb-1">{% trans "Create Group" %}</div>
           </temba-modax>
         </div>
       </div>
@@ -217,7 +217,7 @@
         <div class="mt-6">
           {% block account-details %}
           {% endblock account-details %}
-          <a href="{% url 'api' %}" class="button-light lift inline-block">{% trans "API Documentation" %}</a>
+          <a href="{% url 'api' %}" class="button-light lift">{% trans "API Documentation" %}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The class-based buttons (`button-primary`, `button-light`, etc.) now set `display: inline-flex` in the scss source, so the `inline-block` utility class left on these elements was overriding the intended display. This removes it from the welcome page, the public style guide, and the WhatsApp legacy config page.