### PR TITLE
Remove beta gating of WhatsApp channel type

### DIFF
--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 18:29+0000\n"
+"POT-Creation-Date: 2026-08-03 17:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -4961,6 +4961,9 @@ msgid "Approve the permissions, these are required for us to access the API on y
 msgstr ""
 
 msgid "Add Facebook Business"
+msgstr ""
+
+msgid "Login was cancelled or failed, please try again."
 msgstr ""
 
 msgid "Before clicking the button below, make sure you have access to the phone where you can read the verification code send by SMS message"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 18:25+0000\n"
+"POT-Creation-Date: 2026-08-03 17:20+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -4985,6 +4985,11 @@ msgstr "Apruebe los permisos; son necesarios para que podamos acceder a la API e
 
 msgid "Add Facebook Business"
 msgstr "Añadir Facebook Business"
+
+#, fuzzy
+#| msgid "An error happened, please try again."
+msgid "Login was cancelled or failed, please try again."
+msgstr "Se produjo un error, vuelva a intentarlo."
 
 msgid "Before clicking the button below, make sure you have access to the phone where you can read the verification code send by SMS message"
 msgstr "Antes de hacer clic en el botón de abajo, asegúrese de tener acceso al teléfono en el que pueda leer el código de verificación enviado por SMS"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 18:25+0000\n"
+"POT-Creation-Date: 2026-08-03 17:20+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -4985,6 +4985,11 @@ msgstr "Approuvez les permissions ; elles nous sont nécessaires pour accéder �
 
 msgid "Add Facebook Business"
 msgstr "Ajouter Facebook Business"
+
+#, fuzzy
+#| msgid "An error happened, please try again."
+msgid "Login was cancelled or failed, please try again."
+msgstr "Une erreur s'est produite, veuillez réessayer."
 
 msgid "Before clicking the button below, make sure you have access to the phone where you can read the verification code send by SMS message"
 msgstr "Avant de cliquer sur le bouton ci-dessous, assurez-vous d'avoir accès au téléphone sur lequel vous pourrez lire le code de vérification envoyé par SMS"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 17:02+0000\n"
+"POT-Creation-Date: 2026-08-03 17:20+0000\n"
 "PO-Revision-Date: 2019-05-13 20:14+0000\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -4989,6 +4989,11 @@ msgstr "Aprove as permissões; elas são necessárias para que possamos acessar 
 
 msgid "Add Facebook Business"
 msgstr "Adicionar Facebook Business"
+
+#, fuzzy
+#| msgid "An error happened, please try again."
+msgid "Login was cancelled or failed, please try again."
+msgstr "Ocorreu um erro, por favor tente novamente."
 
 msgid "Before clicking the button below, make sure you have access to the phone where you can read the verification code send by SMS message"
 msgstr "Antes de clicar no botão abaixo, certifique-se de ter acesso ao telefone onde você poderá ler o código de verificação enviado por SMS"

--- a/temba/channels/tests/test_channelcrudl.py
+++ b/temba/channels/tests/test_channelcrudl.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -75,7 +74,7 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertRequestDisallowed(claim_url, [None, self.agent])
         response = self.assertReadFetch(claim_url, [self.editor, self.admin])
 
-        # should see all channel types not for beta only and having a category
+        # should see all channel types having a category
         self.assertEqual(["AT", "MT", "TG"], [t.code for t in response.context["recommended_channels"]])
 
         self.assertEqual(response.context["channel_types"]["PHONE"][0].code, "AC")
@@ -86,25 +85,7 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][0].code, "D3C")
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][1].code, "FBA")
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][2].code, "IG")
-        self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][-2].code, "WC")
-        self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][-1].code, "ZVW")
-
-        self.admin.groups.add(Group.objects.get(name="Beta"))
-
-        response = self.client.get(reverse("channels.channel_claim_all"))
-        self.assertEqual(200, response.status_code)
-
-        # should see all channel types having a category including beta only channel types
-        self.assertEqual(["AT", "MT", "TG"], [t.code for t in response.context["recommended_channels"]])
-
-        self.assertEqual(response.context["channel_types"]["PHONE"][0].code, "AC")
-        self.assertEqual(response.context["channel_types"]["PHONE"][1].code, "BW")
-        self.assertEqual(response.context["channel_types"]["PHONE"][2].code, "BS")
-        self.assertEqual(response.context["channel_types"]["PHONE"][-1].code, "A")
-
-        self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][0].code, "D3C")
-        self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][1].code, "FBA")
-        self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][2].code, "IG")
+        self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][-2].code, "WAC")
         self.assertEqual(response.context["channel_types"]["SOCIAL_MEDIA"][-1].code, "ZVW")
 
     def test_configuration(self):

--- a/temba/channels/types/whatsapp/tests.py
+++ b/temba/channels/types/whatsapp/tests.py
@@ -37,16 +37,6 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
         claim_whatsapp_cloud_url = reverse("channels.types.whatsapp.claim")
         select_whatsapp_cloud_url = reverse("channels.types.whatsapp.select_waba")
 
-        # make sure type is not listed the claim page
-        response = self.client.get(reverse("channels.channel_claim"))
-        self.assertNotContains(response, claim_whatsapp_cloud_url)
-
-        # or directly accessible
-        self.assertRedirect(self.client.get(claim_whatsapp_cloud_url), connect_whatsapp_cloud_url)
-        self.assertLoginRedirect(self.client.get(connect_whatsapp_cloud_url))
-
-        self.make_beta(self.admin)
-
         response = self.client.get(reverse("channels.channel_claim"))
         self.assertContains(response, claim_whatsapp_cloud_url)
         self.assertRedirect(self.client.get(claim_whatsapp_cloud_url), connect_whatsapp_cloud_url)
@@ -522,7 +512,6 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
     )
     def test_select_view(self):
         self.login(self.admin)
-        self.make_beta(self.admin)
 
         select_whatsapp_cloud_url = reverse("channels.types.whatsapp.select_waba")
         connect_whatsapp_cloud_url = reverse("channels.types.whatsapp.connect")
@@ -742,31 +731,7 @@ class WhatsAppTypeTest(TembaTest, CRUDLTestMixin):
         self.assertUpdateFetch(
             update_url,
             [self.editor, self.admin],
-            form_fields={"name": "WABA name"},
-        )
-
-        self.assertUpdateSubmit(
-            update_url,
-            self.admin,
-            {"name": "New WA Name", "is_enabled": False},
-        )
-
-        channel = Channel.objects.get(id=channel.id)
-        self.assertEqual("New WA Name", channel.name)
-        self.assertTrue(channel.is_enabled)  # is_enabled should not be updated as admin is not a beta user
-
-        # make admin a beta user
-        self.make_beta(self.admin)
-        self.assertUpdateFetch(
-            update_url,
-            [self.editor],
-            form_fields={"name": "New WA Name"},
-        )
-
-        self.assertUpdateFetch(
-            update_url,
-            [self.admin],
-            form_fields={"name": "New WA Name", "is_enabled": True},
+            form_fields={"name": "WABA name", "is_enabled": True},
         )
 
         self.assertUpdateSubmit(

--- a/temba/channels/types/whatsapp/type.py
+++ b/temba/channels/types/whatsapp/type.py
@@ -31,7 +31,6 @@ class WhatsAppType(ChannelType):
     code = "WAC"
     name = "WhatsApp"
     category = ChannelType.Category.SOCIAL_MEDIA
-    beta_only = True
 
     unique_addresses = True
 

--- a/temba/channels/types/whatsapp/views.py
+++ b/temba/channels/types/whatsapp/views.py
@@ -454,9 +454,6 @@ class Connect(ChannelTypeMixin, OrgPermsMixin, SmartFormView):
     menu_path = "/settings/workspace"
     title = _("Connect WhatsApp")
 
-    def has_permission(self, request, *args, **kwargs) -> bool:
-        return super().has_permission(request, *args, **kwargs) and self.request.user.is_beta
-
     def pre_process(self, request, *args, **kwargs):
         session_token = self.request.session.get(self.channel_type.SESSION_USER_TOKEN, None)
         if session_token:

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -697,15 +697,6 @@ class ChannelCRUDL(SmartCRUDL):
         def derive_title(self):
             return _("%s Channel") % self.object.type.name
 
-        def derive_exclude(self):
-            if self.request.user.is_staff:
-                return []
-
-            if self.object.type.beta_only and not self.request.user.is_beta:
-                return ["is_enabled"]
-
-            return []
-
         def derive_readonly(self):
             return self.form.Meta.readonly if hasattr(self, "form") else []
 


### PR DESCRIPTION
The WhatsApp Cloud channel type is no longer limited to beta users:

- Removes `beta_only` from the channel type so it appears on the claim page for all users, and the `is_enabled` field on channel update is no longer restricted to beta users.
- Removes the beta-user requirement on the connect view.
- Updates tests accordingly, including regenerated PO files which also pick up a connect page string missed in a previous change.