### PR TITLE
Remove ticket scoping from the contact chat search endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "rapidpro",
       "dependencies": {
-        "@nyaruka/temba-components": "0.173.0",
+        "@nyaruka/temba-components": "0.173.1",
         "codemirror": "5.58.2",
         "colorette": "1.2.2",
         "fa-icons": "0.2.0",
@@ -58,7 +58,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.173.0", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-zn3sfRvfqUgVu2hJgESeHtCHyobeIxF1MJ+ypjvzg5mmNorPO6D8ST7VxhY8buStHhdNRODiT5ZG1AxEReNdiw=="],
+    "@nyaruka/temba-components": ["@nyaruka/temba-components@0.173.1", "", { "dependencies": { "@jsplumb/browser-ui": "^6.2.10", "@lit/localize": "^0.12.2", "@open-wc/lit-helpers": "^0.7.0", "centrifuge": "^5.7.0", "chart.js": "^4.5.1", "chartjs-adapter-luxon": "^1.3.1", "chartjs-plugin-datalabels": "^2.2.0", "color-hash": "^2.0.2", "croppie": "^2.6.5", "geojson": "^0.5.0", "image-size": "^1.1.1", "immer": "10", "leaflet": "1.5.1", "lit": "3.3.2", "lit-element": "^4.2.2", "lit-html": "^3.3.2", "luxon": "3.7", "remarkable": "^2.0.1", "serialize-javascript": "^7.0.3", "tiny-lru": "^11.2.5", "uuid": "^14.0.0", "zustand": "^5.0.3" } }, "sha512-Ae/FzbD3Q9soBMA8Pi6LytGlHGelOn1Yn6YziSzWTg+zTMXtzVSUKIHmh4IBlYIGifYDAj1qjikgCdqEiO+4+w=="],
 
     "@open-wc/lit-helpers": ["@open-wc/lit-helpers@0.7.0", "", {}, "sha512-4NBlx5ve0EvZplCRJbESm0MdMbRCw16alP2y76KAAAwzmFFXXrUj5hFwhw55+sSg5qaRRx6sY+s7usKgnNo3TQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "@nyaruka/temba-components": "0.173.0",
+    "@nyaruka/temba-components": "0.173.1",
     "codemirror": "5.58.2",
     "colorette": "1.2.2",
     "fa-icons": "0.2.0",

--- a/temba/contacts/tests/test_contactcrudl.py
+++ b/temba/contacts/tests/test_contactcrudl.py
@@ -751,9 +751,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
     @mock_mailroom
     def test_chat_search(self, mr_mocks):
         contact = self.create_contact("Joe Blow", urns=["tel:+250781111111"])
-        other_contact = self.create_contact("Frank", urns=["tel:+250782222222"])
         ticket = self.create_ticket(contact)
-        other_ticket = self.create_ticket(contact)
 
         chat_search_url = reverse("contacts.contact_chat_search", args=[contact.uuid])
 
@@ -781,7 +779,6 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
             "uuid": "019a9935-022e-7bb3-9d6f-03d773be624e",
             "type": "msg_created",
             "created_on": "2025-11-17T16:01:00+00:00",
-            "ticket_uuid": str(other_ticket.uuid),
         }
 
         # with results from mailroom
@@ -790,34 +787,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         response = self.client.get(chat_search_url + "?text=hello")
         self.assertEqual(200, response.status_code)
         self.assertEqual({"results": [event1, event2]}, response.json())
-        self.assertEqual([call(self.org, "hello", contact=contact, in_ticket=False)], mr_mocks.calls["msg_search"])
-
-        # a ticket scopes the search to that ticket's messages
-        mr_mocks.msg_search([(contact, event1), (contact, event2)])
-
-        response = self.client.get(chat_search_url + f"?text=hello&ticket={ticket.uuid}")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"results": [event1]}, response.json())
-        self.assertEqual(call(self.org, "hello", contact=contact, in_ticket=True), mr_mocks.calls["msg_search"][1])
-
-        # a ticket belonging to another contact is not a ticket we can search
-        other_contacts_ticket = self.create_ticket(other_contact)
-
-        response = self.client.get(chat_search_url + f"?text=hello&ticket={other_contacts_ticket.uuid}")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"results": []}, response.json())
-
-        # nor is one that doesn't exist or isn't a UUID
-        response = self.client.get(chat_search_url + f"?text=hello&ticket={uuid7()}")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"results": []}, response.json())
-
-        response = self.client.get(chat_search_url + "?text=hello&ticket=xyz")
-        self.assertEqual(200, response.status_code)
-        self.assertEqual({"results": []}, response.json())
-
-        # none of which reached mailroom
-        self.assertEqual(2, len(mr_mocks.calls["msg_search"]))
+        self.assertEqual([call(self.org, "hello", contact=contact)], mr_mocks.calls["msg_search"])
 
     @mock_mailroom
     def test_update(self, mr_mocks):

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -35,7 +35,7 @@ from temba.orgs.views.base import (
     BaseUsagesModal,
 )
 from temba.orgs.views.mixins import BulkActionMixin, OrgObjPermsMixin, OrgPermsMixin, UniqueNameMixin
-from temba.tickets.models import Ticket, Topic
+from temba.tickets.models import Topic
 from temba.users.models import User
 from temba.utils import json, on_transaction_commit
 from temba.utils.fields import CheckboxWidget, InputWidget, SelectWidget, TembaChoiceField
@@ -459,30 +459,9 @@ class ContactCRUDL(SmartCRUDL):
                 return JsonResponse({"results": []})
 
             contact = self.get_object()
+            results = mailroom.get_client().msg_search(request.org, text, contact=contact)
 
-            # an optional ticket scopes the search to that ticket's messages
-            ticket = None
-            if ticket_uuid := request.GET.get("ticket"):
-                if is_uuid(ticket_uuid):
-                    ticket = (
-                        Ticket.get_accessible(request.org, request.user)
-                        .filter(uuid=ticket_uuid, contact=contact)
-                        .first()
-                    )
-
-                # a ticket we can't resolve has no messages to match
-                if not ticket:
-                    return JsonResponse({"results": []})
-
-            results = mailroom.get_client().msg_search(request.org, text, contact=contact, in_ticket=ticket is not None)
-            events = [event for _, event in results]
-
-            if ticket:
-                # relies on mailroom setting ticket_uuid on every msg event it both indexes as in_ticket and returns
-                # here - an event missing it would be silently dropped from ticket scoped searches
-                events = [e for e in events if e.get("ticket_uuid") == str(ticket.uuid)]
-
-            return JsonResponse({"results": events})
+            return JsonResponse({"results": [event for _, event in results]})
 
     class Search(ContactListView):
         def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Summary

The chat UI always shows a contact's complete message history — hosting it on the tickets page only adds that ticket's detail events (notes, assignments) to the timeline. Scoping in-chat search to the selected ticket therefore made search cover less than what was on screen. The chat component no longer sends a `ticket` param (nyaruka/temba-components#1109), so this removes the corresponding scoping from the `chat_search` endpoint: searching within a chat is now always contact-wide, matching the contact read page.

## Changes

- `ContactCRUDL.ChatSearch` no longer accepts a `ticket` param — it always searches all of the contact's messages, dropping the `in_ticket` narrowing and the per-ticket post-filtering of results.
- Simplified `test_chat_search` accordingly.
- Updated `@nyaruka/temba-components` to 0.173.1, which includes the component side of this change.

Cross-ticket search on the tickets page (`TicketCRUDL.Search`) is unaffected — it still searches ticket messages org-wide, and its hand-off into a ticket's chat still lands on the matched message.

## Test plan

- [x] `temba.contacts` chat search test and `temba.tickets` suite pass
- [x] Older components that still send `ticket=` degrade gracefully — the param is ignored and the search is simply contact-wide