### PR TITLE
Show contact refs instead of masked URNs in new contact list for anon orgs

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -281,7 +281,8 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         self.assertGet(endpoint_url + f"?group={group.uuid}", [self.admin], raw=check_groups)
 
-        # each row carries the columns the component renders: name, primary urn, featured field values, last seen
+        # each row carries the columns the component renders: name, primary urn (as scheme + display), featured field
+        # values, last seen; the ref is an anon-only key
         def check_shape(data):
             first = data["results"][0]
             return (
@@ -289,15 +290,18 @@ class EndpointsTest(APITestMixin, TembaTest):
                 and first["name"] == "Frank"
                 and first["fields"]["gender"] == "female"
                 and "last_seen_on" in first
-                and bool(first["urn"])
+                and first["urn"] == {"scheme": "tel", "display": "1234567002"}
+                and "ref" not in first
             )
 
         self.assertGet(endpoint_url, [self.admin], raw=check_shape)
 
-        # anon orgs get the contact ref as the displayed urn (a masked urn is useless in a list)
+        # anon orgs get the contact ref as its own key, and a masked urn display
         with self.anonymous(self.org):
             response = self.assertGet(endpoint_url, [self.admin], results=[frank, joe])
-            self.assertEqual(frank.ref, response.json()["results"][0]["urn"])
+            first = response.json()["results"][0]
+            self.assertEqual(frank.ref, first["ref"])
+            self.assertEqual({"scheme": "tel", "display": "********"}, first["urn"])
 
         # searching goes through mailroom (ES), which returns the ordered window plus a total
         mr_mocks.contact_search("gender = male", contacts=[joe], total=1)

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -294,6 +294,11 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         self.assertGet(endpoint_url, [self.admin], raw=check_shape)
 
+        # anon orgs get the contact ref as the displayed urn (a masked urn is useless in a list)
+        with self.anonymous(self.org):
+            response = self.assertGet(endpoint_url, [self.admin], results=[frank, joe])
+            self.assertEqual(frank.ref, response.json()["results"][0]["urn"])
+
         # searching goes through mailroom (ES), which returns the ordered window plus a total
         mr_mocks.contact_search("gender = male", contacts=[joe], total=1)
         self.assertGet(endpoint_url + "?search=gender+%3D+male", [self.admin], results=[joe])

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -981,19 +981,25 @@ class Contact(LegacyUUIDMixin, SmartModel):
         # pre-check the group dropdown against each row's current membership.
         groups = self.prefetched_groups if hasattr(self, "prefetched_groups") else self.get_groups()
 
-        return {
+        data = {
             "uuid": str(self.uuid),
             "name": self.name,
             "status": statuses.get(self.status),
-            # Pre-formatted primary URN for display (the component shows `urn` verbatim); anon orgs get the contact
-            # ref since a masked URN is useless in a list.
-            "urn": self.ref if org.is_anon else (urn.get_display(org=org, international=True) if urn else ""),
+            # Primary URN as scheme + pre-formatted display (masked by get_display for anon orgs); structured so the
+            # component can render the scheme if it wants to.
+            "urn": {"scheme": urn.scheme, "display": urn.get_display(org=org, international=True)} if urn else None,
             "urns": [serialize_urn(org, u) for u in self.get_urns()],
             "fields": {f.key: self.get_field_serialized(f) for f in fields},
             "groups": [{"uuid": str(g.uuid), "name": g.name} for g in groups],
             "last_seen_on": self.last_seen_on.isoformat() if self.last_seen_on else None,
             "created_on": self.created_on.isoformat() if self.created_on else None,
         }
+
+        # as in the public API, the ref is only exposed on anon orgs, where it stands in for the masked URNs
+        if org.is_anon:
+            data["ref"] = self.ref
+
+        return data
 
     def update(self, name: str, language: str) -> list[modifiers.Modifier]:
         """

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -985,9 +985,9 @@ class Contact(LegacyUUIDMixin, SmartModel):
             "uuid": str(self.uuid),
             "name": self.name,
             "status": statuses.get(self.status),
-            # Pre-formatted primary URN for display (the component shows `urn` verbatim); anon orgs are masked by
-            # get_display.
-            "urn": urn.get_display(org=org, international=True) if urn else "",
+            # Pre-formatted primary URN for display (the component shows `urn` verbatim); anon orgs get the contact
+            # ref since a masked URN is useless in a list.
+            "urn": self.ref if org.is_anon else (urn.get_display(org=org, international=True) if urn else ""),
             "urns": [serialize_urn(org, u) for u in self.get_urns()],
             "fields": {f.key: self.get_field_serialized(f) for f in fields},
             "groups": [{"uuid": str(g.uuid), "name": g.name} for g in groups],

--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -31,7 +31,7 @@
                       history-state-key="contacts"
                       list-title="{{ title }}"
                       {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
-                      {% if user_org.is_anon %}urn-label="{% trans "Ref" %}"{% endif %}
+                      {% if user_org.is_anon %}anon{% endif %}
                       endpoint="{{ new_list_endpoint }}"
                       action-endpoint="{{ request.path }}"
                       content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"

--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -31,6 +31,7 @@
                       history-state-key="contacts"
                       list-title="{{ title }}"
                       {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
+                      {% if user_org.is_anon %}urn-label="{% trans "Ref" %}"{% endif %}
                       endpoint="{{ new_list_endpoint }}"
                       action-endpoint="{{ request.path }}"
                       content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"


### PR DESCRIPTION
## Summary

The new contact list showed `********` in the URN column for anonymous orgs, unlike the legacy list which showed the contact ref (via the `urn_or_anon` template filter). Masked URNs carry no information, while refs are useful for identifying contacts. The internal contacts endpoint now exposes the ref as its own anon-only key (matching the public API convention) and the list component renders it as a dedicated "Ref" column.

## Changes

- **temba/contacts/models.py** — `Contact.as_json` (the internal contacts endpoint shape consumed by `temba-contact-list`) now returns the primary `urn` as a structured `{"scheme", "display"}` object (or `null`), with the display masked for anon orgs as before, so the component can render the scheme if it wants to. For anon orgs the payload additionally carries `"ref"` as its own key — same convention as the public v2 contacts API.
- **templates/contacts/contact_list_new.html** — passes the boolean `anon` attribute to the list component for anon orgs, which makes it render a "Ref" column (showing `ref`) in place of the URN column (requires temba-components with the new attribute; older versions ignore it and show an empty URN column).
- **temba/api/internal/tests.py** — asserts the structured urn shape, that `ref` is absent for regular orgs, and that anon orgs get `ref` plus a masked urn display.

## Behavior

| Org | Old payload | New payload | List renders |
| --- | --- | --- | --- |
| Regular | `"urn": "+1 234..."` | `"urn": {"scheme": "tel", "display": "+1 234..."}` | "URN" column, unchanged |
| Anonymous | `"urn": "********"` | `"urn": {"scheme": "tel", "display": "********"}, "ref": "S5XQ4X"` | "Ref" column showing refs |

## Test plan

- [x] `temba.api.internal` test suite passes
- [x] `code_check.py` clean
- [x] Verified on a local anon workspace that the list shows refs under a "Ref" header