### PR TITLE
Disable allauth rate limiting when testing

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -968,3 +968,6 @@ ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 ACCOUNT_CONFIRM_EMAIL_ON_GET = True
 
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1"]
+
+if TESTING:
+    ACCOUNT_RATE_LIMITS = False  # rate limit state in the cache would otherwise persist between test runs


### PR DESCRIPTION
django-allauth's rate limits are backed by the cache, so when the test cache isn't ephemeral, limit state (e.g. `confirm_email`, 1/3m per email) persists between test runs. Repeated runs of `UserAuthTest.test_signup` then fail with an empty `mail.outbox` because the confirmation email is silently rate limited.

Setting `ACCOUNT_RATE_LIMITS = False` when testing disables rate limiting entirely (allauth resolves it to an empty limits dict), so no limit state is read or written under test. No tests assert on rate-limiting behavior.

Verified by running the signup test twice in quick succession against a shared cache — previously the second run failed, now both pass.