### PR TITLE
Remove unused mailroom client methods for system endpoints

### DIFF
--- a/temba/mailroom/client/client.py
+++ b/temba/mailroom/client/client.py
@@ -468,15 +468,6 @@ class MailroomClient:
             },
         )
 
-    def system_errors(self, log, ret, panic):  # pragma: no cover
-        return self._request("system/errors", {"log": log, "ret": ret, "panic": panic})
-
-    def system_latency(self) -> list:  # pragma: no cover
-        return self._request("system/latency", {}, post=False)
-
-    def system_queues(self) -> dict:  # pragma: no cover
-        return self._request("system/queues", {}, post=False)
-
     def _request(self, endpoint, payload=None, files=None, post=True, encode_json=False):
         if logger.isEnabledFor(logging.DEBUG):  # pragma: no cover
             logger.debug("=============== %s request ===============" % endpoint)

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -761,16 +761,6 @@ class TestClient(MailroomClient):
 
         return {"changed_uuids": [str(t.uuid) for t in tickets]}
 
-    def system_latency(self) -> list:
-        return []
-
-    def system_queues(self) -> dict:
-        return {
-            "batch": {"queued": {}, "active": {}, "paused": {}},
-            "realtime": {"queued": {}, "active": {}, "paused": {}},
-            "throttled": {"queued": {}, "active": {}, "paused": {}},
-        }
-
 
 def mock_mailroom(method=None):
     """


### PR DESCRIPTION
The client methods for the `system/errors`, `system/latency` and `system/queues` endpoints (and the test client stubs for the latter two) are no longer used, so remove them.