### PR TITLE
Update @nyaruka/temba-components to 0.165.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "rapidpro",
       "dependencies": {
-        "@nyaruka/temba-components": "0.164.0",
+        "@nyaruka/temba-components": "0.165.0",
         "codemirror": "5.58.2",
         "colorette": "1.2.2",
         "fa-icons": "0.2.0",
@@ -58,7 +58,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.164.0", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-3RLhGw/122rXIo/AzkJbMkrfWHGJu6rre6g42pZbC7GmdcyTv4IPKvqcjF/q+iJN4jvExRe+Y8wKGaxud/sW/g=="],
+    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.165.0", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-c/CbzK4V4DAl5BHVrqd9n+26stANPV9zxq1qDvC9kHm/8dFz4+lH7bf1oxo4j2kQ5V2QDl3ErEhtP5aqHxQDrg=="],
 
     "@open-wc/lit-helpers": ["@open-wc/lit-helpers@0.7.0", "", {}, "sha512-4NBlx5ve0EvZplCRJbESm0MdMbRCw16alP2y76KAAAwzmFFXXrUj5hFwhw55+sSg5qaRRx6sY+s7usKgnNo3TQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.164.0",
+    "@nyaruka/temba-components": "0.165.0",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.165.0](https://github.com/nyaruka/temba-components/compare/v0.164.0...v0.165.0)

- Add temba-field-list for the contact fields list page [#1061](https://github.com/nyaruka/temba-components/pull/1061)
- Initialize deep-linked search, reflect list state in URL, and sync content menu search [#1060](https://github.com/nyaruka/temba-components/pull/1060)
- Add temba-broadcast-list for the broadcast list pages [#1059](https://github.com/nyaruka/temba-components/pull/1059)
- Switch from pnpm to bun for dependency management [#1050](https://github.com/nyaruka/temba-components/pull/1050)
- Refine fixed-mode exclusion reconciliation in temba-contact-search [#1058](https://github.com/nyaruka/temba-components/pull/1058)
- Don't subscribe to mismatched ticket history channels during contact switches [#1056](https://github.com/nyaruka/temba-components/pull/1056)
- Add fixed mode with interrupt confirmation to temba-contact-search [#1054](https://github.com/nyaruka/temba-components/pull/1054)
- Mobile nav and chat-first layout fixes [#1051](https://github.com/nyaruka/temba-components/pull/1051)