### PR TITLE
Remove DEFAULT_AUTO_FIELD setting so new models default to BigAutoField

### DIFF
--- a/temba/ai/models.py
+++ b/temba/ai/models.py
@@ -65,6 +65,7 @@ class LLM(TembaModel, DependencyMixin):
     ROLE_NAMES = {ROLE_EDITING: "editing", ROLE_ENGINE: "engine"}
     DEFAULT_ROLES = ROLE_EDITING + ROLE_ENGINE
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, related_name="llms", on_delete=models.PROTECT)
     llm_type = models.CharField(max_length=16)
     model = models.CharField(max_length=64)

--- a/temba/airtime/models.py
+++ b/temba/airtime/models.py
@@ -26,6 +26,7 @@ class AirtimeTransfer(TembaUUIDMixin, models.Model):
         (STATUS_DECLINED, "Declined"),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="airtime_transfers")
     status = models.CharField(max_length=1, choices=STATUS_CHOICES)
     external_id = models.CharField(max_length=255, null=True)

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -111,6 +111,7 @@ class Resthook(SmartModel):
     to this particular resthook.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(
         Org,
         on_delete=models.PROTECT,
@@ -162,6 +163,7 @@ class ResthookSubscriber(SmartModel):
     Represents a subscriber on a specific resthook within one of our flows.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     resthook = models.ForeignKey(
         Resthook, on_delete=models.PROTECT, related_name="subscribers", help_text=_("The resthook being subscribed to")
     )
@@ -185,6 +187,8 @@ class WebHookEvent(models.Model):
     """
     Represents a payload to be sent to a resthook
     """
+
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
 
     # the organization this event is tied to
     org = models.ForeignKey(Org, on_delete=models.PROTECT)

--- a/temba/apks/models.py
+++ b/temba/apks/models.py
@@ -17,6 +17,7 @@ class Apk(models.Model):
         (TYPE_MESSAGE_PACK, _("Message Pack Application APK")),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     apk_type = models.CharField(choices=TYPE_CHOICES, max_length=1)
     apk_file = models.FileField(upload_to="apks")
     version = models.TextField(null=False, help_text="Our version, ex: 1.9.8")

--- a/temba/archives/models.py
+++ b/temba/archives/models.py
@@ -31,6 +31,7 @@ class Archive(models.Model):
     PERIOD_MONTHLY = "M"
     PERIOD_CHOICES = ((PERIOD_DAILY, "Day"), (PERIOD_MONTHLY, "Month"))
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True)
     org = models.ForeignKey("orgs.Org", related_name="archives", on_delete=models.PROTECT)
     archive_type = models.CharField(choices=TYPE_CHOICES, max_length=16)

--- a/temba/campaigns/models.py
+++ b/temba/campaigns/models.py
@@ -20,6 +20,7 @@ from temba.utils.models import TembaModel, TembaUUIDMixin, delete_in_batches
 
 
 class Campaign(TembaModel):
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, related_name="campaigns", on_delete=models.PROTECT)
     group = models.ForeignKey(ContactGroup, on_delete=models.PROTECT, related_name="campaigns")
     is_archived = models.BooleanField(default=False)
@@ -349,6 +350,7 @@ class CampaignEvent(TembaUUIDMixin, SmartModel):
     MODE_PASSIVE = "P"
     START_MODES_CHOICES = ((MODE_INTERRUPT, "Interrupt"), (MODE_SKIP, "Skip"), (MODE_PASSIVE, "Passive"))
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     campaign = models.ForeignKey(Campaign, on_delete=models.PROTECT, related_name="events")
     event_type = models.CharField(max_length=1, choices=TYPE_CHOICES, default=TYPE_FLOW)
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=STATUS_READY)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -310,6 +310,7 @@ class Channel(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
     org_limit_key = Org.LIMIT_CHANNELS
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="channels", null=True)
     channel_type = models.CharField(max_length=3)
     name = models.CharField(max_length=64)
@@ -787,6 +788,7 @@ class ChannelEvent(TembaUUIDMixin, models.Model):
     STATUS_HANDLED = "H"
     STATUS_CHOICES = ((STATUS_PENDING, "Pending"), (STATUS_HANDLED, "Handled"))
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT)
     channel = models.ForeignKey(Channel, on_delete=models.PROTECT)
     event_type = models.CharField(max_length=16, choices=TYPE_CHOICES)
@@ -1012,6 +1014,7 @@ class SyncEvent(models.Model):
         (STATUS_FULL, "Full"),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     channel = models.ForeignKey(Channel, related_name="sync_events", on_delete=models.PROTECT)
 
     # power status of the device

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -365,6 +365,7 @@ class ContactField(TembaModel, DependencyMixin):
     # can't create custom contact fields with these keys
     RESERVED_KEYS = {"has", "is", "fields", "urns", "created_on", "last_seen_on"}
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="fields")
 
     key = models.CharField(max_length=MAX_KEY_LEN)
@@ -574,6 +575,7 @@ class Contact(LegacyUUIDMixin, SmartModel):
         STATUS_ARCHIVED: "archived",
     }
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="contacts")
     name = models.CharField(verbose_name=_("Name"), max_length=128, blank=True, null=True)
     language = models.CharField(
@@ -1418,6 +1420,7 @@ class ContactURN(models.Model):
     ANON_MASK = "*" * 8  # Returned instead of URN values for anon orgs
     ANON_MASK_HTML = "•" * 8  # Pretty HTML version of anon mask
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, related_name="urns", on_delete=models.PROTECT)
     contact = models.ForeignKey(Contact, on_delete=models.PROTECT, null=True, related_name="urns")
 
@@ -1522,6 +1525,7 @@ class ContactGroup(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
     MAX_QUERY_LEN = 10_000
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="groups")
     group_type = models.CharField(max_length=1, choices=TYPE_CHOICES, default=TYPE_MANUAL)
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=STATUS_INITIALIZING)
@@ -1821,6 +1825,7 @@ class ContactNote(models.Model):
 
     MAX_LENGTH = 10_000
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     contact = models.ForeignKey(Contact, on_delete=models.PROTECT, related_name="notes")
     text = models.TextField(max_length=MAX_LENGTH, blank=True)
     created_on = models.DateTimeField(default=timezone.now)
@@ -2101,6 +2106,7 @@ class ContactImport(SmartModel):
 
     MAPPING_IGNORE = {"type": "ignore"}
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True, default=uuid4)
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="contact_imports")
     file = models.FileField(upload_to=get_import_upload_path)
@@ -2564,6 +2570,7 @@ class ContactImportBatch(models.Model):
         (ContactImport.STATUS_FAILED, "Failed"),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     contact_import = models.ForeignKey(ContactImport, on_delete=models.PROTECT, related_name="batches")
     status = models.CharField(max_length=1, default=ContactImport.STATUS_PENDING, choices=STATUS_CHOICES)
     specs = models.JSONField()

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -140,6 +140,7 @@ class Flow(LegacyUUIDMixin, TembaModel, DependencyMixin):
         TYPE_SURVEY: 0,
     }
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="flows")
     labels = models.ManyToManyField("FlowLabel", related_name="flows")
     is_archived = models.BooleanField(default=False)
@@ -1256,6 +1257,7 @@ class FlowRevision(models.Model):
     LAST_TRIM_KEY = "temba:last_flow_revision_trim"
     MAX_REVISIONS = 500
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     flow = models.ForeignKey(Flow, on_delete=models.PROTECT, related_name="revisions")
     definition = JSONAsTextField(default=dict)
     spec_version = models.CharField(default=Flow.FINAL_LEGACY_VERSION, max_length=8)
@@ -1688,6 +1690,7 @@ class FlowStart(models.Model):
         (TYPE_TRIGGER, "Trigger"),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True, default=uuid4)
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="flow_starts")
     flow = models.ForeignKey(Flow, on_delete=models.PROTECT, related_name="starts")
@@ -1841,6 +1844,7 @@ class FlowLabel(TembaModel):
     A label applied to a flow rather than a message
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="flow_labels")
 
     @classmethod

--- a/temba/globals/models.py
+++ b/temba/globals/models.py
@@ -18,6 +18,7 @@ class Global(TembaModel, DependencyMixin):
     MAX_NAME_LEN = 36
     MAX_VALUE_LEN = settings.GLOBAL_VALUE_SIZE
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, related_name="globals", on_delete=models.PROTECT)
     key = models.CharField(verbose_name=_("Key"), max_length=MAX_KEY_LEN)
     name = models.CharField(verbose_name=_("Name"), max_length=MAX_NAME_LEN)

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -52,6 +52,7 @@ class Call(models.Model):
 
     RETRY_CHOICES = ((-1, _("Never")), (30, _("After 30 minutes")), (60, _("After 1 hour")), (1440, _("After 1 day")))
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True)
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="calls")
     direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES)

--- a/temba/locations/models.py
+++ b/temba/locations/models.py
@@ -24,6 +24,7 @@ class AdminBoundary(MPTTModel, models.Model):
     PATH_SEPARATOR = ">"
     PADDED_PATH_SEPARATOR = " > "
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     osm_id = models.CharField(max_length=15, unique=True)
     name = models.CharField(max_length=MAX_NAME_LEN)
     level = models.IntegerField()
@@ -153,6 +154,7 @@ class BoundaryAlias(SmartModel):
     An org specific alias for a boundary name
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey("orgs.Org", on_delete=models.PROTECT)
     boundary = models.ForeignKey(AdminBoundary, on_delete=models.PROTECT, related_name="aliases")
     name = models.CharField(max_length=AdminBoundary.MAX_NAME_LEN, help_text="The name for our alias")

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -59,6 +59,7 @@ class Media(models.Model):
     STATUS_FAILED = "F"
     STATUS_CHOICES = ((STATUS_PENDING, "Pending"), (STATUS_READY, "Ready"), (STATUS_FAILED, "Failed"))
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(default=uuid4, unique=True)
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="media")
     url = models.URLField(max_length=2048)
@@ -202,6 +203,7 @@ class Broadcast(models.Model):
         (STATUS_INTERRUPTED, "Interrupted"),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True)
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="broadcasts")
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=STATUS_PENDING)
@@ -1014,6 +1016,7 @@ class Label(TembaModel, DependencyMixin):
 
     org_limit_key = Org.LIMIT_LABELS
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="msgs_labels")
 
     @classmethod
@@ -1113,6 +1116,7 @@ class OptIn(TembaModel):
     Contact optin for a particular messaging topic.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="optins")
 
     @classmethod

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -273,6 +273,7 @@ class Org(SmartModel):
         "contact support."
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True, default=uuid4)
     name = models.CharField(verbose_name=_("Name"), max_length=128)
     parent = models.ForeignKey("orgs.Org", on_delete=models.PROTECT, null=True, related_name="children")
@@ -1221,6 +1222,7 @@ class Org(SmartModel):
 
 
 class OrgMembership(models.Model):
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.CASCADE)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     role_code = models.CharField(max_length=1)
@@ -1265,6 +1267,7 @@ class OrgImport(SmartModel):
         (STATUS_FAILED, "Failed"),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True, default=uuid4)
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="imports")
     file = models.FileField(upload_to=get_import_upload_path)
@@ -1304,6 +1307,7 @@ class Invitation(SmartModel):
     An invitation to an e-mail address to join an org as a specific role.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="invitations")
     email = models.EmailField()
     secret = models.CharField(max_length=64, unique=True)
@@ -1462,6 +1466,7 @@ class Export(TembaUUIDMixin, models.Model):
     # log progress after this number of exported objects have been exported
     LOG_PROGRESS_PER_ROWS = 10000
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="exports")
     export_type = models.CharField(max_length=20)
     status = models.CharField(max_length=1, default=STATUS_PENDING, choices=STATUS_CHOICES)

--- a/temba/request_logs/models.py
+++ b/temba/request_logs/models.py
@@ -43,6 +43,7 @@ class HTTPLog(models.Model):
         (WHATSAPP_CHECK_HEALTH, _("WhatsApp Health Check")),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, related_name="http_logs", on_delete=models.PROTECT)
     log_type = models.CharField(max_length=32, choices=LOG_TYPE_CHOICES)
 

--- a/temba/schedules/models.py
+++ b/temba/schedules/models.py
@@ -56,6 +56,7 @@ class Schedule(models.Model):
     # ordered in the same way as python's weekday function
     DAYS_OF_WEEK_OFFSET = "MTWRFSU"
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey("orgs.Org", on_delete=models.PROTECT, related_name="schedules")
     repeat_period = models.CharField(max_length=1, choices=REPEAT_CHOICES)
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -636,7 +636,6 @@ _default_database_config = {
 # will be used for certain fetch operations
 DATABASES = {"default": _default_database_config, "readonly": _default_database_config.copy()}
 
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # -----------------------------------------------------------------------------------
 # Cache

--- a/temba/templates/models.py
+++ b/temba/templates/models.py
@@ -37,6 +37,7 @@ class Template(TembaModel, DependencyMixin):
     are currently only used for WhatsApp channels.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="templates")
     name = models.CharField(max_length=512)  # overridden to be longer
     base_translation = models.OneToOneField(
@@ -129,6 +130,7 @@ class TemplateTranslation(models.Model):
         (STATUS_IN_APPEAL, _("In Appeal")),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     template = models.ForeignKey(Template, on_delete=models.PROTECT, related_name="translations")
     channel = models.ForeignKey(Channel, on_delete=models.PROTECT, related_name="template_translations")
     locale = models.CharField(max_length=6)  # e.g. eng-US

--- a/temba/tickets/models.py
+++ b/temba/tickets/models.py
@@ -31,6 +31,7 @@ class Shortcut(TembaModel):
     A canned response available from the ticketing interface.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="shortcuts")
     text = models.TextField(max_length=10_000)
 
@@ -56,6 +57,7 @@ class Topic(TembaModel, DependencyMixin):
     The topic of a ticket which controls who can access that ticket.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="topics")
     is_default = models.BooleanField(default=False)
 
@@ -143,6 +145,7 @@ class Team(TembaModel):
     Agent users are assigned to a team which controls which topics they can access.
     """
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="teams")
     topics = models.ManyToManyField(Topic, related_name="teams")
     all_topics = models.BooleanField(default=False)
@@ -203,6 +206,7 @@ class Ticket(models.Model):
 
     MAX_NOTE_LENGTH = 10_000
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     uuid = models.UUIDField(unique=True)
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="tickets", db_index=False)  # indexed below
     contact = models.ForeignKey(Contact, on_delete=models.PROTECT, related_name="tickets", db_index=False)

--- a/temba/triggers/models.py
+++ b/temba/triggers/models.py
@@ -98,6 +98,7 @@ class Trigger(SmartModel):
         (MATCH_FIRST_WORD, _("Message starts with the keyword")),
     )
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="triggers")
     trigger_type = models.CharField(max_length=1, default=TYPE_KEYWORD)
     is_archived = models.BooleanField(default=False)

--- a/temba/users/models.py
+++ b/temba/users/models.py
@@ -48,6 +48,7 @@ class User(TembaUUIDMixin, AbstractBaseUser, PermissionsMixin):
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS = []
 
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     first_name = models.CharField(_("first name"), max_length=150, blank=True)
     last_name = models.CharField(_("last name"), max_length=150, blank=True)
     email = models.EmailField(_("email address"), unique=True)


### PR DESCRIPTION
Follow-up to #6748. Django 6 changed the framework default of `DEFAULT_AUTO_FIELD` to `BigAutoField`; we were pinning it to `AutoField` globally, which meant new models would keep getting 32-bit primary keys.

This removes the setting so new models default to `BigAutoField`, while keeping existing models exactly as they are: each model that relied on the implicit `AutoField` pk now declares it explicitly, matching the field state already recorded in its migrations (`AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")`). The largest tables already declared `BigAutoField` explicitly and are untouched.

No migrations are generated and no schema changes result — `makemigrations --check` is clean, which CI enforces. Full test suite passes.