### PR TITLE
Remove chat refreshes made redundant by socket delivery of ticket events

### DIFF
--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -352,7 +352,6 @@ class TicketCRUDL(SmartCRUDL):
                         _("Add Note"),
                         "add-note",
                         f"{reverse('tickets.ticket_note', args=[ticket.uuid])}",
-                        on_submit="handleNoteAdded()",
                     )
 
                 if not ticket.contact.current_flow:

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -474,23 +474,11 @@
 
     function removeTicket(uuid) {
       var tickets = document.querySelector("temba-ticket-list");
-      var chat = document.querySelector("temba-contact-chat");
       tickets.removeItem(uuid);
-    }
-
-    function handleTicketAssigned() {
-      var chat = document.querySelector("temba-contact-chat");
-      chat.refresh();
-    }
-
-    function handleNoteAdded() {
-      var chat = document.querySelector("temba-contact-chat");
-      chat.refresh();
     }
 
     function handleTicketUpdated(event) {
       var tickets = document.querySelector("temba-ticket-list");
-      var chat = document.querySelector("temba-contact-chat");
 
       if (event.detail.ticket) {
         const ticket = event.detail.ticket;
@@ -527,7 +515,6 @@
           }
 
           tickets.refresh();
-          chat.refresh();
           refreshMenu();
 
           var contentMenu = document.querySelector("#default-content-menu");


### PR DESCRIPTION
Now that the chat component receives new history events live over WebSockets, the ticket list page no longer needs to manually refresh the chat after ticket actions:

- Removed `handleTicketAssigned` and `handleNoteAdded` — these were dead code, defined but never wired to any component event.
- Removed the `chat.refresh()` call in `handleTicketUpdated` — assignment, status and topic change events now arrive over the ticket's history channel, so the chat doesn't need a manual refresh. The ticket list, menu and content menu refreshes remain since they aren't event driven.
- Removed an unused variable in `removeTicket`.

The remaining `chat.refresh()` calls (ticket selection, flow started, contact updated) are kept because they refetch contact *data* (name, fields, groups), which isn't delivered over the history channel.