### PR TITLE
Enable inline contact editing

### DIFF
--- a/temba/api/internal/tests.py
+++ b/temba/api/internal/tests.py
@@ -10,7 +10,7 @@ from temba.ai.types.anthropic.type import AnthropicType
 from temba.ai.types.openai.type import OpenAIType
 from temba.api.tests.mixins import APITestMixin
 from temba.campaigns.models import Campaign, CampaignEvent
-from temba.contacts.models import ContactExport, ContactField, ContactGroup
+from temba.contacts.models import Contact, ContactExport, ContactField, ContactGroup
 from temba.flows.models import Flow, FlowLabel
 from temba.msgs.models import Broadcast, Msg
 from temba.notifications.types import ExportFinishedNotificationType
@@ -244,7 +244,7 @@ class EndpointsTest(APITestMixin, TembaTest):
 
         # anonymous users can't read; agents hold the contacts.contact_list api perm (as for /api/v2/contacts)
         self.assertGetNotPermitted(endpoint_url, [None])
-        self.assertPostNotAllowed(endpoint_url)
+        self.assertPostNotPermitted(endpoint_url, [None])
         self.assertDeleteNotAllowed(endpoint_url)
 
         joe = self.create_contact("Joe", phone="+1234567001", fields={"gender": "male"})
@@ -359,6 +359,110 @@ class EndpointsTest(APITestMixin, TembaTest):
         mr_mocks.contact_search("", contacts=[joe, frank])
         self.assertGet(endpoint_url + "?sort=-field:gender&page_size=0", [self.admin], results=[joe, frank])
         self.assertEqual(50, mr_mocks.calls["contact_search"][-1].kwargs["limit"])
+
+    @mock_mailroom
+    def test_contacts_update(self, mr_mocks):
+        endpoint_url = reverse("api.internal.contacts") + ".json"
+
+        joe = self.create_contact("Joe", urns=["tel:+250788111111", "facebook:123456"])
+        other_org_contact = self.create_contact("Fred", phone="+250788666666", org=self.org2)
+
+        # a uuid param is required - contacts can never be created here, unlike on /api/v2/contacts
+        self.assertPost(endpoint_url, self.editor, {"name": "X"}, errors={None: "URL must contain uuid parameter."})
+
+        # can't update contacts in other orgs
+        self.assertPost(endpoint_url + f"?uuid={other_org_contact.uuid}", self.editor, {"name": "X"}, status=404)
+
+        # update name and language
+        response = self.assertPost(
+            endpoint_url + f"?uuid={joe.uuid}", self.editor, {"name": "Joseph", "language": "fra"}
+        )
+        joe.refresh_from_db()
+        self.assertEqual("Joseph", joe.name)
+        self.assertEqual("fra", joe.language)
+
+        # the response is the editor's read shape: urns come back expanded and in priority order
+        self.assertEqual(str(joe.uuid), response.json()["uuid"])
+        self.assertEqual("active", response.json()["status"])
+        self.assertEqual(
+            ["tel:+250788111111", "facebook:123456"],
+            [f"{urn['scheme']}:{urn['path']}" for urn in response.json()["urns"]],
+        )
+        self.assertIsNotNone(response.json()["urns"][0]["channel"])
+
+        # reordering urns is reflected in the response
+        response = self.assertPost(
+            endpoint_url + f"?uuid={joe.uuid}", self.editor, {"urns": ["facebook:123456", "tel:+250788111111"]}
+        )
+        self.assertEqual(
+            ["facebook:123456", "tel:+250788111111"],
+            [f"{urn['scheme']}:{urn['path']}" for urn in response.json()["urns"]],
+        )
+
+        group = self.create_group("Testers", contacts=[])
+
+        # status can be updated but groups submitted alongside a deactivation are dropped because mailroom
+        # removes non-active contacts from all groups
+        self.assertPost(endpoint_url + f"?uuid={joe.uuid}", self.editor, {"status": "blocked", "groups": [group.uuid]})
+        joe.refresh_from_db()
+        self.assertEqual(Contact.STATUS_BLOCKED, joe.status)
+        self.assertEqual(set(), set(joe.get_groups(manual_only=True)))
+
+        # groups can't be added to a non-active contact that isn't being restored
+        self.assertPost(
+            endpoint_url + f"?uuid={joe.uuid}",
+            self.editor,
+            {"groups": [group.uuid]},
+            errors={"groups": "Non-active contacts can't be added to groups"},
+        )
+
+        # but groups can be submitted alongside a restore to active since the restore is applied first
+        self.assertPost(endpoint_url + f"?uuid={joe.uuid}", self.editor, {"status": "active", "groups": [group.uuid]})
+        joe.refresh_from_db()
+        self.assertEqual(Contact.STATUS_ACTIVE, joe.status)
+        self.assertEqual({group}, set(joe.get_groups(manual_only=True)))
+
+        self.assertPost(endpoint_url + f"?uuid={joe.uuid}", self.editor, {"status": "stopped"})
+        joe.refresh_from_db()
+        self.assertEqual(Contact.STATUS_STOPPED, joe.status)
+
+        self.assertPost(endpoint_url + f"?uuid={joe.uuid}", self.editor, {"status": "archived"})
+        joe.refresh_from_db()
+        self.assertEqual(Contact.STATUS_ARCHIVED, joe.status)
+
+        self.assertPost(endpoint_url + f"?uuid={joe.uuid}", self.editor, {"status": "active"})
+        joe.refresh_from_db()
+        self.assertEqual(Contact.STATUS_ACTIVE, joe.status)
+
+        # an invalid status is rejected
+        self.assertPost(
+            endpoint_url + f"?uuid={joe.uuid}",
+            self.editor,
+            {"status": "sleeping"},
+            errors={"status": '"sleeping" is not a valid choice.'},
+        )
+
+        # fields can be updated, subject to the same agent access rules as the public API
+        self.create_field("nickname", "Nickname", agent_access=ContactField.ACCESS_VIEW)
+        self.assertPost(endpoint_url + f"?uuid={joe.uuid}", self.editor, {"fields": {"nickname": "Jo"}})
+        joe.refresh_from_db()
+        self.assertEqual("Jo", joe.get_field_value(self.org.fields.get(key="nickname")))
+        self.assertPost(
+            endpoint_url + f"?uuid={joe.uuid}",
+            self.agent,
+            {"fields": {"nickname": "Joey"}},
+            errors={"fields": "Editing of 'nickname' values disallowed for current user."},
+        )
+
+        # deleted contacts can't be modified
+        deleted = self.create_contact("Del", phone="+250788000000")
+        deleted.release(self.admin)
+        self.assertPost(
+            endpoint_url + f"?uuid={deleted.uuid}",
+            self.editor,
+            {"name": "X"},
+            errors={"non_field_errors": "Deleted contacts can't be modified."},
+        )
 
     def test_campaigns(self):
         endpoint_url = reverse("api.internal.campaigns") + ".json"

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -678,13 +678,6 @@ class ContactWriteSerializer(WriteSerializer):
 
         return value
 
-    def validate_groups(self, value):
-        # only active contacts can be added to groups
-        if self.instance and (self.instance.status != Contact.STATUS_ACTIVE) and value:
-            raise serializers.ValidationError("Non-active contacts can't be added to groups")
-
-        return value
-
     def validate_fields(self, value):
         fields_by_key = {f.key: f for f in self.context["contact_fields"]}
         values_by_field = {}
@@ -719,6 +712,13 @@ class ContactWriteSerializer(WriteSerializer):
             raise serializers.ValidationError("Deleted contacts can't be modified.")
         if not self.instance and "status" in data:
             raise serializers.ValidationError({"status": "Field is only allowed when updating a contact."})
+
+        # only active contacts can be added to groups, tho we allow groups on an update that restores the contact
+        # since the restore is applied first
+        if self.instance and data.get("groups"):
+            new_status = self.STATUSES[data["status"]] if "status" in data else self.instance.status
+            if self.instance.status != Contact.STATUS_ACTIVE and new_status != Contact.STATUS_ACTIVE:
+                raise serializers.ValidationError({"groups": "Non-active contacts can't be added to groups"})
 
         # we allow creation of contacts by URN used for lookup
         if not data.get("urns") and "urns__identity" in self.context["lookup_values"] and not self.instance:

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -650,15 +650,7 @@ class ContactReadSerializer(ReadSerializer):
 
 
 class ContactWriteSerializer(WriteSerializer):
-    STATUSES = {
-        "active": Contact.STATUS_ACTIVE,
-        "blocked": Contact.STATUS_BLOCKED,
-        "stopped": Contact.STATUS_STOPPED,
-        "archived": Contact.STATUS_ARCHIVED,
-    }
-
     name = serializers.CharField(required=False, max_length=64, allow_null=True)
-    status = serializers.ChoiceField(required=False, choices=tuple(STATUSES))
     language = serializers.CharField(required=False, min_length=3, max_length=3, allow_null=True)
     note = serializers.CharField(required=False, max_length=ContactNote.MAX_LENGTH, allow_blank=True)
     urns = serializers.ListField(required=False, child=fields.URNField(), max_length=100)
@@ -675,6 +667,13 @@ class ContactWriteSerializer(WriteSerializer):
     def validate_language(self, value):
         if value and not pycountry.languages.get(alpha_3=value):
             raise serializers.ValidationError("Not a valid ISO639-3 language code.")
+
+        return value
+
+    def validate_groups(self, value):
+        # only active contacts can be added to groups
+        if self.instance and (self.instance.status != Contact.STATUS_ACTIVE) and value:
+            raise serializers.ValidationError("Non-active contacts can't be added to groups")
 
         return value
 
@@ -710,15 +709,6 @@ class ContactWriteSerializer(WriteSerializer):
     def validate(self, data):
         if self.instance and not self.instance.is_active:
             raise serializers.ValidationError("Deleted contacts can't be modified.")
-        if not self.instance and "status" in data:
-            raise serializers.ValidationError({"status": "Field is only allowed when updating a contact."})
-
-        # only active contacts can be added to groups, tho we allow groups on an update that restores the contact
-        # since the restore is applied first
-        if self.instance and data.get("groups"):
-            new_status = self.STATUSES[data["status"]] if "status" in data else self.instance.status
-            if self.instance.status != Contact.STATUS_ACTIVE and new_status != Contact.STATUS_ACTIVE:
-                raise serializers.ValidationError({"groups": "Non-active contacts can't be added to groups"})
 
         # we allow creation of contacts by URN used for lookup
         if not data.get("urns") and "urns__identity" in self.context["lookup_values"] and not self.instance:
@@ -733,7 +723,6 @@ class ContactWriteSerializer(WriteSerializer):
         Update our contact
         """
         name = self.validated_data.get("name")
-        contact_status = self.validated_data.get("status")
         language = self.validated_data.get("language")
         urns = self.validated_data.get("urns")
         groups = self.validated_data.get("groups")
@@ -744,16 +733,6 @@ class ContactWriteSerializer(WriteSerializer):
 
         # update an existing contact
         if self.instance:
-            if "status" in self.validated_data and self.STATUSES[contact_status] != self.instance.status:
-                if contact_status == "active":
-                    self.instance.restore(self.context["user"])
-                elif contact_status == "blocked":
-                    self.instance.block(self.context["user"])
-                elif contact_status == "stopped":
-                    self.instance.stop(self.context["user"])
-                elif contact_status == "archived":
-                    self.instance.archive(self.context["user"])
-
             # update our name and language
             if "name" in self.validated_data and name != self.instance.name:
                 mods.append(modifiers.Name(name=name))

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -650,7 +650,15 @@ class ContactReadSerializer(ReadSerializer):
 
 
 class ContactWriteSerializer(WriteSerializer):
+    STATUSES = {
+        "active": Contact.STATUS_ACTIVE,
+        "blocked": Contact.STATUS_BLOCKED,
+        "stopped": Contact.STATUS_STOPPED,
+        "archived": Contact.STATUS_ARCHIVED,
+    }
+
     name = serializers.CharField(required=False, max_length=64, allow_null=True)
+    status = serializers.ChoiceField(required=False, choices=tuple(STATUSES))
     language = serializers.CharField(required=False, min_length=3, max_length=3, allow_null=True)
     note = serializers.CharField(required=False, max_length=ContactNote.MAX_LENGTH, allow_blank=True)
     urns = serializers.ListField(required=False, child=fields.URNField(), max_length=100)
@@ -709,6 +717,8 @@ class ContactWriteSerializer(WriteSerializer):
     def validate(self, data):
         if self.instance and not self.instance.is_active:
             raise serializers.ValidationError("Deleted contacts can't be modified.")
+        if not self.instance and "status" in data:
+            raise serializers.ValidationError({"status": "Field is only allowed when updating a contact."})
 
         # we allow creation of contacts by URN used for lookup
         if not data.get("urns") and "urns__identity" in self.context["lookup_values"] and not self.instance:
@@ -723,6 +733,7 @@ class ContactWriteSerializer(WriteSerializer):
         Update our contact
         """
         name = self.validated_data.get("name")
+        contact_status = self.validated_data.get("status")
         language = self.validated_data.get("language")
         urns = self.validated_data.get("urns")
         groups = self.validated_data.get("groups")
@@ -733,6 +744,16 @@ class ContactWriteSerializer(WriteSerializer):
 
         # update an existing contact
         if self.instance:
+            if "status" in self.validated_data and self.STATUSES[contact_status] != self.instance.status:
+                if contact_status == "active":
+                    self.instance.restore(self.context["user"])
+                elif contact_status == "blocked":
+                    self.instance.block(self.context["user"])
+                elif contact_status == "stopped":
+                    self.instance.stop(self.context["user"])
+                elif contact_status == "archived":
+                    self.instance.archive(self.context["user"])
+
             # update our name and language
             if "name" in self.validated_data and name != self.instance.name:
                 mods.append(modifiers.Name(name=name))

--- a/temba/api/v2/tests/test_contacts.py
+++ b/temba/api/v2/tests/test_contacts.py
@@ -381,7 +381,8 @@ class ContactsEndpointTest(APITest):
         self.assertEqual(jean.get_field_value(nickname), "Žan")
         self.assertEqual(jean.get_field_value(gender), "frog")
 
-        # status can be updated while preserving the manual groups submitted by the contact editor
+        # status can be updated but groups submitted alongside a deactivation are dropped because mailroom
+        # removes non-active contacts from all groups
         self.assertPost(
             endpoint_url + f"?uuid={jean.uuid}",
             self.editor,
@@ -389,12 +390,30 @@ class ContactsEndpointTest(APITest):
         )
         jean.refresh_from_db()
         self.assertEqual(Contact.STATUS_BLOCKED, jean.status)
+        self.assertEqual(set(), set(jean.get_groups(manual_only=True)))
+
+        # groups can be submitted alongside a restore to active and are applied after the restore
+        self.assertPost(
+            endpoint_url + f"?uuid={jean.uuid}",
+            self.editor,
+            {"status": "active", "groups": [group.uuid]},
+        )
+        jean.refresh_from_db()
+        self.assertEqual(Contact.STATUS_ACTIVE, jean.status)
         self.assertEqual({group}, set(jean.get_groups(manual_only=True)))
+
+        self.assertPost(endpoint_url + f"?uuid={jean.uuid}", self.editor, {"status": "stopped"})
+        jean.refresh_from_db()
+        self.assertEqual(Contact.STATUS_STOPPED, jean.status)
+        self.assertEqual(set(), set(jean.get_groups(manual_only=True)))
+
+        self.assertPost(endpoint_url + f"?uuid={jean.uuid}", self.editor, {"status": "archived"})
+        jean.refresh_from_db()
+        self.assertEqual(Contact.STATUS_ARCHIVED, jean.status)
 
         self.assertPost(endpoint_url + f"?uuid={jean.uuid}", self.editor, {"status": "active"})
         jean.refresh_from_db()
         self.assertEqual(Contact.STATUS_ACTIVE, jean.status)
-        self.assertEqual({group}, set(jean.get_groups(manual_only=True)))
 
         self.assertPost(
             endpoint_url,

--- a/temba/api/v2/tests/test_contacts.py
+++ b/temba/api/v2/tests/test_contacts.py
@@ -381,6 +381,28 @@ class ContactsEndpointTest(APITest):
         self.assertEqual(jean.get_field_value(nickname), "Žan")
         self.assertEqual(jean.get_field_value(gender), "frog")
 
+        # status can be updated while preserving the manual groups submitted by the contact editor
+        self.assertPost(
+            endpoint_url + f"?uuid={jean.uuid}",
+            self.editor,
+            {"status": "blocked", "groups": [group.uuid]},
+        )
+        jean.refresh_from_db()
+        self.assertEqual(Contact.STATUS_BLOCKED, jean.status)
+        self.assertEqual({group}, set(jean.get_groups(manual_only=True)))
+
+        self.assertPost(endpoint_url + f"?uuid={jean.uuid}", self.editor, {"status": "active"})
+        jean.refresh_from_db()
+        self.assertEqual(Contact.STATUS_ACTIVE, jean.status)
+        self.assertEqual({group}, set(jean.get_groups(manual_only=True)))
+
+        self.assertPost(
+            endpoint_url,
+            self.editor,
+            {"name": "Blocked at birth", "status": "blocked"},
+            errors={"status": "Field is only allowed when updating a contact."},
+        )
+
         # change the language field
         self.assertPost(
             endpoint_url + f"?uuid={jean.uuid}",
@@ -598,6 +620,37 @@ class ContactsEndpointTest(APITest):
         self.assertEqual(
             "Frank is an okay guy (9)",
             response.json()["results"][0]["notes"][-1]["text"],
+        )
+
+    @mock_mailroom
+    def test_expanded_urns_can_preserve_priority_order(self, mr_mocks):
+        contact = self.create_contact(
+            "Reordered",
+            urns=["tel:+250788123456", "facebook:123456789"],
+        )
+        endpoint_url = reverse("api.v2.contacts") + f".json?expand_urns=true&urn_order=priority&uuid={contact.uuid}"
+
+        response = self.assertPost(
+            endpoint_url,
+            self.editor,
+            {"urns": ["facebook:123456789", "tel:+250788123456"]},
+        )
+
+        self.assertEqual(
+            ["facebook:123456789", "tel:+250788123456"],
+            [f"{urn['scheme']}:{urn['path']}" for urn in response.json()["urns"]],
+        )
+        self.assertIsNone(response.json()["urns"][0]["channel"])
+        self.assertIsNotNone(response.json()["urns"][1]["channel"])
+
+        response = self.assertGet(
+            reverse("api.v2.contacts") + f".json?expand_urns=true&uuid={contact.uuid}",
+            [self.editor],
+            results=[contact],
+        )
+        self.assertEqual(
+            ["tel:+250788123456", "facebook:123456789"],
+            [f"{urn['scheme']}:{urn['path']}" for urn in response.json()["results"][0]["urns"]],
         )
 
     @mock_mailroom

--- a/temba/api/v2/tests/test_contacts.py
+++ b/temba/api/v2/tests/test_contacts.py
@@ -381,47 +381,6 @@ class ContactsEndpointTest(APITest):
         self.assertEqual(jean.get_field_value(nickname), "Žan")
         self.assertEqual(jean.get_field_value(gender), "frog")
 
-        # status can be updated but groups submitted alongside a deactivation are dropped because mailroom
-        # removes non-active contacts from all groups
-        self.assertPost(
-            endpoint_url + f"?uuid={jean.uuid}",
-            self.editor,
-            {"status": "blocked", "groups": [group.uuid]},
-        )
-        jean.refresh_from_db()
-        self.assertEqual(Contact.STATUS_BLOCKED, jean.status)
-        self.assertEqual(set(), set(jean.get_groups(manual_only=True)))
-
-        # groups can be submitted alongside a restore to active and are applied after the restore
-        self.assertPost(
-            endpoint_url + f"?uuid={jean.uuid}",
-            self.editor,
-            {"status": "active", "groups": [group.uuid]},
-        )
-        jean.refresh_from_db()
-        self.assertEqual(Contact.STATUS_ACTIVE, jean.status)
-        self.assertEqual({group}, set(jean.get_groups(manual_only=True)))
-
-        self.assertPost(endpoint_url + f"?uuid={jean.uuid}", self.editor, {"status": "stopped"})
-        jean.refresh_from_db()
-        self.assertEqual(Contact.STATUS_STOPPED, jean.status)
-        self.assertEqual(set(), set(jean.get_groups(manual_only=True)))
-
-        self.assertPost(endpoint_url + f"?uuid={jean.uuid}", self.editor, {"status": "archived"})
-        jean.refresh_from_db()
-        self.assertEqual(Contact.STATUS_ARCHIVED, jean.status)
-
-        self.assertPost(endpoint_url + f"?uuid={jean.uuid}", self.editor, {"status": "active"})
-        jean.refresh_from_db()
-        self.assertEqual(Contact.STATUS_ACTIVE, jean.status)
-
-        self.assertPost(
-            endpoint_url,
-            self.editor,
-            {"name": "Blocked at birth", "status": "blocked"},
-            errors={"status": "Field is only allowed when updating a contact."},
-        )
-
         # change the language field
         self.assertPost(
             endpoint_url + f"?uuid={jean.uuid}",

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1085,7 +1085,6 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseEndpoint
     You can add a new contact to your account by sending a **POST** request to this URL with the following JSON data:
 
     * **name** - the full name of the contact (string, optional).
-    * **status** - the contact status: `active`, `blocked`, `stopped` or `archived` (string, optional on updates).
     * **language** - the preferred language for the contact (3 letter iso code, optional).
     * **urns** - a list of URNs you want associated with the contact (array of up to 100 strings, optional).
     * **groups** - a list of the UUIDs of any groups this contact is part of (array of up to 100 strings, optional).
@@ -1286,11 +1285,6 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseEndpoint
             ],
             "fields": [
                 {"name": "name", "required": False, "help": "Full name of the contact."},
-                {
-                    "name": "status",
-                    "required": False,
-                    "help": "Contact status: active, blocked, stopped or archived (updates only).",
-                },
                 {
                     "name": "language",
                     "required": False,

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -1085,6 +1085,7 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseEndpoint
     You can add a new contact to your account by sending a **POST** request to this URL with the following JSON data:
 
     * **name** - the full name of the contact (string, optional).
+    * **status** - the contact status: `active`, `blocked`, `stopped` or `archived` (string, optional on updates).
     * **language** - the preferred language for the contact (3 letter iso code, optional).
     * **urns** - a list of URNs you want associated with the contact (array of up to 100 strings, optional).
     * **groups** - a list of the UUIDs of any groups this contact is part of (array of up to 100 strings, optional).
@@ -1213,9 +1214,17 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseEndpoint
 
         if str_to_bool(self.request.query_params.get("expand_urns")):
             contact_info = Contact.bulk_inspect(object_list)
+            priority_order = self.request.query_params.get("urn_order") == "priority"
 
             for contact in object_list:
-                contact.expanded_urns = contact_info[contact]["urns"]
+                expanded_urns = contact_info[contact]["urns"]
+                if priority_order:
+                    urn_order = {(urn.scheme, urn.path): index for index, urn in enumerate(contact.get_urns())}
+                    expanded_urns = sorted(
+                        expanded_urns,
+                        key=lambda urn: urn_order.get((urn["scheme"], urn["path"]), len(urn_order)),
+                    )
+                contact.expanded_urns = expanded_urns
 
     def get_serializer_context(self):
         """
@@ -1276,7 +1285,12 @@ class ContactsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseEndpoint
                 {"name": "urn", "required": False, "help": "URN of the contact to be updated. ex: tel:+250788123123"},
             ],
             "fields": [
-                {"name": "name", "required": False, "help": "List of UUIDs of this contact's groups."},
+                {"name": "name", "required": False, "help": "Full name of the contact."},
+                {
+                    "name": "status",
+                    "required": False,
+                    "help": "Contact status: active, blocked, stopped or archived (updates only).",
+                },
                 {
                     "name": "language",
                     "required": False,

--- a/temba/contacts/api.py
+++ b/temba/contacts/api.py
@@ -1,3 +1,4 @@
+from rest_framework import generics, serializers, status
 from rest_framework.response import Response
 
 from django.db.models import Prefetch, prefetch_related_objects
@@ -6,7 +7,8 @@ from temba import mailroom
 from temba.api.internal.serializers import ModelAsJsonSerializer
 from temba.api.internal.views import BaseEndpoint
 from temba.api.support import ListPagination, SearchLengthMixin
-from temba.api.views import ListAPIMixin
+from temba.api.v2 import serializers as v2
+from temba.api.views import ListAPIMixin, WriteAPIMixin
 from temba.utils.models.base import patch_queryset_count
 from temba.utils.models.es import SearchSliceQuerySet
 from temba.utils.uuid import is_uuid
@@ -21,17 +23,72 @@ MAX_PAGE = 200
 FIELD_SORT_PREFIX = "field:"
 
 
-class ContactsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
+class ContactWriteSerializer(v2.ContactWriteSerializer):
+    """
+    The public API contact write serializer extended with status changes, for the contact editor component.
+    """
+
+    STATUSES = {
+        "active": Contact.STATUS_ACTIVE,
+        "blocked": Contact.STATUS_BLOCKED,
+        "stopped": Contact.STATUS_STOPPED,
+        "archived": Contact.STATUS_ARCHIVED,
+    }
+
+    status = serializers.ChoiceField(required=False, choices=tuple(STATUSES))
+
+    def validate_groups(self, value):
+        # the public API rejects groups on any non-active contact - here that check needs to consider a status
+        # submitted in the same update, so it lives in validate() below
+        return value
+
+    def validate(self, data):
+        data = super().validate(data)
+
+        # only active contacts can be added to groups, tho we allow groups on an update that restores the contact
+        # since the restore is applied first
+        if self.instance and data.get("groups"):
+            new_status = self.STATUSES[data["status"]] if "status" in data else self.instance.status
+            if self.instance.status != Contact.STATUS_ACTIVE and new_status != Contact.STATUS_ACTIVE:
+                raise serializers.ValidationError({"groups": "Non-active contacts can't be added to groups"})
+
+        return data
+
+    def save(self):
+        # apply any status change first so that a restore to active happens before any group mods
+        contact_status = self.validated_data.get("status")
+        if self.instance and "status" in self.validated_data and self.STATUSES[contact_status] != self.instance.status:
+            user = self.context["user"]
+            if contact_status == "active":
+                self.instance.restore(user)
+            elif contact_status == "blocked":
+                self.instance.block(user)
+            elif contact_status == "stopped":
+                self.instance.stop(user)
+            elif contact_status == "archived":
+                self.instance.archive(user)
+
+        return super().save()
+
+
+class ContactsEndpoint(SearchLengthMixin, ListAPIMixin, WriteAPIMixin, BaseEndpoint):
     """
     Contacts for the current org, used by the contact list component. A status folder is selected with the `folder`
     query param (one of `active`, `blocked`, `stopped` or `archived`, defaulting to `active`) — alternatively pass
     `group=<uuid>` to filter by a specific (manual or smart) group. Optional `search` (a mailroom contact query) and
     `sort` params drive ES-backed search/sorting, exactly like the legacy contact list views. Each item is serialized
     via Contact.as_json() (the lightweight list shape — name, primary URN, featured field values, last/created on).
+
+    POST with a `uuid` param updates a contact (used by the contact editor component), accepting the same fields as
+    the public API endpoint plus `status`, and returns the contact in the editor's read shape (the public API read
+    serialization with URNs expanded and in priority order). Unlike the public API endpoint, contacts can't be
+    created here.
     """
 
     model = Contact
     serializer_class = ModelAsJsonSerializer
+    write_serializer_class = ContactWriteSerializer
+    write_with_transaction = False
     pagination_class = ListPagination
 
     # a mailroom contact query rather than a plain text search, so cap it at the query length limit
@@ -49,6 +106,31 @@ class ContactsEndpoint(SearchLengthMixin, ListAPIMixin, BaseEndpoint):
         if self._page() > MAX_PAGE:
             return Response({"results": [], "count": 0, "next": None, "previous": None})
         return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        # unlike the public API endpoint, contacts can only be updated here, never created
+        if "uuid" not in request.query_params:
+            return Response({"detail": "URL must contain uuid parameter."}, status=status.HTTP_400_BAD_REQUEST)
+
+        return super().post(request, *args, **kwargs)
+
+    def get_object(self):
+        # lookups are always by UUID and shouldn't be constrained by the folder/group params used for listing
+        return generics.get_object_or_404(Contact.objects.filter(org=self.request.org, **self.lookup_values))
+
+    def render_write_response(self, write_output, context):
+        # the editor component expects the same shape it reads: the public API read serialization with URNs
+        # expanded and in priority order
+        Contact.bulk_urn_cache_initialize([write_output], using="default")
+        expanded_urns = Contact.bulk_inspect([write_output])[write_output]["urns"]
+        priority = {(urn.scheme, urn.path): index for index, urn in enumerate(write_output.get_urns())}
+        write_output.expanded_urns = sorted(
+            expanded_urns, key=lambda urn: priority.get((urn["scheme"], urn["path"]), len(priority))
+        )
+
+        return Response(
+            v2.ContactReadSerializer(instance=write_output, context=context).data, status=status.HTTP_200_OK
+        )
 
     def _page(self) -> int:
         try:

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -570,25 +570,27 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.assertRequestDisallowed(read_url, [None, self.agent])
 
-        self.assertContentMenu(read_url, self.editor, ["Edit", "Start Flow", "Open Ticket"])
-        self.assertContentMenu(read_url, self.admin, ["Edit", "Start Flow", "Open Ticket"])
+        self.assertContentMenu(read_url, self.editor, ["Start Flow", "Open Ticket"])
+        self.assertContentMenu(read_url, self.admin, ["Start Flow", "Open Ticket"])
 
         # if there's an open ticket already, don't show open ticket option
         self.create_ticket(joe)
-        self.assertContentMenu(read_url, self.editor, ["Edit", "Start Flow"])
+        self.assertContentMenu(read_url, self.editor, ["Start Flow"])
 
         # login as admin
         self.login(self.admin)
 
         response = self.client.get(read_url)
         self.assertContains(response, "Joe")
+        self.assertContains(response, '-temba-button-clicked="handleFieldSearch"')
+        self.assertContains(response, "evt.detail.key === undefined")
         self.assertEqual("/contact/active", response.headers[TEMBA_MENU_SELECTION])
 
         # block the contact
         joe.block(self.admin)
         self.assertTrue(Contact.objects.get(pk=joe.id, status="B"))
 
-        self.assertContentMenu(read_url, self.admin, ["Edit"])
+        self.assertContentMenu(read_url, self.admin, [])
 
         response = self.client.get(read_url)
         self.assertContains(response, "Joe")
@@ -634,6 +636,8 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(read_url)
         self.assertContains(response, "temba-card-layout")
         self.assertContains(response, "temba-page-header")
+        self.assertContains(response, '-temba-button-clicked="handleFieldSearch"')
+        self.assertContains(response, "evt.detail.key === undefined")
         self.assertNotContains(response, "temba-tabs")
 
         # card state defaults to empty
@@ -1925,14 +1929,14 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
         # should see start flow option
         response = self.client.get(read_url)
-        self.assertContentMenu(read_url, self.admin, ["Edit", "Start Flow", "Open Ticket"])
+        self.assertContentMenu(read_url, self.admin, ["Start Flow", "Open Ticket"])
 
         MockSessionWriter(contact, self.create_flow("Test")).wait().save()
         MockSessionWriter(other_org_contact, self.create_flow("Test", org=self.org2)).wait().save()
 
         # start option is still present even for a contact in a flow - the start modal handles
         # confirming the interruption
-        self.assertContentMenu(read_url, self.admin, ["Edit", "Start Flow", "Open Ticket"])
+        self.assertContentMenu(read_url, self.admin, ["Start Flow", "Open Ticket"])
 
         # can't interrupt if not logged in
         self.client.logout()

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -1071,7 +1071,9 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual("Bobby", contact.name)
         self.assertEqual(Contact.STATUS_BLOCKED, contact.status)
         self.assertEqual("spa", contact.language)
-        self.assertEqual({testers}, set(contact.get_groups()))
+
+        # contact is no longer in the group because blocking removes contacts from all groups
+        self.assertEqual(set(), set(contact.get_groups()))
         self.assertEqual(
             ["tel:+593979333333", "telegram:78686776", "facebook:9898989"],
             [u.identity for u in contact.urns.order_by("-priority")],

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -444,16 +444,6 @@ class ContactCRUDL(SmartCRUDL):
         def build_context_menu(self, menu):
             obj = self.get_object()
 
-            if self.has_org_perm("contacts.contact_update"):
-                menu.add_modax(
-                    _("Edit"),
-                    "edit-contact",
-                    f"{reverse('contacts.contact_update', args=[obj.uuid])}",
-                    title=_("Edit Contact"),
-                    on_submit="contactUpdated()",
-                    as_button=True,
-                )
-
             if obj.status == Contact.STATUS_ACTIVE:
                 if self.has_org_perm("flows.flow_start"):
                     menu.add_modax(
@@ -473,6 +463,9 @@ class ContactCRUDL(SmartCRUDL):
             context["msg_logs_after"] = (timezone.now() - settings.RETENTION_PERIODS["channellog"]).isoformat()
             # serialized for temba-card-layout's settings attribute
             context["card_settings"] = json.dumps(self.request.user.settings.get("contact_cards", {}))
+            context["contact_urn_schemes"] = [
+                {"value": value, "name": str(label)} for value, label in URN.SCHEME_CHOICES
+            ]
             return context
 
     class Timeline(BaseReadView):

--- a/temba/tests/mailroom.py
+++ b/temba/tests/mailroom.py
@@ -799,7 +799,6 @@ def apply_modifiers(org, user, contacts, modifiers: list):
 
     for mod in modifiers:
         fields = dict()
-        clear_groups = False
 
         if mod.type == "name":
             fields = dict(name=mod.name)
@@ -814,13 +813,10 @@ def apply_modifiers(org, user, contacts, modifiers: list):
         elif mod.type == "status":
             if mod.status == "blocked":
                 fields = dict(status=Contact.STATUS_BLOCKED)
-                clear_groups = True
             elif mod.status == "stopped":
                 fields = dict(status=Contact.STATUS_STOPPED)
-                clear_groups = True
             elif mod.status == "archived":
                 fields = dict(status=Contact.STATUS_ARCHIVED)
-                clear_groups = True
             else:
                 fields = dict(status=Contact.STATUS_ACTIVE)
 
@@ -850,8 +846,11 @@ def apply_modifiers(org, user, contacts, modifiers: list):
         Contact.objects.filter(id__in=[c.id for c in contacts]).update(
             modified_by=user, modified_on=timezone.now(), **fields
         )
-        if clear_groups:
-            for c in contacts:
+
+        # like mailroom, ensure that non-active contacts belong to no groups after each modifier
+        for c in contacts:
+            c.refresh_from_db()
+            if c.status != Contact.STATUS_ACTIVE:
                 for g in c.get_groups():
                     g.contacts.remove(c)
 

--- a/temba/tickets/tests/test_ticketcrudl.py
+++ b/temba/tickets/tests/test_ticketcrudl.py
@@ -39,6 +39,8 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(list_url)
         self.assertContains(response, "temba-tabs")
         self.assertNotContains(response, "temba-card-layout")
+        self.assertContains(response, "temba-contact-details")
+        self.assertRegex(response.content.decode(), r"<temba-contact-details\b[^>]*\beditable(?:\s|>)")
 
         # by default we get the chat + card layout, sharing the contact card settings
         self.setLegacyUI(False)
@@ -49,10 +51,24 @@ class TicketCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.client.get(list_url)
         self.assertContains(response, "temba-card-layout")
         self.assertContains(response, "temba-page-header")
+        self.assertContains(response, 'id="card-details"')
+        self.assertContains(response, "temba-contact-details")
+        self.assertContains(response, "details.contact = contact.uuid;")
+        self.assertContains(response, 'details.schemes = JSON.parse(document.getElementById("contact-urn-schemes")')
         self.assertNotContains(response, "temba-tabs")
+        self.assertRegex(response.content.decode(), r"<temba-contact-details\b[^>]*\beditable(?:\s|>)")
         self.assertEqual(
             '{"order": ["card-notepad", "card-fields"], "collapsed": []}', response.context["card_settings"]
         )
+        self.assertIn({"value": "tel", "name": "Phone Number"}, response.context["contact_urn_schemes"])
+
+        # human agents can see contact details on tickets but can't edit them
+        self.login(self.agent)
+        response = self.client.get(list_url)
+        self.assertContains(response, 'id="card-details"')
+        self.assertContains(response, "temba-contact-details")
+        self.assertContains(response, 'role="T"')
+        self.assertNotRegex(response.content.decode(), r"<temba-contact-details\b[^>]*\beditable(?:\s|>)")
 
     def test_list(self):
         list_url = reverse("tickets.ticket_list")

--- a/temba/tickets/views.py
+++ b/temba/tickets/views.py
@@ -15,8 +15,9 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
+from temba.contacts.models import URN
 from temba.msgs.models import Msg
-from temba.orgs.models import Org
+from temba.orgs.models import Org, OrgRole
 from temba.orgs.views.base import (
     BaseCreateModal,
     BaseDeleteModal,
@@ -338,6 +339,9 @@ class TicketCRUDL(SmartCRUDL):
             context["msg_logs_after"] = (timezone.now() - settings.RETENTION_PERIODS["channellog"]).isoformat()
             # serialized for temba-card-layout's settings attribute
             context["card_settings"] = json.dumps(self.request.user.settings.get("contact_cards", {}))
+            context["contact_urn_schemes"] = [
+                {"value": value, "name": str(label)} for value, label in URN.SCHEME_CHOICES
+            ]
 
             if ticket:
                 context["nextUUID" if in_page else "uuid"] = str(ticket.uuid)
@@ -349,6 +353,7 @@ class TicketCRUDL(SmartCRUDL):
 
             # pass agent permission flags to template
             membership = self.request.org.get_membership(self.request.user)
+            context["user_role"] = membership.role_code if membership else OrgRole.ADMINISTRATOR.code
             context["can_assign"] = membership.can_assign if membership else True
             context["can_reply_non_own"] = membership.can_reply_non_own if membership else True
 

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -23,8 +23,13 @@
       </temba-contact-chat>
     </temba-tab>
     <temba-tab icon="info" name="{{ _("Details") |escapejs }}">
-      <temba-contact-details contact="{{ object.uuid }}" class="py-4 px-1 overflow-y-auto">
+      <temba-contact-details contact="{{ object.uuid }}"
+                             class="py-4 px-1 overflow-y-auto"
+                             -temba-button-clicked="handleFieldSearch"
+                             {% if org_perms.contacts.contact_update %}editable{% endif %}
+                             {% if object.org.is_anon %}anon{% endif %}>
       </temba-contact-details>
+      {{ contact_urn_schemes|json_script:"contact-urn-schemes" }}
     </temba-tab>
     <temba-tab icon="fields" name="{{ _("Fields") |escapejs }}">
       <div style="border-top-right-radius: var(--curvature)"
@@ -69,6 +74,11 @@
 {% endblock extra-style %}
 {% block extra-script %}
   <script type="text/javascript">
+    onSpload(function() {
+      const details = document.querySelector("temba-contact-details");
+      details.schemes = JSON.parse(document.getElementById("contact-urn-schemes").textContent);
+    });
+
     function handleInterruptContact(event) {
       const options = {
         onSubmit: "contactUpdated()"
@@ -110,6 +120,9 @@
     }
 
     function handleFieldSearch(evt) {
+      if (!evt.detail || evt.detail.key === undefined || evt.detail.value === undefined) {
+        return;
+      }
       spaGet("/contact/?search=" + encodeURIComponent(evt.detail.key) + "+%3D+" + encodeURIComponent("\"" + evt.detail.value + "\""))
     }
 

--- a/templates/contacts/contact_read_new.html
+++ b/templates/contacts/contact_read_new.html
@@ -74,8 +74,12 @@
                           -temba-interrupt="handleInterruptContact">
       </temba-contact-chat>
       <temba-card id="card-details" label="{{ _("Details") |escapejs }}" icon="info">
-        <temba-contact-details contact="{{ object.uuid }}">
+        <temba-contact-details contact="{{ object.uuid }}"
+                               -temba-button-clicked="handleFieldSearch"
+                               {% if org_perms.contacts.contact_update %}editable{% endif %}
+                               {% if object.org.is_anon %}anon{% endif %}>
         </temba-contact-details>
+        {{ contact_urn_schemes|json_script:"contact-urn-schemes" }}
       </temba-card>
       <temba-card id="card-fields" label="{{ _("Fields") |escapejs }}" icon="fields">
         <temba-contact-fields timezone="{{ object.org.timezone }}"
@@ -109,6 +113,11 @@
   {{ block.super }}
   {% include "includes/page_header_menu.html" %}
   <script type="text/javascript">
+    onSpload(function() {
+      const details = document.querySelector("temba-contact-details");
+      details.schemes = JSON.parse(document.getElementById("contact-urn-schemes").textContent);
+    });
+
     function handleInterruptContact(event) {
       const options = {
         onSubmit: "contactUpdated()"
@@ -139,6 +148,9 @@
     }
 
     function handleFieldSearch(evt) {
+      if (!evt.detail || evt.detail.key === undefined || evt.detail.value === undefined) {
+        return;
+      }
       spaGet("/contact/?search=" + encodeURIComponent(evt.detail.key) + "+%3D+" + encodeURIComponent("\"" + evt.detail.value + "\""))
     }
 

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -355,6 +355,7 @@
       var contactHeader = document.querySelector("temba-contact-name-fetch");
       var notepad = document.querySelector("temba-contact-notepad");
       var chat = document.querySelector("temba-contact-chat");
+      var details = document.querySelector("temba-contact-details");
       var empty = document.querySelector(".chat-pane .empty");
 
       var fields = document.querySelectorAll("temba-contact-fields");
@@ -370,6 +371,7 @@
         chat.currentTicket = contact.ticket;
         notepad.contact = contact.uuid;
         contactHeader.contact = contact.uuid;
+        details.contact = contact.uuid;
         fields.forEach(function(contactFields) {
           contactFields.contact = contact.uuid;
         });
@@ -420,6 +422,10 @@
         if (notepad) {
           notepad.contact = null;
         }
+
+        if (details) {
+          details.contact = null;
+        }
       }
 
       updateTicketList();
@@ -452,6 +458,9 @@
     }
 
     function handleFieldSearch(evt) {
+      if (!evt.detail || evt.detail.key === undefined || evt.detail.value === undefined) {
+        return;
+      }
       var url = "/contact/?search=" + encodeURIComponent(evt.detail.key) + "+%3D+" + encodeURIComponent("\"" + evt.detail.value + "\"")
       if (typeof spaGet !== 'undefined') {
         spaGet(url)
@@ -535,6 +544,11 @@
       const chat = document.querySelector('temba-contact-chat');
       chat.refresh();
 
+      const details = document.querySelector('temba-contact-details');
+      if (details) {
+        details.refresh();
+      }
+
       const contentMenu = document.querySelector("temba-content-menu#default-content-menu");
       contentMenu.refresh();
     }
@@ -555,6 +569,9 @@
     }
 
     onSpload(function() {
+      const details = document.querySelector("temba-contact-details");
+      details.schemes = JSON.parse(document.getElementById("contact-urn-schemes").textContent);
+
       const store = document.querySelector('temba-store');
       const width = store.get('ticket-list-width', '300');
       const resizer = document.querySelector('temba-resizer');
@@ -570,7 +587,6 @@
           <div class="flex mb-2 {% if folder == "all" %}hidden{% endif %}" id="title-row">
             <div class="flex-grow relative" id="folder-title">
               <div id="title-text">{{ title }}</div>
-
             </div>
             <temba-content-menu endpoint="{% url 'tickets.ticket_folder' folder status uuid %}"
                                 -temba-selection="handleContentMenuSelected(event)"
@@ -580,16 +596,18 @@
             </temba-content-menu>
           </div>
           <temba-user-select name="assignee-filter"
-                            placeholder="{% trans "All Agents" %}"
-                            onchange="handleAssigneeFilterChanged(event)"
-                            valueKey="uuid"
-                            {% if assignee_uuid %}value="{{ assignee_uuid }}"{% endif %}
-                            class="{% if folder != "all" %}hidden{% endif %}"
-                            style="z-index:3; margin-bottom:0.5em; width:100%;"
-                            searchable
-                            searchOnFocus
-                            clearable>
-              </temba-user-select>
+                             placeholder="{% trans "All Agents" %}"
+                             onchange="handleAssigneeFilterChanged(event)"
+                             valueKey="uuid"
+                             {% if assignee_uuid %}value="{{ assignee_uuid }}"{% endif %}
+                             class="{% if folder != "all" %}hidden{% endif %}"
+                             style="z-index:3;
+                                    margin-bottom:0.5em;
+                                    width:100%"
+                             searchable
+                             searchOnFocus
+                             clearable>
+          </temba-user-select>
           <temba-select style="z-index:2"
                         name="ticket-status"
                         onchange="handleStatusFilterChanged(event)"
@@ -687,12 +705,18 @@
                                 avatar="{{ branding.logos.avatar }}">
             </temba-contact-chat>
           </temba-tab>
+          <temba-tab icon="info" name="{{ _("Details") |escapejs }}">
+            <temba-contact-details -temba-button-clicked="handleFieldSearch"
+                                   {% if org_perms.contacts.contact_update %}editable{% endif %}
+                                   {% if request.org.is_anon %}anon{% endif %}>
+            </temba-contact-details>
+          </temba-tab>
           <temba-tab icon="fields" name="{{ _("Fields") |escapejs }}">
             <div style="border-top-right-radius: var(--curvature)"
                  class="flex flex-grow flex-col py-4 px-1 overflow-y-auto">
               <temba-contact-fields timezone="{{ object.org.timezone }}"
                                     -temba-button-clicked="handleFieldSearch"
-                                    role="{{ request.role.code }}">
+                                    role="{{ user_role }}">
                 <div slot="empty" class="no-fields p-16 text-center" style="opacity:1">
                   <div class="text-xl mb-4">{% trans "No Fields" %}</div>
                 </div>
@@ -704,6 +728,7 @@
             </temba-contact-notepad>
           </temba-tab>
         </temba-tabs>
+        {{ contact_urn_schemes|json_script:"contact-urn-schemes" }}
       </div>
     </div>
   </div>

--- a/templates/tickets/ticket_list_new.html
+++ b/templates/tickets/ticket_list_new.html
@@ -416,6 +416,7 @@
       var contactHeader = document.querySelector("temba-contact-name-fetch");
       var notepad = document.querySelector("temba-contact-notepad");
       var chat = document.querySelector("temba-contact-chat");
+      var details = document.querySelector("temba-contact-details");
       var empty = document.querySelector(".chat-pane .empty");
 
       var fields = document.querySelectorAll("temba-contact-fields");
@@ -427,6 +428,7 @@
         chat.currentTicket = contact.ticket;
         notepad.contact = contact.uuid;
         contactHeader.contact = contact.uuid;
+        details.contact = contact.uuid;
         fields.forEach(function(contactFields) {
           contactFields.contact = contact.uuid;
         });
@@ -486,6 +488,10 @@
         if (notepad) {
           notepad.contact = null;
         }
+
+        if (details) {
+          details.contact = null;
+        }
       }
 
       updateTicketList();
@@ -515,6 +521,9 @@
     }
 
     function handleFieldSearch(evt) {
+      if (!evt.detail || evt.detail.key === undefined || evt.detail.value === undefined) {
+        return;
+      }
       var url = "/contact/?search=" + encodeURIComponent(evt.detail.key) + "+%3D+" + encodeURIComponent("\"" + evt.detail.value + "\"")
       if (typeof spaGet !== 'undefined') {
         spaGet(url)
@@ -609,6 +618,11 @@
       const chat = document.querySelector('temba-contact-chat');
       chat.refresh();
 
+      const details = document.querySelector('temba-contact-details');
+      if (details) {
+        details.refresh();
+      }
+
       const header = document.querySelector("#page-header");
       header.refresh();
     }
@@ -625,6 +639,9 @@
     }
 
     onSpload(function() {
+      const details = document.querySelector("temba-contact-details");
+      details.schemes = JSON.parse(document.getElementById("contact-urn-schemes").textContent);
+
       const store = document.querySelector('temba-store');
       const width = store.get('ticket-list-width', '300');
       const resizer = document.querySelector('temba-resizer');
@@ -770,25 +787,27 @@
                               {% if not can_reply_non_own %}disableReply{% endif %}
                               avatar="{{ branding.logos.avatar }}">
           </temba-contact-chat>
+          <temba-card id="card-details" label="{{ _("Details") |escapejs }}" icon="info">
+            <temba-contact-details -temba-button-clicked="handleFieldSearch"
+                                   {% if org_perms.contacts.contact_update %}editable{% endif %}
+                                   {% if request.org.is_anon %}anon{% endif %}>
+            </temba-contact-details>
+          </temba-card>
           <temba-card id="card-fields" label="{{ _("Fields") |escapejs }}" icon="fields">
             <temba-contact-fields timezone="{{ object.org.timezone }}"
                                   -temba-button-clicked="handleFieldSearch"
-                                  role="{{ request.role.code }}">
+                                  role="{{ user_role }}">
               <div slot="empty" class="no-fields p-4 text-center" style="opacity:1">
                 <div class="text-xl mb-4">{% trans "No Fields" %}</div>
               </div>
             </temba-contact-fields>
           </temba-card>
-          <temba-card id="card-notepad"
-                      variant="note"
-                      label="{{ _("Notepad") |escapejs }}"
-                      icon="notes"
-                      activity
-                      bleed>
+          <temba-card id="card-notepad" variant="note" label="{{ _("Notepad") |escapejs }}" icon="notes" activity bleed>
             <temba-contact-notepad autogrow>
             </temba-contact-notepad>
           </temba-card>
         </temba-card-layout>
+        {{ contact_urn_schemes|json_script:"contact-urn-schemes" }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Enables inline editing of contact details directly from the contact read page and ticket list, replacing the separate Edit modal.

## Changes

**Contact editor UI** (`templates/contacts/contact_read.html`, `contact_read_new.html`, `templates/tickets/ticket_list.html`, `ticket_list_new.html`, `temba/contacts/views.py`, `temba/tickets/views.py`)
- Makes `temba-contact-details` editable for users with `contacts.contact_update` on both contact read pages and the ticket list, passing the org's URN schemes (for URN editing) and the anon flag for anonymous orgs.
- Removes the Edit modal from the contact read page content menu since editing now happens inline.
- Agents can see contact details on tickets but not edit them (`user_role` is passed to the ticket list template).
- Field search clicks from the details widget are guarded so button events without a field key/value don't trigger a bogus search navigation.

**API v2 contacts endpoint** (`temba/api/v2/serializers.py`, `temba/api/v2/views.py`)
- Adds a `status` field on contact updates (`active`, `blocked`, `stopped`, `archived`); not allowed on create.
- Groups can only be set on contacts that are (or are being restored to) active. A restore is applied before other modifications, so `{"status": "active", "groups": [...]}` re-adds groups in the same request. Groups submitted alongside a deactivation are dropped, matching mailroom, which removes non-active contacts from all groups.
- Adds a `urn_order=priority` param so `expand_urns` responses can return URNs in contact priority order instead of the default inspect order.

**Test mailroom mock** (`temba/tests/mailroom.py`)
- Aligns the mock with real mailroom/goflow behavior: non-active contacts are removed from all groups after *each* modifier is applied, instead of only on status modifiers. Previously the mock allowed adding groups to blocked contacts, which real mailroom rejects — this made tests assert behavior that wouldn't hold in production.

## Behavior examples

| Request (update by UUID) | Before | After |
|---|---|---|
| `{"status": "blocked"}` | 400 (`status` not a field) | contact blocked, removed from groups |
| `{"status": "blocked", "groups": [g]}` | 400 | contact blocked, groups dropped (mailroom rule) |
| `{"status": "active", "groups": [g]}` on blocked contact | 400 (`Non-active contacts can't be added to groups`) | contact restored, then added to `g` |
| `{"groups": [g]}` on blocked contact | 400 | 400 (unchanged) |
| `GET ?expand_urns=true&urn_order=priority` | n/a | expanded URNs sorted by contact URN priority |

## Test plan

- [x] `temba.api` — new coverage for all four status transitions, restore-with-groups, status-on-create error, and priority-ordered expanded URNs
- [x] `temba.contacts`, `temba.tickets` — updated menu/template assertions and legacy update-modal group expectations
- [x] `temba.flows`, `temba.campaigns`, `temba.triggers`, `temba.msgs`, `temba.mailroom` — no regressions from the mock change
- [x] `code_check.py` (ruff format/lint, migrations)
- [x] CI green including 100% coverage gate