### PR TITLE
Add campaign read page preview using temba-campaign-events

### DIFF
--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -7,6 +7,7 @@ from smartmin.models import SmartModel
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Count, Sum
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, ngettext
 
@@ -508,6 +509,44 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
                 return ngettext("%d week after", "%d weeks after", count) % count
         else:
             return _("on")
+
+    def as_json(self) -> dict:
+        """
+        Internal shape consumed by the temba-campaign-events component: the schedule definition (anchor field,
+        offset and delivery hour) rather than a computed time, plus the content and fire count.
+        """
+
+        definition = {
+            "uuid": str(self.uuid),
+            "type": "message" if self.event_type == self.TYPE_MESSAGE else "flow",
+            "status": "scheduling" if self.status == self.STATUS_SCHEDULING else "ready",
+            "offset": self.offset,
+            "unit": self.unit,
+            "offset_display": str(self.offset_display),
+            "relative_to": {
+                "key": self.relative_to.key,
+                "name": self.relative_to.name,
+                "system": self.relative_to.is_system,
+            },
+            "count": self.get_fire_count(),
+            "edit_url": reverse("campaigns.campaignevent_update", args=[self.uuid]),
+            "delete_url": reverse("campaigns.campaignevent_delete", args=[self.uuid]),
+            "fires_url": reverse("campaigns.campaignevent_fires", args=[self.uuid]),
+        }
+
+        # events on minute/hour offsets fire relative to the anchor time, so only day/week events carry an hour
+        if self.delivery_hour >= 0:
+            definition["delivery_hour_display"] = dict(self.get_hour_choices())[self.delivery_hour]
+
+        if self.event_type == self.TYPE_FLOW:
+            definition["flow"] = {
+                **self.flow.as_export_ref(),
+                "url": reverse("flows.flow_editor", args=[self.flow.uuid]),
+            }
+        else:
+            definition["message"] = self.get_message().get("text", "")
+
+        return definition
 
     def schedule_async(self):
         self.delete_fire_counts()  # new counts will be created with new fire version

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -437,6 +437,14 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
             modified_by=user,
         )
 
+    _hour_displays = None  # lazily built {hour: display} cache for as_json
+
+    @classmethod
+    def get_hour_display(cls, hour: int) -> str:
+        if cls._hour_displays is None:
+            cls._hour_displays = dict(cls.get_hour_choices())
+        return cls._hour_displays[hour]
+
     @classmethod
     def get_hour_choices(cls):
         hours = [(-1, "during the same hour"), (0, "at Midnight")]
@@ -536,7 +544,7 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
 
         # events on minute/hour offsets fire relative to the anchor time, so only day/week events carry an hour
         if self.delivery_hour >= 0:
-            definition["delivery_hour_display"] = dict(self.get_hour_choices())[self.delivery_hour]
+            definition["delivery_hour_display"] = self.get_hour_display(self.delivery_hour)
 
         if self.event_type == self.TYPE_FLOW:
             definition["flow"] = {
@@ -544,7 +552,9 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
                 "url": reverse("flows.flow_editor", args=[self.flow.uuid]),
             }
         else:
-            definition["message"] = self.get_message().get("text", "")
+            # tolerate legacy rows with missing translations so one bad event can't block the whole schedule
+            translation = (self.translations or {}).get(self.base_language) or {}
+            definition["message"] = translation.get("text", "")
 
         return definition
 

--- a/temba/campaigns/tests/test_campaigncrudl.py
+++ b/temba/campaigns/tests/test_campaigncrudl.py
@@ -82,6 +82,127 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertContentMenu(read_url, self.admin, ["Activate", "Export", "-", "Delete"])
 
+    def test_preview_read(self):
+        group = self.create_group("Reporters", contacts=[])
+        campaign = self.create_campaign(self.org, "Welcomes", group)
+
+        read_url = reverse("campaigns.campaign_read", args=[campaign.uuid])
+
+        self.login(self.admin)
+
+        # default render is still the legacy table
+        response = self.client.get(read_url)
+        self.assertNotContains(response, "temba-campaign-events")
+        self.assertIn("events", response.context)
+
+        # entering preview mode swaps in the temba-campaign-events component which fetches the events itself
+        self.client.cookies["temba-preview"] = "1"
+
+        response = self.client.get(read_url)
+        self.assertContains(response, "temba-campaign-events")
+        self.assertContains(response, "Welcomes")
+        self.assertNotIn("events", response.context)
+
+    def test_events(self):
+        group = self.create_group("Reporters", contacts=[])
+        campaign = self.create_campaign(self.org, "Welcomes", group)
+        registered = self.org.fields.get(key="registered")
+        joined = self.create_field("joined", "Joined", value_type="D")
+
+        flow_event = campaign.events.get()
+        message_event = CampaignEvent.create_message_event(
+            self.org,
+            self.admin,
+            campaign,
+            registered,
+            offset=-3,
+            unit="D",
+            translations={"eng": {"text": "Hi @fields.registered"}},
+            base_language="eng",
+            delivery_hour=9,
+        )
+        joined_event = CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, joined, offset=0, unit="D", flow=flow_event.flow
+        )
+
+        events_url = reverse("campaigns.campaign_events", args=[campaign.uuid])
+
+        self.assertRequestDisallowed(events_url, [None, self.agent, self.admin2])
+
+        self.login(self.editor)
+
+        # like the preview read page it feeds, the endpoint only exists in preview mode
+        response = self.client.get(events_url)
+        self.assertEqual(404, response.status_code)
+
+        self.client.cookies["temba-preview"] = "1"
+        response = self.client.get(events_url)
+        self.assertEqual(200, response.status_code)
+
+        # events are sorted by field name then offset, and carry the schedule definition rather than a computed time
+        self.assertEqual(
+            {
+                "campaign": {"uuid": str(campaign.uuid), "name": "Welcomes"},
+                "events": [
+                    {
+                        "uuid": str(joined_event.uuid),
+                        "type": "flow",
+                        "status": "ready",
+                        "offset": 0,
+                        "unit": "D",
+                        "offset_display": "on",
+                        "relative_to": {"key": "joined", "name": "Joined", "system": False},
+                        "count": 0,
+                        "edit_url": f"/campaignevent/update/{joined_event.uuid}/",
+                        "delete_url": f"/campaignevent/delete/{joined_event.uuid}/",
+                        "fires_url": f"/campaignevent/fires/{joined_event.uuid}/",
+                        "flow": {
+                            "uuid": str(flow_event.flow.uuid),
+                            "name": "Welcomes Flow",
+                            "url": f"/flow/editor/{flow_event.flow.uuid}/",
+                        },
+                    },
+                    {
+                        "uuid": str(message_event.uuid),
+                        "type": "message",
+                        "status": "ready",
+                        "offset": -3,
+                        "unit": "D",
+                        "offset_display": "3 days before",
+                        "delivery_hour_display": "at 9:00 a.m.",
+                        "relative_to": {"key": "registered", "name": "Registered", "system": False},
+                        "count": 0,
+                        "edit_url": f"/campaignevent/update/{message_event.uuid}/",
+                        "delete_url": f"/campaignevent/delete/{message_event.uuid}/",
+                        "fires_url": f"/campaignevent/fires/{message_event.uuid}/",
+                        "message": "Hi @fields.registered",
+                    },
+                    {
+                        "uuid": str(flow_event.uuid),
+                        "type": "flow",
+                        "status": "ready",
+                        "offset": 1,
+                        "unit": "W",
+                        "offset_display": "1 week after",
+                        "delivery_hour_display": "at 1:00 p.m.",
+                        "relative_to": {"key": "registered", "name": "Registered", "system": False},
+                        "count": 0,
+                        "edit_url": f"/campaignevent/update/{flow_event.uuid}/",
+                        "delete_url": f"/campaignevent/delete/{flow_event.uuid}/",
+                        "fires_url": f"/campaignevent/fires/{flow_event.uuid}/",
+                        "flow": {
+                            "uuid": str(flow_event.flow.uuid),
+                            "name": "Welcomes Flow",
+                            "url": f"/flow/editor/{flow_event.flow.uuid}/",
+                        },
+                    },
+                ],
+                "can_edit": True,
+                "can_delete": True,
+            },
+            response.json(),
+        )
+
     @mock_mailroom
     def test_update(self, mr_mocks):
         group1 = self.create_group("Reporters", contacts=[])

--- a/temba/campaigns/tests/test_campaigncrudl.py
+++ b/temba/campaigns/tests/test_campaigncrudl.py
@@ -203,6 +203,13 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
             response.json(),
         )
 
+        # archiving the campaign locks editing but deletion stays available
+        campaign.archive(self.admin)
+        response = self.client.get(events_url)
+        self.assertEqual(200, response.status_code)
+        self.assertFalse(response.json()["can_edit"])
+        self.assertTrue(response.json()["can_delete"])
+
     @mock_mailroom
     def test_update(self, mr_mocks):
         group1 = self.create_group("Reporters", contacts=[])

--- a/temba/campaigns/tests/test_eventcrudl.py
+++ b/temba/campaigns/tests/test_eventcrudl.py
@@ -1,3 +1,7 @@
+from uuid import uuid4
+
+from django_valkey import get_valkey_connection
+
 from django.urls import reverse
 
 from temba.campaigns.models import Campaign, CampaignEvent
@@ -14,6 +18,12 @@ from temba.utils.views.mixins import TEMBA_MENU_SELECTION
 
 def _compose(translations):
     return json.dumps(compose_serialize(translations))
+
+
+def add_recent_contact(event, contact, ts: float):
+    r = get_valkey_connection()
+    member = f"{uuid4()}|{contact.id}"
+    r.zadd(f"recent_campaign_fires:{event.id}", mapping={member: ts})
 
 
 class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
@@ -42,6 +52,75 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
             org, user, campaign, registered, offset=2, unit="W", flow=background_flow, delivery_hour="13"
         )
         return campaign
+
+    @mock_mailroom
+    def test_update_preview_success_url(self, mr_mocks):
+        event = self.campaign1.events.order_by("id").first()
+        registered = self.org.fields.get(key="registered")
+        flow = self.org.flows.get(name="Welcomes Flow")
+
+        update_url = reverse("campaigns.campaignevent_update", args=[event.uuid])
+        data = {
+            "event_type": "F",
+            "relative_to": registered.id,
+            "offset": 1,
+            "unit": "W",
+            "delivery_hour": 13,
+            "direction": "A",
+            "flow_to_start": flow.id,
+            "flow_start_mode": "I",
+        }
+
+        self.login(self.admin)
+
+        # outside preview the edit modal continues to the event read page
+        response = self.client.post(update_url, data)
+        self.assertRedirects(
+            response,
+            reverse("campaigns.campaignevent_read", args=[self.campaign1.uuid, event.uuid]),
+            fetch_redirect_response=False,
+        )
+
+        # in preview there is no event read page - it returns to the campaign
+        self.client.cookies["temba-preview"] = "1"
+        response = self.client.post(update_url, data)
+        self.assertRedirects(
+            response, reverse("campaigns.campaign_read", args=[self.campaign1.uuid]), fetch_redirect_response=False
+        )
+
+    def test_fires(self):
+        event = self.campaign1.events.order_by("id").first()
+        contact = self.create_contact("Ann", phone="+1234567890")
+        add_recent_contact(event, contact, 1639338554.969123)
+
+        fires_url = reverse("campaigns.campaignevent_fires", args=[event.uuid])
+
+        self.assertRequestDisallowed(fires_url, [None, self.agent, self.admin2])
+
+        self.login(self.editor)
+
+        # like the preview read page it feeds, the endpoint only exists in preview mode
+        response = self.client.get(fires_url)
+        self.assertEqual(404, response.status_code)
+
+        self.client.cookies["temba-preview"] = "1"
+        response = self.client.get(fires_url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {
+                "fires": [
+                    {
+                        "contact": {
+                            "uuid": str(contact.uuid),
+                            "name": "Ann",
+                            "url": f"/contact/read/{contact.uuid}/",
+                        },
+                        "time": "2021-12-12T19:49:14.969123+00:00",
+                    }
+                ]
+            },
+            response.json(),
+        )
 
     def test_read(self):
         event = self.campaign1.events.order_by("id").first()

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -4,6 +4,7 @@ from smartmin.views import SmartCreateView, SmartCRUDL
 
 from django import forms
 from django.db.models.functions import Lower
+from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.functional import Promise, cached_property
@@ -55,7 +56,7 @@ class CampaignForm(forms.ModelForm):
 
 class CampaignCRUDL(SmartCRUDL):
     model = Campaign
-    actions = ("create", "read", "update", "list", "delete", "archived", "archive", "activate", "menu")
+    actions = ("create", "read", "update", "list", "delete", "archived", "archive", "activate", "menu", "events")
 
     class Menu(BaseMenuView):
         def derive_menu(self):
@@ -111,8 +112,18 @@ class CampaignCRUDL(SmartCRUDL):
     class Read(SpaMixin, ContextMenuMixin, BaseReadView):
         menu_path = "/campaign/active"
 
+        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
+        # the read view renders the temba-campaign-events component (campaigns/campaign_read_new.html) instead of
+        # the legacy table; the component fetches the event schedule itself from the campaign events endpoint.
+        NEW_READ_TEMPLATE = "campaigns/campaign_read_new.html"
+
         def derive_title(self):
             return self.object.name
+
+        def get_template_names(self):
+            if getattr(self.request, "preview", False):
+                return [self.NEW_READ_TEMPLATE]
+            return super().get_template_names()
 
         def build_context_menu(self, menu):
             obj = self.get_object()
@@ -156,8 +167,37 @@ class CampaignCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
-            context["events"] = self.object.get_sorted_events()
+
+            # in preview the component fetches the events itself from the events endpoint
+            if not getattr(self.request, "preview", False):
+                context["events"] = self.object.get_sorted_events()
             return context
+
+    class Events(BaseReadView):
+        """
+        The event schedule of a campaign as JSON, consumed by the temba-campaign-events component on the preview
+        read page — so like that page it only exists in preview mode.
+        """
+
+        permission = "campaigns.campaign_read"
+
+        def get(self, request, *args, **kwargs):
+            # permission checks have already run in dispatch; hide the endpoint itself outside of preview
+            if not getattr(request, "preview", False):
+                raise Http404()
+            return super().get(request, *args, **kwargs)
+
+        def render_to_response(self, context, **response_kwargs):
+            return JsonResponse(
+                {
+                    # the campaign gives the event detail modal its context on any page
+                    "campaign": {"uuid": str(self.object.uuid), "name": self.object.name},
+                    "events": [e.as_json() for e in self.object.get_sorted_events()],
+                    # scheduling-state events additionally can't be edited, which the component derives per event
+                    "can_edit": self.has_org_perm("campaigns.campaignevent_update") and not self.object.is_archived,
+                    "can_delete": self.has_org_perm("campaigns.campaignevent_delete"),
+                }
+            )
 
     class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):
         fields = ("name", "group")
@@ -615,7 +655,7 @@ class CampaignEventForm(forms.ModelForm):
 
 class CampaignEventCRUDL(SmartCRUDL):
     model = CampaignEvent
-    actions = ("create", "delete", "read", "update")
+    actions = ("create", "delete", "read", "update", "fires")
 
     BACKGROUND_WARNING = _(
         "This is a background flow. When it triggers, it will run it for all contacts without interruption."
@@ -688,6 +728,39 @@ class CampaignEventCRUDL(SmartCRUDL):
                     reverse("campaigns.campaignevent_delete", args=[obj.uuid]),
                     title=_("Delete Event"),
                 )
+
+    class Fires(BaseReadView):
+        """
+        The most recent contacts an event fired for, consumed by the recent-contacts popup on the preview campaign
+        read page — so like that page it only exists in preview mode.
+        """
+
+        permission = "campaigns.campaignevent_read"
+        model_org_lookup = "campaign__org"
+
+        def get_object_org(self):
+            return self.get_object().campaign.org
+
+        def get(self, request, *args, **kwargs):
+            # permission checks have already run in dispatch; hide the endpoint itself outside of preview
+            if not getattr(request, "preview", False):
+                raise Http404()
+            return super().get(request, *args, **kwargs)
+
+        def render_to_response(self, context, **response_kwargs):
+            org = self.object.campaign.org
+            fires = [
+                {
+                    "contact": {
+                        "uuid": str(f["contact"].uuid),
+                        "name": f["contact"].get_display(org),
+                        "url": reverse("contacts.contact_read", args=[f["contact"].uuid]),
+                    },
+                    "time": f["time"].isoformat(),
+                }
+                for f in self.object.get_recent_fires()
+            ]
+            return JsonResponse({"fires": fires})
 
     class Delete(BaseDeleteModal):
         model_org_lookup = "campaign__org"
@@ -776,6 +849,9 @@ class CampaignEventCRUDL(SmartCRUDL):
             return obj
 
         def get_success_url(self):
+            # the preview read page has no event read page - the edit modal returns to the campaign
+            if getattr(self.request, "preview", False):
+                return reverse("campaigns.campaign_read", args=[self.object.campaign.uuid])
             return reverse("campaigns.campaignevent_read", args=[self.object.campaign.uuid, self.object.uuid])
 
     class Create(ModalFormMixin, OrgPermsMixin, SmartCreateView):

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -193,7 +193,8 @@ class CampaignCRUDL(SmartCRUDL):
                     # the campaign gives the event detail modal its context on any page
                     "campaign": {"uuid": str(self.object.uuid), "name": self.object.name},
                     "events": [e.as_json() for e in self.object.get_sorted_events()],
-                    # scheduling-state events additionally can't be edited, which the component derives per event
+                    # scheduling-state events additionally can't be edited, which the component derives per event.
+                    # deletion stays available on archived campaigns, matching the legacy event read page.
                     "can_edit": self.has_org_perm("campaigns.campaignevent_update") and not self.object.is_archived,
                     "can_delete": self.has_org_perm("campaigns.campaignevent_delete"),
                 }

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -193,7 +193,8 @@ class CampaignCRUDL(SmartCRUDL):
                     # the campaign gives the event detail modal its context on any page
                     "campaign": {"uuid": str(self.object.uuid), "name": self.object.name},
                     "events": [e.as_json() for e in self.object.get_sorted_events()],
-                    # scheduling-state events additionally can't be edited, which the component derives per event.
+                    # there is no per-event edit flag: the component combines this campaign-level can_edit with
+                    # each event's status (scheduling-state events stay locked until mailroom finishes).
                     # deletion stays available on archived campaigns, matching the legacy event read page.
                     "can_edit": self.has_org_perm("campaigns.campaignevent_update") and not self.object.is_archived,
                     "can_delete": self.has_org_perm("campaigns.campaignevent_delete"),

--- a/templates/campaigns/campaign_read_new.html
+++ b/templates/campaigns/campaign_read_new.html
@@ -1,0 +1,127 @@
+{% extends "smartmin/read.html" %}
+{% load i18n %}
+
+{% comment %}
+  New-style campaign read page rendered when the viewer is in preview
+  mode (request.preview, set by PreviewMiddleware off the temba-preview
+  cookie). The temba-campaign-events component renders the same page
+  header as the new list views (title + content menu), a badges row
+  (group, archived), then the campaign's event schedule — one subway
+  line per anchor field, each in its own card; the component fetches
+  the schedule itself from the campaign events endpoint. There is no
+  event read page here — events are edited / deleted through modals
+  and recent contacts show in a popup.
+{% endcomment %}
+{% block page-header %}
+  {# the component renders its own header (title + content menu); #}
+  {# keep the csrf token and a hidden title for the SPA document.title hook #}
+  {% csrf_token %}
+  <div id="title-text" class="hide">{{ title }}</div>
+{% endblock page-header %}
+{% block extra-style %}
+  {{ block.super }}
+  <style type="text/css">
+    /* The component renders the same flush header bar as the new list
+       pages, so drop the SPA content padding the same way they do. */
+    .spa-content {
+      padding: 0 !important;
+    }
+
+    /* the group pill rides the header as a subtitle, so shrink it down
+       and give it some breathing room under the title */
+    .subtitle-group {
+      font-size: 10.5px;
+      margin-top: 5px;
+      display: inline-block;
+    }
+
+    .subtitle-group a {
+      text-decoration: none;
+    }
+  </style>
+{% endblock extra-style %}
+{% block content %}
+  <temba-campaign-events id="campaign-events"
+                         campaign="{{ object.uuid }}"
+                         header-title="{{ object.name }}"
+                         content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}">
+    <div slot="subtitle" class="subtitle-group">
+      {# in the past we let users delete groups used by campaigns #}
+      {% if object.group.is_active %}
+        <a href="{% url 'contacts.contact_group' object.group.uuid %}"><temba-label icon="group" type="group" clickable>{{ object.group.name }}</temba-label></a>
+      {% else %}
+        <temba-label icon="issue">{% trans "Group required" %}</temba-label>
+      {% endif %}
+    </div>
+    {% if object.is_archived %}
+      <div slot="badges">
+        <a href="{% url 'campaigns.campaign_archived' %}"><temba-label icon="campaign_archived" clickable>{% trans "Archived" %}</temba-label></a>
+      </div>
+    {% endif %}
+  </temba-campaign-events>
+{% endblock content %}
+{% block extra-script %}
+  {{ block.super }}
+  <script type="text/javascript">
+    onSpload(function() {
+      var events = document.querySelector("#campaign-events");
+
+      events.addEventListener("temba-selection", function(event) {
+        var detail = event.detail;
+
+        // the embedded page header fires temba-selection with a content-menu
+        // item - dispatch it the same way the page chrome's content menu
+        // (spa_page_menu.html) does
+        if (detail.item && detail.item.type) {
+          var item = detail.item;
+          var click = detail.event;
+          if (item.type === "link") {
+            if (click) {
+              click.preventDefault();
+              click.stopPropagation();
+              if (click.metaKey && item.url) {
+                window.open(item.url, "_blank");
+                return;
+              }
+            }
+            spaGet(item.url);
+          } else if (item.type === "modax") {
+            showModax(item.title, item.url, {
+              disabled: item.disabled,
+              onSubmit: item.on_submit,
+              onRedirect: item.on_redirect,
+              id: item.modal_id,
+              originX: detail.originX,
+              originY: detail.originY
+            });
+          } else if (item.type === "url_post") {
+            posterize(item.url);
+          } else if (item.type === "js") {
+            if (window[item.id]) {
+              window[item.id]();
+            }
+          }
+          refreshMenu();
+          return;
+        }
+
+        // event rows open the edit / delete modals - both redirect back to
+        // this page on completion which re-fetches the schedule
+        if (detail.action === "edit_event") {
+          showModax("{% trans "Edit Event" %}", detail.event.edit_url, { id: "event-update" });
+          return;
+        }
+        if (detail.action === "delete_event") {
+          showModax("{% trans "Delete Event" %}", detail.event.delete_url, { id: "event-delete" });
+          return;
+        }
+
+        // a flow pill carries the flow's editor url; a contact in the recent
+        // contacts popup carries its read page url
+        if (detail.url) {
+          spaGet(detail.url);
+        }
+      });
+    });
+  </script>
+{% endblock extra-script %}


### PR DESCRIPTION
## Summary

Wires the campaign read page into preview mode: when `request.preview` is set it renders the new `temba-campaign-events` component — the campaign's schedule as one card per anchor field — instead of the legacy table. There is no event read page in preview: events open a detail modal (rendered by the component) with edit/delete actions and the event's recent contacts. Stacked on #6723 (`ericnewcomer/campaign-list`).

## Screenshots

**Before — legacy events table**

![campaign read page with the legacy events table](https://gist.githubusercontent.com/ericnewcomer/ec8c0c4654279031c030eb6479cd677f/raw/9ea5653c49e962be37ecd458b28219614fd5ce0a/campaign-read-legacy.png)

**After — preview read page rendering `temba-campaign-events`, one card per anchor field**

![campaign read page in preview mode showing the schedule as cards grouped by anchor field](https://gist.githubusercontent.com/ericnewcomer/ec8c0c4654279031c030eb6479cd677f/raw/9ea5653c49e962be37ecd458b28219614fd5ce0a/campaign-read-preview.png)

**Event detail modal — edit/delete actions and recent contacts**

![event detail modal with send message content, recent contacts, and edit/delete buttons](https://gist.githubusercontent.com/ericnewcomer/ec8c0c4654279031c030eb6479cd677f/raw/9ea5653c49e962be37ecd458b28219614fd5ce0a/campaign-event-modal.png)

## Changes

- **`temba/campaigns/models.py`** — `CampaignEvent.as_json()`: the schedule *definition* rather than a computed time — offset/unit plus the human `offset_display`, `relative_to` (key, name, and an `is_system` flag so the component can style system fields differently), `delivery_hour_display` for day/week events (via a cached hour-display lookup), the flow ref (with editor URL) or base-language message text (with a safe lookup so a legacy row with missing translations can't 500 the whole schedule), the fire count, and the edit/delete/fires URLs.
- **`temba/campaigns/views.py`**
  - `CampaignCRUDL.Events` — preview-only JSON endpoint (`/campaign/events/<uuid>/`, 404 outside preview after the normal permission checks) returning the campaign ref, sorted events, and `can_edit`/`can_delete` flags. The client combines campaign-level `can_edit` with each event's status; editing is blocked on archived campaigns while deletion stays available, matching the legacy event read page.
  - `CampaignCRUDL.Read` — preview template swap, and the legacy `events` context is skipped in preview since the component fetches its own data.
  - `CampaignEventCRUDL.Fires` — preview-only JSON endpoint serving the event's recent contacts (valkey-backed `get_recent_fires`) with org-appropriate display names and read-page URLs.
  - `CampaignEventCRUDL.Update.get_success_url` — returns to the campaign read page in preview, since the event read page isn't part of that experience.
- **`templates/campaigns/campaign_read_new.html`** — mounts the component with the campaign title, the group pill slotted as a compact header subtitle (or the group-required warning), an Archived badge when relevant, and a selection dispatcher covering content-menu items, the edit/delete modax handoff (the component closes its detail modal first, so modals never stack), and flow/contact navigation.
- **Tests** — `test_preview_read` (template swap both ways), `test_events` (preview gate, full payload shape, field-name/offset sort, archived-campaign flag asymmetry), `test_fires` (preview gate, permissions, payload), `test_update_preview_success_url` (redirect behavior in and out of preview).

## Review notes

Pre-PR review returned ready on the first cycle, verifying org scoping, permission derivation, preview-gating completeness (including that the 404 comes after permission checks so unauthorized users still get the standard redirect), the absence of N+1s on the events payload, and that no request data is interpolated into the template's inline script. Message serialization is deliberately text-only; attachments and quick replies belong to the edit modal.

Post-PR automated review raised four threads, all resolved: the per-event hour-display dict is now built once on the class instead of per event, `as_json` tolerates legacy rows with missing translations, `test_events` asserts the archived-campaign flag asymmetry (`can_edit` false / `can_delete` true), and the `can_edit` comment now spells out that the client combines it with each event's status.

## Test plan

- [x] `temba.campaigns` + `temba.api.internal` suites pass
- [x] ruff + djlint + migrations check clean
- [x] Verified end-to-end in a local dev stack with the preview cookie: schedule renders with real data across multiple anchor fields (including system fields), detail modal flows (edit modax swap, delete confirm, recent contacts navigation), and non-preview requests still get the legacy table with both JSON endpoints returning 404
