### PR TITLE
Persist list column widths in user settings

### DIFF
--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -284,10 +284,14 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # by default we get the temba-contact-list component, pointed at the internal contacts api — check the query
         # count too since the component fetches contacts itself so rendering shouldn't hit the contacts table
         self.setLegacyUI(False)
+        self.admin.settings["list_columns"] = {"contacts": {"name": 240}}
+        self.admin.save(update_fields=("settings",))
 
         with self.assertNumQueries(7):
             response = self.client.get(list_url)
         self.assertContains(response, "temba-contact-list")
+        self.assertContains(response, 'column-width-settings="{&quot;contacts&quot;: {&quot;name&quot;: 240}}"')
+        self.assertContains(response, f'settings-endpoint="{reverse("users.user_settings")}"')
         self.assertEqual(
             f"{reverse('api.internal.contacts')}.json?folder=active", response.context["new_list_endpoint"]
         )

--- a/temba/users/tests/test_settings.py
+++ b/temba/users/tests/test_settings.py
@@ -49,3 +49,38 @@ class UserSettingsTest(TembaTest):
         self.assertEqual(
             {"contact_cards": {"collapsed": ["card-nextup"]}, "other": {"kept": True}}, self.admin.settings
         )
+
+        # list widths are merged by view and column so independent list
+        # pages (and stale tabs) don't overwrite one another
+        response = self.client.post(
+            settings_url,
+            {"list_columns": {"contacts": {"name": 240}, "msgs": {"contact": 160}}},
+            content_type="application/json",
+        )
+        self.assertEqual(200, response.status_code)
+
+        response = self.client.post(
+            settings_url,
+            {"list_columns": {"contacts": {"last_seen_on": 180}, "msgs": {"created_on": 140}}},
+            content_type="application/json",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {
+                "contacts": {"name": 240, "last_seen_on": 180},
+                "msgs": {"contact": 160, "created_on": 140},
+            },
+            response.json()["settings"]["list_columns"],
+        )
+
+        # malformed or out-of-range widths are rejected
+        for invalid in (
+            [],
+            {"contacts": []},
+            {"contacts": {"name": "wide"}},
+            {"contacts": {"name": 79}},
+            {"contacts": {"name": 601}},
+            {"flows": {"name": 240}},
+        ):
+            response = self.client.post(settings_url, {"list_columns": invalid}, content_type="application/json")
+            self.assertEqual(400, response.status_code)

--- a/temba/users/tests/test_settings.py
+++ b/temba/users/tests/test_settings.py
@@ -84,3 +84,41 @@ class UserSettingsTest(TembaTest):
         ):
             response = self.client.post(settings_url, {"list_columns": invalid}, content_type="application/json")
             self.assertEqual(400, response.status_code)
+
+        # a saved value corrupted to a non-dict is discarded rather than merged
+        self.admin.settings["list_columns"] = "junk"
+        self.admin.save(update_fields=("settings",))
+        response = self.client.post(
+            settings_url,
+            {"list_columns": {"contacts": {"name": 200}}},
+            content_type="application/json",
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"contacts": {"name": 200}}, response.json()["settings"]["list_columns"])
+
+        # column names aren't validated against each list's real columns, so a single save is
+        # capped at 20 columns per list...
+        response = self.client.post(
+            settings_url,
+            {"list_columns": {"contacts": {f"field:f{i}": 100 for i in range(21)}}},
+            content_type="application/json",
+        )
+        self.assertEqual(400, response.status_code)
+
+        # ...and merging evicts stale columns before ones in the current save
+        response = self.client.post(
+            settings_url,
+            {"list_columns": {"contacts": {f"field:f{i}": 100 for i in range(20)}}},
+            content_type="application/json",
+        )
+        self.assertEqual(200, response.status_code)
+        response = self.client.post(
+            settings_url,
+            {"list_columns": {"contacts": {"name": 240}}},
+            content_type="application/json",
+        )
+        self.assertEqual(200, response.status_code)
+        saved = response.json()["settings"]["list_columns"]["contacts"]
+        self.assertEqual(20, len(saved))
+        self.assertEqual(240, saved["name"])
+        self.assertNotIn("field:f0", saved)

--- a/temba/users/views.py
+++ b/temba/users/views.py
@@ -54,6 +54,10 @@ class UserSettingsView(LoginRequiredMixin, View):
     ALLOWED_KEYS = {"contact_cards", "list_columns"}
     RESIZABLE_LISTS = {"contacts", "msgs"}
 
+    # column names aren't validated against each list's real columns (custom fields make those
+    # dynamic), so instead cap how many can accumulate per list
+    MAX_LIST_COLUMNS = 20
+
     def post(self, request, *args, **kwargs):
         if len(request.body) > 100_000:
             return JsonResponse({"error": "request body too large"}, status=400)
@@ -75,6 +79,7 @@ class UserSettingsView(LoginRequiredMixin, View):
                 not isinstance(view, str)
                 or view not in self.RESIZABLE_LISTS
                 or not isinstance(widths, dict)
+                or len(widths) > self.MAX_LIST_COLUMNS
                 or any(
                     not isinstance(column, str)
                     or not isinstance(width, int)
@@ -92,16 +97,20 @@ class UserSettingsView(LoginRequiredMixin, View):
             saved_columns = request.user.settings.get("list_columns", {})
             if not isinstance(saved_columns, dict):
                 saved_columns = {}
-            posted["list_columns"] = {
-                **saved_columns,
-                **{
-                    view: {
-                        **(saved_columns.get(view, {}) if isinstance(saved_columns.get(view), dict) else {}),
-                        **widths,
-                    }
-                    for view, widths in list_columns.items()
-                },
-            }
+            merged_columns = {**saved_columns}
+            for view, widths in list_columns.items():
+                saved_widths = saved_columns.get(view)
+                merged_widths = {**(saved_widths if isinstance(saved_widths, dict) else {}), **widths}
+
+                # keep the merged set bounded: evict columns not in this save (stale keys from
+                # renamed or removed fields) before ones the user just resized
+                extra = len(merged_widths) - self.MAX_LIST_COLUMNS
+                if extra > 0:
+                    for column in [c for c in merged_widths if c not in widths][:extra]:
+                        del merged_widths[column]
+
+                merged_columns[view] = merged_widths
+            posted["list_columns"] = merged_columns
 
         request.user.settings = {**request.user.settings, **posted}
         request.user.save(update_fields=("settings",))

--- a/temba/users/views.py
+++ b/temba/users/views.py
@@ -51,7 +51,8 @@ class UserSettingsView(LoginRequiredMixin, View):
     """
 
     # the settings keys the UI is allowed to write
-    ALLOWED_KEYS = {"contact_cards"}
+    ALLOWED_KEYS = {"contact_cards", "list_columns"}
+    RESIZABLE_LISTS = {"contacts", "msgs"}
 
     def post(self, request, *args, **kwargs):
         if len(request.body) > 100_000:
@@ -67,6 +68,40 @@ class UserSettingsView(LoginRequiredMixin, View):
 
         if not set(posted) <= self.ALLOWED_KEYS:
             return JsonResponse({"error": "unsupported settings keys"}, status=400)
+
+        if "list_columns" in posted:
+            list_columns = posted["list_columns"]
+            if not isinstance(list_columns, dict) or any(
+                not isinstance(view, str)
+                or view not in self.RESIZABLE_LISTS
+                or not isinstance(widths, dict)
+                or any(
+                    not isinstance(column, str)
+                    or not isinstance(width, int)
+                    or isinstance(width, bool)
+                    or not 80 <= width <= 600
+                    for column, width in widths.items()
+                )
+                for view, widths in list_columns.items()
+            ):
+                return JsonResponse({"error": "invalid list column settings"}, status=400)
+
+            # Width changes are sent by one list at a time. Merge both the
+            # view and column levels so saving one page (or a stale browser
+            # tab) can't discard widths saved for another.
+            saved_columns = request.user.settings.get("list_columns", {})
+            if not isinstance(saved_columns, dict):
+                saved_columns = {}
+            posted["list_columns"] = {
+                **saved_columns,
+                **{
+                    view: {
+                        **(saved_columns.get(view, {}) if isinstance(saved_columns.get(view), dict) else {}),
+                        **widths,
+                    }
+                    for view, widths in list_columns.items()
+                },
+            }
 
         request.user.settings = {**request.user.settings, **posted}
         request.user.save(update_fields=("settings",))

--- a/temba/utils/views/mixins.py
+++ b/temba/utils/views/mixins.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import date, datetime, timedelta
 from urllib.parse import quote, urlencode
@@ -323,6 +324,9 @@ class SpaMixin:
         context["temba_path"] = self.spa_path
         context["temba_referer"] = self.spa_referrer_path
         context[TEMBA_MENU_SELECTION] = self.derive_menu_path()
+
+        user_settings = getattr(self.request.user, "settings", {}) or {}
+        context["list_column_settings"] = json.dumps(user_settings.get("list_columns", {}))
 
         return context
 

--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -29,6 +29,8 @@
   <temba-contact-list id="contact-list"
                       fill-window
                       history-state-key="contacts"
+                      column-width-settings="{{ list_column_settings }}"
+                      settings-endpoint="{% url 'users.user_settings' %}"
                       list-title="{{ title }}"
                       {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
                       {% if user_org.is_anon %}anon{% endif %}

--- a/templates/msgs/msg_list_new.html
+++ b/templates/msgs/msg_list_new.html
@@ -30,6 +30,8 @@
   <temba-msg-list id="msg-list"
                   fill-window
                   history-state-key="msgs"
+                  column-width-settings="{{ list_column_settings }}"
+                  settings-endpoint="{% url 'users.user_settings' %}"
                   list-title="{{ title }}"
                   {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
                   endpoint="{{ new_list_endpoint }}"


### PR DESCRIPTION
Server side of resizable list columns (nyaruka/temba-components#1076): stores per-user column widths for the new list components and feeds them back to the pages that render them.

## Changes

**`temba/users/views.py` — user settings endpoint**
- Adds `list_columns` to the settings keys the UI may write, validated as `{view: {column: width}}` where view is one of the resizable lists (`contacts`, `msgs`) and widths are ints between 80 and 600.
- Saves merge at both the view and column level, since each list posts only its own widths — saving one page (or a stale browser tab) can't discard widths saved for another. A saved value corrupted to a non-dict is discarded rather than merged.
- Column names can't be validated against each list's real columns (custom fields make those dynamic), so growth is bounded instead: a single save is capped at 20 columns per list, and the merge evicts columns not in the current save (stale keys from renamed or removed fields) before ones the user just resized.

**`temba/utils/views/mixins.py` — `SpaMixin`**
- Exposes the user's saved widths to templates as `list_column_settings` (JSON).

**Templates**
- `contact_list_new.html` and `msg_list_new.html` pass `column-width-settings` and `settings-endpoint` to `temba-contact-list` / `temba-msg-list`, completing the round trip: widths dragged on a list are debounced, POSTed back per list, and restored on the next visit.

**Tests**
- Settings endpoint: view+column-level merging across saves, rejection of malformed/out-of-range/unknown-view payloads, the >20-column cap, stale-column eviction, and recovery from a corrupted saved value.
- Contact list view: asserts the component is rendered with the width settings and settings endpoint attributes.

## Behavior

| Save | Result |
| --- | --- |
| `{"contacts": {"name": 240}}` then `{"msgs": {"contact": 160}}` | both kept — views merge |
| `{"contacts": {"name": 240}}` then `{"contacts": {"last_seen_on": 180}}` | both kept — columns merge |
| 21 columns for one list in one save | 400 |
| save that would push a list past 20 stored columns | stale columns evicted first, posted ones kept |

## Test plan

- [x] `temba.users.tests.test_settings` green in the dev container
- [x] `temba/users/views.py` at 100% coverage (CI enforces `--fail-under=100`)
- [x] CI green