### PR TITLE
Publicize uuid filtering on tickets API endpoint

### DIFF
--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -3205,7 +3205,7 @@ class TicketsEndpoint(ListAPIMixin, BaseEndpoint):
     A **GET** returns the tickets for your organization, most recent first.
 
      * **uuid** - the UUID of the ticket, filterable as `uuid`.
-     * **contact** - the UUID and name of the contact (object), filterable as `contact` with UUID.
+     * **contact** - the UUID and name of the contact (object).
      * **status** - the status of the ticket, either `open` or `closed`.
      * **topic** - the topic of the ticket (object).
      * **assignee** - the user assigned to the ticket (object).
@@ -3259,7 +3259,7 @@ class TicketsEndpoint(ListAPIMixin, BaseEndpoint):
             else:
                 queryset = queryset.filter(id=-1)
 
-        uuid = params.get("uuid") or params.get("ticket")
+        uuid = params.get("uuid")
         if uuid:
             queryset = queryset.filter(uuid=uuid)
 
@@ -3282,9 +3282,9 @@ class TicketsEndpoint(ListAPIMixin, BaseEndpoint):
             "slug": "ticket-list",
             "params": [
                 {
-                    "name": "contact",
+                    "name": "uuid",
                     "required": False,
-                    "help": "A contact UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
+                    "help": "A ticket UUID to filter by, ex: 09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
                 },
             ],
         }


### PR DESCRIPTION
## Summary

Adjusts what the tickets API endpoint advertises as filterable: `uuid` is now documented in the API explorer, and `contact` is no longer promoted as a filter. Also removes an undocumented `ticket` alias for the `uuid` param.

## Changes

`temba/api/v2/views.py` — `TicketsEndpoint`:

- Explorer params now list `uuid` instead of `contact`.
- Endpoint docstring no longer describes `contact` as filterable (the field itself is still returned, and the filter still works — it's just no longer advertised).
- The `ticket` query param, an undocumented alias for `uuid`, is dropped. Only `uuid` is accepted now.

## Behavior

| Request | Before | After |
|---|---|---|
| `?uuid=<ticket uuid>` | filters by ticket | filters by ticket (now documented) |
| `?ticket=<ticket uuid>` | filters by ticket | param ignored, returns all tickets |
| `?contact=<contact uuid>` | filters by contact | filters by contact (no longer documented) |

## Test plan

- [x] `temba.api` test suite passes (75 tests)
- [x] `code_check.py` clean — no missing migrations, ruff format and lint pass
- [x] Confirmed no callers of the `ticket` alias anywhere in the codebase