### PR TITLE
Only run the CI jobs a PR calls for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,13 @@ jobs:
             echo "temba=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          # fail open: if we can't list the changed files, run everything rather than nothing
+          if ! files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename'); then
+            echo "could not list changed files; running everything"
+            echo "components=true" >> "$GITHUB_OUTPUT"
+            echo "temba=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "changed files:"
           echo "$files"
           components=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ jobs:
   changes:
     name: Changes
     runs-on: ubuntu-latest
+    # explicit least-privilege token: listing the PR's files is all this job does,
+    # and it keeps working if the org ever restricts default token permissions
+    permissions:
+      pull-requests: read
     outputs:
       components: ${{ steps.filter.outputs.components }}
       temba: ${{ steps.filter.outputs.temba }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,50 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.filter.outputs.components }}
+      temba: ${{ steps.filter.outputs.temba }}
+    steps:
+      # decide which areas a PR touches so we only run the CI that's called for; jobs
+      # skipped here still report a check run (conclusion: skipped) which satisfies
+      # branch protection, so both jobs can stay required. pushes to main always run
+      # everything to keep a complete baseline.
+      - name: Detect changed areas
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "components=true" >> "$GITHUB_OUTPUT"
+            echo "temba=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          echo "changed files:"
+          echo "$files"
+          components=false
+          temba=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/workflows/ci.yml) components=true; temba=true ;;
+              components/*) components=true ;;
+              *) temba=true ;;
+            esac
+          done <<< "$files"
+          echo "components=$components" >> "$GITHUB_OUTPUT"
+          echo "temba=$temba" >> "$GITHUB_OUTPUT"
+
   components:
     name: Components
+    needs: changes
+    if: needs.changes.outputs.components == 'true'
     runs-on: ubuntu-latest
     steps:
       # screenshot tests render dates so keep the timezone pinned
@@ -26,6 +68,8 @@ jobs:
 
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.temba == 'true'
     runs-on: ubuntu-latest
     container:
       image: python:3.14-trixie


### PR DESCRIPTION
## Summary

Adds path-based filtering to CI so a PR only runs the jobs its changes can affect: components-only PRs run just **Components**, Django-only PRs run just **Test**, and mixed PRs run both. Also stops the duplicate CI runs on PR branches by limiting `push` builds to `main`.

## Changes

- A new lightweight `changes` job (no checkout — it lists the PR's files via the GitHub API with an explicit least-privilege `pull-requests: read` token) decides which areas a PR touches:
  - `components/**` → Components
  - anything else → Test
  - `.github/workflows/ci.yml` → both
- If the file listing fails, the filter **fails open** and runs everything rather than nothing.
- `components` and `test` gate on its outputs with job-level `if:`. A skipped job still reports a check run with conclusion `skipped`, which **satisfies branch protection** — so both jobs stay required without blocking merges they don't apply to.
- `on: [push, pull_request]` → `push: {branches: [main]}` + `pull_request`. PR branches previously built twice per commit (once per event). Pushes to `main` always run both jobs unconditionally, keeping a complete baseline.

## Behavior

| PR touches | Before | After |
|---|---|---|
| `components/` only | Components + Test, twice | Components |
| Django side only | Components + Test, twice | Test |
| both / `ci.yml` | Components + Test, twice | Components + Test |
| push to `main` | Components + Test | Components + Test |

## Notes

- Branch protection has been updated: `Changes`, `Components` and `Test` are all required. `Changes` being required means a filter failure blocks the merge visibly instead of silently skipping jobs.
- Known trade-off: the Test job's `collectstatic`/`compress` steps build and consume the components bundle, so a components-only PR loses that integration check. The build itself is still covered — the Components job runs the same `bun run build` inside `bun run validate` — and any residual breakage surfaces on the next Test-running PR or on `main`.
- Branches without an open PR no longer get push CI — intended, as part of the de-duplication.

## Test plan

- [x] Filter shell logic verified locally against mixed, components-only, and Django-only file lists
- [x] Workflow YAML parses; job graph is `changes` → `components`/`test`
- [x] This PR edits `ci.yml`, so its own runs exercise the `changes` job: both downstream jobs triggered, and each commit produced a single CI run (no more push+PR duplicates)