### PR TITLE
Pass user UUID to contact chat for typing indicators

### DIFF
--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -13,6 +13,7 @@
               class="flex-grow -mt-2">
     <temba-tab icon="message" name="{{ _("Chat") |escapejs }}">
       <temba-contact-chat contact="{{ object.uuid }}"
+                          user="{{ request.user.uuid }}"
                           monitor="true"
                           avatar="{{ branding.logos.avatar }}"
                           {% if object.last_seen_on %}showSearch{% endif %}

--- a/templates/contacts/contact_read_new.html
+++ b/templates/contacts/contact_read_new.html
@@ -64,6 +64,7 @@
                        settings="{{ card_settings }}">
       <temba-contact-chat slot="main"
                           contact="{{ object.uuid }}"
+                          user="{{ request.user.uuid }}"
                           monitor="true"
                           avatar="{{ branding.logos.avatar }}"
                           {% if object.last_seen_on %}showSearch{% endif %}

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -674,6 +674,7 @@
                     class="flex-grow hidden">
           <temba-tab icon="message" name="{{ _("Chat") |escapejs }}">
             <temba-contact-chat agent="{{ request.user.email }}"
+                                user="{{ request.user.uuid }}"
                                 style="opacity: 0"
                                 monitor="true"
                                 -temba-ticket-updated="handleTicketUpdated"

--- a/templates/tickets/ticket_list_new.html
+++ b/templates/tickets/ticket_list_new.html
@@ -757,6 +757,7 @@
                            class="hidden">
           <temba-contact-chat slot="main"
                               agent="{{ request.user.email }}"
+                              user="{{ request.user.uuid }}"
                               style="opacity: 0"
                               monitor="true"
                               -temba-ticket-updated="handleTicketUpdated"


### PR DESCRIPTION
## Summary

Passes the logged-in user's UUID to `<temba-contact-chat>` as a `user` attribute in the templates that embed it. The upcoming temba-components release renders live typing indicators from socket typing events, and uses this attribute to filter out echoes of the user's own typing publications so agents don't see their own indicator.

## Changes

- `templates/tickets/ticket_list.html`, `templates/tickets/ticket_list_new.html`, `templates/contacts/contact_read.html`, `templates/contacts/contact_read_new.html`: add `user="{{ request.user.uuid }}"` to the `<temba-contact-chat>` element.

The attribute is inert with current temba-components, so this can merge independently of the components release.

## Review notes

Reviewed alongside the components change in a two-cycle pre-PR review; no findings against these templates.

## Test plan

- [x] Covered by temba-components tests: typing events whose `_user.uuid` matches the `user` attribute are ignored, others render an indicator