### PR TITLE
Support form and url quick reply types in API

### DIFF
--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -128,9 +128,9 @@ class QuickReplySerializer(serializers.Serializer):
     A serializer for quick replies
     """
 
-    type = serializers.ChoiceField(choices=("text", "location"), default="text")
+    type = serializers.ChoiceField(choices=("text", "form", "url", "location"), default="text")
     text = serializers.CharField(max_length=64, required=False, allow_null=True)
-    extra = serializers.CharField(max_length=72, required=False, allow_null=True)
+    extra = serializers.CharField(max_length=1000, required=False, allow_null=True)
 
     def to_internal_value(self, data):
         value = super().to_internal_value(data)
@@ -148,6 +148,8 @@ class QuickReplySerializer(serializers.Serializer):
 
         if typ == "text" and not data.get("text"):
             raise serializers.ValidationError("Quick replies of type 'text' require a 'text' value.")
+        elif typ in ("form", "url") and not (data.get("text") and data.get("extra")):
+            raise serializers.ValidationError(f"Quick replies of type '{typ}' require 'text' and 'extra' values.")
         elif typ == "location" and data.get("extra"):
             raise serializers.ValidationError("Quick replies of type 'location' cannot have an 'extra' value.")
 

--- a/temba/api/v2/tests/test_messages.py
+++ b/temba/api/v2/tests/test_messages.py
@@ -288,13 +288,34 @@ class MessagesEndpointTest(APITest):
         self.assertIsNone(msg_json["urn"])
         self.assertEqual("failed", msg_json["status"])
 
+        # try to create a message with invalid quick replies
+        response = self.assertPost(
+            endpoint_url,
+            self.admin,
+            {
+                "contact": joe.uuid,
+                "text": "Book an appointment",
+                "quick_replies": [{"type": "form", "text": "Book now"}],
+            },
+            status=400,
+        )
+        self.assertEqual(
+            {"quick_replies": {"0": ["Quick replies of type 'form' require 'text' and 'extra' values."]}},
+            response.json(),
+        )
+
         response = self.assertPost(
             endpoint_url,
             self.admin,
             {
                 "contact": joe.uuid,
                 "text": "What is your preferred color?",
-                "quick_replies": [{"text": "Red"}, {"text": "Green", "extra": "Like grass"}, {"text": "Blue"}],
+                "quick_replies": [
+                    {"text": "Red"},
+                    {"text": "Green", "extra": "Like grass"},
+                    {"type": "form", "text": "Book now", "extra": "123456"},
+                    {"type": "url", "text": "Visit us", "extra": "https://example.com"},
+                ],
             },
             status=201,
         )
@@ -308,7 +329,8 @@ class MessagesEndpointTest(APITest):
                 [
                     {"type": "text", "text": "Red"},
                     {"type": "text", "text": "Green", "extra": "Like grass"},
-                    {"type": "text", "text": "Blue"},
+                    {"type": "form", "text": "Book now", "extra": "123456"},
+                    {"type": "url", "text": "Visit us", "extra": "https://example.com"},
                 ],
             ),
             mr_mocks.calls["msg_send"][-1],
@@ -327,7 +349,8 @@ class MessagesEndpointTest(APITest):
                 "quick_replies": [
                     {"type": "text", "text": "Red"},
                     {"type": "text", "text": "Green", "extra": "Like grass"},
-                    {"type": "text", "text": "Blue"},
+                    {"type": "form", "text": "Book now", "extra": "123456"},
+                    {"type": "url", "text": "Visit us", "extra": "https://example.com"},
                 ],
                 "archived": False,
                 "broadcast": None,

--- a/temba/api/v2/tests/test_serializers.py
+++ b/temba/api/v2/tests/test_serializers.py
@@ -191,6 +191,18 @@ class FieldsTest(APITest):
             field.run_validation([{"type": "location", "text": "Click"}]),
             {"eng": [{"type": "location", "text": "Click"}]},
         )
+        self.assertEqual(
+            field.run_validation([{"type": "form", "text": "Book now", "extra": "123456"}]),
+            {"eng": [{"type": "form", "text": "Book now", "extra": "123456"}]},
+        )
+        self.assertEqual(
+            field.run_validation([{"type": "url", "text": "Create Quotation", "extra": "https://example.com/quote"}]),
+            {"eng": [{"type": "url", "text": "Create Quotation", "extra": "https://example.com/quote"}]},
+        )
+        self.assertEqual(
+            field.run_validation([{"text": "Red", "extra": "x" * 1000}]),
+            {"eng": [{"type": "text", "text": "Red", "extra": "x" * 1000}]},
+        )
 
         self.assertRaises(serializers.ValidationError, field.run_validation, {"eng": ""})  # empty
         self.assertRaises(serializers.ValidationError, field.run_validation, "")  # empty
@@ -202,11 +214,20 @@ class FieldsTest(APITest):
         self.assertRaises(serializers.ValidationError, field.run_validation, {"base": [{"text": "Red"}]})  # not a lang
         self.assertRaises(serializers.ValidationError, field.run_validation, {"eng": [{"text": "1"}] * 11})  # too many
         self.assertRaises(serializers.ValidationError, field.run_validation, {"eng": [{"text": "a" * 65}]})  # too long
+        self.assertRaises(
+            serializers.ValidationError, field.run_validation, {"eng": [{"text": "Red", "extra": "x" * 1001}]}
+        )  # extra too long
         self.assertRaises(serializers.ValidationError, field.run_validation, {"eng": [{"foo": "??"}]})
         self.assertRaises(serializers.ValidationError, field.run_validation, {"eng": [{"text": {}}]})  # invalid text
         self.assertRaises(
             serializers.ValidationError, field.run_validation, {"eng": [{"type": "text"}]}
         )  # missing text
+        self.assertRaises(
+            serializers.ValidationError, field.run_validation, {"eng": [{"type": "form", "text": "Book now"}]}
+        )  # missing extra for form type
+        self.assertRaises(
+            serializers.ValidationError, field.run_validation, {"eng": [{"type": "url", "extra": "http://x.com"}]}
+        )  # missing text for url type
         self.assertRaises(
             serializers.ValidationError, field.run_validation, {"eng": [{"type": "location", "extra": "what?"}]}
         )  # can't have extra for location type

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -2222,7 +2222,11 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
      * **contact** - the UUID of the contact (string)
      * **text** - the text of the message (string)
      * **attachments** - the attachments of the message (list of strings, maximum 10)
-     * **quick_replies** - the quick_replies of the message (list of objects, maximum 10)
+     * **quick_replies** - the quick_replies of the message (list of objects, maximum 10). Each is an object with a
+       `type` which can be `text` (default), `form`, `url` or `location`, a `text` value (max. 64 characters) and an
+       `extra` value (max. 1000 characters). For type `text`, `extra` is an optional description, for type `form` it's
+       the channel specific ID of the form to be opened (e.g. a WhatsApp flow ID), and for type `url` it's the URL to
+       be opened.
 
     Example:
 
@@ -2231,7 +2235,7 @@ class MessagesEndpoint(ListAPIMixin, WriteAPIMixin, BaseEndpoint):
             "contact": "d33e9ad5-5c35-414c-abd4-e7451c69ff1d",
             "text": "Burger or pizza?",
             "attachments": [],
-            "quick_repies": [{"text": "Burger", "extra": "With cheese"}, {"text": "Pizza"}]
+            "quick_replies": [{"text": "Burger", "extra": "With cheese"}, {"text": "Pizza"}]
 
         }
 


### PR DESCRIPTION
Updates the messages and broadcasts API endpoints to match recent quick reply changes in goflow (nyaruka/goflow#1587 and nyaruka/goflow#1595):

* Quick replies can now have type `form` (extra = channel-specific ID of the form to open, e.g. a WhatsApp flow ID) or `url` (extra = URL to open), in addition to `text` and `location`.
* Max length of a quick reply's `extra` value raised from 72 to 1000 to match goflow's new limit (text stays 64).
* `form` and `url` quick replies are validated to require both `text` and `extra` values.
* Messages endpoint docs now describe the quick reply object shape and per-type semantics (and fixes a `quick_repies` typo in the POST example).

Note that incoming message payloads (goflow's new `@input.payload`) aren't exposed on the messages endpoint since they aren't stored on the msgs table — that would need a schema change and can be a follow-up if wanted.