### PR TITLE
Guard malformed group/label UUID params on internal list endpoints

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -202,8 +202,9 @@ class EndpointsTest(APITestMixin, TembaTest):
         other_label = self.create_label("Other", org=self.org2)
         self.assertGet(endpoint_url + f"?label={other_label.uuid}", [self.admin], results=[])
 
-        # an unknown label uuid returns nothing
+        # an unknown or malformed label uuid returns nothing
         self.assertGet(endpoint_url + f"?label={contact1.uuid}", [self.admin], results=[])
+        self.assertGet(endpoint_url + "?label=foo", [self.admin], results=[])
 
         # can search by message text or contact name
         response = self.assertGet(endpoint_url + "?search=hello", [self.admin], results=[msg1])
@@ -269,9 +270,10 @@ class EndpointsTest(APITestMixin, TembaTest):
         # an unknown folder yields no contacts
         self.assertGet(endpoint_url + "?folder=nope", [self.admin], results=[])
 
-        # a specific group can be selected by uuid
+        # a specific group can be selected by uuid; a malformed group yields no contacts
         group = self.create_group("Crew", contacts=[joe])
         self.assertGet(endpoint_url + f"?group={group.uuid}", [self.admin], results=[joe])
+        self.assertGet(endpoint_url + "?group=foo", [self.admin], results=[])
 
         # each row carries its group memberships so the component can pre-check the group dropdown
         def check_groups(data):

--- a/temba/contacts/api.py
+++ b/temba/contacts/api.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from rest_framework.response import Response
 
 from django.db.models import Prefetch, prefetch_related_objects
@@ -72,6 +74,12 @@ class ContactsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         org = self.request.org
         group_uuid = self.request.query_params.get("group")
         if group_uuid:
+            # Validate before the lookup — an unparseable value would otherwise raise in the database's UUID
+            # coercion (500). Mirrors FlowsEndpoint's label guard.
+            try:
+                UUID(group_uuid)
+            except ValueError:
+                return None
             # Mirror GroupsEndpoint.filter_queryset: skip still-evaluating smart groups so we never page over a group
             # whose membership isn't yet populated.
             return (

--- a/temba/contacts/api.py
+++ b/temba/contacts/api.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from rest_framework.response import Response
 
 from django.db.models import Prefetch, prefetch_related_objects
@@ -11,6 +9,7 @@ from temba.api.support import ListPagination, SearchLengthMixin
 from temba.api.views import ListAPIMixin
 from temba.utils.models.base import patch_queryset_count
 from temba.utils.models.es import SearchSliceQuerySet
+from temba.utils.uuid import is_uuid
 
 from .models import Contact, ContactField, ContactGroup
 
@@ -76,9 +75,7 @@ class ContactsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         if group_uuid:
             # Validate before the lookup — an unparseable value would otherwise raise in the database's UUID
             # coercion (500). Mirrors FlowsEndpoint's label guard.
-            try:
-                UUID(group_uuid)
-            except ValueError:
+            if not is_uuid(group_uuid):
                 return None
             # Mirror GroupsEndpoint.filter_queryset: skip still-evaluating smart groups so we never page over a group
             # whose membership isn't yet populated.

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -41,6 +41,7 @@ from temba.utils import json, on_transaction_commit
 from temba.utils.fields import CheckboxWidget, InputWidget, SelectWidget, TembaChoiceField
 from temba.utils.models import patch_queryset_count
 from temba.utils.models.es import SearchSliceQuerySet
+from temba.utils.uuid import is_uuid
 from temba.utils.views.mixins import ContextMenuMixin, ModalFormMixin, NonAtomicMixin, SpaMixin
 
 from .forms import ContactGroupForm, CreateContactForm, UpdateContactForm
@@ -147,21 +148,13 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
             if uuids:
                 # Only keep well-formed UUIDs — `uuid__in` runs each value through UUIDField.get_prep_value, so a single
                 # malformed value (a hostile post, or a stale id-based form post) would otherwise raise ValueError (500).
-                valid = []
-                for u in uuids:
-                    try:
-                        valid.append(UUID(u))
-                    except ValueError:
-                        pass
+                valid = [u for u in uuids if is_uuid(u)]
                 ids = Contact.objects.filter(org=request.org, uuid__in=valid).values_list("id", flat=True)
                 data.setlist("objects", [str(i) for i in ids])
             label = data.get("label")
             if label:
-                try:
-                    UUID(label)
-                except ValueError:
-                    pass  # already an id (legacy form post) — leave alone
-                else:
+                # a non-uuid value (the legacy form's integer id) is left alone
+                if is_uuid(label):
                     group = request.org.groups.filter(uuid=label).first()
                     data["label"] = str(group.id) if group else ""
             elif data.get("action") == "unlabel" and self.group is not None:

--- a/temba/flows/api.py
+++ b/temba/flows/api.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from django.db.models import Q, Sum, Value
 from django.db.models.functions import Coalesce, Lower
 
@@ -7,6 +5,7 @@ from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
 from temba.api.support import ListPagination, NameCursorPagination, SearchLengthMixin
 from temba.api.views import ListAPIMixin
+from temba.utils.uuid import is_uuid
 
 from .models import Flow, FlowLabel, FlowRun
 
@@ -41,9 +40,7 @@ class FlowsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
             # Validate before the lookup — an unparseable value would otherwise raise in the database's UUID
             # coercion (500). FlowLabel.objects rather than org.flow_labels for the same readonly-alias reason as
             # the flows queryset above.
-            try:
-                UUID(label_uuid)
-            except ValueError:
+            if not is_uuid(label_uuid):
                 return Flow.objects.none()
             label = FlowLabel.objects.filter(org=org, uuid=label_uuid, is_active=True).first()
             if not label:

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -56,6 +56,7 @@ from temba.utils.fields import (
     TembaChoiceField,
 )
 from temba.utils.text import slugify_with
+from temba.utils.uuid import is_uuid
 from temba.utils.views.mixins import ContextMenuMixin, ModalFormMixin, SpaMixin
 
 from .models import (
@@ -646,25 +647,15 @@ class FlowCRUDL(SmartCRUDL):
                     # Only keep well-formed UUIDs — `uuid__in` runs each value through UUIDField.get_prep_value, so a
                     # single malformed value (a hostile post, or a stale id-based form post) would otherwise raise
                     # ValueError (500).
-                    valid = []
-                    for u in uuids:
-                        try:
-                            valid.append(UUID(u))
-                        except ValueError:
-                            pass
+                    valid = [u for u in uuids if is_uuid(u)]
                     ids = Flow.objects.filter(org=request.org, is_active=True, uuid__in=valid).values_list(
                         "id", flat=True
                     )
                     data.setlist("objects", [str(i) for i in ids])
                 label = data.get("label")
-                if label:
-                    try:
-                        UUID(label)
-                    except ValueError:
-                        pass  # already an id (legacy form post) — leave alone
-                    else:
-                        obj = request.org.flow_labels.filter(uuid=label).first()
-                        data["label"] = str(obj.id) if obj else ""
+                if label and is_uuid(label):  # a non-uuid value (the legacy form's integer id) is left alone
+                    obj = request.org.flow_labels.filter(uuid=label).first()
+                    data["label"] = str(obj.id) if obj else ""
                 request.POST = data
 
             return super().post(request, *args, **kwargs)

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from functools import cached_property
 
 from django.db.models import Q
 from django.utils import timezone
@@ -68,11 +69,13 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     serializer_class = ModelAsJsonSerializer
     pagination_class = Pagination
 
-    def get_label(self):
+    @cached_property
+    def label(self):
         """
-        Gets the label referenced by the `label` query param, or None if it's malformed or not a label in the current
+        The label referenced by the `label` query param, or None if it's malformed or not a label in the current
         org. Validated before the lookup — an unparseable value would otherwise raise in the database's UUID
-        coercion (500). Mirrors FlowsEndpoint's label guard.
+        coercion (500). Mirrors FlowsEndpoint's label guard. Cached because it's read by both derive_queryset and
+        get_total_count on the same request.
         """
         label_uuid = self.request.query_params.get("label")
         if not label_uuid or not is_uuid(label_uuid):
@@ -84,8 +87,7 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         # when there's no search, avoiding a COUNT(*) on the messages table.
         org = self.request.org
         if self.request.query_params.get("label"):
-            label = self.get_label()
-            return label.get_visible_count() if label else 0
+            return self.label.get_visible_count() if self.label else 0
 
         folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
         if not folder:
@@ -98,7 +100,7 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         # `org` and `channel` are select_related because Msg.as_json reads self.org (for contact display) and
         # self.channel.is_active/uuid (for the channel-log link gated on the channels.channel_logs perm).
         if self.request.query_params.get("label"):
-            label = self.get_label()
+            label = self.label
             if not label:
                 return Msg.objects.none()
             return (

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from uuid import UUID
 
 from django.db.models import Q
 from django.utils import timezone
@@ -67,13 +68,27 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     serializer_class = ModelAsJsonSerializer
     pagination_class = Pagination
 
+    def get_label(self):
+        """
+        Gets the label referenced by the `label` query param, or None if it's malformed or not a label in the current
+        org. Validated before the lookup — an unparseable value would otherwise raise in the database's UUID
+        coercion (500). Mirrors FlowsEndpoint's label guard.
+        """
+        label_uuid = self.request.query_params.get("label")
+        if not label_uuid:
+            return None
+        try:
+            UUID(label_uuid)
+        except ValueError:
+            return None
+        return self.request.org.msgs_labels.filter(uuid=label_uuid).first()
+
     def get_total_count(self) -> int:
         # Cheap pre-calculated total for the active folder/label (squashed count tables) — used as the list's total
         # when there's no search, avoiding a COUNT(*) on the messages table.
         org = self.request.org
-        label_uuid = self.request.query_params.get("label")
-        if label_uuid:
-            label = org.msgs_labels.filter(uuid=label_uuid).first()
+        if self.request.query_params.get("label"):
+            label = self.get_label()
             return label.get_visible_count() if label else 0
 
         folder = self.FOLDERS.get(self.request.query_params.get("folder", "inbox").lower())
@@ -86,9 +101,8 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         # messages for that label aren't a MsgFolder slice.
         # `org` and `channel` are select_related because Msg.as_json reads self.org (for contact display) and
         # self.channel.is_active/uuid (for the channel-log link gated on the channels.channel_logs perm).
-        label_uuid = self.request.query_params.get("label")
-        if label_uuid:
-            label = self.request.org.msgs_labels.filter(uuid=label_uuid).first()
+        if self.request.query_params.get("label"):
+            label = self.get_label()
             if not label:
                 return Msg.objects.none()
             return (

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from uuid import UUID
 
 from django.db.models import Q
 from django.utils import timezone
@@ -8,6 +7,7 @@ from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
 from temba.api.support import CreatedOnCursorPagination, SearchCountMixin, SearchLengthMixin, SentOnCursorPagination
 from temba.api.views import ListAPIMixin
+from temba.utils.uuid import is_uuid
 
 from .models import Msg, MsgFolder
 
@@ -75,11 +75,7 @@ class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         coercion (500). Mirrors FlowsEndpoint's label guard.
         """
         label_uuid = self.request.query_params.get("label")
-        if not label_uuid:
-            return None
-        try:
-            UUID(label_uuid)
-        except ValueError:
+        if not label_uuid or not is_uuid(label_uuid):
             return None
         return self.request.org.msgs_labels.filter(uuid=label_uuid).first()
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -3,7 +3,6 @@ import os
 from datetime import timedelta
 from functools import cached_property
 from urllib.parse import quote_plus
-from uuid import UUID
 
 import magic
 from smartmin.views import SmartCreateView, SmartCRUDL, SmartDeleteView, SmartUpdateView
@@ -36,6 +35,7 @@ from temba.utils import json
 from temba.utils.compose import compose_deserialize, compose_serialize
 from temba.utils.fields import CompletionTextarea, ContactSearchWidget, InputWidget, SelectWidget
 from temba.utils.models import patch_queryset_count
+from temba.utils.uuid import is_uuid
 from temba.utils.views.mixins import (
     ContextMenuMixin,
     ModalFormMixin,
@@ -118,15 +118,10 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
         # POST that happens to carry a `label` key isn't rewritten.
         if request.POST.get("action") in ("label", "unlabel"):
             label = request.POST.get("label")
-            if label:
-                try:
-                    UUID(label)
-                except ValueError:
-                    pass
-                else:
-                    obj = self.request.org.msgs_labels.filter(uuid=label).first()
-                    request.POST = request.POST.copy()
-                    request.POST["label"] = str(obj.id) if obj else ""
+            if label and is_uuid(label):
+                obj = self.request.org.msgs_labels.filter(uuid=label).first()
+                request.POST = request.POST.copy()
+                request.POST["label"] = str(obj.id) if obj else ""
 
         return super().post(request, *args, **kwargs)
 


### PR DESCRIPTION
The internal contacts and messages list endpoints passed their `group=` / `label=` query params straight into a UUID field lookup, so a malformed value (e.g. `?group=foo`) raised in the database's UUID coercion and returned a 500. The flows endpoint already validates its `label=` param before the lookup — this applies the same guard to the other two:

* `ContactsEndpoint.derive_group` validates the `group=` param and treats a malformed value like an unknown group (empty results).
* `MessagesEndpoint` resolves its `label=` param through a new `get_label()` (shared by `derive_queryset` and `get_total_count`) which validates before the lookup; malformed values yield empty results and a zero count.

Adds malformed-param cases to the existing endpoint tests.