### PR TITLE
Move base test fixture creation to setUpTestData

### DIFF
--- a/temba/archives/tests/test_archivecrudl.py
+++ b/temba/archives/tests/test_archivecrudl.py
@@ -8,6 +8,7 @@ from temba.tests import CRUDLTestMixin, TembaTest, cleanup
 
 
 class ArchiveCRUDLTest(TembaTest, CRUDLTestMixin):
+    @cleanup(s3=True)
     def test_list_views(self):
         # a daily archive that has been rolled up and will not appear in the results
         d1 = self.create_archive(Archive.TYPE_MSG, "D", date(2020, 7, 31), [{"id": 1}, {"id": 2}])

--- a/temba/tests/base.py
+++ b/temba/tests/base.py
@@ -58,54 +58,52 @@ class TembaTest(SmartminTest):
     databases = ("default", "readonly")
     default_password = "Qwerty123"
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
-        # fail loudly if a test reaches a live mailroom instead of mocking it
-        install_mailroom_guard(self)
-
-        self.superuser = User.objects.create_user("super@user.com", self.default_password, is_superuser=True)
+        cls.superuser = User.objects.create_user("super@user.com", cls.default_password, is_superuser=True)
 
         # create different user types
-        self.non_org_user = self.create_user("nonorg@textit.com")
-        self.admin = self.create_user("admin@textit.com", first_name="Andy")
-        self.editor = self.create_user("editor@textit.com", first_name="Ed", last_name="McEdits")
-        self.agent = self.create_user("agent@textit.com", first_name="Agnes")
-        self.customer_support = self.create_user("support@textit.com", is_staff=True)
+        cls.non_org_user = cls.create_user("nonorg@textit.com")
+        cls.admin = cls.create_user("admin@textit.com", first_name="Andy")
+        cls.editor = cls.create_user("editor@textit.com", first_name="Ed", last_name="McEdits")
+        cls.agent = cls.create_user("agent@textit.com", first_name="Agnes")
+        cls.customer_support = cls.create_user("support@textit.com", is_staff=True)
 
         # mark all of their emails as verified
         for user in User.objects.all():
             EmailAddress.objects.create(user=user, email=user.email, verified=True, primary=True)
 
-        self.org = Org.objects.create(
+        cls.org = Org.objects.create(
             name="Nyaruka",
             timezone=ZoneInfo("Africa/Kigali"),
             flow_languages=["eng", "kin"],
-            created_by=self.admin,
-            modified_by=self.admin,
+            created_by=cls.admin,
+            modified_by=cls.admin,
         )
-        self.org.initialize()
-        self.org.add_user(self.admin, OrgRole.ADMINISTRATOR)
-        self.org.add_user(self.editor, OrgRole.EDITOR)
-        self.org.add_user(self.agent, OrgRole.AGENT)
+        cls.org.initialize()
+        cls.org.add_user(cls.admin, OrgRole.ADMINISTRATOR)
+        cls.org.add_user(cls.editor, OrgRole.EDITOR)
+        cls.org.add_user(cls.agent, OrgRole.AGENT)
 
         # setup a second org with a single admin
-        self.admin2 = self.create_user("administrator@trileet.com")
-        EmailAddress.objects.create(user=self.admin2, email=self.admin2.email, verified=True, primary=True)
-        self.org2 = Org.objects.create(
+        cls.admin2 = cls.create_user("administrator@trileet.com")
+        EmailAddress.objects.create(user=cls.admin2, email=cls.admin2.email, verified=True, primary=True)
+        cls.org2 = Org.objects.create(
             name="Trileet Inc.",
             timezone=ZoneInfo("US/Pacific"),
             flow_languages=["eng"],
-            created_by=self.admin2,
-            modified_by=self.admin2,
+            created_by=cls.admin2,
+            modified_by=cls.admin2,
         )
-        self.org2.initialize()
-        self.org2.add_user(self.admin2, OrgRole.ADMINISTRATOR)
+        cls.org2.initialize()
+        cls.org2.add_user(cls.admin2, OrgRole.ADMINISTRATOR)
 
         # a single Android channel
-        self.channel = Channel.create(
-            self.org,
-            self.admin,
+        cls.channel = Channel.create(
+            cls.org,
+            cls.admin,
             "RW",
             "A",
             name="Test Channel",
@@ -115,6 +113,12 @@ class TembaTest(SmartminTest):
             config={Channel.CONFIG_FCM_ID: "123"},
             normalize_urns=False,
         )
+
+    def setUp(self):
+        super().setUp()
+
+        # fail loudly if a test reaches a live mailroom instead of mocking it
+        install_mailroom_guard(self)
 
         # OrgRole.group and OrgRole.permissions are cached properties so get those cached before test starts to avoid
         # query count differences when a test is first to request it and when it's not.
@@ -196,8 +200,9 @@ class TembaTest(SmartminTest):
         flow.org = self.org
         return flow
 
-    def create_user(self, email, group_names=(), **kwargs):
-        user = User.objects.create_user(email=email, password=self.default_password, **kwargs)
+    @classmethod
+    def create_user(cls, email, group_names=(), **kwargs):
+        user = User.objects.create_user(email=email, password=cls.default_password, **kwargs)
         user.save()
 
         for group in group_names:


### PR DESCRIPTION
## Summary

Moves the shared fixture creation in `TembaTest` from per-test `setUp` to class-level `setUpTestData`, roughly halving the runtime of the test suite (1112 tests: ~238s → ~127s locally).

## Changes

- **`temba/tests/base.py`**: the users (superuser, admin, editor, agent, support, non-org), their verified email addresses, both orgs (with `initialize()`) and the Android channel are now created once per test class in `setUpTestData` instead of before every test method. Django rolls back per-test database changes and gives each test method deep copies of the class-level objects, so `self.org`, `self.admin` etc. behave as before. `setUp` still installs the mailroom guard and warms the `OrgRole` caches per test. `create_user` becomes a classmethod so it's usable from both contexts (still callable as `self.create_user(...)`).
- **`temba/archives/tests/test_archivecrudl.py`**: adds `@cleanup(s3=True)` to `test_list_views`. Archive S3 keys include the org id, which is now shared by all tests in a class, so archives left behind by one test collided with an identical upload in the next (storage appended a dedup suffix). This was the only test in the suite affected.

Note for future tests: fixture objects now share ids across tests within a class, so tests that write org/user-keyed state to external stores (S3, DynamoDB, Valkey) need the appropriate `@cleanup(...)` decorator rather than relying on unique ids per test.

## Test plan

- [x] Full suite passes (`manage.py test temba --keepdb`): 1112 tests, OK
- [x] `code_check.py` passes (formatting, lint, migrations, locale files)