### PR TITLE
Update @nyaruka/temba-components to 0.172.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "rapidpro",
       "dependencies": {
-        "@nyaruka/temba-components": "0.170.1",
+        "@nyaruka/temba-components": "0.172.0",
         "codemirror": "5.58.2",
         "colorette": "1.2.2",
         "fa-icons": "0.2.0",
@@ -58,7 +58,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.170.1", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-VxqkUDBlN+j84cvd1l1lye0/DkcSV2kKT6Iam/BLfuiH1/OUOo2t6dBZ9c/M3DKJAbDTmZ5/gug+lGsSn5dvtw=="],
+    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.172.0", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-c7APhe+5bj5sfRPrq4C7ijLIbXMV4SCDTSgNMOMWML8RxFLwZJYTfcHek3VV+F5KCqCe8tSPR7Iys6nSf+9gkQ=="],
 
     "@open-wc/lit-helpers": ["@open-wc/lit-helpers@0.7.0", "", {}, "sha512-4NBlx5ve0EvZplCRJbESm0MdMbRCw16alP2y76KAAAwzmFFXXrUj5hFwhw55+sSg5qaRRx6sY+s7usKgnNo3TQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.170.1",
+    "@nyaruka/temba-components": "0.172.0",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",


### PR DESCRIPTION
## Changes in @nyaruka/temba-components [v0.172.0](https://github.com/nyaruka/temba-components/compare/v0.171.0...v0.172.0)

- 4/4 Share the subscriber fan-out and expose the connection's state [#1102](https://github.com/nyaruka/temba-components/pull/1102)
- 3/4 Type what each realtime topic publishes [#1101](https://github.com/nyaruka/temba-components/pull/1101)
- 2/4 Give the central watcher the contact chat's history channel [#1100](https://github.com/nyaruka/temba-components/pull/1100)
- 1/4 Own listener teardown in RapidElement and stop compiling on every dispatch [#1099](https://github.com/nyaruka/temba-components/pull/1099)
- Fix the flow search table tests against the new SearchModal base [#1106](https://github.com/nyaruka/temba-components/pull/1106)
- Align editor input limits with flow engine validation limits [#1093](https://github.com/nyaruka/temba-components/pull/1093)
- Add cross-ticket search modal with a reusable SearchModal base [#1083](https://github.com/nyaruka/temba-components/pull/1083)
- Stop a menu refresh from orphaning a load already in flight [#1103](https://github.com/nyaruka/temba-components/pull/1103)
- Wait for a screenshot's images, and stop fetching them from s3 in tests [#1104](https://github.com/nyaruka/temba-components/pull/1104)
- Add fallbacks for browsers without color-mix() support [#1096](https://github.com/nyaruka/temba-components/pull/1096)