### PR TITLE
Add subscription authorization for flow channels to websockets API

### DIFF
--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -218,6 +218,54 @@ class EndpointsTest(APITestMixin, TembaTest):
         session.save()
         assertForbidden(f"notifications:{self.org.uuid}:{self.admin.uuid}")
 
+    def test_subscribe_flow(self):
+        flow = self.create_flow("Test Flow")
+        other_flow = self.create_flow("Other Flow", org=self.org2)
+
+        def subscribe(channel, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+
+        def assertAllowed(channel):
+            response = subscribe(channel)
+            self.assertEqual(200, response.status_code)
+            self.assertExpiry(response.json()["result"]["expire_at"])
+
+        def assertForbidden(channel):
+            response = subscribe(channel)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
+
+        self.login(self.editor)
+
+        # a user with the flow editor permission may watch a flow in their current workspace
+        assertAllowed(f"flow:{flow.uuid}")
+
+        assertForbidden(f"flow:{other_flow.uuid}")  # flow in another workspace
+        assertForbidden(f"flow:{uuid4()}")  # flow not found
+        assertForbidden("flow:not-a-uuid")  # malformed flow uuid
+        assertForbidden(f"flow:{flow.uuid}:extra")  # too many segments
+        assertForbidden("flow")  # too few segments
+
+        # an inactive flow is denied
+        flow.is_active = False
+        flow.save(update_fields=("is_active",))
+        assertForbidden(f"flow:{flow.uuid}")
+        flow.is_active = True
+        flow.save(update_fields=("is_active",))
+
+        # sub_refresh applies the same authorization, so revoked access expires on the next refresh
+        response = self.post("api.websockets.sub_refresh", {"channel": f"flow:{flow.uuid}", "client": "conn-1"})
+        self.assertEqual(200, response.status_code)
+        self.assertExpiry(response.json()["result"]["expire_at"])
+
+        response = self.post("api.websockets.sub_refresh", {"channel": f"flow:{other_flow.uuid}", "client": "conn-1"})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"result": {"expired": True}}, response.json())
+
+        # an agent's role lacks the flow editor permission, so they can't watch any flow
+        self.login(self.agent)
+        assertForbidden(f"flow:{flow.uuid}")
+
     def test_subscribe_ticket_topic_access(self):
         # an agent restricted to a team's topics can only watch the history of tickets they're allowed to view - the
         # same scoping the ticketing UI applies, not just "the ticket exists for this contact"

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -94,8 +94,9 @@ class ConnectEndpoint(BaseEndpoint):
     On success the result carries:
       * ``user`` - the user identifier (uuid);
       * ``channels`` - empty: there are no server-side channels. The browser subscribes to everything it wants - its
-        own ``notifications:<org-uuid>:<user-uuid>`` channel and any contact/ticket ``history`` channels - through the
-        subscribe proxy, which authorizes each one against the live session;
+        own ``notifications:<org-uuid>:<user-uuid>`` channel, any contact/ticket ``history`` channels, and any
+        ``flow`` channels for flows open in the editor - through the subscribe proxy, which authorizes each one
+        against the live session;
       * ``meta`` - the user's identity (uuids and ids) attached to the connection so the subscription-authorization
         proxies can act on it without re-reading the session; ``meta`` is server-side only and never sent to the browser;
       * ``expire_at`` - when the realtime server should next call the refresh proxy to re-validate the connection.
@@ -160,6 +161,8 @@ class SubscriptionEndpoint(BaseEndpoint):
             return self._notifications_allowed(request, parts)
         if namespace == "history":
             return self._history_allowed(request, parts)
+        if namespace == "flow":
+            return self._flow_allowed(request, parts)
 
         return False
 
@@ -194,6 +197,22 @@ class SubscriptionEndpoint(BaseEndpoint):
             return True
 
         return Ticket.get_accessible(org, request.user).filter(uuid=parts[1], contact=contact).exists()
+
+    def _flow_allowed(self, request, parts: list) -> bool:
+        """
+        ``flow:<flow-uuid>`` - realtime events for a flow open in the editor (e.g. activity changes). Access mirrors
+        the editor's own read views: the flow must belong to the workspace and be active (archived flows can still be
+        opened in the editor, so they aren't excluded), and the user must have the ``flows.flow_editor`` permission in
+        the workspace. The uuid is validated before it reaches a query, since the uuid column would raise on a
+        malformed value.
+        """
+        if len(parts) != 1 or not is_uuid(parts[0]):
+            return False
+
+        if not request.user.has_org_perm(request.org, "flows.flow_editor"):
+            return False
+
+        return request.org.flows.filter(uuid=parts[0], is_active=True).exists()
 
     def record_subscription(self, channel: str):
         """


### PR DESCRIPTION
Adds authorization for the new `flow` channel namespace to the websockets subscription proxies, ahead of realtime flow editor updates (flow activity first) being published to `flow:<flow-uuid>` channels.

## What changed

* `SubscriptionEndpoint.is_allowed` now dispatches the `flow` namespace to a new `_flow_allowed` method, following the same pattern as `notifications` and `history`.
* A `flow:<flow-uuid>` subscription is allowed when the channel has exactly one segment which is a valid uuid (validated before it touches a query), the user has the `flows.flow_editor` permission in their current workspace, and the flow is an active flow in that workspace. Archived flows are deliberately allowed since the editor opens them too — this mirrors what the editor's own read views (e.g. the flow activity view) permit.
* Tests cover the allowed case for an editor plus denials for a flow in another workspace, an unknown or malformed uuid, wrong segment counts, an inactive flow, and an agent whose role lacks the permission, and verify `sub_refresh` re-arms authorized subscriptions and expires unauthorized ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)