### PR TITLE
Always show Start Flow for active contacts, confirming interruption on seeded starts

### DIFF
--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1910,8 +1910,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         MockSessionWriter(contact, self.create_flow("Test")).wait().save()
         MockSessionWriter(other_org_contact, self.create_flow("Test", org=self.org2)).wait().save()
 
-        # start option should be gone
-        self.assertContentMenu(read_url, self.admin, ["Edit", "Open Ticket"])
+        # start option is still present even for a contact in a flow - the start modal handles
+        # confirming the interruption
+        self.assertContentMenu(read_url, self.admin, ["Edit", "Start Flow", "Open Ticket"])
 
         # can't interrupt if not logged in
         self.client.logout()
@@ -1996,7 +1997,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             object_unchanged=contact,
         )
 
-        # submit with flow...
+        # submit with flow... the start is locked to the seeded contact so the query is ignored
         contact_search = dict(query=f"uuid='{contact.uuid}'", advanced=True)
         self.assertUpdateSubmit(
             start_url, self.admin, {"flow": background_flow.id, "contact_search": json.dumps(contact_search)}
@@ -2011,9 +2012,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
                     typ="M",
                     flow=background_flow,
                     groups=[],
-                    contacts=[],
+                    contacts=[contact],
                     urns=[],
-                    query=f"uuid='{contact.uuid}'",
+                    query=None,
                     exclude=Exclusions(),
                     params={},
                 )

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -462,7 +462,7 @@ class ContactCRUDL(SmartCRUDL):
                 )
 
             if obj.status == Contact.STATUS_ACTIVE:
-                if not obj.current_flow and self.has_org_perm("flows.flow_start"):
+                if self.has_org_perm("flows.flow_start"):
                     menu.add_modax(
                         _("Start Flow"),
                         "start-flow",

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1574,6 +1574,35 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
             ),
         )
 
+        # a submitted in_a_flow exclusion is ignored - the user has already confirmed interrupting
+        # the contact's current flow
+        contact_search = dict(
+            recipients=[{"id": str(contact.uuid), "name": contact.name, "type": "contact"}],
+            advanced=False,
+            exclusions={"in_a_flow": True, "non_active": True},
+        )
+        self.assertUpdateSubmit(
+            start_url,
+            self.admin,
+            {"flow": flow.id, "contact_search": json.dumps(contact_search)},
+        )
+
+        self.assertEqual(
+            mr_mocks.calls["flow_start"][-1],
+            call(
+                self.org,
+                self.admin,
+                typ="M",
+                flow=flow,
+                groups=[],
+                contacts=[contact],
+                urns=[],
+                query=None,
+                exclude=Exclusions(non_active=True),
+                params={},
+            ),
+        )
+
         # seeding with multiple contacts doesn't lock the recipients
         multi_url = f"{reverse('flows.flow_start', args=[])}?c={contact.uuid},{other.uuid}"
         response = self.assertUpdateFetch(multi_url, [self.admin], form_fields=["flow", "contact_search"])

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1579,6 +1579,12 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.assertUpdateFetch(multi_url, [self.admin], form_fields=["flow", "contact_search"])
         self.assertNotIn("fixed", response.context["form"].fields["contact_search"].widget.attrs)
 
+        # seeding with another org's contact doesn't lock the recipients
+        other_org_contact = self.create_contact("Hans", phone="+593979099333", org=self.org2)
+        other_org_url = f"{reverse('flows.flow_start', args=[])}?c={other_org_contact.uuid}"
+        response = self.assertUpdateFetch(other_org_url, [self.admin], form_fields=["flow", "contact_search"])
+        self.assertNotIn("fixed", response.context["form"].fields["contact_search"].widget.attrs)
+
     @mock_mailroom
     def test_start_background_flow(self, mr_mocks):
         flow = self.create_flow("Background", flow_type=Flow.TYPE_BACKGROUND)

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1528,6 +1528,58 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         )
 
     @mock_mailroom
+    def test_start_seeded_contact(self, mr_mocks):
+        contact = self.create_contact("Bob", phone="+593979099111")
+        other = self.create_contact("Jim", phone="+593979099222")
+        flow = self.create_flow("Test")
+        current = self.create_flow("Current")
+
+        start_url = f"{reverse('flows.flow_start', args=[])}?c={contact.uuid}"
+
+        # seeded with a single contact, the recipients are fixed
+        response = self.assertUpdateFetch(start_url, [self.editor, self.admin], form_fields=["flow", "contact_search"])
+        attrs = response.context["form"].fields["contact_search"].widget.attrs
+        self.assertTrue(attrs.get("fixed"))
+        self.assertNotIn("current_flow", attrs)
+
+        # if the contact is in a flow, that's passed to the widget so it can ask for confirmation
+        contact.current_flow = current
+        contact.save(update_fields=("current_flow",))
+
+        response = self.assertUpdateFetch(start_url, [self.admin], form_fields=["flow", "contact_search"])
+        attrs = response.context["form"].fields["contact_search"].widget.attrs
+        self.assertTrue(attrs.get("fixed"))
+        self.assertEqual("Current", attrs.get("current_flow"))
+
+        # submitted recipients are ignored - the start is locked to the seeded contact
+        self.assertUpdateSubmit(
+            start_url,
+            self.admin,
+            {"flow": flow.id, "contact_search": get_contact_search(contacts=[other])},
+        )
+
+        self.assertEqual(
+            mr_mocks.calls["flow_start"][-1],
+            call(
+                self.org,
+                self.admin,
+                typ="M",
+                flow=flow,
+                groups=[],
+                contacts=[contact],
+                urns=[],
+                query=None,
+                exclude=Exclusions(),
+                params={},
+            ),
+        )
+
+        # seeding with multiple contacts doesn't lock the recipients
+        multi_url = f"{reverse('flows.flow_start', args=[])}?c={contact.uuid},{other.uuid}"
+        response = self.assertUpdateFetch(multi_url, [self.admin], form_fields=["flow", "contact_search"])
+        self.assertNotIn("fixed", response.context["form"].fields["contact_search"].widget.attrs)
+
+    @mock_mailroom
     def test_start_background_flow(self, mr_mocks):
         flow = self.create_flow("Background", flow_type=Flow.TYPE_BACKGROUND)
 

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1591,7 +1591,7 @@ class FlowCRUDL(SmartCRUDL):
                 ),
             )
 
-            def __init__(self, org, flow, **kwargs):
+            def __init__(self, org, flow, contact, **kwargs):
                 super().__init__(**kwargs)
                 self.org = org
 
@@ -1600,6 +1600,14 @@ class FlowCRUDL(SmartCRUDL):
                     is_archived=False,
                     is_active=True,
                 ).order_by(Lower("name"))
+
+                if contact:
+                    # seeded from a single contact (e.g. their read page) so recipients can't be
+                    # changed, and if they're in a flow the user must confirm interrupting it
+                    search_attrs = self.fields["contact_search"].widget.attrs
+                    search_attrs["fixed"] = True
+                    if contact.current_flow:
+                        search_attrs["current_flow"] = contact.current_flow.name
 
                 if flow:
                     self.fields["flow"].widget = forms.HiddenInput(
@@ -1674,24 +1682,44 @@ class FlowCRUDL(SmartCRUDL):
             flow_id = self.request.GET.get("flow", None)
             return self.request.org.flows.filter(id=flow_id, is_active=True).first() if flow_id else None
 
+        @cached_property
+        def contact(self):
+            """
+            When seeded with a single contact (e.g. from their read page or a ticket) the start is
+            locked to that contact.
+            """
+            uuids = [u for u in self.request.GET.get("c", "").split(",") if u]
+            if len(uuids) == 1:
+                return (
+                    self.request.org.contacts.filter(uuid=uuids[0], is_active=True)
+                    .select_related("current_flow")
+                    .first()
+                )
+            return None
+
         def get_form_kwargs(self):
             kwargs = super().get_form_kwargs()
             kwargs["org"] = self.request.org
             kwargs["flow"] = self.flow
+            kwargs["contact"] = self.contact
             return kwargs
 
         def form_valid(self, form):
             contact_search = form.cleaned_data["contact_search"]
             flow = form.cleaned_data["flow"]
 
-            recipients = contact_search.get("recipients", [])
-            groups, contacts = ContactSearchWidget.parse_recipients(self.request.org, recipients)
+            if self.contact:
+                groups, contacts, query = [], [self.contact], None
+            else:
+                recipients = contact_search.get("recipients", [])
+                groups, contacts = ContactSearchWidget.parse_recipients(self.request.org, recipients)
+                query = contact_search["parsed_query"] if "parsed_query" in contact_search else None
 
             flow.start(
                 self.request.user,
                 groups=groups,
                 contacts=contacts,
-                query=contact_search["parsed_query"] if "parsed_query" in contact_search else None,
+                query=query,
                 exclude=Exclusions(**contact_search.get("exclusions", {})),
             )
             return super().form_valid(form)

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -1654,7 +1654,7 @@ class FlowCRUDL(SmartCRUDL):
         def derive_initial(self):
             org = self.request.org
             contacts = self.request.GET.get("c", "")
-            contacts = org.contacts.filter(uuid__in=contacts.split(","))
+            contacts = org.contacts.filter(uuid__in=contacts.split(","), is_active=True)
             recipients = []
             for contact in contacts:
                 urn = contact.get_urn()
@@ -1708,8 +1708,12 @@ class FlowCRUDL(SmartCRUDL):
             contact_search = form.cleaned_data["contact_search"]
             flow = form.cleaned_data["flow"]
 
+            exclusions = contact_search.get("exclusions", {})
+
             if self.contact:
                 groups, contacts, query = [], [self.contact], None
+                # user has already confirmed interrupting the contact's current flow
+                exclusions = {k: v for k, v in exclusions.items() if k != "in_a_flow"}
             else:
                 recipients = contact_search.get("recipients", [])
                 groups, contacts = ContactSearchWidget.parse_recipients(self.request.org, recipients)
@@ -1720,7 +1724,7 @@ class FlowCRUDL(SmartCRUDL):
                 groups=groups,
                 contacts=contacts,
                 query=query,
-                exclude=Exclusions(**contact_search.get("exclusions", {})),
+                exclude=Exclusions(**exclusions),
             )
             return super().form_valid(form)
 

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -149,12 +149,13 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         )
         self.assertEqual(("tickets", "mine", "open", str(ticket.uuid)), response.context["temba_referer"])
 
-        # contacts in a flow don't get a start flow option
+        # contacts in a flow still get a start flow option - the start modal handles confirming
+        # the interruption
         flow = self.create_flow("Test")
         self.contact.current_flow = flow
         self.contact.save()
         deep_link = f"{list_url}all/open/{str(ticket.uuid)}/"
-        self.assertContentMenu(deep_link, self.admin, ["Add Note"])
+        self.assertContentMenu(deep_link, self.admin, ["Add Note", "Start Flow"])
 
         # closed our tickets don't get extra menu options
         ticket.status = Ticket.STATUS_CLOSED

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -365,15 +365,14 @@ class TicketCRUDL(SmartCRUDL):
                         f"{reverse('tickets.ticket_note', args=[ticket.uuid])}",
                     )
 
-                if not ticket.contact.current_flow:
-                    if self.has_org_perm("flows.flow_start"):
-                        menu.add_modax(
-                            _("Start Flow"),
-                            "start-flow",
-                            f"{reverse('flows.flow_start')}?c={ticket.contact.uuid}",
-                            disabled=True,
-                            on_submit="handleFlowStarted()",
-                        )
+                if self.has_org_perm("flows.flow_start"):
+                    menu.add_modax(
+                        _("Start Flow"),
+                        "start-flow",
+                        f"{reverse('flows.flow_start')}?c={ticket.contact.uuid}",
+                        disabled=True,
+                        on_submit="handleFlowStarted()",
+                    )
 
         def get_queryset(self, **kwargs):
             return super().get_queryset(**kwargs).none()


### PR DESCRIPTION
## Summary

The "Start Flow" option was hidden on the contact read and ticket pages whenever the contact was currently in a flow, which reads as the feature being missing — especially for workspaces whose flows keep contacts at a wait for long periods. The option now always shows for active contacts, and the start modal asks for explicit confirmation before interrupting the contact's current flow.

## Changes

- **`contacts/views.py`, `tickets/views.py`** — the contact read and ticket context menus no longer hide "Start Flow" when the contact has a `current_flow`; permission and contact-status gates are unchanged.
- **`flows/views.py` (`FlowCRUDL.Start`)** — when seeded with exactly one contact via `?c=`, the start is locked to that contact: the form passes `fixed` and `current_flow` (the name of the flow they're waiting in) to the contact-search widget, and `form_valid` ignores submitted recipients/query in favor of the seeded contact. Multi-contact seeds and unseeded starts keep the existing editable behavior. The preview endpoint still evaluates warnings and blockers on flow selection.
- The client-side confirmation UI ("It's okay to interrupt **<flow>** and start this one") lives in `temba-contact-search` (nyaruka/temba-components#1054). Until that release is bumped here, older components degrade gracefully: the seeded modal keeps today's editable recipients with the `in_a_flow` exclusion defaulted on.

## Review notes

- Pre-PR review verdict: ready — org scoping (`request.org.contacts`), permission gating, and the server-side recipient lock verified.
- Review-driven addition: explicit test that seeding with another org's contact uuid does not lock the form.

## Test plan

- [x] Contact read menu shows "Start Flow" for a contact currently in a flow (contact + interrupt tests updated)
- [x] Ticket menu likewise
- [x] Seeded single-contact fetch renders `fixed`/`current_flow` widget attrs; submit is locked to the seeded contact even if other recipients are posted
- [x] Multi-contact and cross-org seeds stay unlocked
- [x] flows/contacts/tickets CRUDL suites pass (92 tests); `code_check.py` clean