### PR TITLE
Make new UI the default with a legacy opt-out

### DIFF
--- a/temba/campaigns/tests/test_campaigncrudl.py
+++ b/temba/campaigns/tests/test_campaigncrudl.py
@@ -69,6 +69,9 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
 
         read_url = reverse("campaigns.campaign_read", args=[campaign.uuid])
 
+        # opt into legacy mode to test the legacy read page
+        self.setLegacyUI()
+
         self.assertRequestDisallowed(read_url, [None, self.agent, self.admin2])
         response = self.assertReadFetch(read_url, [self.editor, self.admin], context_object=campaign)
         self.assertContains(response, "Welcomes")
@@ -82,7 +85,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertContentMenu(read_url, self.admin, ["Activate", "Export", "-", "Delete"])
 
-    def test_preview_read(self):
+    def test_new_read(self):
         group = self.create_group("Reporters", contacts=[])
         campaign = self.create_campaign(self.org, "Welcomes", group)
 
@@ -90,13 +93,14 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.admin)
 
-        # default render is still the legacy table
+        # legacy mode renders the legacy table
+        self.setLegacyUI()
         response = self.client.get(read_url)
         self.assertNotContains(response, "temba-campaign-events")
         self.assertIn("events", response.context)
 
-        # entering preview mode swaps in the temba-campaign-events component which fetches the events itself
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the temba-campaign-events component which fetches the events itself
+        self.setLegacyUI(False)
 
         response = self.client.get(read_url)
         self.assertContains(response, "temba-campaign-events")
@@ -131,11 +135,12 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.editor)
 
-        # like the preview read page it feeds, the endpoint only exists in preview mode
+        # like the new read page it feeds, the endpoint doesn't exist in legacy mode
+        self.setLegacyUI()
         response = self.client.get(events_url)
         self.assertEqual(404, response.status_code)
 
-        self.client.cookies["temba-preview"] = "1"
+        self.setLegacyUI(False)
         response = self.client.get(events_url)
         self.assertEqual(200, response.status_code)
 
@@ -291,6 +296,9 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(CampaignEvent.objects.filter(campaign=campaign, is_active=False).count(), 3)
 
     def test_list(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         list_url = reverse("campaigns.campaign_list")
 
         group = self.create_group("Reporters", contacts=[])
@@ -307,7 +315,7 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContentMenu(list_url, self.admin, ["New Campaign"])
 
     @mock_mailroom
-    def test_preview_list(self, mr_mocks):
+    def test_new_list(self, mr_mocks):
         group = self.create_group("Reporters", contacts=[])
         campaign1 = self.create_campaign(self.org, "Welcomes", group)
         campaign2 = self.create_campaign(self.org, "Follow Ups", group)
@@ -317,12 +325,13 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.admin)
 
-        # default render is still the legacy table
+        # legacy mode renders the legacy table
+        self.setLegacyUI()
         response = self.client.get(list_url)
         self.assertNotContains(response, "temba-campaign-list")
 
-        # entering preview mode swaps in the temba-campaign-list component, pointed at the internal campaigns api
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the temba-campaign-list component, pointed at the internal campaigns api
+        self.setLegacyUI(False)
 
         response = self.client.get(list_url)
         self.assertContains(response, "temba-campaign-list")
@@ -364,6 +373,9 @@ class CampaignCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(other_org_campaign.is_archived)
 
     def test_archived(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         archived_url = reverse("campaigns.campaign_archived")
 
         group = self.create_group("Reporters", contacts=[])

--- a/temba/campaigns/tests/test_eventcrudl.py
+++ b/temba/campaigns/tests/test_eventcrudl.py
@@ -54,7 +54,7 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
         return campaign
 
     @mock_mailroom
-    def test_update_preview_success_url(self, mr_mocks):
+    def test_update_success_url(self, mr_mocks):
         event = self.campaign1.events.order_by("id").first()
         registered = self.org.fields.get(key="registered")
         flow = self.org.flows.get(name="Welcomes Flow")
@@ -73,7 +73,8 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.admin)
 
-        # outside preview the edit modal continues to the event read page
+        # in legacy mode the edit modal continues to the event read page
+        self.setLegacyUI()
         response = self.client.post(update_url, data)
         self.assertRedirects(
             response,
@@ -81,8 +82,8 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
             fetch_redirect_response=False,
         )
 
-        # in preview there is no event read page - it returns to the campaign
-        self.client.cookies["temba-preview"] = "1"
+        # by default there is no event read page - it returns to the campaign
+        self.setLegacyUI(False)
         response = self.client.post(update_url, data)
         self.assertRedirects(
             response, reverse("campaigns.campaign_read", args=[self.campaign1.uuid]), fetch_redirect_response=False
@@ -99,11 +100,12 @@ class CampaignEventCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.editor)
 
-        # like the preview read page it feeds, the endpoint only exists in preview mode
+        # like the new read page it feeds, the endpoint doesn't exist in legacy mode
+        self.setLegacyUI()
         response = self.client.get(fires_url)
         self.assertEqual(404, response.status_code)
 
-        self.client.cookies["temba-preview"] = "1"
+        self.setLegacyUI(False)
         response = self.client.get(fires_url)
         self.assertEqual(200, response.status_code)
         self.assertEqual(

--- a/temba/campaigns/views.py
+++ b/temba/campaigns/views.py
@@ -112,16 +112,16 @@ class CampaignCRUDL(SmartCRUDL):
     class Read(SpaMixin, ContextMenuMixin, BaseReadView):
         menu_path = "/campaign/active"
 
-        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
-        # the read view renders the temba-campaign-events component (campaigns/campaign_read_new.html) instead of
-        # the legacy table; the component fetches the event schedule itself from the campaign events endpoint.
+        # By default the read view renders the temba-campaign-events component (campaigns/campaign_read_new.html);
+        # the component fetches the event schedule itself from the campaign events endpoint. Viewers can opt back
+        # into the legacy table via legacy mode (LegacyMiddleware → request.legacy).
         NEW_READ_TEMPLATE = "campaigns/campaign_read_new.html"
 
         def derive_title(self):
             return self.object.name
 
         def get_template_names(self):
-            if getattr(self.request, "preview", False):
+            if not getattr(self.request, "legacy", False):
                 return [self.NEW_READ_TEMPLATE]
             return super().get_template_names()
 
@@ -168,22 +168,22 @@ class CampaignCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
 
-            # in preview the component fetches the events itself from the events endpoint
-            if not getattr(self.request, "preview", False):
+            # outside legacy mode the component fetches the events itself from the events endpoint
+            if getattr(self.request, "legacy", False):
                 context["events"] = self.object.get_sorted_events()
             return context
 
     class Events(BaseReadView):
         """
-        The event schedule of a campaign as JSON, consumed by the temba-campaign-events component on the preview
-        read page — so like that page it only exists in preview mode.
+        The event schedule of a campaign as JSON, consumed by the temba-campaign-events component on the new
+        read page — so like that page it doesn't exist in legacy mode.
         """
 
         permission = "campaigns.campaign_read"
 
         def get(self, request, *args, **kwargs):
-            # permission checks have already run in dispatch; hide the endpoint itself outside of preview
-            if not getattr(request, "preview", False):
+            # permission checks have already run in dispatch; hide the endpoint itself in legacy mode
+            if getattr(request, "legacy", False):
                 raise Http404()
             return super().get(request, *args, **kwargs)
 
@@ -222,9 +222,10 @@ class CampaignCRUDL(SmartCRUDL):
         default_template = "campaigns/campaign_list.html"
         default_order = ("-modified_on",)
 
-        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
-        # every campaign list view renders the temba-campaign-list component (campaigns/campaign_list_new.html)
-        # instead of its legacy table; the component fetches/pages campaigns itself from the internal campaigns API.
+        # By default every campaign list view renders the temba-campaign-list component
+        # (campaigns/campaign_list_new.html); the component fetches/pages campaigns itself from the internal
+        # campaigns API. Viewers can opt back into the legacy table via legacy mode (LegacyMiddleware →
+        # request.legacy).
         NEW_LIST_TEMPLATE = "campaigns/campaign_list_new.html"
 
         # Optional subtitle rendered under the title on the new-list view.
@@ -237,9 +238,9 @@ class CampaignCRUDL(SmartCRUDL):
         }
 
         def _use_new_list(self) -> bool:
-            # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered
+            # `getattr` defaults to False so a view called via RequestFactory (or if LegacyMiddleware is reordered
             # out) doesn't AttributeError.
-            return getattr(self.request, "preview", False)
+            return not getattr(self.request, "legacy", False)
 
         def get_template_names(self):
             if self._use_new_list():
@@ -283,8 +284,8 @@ class CampaignCRUDL(SmartCRUDL):
             return super().post(request, *args, **kwargs)
 
         def get_queryset(self, *args, **kwargs):
-            # In preview the temba-campaign-list component fetches and pages campaigns from the internal campaigns
-            # API, so a GET page needs no object list. A POST (bulk action) still needs the real queryset, since
+            # On the new list the temba-campaign-list component fetches and pages campaigns from the internal
+            # campaigns API, so a GET page needs no object list. A POST (bulk action) still needs the real queryset, since
             # BulkActionMixin validates the posted `objects` against it.
             if self._use_new_list() and self.request.method == "GET":
                 return Campaign.objects.none()
@@ -733,8 +734,8 @@ class CampaignEventCRUDL(SmartCRUDL):
 
     class Fires(BaseReadView):
         """
-        The most recent contacts an event fired for, consumed by the recent-contacts popup on the preview campaign
-        read page — so like that page it only exists in preview mode.
+        The most recent contacts an event fired for, consumed by the recent-contacts popup on the new campaign
+        read page — so like that page it doesn't exist in legacy mode.
         """
 
         permission = "campaigns.campaignevent_read"
@@ -744,8 +745,8 @@ class CampaignEventCRUDL(SmartCRUDL):
             return self.get_object().campaign.org
 
         def get(self, request, *args, **kwargs):
-            # permission checks have already run in dispatch; hide the endpoint itself outside of preview
-            if not getattr(request, "preview", False):
+            # permission checks have already run in dispatch; hide the endpoint itself in legacy mode
+            if getattr(request, "legacy", False):
                 raise Http404()
             return super().get(request, *args, **kwargs)
 
@@ -851,8 +852,8 @@ class CampaignEventCRUDL(SmartCRUDL):
             return obj
 
         def get_success_url(self):
-            # the preview read page has no event read page - the edit modal returns to the campaign
-            if getattr(self.request, "preview", False):
+            # the new read page has no event read page - the edit modal returns to the campaign
+            if not getattr(self.request, "legacy", False):
                 return reverse("campaigns.campaign_read", args=[self.object.campaign.uuid])
             return reverse("campaigns.campaignevent_read", args=[self.object.campaign.uuid, self.object.uuid])
 

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -135,6 +135,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
     @mock_mailroom
     def test_list(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         list_url = reverse("contacts.contact_list")
 
         self.assertRequestDisallowed(list_url, [None, self.agent])
@@ -263,7 +266,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(Contact.STATUS_ARCHIVED, joe.status)
 
     @mock_mailroom
-    def test_preview_list(self, mr_mocks):
+    def test_new_list(self, mr_mocks):
         joe = self.create_contact("Joe", phone="123")
         frank = self.create_contact("Frank", phone="124")
         group = self.create_group("Crew", contacts=[joe, frank])
@@ -273,12 +276,13 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.login(self.admin)
 
-        # default render is still the legacy table
+        # legacy mode renders the legacy table
+        self.setLegacyUI()
         response = self.client.get(list_url)
         self.assertNotContains(response, "temba-contact-list")
 
-        # entering preview mode swaps in the temba-contact-list component, pointed at the internal contacts api
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the temba-contact-list component, pointed at the internal contacts api
+        self.setLegacyUI(False)
 
         response = self.client.get(list_url)
         self.assertContains(response, "temba-contact-list")
@@ -336,9 +340,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.post(list_url, {"action": "archive", "objects": "not-a-uuid"})
         self.assertEqual(200, response.status_code)
 
-        del self.client.cookies["temba-preview"]
+        self.setLegacyUI()
 
-        # back on the legacy (non-preview) list, the content menu still surfaces Create Smart Group when the search is
+        # back on the legacy list, the content menu still surfaces Create Smart Group when the search is
         # saveable as a group — build_context_menu reads the search straight off the request query string here
         self.assertContentMenu(
             list_url + "?search=age+%3E+30",
@@ -348,6 +352,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
     @mock_mailroom
     def test_blocked(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         joe = self.create_contact("Joe", urns=["twitter:joe"])
         frank = self.create_contact("Frank", urns=["twitter:frank"])
         billy = self.create_contact("Billy", urns=["twitter:billy"])
@@ -384,6 +391,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
     @mock_mailroom
     def test_stopped(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         joe = self.create_contact("Joe", urns=["twitter:joe"])
         frank = self.create_contact("Frank", urns=["twitter:frank"])
         billy = self.create_contact("Billy", urns=["twitter:billy"])
@@ -421,6 +431,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
     @patch("temba.contacts.models.Contact.BULK_RELEASE_IMMEDIATELY_LIMIT", 5)
     @mock_mailroom
     def test_archived(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         joe = self.create_contact("Joe", urns=["twitter:joe"])
         frank = self.create_contact("Frank", urns=["twitter:frank"])
         billy = self.create_contact("Billy", urns=["twitter:billy"])
@@ -480,6 +493,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
     @mock_mailroom
     def test_group(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         open_tickets = self.org.groups.get(name="Open Tickets")
         joe = self.create_contact("Joe", phone="123")
         frank = self.create_contact("Frank", phone="124")
@@ -545,6 +561,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
     @mock_mailroom
     def test_read(self, mr_mocks):
+        # opt into legacy mode to test the legacy read page
+        self.setLegacyUI()
+
         joe = self.create_contact("Joe", phone="123")
 
         read_url = reverse("contacts.contact_read", args=[joe.uuid])
@@ -596,20 +615,21 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(response.status_code, 404)
 
     @mock_mailroom
-    def test_preview_read(self, mr_mocks):
+    def test_new_read(self, mr_mocks):
         joe = self.create_contact("Joe", phone="123")
 
         read_url = reverse("contacts.contact_read", args=[joe.uuid])
 
         self.login(self.admin)
 
-        # default render is still the tabbed layout
+        # legacy mode renders the tabbed layout
+        self.setLegacyUI()
         response = self.client.get(read_url)
         self.assertContains(response, "temba-tabs")
         self.assertNotContains(response, "temba-card-layout")
 
-        # entering preview mode swaps in the chat + card column layout
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the chat + card column layout
+        self.setLegacyUI(False)
 
         response = self.client.get(read_url)
         self.assertContains(response, "temba-card-layout")

--- a/temba/contacts/tests/test_field.py
+++ b/temba/contacts/tests/test_field.py
@@ -101,6 +101,9 @@ class ContactFieldTest(TembaTest):
 
     @mock_mailroom
     def test_contact_field_list_sort_fields(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         url = reverse("contacts.contact_list")
         self.login(self.admin)
 

--- a/temba/contacts/tests/test_fieldcrudl.py
+++ b/temba/contacts/tests/test_fieldcrudl.py
@@ -263,6 +263,9 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(birth.show_in_table)
 
     def test_list(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         list_url = reverse("contacts.contactfield_list")
 
         self.assertRequestDisallowed(list_url, [None, self.agent])
@@ -275,17 +278,18 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertContains(response, "You have reached the per-workspace limit")
             self.assertContentMenu(list_url, self.admin, [])
 
-    def test_preview_list(self):
+    def test_new_list(self):
         list_url = reverse("contacts.contactfield_list")
 
         self.login(self.admin)
 
-        # default render is still the legacy field manager
+        # legacy mode renders the legacy field manager
+        self.setLegacyUI()
         response = self.client.get(list_url)
         self.assertContains(response, "temba-field-manager")
 
-        # entering preview mode swaps in the temba-field-list component which fetches the fields itself
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the temba-field-list component which fetches the fields itself
+        self.setLegacyUI(False)
 
         response = self.client.get(list_url)
         self.assertContains(response, "temba-field-list")
@@ -310,11 +314,12 @@ class ContactFieldCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.editor)
 
-        # like the preview list page it feeds, the endpoint only exists in preview mode
+        # like the new list page it feeds, the endpoint doesn't exist in legacy mode
+        self.setLegacyUI()
         response = self.client.get(detail_url)
         self.assertEqual(404, response.status_code)
 
-        self.client.cookies["temba-preview"] = "1"
+        self.setLegacyUI(False)
         response = self.client.get(detail_url)
         self.assertEqual(200, response.status_code)
         self.assertEqual(

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1181,13 +1181,13 @@ class ContactFieldCRUDL(SmartCRUDL):
         menu_path = "/contact/fields"
         title = _("Fields")
 
-        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
-        # the list renders the temba-field-list component (contacts/contactfield_list_new.html) instead of the
-        # legacy field manager; the component fetches the fields itself from the API.
+        # By default the list renders the temba-field-list component (contacts/contactfield_list_new.html); the
+        # component fetches the fields itself from the API. Viewers can opt back into the legacy field manager via
+        # legacy mode (LegacyMiddleware → request.legacy).
         NEW_LIST_TEMPLATE = "contacts/contactfield_list_new.html"
 
         def get_template_names(self):
-            if getattr(self.request, "preview", False):
+            if not getattr(self.request, "legacy", False):
                 return [self.NEW_LIST_TEMPLATE]
             return super().get_template_names()
 
@@ -1209,14 +1209,14 @@ class ContactFieldCRUDL(SmartCRUDL):
     class Detail(FieldLookupMixin, OrgPermsMixin, SmartView, View):
         """
         A field's usages and permissions as JSON, consumed by the temba-field-list component's detail modal on
-        the preview list page — so like that page it only exists in preview mode.
+        the new list page — so like that page it doesn't exist in legacy mode.
         """
 
         permission = "contacts.contactfield_read"
         USAGES_LIMIT = 25
 
         def get(self, request, *args, **kwargs):
-            if not getattr(request, "preview", False):
+            if getattr(request, "legacy", False):
                 raise Http404()
 
             field = self.get_object()

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -71,9 +71,9 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
     search_error = None
     search_max_length = ContactGroup.MAX_QUERY_LEN
 
-    # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview, every
-    # contact list view renders the temba-contact-list component (contacts/contact_list_new.html) instead of its
-    # legacy table; the component fetches/pages contacts itself from the internal contacts API.
+    # By default every contact list view renders the temba-contact-list component (contacts/contact_list_new.html);
+    # the component fetches/pages contacts itself from the internal contacts API. Viewers can opt back into the
+    # legacy table via legacy mode (LegacyMiddleware → request.legacy).
     NEW_LIST_TEMPLATE = "contacts/contact_list_new.html"
 
     # Optional subtitle rendered under the title on the new-list view; subclasses override to carry the intro text the
@@ -114,9 +114,9 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
     }
 
     def _use_new_list(self) -> bool:
-        # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered out)
+        # `getattr` defaults to False so a view called via RequestFactory (or if LegacyMiddleware is reordered out)
         # doesn't AttributeError.
-        return getattr(self.request, "preview", False)
+        return not getattr(self.request, "legacy", False)
 
     def get_template_names(self):
         if self._use_new_list():
@@ -189,8 +189,8 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
         return ContactGroup.get_groups(self.request.org, manual_only=True)
 
     def get_queryset(self, **kwargs):
-        # In preview the temba-contact-list component fetches and pages contacts from the internal contacts API, so a
-        # GET page needs no object list — skip the mailroom/DB query entirely. A POST (bulk action) still needs the
+        # On the new list the temba-contact-list component fetches and pages contacts from the internal contacts API,
+        # so a GET page needs no object list — skip the mailroom/DB query entirely. A POST (bulk action) still needs the
         # real queryset, since BulkActionMixin validates the posted `objects` against it.
         if self._use_new_list() and self.request.method == "GET":
             return Contact.objects.none()
@@ -430,7 +430,7 @@ class ContactCRUDL(SmartCRUDL):
         NEW_READ_TEMPLATE = "contacts/contact_read_new.html"
 
         def get_template_names(self):
-            if self.request.preview:
+            if not getattr(self.request, "legacy", False):
                 return [self.NEW_READ_TEMPLATE]
 
             return super().get_template_names()
@@ -628,7 +628,7 @@ class ContactCRUDL(SmartCRUDL):
         menu_path = "/contact/active"
 
         def get_bulk_actions(self):
-            # "label" (the group dropdown) is a preview-list-only action — the legacy table has no UI for it.
+            # "label" (the group dropdown) is a new-list-only action — the legacy table has no UI for it.
             update = ("label", "block", "archive") if self._use_new_list() else ("block", "archive")
             actions = update if self.has_org_perm("contacts.contact_update") else ()
             if self.has_org_perm("msgs.broadcast_create"):

--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -190,6 +190,9 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual([["test"]], list(flow2.triggers.order_by("id").values_list("keywords", flat=True)))
 
     def test_views(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         list_url = reverse("flows.flow_list")
         create_url = reverse("flows.flow_create")
 
@@ -567,6 +570,9 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
     @mock_mailroom
     def test_list_views(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
 
@@ -677,6 +683,9 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, flow1.name)
 
     def test_filter(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
 
@@ -699,7 +708,7 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(f"/flow/labels/{label2.uuid}", response.headers.get(TEMBA_MENU_SELECTION))
 
     @mock_mailroom
-    def test_preview_list(self, mr_mocks):
+    def test_new_list(self, mr_mocks):
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
         label = FlowLabel.create(self.org, self.admin, "Important")
@@ -709,12 +718,13 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.admin)
 
-        # default render is still the legacy table
+        # legacy mode renders the legacy table
+        self.setLegacyUI()
         response = self.client.get(list_url)
         self.assertNotContains(response, "temba-flow-list")
 
-        # entering preview mode swaps in the temba-flow-list component, pointed at the internal flows api
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the temba-flow-list component, pointed at the internal flows api
+        self.setLegacyUI(False)
 
         response = self.client.get(list_url)
         self.assertContains(response, "temba-flow-list")

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -590,9 +590,9 @@ class FlowCRUDL(SmartCRUDL):
         default_order = ("-saved_on",)
         search_fields = ("name__icontains",)
 
-        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
-        # every flow list view renders the temba-flow-list component (flows/flow_list_new.html) instead of its legacy
-        # table; the component fetches/pages flows itself from the internal flows API.
+        # By default every flow list view renders the temba-flow-list component (flows/flow_list_new.html); the
+        # component fetches/pages flows itself from the internal flows API. Viewers can opt back into the legacy
+        # table via legacy mode (LegacyMiddleware → request.legacy).
         NEW_LIST_TEMPLATE = "flows/flow_list_new.html"
 
         # Optional subtitle rendered under the title on the new-list view.
@@ -614,9 +614,9 @@ class FlowCRUDL(SmartCRUDL):
         }
 
         def _use_new_list(self) -> bool:
-            # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered
+            # `getattr` defaults to False so a view called via RequestFactory (or if LegacyMiddleware is reordered
             # out) doesn't AttributeError.
-            return getattr(self.request, "preview", False)
+            return not getattr(self.request, "legacy", False)
 
         def get_template_names(self):
             if self._use_new_list():
@@ -661,8 +661,8 @@ class FlowCRUDL(SmartCRUDL):
             return super().post(request, *args, **kwargs)
 
         def get_queryset(self, **kwargs):
-            # In preview the temba-flow-list component fetches and pages flows from the internal flows API, so a GET
-            # page needs no object list. A POST (bulk action) still needs the real queryset, since BulkActionMixin
+            # On the new list the temba-flow-list component fetches and pages flows from the internal flows API, so
+            # a GET page needs no object list. A POST (bulk action) still needs the real queryset, since BulkActionMixin
             # validates the posted `objects` against it.
             if self._use_new_list() and self.request.method == "GET":
                 return Flow.objects.none()
@@ -1174,7 +1174,7 @@ class FlowCRUDL(SmartCRUDL):
 
             flow_ids = self.request.GET.get("ids")
             if flow_ids:
-                # the legacy list passes ids, the new (preview mode) list component passes uuids
+                # the legacy list passes ids, the new list component passes uuids
                 ids, uuids = [], []
                 for val in flow_ids.split(","):
                     if val.isdigit():
@@ -1852,7 +1852,7 @@ class FlowLabelCRUDL(SmartCRUDL):
         def post_save(self, obj, *args, **kwargs):
             obj = super().post_save(obj, *args, **kwargs)
 
-            # the legacy list seeds this field with ids, the new (preview mode) list component with uuids
+            # the legacy list seeds this field with ids, the new list component with uuids
             if self.form.cleaned_data["flows"]:
                 ids, uuids = [], []
                 for val in self.form.cleaned_data["flows"].split(","):

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -149,9 +149,8 @@ class LegacyMiddleware:
 
     def __call__(self, request):
         toggle = request.GET.get("legacy")
-        # Only evaluate request.user when the toggle is actually present — otherwise reading is_authenticated on
-        # every request would force the lazy user to materialize before OrgMiddleware needs it (and break the
-        # query-count baselines of every list view).
+        # only evaluate request.user when the toggle is actually present to avoid an unnecessary lookup on every
+        # request (OrgMiddleware has already materialized the lazy user by this point)
         authed = toggle in ("1", "0") and request.user.is_authenticated
         if toggle == "1" and authed:
             request.legacy = True
@@ -172,7 +171,7 @@ class LegacyMiddleware:
                     httponly=True,
                     samesite="Lax",
                 )
-            else:
+            elif self.COOKIE in request.COOKIES:
                 response.delete_cookie(self.COOKIE)
         return response
 

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -131,34 +131,34 @@ class LanguageMiddleware:
         return response
 
 
-class PreviewMiddleware:
+class LegacyMiddleware:
     """
-    Exposes a global `preview` flag for opting into features that aren't fully rolled out yet. `?preview=1` opts in
-    (sets a year-long `temba-preview` cookie); `?preview=0` opts out (clears it); anything else falls back to the
-    cookie. The current state is set on `request.preview` so views and templates can gate features off `if
-    request.preview`.
+    Exposes a global `legacy` flag for opting back into the old implementations of sections that have been rebuilt
+    as components. `?legacy=1` opts in (sets a year-long `temba-legacy` cookie); `?legacy=0` opts out (clears it);
+    anything else falls back to the cookie. The current state is set on `request.legacy` so views and templates can
+    gate features off `if request.legacy`.
 
     The write side (cookie set/clear) is gated on `request.user.is_authenticated` so a cross-origin
-    `<img src=".../?preview=1">` can't silently plant the cookie on an unauthenticated victim.
+    `<img src=".../?legacy=1">` can't silently plant the cookie on an unauthenticated victim.
     """
 
-    COOKIE = "temba-preview"
+    COOKIE = "temba-legacy"
 
     def __init__(self, get_response=None):
         self.get_response = get_response
 
     def __call__(self, request):
-        toggle = request.GET.get("preview")
+        toggle = request.GET.get("legacy")
         # Only evaluate request.user when the toggle is actually present — otherwise reading is_authenticated on
         # every request would force the lazy user to materialize before OrgMiddleware needs it (and break the
         # query-count baselines of every list view).
         authed = toggle in ("1", "0") and request.user.is_authenticated
         if toggle == "1" and authed:
-            request.preview = True
+            request.legacy = True
         elif toggle == "0" and authed:
-            request.preview = False
+            request.legacy = False
         else:
-            request.preview = request.COOKIES.get(self.COOKIE) == "1"
+            request.legacy = request.COOKIES.get(self.COOKIE) == "1"
 
         response = self.get_response(request)
 

--- a/temba/msgs/tests/test_broadcastcrudl.py
+++ b/temba/msgs/tests/test_broadcastcrudl.py
@@ -592,6 +592,9 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_list(self):
         list_url = reverse("msgs.broadcast_list")
 
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         self.assertRequestDisallowed(list_url, [None, self.agent])
         self.assertListFetch(list_url, [self.editor, self.admin], context_objects=[])
         self.assertContentMenu(list_url, self.editor, ["New Broadcast"])
@@ -605,9 +608,9 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertListFetch(list_url, [self.admin], context_objects=[broadcast])
 
-        # entering preview mode swaps in the temba-broadcast-list component, pointed at the internal broadcasts api
+        # by default we get the temba-broadcast-list component, pointed at the internal broadcasts api
         self.login(self.admin)
-        self.client.cookies["temba-preview"] = "1"
+        self.setLegacyUI(False)
 
         response = self.client.get(list_url)
         self.assertContains(response, "temba-broadcast-list")
@@ -620,6 +623,9 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
 
     def test_scheduled(self):
         scheduled_url = reverse("msgs.broadcast_scheduled")
+
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
 
         self.assertRequestDisallowed(scheduled_url, [None, self.agent])
         self.assertListFetch(scheduled_url, [self.editor, self.admin], context_objects=[])
@@ -654,9 +660,9 @@ class BroadcastCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertListFetch(scheduled_url, [self.editor], context_objects=[bc2, bc1])
 
-        # entering preview mode swaps in the temba-broadcast-list component in scheduled mode
+        # by default we get the temba-broadcast-list component in scheduled mode
         self.login(self.editor)
-        self.client.cookies["temba-preview"] = "1"
+        self.setLegacyUI(False)
 
         response = self.client.get(scheduled_url)
         self.assertContains(response, "temba-broadcast-list")

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -50,24 +50,25 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         inbox_url = reverse("msgs.msg_inbox")
 
-        # check query count on the legacy list (the default until the viewer enters preview mode)
+        # check query count on the legacy list (viewers opt in via legacy mode)
         self.login(self.admin)
+        self.setLegacyUI()
         with self.assertNumQueries(11):
             self.client.get(inbox_url)
 
-        # the inbox renders the temba-msg-list component when the viewer is in preview mode; the default render is
-        # still the legacy list backed by this view's queryset
+        # the inbox renders the temba-msg-list component by default; in legacy mode it's the legacy list backed by
+        # this view's queryset
         self.assertRequestDisallowed(inbox_url, [None, self.agent])
         response = self.assertListFetch(inbox_url, [self.editor, self.admin], context_objects=[msg4, msg3, msg2, msg1])
-        self.client.cookies["temba-preview"] = "1"
-        preview_response = self.client.get(inbox_url)
-        self.assertContains(preview_response, "temba-msg-list")
+        self.setLegacyUI(False)
+        new_response = self.client.get(inbox_url)
+        self.assertContains(new_response, "temba-msg-list")
 
         # the label bulk action carries the create affordance for viewers who can create labels
-        preview_actions = {a["key"]: a for a in preview_response.context["new_list_bulk_actions"]}
-        self.assertTrue(preview_actions["label"]["allowCreate"])
+        new_actions = {a["key"]: a for a in new_response.context["new_list_bulk_actions"]}
+        self.assertTrue(new_actions["label"]["allowCreate"])
 
-        del self.client.cookies["temba-preview"]
+        self.setLegacyUI()
 
         # check that we have the appropriate bulk actions
         self.assertEqual(("archive", "label"), response.context["actions"])
@@ -126,6 +127,9 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContentMenu(inbox_url, self.admin, ["Send", "New Label", "Export"])
 
     def test_flows(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         flow = self.create_flow("Test")
         contact1 = self.create_contact("Joe Blow", phone="+250788000001")
         msg1 = self.create_incoming_msg(contact1, "test 1", status="H", flow=flow)
@@ -147,6 +151,9 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
     @mock_mailroom
     def test_archived(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         contact1 = self.create_contact("Joe Blow", phone="+250788000001")
         contact2 = self.create_contact("Frank", phone="+250788000002")
         msg1 = self.create_incoming_msg(contact1, "message number 1", visibility=Msg.VISIBILITY_ARCHIVED)
@@ -187,6 +194,9 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual([call(self.org, self.admin, [msg2])], mr_mocks.calls["msg_delete"])
 
     def test_outbox(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         contact1 = self.create_contact("", phone="+250788382382")
         contact2 = self.create_contact("Joe Blow", phone="+250788000001")
         contact3 = self.create_contact("Frank Blow", phone="+250788000002")
@@ -239,6 +249,9 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
             self.assertContains(response, "Your channels are taking a while")
 
     def test_sent(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         contact1 = self.create_contact("Joe Blow", phone="+250788000001")
         contact2 = self.create_contact("Frank Blow", phone="+250788000002")
         msg1 = self.create_outgoing_msg(contact1, "Hi 1", status="W", sent_on=timezone.now() - timedelta(hours=1))
@@ -260,6 +273,9 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
     @mock_mailroom
     def test_failed(self, mr_mocks):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         contact1 = self.create_contact("Joe Blow", phone="+250788000001")
         msg1 = self.create_outgoing_msg(contact1, "message number 1", status="F")
 
@@ -321,6 +337,9 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         label1_url = reverse("msgs.msg_filter", args=[label1.uuid])
         label3_url = reverse("msgs.msg_filter", args=[label3.uuid])
 
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         # can't visit a filter page as a non-org user
         response = self.requestView(label3_url, self.non_org_user)
         self.assertRedirect(response, reverse("orgs.org_choose"))
@@ -345,17 +364,17 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContentMenu(label3_url, self.editor, ["Edit", "Delete", "-", "Export", "Usages"])
         self.assertContentMenu(label1_url, self.admin, ["Edit", "Delete", "-", "Export", "Usages"])
 
-        # in preview mode the filter view renders the new list and exposes a label-scoped endpoint and label-name subtitle
-        self.client.cookies["temba-preview"] = "1"
+        # by default the filter view renders the new list and exposes a label-scoped endpoint and label-name subtitle
+        self.setLegacyUI(False)
         try:
-            preview_response = self.client.get(label1_url)
-            self.assertContains(preview_response, "temba-msg-list")
+            new_response = self.client.get(label1_url)
+            self.assertContains(new_response, "temba-msg-list")
             self.assertEqual(
-                f"/api/internal/messages.json?label={label1.uuid}", preview_response.context["new_list_endpoint"]
+                f"/api/internal/messages.json?label={label1.uuid}", new_response.context["new_list_endpoint"]
             )
-            self.assertIn("label1", preview_response.context["new_list_subtitle"])
+            self.assertIn("label1", new_response.context["new_list_subtitle"])
         finally:
-            del self.client.cookies["temba-preview"]
+            self.setLegacyUI()
 
     def test_export(self):
         export_url = reverse("msgs.msg_export")

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -65,8 +65,8 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     folder = None
     paginate_by = 100
 
-    # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview, every
-    # MsgListView subclass with a folder/label renders msgs/msg_list_new.html instead of its legacy template.
+    # By default every MsgListView subclass with a folder/label renders msgs/msg_list_new.html. Viewers can opt
+    # back into the legacy template via legacy mode (LegacyMiddleware → request.legacy).
     NEW_LIST_TEMPLATE = "msgs/msg_list_new.html"
 
     # Optional subtitle rendered under the title on the new-list view;
@@ -94,9 +94,9 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
     def _use_new_list(self) -> bool:
         # The folder for a message list is either one of the built-in MsgFolder enum values (Inbox / Handled / …) or
         # a user-defined Label (the filter view binds it in derive_folder); both render through the same new-list
-        # template when the viewer is in preview mode. `getattr` defaults to False so a view called via RequestFactory
-        # (or if PreviewMiddleware is ever reordered out) doesn't AttributeError.
-        return getattr(self.request, "preview", False) and isinstance(self.derive_folder(), (MsgFolder, Label))
+        # template unless the viewer is in legacy mode. `getattr` defaults to False so a view called via
+        # RequestFactory (or if LegacyMiddleware is ever reordered out) doesn't AttributeError.
+        return not getattr(self.request, "legacy", False) and isinstance(self.derive_folder(), (MsgFolder, Label))
 
     def get_template_names(self):
         if self._use_new_list():
@@ -242,18 +242,18 @@ class BroadcastCRUDL(SmartCRUDL):
 
         paginate_by = 25
 
-        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
-        # both broadcast list views render the temba-broadcast-list component (msgs/broadcast_list_new.html) instead
-        # of their legacy card grids; the component fetches/pages broadcasts itself from the internal broadcasts API.
+        # By default both broadcast list views render the temba-broadcast-list component
+        # (msgs/broadcast_list_new.html); the component fetches/pages broadcasts itself from the internal broadcasts
+        # API. Viewers can opt back into the legacy card grids via legacy mode (LegacyMiddleware → request.legacy).
         NEW_LIST_TEMPLATE = "msgs/broadcast_list_new.html"
 
         # The internal-API folder (and the component's `mode`) this view lists — `sent` or `scheduled`.
         new_list_folder = "sent"
 
         def _use_new_list(self) -> bool:
-            # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered
+            # `getattr` defaults to False so a view called via RequestFactory (or if LegacyMiddleware is reordered
             # out) doesn't AttributeError.
-            return getattr(self.request, "preview", False)
+            return not getattr(self.request, "legacy", False)
 
         def get_template_names(self):
             if self._use_new_list():
@@ -267,7 +267,7 @@ class BroadcastCRUDL(SmartCRUDL):
             return super().get_paginate_by(queryset)
 
         def get_queryset(self, **kwargs):
-            # In preview the temba-broadcast-list component fetches and pages broadcasts from the internal
+            # On the new list the temba-broadcast-list component fetches and pages broadcasts from the internal
             # broadcasts API, so a GET page needs no object list.
             if self._use_new_list() and self.request.method == "GET":
                 return Broadcast.objects.none()

--- a/temba/orgs/tests/test_org.py
+++ b/temba/orgs/tests/test_org.py
@@ -862,8 +862,8 @@ class AnonOrgTest(TembaTest):
         self.assertNotContains(response, "788 123 123")
         self.assertContains(response, contact.ref)
 
-        # create an incoming message - by default (preview off) the inbox renders the legacy template which prints
-        # the contact via name_or_urn, so URN masking still needs coverage on that path. In preview mode the temba-msg-list
+        # create an incoming message - in legacy mode the inbox renders the legacy template which prints the
+        # contact via name_or_urn, so URN masking still needs coverage on that path. By default the temba-msg-list
         # component fetches messages from the internal API (separately covered in temba/api/internal/tests.py).
         msg2 = self.create_incoming_msg(contact, "ok")
 

--- a/temba/orgs/tests/test_org.py
+++ b/temba/orgs/tests/test_org.py
@@ -838,6 +838,9 @@ class AnonOrgTest(TembaTest):
         self.org.save()
 
     def test_contacts(self):
+        # opt into legacy mode as only the legacy lists render contacts server-side
+        self.setLegacyUI()
+
         # are there real phone numbers on the contact list page?
         contact = self.create_contact(None, phone="+250788123123")
         self.login(self.admin)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -205,7 +205,7 @@ MIDDLEWARE = (
     "temba.middleware.LanguageMiddleware",
     "temba.middleware.TimezoneMiddleware",
     "temba.middleware.ToastMiddleware",
-    "temba.middleware.PreviewMiddleware",
+    "temba.middleware.LegacyMiddleware",
     "allauth.account.middleware.AccountMiddleware",
 )
 

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -150,7 +150,9 @@ class TembaTest(SmartminTest):
     def setLegacyUI(self, legacy: bool = True):
         """
         Opts the test client in or out of legacy UI mode (LegacyMiddleware reads the temba-legacy cookie). The
-        cookie is re-applied by CRUDLTestMixin.requestView since Client.logout() clears all cookies.
+        cookie is re-applied by CRUDLTestMixin.requestView since Client.logout() clears all cookies. Note that this
+        deliberately writes the cookie directly, bypassing the middleware's authed write gate — that gate itself is
+        covered by MiddlewareTest.test_legacy.
         """
         self._legacy_ui = legacy
         if legacy:

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -147,6 +147,17 @@ class TembaTest(SmartminTest):
         self.org.root_location = self.country
         self.org.save(update_fields=("root_location",))
 
+    def setLegacyUI(self, legacy: bool = True):
+        """
+        Opts the test client in or out of legacy UI mode (LegacyMiddleware reads the temba-legacy cookie). The
+        cookie is re-applied by CRUDLTestMixin.requestView since Client.logout() clears all cookies.
+        """
+        self._legacy_ui = legacy
+        if legacy:
+            self.client.cookies["temba-legacy"] = "1"
+        elif "temba-legacy" in self.client.cookies:
+            del self.client.cookies["temba-legacy"]
+
     def login(self, user, *, choose_org=None):
         self.assertTrue(
             self.client.login(username=user.email, password=self.default_password),

--- a/temba/tests/crudl.py
+++ b/temba/tests/crudl.py
@@ -19,6 +19,11 @@ class CRUDLTestMixin:
         pre_msg_prefix = f"before {msg_prefix}"
 
         self.client.logout()
+
+        # logout() clears all cookies, so re-apply legacy UI mode if the test opted in via setLegacyUI
+        if getattr(self, "_legacy_ui", False):
+            self.client.cookies["temba-legacy"] = "1"
+
         if user:
             self.login(user, choose_org=choose_org)
 

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -28,19 +28,20 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.support_only = Team.create(self.org, self.admin, "Support", topics=[self.support])
         self.org.add_user(self.agent3, OrgRole.AGENT, team=self.support_only)
 
-    def test_preview_list(self):
+    def test_new_list(self):
         list_url = reverse("tickets.ticket_list")
 
         self.login(self.admin)
 
-        # default render is still the tabbed layout
+        # legacy mode renders the tabbed layout
+        self.setLegacyUI()
+
         response = self.client.get(list_url)
         self.assertContains(response, "temba-tabs")
         self.assertNotContains(response, "temba-card-layout")
 
-        # entering preview mode swaps in the chat + card layout, sharing the
-        # contact card settings
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the chat + card layout, sharing the contact card settings
+        self.setLegacyUI(False)
 
         self.admin.settings = {"contact_cards": {"order": ["card-notepad", "card-fields"], "collapsed": []}}
         self.admin.save(update_fields=("settings",))
@@ -52,8 +53,6 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(
             '{"order": ["card-notepad", "card-fields"], "collapsed": []}', response.context["card_settings"]
         )
-
-        del self.client.cookies["temba-preview"]
 
     def test_list(self):
         list_url = reverse("tickets.ticket_list")

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -279,7 +279,7 @@ class TicketCRUDL(SmartCRUDL):
         NEW_LIST_TEMPLATE = "tickets/ticket_list_new.html"
 
         def get_template_names(self):
-            if self.request.preview:
+            if not getattr(self.request, "legacy", False):
                 return [self.NEW_LIST_TEMPLATE]
 
             return super().get_template_names()

--- a/temba/triggers/tests/test_triggercrudl.py
+++ b/temba/triggers/tests/test_triggercrudl.py
@@ -1033,6 +1033,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
     def test_list(self, mock_activate_trigger, mock_deactivate_trigger):
         list_url = reverse("triggers.trigger_list")
 
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         flow1 = self.create_flow("Report")
         flow2 = self.create_flow("Survey")
         flow3 = self.create_flow("Test", org=self.org2)
@@ -1114,7 +1117,7 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(response.status_code, 302)
         self.assertRedirect(response, reverse("triggers.trigger_create"))
 
-    def test_preview_list(self):
+    def test_new_list(self):
         flow = self.create_flow("Test")
         trigger1 = Trigger.create(
             self.org, self.admin, Trigger.TYPE_KEYWORD, flow, keywords=["start"], match_type=Trigger.MATCH_ONLY_WORD
@@ -1133,12 +1136,13 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.login(self.admin)
 
-        # default render is still the legacy table
+        # legacy mode renders the legacy table
+        self.setLegacyUI()
         response = self.client.get(list_url)
         self.assertNotContains(response, "temba-trigger-list")
 
-        # entering preview mode swaps in the temba-trigger-list component, pointed at the internal triggers api
-        self.client.cookies["temba-preview"] = "1"
+        # by default we get the temba-trigger-list component, pointed at the internal triggers api
+        self.setLegacyUI(False)
 
         response = self.client.get(list_url)
         self.assertContains(response, "temba-trigger-list")
@@ -1176,6 +1180,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertFalse(trigger2.is_archived)
 
     def test_archived(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         flow = self.create_flow("Test")
         other_org_flow = self.create_flow("Test", org=self.org2)
 
@@ -1395,6 +1402,9 @@ class TriggerCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertContains(response, trigger7.keywords[0])
 
     def test_folder(self):
+        # opt into legacy mode to test the legacy list rendering
+        self.setLegacyUI()
+
         flow1 = self.create_flow("Flow 1")
         flow2 = self.create_flow("Flow 2")
         flow3 = self.create_flow("Flow 3", org=self.org2)

--- a/temba/triggers/views.py
+++ b/temba/triggers/views.py
@@ -431,9 +431,9 @@ class TriggerCRUDL(SmartCRUDL):
         default_template = "triggers/trigger_list.html"
         search_fields = ("keywords__icontains", "flow__name__icontains", "channel__name__icontains")
 
-        # Gated behind global preview mode (PreviewMiddleware → request.preview). When the viewer is in preview,
-        # every trigger list view renders the temba-trigger-list component (triggers/trigger_list_new.html) instead
-        # of its legacy table; the component fetches/pages triggers itself from the internal triggers API.
+        # By default every trigger list view renders the temba-trigger-list component
+        # (triggers/trigger_list_new.html); the component fetches/pages triggers itself from the internal triggers
+        # API. Viewers can opt back into the legacy table via legacy mode (LegacyMiddleware → request.legacy).
         NEW_LIST_TEMPLATE = "triggers/trigger_list_new.html"
 
         # Optional subtitle rendered under the title on the new-list view.
@@ -453,9 +453,9 @@ class TriggerCRUDL(SmartCRUDL):
         }
 
         def _use_new_list(self) -> bool:
-            # `getattr` defaults to False so a view called via RequestFactory (or if PreviewMiddleware is reordered
+            # `getattr` defaults to False so a view called via RequestFactory (or if LegacyMiddleware is reordered
             # out) doesn't AttributeError.
-            return getattr(self.request, "preview", False)
+            return not getattr(self.request, "legacy", False)
 
         def get_template_names(self):
             if self._use_new_list():
@@ -488,8 +488,8 @@ class TriggerCRUDL(SmartCRUDL):
             )
 
         def get_queryset(self, *args, **kwargs):
-            # In preview the temba-trigger-list component fetches and pages triggers from the internal triggers API,
-            # so a GET page needs no object list. A POST (bulk action) still needs the real queryset, since
+            # On the new list the temba-trigger-list component fetches and pages triggers from the internal triggers
+            # API, so a GET page needs no object list. A POST (bulk action) still needs the real queryset, since
             # BulkActionMixin validates the posted `objects` against it.
             if self._use_new_list() and self.request.method == "GET":
                 return Trigger.objects.none()

--- a/temba/users/tests/test_auth.py
+++ b/temba/users/tests/test_auth.py
@@ -134,7 +134,7 @@ class UserAuthTest(TembaTest):
 
         # should get signed up, logged in and redirected to inbox
         self.assertNotContains(response, "Sign Up Closed")
-        self.assertContains(response, "Your Message Hub")
+        self.assertContains(response, "temba-msg-list")
 
         # make sure we didn't honor the tampered email
         self.assertFalse(User.objects.filter(email="bobbyburgers@burgers.com").exists())

--- a/temba/utils/tests/test_middleware.py
+++ b/temba/utils/tests/test_middleware.py
@@ -76,39 +76,39 @@ class MiddlewareTest(TembaTest):
         with override_brand(redirect="/redirect"):
             self.assertRedirect(self.client.get(reverse("public.public_index")), "/redirect")
 
-    def test_preview(self):
+    def test_legacy(self):
         index_url = reverse("public.public_index")
 
-        # an unauthenticated request can't toggle the cookie — blocks cross-origin <img src=".../?preview=1"> planting
-        response = self.client.get(index_url + "?preview=1")
-        self.assertNotIn("temba-preview", response.cookies)
-        self.assertFalse(response.wsgi_request.preview)
+        # an unauthenticated request can't toggle the cookie — blocks cross-origin <img src=".../?legacy=1"> planting
+        response = self.client.get(index_url + "?legacy=1")
+        self.assertNotIn("temba-legacy", response.cookies)
+        self.assertFalse(response.wsgi_request.legacy)
 
         self.login(self.admin)
 
-        # ?preview=1 opts in and sets the year-long hardened cookie, with request.preview set on the same request
-        response = self.client.get(index_url + "?preview=1")
-        cookie = response.cookies["temba-preview"]
+        # ?legacy=1 opts in and sets the year-long hardened cookie, with request.legacy set on the same request
+        response = self.client.get(index_url + "?legacy=1")
+        cookie = response.cookies["temba-legacy"]
         self.assertEqual("1", cookie.value)
         self.assertEqual(365 * 24 * 60 * 60, cookie["max-age"])
         self.assertEqual("Lax", cookie["samesite"])
         self.assertTrue(cookie["httponly"])
-        self.assertTrue(response.wsgi_request.preview)
+        self.assertTrue(response.wsgi_request.legacy)
 
         # subsequent request without the toggle reads the cookie back
         response = self.client.get(index_url)
-        self.assertTrue(response.wsgi_request.preview)
-        self.assertNotIn("temba-preview", response.cookies)
+        self.assertTrue(response.wsgi_request.legacy)
+        self.assertNotIn("temba-legacy", response.cookies)
 
         # unrecognized values don't toggle and fall back to the cookie
-        response = self.client.get(index_url + "?preview=on")
-        self.assertTrue(response.wsgi_request.preview)
-        self.assertNotIn("temba-preview", response.cookies)
+        response = self.client.get(index_url + "?legacy=on")
+        self.assertTrue(response.wsgi_request.legacy)
+        self.assertNotIn("temba-legacy", response.cookies)
 
-        # ?preview=0 opts out and clears the cookie
-        response = self.client.get(index_url + "?preview=0")
-        self.assertEqual("", response.cookies["temba-preview"].value)
-        self.assertFalse(response.wsgi_request.preview)
+        # ?legacy=0 opts out and clears the cookie
+        response = self.client.get(index_url + "?legacy=0")
+        self.assertEqual("", response.cookies["temba-legacy"].value)
+        self.assertFalse(response.wsgi_request.legacy)
 
     def test_language(self):
         def assert_text(text: str):

--- a/temba/utils/tests/test_middleware.py
+++ b/temba/utils/tests/test_middleware.py
@@ -110,6 +110,12 @@ class MiddlewareTest(TembaTest):
         self.assertEqual("", response.cookies["temba-legacy"].value)
         self.assertFalse(response.wsgi_request.legacy)
 
+        # ?legacy=0 with no cookie set doesn't emit a pointless Set-Cookie header
+        del self.client.cookies["temba-legacy"]
+        response = self.client.get(index_url + "?legacy=0")
+        self.assertNotIn("temba-legacy", response.cookies)
+        self.assertFalse(response.wsgi_request.legacy)
+
     def test_language(self):
         def assert_text(text: str):
             self.assertContains(self.client.get(settings.LOGIN_URL, follow=True), text)

--- a/templates/campaigns/campaign_list_new.html
+++ b/templates/campaigns/campaign_list_new.html
@@ -3,8 +3,8 @@
 
 {% comment %}
   Generic new-list template used by the campaign list views (Active /
-  Archived) when the viewer is in preview mode (request.preview, set
-  by PreviewMiddleware off the temba-preview cookie). Endpoint,
+  Archived) unless the viewer is in legacy mode (request.legacy, set
+  by LegacyMiddleware off the temba-legacy cookie). Endpoint,
   subtitle and bulk actions come from the view's context_data so the
   template stays the same across both.
 {% endcomment %}

--- a/templates/campaigns/campaign_read_new.html
+++ b/templates/campaigns/campaign_read_new.html
@@ -2,8 +2,8 @@
 {% load i18n %}
 
 {% comment %}
-  New-style campaign read page rendered when the viewer is in preview
-  mode (request.preview, set by PreviewMiddleware off the temba-preview
+  New-style campaign read page rendered unless the viewer is in legacy
+  mode (request.legacy, set by LegacyMiddleware off the temba-legacy
   cookie). The temba-campaign-events component renders the same page
   header as the new list views (title + content menu), a badges row
   (group, archived), then the campaign's event schedule — one subway

--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -3,8 +3,8 @@
 
 {% comment %}
   Generic new-list template used by every contact list view (Active /
-  Blocked / Stopped / Archived / Group) when the viewer is in preview
-  mode (request.preview, set by PreviewMiddleware off the temba-preview
+  Blocked / Stopped / Archived / Group) unless the viewer is in legacy
+  mode (request.legacy, set by LegacyMiddleware off the temba-legacy
   cookie). Endpoint, subtitle and bulk actions come from the view's
   context_data so the template stays the same across all of them.
 {% endcomment %}

--- a/templates/contacts/contact_read_new.html
+++ b/templates/contacts/contact_read_new.html
@@ -2,8 +2,9 @@
 {% load i18n humanize smartmin sms contacts temba %}
 
 {% comment %}
-  Preview-mode contact read page (request.preview, set by PreviewMiddleware
-  off the temba-preview cookie). Chat is the main view with the other panels
+  Default contact read page (rendered unless the viewer opts into legacy
+  mode via request.legacy, set by LegacyMiddleware off the temba-legacy
+  cookie). Chat is the main view with the other panels
   as collapsible, drag-sortable cards in a right column. Card order and
   collapsed state persist per user in User.settings under "contact_cards".
 {% endcomment %}

--- a/templates/contacts/contactfield_list_new.html
+++ b/templates/contacts/contactfield_list_new.html
@@ -2,8 +2,8 @@
 {% load i18n %}
 
 {% comment %}
-  New-style contact fields list rendered when the viewer is in preview
-  mode (request.preview, set by PreviewMiddleware off the temba-preview
+  New-style contact fields list rendered unless the viewer is in legacy
+  mode (request.legacy, set by LegacyMiddleware off the temba-legacy
   cookie). The temba-field-list component renders the same page header
   as the new list views (title + content menu), then the fields as two
   cards — Featured (drag to order, drag out to un-feature) and Other

--- a/templates/flows/flow_list_new.html
+++ b/templates/flows/flow_list_new.html
@@ -3,8 +3,8 @@
 
 {% comment %}
   Generic new-list template used by every flow list view (Active /
-  Archived / label Filter) when the viewer is in preview mode
-  (request.preview, set by PreviewMiddleware off the temba-preview
+  Archived / label Filter) unless the viewer is in legacy mode
+  (request.legacy, set by LegacyMiddleware off the temba-legacy
   cookie). Endpoint, subtitle and bulk actions come from the view's
   context_data so the template stays the same across all of them.
 {% endcomment %}

--- a/templates/includes/page_header_menu.html
+++ b/templates/includes/page_header_menu.html
@@ -1,6 +1,6 @@
 {% comment %}
   Menu dispatch for pages whose content menu lives in a temba-page-header
-  (the preview-mode chat + cards pages). Same contract and function names
+  (the chat + cards pages). Same contract and function names
   as spa_page_menu.html, so handlers written against either work.
 {% endcomment %}
 <script type="text/javascript">

--- a/templates/msgs/broadcast_list_new.html
+++ b/templates/msgs/broadcast_list_new.html
@@ -4,8 +4,8 @@
 {% comment %}
   New-list template shared by both broadcast list views — the sent list
   (msgs.broadcast_list) and the scheduled list (msgs.broadcast_scheduled)
-  — when the viewer is in preview mode (request.preview, set by
-  PreviewMiddleware off the temba-preview cookie). The endpoint and the
+  — unless the viewer is in legacy mode (request.legacy, set by
+  LegacyMiddleware off the temba-legacy cookie). The endpoint and the
   component's mode come from the view's context_data. In place of a
   broadcast read page, the component opens a floating detail dialog per
   row; on the scheduled list its Edit / Delete actions fire

--- a/templates/msgs/msg_list_new.html
+++ b/templates/msgs/msg_list_new.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 
 {% comment %}
-  Generic new-list template used by every MsgListView subclass when
-  the viewer is in preview mode (request.preview, set by
-  PreviewMiddleware off the temba-preview cookie). Endpoint, subtitle
+  Generic new-list template used by every MsgListView subclass unless
+  the viewer is in legacy mode (request.legacy, set by
+  LegacyMiddleware off the temba-legacy cookie). Endpoint, subtitle
   and bulk actions come from the view's context_data so the template
   stays the same across Inbox / Flow / Archived / Outbox / Sent /
   Failed and the per-label Filter view.

--- a/templates/tickets/ticket_list_new.html
+++ b/templates/tickets/ticket_list_new.html
@@ -2,8 +2,9 @@
 {% load smartmin i18n contacts %}
 
 {% comment %}
-  Preview-mode ticket page (request.preview, set by PreviewMiddleware off
-  the temba-preview cookie). The chat pane uses the same chat + card layout
+  Default ticket page (rendered unless the viewer opts into legacy mode
+  via request.legacy, set by LegacyMiddleware off the temba-legacy
+  cookie). The chat pane uses the same chat + card layout
   as the contact read page, sharing card order / collapsed state via
   User.settings "contact_cards" — temba-card-layout loads and persists that
   state itself via its settings/settings-endpoint attributes.

--- a/templates/triggers/trigger_list_new.html
+++ b/templates/triggers/trigger_list_new.html
@@ -3,8 +3,8 @@
 
 {% comment %}
   Generic new-list template used by every trigger list view (Active /
-  Archived / type Folder) when the viewer is in preview mode
-  (request.preview, set by PreviewMiddleware off the temba-preview
+  Archived / type Folder) unless the viewer is in legacy mode
+  (request.legacy, set by LegacyMiddleware off the temba-legacy
   cookie). Endpoint, subtitle and bulk actions come from the view's
   context_data so the template stays the same across all of them.
 {% endcomment %}


### PR DESCRIPTION
## Summary

Makes the component-based UI ("preview mode") the default everywhere, and replaces the preview opt-in with a legacy opt-out: `PreviewMiddleware` / the `temba-preview` cookie become `LegacyMiddleware` / a `temba-legacy` cookie, exposed to views and templates as `request.legacy`.

## Changes

**Middleware** (`temba/middleware.py`, `settings_common.py`)
* `LegacyMiddleware` replaces `PreviewMiddleware`: `?legacy=1` sets a year-long `temba-legacy` cookie, `?legacy=0` clears it, anything else falls back to the cookie.
* Cookie writes remain gated on `request.user.is_authenticated` so a cross-origin `<img src=".../?legacy=1">` can't plant the cookie on an unauthenticated victim.
* `delete_cookie` on `?legacy=0` now only fires when the cookie is actually present, so bookmarked/bot-hit URLs don't emit pointless `Set-Cookie` headers.

**View gates flipped** — every `request.preview` check became `not request.legacy`, so the new components render by default and `?legacy=1` restores the old implementation:
* contact lists, contact read, and the contact fields list (including its `detail` JSON endpoint)
* message lists and broadcast lists
* trigger lists
* flow lists
* campaign lists, campaign read, and its `events` / `fires` JSON endpoints (these now 404 only in legacy mode); the campaign event edit modal returns to the campaign read page by default
* ticket list

**Templates** — header comments in the `*_new.html` templates updated to describe the new default rather than preview mode.

## Behavior

| Request | Before | After |
|---|---|---|
| No cookie | legacy UI | new component UI |
| `?preview=1` / `temba-preview` cookie | new component UI | no effect (cookie ignored) |
| `?legacy=1` / `temba-legacy` cookie | n/a | legacy UI |
| campaign `events`/`fires`, field `detail` endpoints | 404 unless in preview | 404 only in legacy mode |

Users who previously opted into preview will just get the same UI by default; their stale `temba-preview` cookie is ignored.

## Tests

* Added `TembaTest.setLegacyUI()` — `requestView()` calls `client.logout()` which clears all cookies, so the helper marks the test client as legacy and `requestView` re-applies the cookie. It deliberately bypasses the middleware's authed write gate, which is itself covered by `MiddlewareTest.test_legacy`.
* Tests that exercise legacy rendering (server-rendered object lists, query counts, anon URN masking, legacy empty states, field limit banner) opt in via `setLegacyUI()`; the former `test_preview_*` tests became `test_new_*` and assert the components render by default.
* `MiddlewareTest.test_legacy` covers the toggle, cookie hardening, unauthenticated write protection, and the no-op `?legacy=0` case.

## Test plan

- [x] Full suite (1063 tests) green locally and on CI
- [x] `code_check.py` (ruff format, ruff, migrations, djlint) clean