### PR TITLE
Put archive last in list bulk actions

### DIFF
--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -155,7 +155,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
 
         self.assertEqual([frank, joe], list(response.context["object_list"]))
         self.assertIsNone(response.context["search_error"])
-        self.assertEqual(["block", "archive", "send", "start-flow"], list(response.context["actions"]))
+        self.assertEqual(["block", "send", "start-flow", "archive"], list(response.context["actions"]))
         self.assertContentMenu(list_url, self.editor, ["New Contact", "New Group", "Export"])
 
         active_contacts = self.org.active_contacts_group
@@ -224,7 +224,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         age_query = "?search=age%20%3E%2050"
         response = self.client.get(list_url)
         self.assertEqual([frank, joe], list(response.context["object_list"]))
-        self.assertEqual(["block", "archive", "send", "start-flow"], list(response.context["actions"]))
+        self.assertEqual(["block", "send", "start-flow", "archive"], list(response.context["actions"]))
 
         self.assertContentMenu(
             list_url,
@@ -299,7 +299,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # send / start-flow are clientOnly (they open a modal); the group dropdown carries a labelsEndpoint of the
         # workspace's static groups; the rest post to the action endpoint
         actions = {a["key"]: a for a in response.context["new_list_bulk_actions"]}
-        self.assertEqual(["label", "block", "archive", "send", "start-flow"], list(actions.keys()))
+        self.assertEqual(["label", "block", "send", "start-flow", "archive"], list(actions.keys()))
         self.assertTrue(actions["send"]["clientOnly"])
         self.assertTrue(actions["start-flow"]["clientOnly"])
         self.assertNotIn("clientOnly", actions["archive"])
@@ -537,7 +537,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.assertReadFetch(group2_url, [self.editor])
 
         self.assertEqual([frank], list(response.context["object_list"]))
-        self.assertEqual(["block", "archive", "send", "start-flow"], list(response.context["actions"]))
+        self.assertEqual(["block", "send", "start-flow", "archive"], list(response.context["actions"]))
         self.assertContains(response, "age &gt; 40")
 
         # try unlabel bulk action
@@ -548,7 +548,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         # can access system group like any other except no options to edit or delete
         response = self.assertReadFetch(open_tickets_url, [self.editor])
         self.assertEqual([], list(response.context["object_list"]))
-        self.assertEqual(["block", "archive", "send", "start-flow"], list(response.context["actions"]))
+        self.assertEqual(["block", "send", "start-flow", "archive"], list(response.context["actions"]))
         self.assertContains(response, "tickets &gt; 0")
         self.assertContentMenu(open_tickets_url, self.admin, ["Export", "Usages"])
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -625,12 +625,15 @@ class ContactCRUDL(SmartCRUDL):
 
         def get_bulk_actions(self):
             # "label" (the group dropdown) is a new-list-only action — the legacy table has no UI for it.
-            update = ("label", "block", "archive") if self._use_new_list() else ("block", "archive")
-            actions = update if self.has_org_perm("contacts.contact_update") else ()
+            can_update = self.has_org_perm("contacts.contact_update")
+            actions = (("label", "block") if self._use_new_list() else ("block",)) if can_update else ()
             if self.has_org_perm("msgs.broadcast_create"):
                 actions += ("send",)
             if self.has_org_perm("flows.flow_start"):
                 actions += ("start-flow",)
+            # archive always trails the other actions
+            if can_update:
+                actions += ("archive",)
             return actions
 
         def has_context_menu(self):
@@ -749,13 +752,17 @@ class ContactCRUDL(SmartCRUDL):
 
         def get_bulk_actions(self):
             actions = ()
-            if self.has_org_perm("contacts.contact_update"):
+            can_update = self.has_org_perm("contacts.contact_update")
+            if can_update:
                 # the group action ("Remove from group") leads, matching the "Group" dropdown's slot on the active list
-                actions += ("block", "archive") if self.group.is_smart else ("unlabel", "block")
+                actions += ("block",) if self.group.is_smart else ("unlabel", "block")
             if self.has_org_perm("msgs.broadcast_create"):
                 actions += ("send",)
             if self.has_org_perm("flows.flow_start"):
                 actions += ("start-flow",)
+            # archive always trails the other actions
+            if can_update and self.group.is_smart:
+                actions += ("archive",)
             return actions
 
         def get_bulk_action_labels(self):

--- a/temba/msgs/tests/test_msgcrudl.py
+++ b/temba/msgs/tests/test_msgcrudl.py
@@ -77,7 +77,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.setLegacyUI()
 
         # check that we have the appropriate bulk actions
-        self.assertEqual(("archive", "label"), response.context["actions"])
+        self.assertEqual(("label", "archive"), response.context["actions"])
 
         # error response if search query too long
         self.assertListFetch(inbox_url + "?search=" + "x" * 1001, [self.editor], status=413)
@@ -153,7 +153,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRequestDisallowed(flows_url, [None, self.agent])
         response = self.assertListFetch(flows_url, [self.editor, self.admin], context_objects=[msg2, msg1])
 
-        self.assertEqual(("archive", "label"), response.context["actions"])
+        self.assertEqual(("label", "archive"), response.context["actions"])
 
     @mock_mailroom
     def test_archived(self, mr_mocks):
@@ -354,7 +354,7 @@ class MsgCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.requestView(label3_url, self.editor, HTTP_X_TEMBA_SPA=1)
         self.assertEqual(f"/msg/labels/{label3.uuid}", response.headers[TEMBA_MENU_SELECTION])
         self.assertEqual(200, response.status_code)
-        self.assertEqual(("archive", "label"), response.context["actions"])
+        self.assertEqual(("label", "archive"), response.context["actions"])
 
         # check that non-visible messages are excluded, and messages and ordered newest to oldest
         self.assertEqual([msg6, msg3, msg2, msg1], list(response.context["object_list"]))

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -839,7 +839,7 @@ class MsgCRUDL(SmartCRUDL):
         subtitle = _("Incoming messages that weren't automatically handled by a flow.")
         folder = MsgFolder.INBOX
         search_fields = ("text__icontains", "contact__name__icontains")
-        bulk_actions = ("archive", "label")
+        bulk_actions = ("label", "archive")
         allow_export = True
         menu_path = "/msg/inbox"
 
@@ -855,7 +855,7 @@ class MsgCRUDL(SmartCRUDL):
         subtitle = _("Incoming messages that were handled by a flow.")
         folder = MsgFolder.HANDLED
         search_fields = ("text__icontains", "contact__name__icontains")
-        bulk_actions = ("archive", "label")
+        bulk_actions = ("label", "archive")
         allow_export = True
         menu_path = "/msg/handled"
 
@@ -907,7 +907,7 @@ class MsgCRUDL(SmartCRUDL):
 
     class Filter(MsgListView):
         search_fields = ("text__icontains", "contact__name__icontains")
-        bulk_actions = ("archive", "label")
+        bulk_actions = ("label", "archive")
 
         def derive_menu_path(self):
             return f"/msg/labels/{self.label.uuid}"


### PR DESCRIPTION
Archive now consistently trails the other bulk actions on every list page:

* **Msgs** — the inbox, handled and label folder views change `("archive", "label")` to `("label", "archive")`.
* **Contacts** — the active list was `label, block, archive, send, start-flow`; archive is now appended last (still gated on `contacts.contact_update`). Smart group pages get the same treatment (`block, send, start-flow, archive`); non-smart groups have no archive action and are unchanged.

Flows (`label, export-results, archive`), triggers, campaigns and the blocked/stopped contact lists already had archive last. Test assertions on the old orders updated to match.