### PR TITLE
Add translatable message for too_complex contact query error code

### DIFF
--- a/temba/mailroom/client/exceptions.py
+++ b/temba/mailroom/client/exceptions.py
@@ -52,6 +52,7 @@ class QueryValidationException(Exception):
         "unknown_property": _("Can't resolve '%(property)s' to a field or URN scheme."),
         "unknown_property_type": _("Prefixes must be 'fields' or 'urns'."),
         "redacted_urns": _("Can't query on URNs in an anonymous workspace."),
+        "too_complex": _("This query is too complex. Please simplify it and try again."),
     }
 
     def __init__(self, error: str, code: str, extra: dict = None):

--- a/temba/mailroom/client/tests.py
+++ b/temba/mailroom/client/tests.py
@@ -1241,6 +1241,10 @@ class QueryExceptionTest(TembaTest):
                 QueryValidationException("cannot query on redacted URNs", "redacted_urns", {}),
                 "Can't query on URNs in an anonymous workspace.",
             ),
+            (
+                QueryValidationException("query is too complex", "too_complex", {}),
+                "This query is too complex. Please simplify it and try again.",
+            ),
             (QueryValidationException("no code here", "", {}), "no code here"),
         )
 


### PR DESCRIPTION
Contact query parsing rejects queries that exceed complexity limits with a `too_complex` error code. That code had no entry in the `QueryValidationException.messages` map, so `__str__` fell through to returning the raw error string from the engine — untranslated English for users in non-English workspaces.

## Changes

- Add a `too_complex` entry to the message map, wrapped in `gettext_lazy` like the others. The error carries no `extra` fields, so the message deliberately uses no `%(...)s` interpolation.
- Add the corresponding case to `QueryExceptionTest.test_str`.

## Notes for reviewers

The message is intentionally generic ("This query is too complex. Please simplify it and try again.") to match the generic error code — the underlying limits are not disclosed.

Grepped for a second copy of this code-to-message mapping (e.g. client-side) using the existing codes; there is only the one in `temba/mailroom/client/exceptions.py`, so no other surface needed updating.