### PR TITLE
New preview list page for contact fields

### DIFF
--- a/temba/contacts/tests/test_fieldcrudl.py
+++ b/temba/contacts/tests/test_fieldcrudl.py
@@ -356,8 +356,24 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             response.json()["usages"],
         )
 
+        # usages are capped but counts carry the full total
+        for i in range(26):
+            self.create_flow(f"Flow {i}").field_dependencies.add(self.gender)
+
+        response = self.client.get(reverse("contacts.contactfield_detail", args=[self.gender.key]))
+        self.assertEqual(25, len(response.json()["usages"]["flows"]))
+        self.assertEqual(26, response.json()["counts"]["flows"])
+
+        # system fields can't be edited or deleted
+        response = self.client.get(reverse("contacts.contactfield_detail", args=["created_on"]))
+        self.assertEqual(200, response.status_code)
+        self.assertFalse(response.json()["can_edit"])
+        self.assertFalse(response.json()["can_delete"])
+
     def test_update_priority(self):
         priority_url = reverse("contacts.contactfield_update_priority")
+
+        self.assertRequestDisallowed(priority_url, [None, self.agent])
 
         self.login(self.admin)
 
@@ -393,6 +409,11 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         # anything not listed is un-featured and zeroed
         self.assertFalse(self.age.show_in_table)
         self.assertEqual(0, self.age.priority)
+
+        # an empty featured list un-features everything
+        response = self.client.post(priority_url, {"featured": []}, content_type="application/json")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, ContactField.user_fields.filter(org=self.org, is_active=True, show_in_table=True).count())
 
         # bad input is a 400
         response = self.client.post(priority_url, "notjson", content_type="application/json")

--- a/temba/contacts/tests/test_fieldcrudl.py
+++ b/temba/contacts/tests/test_fieldcrudl.py
@@ -328,9 +328,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
                 },
                 "usages": {
                     "flows": [{"uuid": str(flow.uuid), "name": "Flow", "url": f"/flow/editor/{flow.uuid}/"}],
-                    "groups": [
-                        {"uuid": str(group.uuid), "name": "Farmers", "url": f"/contact/group/{group.uuid}/"}
-                    ],
+                    "groups": [{"uuid": str(group.uuid), "name": "Farmers", "url": f"/contact/group/{group.uuid}/"}],
                     "campaign_events": [
                         {
                             "id": campaign.events.get().id,
@@ -364,9 +362,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.login(self.admin)
 
         # the legacy shape is a map of key to priority
-        response = self.client.post(
-            priority_url, {"age": 10, "gender": 5, "other": 3}, content_type="application/json"
-        )
+        response = self.client.post(priority_url, {"age": 10, "gender": 5, "other": 3}, content_type="application/json")
         self.assertEqual(200, response.status_code)
 
         self.age.refresh_from_db()

--- a/temba/contacts/tests/test_fieldcrudl.py
+++ b/temba/contacts/tests/test_fieldcrudl.py
@@ -30,7 +30,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.assertCreateFetch(
                 create_url,
                 [self.editor, self.admin],
-                form_fields=["name", "value_type", "show_in_table", "agent_access"],
+                form_fields=["name", "value_type", "agent_access"],
             )
             self.assertEqual(
                 [("T", "Text"), ("N", "Number"), ("D", "Date & Time")],
@@ -40,7 +40,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.assertCreateFetch(
             create_url,
             [self.editor, self.admin],
-            form_fields=["name", "value_type", "show_in_table", "agent_access"],
+            form_fields=["name", "value_type", "agent_access"],
         )
         self.assertEqual(
             [("T", "Text"), ("N", "Number"), ("D", "Date & Time"), ("S", "State"), ("I", "District"), ("W", "Ward")],
@@ -51,7 +51,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "", "value_type": "T", "show_in_table": True, "agent_access": "E"},
+            {"name": "", "value_type": "T", "agent_access": "E"},
             form_errors={"name": "This field is required."},
         )
 
@@ -59,7 +59,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "???", "value_type": "T", "show_in_table": True, "agent_access": "E"},
+            {"name": "???", "value_type": "T", "agent_access": "E"},
             form_errors={"name": "Can only contain letters, numbers and hypens."},
         )
 
@@ -67,7 +67,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "HAS", "value_type": "T", "show_in_table": True, "agent_access": "E"},
+            {"name": "HAS", "value_type": "T", "agent_access": "E"},
             form_errors={"name": "Can't be a reserved word."},
         )
 
@@ -75,17 +75,17 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "AGE", "value_type": "N", "show_in_table": True, "agent_access": "E"},
+            {"name": "AGE", "value_type": "N", "agent_access": "E"},
             form_errors={"name": "Must be unique."},
         )
 
-        # submit with valid data
+        # submit with valid data - new fields always start unfeatured
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "Goats", "value_type": "N", "show_in_table": True, "agent_access": "E"},
+            {"name": "Goats", "value_type": "N", "agent_access": "E"},
             new_obj_query=ContactField.user_fields.filter(
-                org=self.org, name="Goats", value_type="N", show_in_table=True, agent_access="E"
+                org=self.org, name="Goats", value_type="N", show_in_table=False, agent_access="E"
             ),
             success_status=200,
         )
@@ -96,9 +96,9 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertCreateSubmit(
             create_url,
             self.admin,
-            {"name": "Age", "value_type": "N", "show_in_table": True, "agent_access": "N"},
+            {"name": "Age", "value_type": "N", "agent_access": "N"},
             new_obj_query=ContactField.user_fields.filter(
-                org=self.org, name="Age", value_type="N", show_in_table=True, agent_access="N", is_active=True
+                org=self.org, name="Age", value_type="N", agent_access="N", is_active=True
             ),
             success_status=200,
         )
@@ -119,14 +119,14 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.assertUpdateFetch(
                 update_url,
                 [self.editor, self.admin],
-                form_fields={"name": "Age", "value_type": "N", "show_in_table": True, "agent_access": "V"},
+                form_fields={"name": "Age", "value_type": "N", "agent_access": "V"},
             )
             self.assertEqual(3, len(response.context["form"].fields["value_type"].choices))
 
         response = self.assertUpdateFetch(
             update_url,
             [self.editor, self.admin],
-            form_fields={"name": "Age", "value_type": "N", "show_in_table": True, "agent_access": "V"},
+            form_fields={"name": "Age", "value_type": "N", "agent_access": "V"},
         )
         self.assertEqual(6, len(response.context["form"].fields["value_type"].choices))
 
@@ -134,7 +134,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "Age", "value_type": "N", "show_in_table": True, "agent_access": "V"},
+            {"name": "Age", "value_type": "N", "agent_access": "V"},
             success_status=200,
         )
 
@@ -142,7 +142,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "", "value_type": "N", "show_in_table": True, "agent_access": "V"},
+            {"name": "", "value_type": "N", "agent_access": "V"},
             form_errors={"name": "This field is required."},
             object_unchanged=self.age,
         )
@@ -151,7 +151,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "???", "value_type": "N", "show_in_table": True, "agent_access": "V"},
+            {"name": "???", "value_type": "N", "agent_access": "V"},
             form_errors={"name": "Can only contain letters, numbers and hypens."},
             object_unchanged=self.age,
         )
@@ -160,23 +160,24 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "GENDER", "value_type": "N", "show_in_table": True, "agent_access": "V"},
+            {"name": "GENDER", "value_type": "N", "agent_access": "V"},
             form_errors={"name": "Must be unique."},
             object_unchanged=self.age,
         )
 
-        # submit with different name, type and agent access
+        # submit with different name, type and agent access - featured state is untouched (it's
+        # managed from the list page, not this form)
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "Age In Years", "value_type": "T", "show_in_table": False, "agent_access": "E"},
+            {"name": "Age In Years", "value_type": "T", "agent_access": "E"},
             success_status=200,
         )
 
         self.age.refresh_from_db()
         self.assertEqual("Age In Years", self.age.name)
         self.assertEqual("T", self.age.value_type)
-        self.assertFalse(self.age.show_in_table)
+        self.assertTrue(self.age.show_in_table)
         self.assertEqual("E", self.age.agent_access)
 
         # simulate an org which has reached the limit for fields - should still be able to update a field
@@ -184,7 +185,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertUpdateSubmit(
                 update_url,
                 self.admin,
-                {"name": "Age 2", "value_type": "T", "show_in_table": True, "agent_access": "E"},
+                {"name": "Age 2", "value_type": "T", "agent_access": "E"},
                 success_status=200,
             )
 
@@ -203,14 +204,14 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateFetch(
             update_url,
             [self.editor, self.admin],
-            form_fields={"name": "Registered", "value_type": "D", "show_in_table": False, "agent_access": "V"},
+            form_fields={"name": "Registered", "value_type": "D", "agent_access": "V"},
         )
 
         # try to submit with different type
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "Registered", "value_type": "T", "show_in_table": False, "agent_access": "V"},
+            {"name": "Registered", "value_type": "T", "agent_access": "V"},
             form_errors={"value_type": "Can't change type of date field being used by campaign events."},
             object_unchanged=registered,
         )
@@ -219,7 +220,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "Registered On", "value_type": "D", "show_in_table": False, "agent_access": "V"},
+            {"name": "Registered On", "value_type": "D", "agent_access": "V"},
             success_status=200,
         )
 
@@ -237,14 +238,14 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateFetch(
             update_url,
             [self.editor, self.admin],
-            form_fields={"name": "Birth", "value_type": "N", "show_in_table": False, "agent_access": "V"},
+            form_fields={"name": "Birth", "value_type": "N", "agent_access": "V"},
         )
 
         # try to submit with different type
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "Birth", "value_type": "T", "show_in_table": False, "agent_access": "V"},
+            {"name": "Birth", "value_type": "T", "agent_access": "V"},
             form_errors={"value_type": "Can't change type of field being used by a smart group."},
             object_unchanged=birth,
         )
@@ -253,7 +254,7 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateSubmit(
             update_url,
             self.admin,
-            {"name": "YearsOld", "value_type": "N", "show_in_table": False, "agent_access": "V"},
+            {"name": "YearsOld", "value_type": "N", "agent_access": "V"},
             success_status=200,
         )
         birth.refresh_from_db()
@@ -273,6 +274,133 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             response = self.assertListFetch(list_url, [self.admin])
             self.assertContains(response, "You have reached the per-workspace limit")
             self.assertContentMenu(list_url, self.admin, [])
+
+    def test_preview_list(self):
+        list_url = reverse("contacts.contactfield_list")
+
+        self.login(self.admin)
+
+        # default render is still the legacy field manager
+        response = self.client.get(list_url)
+        self.assertContains(response, "temba-field-manager")
+
+        # entering preview mode swaps in the temba-field-list component which fetches the fields itself
+        self.client.cookies["temba-preview"] = "1"
+
+        response = self.client.get(list_url)
+        self.assertContains(response, "temba-field-list")
+        self.assertNotContains(response, "temba-field-manager")
+
+    @mock_mailroom
+    def test_detail(self, mr_mocks):
+        field = self.create_field("joined", "Joined", value_type="D")
+
+        flow = self.create_flow("Flow")
+        flow.field_dependencies.add(field)
+
+        group = self.create_group("Farmers", query='joined != ""')
+        campaign = Campaign.create(self.org, self.admin, "Planting Reminders", group)
+        CampaignEvent.create_flow_event(
+            self.org, self.admin, campaign, relative_to=field, offset=1, unit="W", flow=flow
+        )
+
+        detail_url = reverse("contacts.contactfield_detail", args=[field.key])
+
+        self.assertRequestDisallowed(detail_url, [None, self.agent, self.admin2])
+
+        self.login(self.editor)
+
+        # like the preview list page it feeds, the endpoint only exists in preview mode
+        response = self.client.get(detail_url)
+        self.assertEqual(404, response.status_code)
+
+        self.client.cookies["temba-preview"] = "1"
+        response = self.client.get(detail_url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {
+                "field": {
+                    "key": "joined",
+                    "name": "Joined",
+                    "value_type": "D",
+                    "featured": False,
+                    "agent_access": "V",
+                },
+                "usages": {
+                    "flows": [{"uuid": str(flow.uuid), "name": "Flow", "url": f"/flow/editor/{flow.uuid}/"}],
+                    "groups": [
+                        {"uuid": str(group.uuid), "name": "Farmers", "url": f"/contact/group/{group.uuid}/"}
+                    ],
+                    "campaign_events": [
+                        {
+                            "id": campaign.events.get().id,
+                            "campaign": {
+                                "uuid": str(campaign.uuid),
+                                "name": "Planting Reminders",
+                                "url": f"/campaign/read/{campaign.uuid}/",
+                            },
+                            "offset_display": "1 week after Joined",
+                        }
+                    ],
+                },
+                "counts": {"flows": 1, "groups": 1, "campaign_events": 1},
+                "can_edit": True,
+                "can_delete": True,
+            },
+            response.json(),
+        )
+
+        # a field with no dependents renders empty usages
+        response = self.client.get(reverse("contacts.contactfield_detail", args=[self.gender.key]))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {"flows": [], "groups": [], "campaign_events": []},
+            response.json()["usages"],
+        )
+
+    def test_update_priority(self):
+        priority_url = reverse("contacts.contactfield_update_priority")
+
+        self.login(self.admin)
+
+        # the legacy shape is a map of key to priority
+        response = self.client.post(
+            priority_url, {"age": 10, "gender": 5, "other": 3}, content_type="application/json"
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.age.refresh_from_db()
+        self.gender.refresh_from_db()
+        self.other_org_field.refresh_from_db()
+        self.assertEqual(10, self.age.priority)
+        self.assertEqual(5, self.gender.priority)
+        self.assertEqual(0, self.other_org_field.priority)  # other org's field is unchanged
+
+        # the new shape is the full ordered featured set - first is highest priority
+        response = self.client.post(
+            priority_url, {"featured": ["gender", "state", "other"]}, content_type="application/json"
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.age.refresh_from_db()
+        self.gender.refresh_from_db()
+        self.state.refresh_from_db()
+        self.other_org_field.refresh_from_db()
+
+        # listed fields are featured with descending priorities (unknown / cross-org keys ignored)
+        self.assertTrue(self.gender.show_in_table)
+        self.assertEqual(3, self.gender.priority)
+        self.assertTrue(self.state.show_in_table)
+        self.assertEqual(2, self.state.priority)
+        self.assertFalse(self.other_org_field.show_in_table)
+
+        # anything not listed is un-featured and zeroed
+        self.assertFalse(self.age.show_in_table)
+        self.assertEqual(0, self.age.priority)
+
+        # bad input is a 400
+        response = self.client.post(priority_url, "notjson", content_type="application/json")
+        self.assertEqual(400, response.status_code)
 
     @mock_mailroom
     def test_usages(self, mr_mocks):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
 from django.db import transaction
 from django.db.models.functions import Upper
-from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect, JsonResponse
+from django.http import Http404, HttpResponse, HttpResponseNotFound, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
@@ -1075,11 +1075,10 @@ class ContactFieldForm(UniqueNameMixin, forms.ModelForm):
 
     class Meta:
         model = ContactField
-        fields = ("name", "value_type", "show_in_table", "agent_access")
+        fields = ("name", "value_type", "agent_access")
         labels = {
             "name": _("Name"),
             "value_type": _("Data Type"),
-            "show_in_table": _("Featured"),
             "agent_access": _("Agent Access"),
         }
         help_texts = {
@@ -1089,7 +1088,6 @@ class ContactFieldForm(UniqueNameMixin, forms.ModelForm):
         widgets = {
             "name": InputWidget(attrs={"widget_only": False}),
             "value_type": SelectWidget(attrs={"widget_only": False}),
-            "show_in_table": CheckboxWidget(attrs={"widget_only": True}),
             "agent_access": SelectWidget(attrs={"widget_only": False}),
         }
 
@@ -1113,7 +1111,7 @@ class FieldLookupMixin:
 
 class ContactFieldCRUDL(SmartCRUDL):
     model = ContactField
-    actions = ("list", "create", "update", "update_priority", "delete", "usages")
+    actions = ("list", "create", "update", "update_priority", "delete", "usages", "detail")
 
     class Create(BaseCreateModal):
         queryset = ContactField.user_fields
@@ -1127,7 +1125,6 @@ class ContactFieldCRUDL(SmartCRUDL):
                 self.request.user,
                 name=form.cleaned_data["name"],
                 value_type=form.cleaned_data["value_type"],
-                featured=form.cleaned_data["show_in_table"],
                 agent_access=form.cleaned_data["agent_access"],
             )
             return self.render_modal_response(form)
@@ -1137,14 +1134,6 @@ class ContactFieldCRUDL(SmartCRUDL):
         form_class = ContactFieldForm
         submit_button_name = _("Update")
         success_url = "hide"
-
-        def pre_save(self, obj):
-            obj = super().pre_save(obj)
-
-            # clear our priority if no longer featured
-            if not obj.show_in_table:
-                obj.priority = 0
-            return obj
 
         def form_valid(self, form):
             super().form_valid(form)
@@ -1158,9 +1147,21 @@ class ContactFieldCRUDL(SmartCRUDL):
         def post(self, request, *args, **kwargs):
             try:
                 post_data = json.loads(request.body)
+                featured = post_data.get("featured") if isinstance(post_data, dict) else None
+
                 with transaction.atomic():
-                    for key, priority in post_data.items():
-                        ContactField.user_fields.filter(key=key, org=self.request.org).update(priority=priority)
+                    if isinstance(featured, list):
+                        # the full ordered featured set: first is highest priority, and any featured field not
+                        # listed is un-featured
+                        org_fields = ContactField.user_fields.filter(org=self.request.org, is_active=True)
+                        for idx, key in enumerate(featured):
+                            org_fields.filter(key=key).update(show_in_table=True, priority=len(featured) - idx)
+                        org_fields.filter(show_in_table=True).exclude(key__in=featured).update(
+                            show_in_table=False, priority=0
+                        )
+                    else:
+                        for key, priority in post_data.items():
+                            ContactField.user_fields.filter(key=key, org=self.request.org).update(priority=priority)
 
                 return HttpResponse('{"status":"OK"}', status=200, content_type="application/json")
 
@@ -1174,6 +1175,16 @@ class ContactFieldCRUDL(SmartCRUDL):
     class List(SpaMixin, ContextMenuMixin, BaseListView):
         menu_path = "/contact/fields"
         title = _("Fields")
+
+        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
+        # the list renders the temba-field-list component (contacts/contactfield_list_new.html) instead of the
+        # legacy field manager; the component fetches the fields itself from the API.
+        NEW_LIST_TEMPLATE = "contacts/contactfield_list_new.html"
+
+        def get_template_names(self):
+            if getattr(self.request, "preview", False):
+                return [self.NEW_LIST_TEMPLATE]
+            return super().get_template_names()
 
         def build_context_menu(self, menu):
             if self.has_org_perm("contacts.contactfield_create") and not self.is_limit_reached():
@@ -1189,6 +1200,66 @@ class ContactFieldCRUDL(SmartCRUDL):
     class Usages(FieldLookupMixin, BaseUsagesModal):
         permission = "contacts.contactfield_read"
         queryset = ContactField.user_fields
+
+    class Detail(FieldLookupMixin, OrgPermsMixin, SmartView, View):
+        """
+        A field's usages and permissions as JSON, consumed by the temba-field-list component's detail modal on
+        the preview list page — so like that page it only exists in preview mode.
+        """
+
+        permission = "contacts.contactfield_read"
+        USAGES_LIMIT = 25
+
+        def get(self, request, *args, **kwargs):
+            if not getattr(request, "preview", False):
+                raise Http404()
+
+            field = self.get_object()
+            dependents = field.get_dependents()
+            flows = dependents["flow"].order_by("name")
+            groups = dependents["group"].order_by("name")
+            events = dependents["campaign_event"].select_related("campaign", "relative_to").order_by("campaign__name")
+
+            return JsonResponse(
+                {
+                    "field": {
+                        "key": field.key,
+                        "name": field.name,
+                        "value_type": field.value_type,
+                        "featured": field.show_in_table,
+                        "agent_access": field.agent_access,
+                    },
+                    "usages": {
+                        "flows": [
+                            {"uuid": str(f.uuid), "name": f.name, "url": reverse("flows.flow_editor", args=[f.uuid])}
+                            for f in flows[: self.USAGES_LIMIT]
+                        ],
+                        "groups": [
+                            {"uuid": str(g.uuid), "name": g.name, "url": reverse("contacts.contact_group", args=[g.uuid])}
+                            for g in groups[: self.USAGES_LIMIT]
+                        ],
+                        "campaign_events": [
+                            {
+                                "id": e.id,
+                                "campaign": {
+                                    "uuid": str(e.campaign.uuid),
+                                    "name": e.campaign.name,
+                                    "url": reverse("campaigns.campaign_read", args=[e.campaign.uuid]),
+                                },
+                                "offset_display": f"{e.offset_display} {e.relative_to.name}",
+                            }
+                            for e in events[: self.USAGES_LIMIT]
+                        ],
+                    },
+                    "counts": {
+                        "flows": flows.count(),
+                        "groups": groups.count(),
+                        "campaign_events": events.count(),
+                    },
+                    "can_edit": self.has_org_perm("contacts.contactfield_update") and not field.is_system,
+                    "can_delete": self.has_org_perm("contacts.contactfield_delete") and not field.is_system,
+                }
+            )
 
 
 class ContactImportCRUDL(SmartCRUDL):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1235,7 +1235,11 @@ class ContactFieldCRUDL(SmartCRUDL):
                             for f in flows[: self.USAGES_LIMIT]
                         ],
                         "groups": [
-                            {"uuid": str(g.uuid), "name": g.name, "url": reverse("contacts.contact_group", args=[g.uuid])}
+                            {
+                                "uuid": str(g.uuid),
+                                "name": g.name,
+                                "url": reverse("contacts.contact_group", args=[g.uuid]),
+                            }
                             for g in groups[: self.USAGES_LIMIT]
                         ],
                         "campaign_events": [

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1104,9 +1104,14 @@ class FieldLookupMixin:
         return False
 
     def get_object(self):
-        if self.request.org:
-            return self.request.org.fields.filter(key=self.kwargs["key"], is_active=True).first()
-        return None
+        # cached because permission checking during dispatch also fetches the object
+        if not hasattr(self, "_object"):
+            self._object = (
+                self.request.org.fields.filter(key=self.kwargs["key"], is_active=True).first()
+                if self.request.org
+                else None
+            )
+        return self._object
 
 
 class ContactFieldCRUDL(SmartCRUDL):

--- a/templates/contacts/contactfield_create.html
+++ b/templates/contacts/contactfield_create.html
@@ -8,7 +8,6 @@
     <div class="flex items-start flex-col">
       <div class="w-full">{% render_field 'name' %}</div>
       <div class="w-full">{% render_field 'value_type' %}</div>
-      {% render_field 'show_in_table' %}
       {% render_field 'agent_access' %}
     </div>
   {% endif %}

--- a/templates/contacts/contactfield_list_new.html
+++ b/templates/contacts/contactfield_list_new.html
@@ -1,0 +1,114 @@
+{% extends "smartmin/list.html" %}
+{% load i18n %}
+
+{% comment %}
+  New-style contact fields list rendered when the viewer is in preview
+  mode (request.preview, set by PreviewMiddleware off the temba-preview
+  cookie). The temba-field-list component renders the same page header
+  as the new list views (title + content menu), then the fields as two
+  cards — Featured (drag to order, drag out to un-feature) and Other
+  Fields (drag into Featured to feature); the component reads the
+  fields from the store and saves the featured set to the priority
+  endpoint. There is no field read page — clicking a row opens a detail
+  modal with the field's usages, and fields are edited / deleted
+  through modals from there.
+{% endcomment %}
+{% block page-header %}
+  {# the component renders its own header (title + content menu); #}
+  {# keep the csrf token and a hidden title for the SPA document.title hook #}
+  {% csrf_token %}
+  <div id="title-text" class="hide">{{ title }}</div>
+{% endblock page-header %}
+{% block extra-style %}
+  {{ block.super }}
+  <style type="text/css">
+    /* The component renders the same flush header bar as the new list
+       pages, so drop the SPA content padding the same way they do. */
+    .spa-content {
+      padding: 0 !important;
+    }
+  </style>
+{% endblock extra-style %}
+{% block content %}
+  <temba-field-list id="field-list"
+                    header-title="{{ title }}"
+                    content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"
+                    priority-endpoint="{% url 'contacts.contactfield_update_priority' %}"
+                    detail-endpoint="/contactfield/detail/">
+  </temba-field-list>
+{% endblock content %}
+{% block extra-script %}
+  {{ block.super }}
+  <script type="text/javascript">
+    function handleFieldUpdated() {
+      document.querySelector("temba-store").refreshFields();
+      refreshMenu();
+    }
+
+    onSpload(function() {
+      var list = document.querySelector("#field-list");
+
+      list.addEventListener("temba-selection", function(event) {
+        var detail = event.detail;
+
+        // the embedded page header fires temba-selection with a content-menu
+        // item - dispatch it the same way the page chrome's content menu
+        // (spa_page_menu.html) does
+        if (detail.item && detail.item.type) {
+          var item = detail.item;
+          var click = detail.event;
+          if (item.type === "link") {
+            if (click) {
+              click.preventDefault();
+              click.stopPropagation();
+              if (click.metaKey && item.url) {
+                window.open(item.url, "_blank");
+                return;
+              }
+            }
+            spaGet(item.url);
+          } else if (item.type === "modax") {
+            showModax(item.title, item.url, {
+              disabled: item.disabled,
+              onSubmit: item.on_submit,
+              onRedirect: item.on_redirect,
+              id: item.modal_id,
+              originX: detail.originX,
+              originY: detail.originY
+            });
+          } else if (item.type === "url_post") {
+            posterize(item.url);
+          } else if (item.type === "js") {
+            if (window[item.id]) {
+              window[item.id]();
+            }
+          }
+          refreshMenu();
+          return;
+        }
+
+        // rows open the edit / delete modals from the detail popup
+        if (detail.action === "update") {
+          showModax("{% trans "Update Field" %}", "/contactfield/update/" + detail.key + "/", {
+            id: "field-update",
+            onSubmit: "handleFieldUpdated()"
+          });
+          return;
+        }
+        if (detail.action === "delete") {
+          showModax("{% trans "Delete Field" %}", "/contactfield/delete/" + detail.key + "/", {
+            id: "field-delete",
+            onSubmit: "handleFieldUpdated()"
+          });
+          return;
+        }
+
+        // a usage pill in the detail popup carries the flow / group /
+        // campaign url
+        if (detail.url) {
+          spaGet(detail.url);
+        }
+      });
+    });
+  </script>
+{% endblock extra-script %}


### PR DESCRIPTION
## Summary

New preview list page for contact fields, rendered by the `temba-field-list` component (nyaruka/temba-components#1061). Featuring and ordering move to the list itself (star toggles + drag), so the field form's Featured checkbox goes away, and the component's floating detail modal gets a JSON endpoint for a field's usages.

## Changes

- **`ContactFieldCRUDL.List`** — swaps to `contacts/contactfield_list_new.html` when `request.preview`, mirroring the campaign views; the legacy page and `temba-field-manager` are untouched.
- **`ContactFieldCRUDL.Detail`** (new) — preview-gated JSON endpoint at `/contactfield/detail/<key>/` returning the field, its usages (flows/groups/campaign events with names and links, capped at 25 with counts), and `can_edit`/`can_delete` — consumed by the component's detail modal, following the `CampaignCRUDL.Events` pattern.
- **`ContactFieldCRUDL.UpdatePriority`** — still accepts the legacy `{key: priority}` map, and now also `{"featured": [ordered keys]}`: listed fields are featured with descending priorities (first = highest) and any other featured field is un-featured, atomically. Cross-org/unknown keys are ignored.
- **`ContactFieldForm`** — drops the `show_in_table` ("Featured") checkbox from create/update; new fields start unfeatured and featuring is managed from the list page. `Create.form_valid` and `Update.pre_save` adjusted accordingly.
- **`templates/contacts/contactfield_list_new.html`** (new) — wires the component: content-menu dispatch, update/delete modax handling, `spaGet` for usage links, store/menu refresh on changes.
- **Tests** — `test_preview_list`, `test_detail`, and `test_update_priority` (both payload shapes, un-featuring, org scoping, bad input) added; `test_create`/`test_update` updated for the slimmer form.

## Review notes

Pre-PR review passed with suggestions only (noted, not blocking): `Detail` resolves the field twice via `FieldLookupMixin`; the preview list still paginates a queryset the template ignores; the template hardcodes update/delete URLs where campaigns pass them through the JSON payload.

## Test plan

- [x] `test_fieldcrudl` passes (aside from two pre-existing environment-dependent locations-feature failures that fail identically on main in this dev stack)
- [x] Legacy list page, usages modal, and old priority payload shape still work
- [x] Exercised the preview page end-to-end on a local dev stack: reorder, star toggles, detail modal usages/edit/delete, menu refresh
