### PR TITLE
Stream the components build during collectstatic and bound it with timeouts

### DIFF
--- a/temba/utils/staticfiles.py
+++ b/temba/utils/staticfiles.py
@@ -38,9 +38,16 @@ class ComponentsFinder(FileSystemFinder):
         yield from super().list(ignore_patterns)
 
     def build(self):
-        print(f"Building components bundle in {settings.COMPONENTS_DIR}...")
-
+        # output streams through so a slow install/build (e.g. a deploy host's first full components
+        # install) shows progress rather than looking hung, and the timeouts turn a genuine hang into
+        # a loud failure
         for args in (["bun", "install", "--frozen-lockfile"], ["bun", "run", "build"]):
-            proc = subprocess.run(args, cwd=settings.COMPONENTS_DIR, capture_output=True, text=True)
+            print(f"Running {' '.join(args)} in {settings.COMPONENTS_DIR}...")
+
+            try:
+                proc = subprocess.run(args, cwd=settings.COMPONENTS_DIR, timeout=600)
+            except subprocess.TimeoutExpired:
+                raise CommandError(f"{' '.join(args)} timed out after 600 seconds")
+
             if proc.returncode != 0:
-                raise CommandError(f"{' '.join(args)} failed:\n{proc.stdout}\n{proc.stderr}")
+                raise CommandError(f"{' '.join(args)} failed with exit code {proc.returncode}")

--- a/temba/utils/tests/test_staticfiles.py
+++ b/temba/utils/tests/test_staticfiles.py
@@ -36,13 +36,8 @@ class ComponentsFinderTest(TembaTest):
 
                 mock_run.assert_has_calls(
                     [
-                        call(
-                            ["bun", "install", "--frozen-lockfile"],
-                            cwd=components_dir,
-                            capture_output=True,
-                            text=True,
-                        ),
-                        call(["bun", "run", "build"], cwd=components_dir, capture_output=True, text=True),
+                        call(["bun", "install", "--frozen-lockfile"], cwd=components_dir, timeout=600),
+                        call(["bun", "run", "build"], cwd=components_dir, timeout=600),
                     ]
                 )
                 self.assertIn("svg/index.svg", listed)
@@ -50,7 +45,14 @@ class ComponentsFinderTest(TembaTest):
 
                 # a failed build aborts the listing
                 with patch("temba.utils.staticfiles.subprocess.run") as mock_run:
-                    mock_run.return_value = subprocess.CompletedProcess([], returncode=1, stdout="out", stderr="boom")
+                    mock_run.return_value = subprocess.CompletedProcess([], returncode=1)
+
+                    with self.assertRaises(CommandError):
+                        list(finder.list([]))
+
+                # as does one that hangs past the timeout
+                with patch("temba.utils.staticfiles.subprocess.run") as mock_run:
+                    mock_run.side_effect = subprocess.TimeoutExpired(cmd="bun", timeout=600)
 
                     with self.assertRaises(CommandError):
                         list(finder.list([]))


### PR DESCRIPTION
## Summary

Follow-up to #6820. On a deploy host, collectstatic's components build downloads the full dev dependency tree on first run and the build itself takes minutes — with output captured, that read as a hung collectstatic during deploys. The bun output now streams through so progress is visible, and each step fails loudly after 600 seconds instead of hanging indefinitely.

## Changes

- `ComponentsFinder.build()` no longer captures the bun output — install/build progress streams to the console, and each step is announced before it runs
- both steps get a 600s timeout; `TimeoutExpired` and non-zero exits raise `CommandError` with the step named

## Test plan

- [x] Finder test updated for the new subprocess invocation and covers the timeout path
- [x] `code_check.py` clean