### PR TITLE
Skip puppeteer's Chrome download when building components in collectstatic

### DIFF
--- a/temba/users/models.py
+++ b/temba/users/models.py
@@ -6,7 +6,6 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import storages
 from django.db import models
 from django.utils import timezone
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from temba.utils.fields import UploadToIdPathAndRename

--- a/temba/utils/staticfiles.py
+++ b/temba/utils/staticfiles.py
@@ -40,7 +40,10 @@ class ComponentsFinder(FileSystemFinder):
     def build(self):
         print(f"Building components bundle in {settings.COMPONENTS_DIR}...")
 
+        # puppeteer is only used for testing so skip its Chrome download
+        env = {**os.environ, "PUPPETEER_SKIP_DOWNLOAD": "true"}
+
         for args in (["bun", "install", "--frozen-lockfile"], ["bun", "run", "build"]):
-            proc = subprocess.run(args, cwd=settings.COMPONENTS_DIR, capture_output=True, text=True)
+            proc = subprocess.run(args, cwd=settings.COMPONENTS_DIR, env=env)
             if proc.returncode != 0:
-                raise CommandError(f"{' '.join(args)} failed:\n{proc.stdout}\n{proc.stderr}")
+                raise CommandError(f"{' '.join(args)} failed")

--- a/temba/utils/tests/test_staticfiles.py
+++ b/temba/utils/tests/test_staticfiles.py
@@ -1,7 +1,7 @@
 import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
 from django.core.management.base import CommandError
 from django.test import override_settings
@@ -36,15 +36,13 @@ class ComponentsFinderTest(TembaTest):
 
                 mock_run.assert_has_calls(
                     [
-                        call(
-                            ["bun", "install", "--frozen-lockfile"],
-                            cwd=components_dir,
-                            capture_output=True,
-                            text=True,
-                        ),
-                        call(["bun", "run", "build"], cwd=components_dir, capture_output=True, text=True),
+                        call(["bun", "install", "--frozen-lockfile"], cwd=components_dir, env=ANY),
+                        call(["bun", "run", "build"], cwd=components_dir, env=ANY),
                     ]
                 )
+
+                # the build env should prevent puppeteer from downloading Chrome
+                self.assertEqual("true", mock_run.call_args_list[0].kwargs["env"]["PUPPETEER_SKIP_DOWNLOAD"])
                 self.assertIn("svg/index.svg", listed)
                 self.assertIn("temba-components.js", listed)
 


### PR DESCRIPTION
## Summary

The components build that collectstatic runs triggers puppeteer's postinstall on a fresh install, which downloads a full Chrome-for-Testing build (~170MB) — several minutes of dead time on a deploy host's first install. Puppeteer is only used by the test runner, so the browser download is pure waste for collectstatic, which only builds the bundle.

## Changes

- `ComponentsFinder.build()` now runs `bun install` / `bun run build` with `PUPPETEER_SKIP_DOWNLOAD=true` in the environment, so no Chrome download happens. (Output streaming and timeouts landed separately on main; this branch is merged up and adds the env var on top.)
- Updated `ComponentsFinderTest` to assert the env var is set.
- Removed an unused `cached_property` import in `temba/users/models.py` left behind by the Beta auth group removal (ruff fallout, separate commit).

## Test plan

- [x] `temba.utils.tests.test_staticfiles` passes in the devcontainer
- [x] `code_check.py` passes (ruff format/check, migrations, locale files)