### PR TITLE
Use full-page OAuth dialog for WhatsApp Cloud embedded signup

### DIFF
--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -135,7 +135,7 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
             response = self.client.post(connect_whatsapp_cloud_url, dict(user_access_token="X" * 36), follow=True)
             self.assertEqual(response.status_code, 200)
 
-            self.assertEqual(wa_cloud_get.call_args_list[0][0][0], "https://graph.facebook.com/v22.0/debug_token")
+            self.assertEqual(wa_cloud_get.call_args_list[0][0][0], "https://graph.facebook.com/v25.0/debug_token")
             self.assertEqual(
                 wa_cloud_get.call_args_list[0][1],
                 {"params": {"access_token": "FB_APP_ID|FB_APP_SECRET", "input_token": "Z" * 48}},
@@ -288,18 +288,18 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
             self.assertEqual(3, wa_cloud_post.call_count)
 
             self.assertEqual(
-                "https://graph.facebook.com/v22.0/111111111111111/assigned_users",
+                "https://graph.facebook.com/v25.0/111111111111111/assigned_users",
                 wa_cloud_post.call_args_list[0][0][0],
             )
             self.assertEqual({"Authorization": "Bearer WA_ADMIN_TOKEN"}, wa_cloud_post.call_args_list[0][1]["headers"])
 
             self.assertEqual(
-                "https://graph.facebook.com/v22.0/111111111111111/subscribed_apps",
+                "https://graph.facebook.com/v25.0/111111111111111/subscribed_apps",
                 wa_cloud_post.call_args_list[1][0][0],
             )
 
             self.assertEqual(
-                "https://graph.facebook.com/v22.0/123123123/register", wa_cloud_post.call_args_list[2][0][0]
+                "https://graph.facebook.com/v25.0/123123123/register", wa_cloud_post.call_args_list[2][0][0]
             )
             self.assertEqual(
                 {"messaging_product": "whatsapp", "pin": "111111"}, wa_cloud_post.call_args_list[2][1]["data"]
@@ -342,7 +342,7 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
             )
             self.assertEqual(200, response.status_code)
 
-            self.assertEqual("https://graph.facebook.com/v22.0/123123123/request_code", wa_cloud_post.call_args[0][0])
+            self.assertEqual("https://graph.facebook.com/v25.0/123123123/request_code", wa_cloud_post.call_args[0][0])
 
             # submit verification code
             response = self.client.post(
@@ -352,7 +352,7 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
             )
             self.assertEqual(200, response.status_code)
 
-            self.assertEqual("https://graph.facebook.com/v22.0/123123123/register", wa_cloud_post.call_args[0][0])
+            self.assertEqual("https://graph.facebook.com/v25.0/123123123/register", wa_cloud_post.call_args[0][0])
             self.assertEqual({"messaging_product": "whatsapp", "pin": "111111"}, wa_cloud_post.call_args[1]["data"])
 
             response = self.client.get(reverse("channels.types.whatsapp.verify_code", args=(channel.uuid,)))
@@ -670,7 +670,7 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
             MockResponse(200, '{"data": ["foo", "bar"]}', headers={"Authorization": "Bearer WA_ADMIN_TOKEN"}),
             MockResponse(
                 200,
-                '{"data": ["foo"], "paging": {"cursors": {"after": "MjQZD"}, "next": "https://graph.facebook.com/v22.0/111111111111111/message_templates?after=MjQZD" } }',
+                '{"data": ["foo"], "paging": {"cursors": {"after": "MjQZD"}, "next": "https://graph.facebook.com/v25.0/111111111111111/message_templates?after=MjQZD" } }',
                 headers={"Authorization": "Bearer WA_ADMIN_TOKEN"},
             ),
             MockResponse(
@@ -702,7 +702,7 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
             self.assertNotIn("WA_ADMIN_TOKEN", json.dumps(log.get_display()))
 
         mock_get.assert_called_with(
-            "https://graph.facebook.com/v22.0/111111111111111/message_templates",
+            "https://graph.facebook.com/v25.0/111111111111111/message_templates",
             params={"limit": 255},
             headers={"Authorization": "Bearer WA_ADMIN_TOKEN"},
         )
@@ -714,12 +714,12 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
         mock_get.assert_has_calls(
             [
                 call(
-                    "https://graph.facebook.com/v22.0/111111111111111/message_templates",
+                    "https://graph.facebook.com/v25.0/111111111111111/message_templates",
                     params={"limit": 255},
                     headers={"Authorization": "Bearer WA_ADMIN_TOKEN"},
                 ),
                 call(
-                    "https://graph.facebook.com/v22.0/111111111111111/message_templates?after=MjQZD",
+                    "https://graph.facebook.com/v25.0/111111111111111/message_templates?after=MjQZD",
                     params={"limit": 255},
                     headers={"Authorization": "Bearer WA_ADMIN_TOKEN"},
                 ),

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -22,7 +22,7 @@ from ...views import ClaimViewMixin
 logger = logging.getLogger(__name__)
 
 # base URL for all WhatsApp Cloud Graph API calls (also imported by type.py) - bump the version here in one place
-WHATSAPP_GRAPH_API_BASE = "https://graph.facebook.com/v22.0"
+WHATSAPP_GRAPH_API_BASE = "https://graph.facebook.com/v25.0"
 
 # WhatsApp Cloud only requires the business_management OAuth scope at the top level; the
 # whatsapp_business_management and whatsapp_business_messaging permissions are granted as

--- a/templates/channels/types/whatsapp/claim.html
+++ b/templates/channels/types/whatsapp/claim.html
@@ -49,12 +49,12 @@
       {% if facebook_login_whatsapp_config_id %}
       connectFB.addEventListener('click', function(evt) {
         fetchAjax("{{clear_session_token_url}}");
-        location.replace("https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_whatsapp_url}}" + "&config_id={{ facebook_login_whatsapp_config_id }}&response_type=code&override_default_response_type=true");
+        location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_whatsapp_url}}" + "&config_id={{ facebook_login_whatsapp_config_id }}&response_type=code&override_default_response_type=true");
       });
       {% else %}
       connectFB.addEventListener('click', function(evt) {
         fetchAjax("{{clear_session_token_url}}");
-        location.replace("https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_whatsapp_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token");
+        location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_whatsapp_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token");
       });
       {% endif %}
 

--- a/templates/channels/types/whatsapp/connect.html
+++ b/templates/channels/types/whatsapp/connect.html
@@ -78,9 +78,9 @@
     // here with the code/token that the handler above picks up and submits.
     function launchWhatsAppSignup() {
       {% if facebook_login_whatsapp_config_id %}
-      location.replace("https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&config_id={{ facebook_login_whatsapp_config_id }}&response_type=code&override_default_response_type=true");
+      location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&config_id={{ facebook_login_whatsapp_config_id }}&response_type=code&override_default_response_type=true");
       {% else %}
-      location.replace("https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token");
+      location.replace("https://www.facebook.com/v25.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token");
       {% endif %}
     }
   </script>

--- a/templates/channels/types/whatsapp/connect.html
+++ b/templates/channels/types/whatsapp/connect.html
@@ -10,6 +10,7 @@
       {{ claim_error }}
     </temba-alert>
   {% endif %}
+  <temba-alert level="error" class="my-4 hidden" id="connect-error"></temba-alert>
 {% endblock pre-form %}
 {% block form %}
   <div class="mt-4 card">
@@ -44,6 +45,18 @@
       const urlParams = new URLSearchParams(window.location.search)
 
       var accessToken = urlParams.get("code") || result.long_lived_token || result.access_token;
+
+      var oauthError = urlParams.get("error") || result.error;
+      var errorDescription = urlParams.get("error_description");
+      if (!errorDescription && result.error_description) {
+        errorDescription = decodeURIComponent(result.error_description.replace(/\+/g, " "));
+      }
+
+      // don't leave the code/token or error details in the address bar and browser history
+      if (accessToken || oauthError) {
+        history.replaceState(null, "", window.location.pathname);
+      }
+
       if (accessToken) {
         var userAccessToken = document.getElementById("user-access-token");
         var claimForm = document.getElementById("claim-form");
@@ -54,6 +67,10 @@
         if (claimForm) {
           claimForm.submit();
         }
+      } else if (oauthError) {
+        var errorAlert = document.getElementById("connect-error");
+        errorAlert.textContent = errorDescription || "{% trans 'Login was cancelled or failed, please try again.' %}";
+        errorAlert.classList.remove("hidden");
       }
     });
 

--- a/templates/channels/types/whatsapp/connect.html
+++ b/templates/channels/types/whatsapp/connect.html
@@ -57,79 +57,14 @@
       }
     });
 
-    window.fbAsyncInit = function() {
-      // JavaScript SDK configuration and setup
-      FB.init({
-        appId: '{{ facebook_app_id }}', // Meta App ID
-        cookie: true, // enable cookies
-        xfbml: true, // parse social plugins on this page
-        version: 'v22.0' //Graph API version
-      });
-    };
-    // Load the JavaScript SDK asynchronously
-    (function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) return;
-      js = d.createElement(s);
-      js.id = id;
-      js.src = "https://connect.facebook.net/en_US/sdk.js";
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));
-
-    function submitClaimForm(accessToken) {
-      if (accessToken) {
-        var userAccessToken = document.getElementById("user-access-token");
-        var claimForm = document.getElementById("claim-form");
-
-        if (userAccessToken) {
-          userAccessToken.value = accessToken;
-        }
-        if (claimForm) {
-          claimForm.submit();
-        }
-      }
-    }
-
-    // Facebook Login with JavaScript SDK
+    // Launch the embedded signup via the full-page OAuth dialog which redirects back
+    // here with the code/token that the handler above picks up and submits.
     function launchWhatsAppSignup() {
-      // Launch Facebook login
-
-      // The only per-config differences are the fallback OAuth URL, the FB.login
-      // options, and which authResponse field carries the token/code.
       {% if facebook_login_whatsapp_config_id %}
-      var fallbackUrl = "https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&config_id={{ facebook_login_whatsapp_config_id }}&response_type=code&override_default_response_type=true";
-      var loginOptions = {
-        config_id: '{{ facebook_login_whatsapp_config_id }}',
-        response_type: 'code',
-        override_default_response_type: true
-      };
-      var getToken = function(authResponse) { return authResponse.code; };
+      location.replace("https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&config_id={{ facebook_login_whatsapp_config_id }}&response_type=code&override_default_response_type=true");
       {% else %}
-      var fallbackUrl = "https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token";
-      var loginOptions = {
-        scope: 'business_management,whatsapp_business_management,whatsapp_business_messaging',
-        extras: {
-          feature: 'whatsapp_embedded_signup',
-          setup: {}
-        }
-      };
-      var getToken = function(authResponse) { return authResponse.accessToken; };
+      location.replace("https://www.facebook.com/v22.0/dialog/oauth?client_id={{ facebook_app_id }}&redirect_uri=" + window.location.origin + "{{connect_url}}" + "&scope=business_management,whatsapp_business_management,whatsapp_business_messaging&response_type=token");
       {% endif %}
-
-      // Fall back to the full-page OAuth dialog only when the JS SDK popup is unavailable,
-      // so the embedded signup is never launched a second time after the popup has run.
-      if (typeof FB === 'undefined' || !FB.login) {
-        location.replace(fallbackUrl);
-        return;
-      }
-      FB.login(function(response) {
-        if (response.authResponse) {
-          submitClaimForm(getToken(response.authResponse));
-        } else {
-          // User cancelled or did not fully authorize; leave the button so they can retry.
-          console.log('User cancelled login or did not fully authorize');
-        }
-      }, loginOptions);
     }
   </script>
 {% endblock extra-script %}


### PR DESCRIPTION
The Facebook JS SDK popup flow frequently completes without delivering an `authResponse` to the `FB.login` callback (a known Meta issue when the code is not handed back to the opener window), which left the connect page stuck doing nothing after the popup closed.

This removes the JS SDK from the connect page entirely and launches the embedded signup via the full-page OAuth dialog instead — the `config_id` variant when a login configuration is set, otherwise the scope-based `response_type=token` variant. The dialog redirects back to the connect page with the code/token, which the existing page handler picks up and submits; server-side exchange and validation are unchanged. The other claim templates already used this redirect approach.