### PR TITLE
Refactor websockets subscription authorization into pattern-based socket routes

### DIFF
--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -160,6 +160,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         assertForbidden({"not": "a string"})  # non-string socket is a clean deny, not a 500
         assertForbidden("history:not-a-uuid")  # malformed contact uuid
         assertForbidden(f"history:{contact.uuid}:not-a-uuid")  # malformed ticket uuid
+        assertForbidden(f"history:{contact.uuid}\n")  # trailing newline isn't part of the canonical name
+        assertForbidden(f"history:{str(contact.uuid).upper()}")  # nor is an uppercase uuid encoding
         assertForbidden(f"history:{contact.uuid}:{ticket.uuid}:extra")  # too many segments
         assertForbidden("history")  # too few segments
         assertForbidden(f"presence:{contact.uuid}")  # unknown namespace

--- a/temba/api/websockets/tests.py
+++ b/temba/api/websockets/tests.py
@@ -29,7 +29,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual(200, response.status_code)
         result = response.json()["result"]
         self.assertExpiry(result.pop("expire_at"))
-        # connect attaches no server-side channels - the browser subscribes to what it wants itself
+        # connect attaches no server-side subscriptions - the browser subscribes to the sockets it wants itself
         self.assertEqual({"user": str(user.uuid), "channels": [], "meta": meta}, result)
 
     def test_connect(self):
@@ -39,8 +39,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.login(self.admin)
         self.assertEqual(405, self.client.get(endpoint_url, HTTP_X_WEBSOCKETS_SECRET=SECRET).status_code)
 
-        # an authenticated user gets no server-side channels (the browser subscribes to its own notifications and any
-        # history channels itself), but their identity is attached to the connection meta
+        # an authenticated user gets no server-side subscriptions (the browser subscribes to its own notifications and
+        # any history sockets itself), but their identity is attached to the connection meta
         self.login(self.admin)
         self.assertConnect(
             self.post("api.websockets.connect"),
@@ -131,8 +131,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         other = self.create_contact("Bob", phone="+1235", org=self.org2)
         other_ticket = self.create_ticket(other)
 
-        def subscribe(channel, client="conn-1"):
-            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+        def subscribe(socket, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": socket, "client": client})
 
         self.login(self.admin)
 
@@ -146,8 +146,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual(200, response.status_code)
         self.assertExpiry(response.json()["result"]["expire_at"])
 
-        def assertForbidden(channel):
-            response = subscribe(channel)
+        def assertForbidden(socket):
+            response = subscribe(socket)
             self.assertEqual(200, response.status_code)
             self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
 
@@ -157,7 +157,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         assertForbidden(f"history:{contact.uuid}:{ticket2.uuid}")  # ticket belongs to a different contact, same org
         assertForbidden(f"history:{contact.uuid}:{other_ticket.uuid}")  # ticket in another workspace
         assertForbidden(f"history:{other.uuid}:{other_ticket.uuid}")  # both in another workspace
-        assertForbidden({"not": "a string"})  # non-string channel is a clean deny, not a 500
+        assertForbidden({"not": "a string"})  # non-string socket is a clean deny, not a 500
         assertForbidden("history:not-a-uuid")  # malformed contact uuid
         assertForbidden(f"history:{contact.uuid}:not-a-uuid")  # malformed ticket uuid
         assertForbidden(f"history:{contact.uuid}:{ticket.uuid}:extra")  # too many segments
@@ -184,22 +184,22 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual({"disconnect": {"code": 4401, "reason": "unauthorized"}}, response.json())
 
     def test_subscribe_notifications(self):
-        def subscribe(channel, client="conn-1"):
-            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+        def subscribe(socket, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": socket, "client": client})
 
-        def assertAllowed(channel):
-            response = subscribe(channel)
+        def assertAllowed(socket):
+            response = subscribe(socket)
             self.assertEqual(200, response.status_code)
             self.assertExpiry(response.json()["result"]["expire_at"])
 
-        def assertForbidden(channel):
-            response = subscribe(channel)
+        def assertForbidden(socket):
+            response = subscribe(socket)
             self.assertEqual(200, response.status_code)
             self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
 
         self.login(self.admin)
 
-        # a user may watch their own notifications channel for their current workspace
+        # a user may watch their own notifications socket for their current workspace
         assertAllowed(f"notifications:{self.org.uuid}:{self.admin.uuid}")
 
         # but not another user's, even in the same workspace
@@ -222,16 +222,16 @@ class EndpointsTest(APITestMixin, TembaTest):
         flow = self.create_flow("Test Flow")
         other_flow = self.create_flow("Other Flow", org=self.org2)
 
-        def subscribe(channel, client="conn-1"):
-            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+        def subscribe(socket, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": socket, "client": client})
 
-        def assertAllowed(channel):
-            response = subscribe(channel)
+        def assertAllowed(socket):
+            response = subscribe(socket)
             self.assertEqual(200, response.status_code)
             self.assertExpiry(response.json()["result"]["expire_at"])
 
-        def assertForbidden(channel):
-            response = subscribe(channel)
+        def assertForbidden(socket):
+            response = subscribe(socket)
             self.assertEqual(200, response.status_code)
             self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
 
@@ -279,21 +279,21 @@ class EndpointsTest(APITestMixin, TembaTest):
         support_ticket = self.create_ticket(contact, topic=support)
         assigned_ticket = self.create_ticket(contact, topic=support, assignee=self.agent)
 
-        def subscribe(channel, *, client="conn-1"):
-            return self.post("api.websockets.subscribe", {"channel": channel, "client": client})
+        def subscribe(socket, *, client="conn-1"):
+            return self.post("api.websockets.subscribe", {"channel": socket, "client": client})
 
-        def assertAllowed(channel):
-            response = subscribe(channel)
+        def assertAllowed(socket):
+            response = subscribe(socket)
             self.assertEqual(200, response.status_code)
             self.assertExpiry(response.json()["result"]["expire_at"])
 
-        def assertForbidden(channel):
-            response = subscribe(channel)
+        def assertForbidden(socket):
+            response = subscribe(socket)
             self.assertEqual(200, response.status_code)
             self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
 
-        def sub_refresh(channel, *, client="conn-1"):
-            return self.post("api.websockets.sub_refresh", {"channel": channel, "client": client})
+        def sub_refresh(socket, *, client="conn-1"):
+            return self.post("api.websockets.sub_refresh", {"channel": socket, "client": client})
 
         self.login(self.agent)
 
@@ -328,9 +328,9 @@ class EndpointsTest(APITestMixin, TembaTest):
 
     def test_sub_refresh(self):
         contact = self.create_contact("Ann", phone="+1234", org=self.org)
-        channel = f"history:{contact.uuid}"
+        socket = f"history:{contact.uuid}"
 
-        def sub_refresh(ch=channel, client="conn-1"):
+        def sub_refresh(ch=socket, client="conn-1"):
             return self.post("api.websockets.sub_refresh", {"channel": ch, "client": client})
 
         # still authorized -> the subscription is extended
@@ -339,7 +339,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual(200, response.status_code)
         self.assertExpiry(response.json()["result"]["expire_at"])
 
-        # a channel the user may no longer access -> let the subscription expire
+        # a socket the user may no longer access -> let the subscription expire
         response = sub_refresh(f"history:{uuid4()}")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"result": {"expired": True}}, response.json())
@@ -369,8 +369,8 @@ class EndpointsTest(APITestMixin, TembaTest):
 
     def test_subscription_index(self):
         contact = self.create_contact("Ann", phone="+1234", org=self.org)
-        channel = f"history:{contact.uuid}"
-        key = f"socket-subs:{channel}"
+        socket = f"history:{contact.uuid}"
+        key = f"socket-subs:{socket}"
 
         r = get_valkey_connection()
         r.delete(key)
@@ -386,8 +386,8 @@ class EndpointsTest(APITestMixin, TembaTest):
         self.assertEqual({"error": {"code": 403, "message": "forbidden"}}, response.json())
         self.assertEqual(0, r.exists(denied_key))
 
-        # subscribe sets a per-channel presence flag with a TTL backstop
-        response = self.post("api.websockets.subscribe", {"channel": channel, "client": "conn-1"})
+        # subscribe sets a per-socket presence flag with a TTL backstop
+        response = self.post("api.websockets.subscribe", {"channel": socket, "client": "conn-1"})
         self.assertEqual(200, response.status_code)
         self.assertEqual(b"1", r.get(key))
         self.assertGreater(r.ttl(key), 0)
@@ -396,7 +396,7 @@ class EndpointsTest(APITestMixin, TembaTest):
         # sub_refresh re-arms the key's TTL - after it has aged, a refresh sets it back toward the full TTL
         r.expire(key, 5)
         self.assertLessEqual(r.ttl(key), 5)
-        response = self.post("api.websockets.sub_refresh", {"channel": channel, "client": "conn-1"})
+        response = self.post("api.websockets.sub_refresh", {"channel": socket, "client": "conn-1"})
         self.assertEqual(200, response.status_code)
         self.assertGreater(r.ttl(key), 5)
 

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -17,6 +17,8 @@ isn't the realtime server even if the path is ever reachable - but the secret is
 API off the public internet.
 """
 
+import re
+
 from django_valkey import get_valkey_connection
 from rest_framework.permissions import BasePermission
 from rest_framework.renderers import JSONRenderer
@@ -28,7 +30,6 @@ from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 
 from temba.tickets.models import Ticket
-from temba.utils.uuid import is_uuid
 
 from ..support import APISessionAuthentication
 
@@ -146,73 +147,83 @@ class SubscriptionEndpoint(BaseEndpoint):
         """Unix time at which the realtime server should next re-check this subscription via the sub_refresh proxy."""
         return int(timezone.now().timestamp()) + SUBSCRIPTION_WINDOW
 
+    # the channel patterns we authorize, routed to handler methods below with the named groups as kwargs. Like a URL
+    # conf, the pattern does all the shape validation: a channel that doesn't fully match a route - unknown namespace,
+    # wrong number of segments, or a segment that isn't a canonical lowercase-dashed uuid - is denied before any
+    # handler runs, so handlers never see a malformed value (the uuid columns they query would raise on one). Only
+    # canonical uuids are accepted because a channel name is an exact string key: events are published to the
+    # canonical form, so a subscription to any other encoding could never receive anything anyway.
+    UUID_PATTERN = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    CHANNEL_ROUTES = (
+        (
+            re.compile(rf"^notifications:(?P<org_uuid>{UUID_PATTERN}):(?P<user_uuid>{UUID_PATTERN})$"),
+            "_notifications_allowed",
+        ),
+        (re.compile(rf"^history:(?P<contact_uuid>{UUID_PATTERN})$"), "_contact_history_allowed"),
+        (
+            re.compile(rf"^history:(?P<contact_uuid>{UUID_PATTERN}):(?P<ticket_uuid>{UUID_PATTERN})$"),
+            "_ticket_history_allowed",
+        ),
+        (re.compile(rf"^flow:(?P<flow_uuid>{UUID_PATTERN})$"), "_flow_allowed"),
+    )
+
     def is_allowed(self, request, channel: str) -> bool:
         """
-        Default-deny authorization of a client-requested channel for the current user's current workspace. Channels
-        are namespaced (``<namespace>:<...>``); this dispatches on the namespace so adding a new channel type later is
-        a one-method change. Callers must have already established an authenticated user with a current workspace.
+        Default-deny authorization of a client-requested channel for the current user's current workspace, routed by
+        matching the channel name against ``CHANNEL_ROUTES`` - so adding a new channel type later is one route and one
+        handler. Callers must have already established an authenticated user with a current workspace.
         """
         if not isinstance(channel, str):  # malformed payload (e.g. a non-string channel) is just a denial, not a 500
             return False
 
-        namespace, *parts = channel.split(":")
-
-        if namespace == "notifications":
-            return self._notifications_allowed(request, parts)
-        if namespace == "history":
-            return self._history_allowed(request, parts)
-        if namespace == "flow":
-            return self._flow_allowed(request, parts)
+        for pattern, handler in self.CHANNEL_ROUTES:
+            match = pattern.match(channel)
+            if match:
+                return getattr(self, handler)(request, **match.groupdict())
 
         return False
 
-    def _notifications_allowed(self, request, parts: list) -> bool:
+    def _notifications_allowed(self, request, org_uuid: str, user_uuid: str) -> bool:
         """
         ``notifications:<org-uuid>:<user-uuid>`` - a user's own notifications in their current workspace. There's
         nothing to look up: a user may watch exactly the channel scoped to their current org and their own uuid, so we
-        just match the requested segments against the live session rather than touching the database. Any other shape -
-        a different user, a different workspace, or the wrong number of segments - simply fails the equality check.
+        just match the requested segments against the live session rather than touching the database.
         """
-        return parts == [str(request.org.uuid), str(request.user.uuid)]
+        return org_uuid == str(request.org.uuid) and user_uuid == str(request.user.uuid)
 
-    def _history_allowed(self, request, parts: list) -> bool:
+    def _contact_history_allowed(self, request, contact_uuid: str) -> bool:
         """
-        ``history:<contact-uuid>`` (a contact's history) or ``history:<contact-uuid>:<ticket-uuid>`` (a ticket's
-        history). The contact must belong to the workspace and be active. For the ticket form the ticket must in turn
-        belong to that contact - and so to the same workspace, since a ticket always shares its contact's org - and the
-        user must actually be allowed to view it: an agent on a topic-restricted team can only see tickets in their
-        team's topics (plus any assigned to them), exactly as the ticketing UI scopes them, so we authorize through
-        ``Ticket.get_accessible`` rather than just checking the ticket exists. Every segment is validated as a uuid
-        before it reaches a query, since the uuid columns are ``UUIDField`` and would raise on a malformed value.
+        ``history:<contact-uuid>`` - a contact's history. The contact must belong to the workspace and be active.
         """
-        if not (1 <= len(parts) <= 2) or not all(is_uuid(p) for p in parts):
-            return False
+        return request.org.contacts.filter(uuid=contact_uuid, is_active=True).exists()
 
+    def _ticket_history_allowed(self, request, contact_uuid: str, ticket_uuid: str) -> bool:
+        """
+        ``history:<contact-uuid>:<ticket-uuid>`` - a ticket's history. The contact must belong to the workspace and be
+        active, and the ticket must in turn belong to that contact - and so to the same workspace, since a ticket
+        always shares its contact's org - and the user must actually be allowed to view it: an agent on a
+        topic-restricted team can only see tickets in their team's topics (plus any assigned to them), exactly as the
+        ticketing UI scopes them, so we authorize through ``Ticket.get_accessible`` rather than just checking the
+        ticket exists.
+        """
         org = request.org
-        contact = org.contacts.filter(uuid=parts[0], is_active=True).first()
+        contact = org.contacts.filter(uuid=contact_uuid, is_active=True).first()
         if not contact:
             return False
 
-        if len(parts) == 1:
-            return True
+        return Ticket.get_accessible(org, request.user).filter(uuid=ticket_uuid, contact=contact).exists()
 
-        return Ticket.get_accessible(org, request.user).filter(uuid=parts[1], contact=contact).exists()
-
-    def _flow_allowed(self, request, parts: list) -> bool:
+    def _flow_allowed(self, request, flow_uuid: str) -> bool:
         """
         ``flow:<flow-uuid>`` - realtime events for a flow open in the editor (e.g. activity changes). Access mirrors
         the editor's own read views: the flow must belong to the workspace and be active (archived flows can still be
         opened in the editor, so they aren't excluded), and the user must have the ``flows.flow_editor`` permission in
-        the workspace. The uuid is validated before it reaches a query, since the uuid column would raise on a
-        malformed value.
+        the workspace.
         """
-        if len(parts) != 1 or not is_uuid(parts[0]):
-            return False
-
         if not request.user.has_org_perm(request.org, "flows.flow_editor"):
             return False
 
-        return request.org.flows.filter(uuid=parts[0], is_active=True).exists()
+        return request.org.flows.filter(uuid=flow_uuid, is_active=True).exists()
 
     def record_subscription(self, channel: str):
         """

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -4,7 +4,7 @@ browsers directly.
 
 These handle connection authentication and lifecycle: ``connect`` authenticates a new connection from the forwarded
 session cookie, and ``refresh`` periodically re-validates it. The connect result also attaches the user's identity to
-the connection's server-side ``meta``, so the proxies that authorize individual channel subscriptions (handled by
+the connection's server-side ``meta``, so the proxies that authorize individual socket subscriptions (handled by
 another internal service) can act on that identity without re-reading the Django session.
 
 Unlike the rest of the internal API (``/api/internal/``), which is called by the editor running in the user's
@@ -40,7 +40,7 @@ CONNECTION_TTL = 5 * 60
 # it lapses so we can re-authorize.
 SUBSCRIPTION_WINDOW = 60
 
-# how long (seconds) a channel's presence key survives without a refresh. It must comfortably exceed SUBSCRIPTION_WINDOW
+# how long (seconds) a socket's presence key survives without a refresh. It must comfortably exceed SUBSCRIPTION_WINDOW
 # plus the realtime server's refresh delay: the server drives sub_refresh from the expire_at we return (one window),
 # but refresh requests can be delayed up to ~1 minute, so consecutive refreshes can be ~SUBSCRIPTION_WINDOW + 60s apart.
 # 150s (60s window + ~60s delay + buffer) keeps the key alive across that gap while still expiring within a couple of
@@ -94,9 +94,9 @@ class ConnectEndpoint(BaseEndpoint):
 
     On success the result carries:
       * ``user`` - the user identifier (uuid);
-      * ``channels`` - empty: there are no server-side channels. The browser subscribes to everything it wants - its
-        own ``notifications:<org-uuid>:<user-uuid>`` channel, any contact/ticket ``history`` channels, and any
-        ``flow`` channels for flows open in the editor - through the subscribe proxy, which authorizes each one
+      * ``channels`` - empty: there are no server-side subscriptions. The browser subscribes to every socket it wants
+        - its own ``notifications:<org-uuid>:<user-uuid>`` socket, any contact/ticket ``history`` sockets, and any
+        ``flow`` sockets for flows open in the editor - through the subscribe proxy, which authorizes each one
         against the live session;
       * ``meta`` - the user's identity (uuids and ids) attached to the connection so the subscription-authorization
         proxies can act on it without re-reading the session; ``meta`` is server-side only and never sent to the browser;
@@ -137,24 +137,28 @@ class RefreshEndpoint(BaseEndpoint):
 
 class SubscriptionEndpoint(BaseEndpoint):
     """
-    Base for the channel-subscription proxies (``subscribe`` and ``sub_refresh``). Both authorize a single
-    client-requested channel against the live Django session - ``request.user`` and ``request.org`` - and, when
+    Base for the socket-subscription proxies (``subscribe`` and ``sub_refresh``). Both authorize a single
+    client-requested socket against the live Django session - ``request.user`` and ``request.org`` - and, when
     allowed, record the subscription in a valkey index. The authorization deliberately reads the *current* workspace
     rather than anything carried on the connection, so access that has been revoked since connect stops working here.
+
+    We call these subscribable names "sockets" (matching the services that publish to them) rather than the realtime
+    server's own term "channel", which is already taken by messaging channels - the ``channel`` fields in the proxy
+    request bodies are the realtime server's protocol and keep its naming.
     """
 
     def subscription_expire_at(self) -> int:
         """Unix time at which the realtime server should next re-check this subscription via the sub_refresh proxy."""
         return int(timezone.now().timestamp()) + SUBSCRIPTION_WINDOW
 
-    # the channel patterns we authorize, routed to handler methods below with the named groups as kwargs. Like a URL
-    # conf, the pattern does all the shape validation: a channel that doesn't fully match a route - unknown namespace,
-    # wrong number of segments, or a segment that isn't a canonical lowercase-dashed uuid - is denied before any
-    # handler runs, so handlers never see a malformed value (the uuid columns they query would raise on one). Only
-    # canonical uuids are accepted because a channel name is an exact string key: events are published to the
-    # canonical form, so a subscription to any other encoding could never receive anything anyway.
+    # the socket name patterns we authorize, routed to handler methods below with the named groups as kwargs. Like a
+    # URL conf, the pattern does all the shape validation: a socket that doesn't fully match a route - unknown
+    # namespace, wrong number of segments, or a segment that isn't a canonical lowercase-dashed uuid - is denied before
+    # any handler runs, so handlers never see a malformed value (the uuid columns they query would raise on one). Only
+    # canonical uuids are accepted because a socket name is an exact string key: events are published to the canonical
+    # form, so a subscription to any other encoding could never receive anything anyway.
     UUID_PATTERN = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    CHANNEL_ROUTES = (
+    SOCKET_ROUTES = (
         (
             re.compile(rf"^notifications:(?P<org_uuid>{UUID_PATTERN}):(?P<user_uuid>{UUID_PATTERN})$"),
             "_notifications_allowed",
@@ -167,17 +171,17 @@ class SubscriptionEndpoint(BaseEndpoint):
         (re.compile(rf"^flow:(?P<flow_uuid>{UUID_PATTERN})$"), "_flow_allowed"),
     )
 
-    def is_allowed(self, request, channel: str) -> bool:
+    def is_allowed(self, request, socket: str) -> bool:
         """
-        Default-deny authorization of a client-requested channel for the current user's current workspace, routed by
-        matching the channel name against ``CHANNEL_ROUTES`` - so adding a new channel type later is one route and one
+        Default-deny authorization of a client-requested socket for the current user's current workspace, routed by
+        matching the socket name against ``SOCKET_ROUTES`` - so adding a new socket type later is one route and one
         handler. Callers must have already established an authenticated user with a current workspace.
         """
-        if not isinstance(channel, str):  # malformed payload (e.g. a non-string channel) is just a denial, not a 500
+        if not isinstance(socket, str):  # malformed payload (e.g. a non-string socket) is just a denial, not a 500
             return False
 
-        for pattern, handler in self.CHANNEL_ROUTES:
-            match = pattern.match(channel)
+        for pattern, handler in self.SOCKET_ROUTES:
+            match = pattern.match(socket)
             if match:
                 return getattr(self, handler)(request, **match.groupdict())
 
@@ -186,7 +190,7 @@ class SubscriptionEndpoint(BaseEndpoint):
     def _notifications_allowed(self, request, org_uuid: str, user_uuid: str) -> bool:
         """
         ``notifications:<org-uuid>:<user-uuid>`` - a user's own notifications in their current workspace. There's
-        nothing to look up: a user may watch exactly the channel scoped to their current org and their own uuid, so we
+        nothing to look up: a user may watch exactly the socket scoped to their current org and their own uuid, so we
         just match the requested segments against the live session rather than touching the database.
         """
         return org_uuid == str(request.org.uuid) and user_uuid == str(request.user.uuid)
@@ -225,29 +229,29 @@ class SubscriptionEndpoint(BaseEndpoint):
 
         return request.org.flows.filter(uuid=flow_uuid, is_active=True).exists()
 
-    def record_subscription(self, channel: str):
+    def record_subscription(self, socket: str):
         """
-        Mark a channel as having at least one active subscriber by (re)setting a per-channel presence key in valkey
-        with a TTL. We track presence only - whether a channel has any subscribers, not who or how many - because the
-        consuming service (which publishes a channel's events) only needs to know whether anyone is watching before it
-        bothers publishing, so one key per channel is all we keep. Every subscribe and sub_refresh re-sets the key, so
+        Mark a socket as having at least one active subscriber by (re)setting a per-socket presence key in valkey
+        with a TTL. We track presence only - whether a socket has any subscribers, not who or how many - because the
+        consuming service (which publishes a socket's events) only needs to know whether anyone is watching before it
+        bothers publishing, so one key per socket is all we keep. Every subscribe and sub_refresh re-sets the key, so
         it stays present while some subscriber keeps refreshing and expires once the last one stops. The realtime
         server has no unsubscribe or disconnect callback, so this TTL is the only garbage collection.
 
-        The key name (``socket-subs:<channel>``) and the presence-via-``EXISTS`` semantics are a contract shared with
+        The key name (``socket-subs:<socket>``) and the presence-via-``EXISTS`` semantics are a contract shared with
         the consuming service that reads it - keep them in sync.
         """
         r = get_valkey_connection()
-        r.set(f"socket-subs:{channel}", "1", ex=SUBSCRIPTION_TTL)
+        r.set(f"socket-subs:{socket}", "1", ex=SUBSCRIPTION_TTL)
 
 
 class SubscribeEndpoint(SubscriptionEndpoint):
     """
-    Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a channel. The request
-    body carries the requested ``channel``, which we authorize against the live session.
+    Subscribe proxy called by the realtime messaging server when a browser asks to subscribe to a socket. The request
+    body carries the requested socket name (in its ``channel`` field), which we authorize against the live session.
 
     An unauthenticated request is told to disconnect (its connection should never have got this far). Otherwise, if the
-    user has a current workspace and may access the channel, we record the subscription and return an ``expire_at`` so
+    user has a current workspace and may access the socket, we record the subscription and return an ``expire_at`` so
     the realtime server schedules a sub_refresh; anything else is refused with a forbidden error, which Centrifugo
     surfaces to the browser as a failed subscribe without tearing down the whole connection.
     """
@@ -256,10 +260,10 @@ class SubscribeEndpoint(SubscriptionEndpoint):
         if not request.user.is_authenticated:
             return Response({"disconnect": {"code": 4401, "reason": "unauthorized"}})
 
-        channel = request.data.get("channel", "")
+        socket = request.data.get("channel", "")
 
-        if request.org and self.is_allowed(request, channel):
-            self.record_subscription(channel)
+        if request.org and self.is_allowed(request, socket):
+            self.record_subscription(socket)
             return Response({"result": {"expire_at": self.subscription_expire_at()}})
 
         return Response({"error": {"code": 403, "message": "forbidden"}})
@@ -274,10 +278,10 @@ class SubRefreshEndpoint(SubscriptionEndpoint):
     """
 
     def post(self, request, *args, **kwargs):
-        channel = request.data.get("channel", "")
+        socket = request.data.get("channel", "")
 
-        if request.user.is_authenticated and request.org and self.is_allowed(request, channel):
-            self.record_subscription(channel)
+        if request.user.is_authenticated and request.org and self.is_allowed(request, socket):
+            self.record_subscription(socket)
             return Response({"result": {"expire_at": self.subscription_expire_at()}})
 
         return Response({"result": {"expired": True}})

--- a/temba/api/websockets/views.py
+++ b/temba/api/websockets/views.py
@@ -160,15 +160,15 @@ class SubscriptionEndpoint(BaseEndpoint):
     UUID_PATTERN = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
     SOCKET_ROUTES = (
         (
-            re.compile(rf"^notifications:(?P<org_uuid>{UUID_PATTERN}):(?P<user_uuid>{UUID_PATTERN})$"),
+            re.compile(rf"notifications:(?P<org_uuid>{UUID_PATTERN}):(?P<user_uuid>{UUID_PATTERN})"),
             "_notifications_allowed",
         ),
-        (re.compile(rf"^history:(?P<contact_uuid>{UUID_PATTERN})$"), "_contact_history_allowed"),
+        (re.compile(rf"history:(?P<contact_uuid>{UUID_PATTERN})"), "_contact_history_allowed"),
         (
-            re.compile(rf"^history:(?P<contact_uuid>{UUID_PATTERN}):(?P<ticket_uuid>{UUID_PATTERN})$"),
+            re.compile(rf"history:(?P<contact_uuid>{UUID_PATTERN}):(?P<ticket_uuid>{UUID_PATTERN})"),
             "_ticket_history_allowed",
         ),
-        (re.compile(rf"^flow:(?P<flow_uuid>{UUID_PATTERN})$"), "_flow_allowed"),
+        (re.compile(rf"flow:(?P<flow_uuid>{UUID_PATTERN})"), "_flow_allowed"),
     )
 
     def is_allowed(self, request, socket: str) -> bool:
@@ -181,7 +181,7 @@ class SubscriptionEndpoint(BaseEndpoint):
             return False
 
         for pattern, handler in self.SOCKET_ROUTES:
-            match = pattern.match(socket)
+            match = pattern.fullmatch(socket)  # unlike $ anchoring, fullmatch won't tolerate a trailing newline
             if match:
                 return getattr(self, handler)(request, **match.groupdict())
 


### PR DESCRIPTION
Follow-up to #6766. Replaces the namespace if-chain in `SubscriptionEndpoint.is_allowed` with a table of socket name patterns routed to handler methods, like a URL conf — and renames the subscribable names from "channels" to "sockets" in internal naming, since "channel" is already taken by messaging channels (the `channel` fields in the proxy request bodies are the realtime server's protocol and keep its naming).

## What changed

* Socket shapes are now declared in `SOCKET_ROUTES` — compiled regexes with named uuid groups mapped to handler methods. The table doubles as documentation of every socket the API accepts.
* The patterns do all the shape validation: unknown namespace, wrong segment count, or a non-uuid segment is denied before any handler runs, so handlers receive pre-validated named values as kwargs and contain only authorization logic. This also makes it impossible for a future socket type to forget the validate-before-query rule.
* The two arities of `history` split into separate `_contact_history_allowed` / `_ticket_history_allowed` handlers.
* Slightly stricter than before: only canonical lowercase-dashed uuids match, where `is_uuid` also accepted alternate encodings (braces, urn prefixes). That's correct here — a socket name is an exact string key and events are only published to the canonical form, so a subscription under any other encoding could never receive anything anyway.

No behavior change otherwise — the existing subscription tests pass with only naming updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)