### PR TITLE
Allow whatsapp URNs to hold either a phone number or a business-scoped user id

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -98,6 +98,10 @@ class URN:
 
     FACEBOOK_PATH_REF_PREFIX = "ref:"
 
+    # a WhatsApp business-scoped user id: two-letter country code, dot, 1-128 alphanumerics (shared by
+    # the whatsapp and bsuid schemes, matching gocommon's whatsAppBSUIDRegex)
+    BSUID_PATH_REGEX = r"^[A-Z]{2}\.[a-zA-Z0-9]{1,128}$"
+
     def __init__(self):  # pragma: no cover
         raise ValueError("Class shouldn't be instantiated")
 
@@ -135,17 +139,17 @@ class URN:
         """
         scheme, path, query, display = cls.to_parts(urn)
 
-        if scheme in [cls.TEL_SCHEME, cls.WHATSAPP_SCHEME] and formatted:
+        # tel URNs, and legacy all-digit whatsapp URNs, are shown as friendly phone numbers; business-scoped
+        # whatsapp ids (not all digits) fall through and are shown as-is
+        if formatted and (scheme == cls.TEL_SCHEME or (scheme == cls.WHATSAPP_SCHEME and path.isdigit())):
             try:
-                # whatsapp scheme is E164 without a leading +, add it so parsing works
-                if scheme == cls.WHATSAPP_SCHEME:
-                    path = "+" + path
-
-                if path and path[0] == "+":
+                # whatsapp phone paths are E164 without a leading +, add it so parsing works
+                number = path if scheme == cls.TEL_SCHEME else "+" + path
+                if number and number[0] == "+":
                     phone_format = phonenumbers.PhoneNumberFormat.NATIONAL
                     if international:
                         phone_format = phonenumbers.PhoneNumberFormat.INTERNATIONAL
-                    return phonenumbers.format_number(phonenumbers.parse(path, None), phone_format)
+                    return phonenumbers.format_number(phonenumbers.parse(number, None), phone_format)
             except phonenumbers.NumberParseException:  # pragma: no cover
                 pass
 
@@ -204,13 +208,18 @@ class URN:
                 except ValueError:
                     return False
 
-        # telegram, whatsapp and instagram use integer ids
-        elif scheme in [cls.TELEGRAM_SCHEME, cls.WHATSAPP_SCHEME, cls.INSTAGRAM_SCHEME]:
+        # telegram and instagram use integer ids
+        elif scheme in [cls.TELEGRAM_SCHEME, cls.INSTAGRAM_SCHEME]:
             return regex.match(r"^[0-9]+$", path, regex.V0)
 
-        # bsuid (WhatsApp business-scoped user id): two-letter country code, dot, 1-128 alphanumerics
+        # whatsapp holds either a phone number (all digits, legacy) or a business-scoped user id; the digit
+        # form is accepted transitionally for existing/legacy rows and can be dropped once nothing writes it
+        elif scheme == cls.WHATSAPP_SCHEME:
+            return regex.match(r"^[0-9]+$", path, regex.V0) or regex.match(cls.BSUID_PATH_REGEX, path, regex.V0)
+
+        # bsuid is a WhatsApp business-scoped user id
         elif scheme == cls.BSUID_SCHEME:
-            return regex.match(r"^[A-Z]{2}\.[a-zA-Z0-9]{1,128}$", path, regex.V0)
+            return regex.match(cls.BSUID_PATH_REGEX, path, regex.V0)
 
         # validate Viber URNS look right (this is a guess)
         elif scheme == cls.VIBER_SCHEME:  # pragma: needs cover
@@ -254,8 +263,8 @@ class URN:
         elif scheme == cls.EMAIL_SCHEME:
             norm_path = norm_path.lower()
 
-        elif scheme == cls.BSUID_SCHEME:
-            # BSUIDs have format CC.ALPHANUMERIC - uppercase the country code
+        elif scheme in [cls.WHATSAPP_SCHEME, cls.BSUID_SCHEME]:
+            # whatsapp/bsuid have format CC.ALPHANUMERIC - uppercase the country code
             if len(norm_path) > 2 and norm_path[2] == ".":
                 norm_path = norm_path[:2].upper() + norm_path[2:]
 

--- a/temba/contacts/tests/test_urn.py
+++ b/temba/contacts/tests/test_urn.py
@@ -17,11 +17,18 @@ class ContactURNTest(TembaTest):
         self.assertEqual(urn.get_display(self.org, international=True), "+250 788 383 383")
         self.assertEqual(urn.get_display(self.org, formatted=False, international=True), "+250788383383")
 
-        # friendly tel formatting for whatsapp too
+        # legacy all-digit whatsapp URNs still get friendly phone formatting
         urn = ContactURN.objects.create(
             org=self.org, scheme="whatsapp", path="12065551212", identity="whatsapp:12065551212", priority=50
         )
         self.assertEqual(urn.get_display(self.org), "(206) 555-1212")
+
+        # a business-scoped whatsapp id (not all digits) is shown as-is (no phone formatting, no leading +)
+        urn = ContactURN.objects.create(
+            org=self.org, scheme="whatsapp", path="US.abcDEF123", identity="whatsapp:US.abcDEF123", priority=50
+        )
+        self.assertEqual(urn.get_display(self.org), "US.abcDEF123")
+        self.assertEqual(urn.get_display(self.org, international=True), "US.abcDEF123")
 
         # use path for other schemes
         urn = ContactURN.objects.create(
@@ -81,8 +88,15 @@ class URNTest(TembaTest):
         self.assertTrue(URN.validate("instagram:12345678901234567"))
 
     def test_whatsapp_urn(self):
+        # whatsapp holds either a phone number (all digits, legacy) or a business-scoped id (CC.alphanumeric)
         self.assertTrue(URN.validate("whatsapp:12065551212"))
+        self.assertTrue(URN.validate("whatsapp:BR.1A2B3C4D5E6F7G8H9I0J"))
+        self.assertTrue(URN.validate("whatsapp:US.abcDEF123"))
+
+        # malformed values are still invalid
         self.assertFalse(URN.validate("whatsapp:+12065551212"))
+        self.assertFalse(URN.validate("whatsapp:br.1A2B3C4D"))
+        self.assertFalse(URN.validate("whatsapp:BR.abc-123"))
 
     def test_bsuid_urn(self):
         # valid BSUIDs: two-letter country code, dot, 1-128 alphanumerics
@@ -173,9 +187,11 @@ class URNTest(TembaTest):
         # external ids are case sensitive
         self.assertEqual(URN.normalize("ext: eXterNAL123 "), "ext:eXterNAL123")
 
-        # bsuid - uppercase the two-letter country code prefix
+        # whatsapp/bsuid - uppercase the two-letter country code prefix
         self.assertEqual(URN.normalize("bsuid:br.1A2B3C4D"), "bsuid:BR.1A2B3C4D")
         self.assertEqual(URN.normalize("bsuid:BR.1A2B3C4D"), "bsuid:BR.1A2B3C4D")
+        self.assertEqual(URN.normalize("whatsapp:br.1A2B3C4D"), "whatsapp:BR.1A2B3C4D")
+        self.assertEqual(URN.normalize("whatsapp:BR.1A2B3C4D"), "whatsapp:BR.1A2B3C4D")
 
     def test_validate(self):
         self.assertFalse(URN.validate("xxxx", None))  # un-parseable URNs don't validate


### PR DESCRIPTION
## Summary

WhatsApp is transitioning user identity from phone numbers to business-scoped user IDs (BSUIDs: a two-letter uppercase country code, a dot, then up to 128 alphanumerics, e.g. `US.13491208655302741918`). Message routing already handles both forms by URN content, so this updates the Python-side `URN` class to let the `whatsapp` scheme hold either form. The separate `bsuid` scheme is unchanged, and the two now share the same validation regex and normalization so they stay in lockstep.

## Changes

* `URN.validate` accepts a `whatsapp` path that is either all digits (a phone number, the legacy form) or a BSUID, using a new shared `BSUID_PATH_REGEX` constant (`^[A-Z]{2}\.[a-zA-Z0-9]{1,128}$`, matching gocommon's whatsapp scheme). The `bsuid` scheme now validates against the same constant.
* `URN.normalize` uppercases the two-letter country code prefix for `whatsapp` paths in the BSUID form (third character is `.`), same as it already does for `bsuid`. Legacy all-digit paths are unaffected since they can't have a dot at that position.
* `URN.format` applies friendly phone-number formatting only to all-digit `whatsapp` paths; BSUIDs are displayed as-is, with no leading `+` and no phone formatting.

## Behavior examples

* `URN.validate("whatsapp:12065551212")` → valid (unchanged)
* `URN.validate("whatsapp:US.abcDEF123")` → now valid (previously rejected)
* `URN.validate("whatsapp:br.1A2B3C4D")` / `URN.validate("whatsapp:BR.abc-123")` → invalid
* `URN.normalize("whatsapp:br.1A2B3C4D")` → `whatsapp:BR.1A2B3C4D`
* Display of `whatsapp:12065551212` → `(206) 555-1212` (unchanged); display of `whatsapp:US.abcDEF123` → `US.abcDEF123`

## Test plan

* `temba.contacts.tests.test_urn` extended to cover: validation of both `whatsapp` forms plus malformed values, country-code uppercasing in normalization for both `whatsapp` and `bsuid`, and display of legacy vs business-scoped `whatsapp` URNs — all passing
* CI green