### PR TITLE
Limit channel disconnected incidents to 1 per channel per 24 hours

### DIFF
--- a/temba/channels/tests/test_incidents.py
+++ b/temba/channels/tests/test_incidents.py
@@ -51,3 +51,28 @@ class ChannelIncidentsTest(TembaTest):
         # still only one incident, but it is now ended
         incident = self.org.incidents.get()
         self.assertIsNotNone(incident.ended_on)
+
+        # channel disconnects again shortly after
+        self.channel.last_seen = timezone.now() - timedelta(minutes=40)
+        self.channel.save(update_fields=("last_seen",))
+
+        check_android_channels()
+
+        # no new incident or notifications because we already had one for this channel in the last 24 hours
+        incident = self.org.incidents.get()
+        self.assertEqual(1, self.admin.notifications.count())
+
+        send_notification_emails()
+        self.assertEqual(1, len(mail.outbox))
+
+        # but if the last incident started more than 24 hours ago, a new one can be created
+        incident.started_on = timezone.now() - timedelta(hours=25)
+        incident.save(update_fields=("started_on",))
+
+        check_android_channels()
+
+        self.assertEqual(2, self.org.incidents.count())
+        self.assertEqual(2, self.admin.notifications.count())
+
+        send_notification_emails()
+        self.assertEqual(2, len(mail.outbox))

--- a/temba/notifications/incidents/builtin.py
+++ b/temba/notifications/incidents/builtin.py
@@ -20,7 +20,8 @@ class ChannelDisconnectedIncidentType(IncidentType):
     def get_or_create(cls, channel):
         """
         Creates a channel disconnected incident if one is not already ongoing and we haven't already started one for
-        this channel in the last 24 hours - so users get at most one notification per channel per day.
+        this channel in the last 24 hours - so users get at most one notification per channel per day. Note that the
+        returned incident can thus be an already ended one from the last 24 hours.
         """
         existing = (
             Incident.objects.filter(org=channel.org, incident_type=cls.slug, scope=str(channel.id))

--- a/temba/notifications/incidents/builtin.py
+++ b/temba/notifications/incidents/builtin.py
@@ -1,4 +1,8 @@
+from datetime import timedelta
+
+from django.db.models import Q
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from ..models import Incident, IncidentType
@@ -15,8 +19,18 @@ class ChannelDisconnectedIncidentType(IncidentType):
     @classmethod
     def get_or_create(cls, channel):
         """
-        Creates a channel disconnected incident if one is not already ongoing
+        Creates a channel disconnected incident if one is not already ongoing and we haven't already started one for
+        this channel in the last 24 hours - so users get at most one notification per channel per day.
         """
+        existing = (
+            Incident.objects.filter(org=channel.org, incident_type=cls.slug, scope=str(channel.id))
+            .filter(Q(ended_on=None) | Q(started_on__gt=timezone.now() - timedelta(hours=24)))
+            .order_by("-started_on")
+            .first()
+        )
+        if existing:
+            return existing
+
         return Incident.get_or_create(channel.org, cls.slug, scope=str(channel.id), channel=channel)
 
     def get_notification_target_url(self, incident) -> str:

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -479,14 +479,23 @@ class NotificationTest(TembaTest):
         self.assertEqual(1, self.admin.notifications.filter(is_seen=False).count())
         self.assertEqual(0, self.admin.notifications.filter(is_seen=True).count())
 
-        # a new incident after the first was ended
+        # no new incident (or notifications) because we already had one for this channel in the last 24 hours
         incident3 = ChannelDisconnectedIncidentType.get_or_create(channel=self.channel)
-        self.assertNotEqual(incident.pk, incident3.pk)
+        self.assertEqual(incident.pk, incident3.pk)
+
+        send_notification_emails()
+        self.assertEqual(2, len(mail.outbox))
+
+        # but a new incident can be created if the last one started more than 24 hours ago
+        incident.started_on = timezone.now() - timedelta(hours=25)
+        incident.save(update_fields=("started_on",))
+
+        incident4 = ChannelDisconnectedIncidentType.get_or_create(channel=self.channel)
+        self.assertNotEqual(incident.pk, incident4.pk)
 
         send_notification_emails()
         self.assertEqual(4, len(mail.outbox))
 
-        self.assertEqual(4, len(mail.outbox))
         self.assertEqual("[Nyaruka] Incident: Channel Disconnected", mail.outbox[0].subject)
         self.assertEqual(["admin@textit.com"], mail.outbox[0].recipients())
         self.assertEqual("[Nyaruka] Incident: Channel Disconnected", mail.outbox[1].subject)

--- a/temba/notifications/tests/test_notification.py
+++ b/temba/notifications/tests/test_notification.py
@@ -506,6 +506,17 @@ class NotificationTest(TembaTest):
         self.assertEqual(2, self.admin.notifications.filter(is_seen=False).count())
         self.assertEqual(0, self.admin.notifications.filter(is_seen=True).count())
 
+        # an ongoing incident is returned as is even if it started more than 24 hours ago
+        incident4.started_on = timezone.now() - timedelta(hours=25)
+        incident4.save(update_fields=("started_on",))
+
+        incident5 = ChannelDisconnectedIncidentType.get_or_create(channel=self.channel)
+        self.assertEqual(incident4.pk, incident5.pk)
+        self.assertIsNone(incident5.ended_on)
+
+        send_notification_emails()
+        self.assertEqual(4, len(mail.outbox))  # no new emails
+
     def test_counts(self):
         imp = ContactImport.objects.create(
             org=self.org, mappings={}, num_records=5, created_by=self.editor, modified_by=self.editor


### PR DESCRIPTION
Android channels that repeatedly lose and regain connectivity currently generate a new `channel:disconnected` incident on every disconnect, each of which emails all workspace admins. For a flapping channel that can mean multiple emails a day about the same underlying problem.

This changes `ChannelDisconnectedIncidentType.get_or_create` so that a new incident is only created if there's no ongoing incident for the channel *and* no previous incident for it was started within the last 24 hours. Since notifications (and their emails) are only created for new incidents, admins now get at most one notification per channel per day.

Notes for review:

* If a channel is still disconnected after its previous incident ended, the previous (ended) incident is returned rather than creating a new one - callers only use the return value in tests.
* Incidents for a genuinely still-down channel behave as before: the ongoing incident stays open until the channel is seen again.
* Other incident types are unaffected.