### PR TITLE
Navigate plain href items in menu popups

### DIFF
--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -424,7 +424,7 @@ function handleMenuClicked(event) {
     if (item.posterize) {
       posterize(item.href);
     } else if (item.target == '_blank' || isExternalUrl(item.href)) {
-      window.open(item.href, '_blank');
+      window.open(item.href, '_blank', 'noopener');
     } else {
       spaGet(item.href);
     }

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -392,6 +392,12 @@ function fetchAjax(url, options, fullPage = false) {
     });
 }
 
+// anything with its own scheme (http:, mailto:, tel:) or protocol relative
+// leaves the app, everything else is an in-app path we can load in the spa
+function isExternalUrl(href) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('//');
+}
+
 function handleMenuClicked(event) {
   var items = event.detail;
 
@@ -412,11 +418,12 @@ function handleMenuClicked(event) {
     return;
   }
 
-  if (item.href) {
+  // popup parents open their menu, they don't navigate
+  if (item.href && !item.popup) {
     // posterize if called for
     if (item.posterize) {
       posterize(item.href);
-    } else if (item.target == '_blank' || item.href.startsWith('http')) {
+    } else if (item.target == '_blank' || isExternalUrl(item.href)) {
       window.open(item.href, '_blank');
     } else {
       spaGet(item.href);

--- a/static/js/frame.js
+++ b/static/js/frame.js
@@ -412,9 +412,15 @@ function handleMenuClicked(event) {
     return;
   }
 
-  // posterize if called for
-  if (item.href && item.posterize) {
-    posterize(item.href);
+  if (item.href) {
+    // posterize if called for
+    if (item.posterize) {
+      posterize(item.href);
+    } else if (item.target == '_blank' || item.href.startsWith('http')) {
+      window.open(item.href, '_blank');
+    } else {
+      spaGet(item.href);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`handleMenuClicked` previously only acted on popup menu children that carried an `event`, were modax buttons, or had `posterize` set — a plain `href` child did nothing when clicked. This wires up navigation for link items in menu popups (paired with nyaruka/temba-components#1077, which adds the `link` item type).

## Changes

- `static/js/frame.js`: popup children with an `href` now navigate — external URLs (any scheme-prefixed or protocol-relative href) and items with `target: "_blank"` open in a new tab with `noopener`; other internal hrefs load through the SPA (`spaGet`).
- Guarded so popup *parent* items never trigger navigation (opening a popup shouldn't navigate, even if a parent gains an `href` later).
- `isExternalUrl()` helper anchors the scheme test so relative paths and query strings containing `:` stay in the SPA.

## Behavior

| Popup child item | Before | After |
|---|---|---|
| `href: "https://example.com"` | nothing | new tab (`noopener`) |
| `href: "/policy/", target: "_blank"` | nothing | new tab (`noopener`) |
| `href: "/tickets/"` | nothing | SPA navigation |
| `event: "temba-x"` | custom event | custom event (unchanged) |
| `href` + `posterize` | POST | POST (unchanged) |

## Review notes

- Navigation branch was reachable by popup parents → guarded with `!item.popup`.
- `startsWith('http')` misclassified protocol-relative and non-http scheme URLs → proper scheme regex.
- External opens hardened with `noopener` (review feedback).

## Test plan

- [x] Menu popup link items navigate correctly in the components test suite (fires `temba-button-clicked` with the item, handled by this code path)
- [x] Existing popup children with `event`/`posterize` (workspace Account/Sign Out) unaffected — their branches return first
- [x] Prettier-clean on the touched lines