### PR TITLE
Add management command to convert legacy bsuid URNs to whatsapp

### DIFF
--- a/temba/contacts/management/commands/convert_bsuid_urns.py
+++ b/temba/contacts/management/commands/convert_bsuid_urns.py
@@ -94,8 +94,10 @@ class Command(BaseCommand):
                 owner_contact_id, kept_urn_id = owner
                 if owner_contact_id == u.contact_id:
                     # the bsuid URN duplicates a whatsapp URN the same contact already has, so move its
-                    # references onto the survivor and drop it
-                    u.reassign_content_to(kept_urn_id)
+                    # references (all on_delete=PROTECT) onto the survivor and drop it
+                    u.msgs.update(contact_urn_id=kept_urn_id)
+                    u.calls.update(contact_urn_id=kept_urn_id)
+                    u.channel_events.update(contact_urn_id=kept_urn_id)
                     u.delete()
                     num_dropped += 1
                     if u.contact_id:

--- a/temba/contacts/management/commands/convert_bsuid_urns.py
+++ b/temba/contacts/management/commands/convert_bsuid_urns.py
@@ -1,0 +1,139 @@
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+from django.db import IntegrityError
+from django.db.models.functions import Now
+
+from temba import mailroom
+from temba.contacts.models import URN, Contact, ContactURN
+
+BATCH_SIZE = 1000
+
+
+class Command(BaseCommand):
+    help = (
+        "Converts legacy bsuid:<CC.xxx> contact URNs to the whatsapp scheme (path unchanged). A bsuid URN whose "
+        "whatsapp identity already exists on the same contact is redundant, so its message/call/event references "
+        "are moved onto the surviving whatsapp URN and it's deleted. One whose whatsapp identity belongs to a "
+        "different contact is left untouched and can be retried by re-running the command."
+    )
+
+    def handle(self, *args, **options):
+        num_converted = num_dropped = num_skipped = 0
+        contacts_changed = set()
+        last_id = 0
+
+        while True:
+            # process one batch of bsuid URNs, cursoring by id so that skipped (collision) rows aren't
+            # re-fetched forever
+            batch = list(
+                ContactURN.objects.filter(scheme=URN.BSUID_SCHEME, id__gt=last_id)
+                .order_by("id")
+                .only("id", "org_id", "path", "contact_id", "priority")[:BATCH_SIZE]
+            )
+            if not batch:
+                break
+
+            last_id = batch[-1].id
+
+            converted, dropped, skipped, changed = self._convert(batch)
+
+            # bump modified_on on changed contacts and have mailroom re-index them
+            if changed:
+                Contact.objects.filter(id__in=changed).update(modified_on=Now())
+                self._reindex(changed)
+
+            num_converted += converted
+            num_dropped += dropped
+            num_skipped += skipped
+            contacts_changed |= changed
+
+        self.stdout.write(
+            f"Converted {num_converted} bsuid URNs to whatsapp ({num_dropped} redundant dropped, "
+            f"{num_skipped} skipped as whatsapp URN belongs to a different contact) "
+            f"across {len(contacts_changed)} contacts"
+        )
+
+    def _convert(self, urns) -> tuple:
+        """
+        Converts the given bsuid URNs to the whatsapp scheme, path unchanged. A URN whose target identity already
+        exists on the same contact is redundant (courier writes both forms), so its content references are moved
+        onto the survivor and it's deleted. One whose target identity is owned by a different contact can't be
+        converted without violating the (identity, org) uniqueness constraint, so it's left untouched.
+
+        Returns (num_converted, num_dropped, num_skipped, {ids of changed contacts}).
+        """
+
+        # existing (org_id, identity) -> (owning contact_id, URN id), to detect collisions and, for same-contact
+        # collisions, find the surviving URN to move references onto
+        existing = {
+            (org_id, identity): (contact_id, urn_id)
+            for org_id, identity, contact_id, urn_id in ContactURN.objects.filter(
+                org_id__in={u.org_id for u in urns},
+                identity__in={URN.from_parts(URN.WHATSAPP_SCHEME, u.path) for u in urns},
+            ).values_list("org_id", "identity", "contact_id", "id")
+        }
+
+        # the highest priority all-digit (i.e. phone) whatsapp URN of each contact, so that converted URNs can
+        # be kept below it
+        phone_priorities = {}
+        for contact_id, priority in ContactURN.objects.filter(
+            scheme=URN.WHATSAPP_SCHEME,
+            contact_id__in={u.contact_id for u in urns if u.contact_id},
+            path__regex=r"^[0-9]+$",
+        ).values_list("contact_id", "priority"):
+            if priority > phone_priorities.get(contact_id, -1):
+                phone_priorities[contact_id] = priority
+
+        to_update, changed, num_dropped, num_skipped = [], set(), 0, 0
+        for u in urns:
+            identity = URN.from_parts(URN.WHATSAPP_SCHEME, u.path)
+
+            owner = existing.get((u.org_id, identity))
+            if owner:
+                owner_contact_id, kept_urn_id = owner
+                if owner_contact_id == u.contact_id:
+                    # the bsuid URN duplicates a whatsapp URN the same contact already has, so move its
+                    # references onto the survivor and drop it
+                    u.reassign_content_to(kept_urn_id)
+                    u.delete()
+                    num_dropped += 1
+                    if u.contact_id:
+                        changed.add(u.contact_id)
+                else:
+                    num_skipped += 1
+                continue
+
+            u.scheme, u.identity = URN.WHATSAPP_SCHEME, identity
+
+            # a converted URN mustn't outrank the contact's phone whatsapp URN
+            phone_priority = phone_priorities.get(u.contact_id)
+            if phone_priority is not None and phone_priority <= u.priority:
+                u.priority = phone_priority - 1
+
+            to_update.append(u)
+
+        if to_update:
+            try:
+                ContactURN.objects.bulk_update(to_update, ["scheme", "identity", "priority"])
+            except IntegrityError:
+                # a concurrent writer inserted a colliding identity between our check and the update; skip
+                # this batch - the command is safe to re-run and will retry it
+                self.stdout.write(f"skipped a batch of {len(to_update)} URNs due to a collision")
+                return 0, num_dropped, num_skipped, changed
+
+        changed.update(u.contact_id for u in to_update if u.contact_id)
+
+        return len(to_update), num_dropped, num_skipped, changed
+
+    def _reindex(self, contact_ids):
+        """
+        Tells mailroom to re-index the given contacts in search.
+        """
+        by_org = defaultdict(list)
+        for contact in Contact.objects.filter(id__in=contact_ids).select_related("org"):
+            by_org[contact.org].append(contact)
+
+        client = mailroom.get_client()
+        for org, contacts in by_org.items():
+            client.contact_reindex(org, contacts)

--- a/temba/contacts/management/commands/tests.py
+++ b/temba/contacts/management/commands/tests.py
@@ -1,0 +1,178 @@
+from datetime import datetime, timezone as tzone
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+from temba.contacts.models import ContactURN
+from temba.tests import TembaTest, mock_mailroom
+
+
+class ConvertBsuidUrnsTest(TembaTest):
+    def urns(self, contact) -> set:
+        contact.refresh_from_db()
+        return {(u.scheme, u.path, u.identity) for u in contact.urns.all()}
+
+    @mock_mailroom
+    def test_command(self, mr_mocks):
+        # a contact with a whatsapp phone URN and no bsuid -> never touched
+        contact1 = self.create_contact("Ann", urns=["whatsapp:250788000001"])
+
+        # a contact reachable only by a bsuid URN -> converted to whatsapp
+        contact2 = self.create_contact("Bob", urns=["bsuid:RW.abc123"])
+
+        # a typical WhatsApp contact with a phone whatsapp URN above its bsuid URN -> bsuid converted, and its
+        # priority (already below the phone's) left alone
+        contact3 = self.create_contact("Cat", urns=["whatsapp:250788000003", "bsuid:RW.def456"])
+
+        # a contact that courier has dual-written -> the bsuid URN is redundant and dropped
+        contact4 = self.create_contact("Dan", urns=["whatsapp:250788000004", "whatsapp:RW.jkl012", "bsuid:RW.jkl012"])
+
+        # a contact with unrelated schemes -> never touched
+        contact5 = self.create_contact("Eve", urns=["tel:+250788000005", "facebook:123456789"])
+
+        # a bsuid contact whose whatsapp identity belongs to a different contact -> left as-is
+        contact6 = self.create_contact("Fay", urns=["bsuid:RW.ghi789"])
+        contact7 = self.create_contact("Gus", urns=["whatsapp:RW.ghi789"])
+
+        # a contact whose bsuid URN outranks its phone whatsapp URN -> converted but dropped below the phone
+        contact8 = self.create_contact("Hal", urns=["bsuid:RW.mno345", "whatsapp:250788000008"])
+
+        start = datetime.now(tzone.utc)
+
+        out = StringIO()
+        call_command("convert_bsuid_urns", stdout=out)
+
+        # no bsuid -> not touched or reindexed
+        self.assertEqual({("whatsapp", "250788000001", "whatsapp:250788000001")}, self.urns(contact1))
+        self.assertLess(contact1.modified_on, start)
+
+        # bsuid URN converted to whatsapp with the path unchanged
+        self.assertEqual({("whatsapp", "RW.abc123", "whatsapp:RW.abc123")}, self.urns(contact2))
+        self.assertGreater(contact2.modified_on, start)
+
+        # bsuid URN converted, phone whatsapp URN untouched and still ranked above it
+        self.assertEqual(
+            {
+                ("whatsapp", "250788000003", "whatsapp:250788000003"),
+                ("whatsapp", "RW.def456", "whatsapp:RW.def456"),
+            },
+            self.urns(contact3),
+        )
+        self.assertEqual(1000, contact3.urns.get(path="250788000003").priority)
+        self.assertEqual(999, contact3.urns.get(path="RW.def456").priority)
+        self.assertGreater(contact3.modified_on, start)
+
+        # redundant bsuid dropped, existing whatsapp URNs untouched
+        self.assertEqual(
+            {
+                ("whatsapp", "250788000004", "whatsapp:250788000004"),
+                ("whatsapp", "RW.jkl012", "whatsapp:RW.jkl012"),
+            },
+            self.urns(contact4),
+        )
+        self.assertGreater(contact4.modified_on, start)
+
+        # unrelated URNs never touched
+        self.assertEqual(
+            {("tel", "+250788000005", "tel:+250788000005"), ("facebook", "123456789", "facebook:123456789")},
+            self.urns(contact5),
+        )
+        self.assertLess(contact5.modified_on, start)
+
+        # bsuid whose whatsapp identity belongs to another contact is left as-is
+        self.assertEqual({("bsuid", "RW.ghi789", "bsuid:RW.ghi789")}, self.urns(contact6))
+        self.assertLess(contact6.modified_on, start)
+        self.assertEqual({("whatsapp", "RW.ghi789", "whatsapp:RW.ghi789")}, self.urns(contact7))
+        self.assertLess(contact7.modified_on, start)
+
+        # bsuid that outranked the phone (1000 vs 999) is converted with its priority dropped below the phone's
+        self.assertEqual(
+            {
+                ("whatsapp", "RW.mno345", "whatsapp:RW.mno345"),
+                ("whatsapp", "250788000008", "whatsapp:250788000008"),
+            },
+            self.urns(contact8),
+        )
+        self.assertEqual(999, contact8.urns.get(path="250788000008").priority)
+        self.assertEqual(998, contact8.urns.get(path="RW.mno345").priority)
+        self.assertGreater(contact8.modified_on, start)
+
+        # every changed contact was sent to mailroom for re-indexing
+        self.assertEqual(1, len(mr_mocks.calls["contact_reindex"]))
+        org_arg, contacts_arg = mr_mocks.calls["contact_reindex"][0].args
+        self.assertEqual(self.org, org_arg)
+        self.assertEqual({contact2, contact3, contact4, contact8}, set(contacts_arg))
+
+        self.assertIn(
+            "Converted 3 bsuid URNs to whatsapp (1 redundant dropped, "
+            "1 skipped as whatsapp URN belongs to a different contact) across 4 contacts",
+            out.getvalue(),
+        )
+
+        # only the collided bsuid remains
+        self.assertEqual({"RW.ghi789"}, set(ContactURN.objects.filter(scheme="bsuid").values_list("path", flat=True)))
+
+    @mock_mailroom
+    def test_dropped_bsuid_moves_references(self, mr_mocks):
+        # a dual-written contact whose bsuid URN is redundant and referenced by a message
+        contact = self.create_contact("Dan", urns=["whatsapp:250788000004", "whatsapp:RW.jkl012", "bsuid:RW.jkl012"])
+        bsuid = contact.urns.get(scheme="bsuid")
+        wa = contact.urns.get(scheme="whatsapp", path="RW.jkl012")
+
+        # a message referencing the bsuid URN that will be dropped (PROTECT would block a bare delete)
+        msg = self.create_incoming_msg(contact, "hi", channel=self.channel)
+        msg.contact_urn = bsuid
+        msg.save(update_fields=["contact_urn"])
+
+        call_command("convert_bsuid_urns", stdout=StringIO())
+
+        # the redundant bsuid URN is gone and its message was moved onto the surviving whatsapp URN
+        self.assertFalse(ContactURN.objects.filter(id=bsuid.id).exists())
+        msg.refresh_from_db()
+        self.assertEqual(wa.id, msg.contact_urn_id)
+
+    @mock_mailroom
+    def test_reapplying_is_safe(self, mr_mocks):
+        contact = self.create_contact("Cat", urns=["whatsapp:250788000003", "bsuid:RW.def456"])
+
+        call_command("convert_bsuid_urns", stdout=StringIO())
+        before = self.urns(contact)
+        contact.refresh_from_db()
+        modified_before = contact.modified_on
+        reindexes_before = len(mr_mocks.calls["contact_reindex"])
+
+        # running again changes nothing and doesn't reindex
+        out = StringIO()
+        call_command("convert_bsuid_urns", stdout=out)
+
+        self.assertEqual(before, self.urns(contact))
+        contact.refresh_from_db()
+        self.assertEqual(modified_before, contact.modified_on)
+        self.assertEqual(reindexes_before, len(mr_mocks.calls["contact_reindex"]))
+        self.assertIn(
+            "Converted 0 bsuid URNs to whatsapp (0 redundant dropped, "
+            "0 skipped as whatsapp URN belongs to a different contact) across 0 contacts",
+            out.getvalue(),
+        )
+
+    @mock_mailroom
+    @patch("temba.contacts.management.commands.convert_bsuid_urns.BATCH_SIZE", 2)
+    def test_batches_and_skips_collisions_across_the_cursor(self, mr_mocks):
+        # an existing whatsapp URN that a later bsuid will collide with when it tries to convert
+        self.create_contact("Taken", urns=["whatsapp:RW.taken0"])
+
+        # several bsuid contacts spanning multiple batches of 2, plus one whose target already exists
+        good = [self.create_contact(f"C{i}", urns=[f"bsuid:RW.user{i}"]) for i in range(5)]
+        collide = self.create_contact("Collide", urns=["bsuid:RW.taken0"])
+
+        # with BATCH_SIZE=2 the collided bsuid is skipped mid-cursor; if last_id didn't advance past it the
+        # command would loop forever, so simply completing proves the cursor advances correctly
+        call_command("convert_bsuid_urns", stdout=StringIO())
+
+        # every non-colliding bsuid was converted to whatsapp across all batches
+        for i, contact in enumerate(good):
+            self.assertEqual({("whatsapp", f"RW.user{i}", f"whatsapp:RW.user{i}")}, self.urns(contact))
+
+        # the colliding bsuid is left untouched
+        self.assertEqual({("bsuid", "RW.taken0", "bsuid:RW.taken0")}, self.urns(collide))

--- a/temba/contacts/management/commands/tests.py
+++ b/temba/contacts/management/commands/tests.py
@@ -3,6 +3,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
+from django.db import IntegrityError
 
 from temba.contacts.models import ContactURN
 from temba.tests import TembaTest, mock_mailroom
@@ -155,6 +156,35 @@ class ConvertBsuidUrnsTest(TembaTest):
             "0 skipped as whatsapp URN belongs to a different contact) across 0 contacts",
             out.getvalue(),
         )
+
+    @mock_mailroom
+    def test_concurrent_collision_abandons_batch_and_rerun_converges(self, mr_mocks):
+        contact = self.create_contact("Ann", urns=["bsuid:RW.abc123"])
+        start = datetime.now(tzone.utc)
+
+        # a concurrent writer inserting a colliding identity between the existing-URNs check and the update
+        # surfaces as an IntegrityError from the bulk update
+        out = StringIO()
+        with patch(
+            "temba.contacts.models.ContactURN.objects.bulk_update",
+            side_effect=IntegrityError("duplicate key value violates unique constraint"),
+        ):
+            call_command("convert_bsuid_urns", stdout=out)
+
+        # the batch is abandoned: URN untouched, nothing counted, bumped or reindexed
+        self.assertEqual({("bsuid", "RW.abc123", "bsuid:RW.abc123")}, self.urns(contact))
+        self.assertIn("skipped a batch of 1 URNs due to a collision", out.getvalue())
+        self.assertIn("Converted 0 bsuid URNs to whatsapp", out.getvalue())
+        self.assertEqual(0, len(mr_mocks.calls["contact_reindex"]))
+        contact.refresh_from_db()
+        self.assertLess(contact.modified_on, start)
+
+        # re-running without the concurrent writer converts it
+        call_command("convert_bsuid_urns", stdout=StringIO())
+
+        self.assertEqual({("whatsapp", "RW.abc123", "whatsapp:RW.abc123")}, self.urns(contact))
+        contact.refresh_from_db()
+        self.assertGreater(contact.modified_on, start)
 
     @mock_mailroom
     @patch("temba.contacts.management.commands.convert_bsuid_urns.BATCH_SIZE", 2)

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1259,7 +1259,7 @@ class Contact(LegacyIDMixin, LegacyUUIDMixin, SmartModel):
         for urn in self.urns.all():
             # delete the urn if it has no associated content.. which should be the case if it wasn't
             # stolen from another contact
-            if not urn.has_content():
+            if not urn.msgs.all() and not urn.channel_events.all() and not urn.calls.all():
                 urn.delete()
             else:
                 urn.contact = None
@@ -1430,10 +1430,6 @@ class ContactURN(LegacyIDMixin, models.Model):
     ANON_MASK = "*" * 8  # Returned instead of URN values for anon orgs
     ANON_MASK_HTML = "•" * 8  # Pretty HTML version of anon mask
 
-    # reverse relations holding content that references a URN (all on_delete=PROTECT), so a URN can't be
-    # deleted until these are moved elsewhere or gone
-    CONTENT_RELATIONS = ("msgs", "calls", "channel_events")
-
     org = models.ForeignKey(Org, related_name="urns", on_delete=models.PROTECT)
     contact = models.ForeignKey(Contact, on_delete=models.PROTECT, null=True, related_name="urns")
 
@@ -1480,19 +1476,6 @@ class ContactURN(LegacyIDMixin, models.Model):
             return self.ANON_MASK
 
         return URN.format(self.urn, international=international, formatted=formatted)
-
-    def has_content(self) -> bool:
-        """
-        Whether any messages, calls or channel events still reference this URN.
-        """
-        return any(getattr(self, rel).exists() for rel in self.CONTENT_RELATIONS)
-
-    def reassign_content_to(self, urn_id: int):
-        """
-        Moves any messages, calls and channel events referencing this URN onto the URN with the given id.
-        """
-        for rel in self.CONTENT_RELATIONS:
-            getattr(self, rel).update(contact_urn_id=urn_id)
 
     @property
     def urn(self) -> str:

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1259,7 +1259,7 @@ class Contact(LegacyIDMixin, LegacyUUIDMixin, SmartModel):
         for urn in self.urns.all():
             # delete the urn if it has no associated content.. which should be the case if it wasn't
             # stolen from another contact
-            if not urn.msgs.all() and not urn.channel_events.all() and not urn.calls.all():
+            if not urn.has_content():
                 urn.delete()
             else:
                 urn.contact = None
@@ -1430,6 +1430,10 @@ class ContactURN(LegacyIDMixin, models.Model):
     ANON_MASK = "*" * 8  # Returned instead of URN values for anon orgs
     ANON_MASK_HTML = "•" * 8  # Pretty HTML version of anon mask
 
+    # reverse relations holding content that references a URN (all on_delete=PROTECT), so a URN can't be
+    # deleted until these are moved elsewhere or gone
+    CONTENT_RELATIONS = ("msgs", "calls", "channel_events")
+
     org = models.ForeignKey(Org, related_name="urns", on_delete=models.PROTECT)
     contact = models.ForeignKey(Contact, on_delete=models.PROTECT, null=True, related_name="urns")
 
@@ -1476,6 +1480,19 @@ class ContactURN(LegacyIDMixin, models.Model):
             return self.ANON_MASK
 
         return URN.format(self.urn, international=international, formatted=formatted)
+
+    def has_content(self) -> bool:
+        """
+        Whether any messages, calls or channel events still reference this URN.
+        """
+        return any(getattr(self, rel).exists() for rel in self.CONTENT_RELATIONS)
+
+    def reassign_content_to(self, urn_id: int):
+        """
+        Moves any messages, calls and channel events referencing this URN onto the URN with the given id.
+        """
+        for rel in self.CONTENT_RELATIONS:
+            getattr(self, rel).update(contact_urn_id=urn_id)
 
     @property
     def urn(self) -> str:


### PR DESCRIPTION
## Summary

Adds a `convert_bsuid_urns` management command that converts legacy `bsuid:<CC.xxx>` contact URNs to the `whatsapp` scheme (path unchanged), now that the whatsapp scheme holds either a phone number or a business-scoped user id and courier writes new business-scoped ids as whatsapp URNs. Once run, the `bsuid` scheme can be retired.

It's a management command rather than a data migration because changed contacts need to be re-indexed in search — the command bumps `modified_on` and calls mailroom's contact re-index endpoint for them, which is out of scope for a migration.

## Changes

* New `convert_bsuid_urns` command that runs in id-ordered batches (cursoring past skipped rows) so it's safe to re-run, and abandons a batch on a concurrent-write `IntegrityError` — logging the deferred count — rather than failing; a later run picks those rows up.
* A bsuid URN whose whatsapp identity already exists on the **same** contact (courier has been writing both forms) is redundant — its message/call/event references are moved onto the surviving whatsapp URN and it's deleted.
* One whose whatsapp identity belongs to a **different** contact is left untouched and counted in the summary; incoming messages reassign such URNs to the right contact, so re-running later converges.
* A converted URN that would outrank the contact's phone whatsapp URN has its priority lowered below the phone's, so the phone stays the contact's top whatsapp destination. Other URNs aren't reordered.
* Prints totals: converted, redundant dropped, skipped due to other-contact collisions, and contacts changed.
* When dropping a redundant URN, its message/call/event references (all `on_delete=PROTECT`) are moved onto the survivor before deletion.

## Test plan

* New tests cover: plain conversion, priority preservation and the priority guard, redundant-drop with message reassignment, other-contact collision skip, `modified_on` bumps and mailroom re-index calls, re-run idempotency, batch cursor advancement past skipped rows, and that a batch abandoned on a concurrent-write `IntegrityError` is converted by a re-run.
* Full `temba.contacts` suite passes; CI green including the coverage gate.
