### PR TITLE
Hydrate temba-store with org and user uuids for realtime channels

### DIFF
--- a/temba/orgs/tests/test_org.py
+++ b/temba/orgs/tests/test_org.py
@@ -194,6 +194,14 @@ class OrgTest(TembaTest):
             response = self.client.get(settings_url)
             self.assertNotContains(response, "Rwanda")
 
+    def test_frame_realtime_context(self):
+        self.login(self.admin)
+
+        # the frame hydrates the store with the uuids needed to address user-scoped realtime channels
+        response = self.client.get(reverse("msgs.msg_inbox"))
+        self.assertContains(response, f'org="{self.org.uuid}"')
+        self.assertContains(response, f'user="{self.admin.uuid}"')
+
     def test_default_country(self):
         # if root location boundary is set and name is valid country, that has priority
         self.org.root_location = AdminBoundary.create(osm_id="171496", name="Ecuador", level=0)

--- a/temba/orgs/tests/test_org.py
+++ b/temba/orgs/tests/test_org.py
@@ -202,6 +202,11 @@ class OrgTest(TembaTest):
         self.assertContains(response, f'org="{self.org.uuid}"')
         self.assertContains(response, f'user="{self.admin.uuid}"')
 
+        # including on frame renders without the SPA mixin's context
+        response = self.client.get(reverse("orgs.org_switch"))
+        self.assertContains(response, f'org="{self.org.uuid}"')
+        self.assertContains(response, f'user="{self.admin.uuid}"')
+
     def test_default_country(self):
         # if root location boundary is set and name is valid country, that has priority
         self.org.root_location = AdminBoundary.create(osm_id="171496", name="Ecuador", level=0)

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -180,7 +180,7 @@
                      workspace="/api/v2/workspace.json"
                      shortcuts="/api/internal/shortcuts.json"
                      users="/api/v2/users.json"
-                     org="{{ active_org.uuid }}"
+                     org="{{ user_org.uuid }}"
                      user="{{ request.user.uuid }}"
                      brand="{{ branding.name }}">
         </temba-store>

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -180,6 +180,8 @@
                      workspace="/api/v2/workspace.json"
                      shortcuts="/api/internal/shortcuts.json"
                      users="/api/v2/users.json"
+                     org="{{ active_org.uuid }}"
+                     user="{{ request.user.uuid }}"
                      brand="{{ branding.name }}">
         </temba-store>
       {% else %}


### PR DESCRIPTION
## Summary

Adds `org` and `user` uuid attributes to the `<temba-store>` element in the frame template so temba-components can address the user-scoped realtime notifications channel (`notifications:<org-uuid>:<user-uuid>`). Companion to nyaruka/temba-components#1063 (nyaruka/temba-components#1057), which consumes notifications over the socket instead of polling.

## Changes

- `templates/frame.html`: hydrate `org="{{ user_org.uuid }}" user="{{ request.user.uuid }}"` on `<temba-store>` in the logged-in branch. The logged-out branch intentionally gets neither, which leaves realtime subscriptions dormant.
- `temba/orgs/tests/test_org.py`: new `test_frame_realtime_context` asserting both attributes render on an SPA page and on a `NoNavMixin` frame render.

## Review notes

- Pre-PR review caught that the block is gated on `user_org` but originally read `active_org.uuid`, which is only set by `SpaMixin` — non-SPA frame renders (e.g. org switch) would have rendered an empty `org`. Switched to `user_org.uuid` (same value on SPA paths) and added test coverage for the non-SPA render.

## Test plan

- [x] `test_frame_realtime_context` passes (SPA and non-SPA renders)
- [x] Verified against a dev stack that the components library resolves the channel from these attributes and receives publications