### PR TITLE
Add preview-mode broadcast lists backed by temba-broadcast-list

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -863,6 +863,11 @@ class EndpointsTest(APITestMixin, TembaTest):
             endpoint_url + "?folder=scheduled&sort=-next_fire", [self.admin], results=[bcast5, bcast3, bcast4]
         )
 
+        # created_on is also a valid sort for the scheduled folder
+        self.assertGet(
+            endpoint_url + "?folder=scheduled&sort=-created_on", [self.admin], results=[bcast5, bcast4, bcast3]
+        )
+
         # search matches the message text inside the translations...
         self.assertGet(endpoint_url + "?search=hello", [self.admin], results=[bcast1])
         self.assertGet(endpoint_url + "?folder=scheduled&search=weekly", [self.admin], results=[bcast3])

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -863,9 +863,13 @@ class EndpointsTest(APITestMixin, TembaTest):
             endpoint_url + "?folder=scheduled&sort=-next_fire", [self.admin], results=[bcast5, bcast3, bcast4]
         )
 
-        # search matches the message text inside the translations
+        # search matches the message text inside the translations...
         self.assertGet(endpoint_url + "?search=hello", [self.admin], results=[bcast1])
         self.assertGet(endpoint_url + "?folder=scheduled&search=weekly", [self.admin], results=[bcast3])
+
+        # ...but not the JSON structure around it (keys, language codes)
+        self.assertGet(endpoint_url + "?search=quick_replies", [self.admin], results=[])
+        self.assertGet(endpoint_url + "?search=eng", [self.admin], results=[])
 
         # each row carries the columns the component renders
         def check_sent_shape(data):

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -12,7 +12,7 @@ from temba.api.tests.mixins import APITestMixin
 from temba.campaigns.models import Campaign, CampaignEvent
 from temba.contacts.models import ContactExport, ContactField, ContactGroup
 from temba.flows.models import Flow, FlowLabel
-from temba.msgs.models import Msg
+from temba.msgs.models import Broadcast, Msg
 from temba.notifications.types import ExportFinishedNotificationType
 from temba.schedules.models import Schedule
 from temba.templates.models import TemplateTranslation
@@ -787,6 +787,118 @@ class EndpointsTest(APITestMixin, TembaTest):
             ],
             num_queries=NUM_BASE_QUERIES + 3,
         )
+
+    def test_broadcasts(self):
+        endpoint_url = reverse("api.internal.broadcasts") + ".json"
+
+        self.assertGetNotPermitted(endpoint_url, [None, self.agent])
+        self.assertPostNotAllowed(endpoint_url)
+        self.assertDeleteNotAllowed(endpoint_url)
+
+        group = self.create_group("Farmers", contacts=[])
+        contact = self.create_contact("Jim", phone="+250788987651")
+
+        bcast1 = self.create_broadcast(
+            self.admin,
+            {
+                "eng": {
+                    "text": "Hello everyone",
+                    "attachments": ["image/jpeg:http://example.com/cat.jpg"],
+                    "quick_replies": ["Yes", "No"],
+                }
+            },
+            groups=[group],
+            contacts=[contact],
+            exclude=mailroom.Exclusions(in_a_flow=True, not_seen_since_days=90),
+        )
+        bcast2 = self.create_broadcast(
+            self.admin, {"eng": {"text": "Sending still"}}, contacts=[contact], status=Broadcast.STATUS_STARTED
+        )
+
+        # scheduled broadcasts live in their own folder, soonest fire first
+        bcast3 = self.create_broadcast(
+            self.admin,
+            {"eng": {"text": "Weekly reminder"}},
+            groups=[group],
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=2), Schedule.REPEAT_DAILY),
+        )
+        bcast4 = self.create_broadcast(
+            self.admin,
+            {"eng": {"text": "Sooner reminder"}},
+            contacts=[contact],
+            schedule=Schedule.create(self.org, timezone.now() + timedelta(days=1), Schedule.REPEAT_WEEKLY),
+        )
+
+        # a scheduled broadcast whose (paused) schedule still carries a stale next fire
+        paused = Schedule.create(self.org, timezone.now() + timedelta(days=3), Schedule.REPEAT_DAILY)
+        paused.is_paused = True
+        paused.save(update_fields=("is_paused",))
+        bcast5 = self.create_broadcast(
+            self.admin, {"eng": {"text": "Paused reminder"}}, contacts=[contact], schedule=paused
+        )
+
+        # and a broadcast in another org that should never appear
+        other_contact = self.create_contact("Bob", phone="+250788111111", org=self.org2)
+        self.create_broadcast(
+            self.admin2,
+            {"eng": {"text": "Other org"}},
+            contacts=[other_contact],
+            org=self.org2,
+            status=Broadcast.STATUS_PENDING,  # org2 has no channel to create messages with
+        )
+
+        # default folder is `sent` (broadcasts without a schedule), newest first
+        self.assertGet(endpoint_url, [self.editor, self.admin], results=[bcast2, bcast1])
+        self.assertGet(
+            endpoint_url + "?folder=sent",
+            [self.admin],
+            results=[bcast2, bcast1],
+            num_queries=NUM_BASE_QUERIES + 5,  # count + broadcasts + 2 M2M prefetches + msg counts
+        )
+        self.assertGet(endpoint_url + "?sort=created_on", [self.admin], results=[bcast1, bcast2])
+
+        # the scheduled folder orders by next fire
+        self.assertGet(endpoint_url + "?folder=scheduled", [self.admin], results=[bcast4, bcast3, bcast5])
+        self.assertGet(
+            endpoint_url + "?folder=scheduled&sort=-next_fire", [self.admin], results=[bcast5, bcast3, bcast4]
+        )
+
+        # search matches the message text inside the translations
+        self.assertGet(endpoint_url + "?search=hello", [self.admin], results=[bcast1])
+        self.assertGet(endpoint_url + "?folder=scheduled&search=weekly", [self.admin], results=[bcast3])
+
+        # each row carries the columns the component renders
+        def check_sent_shape(data):
+            row = [r for r in data["results"] if r["id"] == bcast1.id][0]
+            self.assertEqual("completed", row["status"])
+            self.assertEqual("Hello everyone", row["text"])
+            self.assertEqual(["image/jpeg:http://example.com/cat.jpg"], row["attachments"])
+            self.assertEqual(["Yes", "No"], row["quick_replies"])
+            self.assertEqual([{"uuid": str(group.uuid), "name": "Farmers"}], row["groups"])
+            self.assertEqual([{"uuid": str(contact.uuid), "name": "Jim"}], row["contacts"])
+            self.assertEqual(["Not in a flow", "Active in the last 90 days"], row["exclusions"])
+            self.assertIsNone(row["schedule"])
+            self.assertEqual(1, row["msg_count"])
+            self.assertEqual({"total": 1, "started": 1}, row["progress"])
+            self.assertEqual("admin@textit.com", row["created_by"])
+            return True
+
+        self.assertGet(endpoint_url + "?folder=sent", [self.admin], raw=check_sent_shape)
+
+        # a scheduled row carries the schedule instead of a message count, and a paused schedule's stale
+        # next_fire reads as not scheduled
+        def check_scheduled_shape(data):
+            row = [r for r in data["results"] if r["id"] == bcast3.id][0]
+            self.assertEqual("D", row["schedule"]["repeat_period"])
+            self.assertTrue(row["schedule"]["display"].startswith("each day at"))
+            self.assertIsNotNone(row["schedule"]["next_fire"])
+            self.assertIsNone(row["msg_count"])
+            self.assertIsNone(row["progress"])
+            paused_row = [r for r in data["results"] if r["id"] == bcast5.id][0]
+            self.assertIsNone(paused_row["schedule"]["next_fire"])
+            return True
+
+        self.assertGet(endpoint_url + "?folder=scheduled", [self.admin], raw=check_scheduled_shape)
 
     def test_triggers(self):
         endpoint_url = reverse("api.internal.triggers") + ".json"

--- a/temba/api/internal/urls.py
+++ b/temba/api/internal/urls.py
@@ -5,7 +5,7 @@ from django.urls import re_path
 from temba.campaigns.api import CampaignsEndpoint
 from temba.contacts.api import ContactsEndpoint
 from temba.flows.api import FlowLabelsEndpoint, FlowsEndpoint
-from temba.msgs.api import MessagesEndpoint
+from temba.msgs.api import BroadcastsEndpoint, MessagesEndpoint
 from temba.triggers.api import TriggersEndpoint
 
 from .views import (
@@ -19,6 +19,7 @@ from .views import (
 
 urlpatterns = [
     # ========== endpoints A-Z ===========
+    re_path(r"^broadcasts$", BroadcastsEndpoint.as_view(), name="api.internal.broadcasts"),
     re_path(r"^campaigns$", CampaignsEndpoint.as_view(), name="api.internal.campaigns"),
     re_path(r"^contacts$", ContactsEndpoint.as_view(), name="api.internal.contacts"),
     re_path(r"^flow_labels$", FlowLabelsEndpoint.as_view(), name="api.internal.flow_labels"),

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -25,8 +25,8 @@ class BroadcastsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
     """
     Broadcasts for the current org, used by the broadcast list component. A folder is selected with the `folder`
     query param — `sent` (the default: broadcasts without a schedule) or `scheduled` (broadcasts waiting on one).
-    An optional `search` param filters by message text, and `sort` can be `created_on` (sent) or `next_fire`
-    (scheduled), prefixed with `-` to reverse. Each item is serialized via Broadcast.as_json().
+    An optional `search` param filters by message text, and `sort` can be `created_on` or `next_fire`
+    (scheduled only), prefixed with `-` to reverse. Each item is serialized via Broadcast.as_json().
     """
 
     model = Broadcast
@@ -63,7 +63,7 @@ class BroadcastsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         desc = sort.startswith("-")
         key = sort[1:] if desc else sort
 
-        if key == "created_on" and not scheduled:
+        if key == "created_on":
             order = ("-created_on" if desc else "created_on",)
         elif key == "next_fire" and scheduled:
             order = ("-schedule__next_fire" if desc else "schedule__next_fire",)

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from functools import cached_property
 
 from django.db.models import Q, TextField
+from django.db.models.expressions import RawSQL
 from django.db.models.functions import Cast
 from django.utils import timezone
 
@@ -48,11 +49,15 @@ class BroadcastsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
 
         search = self.request.query_params.get("search")
         if search:
-            # broadcast text lives inside the translations JSON, so search a text cast of it — broadcasts are a
-            # small per-org table, unlike messages, so the cast scan is acceptable
-            qs = qs.annotate(translations_text=Cast("translations", output_field=TextField())).filter(
-                translations_text__icontains=search
-            )
+            # broadcast text lives inside the translations JSON, so search over just the per-language text values
+            # (extracted with a jsonpath) rather than a raw cast of the JSON — a raw cast would also match its
+            # structure (keys like "text", language codes). Broadcasts are a small per-org table, unlike messages,
+            # so the scan is acceptable.
+            qs = qs.annotate(
+                translations_text=Cast(
+                    RawSQL("jsonb_path_query_array(translations, '$.*.text')", []), output_field=TextField()
+                )
+            ).filter(translations_text__icontains=search)
 
         sort = self.request.query_params.get("sort") or ""
         desc = sort.startswith("-")

--- a/temba/msgs/api.py
+++ b/temba/msgs/api.py
@@ -1,16 +1,84 @@
 from datetime import timedelta
 from functools import cached_property
 
-from django.db.models import Q
+from django.db.models import Q, TextField
+from django.db.models.functions import Cast
 from django.utils import timezone
 
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
-from temba.api.support import CreatedOnCursorPagination, SearchCountMixin, SearchLengthMixin, SentOnCursorPagination
+from temba.api.support import (
+    CreatedOnCursorPagination,
+    ListPagination,
+    SearchCountMixin,
+    SearchLengthMixin,
+    SentOnCursorPagination,
+)
 from temba.api.views import ListAPIMixin
 from temba.utils.uuid import is_uuid
 
-from .models import Msg, MsgFolder
+from .models import Broadcast, BroadcastMsgCount, Msg, MsgFolder
+
+
+class BroadcastsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
+    """
+    Broadcasts for the current org, used by the broadcast list component. A folder is selected with the `folder`
+    query param — `sent` (the default: broadcasts without a schedule) or `scheduled` (broadcasts waiting on one).
+    An optional `search` param filters by message text, and `sort` can be `created_on` (sent) or `next_fire`
+    (scheduled), prefixed with `-` to reverse. Each item is serialized via Broadcast.as_json().
+    """
+
+    model = Broadcast
+    serializer_class = ModelAsJsonSerializer
+    pagination_class = ListPagination
+
+    def derive_queryset(self):
+        # Build from Broadcast.objects rather than the org.broadcasts related manager — a related manager would seed
+        # each fetched row with the in-memory org instance, which Django rejects on a GET because the org was loaded
+        # from the default database while this queryset reads from the readonly alias.
+        qs = Broadcast.objects.filter(org=self.request.org, is_active=True)
+
+        scheduled = self.request.query_params.get("folder", "sent").lower() == "scheduled"
+        if scheduled:
+            qs = qs.exclude(schedule=None)
+            default_order = ("schedule__next_fire", "-created_on")
+        else:
+            qs = qs.filter(schedule=None)
+            default_order = ("-created_on",)
+
+        search = self.request.query_params.get("search")
+        if search:
+            # broadcast text lives inside the translations JSON, so search a text cast of it — broadcasts are a
+            # small per-org table, unlike messages, so the cast scan is acceptable
+            qs = qs.annotate(translations_text=Cast("translations", output_field=TextField())).filter(
+                translations_text__icontains=search
+            )
+
+        sort = self.request.query_params.get("sort") or ""
+        desc = sort.startswith("-")
+        key = sort[1:] if desc else sort
+
+        if key == "created_on" and not scheduled:
+            order = ("-created_on" if desc else "created_on",)
+        elif key == "next_fire" and scheduled:
+            order = ("-schedule__next_fire" if desc else "schedule__next_fire",)
+        else:
+            order = default_order
+
+        # `org` is select_related because as_json reads self.org via get_translation (org primary language)
+        return (
+            qs.order_by(*order, "-id")
+            .select_related("org", "schedule", "optin", "template", "created_by")
+            .prefetch_related("groups", "contacts")
+        )
+
+    def filter_queryset(self, queryset):
+        # filtering (folder/search/sort) is fully resolved in derive_queryset; bypass the default backends
+        return queryset
+
+    def prepare_for_serialization(self, page, using: str):
+        # bulk-load the created-message counts for the page so as_json doesn't N+1
+        BroadcastMsgCount.bulk_annotate(page)
 
 
 class MessagesEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -359,6 +359,84 @@ class Broadcast(models.Model):
         if contacts:
             self.contacts.add(*contacts)
 
+    def get_exclusions_display(self) -> list:
+        """
+        Human readable descriptions of this broadcast's exclusions - same wording as includes/exclusions.html.
+        """
+        display = []
+        exclusions = self.exclusions or {}
+        if exclusions.get("in_a_flow"):
+            display.append(_("Not in a flow"))
+        if exclusions.get("started_previously"):
+            display.append(_("No recent runs"))
+        days = exclusions.get("not_seen_since_days")
+        if days == 365:
+            display.append(_("Active in the last year"))
+        elif days:
+            display.append(_("Active in the last %(days)d days") % {"days": days})
+        return display
+
+    def as_json(self, context=None) -> dict:
+        """
+        Internal API shape, consumed by the temba-broadcast-list component. Content fields carry the base
+        translation; `msg_count` relies on BroadcastMsgCount.bulk_annotate having run for the page (falling back to
+        a per-row count). Broadcasts key rows off the numeric id since their uuid isn't exposed to the UI.
+        """
+
+        translation = self.get_translation()
+
+        # a scheduled broadcast hasn't sent anything itself (its fires spawn child broadcasts), so it carries no
+        # count or progress
+        msg_count = None
+        if not self.schedule:
+            msg_count = getattr(self, "msg_count", None)
+            if msg_count is None:
+                msg_count = self.get_message_count()
+
+        return {
+            "id": self.id,
+            "status": self.get_status_display().lower(),
+            "text": translation["text"],
+            "attachments": translation["attachments"],
+            "quick_replies": translation["quick_replies"],
+            "optin": {"uuid": str(self.optin.uuid), "name": self.optin.name} if self.optin else None,
+            "template": {"uuid": str(self.template.uuid), "name": self.template.name} if self.template else None,
+            "groups": [{"uuid": str(g.uuid), "name": g.name} for g in self.groups.all()],
+            "contacts": [{"uuid": str(c.uuid), "name": c.name} for c in self.contacts.all()],
+            "urns": self.urns or [],
+            "query": self.query,
+            "exclusions": [str(e) for e in self.get_exclusions_display()],
+            "schedule": (
+                {
+                    "repeat_period": self.schedule.repeat_period,
+                    "display": self.schedule.get_display(),
+                    # a paused schedule can carry a stale next_fire — null it so the broadcast reads as not
+                    # scheduled, same as the trigger list
+                    "next_fire": (
+                        self.schedule.next_fire.isoformat()
+                        if self.schedule.next_fire and not self.schedule.is_paused
+                        else None
+                    ),
+                }
+                if self.schedule
+                else None
+            ),
+            "msg_count": msg_count,
+            # send progress, matching the v2 API's shape: total is -1 until mailroom resolves the recipient
+            # count at queue time
+            "progress": (
+                None
+                if self.schedule
+                else {
+                    "total": self.contact_count if self.contact_count is not None else -1,
+                    "started": msg_count,
+                }
+            ),
+            "created_on": self.created_on.isoformat(),
+            "created_by": self.created_by.email if self.created_by else None,
+            "modified_on": self.modified_on.isoformat(),
+        }
+
     def __repr__(self):
         return f'<Broadcast: id={self.id} text="{self.get_translation()["text"]}">'
 

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -369,11 +369,13 @@ class Broadcast(models.Model):
             display.append(_("Not in a flow"))
         if exclusions.get("started_previously"):
             display.append(_("No recent runs"))
+        # exclusions is untyped JSON so guard against a non-int creeping into the format below
         days = exclusions.get("not_seen_since_days")
-        if days == 365:
-            display.append(_("Active in the last year"))
-        elif days:
-            display.append(_("Active in the last %(days)d days") % {"days": days})
+        if isinstance(days, int) and days:
+            if days == 365:
+                display.append(_("Active in the last year"))
+            else:
+                display.append(_("Active in the last %(days)d days") % {"days": days})
         return display
 
     def as_json(self, context=None) -> dict:

--- a/temba/msgs/tests/test_broadcast.py
+++ b/temba/msgs/tests/test_broadcast.py
@@ -118,6 +118,9 @@ class BroadcastTest(TembaTest):
         self.assertEqual(2, bcast3.msgs.count())
         self.assertEqual(2, bcast3.get_message_count())
 
+        # as_json falls back to a per-row count when BroadcastMsgCount.bulk_annotate hasn't run for the page
+        self.assertEqual(2, bcast3.as_json()["msg_count"])
+
         self.assertEqual(2, Broadcast.objects.count())
         self.assertEqual(2, Msg.objects.count())
         self.assertEqual(1, Schedule.objects.count())
@@ -139,6 +142,17 @@ class BroadcastTest(TembaTest):
         # can't create broadcast with no recipients
         with self.assertRaises(AssertionError):
             Broadcast.create(self.org, self.admin, {"und": {"text": "no recipients"}}, base_language="und")
+
+    def test_get_exclusions_display(self):
+        def display(exclusions) -> list:
+            return Broadcast(exclusions=exclusions).get_exclusions_display()
+
+        self.assertEqual([], display(None))
+        self.assertEqual(["Not in a flow"], display({"in_a_flow": True}))
+        self.assertEqual(["No recent runs"], display({"started_previously": True}))
+        self.assertEqual(["Active in the last year"], display({"not_seen_since_days": 365}))
+        self.assertEqual(["Active in the last 90 days"], display({"not_seen_since_days": 90}))
+        self.assertEqual([], display({"not_seen_since_days": "junk"}))  # bad data from an old row
 
     @mock_mailroom
     def test_preview(self, mr_mocks):

--- a/temba/msgs/tests/test_broadcastcrudl.py
+++ b/temba/msgs/tests/test_broadcastcrudl.py
@@ -664,8 +664,9 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
             f"{reverse('api.internal.broadcasts')}.json?folder=scheduled", response.context["new_list_endpoint"]
         )
         self.assertEqual("scheduled", response.context["new_list_mode"])
-        # editors can update scheduled broadcasts, so the detail dialog gets its edit/delete actions
-        self.assertContains(response, "can-edit can-delete")
+        # editors can update and delete scheduled broadcasts, so the detail dialog gets its edit/delete actions
+        self.assertContains(response, "can-edit")
+        self.assertContains(response, "can-delete")
 
     def test_scheduled_delete(self):
         self.login(self.editor)

--- a/temba/msgs/tests/test_broadcastcrudl.py
+++ b/temba/msgs/tests/test_broadcastcrudl.py
@@ -611,7 +611,9 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
 
         response = self.client.get(list_url)
         self.assertContains(response, "temba-broadcast-list")
-        self.assertEqual(f"{reverse('api.internal.broadcasts')}.json?folder=sent", response.context["new_list_endpoint"])
+        self.assertEqual(
+            f"{reverse('api.internal.broadcasts')}.json?folder=sent", response.context["new_list_endpoint"]
+        )
         self.assertEqual("sent", response.context["new_list_mode"])
         # the sent list's detail dialog has no edit/delete actions
         self.assertNotContains(response, "can-edit")

--- a/temba/msgs/tests/test_broadcastcrudl.py
+++ b/temba/msgs/tests/test_broadcastcrudl.py
@@ -605,6 +605,17 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertListFetch(list_url, [self.admin], context_objects=[broadcast])
 
+        # entering preview mode swaps in the temba-broadcast-list component, pointed at the internal broadcasts api
+        self.login(self.admin)
+        self.client.cookies["temba-preview"] = "1"
+
+        response = self.client.get(list_url)
+        self.assertContains(response, "temba-broadcast-list")
+        self.assertEqual(f"{reverse('api.internal.broadcasts')}.json?folder=sent", response.context["new_list_endpoint"])
+        self.assertEqual("sent", response.context["new_list_mode"])
+        # the sent list's detail dialog has no edit/delete actions
+        self.assertNotContains(response, "can-edit")
+
     def test_scheduled(self):
         scheduled_url = reverse("msgs.broadcast_scheduled")
 
@@ -640,6 +651,19 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
         bc3.save(update_fields=("is_active",))
 
         self.assertListFetch(scheduled_url, [self.editor], context_objects=[bc2, bc1])
+
+        # entering preview mode swaps in the temba-broadcast-list component in scheduled mode
+        self.login(self.editor)
+        self.client.cookies["temba-preview"] = "1"
+
+        response = self.client.get(scheduled_url)
+        self.assertContains(response, "temba-broadcast-list")
+        self.assertEqual(
+            f"{reverse('api.internal.broadcasts')}.json?folder=scheduled", response.context["new_list_endpoint"]
+        )
+        self.assertEqual("scheduled", response.context["new_list_mode"])
+        # editors can update scheduled broadcasts, so the detail dialog gets its edit/delete actions
+        self.assertContains(response, "can-edit can-delete")
 
     def test_scheduled_delete(self):
         self.login(self.editor)

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -235,54 +235,88 @@ class BroadcastCRUDL(SmartCRUDL):
     )
     model = Broadcast
 
-    class List(SpaMixin, ContextMenuMixin, BulkActionMixin, BaseListView):
+    class BaseList(SpaMixin, ContextMenuMixin, BulkActionMixin, BaseListView):
+        """
+        Base class for the broadcast list views (sent and scheduled)
+        """
+
+        paginate_by = 25
+
+        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
+        # both broadcast list views render the temba-broadcast-list component (msgs/broadcast_list_new.html) instead
+        # of their legacy card grids; the component fetches/pages broadcasts itself from the internal broadcasts API.
+        NEW_LIST_TEMPLATE = "msgs/broadcast_list_new.html"
+
+        # The internal-API folder (and the component's `mode`) this view lists — `sent` or `scheduled`.
+        new_list_folder = "sent"
+
+        def _use_new_list(self) -> bool:
+            # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered
+            # out) doesn't AttributeError.
+            return getattr(self.request, "preview", False)
+
+        def get_template_names(self):
+            if self._use_new_list():
+                return [self.NEW_LIST_TEMPLATE]
+            return super().get_template_names()
+
+        def get_paginate_by(self, queryset):
+            # The temba-broadcast-list component fetches and pages broadcasts itself.
+            if self._use_new_list():
+                return None
+            return super().get_paginate_by(queryset)
+
+        def get_queryset(self, **kwargs):
+            # In preview the temba-broadcast-list component fetches and pages broadcasts from the internal
+            # broadcasts API, so a GET page needs no object list.
+            if self._use_new_list() and self.request.method == "GET":
+                return Broadcast.objects.none()
+
+            return (
+                super()
+                .get_queryset(**kwargs)
+                .filter(is_active=True, org=self.request.org)
+                .select_related("org", "schedule")
+                .prefetch_related("groups", "contacts")
+            )
+
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+
+            # New-list view context: the resolved broadcasts-api endpoint and the component's mode.
+            if self._use_new_list():
+                endpoint = reverse("api.internal.broadcasts")
+                context["new_list_endpoint"] = f"{endpoint}.json?folder={self.new_list_folder}"
+                context["new_list_mode"] = self.new_list_folder
+
+            return context
+
+        def build_context_menu(self, menu):
+            if self.has_org_perm("msgs.broadcast_create"):
+                menu.add_modax(
+                    _("New Broadcast"),
+                    "new-scheduled",
+                    reverse("msgs.broadcast_create"),
+                    as_button=True,
+                )
+
+    class List(BaseList):
         title = _("Broadcasts")
         menu_path = "/msg/broadcasts"
-        paginate_by = 25
         default_order = ("-created_on", "-id")
+        new_list_folder = "sent"
 
         def get_queryset(self, **kwargs):
-            return (
-                super()
-                .get_queryset(**kwargs)
-                .filter(is_active=True, schedule=None, org=self.request.org)
-                .select_related("org", "schedule")
-                .prefetch_related("groups", "contacts")
-            )
+            return super().get_queryset(**kwargs).filter(schedule=None)
 
-        def build_context_menu(self, menu):
-            if self.has_org_perm("msgs.broadcast_create"):
-                menu.add_modax(
-                    _("New Broadcast"),
-                    "new-scheduled",
-                    reverse("msgs.broadcast_create"),
-                    as_button=True,
-                )
-
-    class Scheduled(SpaMixin, ContextMenuMixin, BulkActionMixin, BaseListView):
+    class Scheduled(BaseList):
         title = _("Scheduled Broadcasts")
         menu_path = "/msg/scheduled"
-        paginate_by = 25
         default_order = ("schedule__next_fire", "-created_on")
+        new_list_folder = "scheduled"
 
         def get_queryset(self, **kwargs):
-            return (
-                super()
-                .get_queryset(**kwargs)
-                .filter(is_active=True)
-                .exclude(schedule=None)
-                .select_related("org", "schedule")
-                .prefetch_related("groups", "contacts")
-            )
-
-        def build_context_menu(self, menu):
-            if self.has_org_perm("msgs.broadcast_create"):
-                menu.add_modax(
-                    _("New Broadcast"),
-                    "new-scheduled",
-                    reverse("msgs.broadcast_create"),
-                    as_button=True,
-                )
+            return super().get_queryset(**kwargs).exclude(schedule=None)
 
     class Create(ModalHeaderMixin, OrgPermsMixin, SmartWizardView):
         form_list = [("target", TargetForm), ("compose", ComposeForm), ("schedule", ScheduleForm)]

--- a/templates/msgs/broadcast_list_new.html
+++ b/templates/msgs/broadcast_list_new.html
@@ -36,7 +36,8 @@
                         list-title="{{ title }}"
                         endpoint="{{ new_list_endpoint }}"
                         content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"
-                        {% if new_list_mode == "scheduled" and org_perms.msgs.broadcast_update %}can-edit can-delete{% endif %}
+                        {% if new_list_mode == "scheduled" and org_perms.msgs.broadcast_update %}can-edit{% endif %}
+                        {% if new_list_mode == "scheduled" and org_perms.msgs.broadcast_scheduled_delete %}can-delete{% endif %}
                         empty-message="{% trans "No broadcasts" %}">
   </temba-broadcast-list>
 {% endblock content %}

--- a/templates/msgs/broadcast_list_new.html
+++ b/templates/msgs/broadcast_list_new.html
@@ -1,0 +1,131 @@
+{% extends "smartmin/list.html" %}
+{% load i18n %}
+
+{% comment %}
+  New-list template shared by both broadcast list views — the sent list
+  (msgs.broadcast_list) and the scheduled list (msgs.broadcast_scheduled)
+  — when the viewer is in preview mode (request.preview, set by
+  PreviewMiddleware off the temba-preview cookie). The endpoint and the
+  component's mode come from the view's context_data. In place of a
+  broadcast read page, the component opens a floating detail dialog per
+  row; on the scheduled list its Edit / Delete actions fire
+  temba-selection events handled below.
+{% endcomment %}
+{% block page-header %}
+  {# the temba-broadcast-list renders its own header (title + content menu); #}
+  {# keep the csrf token and a hidden title for the SPA document.title hook #}
+  {% csrf_token %}
+  <div id="title-text" class="hide">{{ title }}</div>
+{% endblock page-header %}
+{% block extra-style %}
+  {{ block.super }}
+  <style type="text/css">
+    /* The list component fills its container edge to edge and brings
+       its own surface, so drop the SPA content padding (and the grey
+       page background it would otherwise reveal around the list). */
+    .spa-content {
+      padding: 0 !important;
+    }
+  </style>
+{% endblock extra-style %}
+{% block content %}
+  <temba-broadcast-list id="broadcast-list"
+                        fill-window
+                        mode="{{ new_list_mode }}"
+                        history-state-key="broadcasts-{{ new_list_mode }}"
+                        list-title="{{ title }}"
+                        endpoint="{{ new_list_endpoint }}"
+                        content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"
+                        {% if new_list_mode == "scheduled" and org_perms.msgs.broadcast_update %}can-edit can-delete{% endif %}
+                        empty-message="{% trans "No broadcasts" %}">
+  </temba-broadcast-list>
+{% endblock content %}
+{% block extra-script %}
+  {{ block.super }}
+  <script type="text/javascript">
+    onSpload(function() {
+      var list = document.querySelector("#broadcast-list");
+
+      // the detail dialog's Edit / Delete actions (scheduled list only)
+      // and the embedded content menu both fire temba-selection
+      list.addEventListener("temba-selection", function(event) {
+        var detail = event.detail;
+        if (detail.action === "edit_broadcast") {
+          showModax("{{ _("Edit Broadcast")|escapejs }}", "/broadcast/update/" + detail.broadcast.id + "/", {
+            onSubmit: "handleBroadcastChanged()"
+          });
+          return;
+        }
+        if (detail.action === "delete_broadcast") {
+          showModax("{{ _("Delete Broadcast")|escapejs }}", "/broadcast/scheduled_delete/" + detail.broadcast.id + "/", {
+            onSubmit: "handleBroadcastChanged()"
+          });
+          return;
+        }
+
+        // a content-menu item - dispatch it the same way the page
+        // chrome's content menu (spa_page_menu.html) does
+        var item = detail.item;
+        if (!item) {
+          return;
+        }
+        var click = detail.event;
+        if (item.type === "link") {
+          if (click) {
+            click.preventDefault();
+            click.stopPropagation();
+            if (click.metaKey && item.url) {
+              window.open(item.url, "_blank");
+              return;
+            }
+          }
+          spaGet(item.url);
+        } else if (item.type === "modax") {
+          showModax(item.title, item.url, {
+            disabled: item.disabled,
+            onSubmit: item.on_submit,
+            onRedirect: item.on_redirect,
+            id: item.modal_id,
+            originX: detail.originX,
+            originY: detail.originY
+          });
+        } else if (item.type === "url_post") {
+          posterize(item.url);
+        } else if (item.type === "js") {
+          if (window[item.id]) {
+            window[item.id]();
+          }
+        }
+        refreshMenu();
+      });
+
+      // See msgs/msg_list_new.html for the full rationale: stash the list's
+      // restorable state (page, sort, search, cursor url) on the current
+      // history entry so a navigation away and back lands on the same page.
+      list.addEventListener("temba-history-change", function(event) {
+        var current = history.state || {};
+        var next = Object.assign({}, current);
+        next[event.detail.key] = event.detail.state;
+        if (!next.url) {
+          next.url = location.href;
+        }
+        if (event.detail.replace) {
+          history.replaceState(next, "");
+        } else {
+          history.pushState(next, "");
+        }
+      });
+    });
+
+    // After the edit / delete modal submits — re-pull the current page
+    // (the broadcast's row may have changed or gone) and the sidebar
+    // menu counts.
+    function handleBroadcastChanged() {
+      refreshMenu();
+      var list = document.querySelector("#broadcast-list");
+      if (list) {
+        list.refresh();
+      }
+    }
+  </script>
+{% endblock extra-script %}


### PR DESCRIPTION
## Summary

Converts both broadcast list pages — sent Broadcasts and Scheduled — to render the new `temba-broadcast-list` component when the viewer is in preview mode, following the trigger and campaign list conversions. Each broadcast is a single row, with a floating detail dialog (the campaign-events pattern) in place of the legacy card grid.

## Changes

- **`temba/msgs/models.py`** — `Broadcast.as_json()` for the internal API: base-translation content (text, attachments, quick replies), template/opt-in refs, recipients (groups/contacts/urns/query), human-readable exclusion strings via new `get_exclusions_display()` (same wording as `includes/exclusions.html`, with a guard that skips non-int `not_seen_since_days` values since exclusions is untyped JSON), schedule with paused schedules reading as not scheduled (null `next_fire`, matching the trigger list), message count (bulk-annotation aware) and v2-shaped send `progress`; scheduled broadcasts carry neither count nor progress.
- **`temba/msgs/api.py`** — new `BroadcastsEndpoint`: `folder=sent|scheduled`, text search over the translations' per-language text values (jsonpath extraction, so JSON keys/language codes don't match), sorting by `created_on` (both folders) or `next_fire` (scheduled), org-scoped queryset with the select/prefetch set `as_json` needs, and `BroadcastMsgCount.bulk_annotate` per page to avoid N+1 counts. Registered as `api.internal.broadcasts`.
- **`temba/msgs/views.py`** — `BroadcastCRUDL.List`/`Scheduled` refactored onto a shared `BaseList` with the same preview gating as triggers: new-list template swap, no server pagination, empty queryset on preview GET (POST keeps the real queryset), endpoint + mode context.
- **`templates/msgs/broadcast_list_new.html`** — embeds the component with `mode`, permission-gated actions (`can-edit` on `msgs.broadcast_update`, `can-delete` on `msgs.broadcast_scheduled_delete`, matching the perms their submit endpoints check), and content-menu endpoint; wires `temba-selection` to the existing update / scheduled-delete modax (plus the standard content-menu dispatch) and `temba-history-change` for list-state restoration.
- **Tests** — internal API `test_broadcasts` (permissions, org isolation, folders, sorting on both folders, search semantics incl. structural-key non-matches, row shape, paused schedules, query counts), preview-mode assertions for both CRUDL list views, direct coverage of `get_exclusions_display` (incl. the year wording and bad-data guard) and of `as_json`'s per-row count fallback when the page wasn't bulk-annotated.

## Review notes

Pre-PR expert review ran one cycle; PR review ran two more:

- The search originally cast the whole translations JSON to text, so structural substrings (`text`, language codes) matched every row — reworked to extract just the per-language text values with `jsonb_path_query_array`, with tests pinning the semantics.
- `can-delete` was gated on `broadcast_update`, which would show a Delete button that 403s for a custom role lacking `broadcast_scheduled_delete` — now gated on the delete perm itself.
- `sort=created_on` on the scheduled folder silently fell back to the default order — now honored (it's a legitimate secondary view and already indexed); unknown sort keys still fall back to the folder default.
- Paused scheduled broadcasts still sort by their stale fire time while rendering as "not scheduled" — kept as-is to match the trigger list's behavior.
- Delimiter punctuation in a search (e.g. `", "`) can match across the jsonpath array's separators — left as-is per review; not worth the extra SQL for a case users won't hit accidentally.

## Test plan

- [x] `manage.py test temba.msgs temba.api.internal` passing, coverage at 100%
- [x] `code_check.py` (ruff format + lint) and `makemigrations --check` clean
- [x] Verified end-to-end against a dev org seeded with varied sent (completed/in-flight/queued/failed/interrupted, query- and URN-addressed, attachments, exclusions) and scheduled (daily/weekly/monthly/one-time/paused) broadcasts: both pages render the component in preview mode, the endpoint serves both folders with search and sorting, and the detail dialog's edit/delete open the existing modals