### PR TITLE
Add preview mode for trigger lists

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -13,9 +13,11 @@ from temba.contacts.models import ContactExport, ContactGroup
 from temba.flows.models import Flow, FlowLabel
 from temba.msgs.models import Msg
 from temba.notifications.types import ExportFinishedNotificationType
+from temba.schedules.models import Schedule
 from temba.templates.models import TemplateTranslation
 from temba.tests import TembaTest, matchers, mock_mailroom
 from temba.tickets.models import Shortcut, TicketExport
+from temba.triggers.models import Trigger
 from temba.utils.uuid import uuid4
 
 NUM_BASE_QUERIES = 3  # number of queries required for any request (internal API is session only)
@@ -702,6 +704,120 @@ class EndpointsTest(APITestMixin, TembaTest):
             ],
             num_queries=NUM_BASE_QUERIES + 3,
         )
+
+    def test_triggers(self):
+        endpoint_url = reverse("api.internal.triggers") + ".json"
+
+        self.assertGetNotPermitted(endpoint_url, [None, self.agent])
+        self.assertPostNotAllowed(endpoint_url)
+        self.assertDeleteNotAllowed(endpoint_url)
+
+        flow1 = self.create_flow("Survey")
+        flow2 = self.create_flow("Support")
+        group1 = self.create_group("Farmers", contacts=[])
+        group2 = self.create_group("Staff", contacts=[])
+        contact1 = self.create_contact("Jim", phone="+250788987651")
+
+        trigger1 = Trigger.create(
+            self.org,
+            self.admin,
+            Trigger.TYPE_KEYWORD,
+            flow1,
+            keywords=["join", "start"],
+            match_type=Trigger.MATCH_FIRST_WORD,
+            groups=[group1],
+            exclude_groups=[group2],
+        )
+        trigger2 = Trigger.create(self.org, self.admin, Trigger.TYPE_CATCH_ALL, flow2)
+        trigger3 = Trigger.create(self.org, self.admin, Trigger.TYPE_MISSED_CALL, flow1, channel=self.channel)
+        trigger4 = Trigger.create(
+            self.org,
+            self.admin,
+            Trigger.TYPE_KEYWORD,
+            flow2,
+            keywords=["stop"],
+            match_type=Trigger.MATCH_ONLY_WORD,
+            is_archived=True,
+        )
+        schedule = Schedule.create(
+            self.org,
+            start_time=timezone.now() + timedelta(days=2),
+            repeat_period=Schedule.REPEAT_DAILY,
+        )
+        trigger5 = Trigger.create(
+            self.org, self.admin, Trigger.TYPE_SCHEDULE, flow1, schedule=schedule, contacts=(contact1,)
+        )
+
+        # and a trigger in another org that should never appear
+        other_org_flow = self.create_flow("Other", org=self.org2)
+        Trigger.create(
+            self.org2,
+            self.admin2,
+            Trigger.TYPE_KEYWORD,
+            other_org_flow,
+            keywords=["other"],
+            match_type=Trigger.MATCH_ONLY_WORD,
+        )
+
+        # default folder is `active` (an unknown folder gets the same), newest first
+        self.assertGet(endpoint_url, [self.editor, self.admin], results=[trigger5, trigger3, trigger2, trigger1])
+        self.assertGet(endpoint_url + "?folder=active", [self.admin], results=[trigger5, trigger3, trigger2, trigger1])
+        self.assertGet(endpoint_url + "?folder=nope", [self.admin], results=[trigger5, trigger3, trigger2, trigger1])
+
+        # archived triggers live in their own folder
+        self.assertGet(endpoint_url + "?folder=archived", [self.admin], results=[trigger4])
+
+        # a type folder uses the legacy folder view's ordering — keyword triggers ahead of catch-all
+        self.assertGet(endpoint_url + "?folder=messages", [self.admin], results=[trigger1, trigger2])
+        self.assertGet(endpoint_url + "?folder=schedule", [self.admin], results=[trigger5])
+
+        # search matches keywords, flow names and channel names
+        self.assertGet(endpoint_url + "?search=joi", [self.admin], results=[trigger1])
+        self.assertGet(endpoint_url + "?search=support", [self.admin], results=[trigger2])
+        self.assertGet(endpoint_url + "?search=test channel", [self.admin], results=[trigger3])
+
+        # each row carries the columns the component renders
+        def check_shape(data):
+            first = [r for r in data["results"] if r["id"] == trigger1.id][0]
+            self.assertEqual("keyword", first["type"])
+            self.assertEqual({"uuid": str(flow1.uuid), "name": "Survey"}, first["flow"])
+            self.assertIsNone(first["channel"])
+            self.assertEqual([{"uuid": str(group1.uuid), "name": "Farmers"}], first["groups"])
+            self.assertEqual([{"uuid": str(group2.uuid), "name": "Staff"}], first["exclude_groups"])
+            self.assertEqual([], first["contacts"])
+            self.assertEqual(["join", "start"], first["keywords"])
+            self.assertEqual("F", first["match_type"])
+            self.assertIsNone(first["schedule"])
+            self.assertEqual(matchers.ISODatetime(), first["created_on"])
+
+            missed_call = [r for r in data["results"] if r["id"] == trigger3.id][0]
+            self.assertEqual(
+                {"uuid": str(self.channel.uuid), "name": "Test Channel", "icon": "channel_a"},
+                missed_call["channel"],
+            )
+
+            scheduled = [r for r in data["results"] if r["id"] == trigger5.id][0]
+            self.assertEqual("schedule", scheduled["type"])
+            self.assertEqual(Schedule.REPEAT_DAILY, scheduled["schedule"]["repeat_period"])
+            self.assertEqual(matchers.ISODatetime(), scheduled["schedule"]["next_fire"])
+            self.assertEqual([{"uuid": str(contact1.uuid), "name": "Jim"}], scheduled["contacts"])
+            return True
+
+        self.assertGet(endpoint_url, [self.admin], raw=check_shape)
+
+        # sortable by created_on in both directions; an unknown sort falls back to the default ordering
+        self.assertGet(
+            endpoint_url + "?sort=created_on", [self.admin], results=[trigger1, trigger2, trigger3, trigger5]
+        )
+        self.assertGet(
+            endpoint_url + "?sort=-created_on", [self.admin], results=[trigger5, trigger3, trigger2, trigger1]
+        )
+        self.assertGet(endpoint_url + "?sort=nope", [self.admin], results=[trigger5, trigger3, trigger2, trigger1])
+
+        # an over-long search query is rejected
+        self.login(self.admin)
+        response = self.client.get(endpoint_url + "?search=" + ("x" * 1001))
+        self.assertEqual(413, response.status_code)
 
     def test_llms(self):
         endpoint_url = reverse("api.internal.llms") + ".json"

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -759,16 +759,49 @@ class EndpointsTest(APITestMixin, TembaTest):
             match_type=Trigger.MATCH_ONLY_WORD,
         )
 
+        trigger6 = Trigger.create(
+            self.org, self.admin, Trigger.TYPE_KEYWORD, flow1, keywords=["apply"], match_type=Trigger.MATCH_ONLY_WORD
+        )
+
+        # an archived scheduled trigger whose (paused) schedule still carries a stale next fire
+        schedule2 = Schedule.create(
+            self.org, start_time=timezone.now() + timedelta(days=3), repeat_period=Schedule.REPEAT_DAILY
+        )
+        schedule2.is_paused = True
+        schedule2.save(update_fields=("is_paused",))
+        trigger7 = Trigger.create(
+            self.org, self.admin, Trigger.TYPE_SCHEDULE, flow2, schedule=schedule2, is_archived=True
+        )
+
         # default folder is `active` (an unknown folder gets the same), newest first
-        self.assertGet(endpoint_url, [self.editor, self.admin], results=[trigger5, trigger3, trigger2, trigger1])
-        self.assertGet(endpoint_url + "?folder=active", [self.admin], results=[trigger5, trigger3, trigger2, trigger1])
-        self.assertGet(endpoint_url + "?folder=nope", [self.admin], results=[trigger5, trigger3, trigger2, trigger1])
+        self.assertGet(
+            endpoint_url, [self.editor, self.admin], results=[trigger6, trigger5, trigger3, trigger2, trigger1]
+        )
+        self.assertGet(
+            endpoint_url + "?folder=active",
+            [self.admin],
+            results=[trigger6, trigger5, trigger3, trigger2, trigger1],
+            num_queries=NUM_BASE_QUERIES + 5,  # count + triggers + 3 M2M prefetches
+        )
+        self.assertGet(
+            endpoint_url + "?folder=nope", [self.admin], results=[trigger6, trigger5, trigger3, trigger2, trigger1]
+        )
 
-        # archived triggers live in their own folder
-        self.assertGet(endpoint_url + "?folder=archived", [self.admin], results=[trigger4])
+        # archived triggers live in their own folder, and an archived trigger's paused schedule reads as
+        # not scheduled (no next fire) despite its stale next_fire value
+        self.assertGet(endpoint_url + "?folder=archived", [self.admin], results=[trigger7, trigger4])
 
-        # a type folder uses the legacy folder view's ordering — keyword triggers ahead of catch-all
-        self.assertGet(endpoint_url + "?folder=messages", [self.admin], results=[trigger1, trigger2])
+        def check_archived_schedule(data):
+            scheduled = [r for r in data["results"] if r["id"] == trigger7.id][0]
+            self.assertEqual(Schedule.REPEAT_DAILY, scheduled["schedule"]["repeat_period"])
+            self.assertIsNone(scheduled["schedule"]["next_fire"])
+            return True
+
+        self.assertGet(endpoint_url + "?folder=archived", [self.admin], raw=check_archived_schedule)
+
+        # a type folder uses the legacy folder view's ordering — keyword triggers ahead of catch-all, and
+        # keyword triggers ordered by their first keyword
+        self.assertGet(endpoint_url + "?folder=messages", [self.admin], results=[trigger6, trigger1, trigger2])
         self.assertGet(endpoint_url + "?folder=schedule", [self.admin], results=[trigger5])
 
         # search matches keywords, flow names and channel names
@@ -807,12 +840,14 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         # sortable by created_on in both directions; an unknown sort falls back to the default ordering
         self.assertGet(
-            endpoint_url + "?sort=created_on", [self.admin], results=[trigger1, trigger2, trigger3, trigger5]
+            endpoint_url + "?sort=created_on", [self.admin], results=[trigger1, trigger2, trigger3, trigger5, trigger6]
         )
         self.assertGet(
-            endpoint_url + "?sort=-created_on", [self.admin], results=[trigger5, trigger3, trigger2, trigger1]
+            endpoint_url + "?sort=-created_on", [self.admin], results=[trigger6, trigger5, trigger3, trigger2, trigger1]
         )
-        self.assertGet(endpoint_url + "?sort=nope", [self.admin], results=[trigger5, trigger3, trigger2, trigger1])
+        self.assertGet(
+            endpoint_url + "?sort=nope", [self.admin], results=[trigger6, trigger5, trigger3, trigger2, trigger1]
+        )
 
         # an over-long search query is rejected
         self.login(self.admin)

--- a/temba/api/internal/urls.py
+++ b/temba/api/internal/urls.py
@@ -5,6 +5,7 @@ from django.urls import re_path
 from temba.contacts.api import ContactsEndpoint
 from temba.flows.api import FlowLabelsEndpoint, FlowsEndpoint
 from temba.msgs.api import MessagesEndpoint
+from temba.triggers.api import TriggersEndpoint
 
 from .views import (
     LLMsEndpoint,
@@ -26,6 +27,7 @@ urlpatterns = [
     re_path(r"^notifications$", NotificationsEndpoint.as_view(), name="api.internal.notifications"),
     re_path(r"^shortcuts$", ShortcutsEndpoint.as_view(), name="api.internal.shortcuts"),
     re_path(r"^templates$", TemplatesEndpoint.as_view(), name="api.internal.templates"),
+    re_path(r"^triggers$", TriggersEndpoint.as_view(), name="api.internal.triggers"),
     re_path(r"^orgs$", OrgsEndpoint.as_view(), name="api.internal.orgs"),
 ]
 

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -3,12 +3,12 @@ import logging
 from rest_framework import exceptions, status
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication, TokenAuthentication
 from rest_framework.exceptions import APIException
-from rest_framework.pagination import CursorPagination
+from rest_framework.pagination import CursorPagination, PageNumberPagination
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.throttling import ScopedRateThrottle
 
 from django.conf import settings
-from django.http import HttpResponseServerError
+from django.http import HttpResponse, HttpResponseServerError
 
 from temba.utils import str_to_bool
 
@@ -152,6 +152,21 @@ class DocumentationRenderer(BrowsableAPIRenderer):
         }
 
 
+class SearchLengthMixin:
+    """
+    View mixin that rejects an over-long `search=` value with a 413 before it can drive an expensive database/ES
+    query — the same cap and response as BaseListView.
+    """
+
+    search_max_length = 1_000
+
+    def get(self, request, *args, **kwargs):
+        search = request.query_params.get("search") or ""
+        if len(search) > self.search_max_length:
+            return HttpResponse("Search query too long", status=413)
+        return super().get(request, *args, **kwargs)
+
+
 class SearchCountMixin:
     """
     Pagination mixin that includes a `count` of matching rows on the response when the request carries a `search=`
@@ -172,6 +187,17 @@ class SearchCountMixin:
         if count is not None:
             response.data["count"] = count
         return response
+
+
+class ListPagination(PageNumberPagination):
+    """
+    Page number pagination for the list component endpoints — matches BaseListView's 50 rows per page, with a cap
+    that keeps an oversized client request from pulling 50k rows.
+    """
+
+    page_size = 50
+    page_size_query_param = "page_size"
+    max_page_size = 500
 
 
 class CreatedOnCursorPagination(CursorPagination):

--- a/temba/contacts/api.py
+++ b/temba/contacts/api.py
@@ -1,34 +1,26 @@
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from django.db.models import Prefetch, prefetch_related_objects
-from django.http import HttpResponse
 
 from temba import mailroom
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
+from temba.api.support import ListPagination, SearchLengthMixin
 from temba.api.views import ListAPIMixin
 from temba.utils.models.base import patch_queryset_count
 from temba.utils.models.es import SearchSliceQuerySet
 
 from .models import Contact, ContactField, ContactGroup
 
-# Match BaseListView/ContactListView: 50 rows per page, and never let a client page past the 200th page (ES deep
-# pagination guard, mirroring ContactListView.pre_process).
-DEFAULT_PAGE_SIZE = 50
-MAX_PAGE_SIZE = 500
+# Never let a client page past the 200th page (ES deep pagination guard, mirroring ContactListView.pre_process).
 MAX_PAGE = 200
-
-# Cap the search query length the same way the legacy list view does so an oversized query can't be used to drive an
-# expensive mailroom/ES request.
-SEARCH_MAX_LENGTH = ContactGroup.MAX_QUERY_LEN
 
 # The contact list component prefixes its custom-field column keys with `field:` (e.g. `field:age`); mailroom's sort
 # wants the bare field key. System columns (last_seen_on, created_on) are sent unprefixed and pass through untouched.
 FIELD_SORT_PREFIX = "field:"
 
 
-class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
+class ContactsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     """
     Contacts for the current org, used by the contact list component. A status folder is selected with the `folder`
     query param (one of `active`, `blocked`, `stopped` or `archived`, defaulting to `active`) — alternatively pass
@@ -37,14 +29,12 @@ class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
     via Contact.as_json() (the lightweight list shape — name, primary URN, featured field values, last/created on).
     """
 
-    class Pagination(PageNumberPagination):
-        page_size = DEFAULT_PAGE_SIZE
-        page_size_query_param = "page_size"
-        max_page_size = MAX_PAGE_SIZE
-
     model = Contact
     serializer_class = ModelAsJsonSerializer
-    pagination_class = Pagination
+    pagination_class = ListPagination
+
+    # a mailroom contact query rather than a plain text search, so cap it at the query length limit
+    search_max_length = ContactGroup.MAX_QUERY_LEN
 
     FOLDERS = {
         "active": ContactGroup.TYPE_DB_ACTIVE,
@@ -54,9 +44,6 @@ class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
     }
 
     def get(self, request, *args, **kwargs):
-        search = request.query_params.get("search") or ""
-        if len(search) > SEARCH_MAX_LENGTH:
-            return HttpResponse("Search query too long", status=413)
         # Don't allow pagination past the 200th page (mirrors ContactListView.pre_process / the ES offset guard).
         if self._page() > MAX_PAGE:
             return Response({"results": [], "count": 0, "next": None, "previous": None})
@@ -74,12 +61,12 @@ class ContactsEndpoint(ListAPIMixin, BaseEndpoint):
         # The search/sort path derives the mailroom offset from this, so it must match the page size DRF slices with
         # or SearchSliceQuerySet's offset guard trips with an IndexError (HTTP 500).
         try:
-            size = int(self.request.query_params.get("page_size", DEFAULT_PAGE_SIZE))
+            size = int(self.request.query_params.get("page_size", ListPagination.page_size))
         except TypeError, ValueError:
-            return DEFAULT_PAGE_SIZE
+            return ListPagination.page_size
         if size <= 0:
-            return DEFAULT_PAGE_SIZE
-        return min(size, MAX_PAGE_SIZE)
+            return ListPagination.page_size
+        return min(size, ListPagination.max_page_size)
 
     def derive_group(self):
         org = self.request.org

--- a/temba/flows/api.py
+++ b/temba/flows/api.py
@@ -1,26 +1,17 @@
 from uuid import UUID
 
-from rest_framework.pagination import PageNumberPagination
-
 from django.db.models import Q, Sum, Value
 from django.db.models.functions import Coalesce, Lower
-from django.http import HttpResponse
 
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
-from temba.api.support import NameCursorPagination
+from temba.api.support import ListPagination, NameCursorPagination, SearchLengthMixin
 from temba.api.views import ListAPIMixin
 
 from .models import Flow, FlowLabel, FlowRun
 
-# Match BaseListView: 50 rows per page with a cap that keeps an oversized client request from pulling 50k rows, and
-# the same 1000 char search cap (rejected with 413).
-DEFAULT_PAGE_SIZE = 50
-MAX_PAGE_SIZE = 500
-SEARCH_MAX_LENGTH = 1_000
 
-
-class FlowsEndpoint(ListAPIMixin, BaseEndpoint):
+class FlowsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     """
     Flows for the current org, used by the flow list component. A folder is selected with the `folder` query param
     (`active` (default) or `archived`) — alternatively pass `label=<uuid>` to filter by a flow label. An optional
@@ -28,26 +19,15 @@ class FlowsEndpoint(ListAPIMixin, BaseEndpoint):
     item is serialized via Flow.as_json() (name, type, labels, run counts, completion, activity sparkline).
     """
 
-    class Pagination(PageNumberPagination):
-        page_size = DEFAULT_PAGE_SIZE
-        page_size_query_param = "page_size"
-        max_page_size = MAX_PAGE_SIZE
-
     model = Flow
     serializer_class = ModelAsJsonSerializer
-    pagination_class = Pagination
+    pagination_class = ListPagination
 
     # the run statuses summed for each sortable count column ("status:" scopes on FlowActivityCount)
     SORT_STATUSES = {
         "runs": None,  # all statuses
         "ongoing": (FlowRun.STATUS_ACTIVE, FlowRun.STATUS_WAITING),
     }
-
-    def get(self, request, *args, **kwargs):
-        search = request.query_params.get("search") or ""
-        if len(search) > SEARCH_MAX_LENGTH:
-            return HttpResponse("Search query too long", status=413)
-        return super().get(request, *args, **kwargs)
 
     def derive_queryset(self):
         # Build from Flow.objects rather than the org.flows related manager — a related manager would seed each

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -1,18 +1,17 @@
 from datetime import timedelta
 
 from django.db.models import Q
-from django.http import HttpResponse
 from django.utils import timezone
 
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
-from temba.api.support import CreatedOnCursorPagination, SearchCountMixin, SentOnCursorPagination
+from temba.api.support import CreatedOnCursorPagination, SearchCountMixin, SearchLengthMixin, SentOnCursorPagination
 from temba.api.views import ListAPIMixin
 
 from .models import Msg, MsgFolder
 
 
-class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
+class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     """
     Messages for the current org, used by the message list components. A folder is selected with the `folder` query
     param (one of `inbox`, `handled`, `archived`, `outbox`, `sent` or `failed`, defaulting to `inbox`) — alternatively
@@ -51,10 +50,8 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
                 self._search_count = view.get_total_count()
             return page
 
-    # Match BaseListView's caps so the legacy and new lists impose the same bounds: a search query is capped at 1000
-    # chars (rejected with 413) and is restricted to messages from the last 90 days so an unbounded `text__icontains`
-    # scan (compounded by the SearchCountMixin COUNT(*)) can't be triggered by a session-authenticated client.
-    SEARCH_MAX_LENGTH = 1_000
+    # A search is restricted to messages from the last 90 days so an unbounded `text__icontains` scan (compounded by
+    # the SearchCountMixin COUNT(*)) can't be triggered by a session-authenticated client.
     SEARCH_WINDOW = timedelta(days=90)
 
     FOLDERS = {
@@ -69,12 +66,6 @@ class MessagesEndpoint(ListAPIMixin, BaseEndpoint):
     model = Msg
     serializer_class = ModelAsJsonSerializer
     pagination_class = Pagination
-
-    def get(self, request, *args, **kwargs):
-        search = request.query_params.get("search") or ""
-        if len(search) > self.SEARCH_MAX_LENGTH:
-            return HttpResponse("Search query too long", status=413)
-        return super().get(request, *args, **kwargs)
 
     def get_total_count(self) -> int:
         # Cheap pre-calculated total for the active folder/label (squashed count tables) — used as the list's total

--- a/temba/triggers/api.py
+++ b/temba/triggers/api.py
@@ -1,0 +1,87 @@
+from rest_framework.pagination import PageNumberPagination
+
+from django.db.models import Q
+from django.http import HttpResponse
+
+from temba.api.internal.serializers import ModelAsJsonSerializer
+from temba.api.internal.views import BaseEndpoint
+from temba.api.views import ListAPIMixin
+
+from .models import Trigger
+from .views import Folder
+
+# Match BaseListView: 50 rows per page with a cap that keeps an oversized client request from pulling 50k rows, and
+# the same 1000 char search cap (rejected with 413).
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 500
+SEARCH_MAX_LENGTH = 1_000
+
+
+class TriggersEndpoint(ListAPIMixin, BaseEndpoint):
+    """
+    Triggers for the current org, used by the trigger list component. A folder is selected with the `folder` query
+    param — `active` (default), `archived`, or one of the type folder slugs (`messages`, `schedule`, `calls`, etc.).
+    An optional `search` param filters by keyword, flow name or channel name, and `sort` can be `created_on` (prefix
+    with `-` to reverse). Each item is serialized via Trigger.as_json().
+    """
+
+    class Pagination(PageNumberPagination):
+        page_size = DEFAULT_PAGE_SIZE
+        page_size_query_param = "page_size"
+        max_page_size = MAX_PAGE_SIZE
+
+    model = Trigger
+    serializer_class = ModelAsJsonSerializer
+    pagination_class = Pagination
+
+    def get(self, request, *args, **kwargs):
+        search = request.query_params.get("search") or ""
+        if len(search) > SEARCH_MAX_LENGTH:
+            return HttpResponse("Search query too long", status=413)
+        return super().get(request, *args, **kwargs)
+
+    def derive_queryset(self):
+        # Build from Trigger.objects rather than the org.triggers related manager — a related manager would seed each
+        # fetched row with the in-memory org instance, which Django rejects on a GET because the org was loaded from
+        # the default database while this queryset reads from the readonly alias.
+        org = self.request.org
+        base = Trigger.objects.filter(org=org, is_active=True)
+
+        folder_slug = (self.request.query_params.get("folder") or "active").lower()
+        folder = Folder.from_slug(folder_slug)
+        if folder:
+            # a type folder — non-archived triggers of those types, in the legacy folder view's ordering
+            qs = base.filter(is_archived=False, trigger_type__in=folder.types)
+            default_order = (Trigger.type_order(), *folder.ordering, "-created_on")
+        elif folder_slug == "archived":
+            qs = base.filter(is_archived=True)
+            default_order = ("-created_on",)
+        else:
+            qs = base.filter(is_archived=False)
+            default_order = ("-created_on",)
+
+        search = self.request.query_params.get("search")
+        if search:
+            # match the legacy list view's search fields
+            qs = qs.filter(
+                Q(keywords__icontains=search) | Q(flow__name__icontains=search) | Q(channel__name__icontains=search)
+            )
+
+        sort = self.request.query_params.get("sort") or ""
+        desc = sort.startswith("-")
+        key = sort[1:] if desc else sort
+
+        if key == "created_on":
+            order = ("-created_on" if desc else "created_on",)
+        else:
+            order = default_order
+
+        return (
+            qs.order_by(*order, "-id")
+            .select_related("flow", "channel", "schedule")
+            .prefetch_related("contacts", "groups", "exclude_groups")
+        )
+
+    def filter_queryset(self, queryset):
+        # filtering (folder/search/sort) is fully resolved in derive_queryset; bypass the default backends
+        return queryset

--- a/temba/triggers/api.py
+++ b/temba/triggers/api.py
@@ -1,23 +1,15 @@
-from rest_framework.pagination import PageNumberPagination
-
 from django.db.models import Q
-from django.http import HttpResponse
 
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
+from temba.api.support import ListPagination, SearchLengthMixin
 from temba.api.views import ListAPIMixin
 
 from .models import Trigger
 from .views import Folder
 
-# Match BaseListView: 50 rows per page with a cap that keeps an oversized client request from pulling 50k rows, and
-# the same 1000 char search cap (rejected with 413).
-DEFAULT_PAGE_SIZE = 50
-MAX_PAGE_SIZE = 500
-SEARCH_MAX_LENGTH = 1_000
 
-
-class TriggersEndpoint(ListAPIMixin, BaseEndpoint):
+class TriggersEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     """
     Triggers for the current org, used by the trigger list component. A folder is selected with the `folder` query
     param — `active` (default), `archived`, or one of the type folder slugs (`messages`, `schedule`, `calls`, etc.).
@@ -25,20 +17,9 @@ class TriggersEndpoint(ListAPIMixin, BaseEndpoint):
     with `-` to reverse). Each item is serialized via Trigger.as_json().
     """
 
-    class Pagination(PageNumberPagination):
-        page_size = DEFAULT_PAGE_SIZE
-        page_size_query_param = "page_size"
-        max_page_size = MAX_PAGE_SIZE
-
     model = Trigger
     serializer_class = ModelAsJsonSerializer
-    pagination_class = Pagination
-
-    def get(self, request, *args, **kwargs):
-        search = request.query_params.get("search") or ""
-        if len(search) > SEARCH_MAX_LENGTH:
-            return HttpResponse("Search query too long", status=413)
-        return super().get(request, *args, **kwargs)
+    pagination_class = ListPagination
 
     def derive_queryset(self):
         # Build from Trigger.objects rather than the org.triggers related manager — a related manager would seed each

--- a/temba/triggers/api.py
+++ b/temba/triggers/api.py
@@ -47,8 +47,10 @@ class TriggersEndpoint(ListAPIMixin, BaseEndpoint):
         org = self.request.org
         base = Trigger.objects.filter(org=org, is_active=True)
 
+        # `archived` is resolved before the type folders so a future Folder member with a colliding name can't
+        # silently change this query's shape
         folder_slug = (self.request.query_params.get("folder") or "active").lower()
-        folder = Folder.from_slug(folder_slug)
+        folder = Folder.from_slug(folder_slug) if folder_slug != "archived" else None
         if folder:
             # a type folder — non-archived triggers of those types, in the legacy folder view's ordering
             qs = base.filter(is_archived=False, trigger_type__in=folder.types)

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -407,11 +407,11 @@ class Trigger(SmartModel):
                 {
                     "repeat_period": self.schedule.repeat_period,
                     "display": self.schedule.get_display(),
-                    # archiving pauses the schedule, so an archived trigger reads as not scheduled (as the
-                    # legacy list does) even when a stale next_fire is still set
+                    # a paused schedule (archiving pauses it, and it can be paused independently) can carry a
+                    # stale next_fire — null it so the trigger reads as not scheduled, as the legacy list does
                     "next_fire": (
                         self.schedule.next_fire.isoformat()
-                        if self.schedule.next_fire and not self.is_archived
+                        if self.schedule.next_fire and not self.schedule.is_paused and not self.is_archived
                         else None
                     ),
                 }

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -381,6 +381,47 @@ class Trigger(SmartModel):
 
         return self.type.export_def(self)
 
+    def as_json(self, context=None) -> dict:
+        """
+        Internal API shape, consumed by the temba-trigger-list component. The type slug drives the row icon and
+        which of the per-type fields (keywords, schedule, referrer) the details cell renders; channel/groups/contacts
+        render as filter pills. Triggers have no uuid so rows key off the numeric id.
+        """
+
+        return {
+            "id": self.id,
+            "type": self.type.slug,
+            "flow": {"uuid": str(self.flow.uuid), "name": self.flow.name},
+            "channel": (
+                {"uuid": str(self.channel.uuid), "name": self.channel.name, "icon": self.channel.type.icon}
+                if self.channel
+                else None
+            ),
+            "groups": [{"uuid": str(g.uuid), "name": g.name} for g in self.groups.all()],
+            "exclude_groups": [{"uuid": str(g.uuid), "name": g.name} for g in self.exclude_groups.all()],
+            "contacts": [{"uuid": str(c.uuid), "name": c.name} for c in self.contacts.all()],
+            "keywords": self.keywords or [],
+            "match_type": self.match_type,
+            "referrer_id": self.referrer_id,
+            "schedule": (
+                {
+                    "repeat_period": self.schedule.repeat_period,
+                    "display": self.schedule.get_display(),
+                    # archiving pauses the schedule, so an archived trigger reads as not scheduled (as the
+                    # legacy list does) even when a stale next_fire is still set
+                    "next_fire": (
+                        self.schedule.next_fire.isoformat()
+                        if self.schedule.next_fire and not self.is_archived
+                        else None
+                    ),
+                }
+                if self.schedule
+                else None
+            ),
+            "priority": self.priority,
+            "created_on": self.created_on.isoformat(),
+        }
+
     @classmethod
     def get_type(cls, *, code: str = None, slug: str = None):
         from .types import TYPES_BY_CODE, TYPES_BY_SLUG

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -1114,6 +1114,67 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(response.status_code, 302)
         self.assertRedirect(response, reverse("triggers.trigger_create"))
 
+    def test_preview_list(self):
+        flow = self.create_flow("Test")
+        trigger1 = Trigger.create(
+            self.org, self.admin, Trigger.TYPE_KEYWORD, flow, keywords=["start"], match_type=Trigger.MATCH_ONLY_WORD
+        )
+        trigger2 = Trigger.create(
+            self.org,
+            self.admin,
+            Trigger.TYPE_KEYWORD,
+            flow,
+            keywords=["stop"],
+            match_type=Trigger.MATCH_ONLY_WORD,
+            is_archived=True,
+        )
+
+        list_url = reverse("triggers.trigger_list")
+
+        self.login(self.admin)
+
+        # default render is still the legacy table
+        response = self.client.get(list_url)
+        self.assertNotContains(response, "temba-trigger-list")
+
+        # entering preview mode swaps in the temba-trigger-list component, pointed at the internal triggers api
+        self.client.cookies["temba-preview"] = "1"
+
+        response = self.client.get(list_url)
+        self.assertContains(response, "temba-trigger-list")
+        self.assertEqual(
+            f"{reverse('api.internal.triggers')}.json?folder=active", response.context["new_list_endpoint"]
+        )
+
+        actions = {a["key"]: a for a in response.context["new_list_bulk_actions"]}
+        self.assertEqual(["archive"], list(actions.keys()))
+
+        # the archived view selects the archived folder and offers restore/delete (delete needs confirmation)
+        response = self.client.get(reverse("triggers.trigger_archived"))
+        self.assertEqual(
+            f"{reverse('api.internal.triggers')}.json?folder=archived", response.context["new_list_endpoint"]
+        )
+        actions = {a["key"]: a for a in response.context["new_list_bulk_actions"]}
+        self.assertEqual(["restore", "delete"], list(actions.keys()))
+        self.assertTrue(actions["delete"]["destructive"])
+        self.assertIn("confirm", actions["delete"])
+
+        # a type folder view selects its folder slug
+        response = self.client.get(reverse("triggers.trigger_folder", kwargs={"folder": "messages"}))
+        self.assertEqual(
+            f"{reverse('api.internal.triggers')}.json?folder=messages", response.context["new_list_endpoint"]
+        )
+
+        # the component posts trigger ids in `objects` — bulk actions apply as-is
+        self.client.post(list_url, {"action": "archive", "objects": trigger1.id})
+        trigger1.refresh_from_db()
+        self.assertTrue(trigger1.is_archived)
+
+        # restore from the archived view
+        self.client.post(reverse("triggers.trigger_archived"), {"action": "restore", "objects": trigger2.id})
+        trigger2.refresh_from_db()
+        self.assertFalse(trigger2.is_archived)
+
     def test_archived(self):
         flow = self.create_flow("Test")
         other_org_flow = self.create_flow("Test", org=self.org2)

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -6,6 +6,7 @@ from django import forms
 from django.db.models.functions import Upper
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
 
 from temba.channels.models import Channel
@@ -420,7 +421,7 @@ class TriggerCRUDL(SmartCRUDL):
             response["REDIRECT"] = self.get_success_url()
             return response
 
-    class BaseList(SpaMixin, BulkActionMixin, BaseListView):
+    class BaseList(SpaMixin, BulkActionMixin, ContextMenuMixin, BaseListView):
         """
         Base class for list views
         """
@@ -430,6 +431,53 @@ class TriggerCRUDL(SmartCRUDL):
         default_template = "triggers/trigger_list.html"
         search_fields = ("keywords__icontains", "flow__name__icontains", "channel__name__icontains")
 
+        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
+        # every trigger list view renders the temba-trigger-list component (triggers/trigger_list_new.html) instead
+        # of its legacy table; the component fetches/pages triggers itself from the internal triggers API.
+        NEW_LIST_TEMPLATE = "triggers/trigger_list_new.html"
+
+        # Optional subtitle rendered under the title on the new-list view.
+        subtitle = ""
+
+        # Bulk-action key -> config consumed by temba-trigger-list (label, icon). Triggers post their numeric ids in
+        # `objects`, matching BulkActionMixin's pk matching, so no uuid translation is needed on POST.
+        BULK_ACTION_CONFIG = {
+            "archive": {"label": _("Archive"), "icon": "archive"},
+            "restore": {"label": _("Restore"), "icon": "restore"},
+            "delete": {
+                "label": _("Delete"),
+                "icon": "delete",
+                "destructive": True,
+                "confirm": _("Are you sure you want to delete the selected triggers? This cannot be undone."),
+            },
+        }
+
+        def _use_new_list(self) -> bool:
+            # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered
+            # out) doesn't AttributeError.
+            return getattr(self.request, "preview", False)
+
+        def get_template_names(self):
+            if self._use_new_list():
+                return [self.NEW_LIST_TEMPLATE]
+            return super().get_template_names()
+
+        def get_paginate_by(self, queryset):
+            # The temba-trigger-list component fetches and pages triggers itself.
+            if self._use_new_list():
+                return None
+            return super().get_paginate_by(queryset)
+
+        def derive_subtitle(self):
+            return self.subtitle
+
+        def derive_new_list_query(self) -> str:
+            return "folder=active"
+
+        def build_context_menu(self, menu):
+            if self.has_org_perm("triggers.trigger_create"):
+                menu.add_link(_("New Trigger"), reverse("triggers.trigger_create"), as_button=True)
+
         def derive_queryset(self, *args, **kwargs):
             return (
                 super()
@@ -438,6 +486,36 @@ class TriggerCRUDL(SmartCRUDL):
                 .select_related("flow", "channel")
                 .prefetch_related("contacts", "groups", "exclude_groups")
             )
+
+        def get_queryset(self, *args, **kwargs):
+            # In preview the temba-trigger-list component fetches and pages triggers from the internal triggers API,
+            # so a GET page needs no object list. A POST (bulk action) still needs the real queryset, since
+            # BulkActionMixin validates the posted `objects` against it.
+            if self._use_new_list() and self.request.method == "GET":
+                return Trigger.objects.none()
+
+            return super().get_queryset(*args, **kwargs)
+
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+
+            # New-list view context: the resolved triggers-api endpoint (folder= for active/archived/type folders),
+            # the subtitle, and the bulk-action configs the temba-trigger-list expects (resolved + JSON-encoded here
+            # so the template stays inert).
+            if self._use_new_list():
+                context["new_list_endpoint"] = f"{reverse('api.internal.triggers')}.json?{self.derive_new_list_query()}"
+                subtitle = self.derive_subtitle()
+                context["new_list_subtitle"] = str(subtitle) if subtitle else ""
+                actions = []
+                for key in self.get_bulk_actions():
+                    cfg = dict(self.BULK_ACTION_CONFIG.get(key, {}))
+                    cfg["key"] = key
+                    # Resolve any i18n lazy proxies so json_script / json.dumps don't choke.
+                    cfg = {k: (str(v) if isinstance(v, Promise) else v) for k, v in cfg.items()}
+                    actions.append(cfg)
+                context["new_list_bulk_actions"] = actions
+
+            return context
 
     class List(BaseList):
         """
@@ -449,8 +527,9 @@ class TriggerCRUDL(SmartCRUDL):
         menu_path = "/trigger/active"
 
         def pre_process(self, request, *args, **kwargs):
-            # if they have no triggers and no search performed, send them to create page
-            obj_count = super().get_queryset(*args, **kwargs).count()
+            # if they have no triggers and no search performed, send them to create page. Counted directly rather
+            # than via get_queryset, which is empty on a preview GET.
+            obj_count = request.org.triggers.filter(is_active=True).count()
             if obj_count == 0 and not request.GET.get("search", ""):
                 return HttpResponseRedirect(reverse("triggers.trigger_create"))
 
@@ -459,7 +538,7 @@ class TriggerCRUDL(SmartCRUDL):
         def get_queryset(self, *args, **kwargs):
             return super().get_queryset(*args, **kwargs).filter(is_archived=False)
 
-    class Archived(ContextMenuMixin, BaseList):
+    class Archived(BaseList):
         """
         Archived triggers of all types
         """
@@ -468,7 +547,11 @@ class TriggerCRUDL(SmartCRUDL):
         title = _("Archived")
         menu_path = "/trigger/archived"
 
+        def derive_new_list_query(self) -> str:
+            return "folder=archived"
+
         def build_context_menu(self, menu):
+            super().build_context_menu(menu)
             menu.add_js("triggers_delete_all", _("Delete All"))
 
         def get_queryset(self, *args, **kwargs):
@@ -495,6 +578,9 @@ class TriggerCRUDL(SmartCRUDL):
 
         def derive_title(self):
             return self.folder.title
+
+        def derive_new_list_query(self) -> str:
+            return f"folder={self.folder.slug}"
 
         def get_queryset(self, *args, **kwargs):
             return (

--- a/templates/triggers/trigger_list_new.html
+++ b/templates/triggers/trigger_list_new.html
@@ -1,0 +1,175 @@
+{% extends "smartmin/list.html" %}
+{% load i18n %}
+
+{% comment %}
+  Generic new-list template used by every trigger list view (Active /
+  Archived / type Folder) when the viewer is in preview mode
+  (request.preview, set by PreviewMiddleware off the temba-preview
+  cookie). Endpoint, subtitle and bulk actions come from the view's
+  context_data so the template stays the same across all of them.
+{% endcomment %}
+{% block page-header %}
+  {# the temba-trigger-list renders its own header (title + content menu); #}
+  {# keep the csrf token and a hidden title for the SPA document.title hook #}
+  {% csrf_token %}
+  <div id="title-text" class="hide">{{ title }}</div>
+{% endblock page-header %}
+{% block extra-style %}
+  {{ block.super }}
+  <style type="text/css">
+    /* The list component fills its container edge to edge and brings
+       its own surface, so drop the SPA content padding (and the grey
+       page background it would otherwise reveal around the list). */
+    .spa-content {
+      padding: 0 !important;
+    }
+  </style>
+{% endblock extra-style %}
+{% block content %}
+  <temba-trigger-list id="trigger-list"
+                      fill-window
+                      history-state-key="triggers"
+                      list-title="{{ title }}"
+                      {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
+                      endpoint="{{ new_list_endpoint }}"
+                      action-endpoint="{{ request.path }}"
+                      content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"
+                      empty-message="{% trans "No triggers" %}">
+  </temba-trigger-list>
+  {{ new_list_bulk_actions|json_script:"new-list-bulk-actions" }}
+  <temba-dialog header="{{ _("Delete All Triggers") |escapejs }}"
+                primaryButtonName="{{ _("Delete") |escapejs }}"
+                destructive="true"
+                class="hide"
+                id="delete-all-confirmation">
+    <div class="p-6">
+      {% blocktrans trimmed %}
+        Are you sure you want to delete all archived triggers? This cannot be undone.
+      {% endblocktrans %}
+      <br>
+      <br>
+      {% blocktrans trimmed %}
+        This operation can take a while to complete. Triggers may remain in this view during the process.
+      {% endblocktrans %}
+    </div>
+  </temba-dialog>
+{% endblock content %}
+{% block extra-script %}
+  {{ block.super }}
+  <script type="text/javascript">
+    onSpload(function() {
+      var list = document.querySelector("#trigger-list");
+      list.bulkActions = JSON.parse(document.getElementById("new-list-bulk-actions").textContent);
+
+      // clicking a row opens the trigger's update modal (triggers have
+      // no read page of their own)
+      {% if org_perms.triggers.trigger_update %}
+      list.addEventListener("temba-row-click", function(event) {
+        var trigger = event.detail.item;
+        if (trigger && trigger.id) {
+          showModax("{{ _("Update Trigger")|escapejs }}", "/trigger/update/" + trigger.id + "/", {
+            onSubmit: "handleTriggerUpdated()"
+          });
+        }
+      });
+      {% endif %}
+
+      // the embedded content menu fires temba-selection - dispatch it the
+      // same way the page chrome's content menu (spa_page_menu.html) does
+      list.addEventListener("temba-selection", function(event) {
+        var item = event.detail.item;
+        var click = event.detail.event;
+        if (item.type === "link") {
+          if (click) {
+            click.preventDefault();
+            click.stopPropagation();
+            if (click.metaKey && item.url) {
+              window.open(item.url, "_blank");
+              return;
+            }
+          }
+          spaGet(item.url);
+        } else if (item.type === "modax") {
+          showModax(item.title, item.url, {
+            disabled: item.disabled,
+            onSubmit: item.on_submit,
+            onRedirect: item.on_redirect,
+            id: item.modal_id,
+            originX: event.detail.originX,
+            originY: event.detail.originY
+          });
+        } else if (item.type === "url_post") {
+          posterize(item.url);
+        } else if (item.type === "js") {
+          if (window[item.id]) {
+            window[item.id]();
+          }
+        }
+        refreshMenu();
+      });
+
+      // Every action is POSTed to action-endpoint by the component, which
+      // then re-fetches the current page itself — we just refresh the
+      // sidebar menu counts after the round-trip completes.
+      list.addEventListener("temba-bulk-action", function(event) {
+        refreshMenu();
+      });
+
+      // See msgs/msg_list_new.html for the full rationale: stash the list's
+      // restorable state (page, sort, search, cursor url) on the current
+      // history entry so a navigation away and back lands on the same page.
+      list.addEventListener("temba-history-change", function(event) {
+        var current = history.state || {};
+        var next = Object.assign({}, current);
+        next[event.detail.key] = event.detail.state;
+        if (!next.url) {
+          next.url = location.href;
+        }
+        if (event.detail.replace) {
+          history.replaceState(next, "");
+        } else {
+          history.pushState(next, "");
+        }
+      });
+    });
+
+    // After the update modal submits — re-pull the current page (the
+    // trigger's row may have changed or moved) and the sidebar counts.
+    function handleTriggerUpdated() {
+      refreshMenu();
+      var list = document.querySelector("#trigger-list");
+      if (list) {
+        list.refresh();
+      }
+    }
+
+    // The Archived view's content menu names this as its Delete All js
+    // handler (dispatched by the temba-selection listener above).
+    function triggers_delete_all() {
+      var deleteAllConfirmation = document.querySelector("#delete-all-confirmation");
+
+      deleteAllConfirmation.classList.remove("hide");
+      deleteAllConfirmation.open = true;
+
+      deleteAllConfirmation.removeEventListener("temba-button-clicked", deleteAllArchivedTriggers);
+      deleteAllConfirmation.addEventListener("temba-button-clicked", deleteAllArchivedTriggers);
+    }
+
+    function deleteAllArchivedTriggers(event) {
+      var deleteAllConfirmation = document.querySelector("#delete-all-confirmation");
+
+      if (event.detail.button.attributes.destructive) {
+        var url = "{% url 'triggers.trigger_archived' %}";
+
+        const formData = new FormData();
+        formData.append("action", "delete");
+        formData.append("all", "true");
+        spaPost(url, {
+          postData: formData
+        });
+      }
+      deleteAllConfirmation.classList.add("hide");
+      deleteAllConfirmation.open = false;
+    }
+  </script>
+{% endblock extra-script %}

--- a/templates/triggers/trigger_list_new.html
+++ b/templates/triggers/trigger_list_new.html
@@ -46,11 +46,6 @@
       {% blocktrans trimmed %}
         Are you sure you want to delete all archived triggers? This cannot be undone.
       {% endblocktrans %}
-      <br>
-      <br>
-      {% blocktrans trimmed %}
-        This operation can take a while to complete. Triggers may remain in this view during the process.
-      {% endblocktrans %}
     </div>
   </temba-dialog>
 {% endblock content %}


### PR DESCRIPTION
## Summary

Adds preview-mode support for the trigger list views, mirroring the flows/messages/contacts pattern: in preview (`temba-preview` cookie via `PreviewMiddleware`), the trigger CRUDL pages render the `temba-trigger-list` component, which fetches and pages triggers itself from a new internal API endpoint. Requires the component from nyaruka/temba-components#1046.

## Changes

- **`Trigger.as_json()`** — internal API row shape: type slug (drives the row icon and per-type details), flow, channel (with type icon), groups / exclude groups / contacts, keywords + match type, referrer, schedule (repeat period, human display, next fire), priority, created on. Triggers have no uuid, so rows key off the numeric id. A schedule's `next_fire` is nulled when the schedule is paused **or** the trigger is archived, so stale fire times read as "not scheduled" — matching the legacy list.
- **`temba/triggers/api.py`** — new `TriggersEndpoint` (`/api/internal/triggers.json`): `folder=active|archived|<type-folder-slug>` (`archived` is resolved before the type-folder enum so a future colliding member can't shadow it; type folders reuse the legacy folder ordering incl. `type_order()` and per-folder keys like `keywords__0`), `search` over keywords / flow name / channel name (matching the legacy list's search fields, capped at 1000 chars → 413), `sort=created_on`, page-number pagination (50/500). Session-auth, permission auto-derives to `triggers.trigger_list`.
- **`TriggerCRUDL.BaseList`** — preview wiring following `FlowCRUDL.BaseList`: `NEW_LIST_TEMPLATE`, `BULK_ACTION_CONFIG` (archive; restore + confirm-gated delete on Archived), `_use_new_list()`, template/pagination switches, empty queryset on preview GETs (POST bulk actions still validate against the real queryset — triggers already post numeric ids, so no uuid translation is needed), and `new_list_*` context. `List.pre_process` now counts triggers directly since the view queryset is empty on preview GETs (also skipping the old per-request prefetches).
- **`BaseList` gains `ContextMenuMixin`** with a "New Trigger" button — this also gives the legacy Active/folder pages a header menu they previously lacked (consistent with flows, where New Flow appears on Archived too); Archived keeps its "Delete All" item.
- **`templates/triggers/trigger_list_new.html`** — renders the component; row clicks open the update modax (and refresh the list + sidebar counts on submit), bulk actions refresh the menu, Archived's Delete All confirmation flow is preserved (without the legacy dialog's always-on "can take a while" line), and list state is stashed on the history entry for back/forward restoration.

## Review notes

Pre-PR review happened on the component side (nyaruka/temba-components#1046). The automated review on this PR surfaced, and this branch addressed:

- Paused-but-unarchived schedules could serialize a stale `next_fire` and render "In N minutes" — `as_json()` now nulls `next_fire` for paused schedules too.
- The `archived` folder slug is resolved ahead of the `Folder` enum lookup to guard against a future name collision changing the query shape.
- Test coverage: pinned query count on the list endpoint (guards `as_json()` N+1 regressions), archived+paused schedule serialization, and `keywords__0` folder ordering.
- Skipped as out of scope: gating the `contacts` prefetch per folder, and extracting the (now four-way duplicated) preview wiring into a shared mixin — worth doing when the next preview list lands.

## Test plan

- [x] `test_triggers` internal API test: permissions, folders (active default / archived / type folders with legacy ordering incl. first-keyword ordering), search by keyword / flow / channel, created-on sort, full row shape incl. channel icon and schedule, archived+paused schedule reads as not scheduled, pinned query count, over-long search rejected, cross-org isolation
- [x] `test_preview_list` CRUDL test: legacy render by default, component + endpoint in preview, per-view bulk-action configs (archive / restore / destructive delete with confirm), folder slugs, id-based archive/restore POSTs
- [x] Full `temba.triggers` suite green; ruff + djlint clean; CI green
- [x] Exercised live in a dev stack against seeded triggers of all ten types (incl. a 50-keyword trigger and paused-schedule archived triggers)