### PR TITLE
Pass featured-field priority endpoint to the contact list

### DIFF
--- a/templates/contacts/contact_list_new.html
+++ b/templates/contacts/contact_list_new.html
@@ -34,6 +34,7 @@
                       list-title="{{ title }}"
                       {% if new_list_subtitle %}subtitle="{{ new_list_subtitle }}"{% endif %}
                       {% if user_org.is_anon %}anon{% endif %}
+                      {% if org_perms.contacts.contactfield_update_priority %}priority-endpoint="{% url 'contacts.contactfield_update_priority' %}"{% endif %}
                       endpoint="{{ new_list_endpoint }}"
                       action-endpoint="{{ request.path }}"
                       content-menu-endpoint="{{ request.path }}?{{ request.GET.urlencode }}"


### PR DESCRIPTION
## Summary

Wires up drag-and-drop column reordering on the contact list: `<temba-contact-list>` gets the `priority-endpoint` attribute (pointing at `contacts.contactfield_update_priority`) when the viewer holds the update-priority permission. With it set, the component lets users drag featured-field columns into a new order and saves the full featured list in column order — the same contract the fields management page uses, so the table and the fields page stay in sync.

Component support lands in nyaruka/temba-components#1088; until a release containing it is pulled in, the attribute is inert (unknown attributes are ignored), so this is safe to merge ahead of the version bump.

## Changes

- `templates/contacts/contact_list_new.html`: add `priority-endpoint="{% url 'contacts.contactfield_update_priority' %}"` to `<temba-contact-list>`, gated on `org_perms.contacts.contactfield_update_priority` — users without the permission get no drag affordance.

## Test plan

- [x] Component behavior (drag, clamped drops, save payload, permission-off case) is covered by the temba-components test suite in nyaruka/temba-components#1088
- [x] Template renders unchanged for users without the permission