### PR TITLE
Update @nyaruka/temba-components to 0.168.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "rapidpro",
       "dependencies": {
-        "@nyaruka/temba-components": "0.167.0",
+        "@nyaruka/temba-components": "0.168.0",
         "codemirror": "5.58.2",
         "colorette": "1.2.2",
         "fa-icons": "0.2.0",
@@ -58,7 +58,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.167.0", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-sBnGLoAfNk/IvTIh0ZC5/pLu6XEzQsESh+ICMCBZWmMkNe87yVS6Zhetx4cEKGBKzpO9l+baWlNvY2+pmmm0RQ=="],
+    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.168.0", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-sDc8gr3R40JgDfGCXvRQeUaAhLND07yu4XrnqQqUMpgqzRA9GwevNk1AS1fiZDt9Bny9YnY4DNI3uL6Zmo/pNA=="],
 
     "@open-wc/lit-helpers": ["@open-wc/lit-helpers@0.7.0", "", {}, "sha512-4NBlx5ve0EvZplCRJbESm0MdMbRCw16alP2y76KAAAwzmFFXXrUj5hFwhw55+sSg5qaRRx6sY+s7usKgnNo3TQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.167.0",
+    "@nyaruka/temba-components": "0.168.0",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.168.0](https://github.com/nyaruka/temba-components/compare/v0.167.0...v0.168.0)

- Allow resizing the chat in the card layout [#1080](https://github.com/nyaruka/temba-components/pull/1080)
- Add link popup menu items and improve dropdown popups [#1077](https://github.com/nyaruka/temba-components/pull/1077)
- Add inline editing to contact details [#1075](https://github.com/nyaruka/temba-components/pull/1075)
- Draw chat popup arrow with CSS clip-path instead of a glyph [#1078](https://github.com/nyaruka/temba-components/pull/1078)
- Fill full width with timezone box when datepicker wraps [#1079](https://github.com/nyaruka/temba-components/pull/1079)
- Enforce engine limits on flow definition fields in the editor [#1062](https://github.com/nyaruka/temba-components/pull/1062)
- Use default() in webhook router operand so null webhook routes cleanly [#1069](https://github.com/nyaruka/temba-components/pull/1069)
- Restyle contact history search to match list page design language [#1072](https://github.com/nyaruka/temba-components/pull/1072)
- Add resizable columns to content lists [#1076](https://github.com/nyaruka/temba-components/pull/1076)
- Add flow status area with flow-tinted treatment to contact chat [#1073](https://github.com/nyaruka/temba-components/pull/1073)
- Condense chat events into pills with day markers and event tooltips [#1074](https://github.com/nyaruka/temba-components/pull/1074)
- Re-enable contact chat screenshot test for active contacts [#1067](https://github.com/nyaruka/temba-components/pull/1067)
- Speed up and de-flake contact chat tests [#1066](https://github.com/nyaruka/temba-components/pull/1066)
- Fix flaky simulator tests by waiting for chat messages to render [#1065](https://github.com/nyaruka/temba-components/pull/1065)