### PR TITLE
Fix mobile layout issues on the ticket page

### DIFF
--- a/templates/tickets/ticket_list_new.html
+++ b/templates/tickets/ticket_list_new.html
@@ -21,8 +21,10 @@
 
     .back-button {
       display: none;
-      padding-right: 0.5em;
-      margin-top: -1em;
+      /* the header bar grows slotted children to fill the strip — the
+         back button holds its own size */
+      flex: 0 0 auto;
+      margin-right: 0.25em;
     }
 
     .back-button:hover {
@@ -50,19 +52,35 @@
 
     .mobile .ticket-ui temba-resizer {
       min-width: 100vw;
-      padding: 0.75em;
       transition: margin-left 0.5s;
     }
 
     .mobile .ticket-ui temba-resizer .ticket-list {
       padding: 0;
-      padding-bottom: 0em;
+    }
+
+    /* the header strip runs flush across the top (over the band painted on
+       .ticket-ui) — the list body below carries the inset instead */
+    .mobile .list-body {
+      padding: 8px;
+    }
+
+    /* no chat column beside the list on mobile, so restore the strip's
+       right inset */
+    .mobile .ticket-list temba-header-bar {
+      padding-right: 8px;
     }
 
     .mobile .ticket-ui .chat-pane {
       padding-right: 0.75em;
       padding-left: 0.75em;
       margin-left: 0;
+    }
+
+    /* the pane already insets both sides — drop the extra right padding
+       the layout adds in tab view to keep clear of the card column edge */
+    .mobile .chat-pane temba-card-layout {
+      padding-right: 0;
     }
 
     .mobile temba-header-bar .back-button {
@@ -79,6 +97,10 @@
 
     .chat-pane .empty {
       position: absolute;
+      /* clear the header strip (52px + 1px rule) — as an absolutely
+         positioned flex child the empty state's static position is the
+         top of the pane, which would print it over the page header */
+      top: 53px;
       opacity: 0;
       padding: 3px 40px;
       pointer-events: none;
@@ -119,6 +141,8 @@
       /* the gap to the ticket list — the resizer's drag handle strip
          (sized to match) rides in this space */
       margin-left: 8px;
+      /* anchor the empty state's top offset to this pane */
+      position: relative;
     }
 
     temba-menu {
@@ -430,6 +454,16 @@
 
       } else {
         ticketUI.classList.remove('has-selection');
+
+        // on mobile the list shouldn't keep a focused ticket — clear the
+        // selection so the same ticket can be tapped again
+        if (window.isMobile && isMobile()) {
+          var tickets = document.querySelector("temba-ticket-list");
+          if (tickets) {
+            tickets.clearSelection();
+          }
+        }
+
         if (layout) {
           layout.classList.add("hidden");
         }
@@ -665,12 +699,13 @@
       </temba-resizer>
       <div class="chat-pane flex-grow flex-col flex">
         <temba-header-bar>
+          {# outside the page header so the hover ring isn't clipped by its title's text truncation #}
+          <temba-icon size="1.2" class="back-button" name="arrow_left" clickable onclick="handleContactChanged()">
+          </temba-icon>
           <temba-page-header id="page-header"
                              content-menu-endpoint="{{ request.path }}"
                              -temba-selection="handleContentMenuSelected(event)">
             <div slot="title" class="flex" style="align-items: center">
-              <temba-icon size="1.2" class="back-button" name="arrow_left" clickable onclick="handleContactChanged()">
-              </temba-icon>
               <temba-contact-name-fetch -temba-refreshed="handleContactRefreshed"
                                         icon-size="16"
                                         onclick="{% if org_perms.contacts.contact_read %}handleNameClicked(){% endif %}"


### PR DESCRIPTION
## Summary

Mobile fixes for the preview-mode ticket page: the list header strip now lines up with the page's header band, the back arrow is positioned correctly with an unclipped hover ring, tab content is evenly inset, and tapping the same ticket after going back reopens it.

## Changes

- **Header strip alignment** — the mobile resizer's `0.75em` padding pushed the list column's header strip out of alignment with the 52px band painted on `.ticket-ui`. The strip now runs flush across the top; the list body carries the inset instead, and the strip regains its right padding on mobile (no adjacent chat column)
- **Back arrow** — moved out of `temba-page-header`'s title slot (whose text-truncation container clipped the icon's hover ring) to a direct child of `temba-header-bar`, replacing the old `margin-top: -1em` hack with normal flex centering
- **Ticket re-selection** — dismissing the chat on mobile now clears the ticket list selection via the new `TembaList.clearSelection()`, so no row stays focused in the list and tapping the same ticket re-fires the change event and reopens the chat
- **Tab inset** — the card layout's extra tab-view right padding is dropped on mobile where the pane already insets both sides
- **Empty state** — anchored below the header strip (`top: 53px` against the now-relative chat pane) instead of printing over the page header

## Review notes

Pre-PR review found no code defects. One coordination note: `tickets.clearSelection()` requires the next `@nyaruka/temba-components` release (nyaruka/temba-components#1051) — this PR should land together with that version bump. Desktop is unaffected either way (the call is mobile-guarded).

## Test plan

- [x] Ticket CRUDL tests pass in the dev stack (two pre-existing query-count assertion failures are caused by deployment-specific apps in the local environment, unrelated to this template-only diff)
- [x] Manually exercised on mobile: header strip alignment, back arrow position/hover, select → back → same ticket reopens with chat history loading