### PR TITLE
Increase time before an unseen Android channel is considered disconnected to 90 minutes

### DIFF
--- a/temba/channels/tasks.py
+++ b/temba/channels/tasks.py
@@ -22,7 +22,7 @@ def check_android_channels():
     from temba.notifications.incidents.builtin import ChannelDisconnectedIncidentType
     from temba.notifications.models import Incident
 
-    last_half_hour = timezone.now() - timedelta(minutes=30)
+    last_seen_cutoff = timezone.now() - timedelta(minutes=90)
 
     ongoing = Incident.objects.filter(incident_type=ChannelDisconnectedIncidentType.slug, ended_on=None).select_related(
         "channel"
@@ -34,7 +34,7 @@ def check_android_channels():
             incident.end()
 
     not_recently_seen = (
-        Channel.objects.filter(channel_type=AndroidType.code, is_active=True, last_seen__lt=last_half_hour)
+        Channel.objects.filter(channel_type=AndroidType.code, is_active=True, last_seen__lt=last_seen_cutoff)
         .exclude(org=None)
         .exclude(last_seen=None)
         .select_related("org")

--- a/temba/channels/tests/test_incidents.py
+++ b/temba/channels/tests/test_incidents.py
@@ -11,8 +11,16 @@ from ..tasks import check_android_channels
 
 class ChannelIncidentsTest(TembaTest):
     def test_disconnected(self):
-        # set our last seen to a while ago
+        # set our last seen to 40 minutes ago - not long enough to be considered disconnected
         self.channel.last_seen = timezone.now() - timedelta(minutes=40)
+        self.channel.save(update_fields=("last_seen",))
+
+        check_android_channels()
+
+        self.assertEqual(0, self.org.incidents.count())
+
+        # but 2 hours is
+        self.channel.last_seen = timezone.now() - timedelta(hours=2)
         self.channel.save(update_fields=("last_seen",))
 
         with override_brand(emails={"notifications": "support@mybrand.com"}):


### PR DESCRIPTION
Android devices routinely go quiet for more than 30 minutes without being actually disconnected - doze mode and battery optimization defer background syncing on idle devices, though they can still wake for real work via FCM. With the current 30 minute threshold, these idle periods generate `channel:disconnected` incidents (and notification emails to all workspace admins) for channels that are working fine, and most such incidents end shortly after they start.

This raises the threshold in `check_android_channels` to 90 minutes, so short idle gaps no longer create incidents, while a genuinely dead device (powered off, app killed) still generates an incident within a couple of hours.

Related to #6737 which addresses repeat notifications from channels that flap on longer cycles.