### PR TITLE
Update @nyaruka/temba-components to 0.164.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.163.0",
+    "@nyaruka/temba-components": "0.164.0",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nyaruka/temba-components@0.163.0":
-  version "0.163.0"
-  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.163.0.tgz#442c45160a8330f5a72b05eda1e1b161d5a6cdd0"
-  integrity sha512-aOlQRiJ5J4mknC68BJjOs1uPYhnYUZb4NkTOuDRioxMXBX6n6uTGwebjNTfXY63MGWJmfGbr0xEcGV2B19Imcg==
+"@nyaruka/temba-components@0.164.0":
+  version "0.164.0"
+  resolved "https://registry.yarnpkg.com/@nyaruka/temba-components/-/temba-components-0.164.0.tgz#20e48978b564585d3f0465303072554de202758c"
+  integrity sha512-3RLhGw/122rXIo/AzkJbMkrfWHGJu6rre6g42pZbC7GmdcyTv4IPKvqcjF/q+iJN4jvExRe+Y8wKGaxud/sW/g==
   dependencies:
     "@jsplumb/browser-ui" "^6.2.10"
     "@lit/localize" "^0.12.2"


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.164.0](https://github.com/nyaruka/temba-components/compare/v0.163.0...v0.164.0)

- Add temba-campaign-events for the campaign read page [#1048](https://github.com/nyaruka/temba-components/pull/1048)
- Add chat-first card layout for contact pages [#1049](https://github.com/nyaruka/temba-components/pull/1049)
- Add temba-campaign-list content list component [#1045](https://github.com/nyaruka/temba-components/pull/1045)
- Add temba-trigger-list component [#1046](https://github.com/nyaruka/temba-components/pull/1046)
- Fetch contacts with expand_urns so URNs are resolved against channels [#1047](https://github.com/nyaruka/temba-components/pull/1047)
- Render attachments in the message list and fix the lightbox [#1039](https://github.com/nyaruka/temba-components/pull/1039)
- Don't clip long flow names or label chips in the flow list [#1044](https://github.com/nyaruka/temba-components/pull/1044)