### PR TITLE
Update @nyaruka/temba-components to 0.169.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "rapidpro",
       "dependencies": {
-        "@nyaruka/temba-components": "0.168.1",
+        "@nyaruka/temba-components": "0.169.0",
         "codemirror": "5.58.2",
         "colorette": "1.2.2",
         "fa-icons": "0.2.0",
@@ -58,7 +58,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.168.1", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-EzD3IbjZXnpiFJsTUPQQUQAjsJ4VxX3ACpxbAIzo29U0CnyhvgX5/eC5TRd1tqnWIDbsutlhwFquMDbsVhh4kg=="],
+    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.169.0", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-lCiYsES+HmQhjBKNW7EHCdqEl4rtR6YSiOs5yTWVCGWld2w4jG+eBShGvki252DpTuTX+INiqR4OwQeShlMSkg=="],
 
     "@open-wc/lit-helpers": ["@open-wc/lit-helpers@0.7.0", "", {}, "sha512-4NBlx5ve0EvZplCRJbESm0MdMbRCw16alP2y76KAAAwzmFFXXrUj5hFwhw55+sSg5qaRRx6sY+s7usKgnNo3TQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.168.1",
+    "@nyaruka/temba-components": "0.169.0",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/templates/contacts/contact_read.html
+++ b/templates/contacts/contact_read.html
@@ -3,8 +3,8 @@
 
 {% block title %}
   <div class="hidden" id="title-text">{{ title|default:"Contact Details" }}</div>
-  <temba-contact-name-fetch contact="{{ object.uuid }}" -temba-refreshed="handleContactRefreshed" showLoading>
-  </temba-contact-name-fetch>
+  <temba-contact-name contact="{{ object.uuid }}" -temba-refreshed="handleContactRefreshed">
+  </temba-contact-name>
 {% endblock title %}
 {% block content %}
   <temba-tabs -temba-context-changed="handleTabChanged"

--- a/templates/contacts/contact_read_new.html
+++ b/templates/contacts/contact_read_new.html
@@ -50,12 +50,11 @@
   <div class="read-page">
     <temba-header-bar>
       <temba-page-header content-menu-endpoint="{{ request.path }}" -temba-selection="handleContentMenuSelected(event)">
-        <temba-contact-name-fetch slot="title"
-                                  contact="{{ object.uuid }}"
-                                  icon-size="16"
-                                  -temba-refreshed="handleContactRefreshed"
-                                  showLoading>
-        </temba-contact-name-fetch>
+        <temba-contact-name slot="title"
+                            contact="{{ object.uuid }}"
+                            icon-size="16"
+                            -temba-refreshed="handleContactRefreshed">
+        </temba-contact-name>
       </temba-page-header>
     </temba-header-bar>
     <temba-card-layout id="card-layout"

--- a/templates/tickets/ticket_list.html
+++ b/templates/tickets/ticket_list.html
@@ -138,7 +138,7 @@
         max-height: 7em;
       }
 
-      temba-contact-name-fetch {
+      temba-contact-name {
         display: none;
       }
 
@@ -232,9 +232,6 @@
     }
 
     function handleFlowStarted(event) {
-
-      var name = document.querySelector("temba-contact-name-fetch");
-      name.refresh();
 
       // give our flow a chance to start
       window.setTimeout(function() {
@@ -352,7 +349,7 @@
       messageSent = false;
       const ticketUI = document.querySelector('.ticket-ui');
 
-      var contactHeader = document.querySelector("temba-contact-name-fetch");
+      var contactHeader = document.querySelector("temba-contact-name");
       var notepad = document.querySelector("temba-contact-notepad");
       var chat = document.querySelector("temba-contact-chat");
       var details = document.querySelector("temba-contact-details");
@@ -678,10 +675,10 @@
           <div class="flex">
             <temba-icon size="1.2" class="back-button" name="arrow_left" clickable onclick="handleContactChanged()">
             </temba-icon>
-            <temba-contact-name-fetch -temba-refreshed="handleContactRefreshed"
-                                      onclick="{% if org_perms.contacts.contact_read %}handleNameClicked(){% endif %}"
-                                      class="{% if org_perms.contacts.contact_read %}clickable{% endif %} text-2xl mb-4">
-            </temba-contact-name-fetch>
+            <temba-contact-name -temba-refreshed="handleContactRefreshed"
+                                onclick="{% if org_perms.contacts.contact_read %}handleNameClicked(){% endif %}"
+                                class="{% if org_perms.contacts.contact_read %}clickable{% endif %} text-2xl mb-4">
+            </temba-contact-name>
             <div class="flex-grow"></div>
             {% include "spa_page_menu.html" %}
           </div>

--- a/templates/tickets/ticket_list_new.html
+++ b/templates/tickets/ticket_list_new.html
@@ -208,7 +208,7 @@
         max-height: 7em;
       }
 
-      temba-contact-name-fetch {
+      temba-contact-name {
         display: none;
       }
 
@@ -297,9 +297,6 @@
     }
 
     function handleFlowStarted(event) {
-
-      var name = document.querySelector("temba-contact-name-fetch");
-      name.refresh();
 
       // give our flow a chance to start
       window.setTimeout(function() {
@@ -413,7 +410,7 @@
       messageSent = false;
       const ticketUI = document.querySelector('.ticket-ui');
 
-      var contactHeader = document.querySelector("temba-contact-name-fetch");
+      var contactHeader = document.querySelector("temba-contact-name");
       var notepad = document.querySelector("temba-contact-notepad");
       var chat = document.querySelector("temba-contact-chat");
       var details = document.querySelector("temba-contact-details");
@@ -724,11 +721,11 @@
                              content-menu-endpoint="{{ request.path }}"
                              -temba-selection="handleContentMenuSelected(event)">
             <div slot="title" class="flex" style="align-items: center">
-              <temba-contact-name-fetch -temba-refreshed="handleContactRefreshed"
-                                        icon-size="16"
-                                        onclick="{% if org_perms.contacts.contact_read %}handleNameClicked(){% endif %}"
-                                        class="{% if org_perms.contacts.contact_read %}clickable{% endif %}">
-              </temba-contact-name-fetch>
+              <temba-contact-name -temba-refreshed="handleContactRefreshed"
+                                  icon-size="16"
+                                  onclick="{% if org_perms.contacts.contact_read %}handleNameClicked(){% endif %}"
+                                  class="{% if org_perms.contacts.contact_read %}clickable{% endif %}">
+              </temba-contact-name>
             </div>
           </temba-page-header>
         </temba-header-bar>


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.169.0](https://github.com/nyaruka/temba-components/compare/v0.168.1...v0.169.0)

- Add central contact watcher for interest-based live updates [#1087](https://github.com/nyaruka/temba-components/pull/1087)

## Template changes

`temba-contact-name-fetch` is replaced by the new live `temba-contact-name`, which registers for a contact's name/urn events with the central watcher and receives its initial value the same way — no fetching configuration needed in templates:

- `contacts/contact_read.html`, `contacts/contact_read_new.html`: swap the tag, drop `showLoading` (no longer needed)
- `tickets/ticket_list.html`, `tickets/ticket_list_new.html`: swap the tag and remove the `name.refresh()` call in `handleFlowStarted` — a flow that renames the contact now publishes a `contact_name_changed` event and the header updates on its own