### PR TITLE
Reflect list search state in the address bar on new-list pages

### DIFF
--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -522,11 +522,14 @@ function loadFromState(state) {
       // aborts the first fetch — but fetchAjax resolves with undefined
       // rather than rejecting, so this .then still fires for the aborted
       // target and would otherwise leave currentSpaUrl pointing at the
-      // intermediate URL). Compare to location.href, which popstate has
-      // already updated to the latest state.url, so the in-flight target
-      // only matches when it is still the current truth.
+      // intermediate URL). Compare to the current entry's state.url rather
+      // than location.href: an entry's address can now carry list-state
+      // query params (e.g. ?search=...) that diverge from its bare state.url,
+      // so location.href wouldn't match target even on the right entry.
+      // history.state is the entry popstate landed on, so its url only
+      // equals the in-flight target when that target is still the current truth.
       return pending.then(function () {
-        if (location.href === target) {
+        if (history.state && history.state.url === target) {
           currentSpaUrl = target;
         }
       }).catch(function () {});

--- a/templates/campaigns/campaign_list_new.html
+++ b/templates/campaigns/campaign_list_new.html
@@ -104,6 +104,9 @@
         if (!next.url) {
           next.url = location.href;
         }
+        // state.url stays the bare page URL while the address bar gets
+        // event.detail.url — see msgs/msg_list_new.html for why the two
+        // must not be normalized to match.
         if (event.detail.replace) {
           history.replaceState(next, "", event.detail.url || null);
         } else {

--- a/templates/campaigns/campaign_list_new.html
+++ b/templates/campaigns/campaign_list_new.html
@@ -105,9 +105,9 @@
           next.url = location.href;
         }
         if (event.detail.replace) {
-          history.replaceState(next, "");
+          history.replaceState(next, "", event.detail.url || null);
         } else {
-          history.pushState(next, "");
+          history.pushState(next, "", event.detail.url || null);
         }
       });
     });

--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -124,6 +124,9 @@
         if (!next.url) {
           next.url = location.href;
         }
+        // state.url stays the bare page URL while the address bar gets
+        // event.detail.url — see msgs/msg_list_new.html for why the two
+        // must not be normalized to match.
         if (event.detail.replace) {
           history.replaceState(next, "", event.detail.url || null);
         } else {

--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -125,9 +125,9 @@
           next.url = location.href;
         }
         if (event.detail.replace) {
-          history.replaceState(next, "");
+          history.replaceState(next, "", event.detail.url || null);
         } else {
-          history.pushState(next, "");
+          history.pushState(next, "", event.detail.url || null);
         }
       });
     });

--- a/templates/flows/flow_list_new.html
+++ b/templates/flows/flow_list_new.html
@@ -137,6 +137,9 @@
         if (!next.url) {
           next.url = location.href;
         }
+        // state.url stays the bare page URL while the address bar gets
+        // event.detail.url — see msgs/msg_list_new.html for why the two
+        // must not be normalized to match.
         if (event.detail.replace) {
           history.replaceState(next, "", event.detail.url || null);
         } else {

--- a/templates/flows/flow_list_new.html
+++ b/templates/flows/flow_list_new.html
@@ -138,9 +138,9 @@
           next.url = location.href;
         }
         if (event.detail.replace) {
-          history.replaceState(next, "");
+          history.replaceState(next, "", event.detail.url || null);
         } else {
-          history.pushState(next, "");
+          history.pushState(next, "", event.detail.url || null);
         }
       });
     });

--- a/templates/msgs/msg_list_new.html
+++ b/templates/msgs/msg_list_new.html
@@ -140,10 +140,17 @@
           // in-list push didn't change the page.
           next.url = location.href;
         }
+        // event.detail.url is the address-bar URL for the new list
+        // state (search/sort/page folded into the query string), so a
+        // committed — or cleared — search stays shareable in the URL.
+        // Deliberately NOT mirrored into state.url: keeping that
+        // stable is what tells loadFromState's same-URL guard that an
+        // in-list back/forward is the component's to handle rather
+        // than a cross-page navigation to re-render.
         if (event.detail.replace) {
-          history.replaceState(next, "");
+          history.replaceState(next, "", event.detail.url || null);
         } else {
-          history.pushState(next, "");
+          history.pushState(next, "", event.detail.url || null);
         }
       });
     });

--- a/templates/triggers/trigger_list_new.html
+++ b/templates/triggers/trigger_list_new.html
@@ -120,6 +120,9 @@
         if (!next.url) {
           next.url = location.href;
         }
+        // state.url stays the bare page URL while the address bar gets
+        // event.detail.url — see msgs/msg_list_new.html for why the two
+        // must not be normalized to match.
         if (event.detail.replace) {
           history.replaceState(next, "", event.detail.url || null);
         } else {

--- a/templates/triggers/trigger_list_new.html
+++ b/templates/triggers/trigger_list_new.html
@@ -121,9 +121,9 @@
           next.url = location.href;
         }
         if (event.detail.replace) {
-          history.replaceState(next, "");
+          history.replaceState(next, "", event.detail.url || null);
         } else {
-          history.pushState(next, "");
+          history.pushState(next, "", event.detail.url || null);
         }
       });
     });


### PR DESCRIPTION
## Summary

Companion to nyaruka/temba-components#1060. The new-list pages now pass the list component's computed address-bar URL (`event.detail.url` on `temba-history-change`) through to `pushState`/`replaceState`, so a committed or cleared search is reflected in the URL and deep links stay shareable. Until the components release ships, `detail.url` is undefined and the handlers behave exactly as before.

## Changes

**`templates/{contacts,msgs,flows,triggers,campaigns}/*_list_new.html`**
- The `temba-history-change` handlers pass `event.detail.url || null` as the URL argument of `pushState`/`replaceState`. The entry's stashed `state.url` deliberately stays the bare page URL — that's what lets `loadFromState` distinguish in-list back/forward (handled by the component) from cross-page navigation (full SPA re-render).
- All five templates carry a comment at the `pushState`/`replaceState` block explaining that `state.url` and the address-bar URL are intentionally different; the full rationale lives in `msg_list_new.html` and the other four point at it (added in review to keep a future editor from "normalizing" the two).

**`static/js/frame.js`**
- `loadFromState`'s post-fetch cache guard now compares the fetch target against the current entry's `state.url` instead of `location.href`. Entry addresses can now carry list-state query params that diverge from the bare `state.url`, so the old comparison left `currentSpaUrl` stale after a cross-page return onto a searched entry — making every subsequent in-list back/forward do a redundant full re-fetch. Keying off entry identity fixes that while preserving the fast back→back supersede protection.

## Review notes

Two pre-PR review cycles with expert review agents, plus one in-PR review comment:
- The `frame.js` guard change was raised as a Medium finding in cycle 1 (the template change alone would have introduced the stale-`currentSpaUrl` regression) and was confirmed correct in cycle 2, including the superseded-fetch and first-entry cases.
- Noted, no change needed: a deep-linked entry bakes its query into `state.url` on the initial full-page load; after clearing the search in place, a later cross-page return re-fetches that stale URL. Confirmed benign — the remounted list restores from its stash and the content menu strips the stale search param.
- In-PR review asked for the `state.url`/address-URL rationale to be mirrored beyond `msg_list_new.html`; addressed with the breadcrumb comments above.

## Test plan

- [x] CI green (the changes are template/static JS only)
- [ ] Manual QA in preview mode with the updated components: open `/contact/?search=...` via a field pill → search initializes and "Create Smart Group" appears; clear the search → URL drops `?search=` and the menu item disappears; commit a search → open a contact → back → back/forward across search states stays a lightweight component refetch (no full-page flicker) with the address bar tracking each state