### PR TITLE
Stop offering optins as a feature in the flow editor

### DIFF
--- a/temba/flows/tests/test_flowcrudl.py
+++ b/temba/flows/tests/test_flowcrudl.py
@@ -1256,11 +1256,11 @@ class FlowCRUDLTest(TembaTest, CRUDLTestMixin):
         # change our channel to use a facebook scheme
         self.channel.schemes = [URN.FACEBOOK_SCHEME]
         self.channel.save()
-        assert_features({"auto_translate", "optins", "airtime", "resthook"})
+        assert_features({"auto_translate", "airtime", "resthook"})
 
         self.setUpLocations()
 
-        assert_features({"auto_translate", "optins", "airtime", "resthook", "locations"})
+        assert_features({"auto_translate", "airtime", "resthook", "locations"})
 
     @mock_mailroom
     def test_template_warnings(self, mr_mocks):

--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -846,11 +846,8 @@ class FlowCRUDL(SmartCRUDL):
         def get_features(self, org) -> list:
             features = ["auto_translate"]
 
-            facebook_channel = org.get_channel(Channel.ROLE_SEND, scheme=URN.FACEBOOK_SCHEME)
             whatsapp_channel = org.get_channel(Channel.ROLE_SEND, scheme=URN.WHATSAPP_SCHEME)
 
-            if facebook_channel:
-                features.append("optins")
             if whatsapp_channel:
                 features.append("whatsapp")
             if org.get_integrations(IntegrationType.Category.AIRTIME):


### PR DESCRIPTION
Removes `optins` from the feature filters passed to the flow editor, so users can no longer add new Request Opt-In actions to flows. Existing flows with these actions are unaffected — they still render, can still be edited, and still execute.

This is the first step in phasing out Facebook opt-in support: Meta deprecated the underlying Recurring Notifications API in January 2026 and has discontinued it outside a handful of regions, so the feature no longer has a path forward. Opt-in triggers and broadcast opt-ins were already hidden from the UI.