### PR TITLE
Update allowed LLM models

### DIFF
--- a/temba/ai/tests/test_llm.py
+++ b/temba/ai/tests/test_llm.py
@@ -9,7 +9,7 @@ from temba.tests import TembaTest, mock_mailroom
 class LLMTest(TembaTest):
     def test_model(self):
         openai = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {"api_key": "sesame"})
-        LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Claude", {})
+        LLM.create(self.org, self.admin, AnthropicType(), "claude-haiku-4-5-20251001", "Claude", {})
 
         self.assertEqual(openai.name, "GPT-4")
         self.assertEqual(openai.type.slug, OpenAIType.slug)

--- a/temba/ai/tests/test_llmcrudl.py
+++ b/temba/ai/tests/test_llmcrudl.py
@@ -16,7 +16,7 @@ class LLMCRUDLTest(TembaTest, CRUDLTestMixin):
         super().setUp()
 
         self.openai = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {})
-        self.anthropic = LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Claude", {})
+        self.anthropic = LLM.create(self.org, self.admin, AnthropicType(), "claude-haiku-4-5-20251001", "Claude", {})
         LLM.create(self.org2, self.admin2, OpenAIType(), "gpt-4o", "Other Org", {})
 
     def test_list(self):

--- a/temba/ai/types/anthropic/tests.py
+++ b/temba/ai/types/anthropic/tests.py
@@ -31,16 +31,16 @@ class AnthropicTypeTest(TembaTest, CRUDLTestMixin):
 
         # get our model list from an api key
         mock_client.return_value.models.list.return_value = [
-            Mock(id="claude-opus-4-7", display_name="Claude Opus 4.7"),
-            Mock(id="claude-3-7-sonnet-20250219", display_name="Claude 3.7 Sonnet"),
+            Mock(id="claude-opus-4-8", display_name="Claude Opus 4.8"),
+            Mock(id="claude-sonnet-5", display_name="Claude Sonnet 5"),
             Mock(id="claude-3-5-sonnet-20240620", display_name="Claude 3.5 Sonnet (Old)"),
         ]
         response = self.process_wizard("connect_view", connect_url, {"credentials": {"api_key": "good_key"}})
         self.assertEqual(
             response.context["form"].fields["model"].choices,
             [
-                ("claude-opus-4-7", "Claude Opus 4.7"),
-                ("claude-3-7-sonnet-20250219", "Claude 3.7 Sonnet"),
+                ("claude-opus-4-8", "Claude Opus 4.8"),
+                ("claude-sonnet-5", "Claude Sonnet 5"),
             ],
         )
 
@@ -50,7 +50,7 @@ class AnthropicTypeTest(TembaTest, CRUDLTestMixin):
             connect_url,
             {
                 "credentials": {"api_key": "good_key"},
-                "model": {"model": "claude-3-7-sonnet-20250219"},
+                "model": {"model": "claude-sonnet-5"},
                 "name": {"name": "Claude"},
             },
         )
@@ -59,5 +59,5 @@ class AnthropicTypeTest(TembaTest, CRUDLTestMixin):
         # check that we created our model
         llm = LLM.objects.get(org=self.org, llm_type="anthropic")
         self.assertEqual("Claude", llm.name)
-        self.assertEqual("claude-3-7-sonnet-20250219", llm.model)
+        self.assertEqual("claude-sonnet-5", llm.model)
         self.assertEqual("good_key", llm.config["api_key"])

--- a/temba/ai/types/google/tests.py
+++ b/temba/ai/types/google/tests.py
@@ -29,21 +29,21 @@ class GoogleTypeTest(TembaTest, CRUDLTestMixin):
 
         # get our model list from an api key
         mock_models = [
-            Mock(display_name="Gemini 2.0 Flash"),
+            Mock(display_name="Gemini 3.6 Flash"),
+            Mock(display_name="Gemini 2.5 Flash"),
             Mock(display_name="Gemini 1.5 Flash"),
-            Mock(display_name="Gemini 1.0 Flash"),
         ]
 
         # because https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
-        mock_models[0].name = "models/gemini-2.0-flash"
-        mock_models[1].name = "models/gemini-1.5-flash"
-        mock_models[2].name = "models/gemini-1.0-flash"
+        mock_models[0].name = "models/gemini-3.6-flash"
+        mock_models[1].name = "models/gemini-2.5-flash"
+        mock_models[2].name = "models/gemini-1.5-flash"
         mock_client.return_value.models.list.return_value = mock_models
 
         response = self.process_wizard("connect_view", connect_url, {"credentials": {"api_key": "good_key"}})
         self.assertEqual(
             response.context["form"].fields["model"].choices,
-            [("models/gemini-2.0-flash", "Gemini 2.0 Flash"), ("models/gemini-1.5-flash", "Gemini 1.5 Flash")],
+            [("models/gemini-3.6-flash", "Gemini 3.6 Flash"), ("models/gemini-2.5-flash", "Gemini 2.5 Flash")],
         )
 
         # select a model and give it a name
@@ -52,7 +52,7 @@ class GoogleTypeTest(TembaTest, CRUDLTestMixin):
             connect_url,
             {
                 "credentials": {"api_key": "good_key"},
-                "model": {"model": "models/gemini-1.5-flash"},
+                "model": {"model": "models/gemini-2.5-flash"},
                 "name": {"name": "Gemini"},
             },
         )
@@ -61,5 +61,5 @@ class GoogleTypeTest(TembaTest, CRUDLTestMixin):
         # check that we created our model
         llm = LLM.objects.get(org=self.org, llm_type="google")
         self.assertEqual("Gemini", llm.name)
-        self.assertEqual("gemini-1.5-flash", llm.model)
+        self.assertEqual("gemini-2.5-flash", llm.model)
         self.assertEqual("good_key", llm.config["api_key"])

--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -1071,8 +1071,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         endpoint_url = reverse("api.internal.llms") + ".json"
 
         openai = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "GPT-4", {}, roles=LLM.ROLE_EDITING)
-        anthropic = LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Claude", {})
-        deleted = LLM.create(self.org, self.admin, AnthropicType(), "claude-3-5-haiku-20241022", "Deleted", {})
+        anthropic = LLM.create(self.org, self.admin, AnthropicType(), "claude-haiku-4-5-20251001", "Claude", {})
+        deleted = LLM.create(self.org, self.admin, AnthropicType(), "claude-haiku-4-5-20251001", "Deleted", {})
         deleted.release(self.admin)
         system = LLM.create(self.org, self.admin, OpenAIType(), "gpt-4o", "System", {})
         system.is_system = True

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -808,23 +808,27 @@ LLM_TYPES = {
     "temba.ai.types.anthropic.type.AnthropicType": {
         # model id -> max output tokens
         "models": {
+            "claude-opus-4-8": 128_000,
             "claude-opus-4-7": 128_000,
             "claude-opus-4-5-20251101": 64_000,
-            "claude-sonnet-4-6": 64_000,
-            "claude-3-7-sonnet-20250219": 64_000,
+            "claude-sonnet-5": 128_000,
+            "claude-sonnet-4-6": 128_000,
             "claude-haiku-4-5-20251001": 64_000,
-            "claude-3-5-haiku-20241022": 8_192,
         },
     },
     "temba.ai.types.google.type.GoogleType": {
         "models": {
+            "gemini-3.6-flash": 65_536,
+            "gemini-3.5-flash": 65_536,
+            "gemini-3.5-flash-lite": 65_536,
             "gemini-2.5-flash": 65_536,
-            "gemini-2.0-flash": 8_192,
-            "gemini-1.5-flash": 8_192,
         },
     },
     "temba.ai.types.openai.type.OpenAIType": {
         "models": {
+            "gpt-5.6-sol": 128_000,
+            "gpt-5.6-terra": 128_000,
+            "gpt-5.6-luna": 128_000,
             "gpt-5.5": 128_000,
             "gpt-5.4": 128_000,
             "gpt-5.4-mini": 128_000,


### PR DESCRIPTION
Updates the default `LLM_TYPES` model lists to reflect current provider catalogs:

**Removed (retired by providers, requests now fail):**
- `claude-3-7-sonnet-20250219`, `claude-3-5-haiku-20241022` (retired Feb 2026)
- `gemini-2.0-flash` (shut down Jun 2026), `gemini-1.5-flash` (1.5 series shut down)

**Added:**
- Anthropic: `claude-opus-4-8`, `claude-sonnet-5`
- Google: `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`
- OpenAI: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`

Also corrects max output tokens for `claude-sonnet-4-6` (64K → 128K).

Existing `LLM` records are unaffected since `model` and `max_output_tokens` are stored on the row — this only changes which models can be selected for new connections. Orgs still configured with a retired model were already broken at the provider and will need to reconnect separately.