### PR TITLE
Skip legacy-only queries on new-format list page GETs

### DIFF
--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -281,10 +281,12 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(list_url)
         self.assertNotContains(response, "temba-contact-list")
 
-        # by default we get the temba-contact-list component, pointed at the internal contacts api
+        # by default we get the temba-contact-list component, pointed at the internal contacts api — check the query
+        # count too since the component fetches contacts itself so rendering shouldn't hit the contacts table
         self.setLegacyUI(False)
 
-        response = self.client.get(list_url)
+        with self.assertNumQueries(7):
+            response = self.client.get(list_url)
         self.assertContains(response, "temba-contact-list")
         self.assertEqual(
             f"{reverse('api.internal.contacts')}.json?folder=active", response.context["new_list_endpoint"]

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -243,13 +243,16 @@ class ContactListView(SpaMixin, BulkActionMixin, BaseListView):
         context = super().get_context_data(**kwargs)
         org = self.request.org
 
-        # prefetch contact URNs
-        Contact.bulk_urn_cache_initialize(context["object_list"])
+        # URNs and field columns are only rendered by the legacy table — the new list component fetches everything
+        # it needs from the internal contacts API
+        if not self._use_new_list():
+            # prefetch contact URNs
+            Contact.bulk_urn_cache_initialize(context["object_list"])
 
-        # get the first 6 featured fields as well as the last seen and created fields
-        featured_fields = ContactField.get_fields(org, featured=True).order_by("-priority", "id")[0:6]
-        proxy_fields = org.fields.filter(key__in=("last_seen_on", "created_on"), is_proxy=True).order_by("-key")
-        context["contact_fields"] = list(featured_fields) + list(proxy_fields)
+            # get the first 6 featured fields as well as the last seen and created fields
+            featured_fields = ContactField.get_fields(org, featured=True).order_by("-priority", "id")[0:6]
+            proxy_fields = org.fields.filter(key__in=("last_seen_on", "created_on"), is_proxy=True).order_by("-key")
+            context["contact_fields"] = list(featured_fields) + list(proxy_fields)
 
         context["search_error"] = self.search_error
         context["sort_direction"] = self.sort_direction

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -50,8 +50,14 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         inbox_url = reverse("msgs.msg_inbox")
 
-        # check query count on the legacy list (viewers opt in via legacy mode)
         self.login(self.admin)
+
+        # check query count on the default (new) list — the temba-msg-list component fetches messages itself so
+        # rendering the page shouldn't hit the msgs table or folder counts
+        with self.assertNumQueries(7):
+            self.client.get(inbox_url)
+
+        # and on the legacy list (viewers opt in via legacy mode)
         self.setLegacyUI()
         with self.assertNumQueries(11):
             self.client.get(inbox_url)

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -144,6 +144,12 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
         return "%s?l=%s&redirect=%s" % (reverse("msgs.msg_export"), label_id, redirect)
 
     def get_queryset(self, **kwargs):
+        # On the new list the temba-msg-list component fetches and pages messages from the internal messages API, so
+        # a GET page needs no object list. A POST (bulk action) still needs the real queryset, since BulkActionMixin
+        # validates the posted `objects` against it.
+        if self._use_new_list() and self.request.method == "GET":
+            return Msg.objects.none()
+
         qs = super().get_queryset(**kwargs).select_related("contact", "channel", "flow")
 
         # if we are searching, limit to last 90, and enforce distinct since we'll be joining on multiple tables
@@ -159,20 +165,28 @@ class MsgListView(ContextMenuMixin, BulkActionMixin, SpaMixin, BaseListView):
 
     def get_context_data(self, **kwargs):
         org = self.request.org
-        counts = MsgFolder.get_counts(org)
         folder = self.derive_folder()
 
-        # if there isn't a search filtering the queryset, we can replace the count function with a pre-calculated value
-        if not self.search_fields or "search" not in self.request.GET:
-            if isinstance(folder, Label):
-                patch_queryset_count(self.object_list, folder.get_visible_count)
-            elif isinstance(folder, MsgFolder):
-                patch_queryset_count(self.object_list, lambda: counts[folder])
+        # folder counts drive pagination and the has_messages empty state, both only used by the legacy list — the
+        # new list component fetches its own counts from the API
+        legacy = not self._use_new_list()
+        if legacy:
+            counts = MsgFolder.get_counts(org)
+
+            # if there isn't a search filtering the queryset, we can replace the count function with a pre-calculated
+            # value
+            if not self.search_fields or "search" not in self.request.GET:
+                if isinstance(folder, Label):
+                    patch_queryset_count(self.object_list, folder.get_visible_count)
+                elif isinstance(folder, MsgFolder):
+                    patch_queryset_count(self.object_list, lambda: counts[folder])
 
         context = super().get_context_data(**kwargs)
-        context["has_messages"] = (
-            any(counts.values()) or Archive.objects.filter(org=org, archive_type=Archive.TYPE_MSG).exists()
-        )
+
+        if legacy:
+            context["has_messages"] = (
+                any(counts.values()) or Archive.objects.filter(org=org, archive_type=Archive.TYPE_MSG).exists()
+            )
 
         # New-list view context: the resolved messages-api endpoint
         # (folder= for the built-in folders, label= for a user label),
@@ -868,7 +882,9 @@ class MsgCRUDL(SmartCRUDL):
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
-            context["outbox_warning"] = MsgFolder.OUTBOX.get_count(self.request.org) >= Org.OUTBOX_WARNING_THRESHOLD
+            # only the legacy list renders the outbox warning
+            if not self._use_new_list():
+                context["outbox_warning"] = MsgFolder.OUTBOX.get_count(self.request.org) >= Org.OUTBOX_WARNING_THRESHOLD
             return context
 
     class Sent(MsgListView):


### PR DESCRIPTION
Since the component-based list pages became the default, the list views render a placeholder page and the components fetch/page data themselves from the internal API — but a few views were still doing legacy-only work on every GET:

* **Contact lists**: still queried the featured + proxy contact fields to build `contact_fields` (and primed the URN cache), which only the legacy table template uses. Now gated to legacy mode.
* **Message lists**: always computed folder counts for `has_messages` (plus an archives existence check when counts were zero), also only used by the legacy template. Counts and the `patch_queryset_count` pagination optimization are now only done in legacy mode. Same for the outbox warning count on the Outbox view.
* **Message lists**: `get_queryset` was the only converted list view not returning `.none()` on new-format GETs — it built the real folder queryset and relied on nothing evaluating it. It now returns `Msg.objects.none()` like the other converted views (POST bulk actions still get the real queryset for validation).

Also adds `assertNumQueries` checks for the default (new-format) GETs of the contact list and message inbox — previously only the legacy renderings had query counts pinned — so both pages are now held at auth/org boilerplate only (7 queries, no msgs/contacts/fields/counts queries).