### PR TITLE
Add login warning for users who should be using SSO

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -956,8 +956,9 @@ SOCIALACCOUNT_PROVIDERS = {}
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 SOCIALACCOUNT_LOGIN_ON_GET = True
 
-# email domains whose users should be warned to switch to SSO when they login with a password instead
-SSO_LOGIN_WARNING_DOMAINS = []
+# maps email domains to the SSO provider (an allauth provider or app id) their users should be logging in with,
+# used to warn those still logging in with a password
+SSO_LOGIN_WARNING_DOMAINS = {}
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
 ACCOUNT_LOGIN_METHODS = ("email",)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -955,6 +955,9 @@ MFA_ADAPTER = "temba.users.adapter.TembaMFAAdapter"
 SOCIALACCOUNT_PROVIDERS = {}
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 SOCIALACCOUNT_LOGIN_ON_GET = True
+
+# email domains whose users should be warned to switch to SSO when they login with a password instead
+SSO_LOGIN_WARNING_DOMAINS = []
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
 ACCOUNT_LOGIN_METHODS = ("email",)

--- a/temba/users/adapter.py
+++ b/temba/users/adapter.py
@@ -5,6 +5,7 @@ from allauth.mfa.adapter import DefaultMFAAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.signals import social_account_added
 
+from django.conf import settings
 from django.contrib import messages
 from django.dispatch import receiver
 from django.utils import timezone
@@ -61,6 +62,23 @@ class InviteAdapterMixin:
 
 
 class TembaAccountAdapter(InviteAdapterMixin, DefaultAccountAdapter):
+    def post_login(self, request, user, *, email_verification, signal_kwargs, email, signup, redirect_url):
+        # users whose email domain should be using SSO get a warning when they login with a password instead
+        is_sso = bool(signal_kwargs and signal_kwargs.get("sociallogin"))
+        domain = user.email.rsplit("@", 1)[-1].lower() if user.email else ""
+        if not is_sso and domain in settings.SSO_LOGIN_WARNING_DOMAINS:
+            request.session["sso_login_warning"] = True
+
+        return super().post_login(
+            request,
+            user,
+            email_verification=email_verification,
+            signal_kwargs=signal_kwargs,
+            email=email,
+            signup=signup,
+            redirect_url=redirect_url,
+        )
+
     def send_mail(self, template_prefix, email, context):
         # our emails need some additional context
         context["branding"] = self.request.branding

--- a/temba/users/adapter.py
+++ b/temba/users/adapter.py
@@ -2,7 +2,7 @@ from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.models import EmailAddress
 from allauth.core import context as allauth_context
 from allauth.mfa.adapter import DefaultMFAAdapter
-from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter, get_adapter as get_socialaccount_adapter
 from allauth.socialaccount.signals import social_account_added
 
 from django.conf import settings
@@ -66,8 +66,14 @@ class TembaAccountAdapter(InviteAdapterMixin, DefaultAccountAdapter):
         # users whose email domain should be using SSO get a warning when they login with a password instead
         is_sso = bool(signal_kwargs and signal_kwargs.get("sociallogin"))
         domain = user.email.rsplit("@", 1)[-1].lower() if user.email else ""
-        if not is_sso and domain in {d.lower() for d in settings.SSO_LOGIN_WARNING_DOMAINS}:
-            request.session["sso_login_warning"] = True
+        warn_domains = {d.lower(): p for d, p in settings.SSO_LOGIN_WARNING_DOMAINS.items()}
+        if not is_sso and domain in warn_domains:
+            try:
+                provider_name = get_socialaccount_adapter().get_provider(request, warn_domains[domain]).name
+            except Exception:
+                provider_name = None  # misconfigured provider id still warns, just without naming the provider
+
+            request.session["sso_login_warning"] = {"provider": provider_name}
 
         return super().post_login(
             request,

--- a/temba/users/adapter.py
+++ b/temba/users/adapter.py
@@ -66,7 +66,7 @@ class TembaAccountAdapter(InviteAdapterMixin, DefaultAccountAdapter):
         # users whose email domain should be using SSO get a warning when they login with a password instead
         is_sso = bool(signal_kwargs and signal_kwargs.get("sociallogin"))
         domain = user.email.rsplit("@", 1)[-1].lower() if user.email else ""
-        if not is_sso and domain in settings.SSO_LOGIN_WARNING_DOMAINS:
+        if not is_sso and domain in {d.lower() for d in settings.SSO_LOGIN_WARNING_DOMAINS}:
             request.session["sso_login_warning"] = True
 
         return super().post_login(

--- a/temba/users/tests/test_auth.py
+++ b/temba/users/tests/test_auth.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlencode
 
+from allauth.account.models import EmailAddress
+
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
@@ -92,6 +94,34 @@ class UserAuthTest(TembaTest):
         emails = self.admin.emailaddress_set.all()
         self.assertEqual(2, emails.count())
         self.assertTrue(emails.filter(email="newemail@temba.io").exists())
+
+    @override_settings(
+        SSO_LOGIN_WARNING_DOMAINS=["sso-corp.com"],
+        SOCIALACCOUNT_PROVIDERS={"google": {"APPS": [{"client_id": "test-id", "secret": "test-secret", "key": ""}]}},
+    )
+    def test_sso_login_warning(self):
+        login_url = reverse("account_login")
+
+        # logging in with a password from a non-matching domain doesn't warn
+        response = self.client.post(
+            login_url, {"login": self.admin.email, "password": self.default_password}, follow=True
+        )
+        self.assertNotContains(response, "sso-login-warning")
+
+        self.client.logout()
+
+        # but a user whose email domain should be using SSO gets warned
+        user = self.create_user("uma@sso-corp.com")
+        EmailAddress.objects.create(user=user, email=user.email, verified=True, primary=True)
+        self.org.add_user(user, OrgRole.EDITOR)
+
+        response = self.client.post(login_url, {"login": user.email, "password": self.default_password}, follow=True)
+        self.assertContains(response, "sso-login-warning")
+        self.assertContains(response, 'header="Sign In with Google"')
+
+        # only on the first page load after login
+        response = self.client.get(response.request["PATH_INFO"])
+        self.assertNotContains(response, "sso-login-warning")
 
     @override_settings(BRAND={"features": []})
     def test_invite_with_closed_signups(self):

--- a/temba/users/tests/test_auth.py
+++ b/temba/users/tests/test_auth.py
@@ -96,11 +96,17 @@ class UserAuthTest(TembaTest):
         self.assertTrue(emails.filter(email="newemail@temba.io").exists())
 
     @override_settings(
-        SSO_LOGIN_WARNING_DOMAINS=["sso-corp.com"],
+        SSO_LOGIN_WARNING_DOMAINS={"SSO-Corp.com": "google", "no-sso-corp.com": "acme"},
         SOCIALACCOUNT_PROVIDERS={"google": {"APPS": [{"client_id": "test-id", "secret": "test-secret", "key": ""}]}},
     )
     def test_sso_login_warning(self):
         login_url = reverse("account_login")
+
+        def create_verified_user(email):
+            user = self.create_user(email)
+            EmailAddress.objects.create(user=user, email=email, verified=True, primary=True)
+            self.org.add_user(user, OrgRole.EDITOR)
+            return user
 
         # logging in with a password from a non-matching domain doesn't warn
         response = self.client.post(
@@ -110,10 +116,8 @@ class UserAuthTest(TembaTest):
 
         self.client.logout()
 
-        # but a user whose email domain should be using SSO gets warned
-        user = self.create_user("uma@sso-corp.com")
-        EmailAddress.objects.create(user=user, email=user.email, verified=True, primary=True)
-        self.org.add_user(user, OrgRole.EDITOR)
+        # but a user whose email domain should be using SSO gets a warning named after the mapped provider
+        user = create_verified_user("uma@sso-corp.com")
 
         response = self.client.post(login_url, {"login": user.email, "password": self.default_password}, follow=True)
         self.assertContains(response, "sso-login-warning")
@@ -122,6 +126,15 @@ class UserAuthTest(TembaTest):
         # only on the first page load after login
         response = self.client.get(response.request["PATH_INFO"])
         self.assertNotContains(response, "sso-login-warning")
+
+        self.client.logout()
+
+        # a domain mapped to a provider that isn't configured still warns, just generically
+        user2 = create_verified_user("ursula@no-sso-corp.com")
+
+        response = self.client.post(login_url, {"login": user2.email, "password": self.default_password}, follow=True)
+        self.assertContains(response, "sso-login-warning")
+        self.assertContains(response, 'header="Use Single Sign-On"')
 
     @override_settings(BRAND={"features": []})
     def test_invite_with_closed_signups(self):

--- a/temba/utils/templatetags/temba.py
+++ b/temba/utils/templatetags/temba.py
@@ -144,3 +144,11 @@ def format_datetime(context, dt, seconds: bool = False):
 def absolute_url(context, url_pattern):
     request = context["request"]
     return request.build_absolute_uri(reverse(url_pattern))
+
+
+@register.simple_tag(takes_context=True)
+def pop_session(context, key):
+    """
+    Removes and returns a value from the request session - for one-time flags such as login warnings.
+    """
+    return context["request"].session.pop(key, None)

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-{% load humanize i18n smartmin sms compress static %}
+{% load humanize i18n smartmin sms compress static temba socialaccount %}
 
 {% block html-tag %}
   <html lang="{{ LANGUAGE_CODE }}">
@@ -211,6 +211,36 @@
           {% endblock error-dialog %}
           <temba-toast duration="5000" error-sticky>
           </temba-toast>
+          {% pop_session "sso_login_warning" as sso_login_warning %}
+          {% if sso_login_warning %}
+            {% get_providers as sso_providers %}
+            {% if sso_providers %}
+              {% blocktrans with provider=sso_providers.0.name asvar sso_warning_title %}Sign In with {{ provider }}{% endblocktrans %}
+            {% else %}
+              {% trans "Use Single Sign-On" as sso_warning_title %}
+            {% endif %}
+            {% trans "Ok" as sso_warning_button %}
+            <temba-dialog open
+                          header="{{ sso_warning_title }}"
+                          cancelButtonName="{{ sso_warning_button }}"
+                          primaryButtonName=""
+                          hideOnClick
+                          id="sso-login-warning">
+              <div class="p-6">
+                {% if sso_providers %}
+                  {% blocktrans trimmed with provider=sso_providers.0.name %}
+                    Signing in with an email and password is going away for your organization. To keep access to your
+                    account, please use <b>Sign In with {{ provider }}</b> the next time you sign in.
+                  {% endblocktrans %}
+                {% else %}
+                  {% blocktrans trimmed %}
+                    Signing in with an email and password is going away for your organization. To keep access to your
+                    account, please use the single sign-on option the next time you sign in.
+                  {% endblocktrans %}
+                {% endif %}
+              </div>
+            </temba-dialog>
+          {% endif %}
           <div class="ajax-scripts"></div>
           <div class="flex-col">
             <div style="height:100vh;width:100%" class="flex flex-col">

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-{% load humanize i18n smartmin sms compress static temba socialaccount %}
+{% load humanize i18n smartmin sms compress static temba %}
 
 {% block html-tag %}
   <html lang="{{ LANGUAGE_CODE }}">
@@ -213,9 +213,8 @@
           </temba-toast>
           {% pop_session "sso_login_warning" as sso_login_warning %}
           {% if sso_login_warning %}
-            {% get_providers as sso_providers %}
-            {% if sso_providers %}
-              {% blocktrans with provider=sso_providers.0.name asvar sso_warning_title %}Sign In with {{ provider }}{% endblocktrans %}
+            {% if sso_login_warning.provider %}
+              {% blocktrans with provider=sso_login_warning.provider asvar sso_warning_title %}Sign In with {{ provider }}{% endblocktrans %}
             {% else %}
               {% trans "Use Single Sign-On" as sso_warning_title %}
             {% endif %}
@@ -227,8 +226,8 @@
                           hideOnClick
                           id="sso-login-warning">
               <div class="p-6">
-                {% if sso_providers %}
-                  {% blocktrans trimmed with provider=sso_providers.0.name %}
+                {% if sso_login_warning.provider %}
+                  {% blocktrans trimmed with provider=sso_login_warning.provider %}
                     Signing in with an email and password is going away for your organization. To keep access to your
                     account, please use <b>Sign In with {{ provider }}</b> the next time you sign in.
                   {% endblocktrans %}


### PR DESCRIPTION
## Summary

Adds a mechanism to warn users who log in with a password when their email domain indicates they should be using SSO instead. Deployments opt in via a new `SSO_LOGIN_WARNING_DOMAINS` setting that maps email domains to the allauth provider (or app id) their users should be using, e.g. `{"unicef.org": "unicef"}`. Default is empty, so nothing changes for deployments that don't configure it. The warning is a dismissable dialog shown once per login, with no removal timeframe stated.

## Changes

* **`temba/settings_common.py`** — new `SSO_LOGIN_WARNING_DOMAINS = {}` setting mapping email domains to the SSO provider their users should be logging in with.
* **`temba/users/adapter.py`** — `TembaAccountAdapter.post_login` checks non-social logins (no `sociallogin` in allauth's `signal_kwargs`) against the configured domains (both sides lowercased) and sets a `sso_login_warning` session flag holding the resolved provider name. The provider is resolved through allauth's `get_provider`, which supports both plain provider ids ("google") and OIDC app ids ("unicef"), so the warning names exactly the provider configured for that domain — even when a deployment has multiple SSO providers. A mapping to an unknown provider still warns, just without naming it. Fires for every password login including password + MFA; SSO logins never set it.
* **`temba/utils/templatetags/temba.py`** — new `pop_session` template tag that removes and returns a session key, so one-time flags are consumed exactly where they're rendered.
* **`templates/frame.html`** — renders an auto-open, dismissable `temba-dialog` when the flag is set, titled "Sign In with {provider}" (falling back to "Use Single Sign-On" if the provider couldn't be resolved). The block sits inside frame.html's `page-container`, which no-nav pages override and SPA partial responses never render — so interstitial pages (e.g. the workspace chooser) and background fetches can't consume the flag before the user sees the dialog.

## Behavior

| Scenario | Result |
| --- | --- |
| Password login, domain mapped to a configured provider | Dialog titled "Sign In with {provider}" on first full page load after login |
| Password login, domain mapped to an unknown provider id | Generic "Use Single Sign-On" dialog |
| Same session, subsequent page loads | No dialog (flag consumed on render) |
| Next password login | Dialog shown again |
| SSO login, any domain | No dialog |
| Password login, domain not in mapping (or setting empty) | No dialog |

## Test plan

- [x] `test_sso_login_warning`: no warning for unmapped domains, provider-named warning for a mapped domain (case-insensitive config), generic warning for a mapping to an unknown provider, shown only on first page load after login
- [x] Full `temba.users` + templatetags suites, `code_check.py`, djlint
- [x] Verified end-to-end in a dev deployment with a configured provider