### PR TITLE
Don't hard-fail dev page loads when the components bundle isn't built yet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           apt install -y --no-install-recommends libgdal-dev ffmpeg gettext
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v9
 
       - name: Install Node
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           apt install -y --no-install-recommends libgdal-dev ffmpeg gettext
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Install Node
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,6 @@ jobs:
           uv venv
           uv sync --frozen
           bun install --frozen-lockfile
-          npm install -g less@4
           uv run python manage.py compilemessages --ignore='.venv' --ignore='node_modules'
           uv run python manage.py migrate
           uv run python manage.py migrate_dynamo --testing

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "croppie": "2.6.5",
         "fa-icons": "0.2.0",
         "is-core-module": "2.4.0",
-        "less": "2.7.1",
         "qrious": "4.0.2",
         "queue-microtask": "1.2.3",
         "sortablejs": "1.8.4",
@@ -63,8 +62,6 @@
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
-
-    "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
@@ -132,8 +129,6 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "errno": ["errno@0.1.8", "", { "dependencies": { "prr": "~1.0.1" }, "bin": { "errno": "cli.js" } }, "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A=="],
-
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
 
     "escalade": ["escalade@3.1.1", "", {}, "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="],
@@ -178,8 +173,6 @@
 
     "ignore": ["ignore@5.3.1", "", {}, "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="],
 
-    "image-size": ["image-size@0.5.5", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ=="],
-
     "import-fresh": ["import-fresh@3.3.0", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw=="],
 
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
@@ -210,8 +203,6 @@
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
-    "less": ["less@2.7.1", "", { "optionalDependencies": { "errno": "^0.1.1", "graceful-fs": "^4.1.2", "image-size": "~0.5.0", "mime": "^1.2.11", "mkdirp": "^0.5.0", "promise": "^7.1.1", "source-map": "^0.5.3" }, "bin": { "lessc": "./bin/lessc" } }, "sha512-C7dSI8hOBbZ7qmnpjMFjpwWRs6bVcrJsRmap7onnTy4N14ye6KtB7UY0ZqY1ejHf/3a2JxzVYAd+yulIRdT1nw=="],
-
     "lilconfig": ["lilconfig@3.1.2", "", {}, "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
@@ -228,13 +219,9 @@
 
     "micromatch": ["micromatch@4.0.7", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q=="],
 
-    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
-
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "modern-normalize": ["modern-normalize@1.1.0", "", {}, "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA=="],
 
@@ -298,10 +285,6 @@
 
     "pretty-hrtime": ["pretty-hrtime@1.0.3", "", {}, "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="],
 
-    "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
-
-    "prr": ["prr@1.0.1", "", {}, "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="],
-
     "purgecss": ["purgecss@3.1.3", "", { "dependencies": { "commander": "^6.0.0", "glob": "^7.0.0", "postcss": "^8.2.1", "postcss-selector-parser": "^6.0.2" }, "bin": { "purgecss": "bin/purgecss.js" } }, "sha512-hRSLN9mguJ2lzlIQtW4qmPS2kh6oMnA9RxdIYK8sz18QYqd6ePp4GNDl18oWHA1f2v2NEQIh51CO8s/E3YGckQ=="],
 
     "qrious": ["qrious@4.0.2", "", {}, "sha512-xWPJIrK1zu5Ypn898fBp8RHkT/9ibquV2Kv24S/JY9VYEhMBMKur1gHVsOiNUh7PHP9uCgejjpZUHUIXXKoU/g=="],
@@ -332,7 +315,7 @@
 
     "sortablejs": ["sortablejs@1.8.4", "", {}, "sha512-Brqnzelu1AhFuc0Fn3N/qFex1tlIiuQIUsfu2J8luJ4cRgXYkWrByxa+y5mWEBlj8A0YoABukflIJwvHyrwJ6Q=="],
 
-    "source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -413,8 +396,6 @@
     "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "postcss-functions/postcss/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
-
-    "postcss-functions/postcss/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "postcss-functions/postcss/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "croppie": "2.6.5",
     "fa-icons": "0.2.0",
     "is-core-module": "2.4.0",
-    "less": "2.7.1",
     "qrious": "4.0.2",
     "queue-microtask": "1.2.3",
     "sortablejs": "1.8.4"

--- a/temba/context_processors.py
+++ b/temba/context_processors.py
@@ -6,7 +6,7 @@ from django.conf import settings
 def config(request):
     dev_bundle = os.path.join(settings.COMPONENTS_DIR, "dev-dist", "temba-modules.js")
     dist_bundle = os.path.join(settings.COMPONENTS_DIR, "dist", "temba-components.js")
-    collected_bundle = os.path.join(settings.STATIC_ROOT, "components", "temba-components.js")
+    collected_bundle = os.path.join(settings.COMPRESS_ROOT, "components", "temba-components.js")
 
     return {
         # in development serve the components as live modules (components/dev-dist, kept fresh by

--- a/temba/context_processors.py
+++ b/temba/context_processors.py
@@ -4,11 +4,20 @@ from django.conf import settings
 
 
 def config(request):
+    dev_bundle = os.path.join(settings.COMPONENTS_DIR, "dev-dist", "temba-modules.js")
+    dist_bundle = os.path.join(settings.COMPONENTS_DIR, "dist", "temba-components.js")
+    collected_bundle = os.path.join(settings.STATIC_ROOT, "components", "temba-components.js")
+
     return {
         # in development serve the components as live modules (components/dev-dist, kept fresh by
-        # `bun run watch`) whenever a watcher has produced them, else the packaged bundle
+        # `bun run watch`) whenever a watcher has produced them, else the packaged bundle — but only
+        # when that actually exists (built dist/ or a collected copy): its {% compress %} block
+        # resolves the file at render time even with compression disabled if any precompiler is
+        # configured — this repo no longer has one, but deployment settings modules that import
+        # these settings may add their own — and a missing file 500s every page, e.g. before a
+        # first components build has finished
         "COMPONENTS_DEV": settings.DEBUG
-        and os.path.exists(os.path.join(settings.COMPONENTS_DIR, "dev-dist", "temba-modules.js")),
+        and (os.path.exists(dev_bundle) or not (os.path.exists(dist_bundle) or os.path.exists(collected_bundle))),
     }
 
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -731,14 +731,6 @@ REST_HANDLE_EXCEPTIONS = not TESTING
 # Compression
 # -----------------------------------------------------------------------------------
 
-if TESTING:
-    # if only testing, disable less compilation
-    COMPRESS_PRECOMPILERS = ()
-else:
-    COMPRESS_PRECOMPILERS = (
-        ("text/less", 'lessc --include-path="%s" {infile} {outfile}' % os.path.join(PROJECT_DIR, "../static", "less")),
-    )
-
 COMPRESS_FILTERS = {
     "css": ["compressor.filters.css_default.CssAbsoluteFilter"],
     "js": [],

--- a/temba/tests/test_context_processors.py
+++ b/temba/tests/test_context_processors.py
@@ -9,8 +9,8 @@ from temba.tests import TembaTest
 
 class ConfigTest(TembaTest):
     def test_components_dev(self):
-        with tempfile.TemporaryDirectory() as components_dir, tempfile.TemporaryDirectory() as static_root:
-            with override_settings(DEBUG=True, COMPONENTS_DIR=components_dir, STATIC_ROOT=static_root):
+        with tempfile.TemporaryDirectory() as components_dir, tempfile.TemporaryDirectory() as compress_root:
+            with override_settings(DEBUG=True, COMPONENTS_DIR=components_dir, COMPRESS_ROOT=compress_root):
                 # no build output at all: stay on the dev module path rather than falling back to a
                 # compress block that hard-fails on the missing packaged bundle
                 self.assertTrue(config(None)["COMPONENTS_DEV"])
@@ -24,7 +24,7 @@ class ConfigTest(TembaTest):
                 # a collected copy counts as well
                 (dist / "temba-components.js").unlink()
                 self.assertTrue(config(None)["COMPONENTS_DEV"])
-                collected = Path(static_root, "components")
+                collected = Path(compress_root, "components")
                 collected.mkdir()
                 (collected / "temba-components.js").write_text("//bundle")
                 self.assertFalse(config(None)["COMPONENTS_DEV"])
@@ -37,5 +37,5 @@ class ConfigTest(TembaTest):
                 self.assertTrue(config(None)["COMPONENTS_DEV"])
 
             # never outside of development
-            with override_settings(DEBUG=False, COMPONENTS_DIR=components_dir, STATIC_ROOT=static_root):
+            with override_settings(DEBUG=False, COMPONENTS_DIR=components_dir, COMPRESS_ROOT=compress_root):
                 self.assertFalse(config(None)["COMPONENTS_DEV"])

--- a/temba/tests/test_context_processors.py
+++ b/temba/tests/test_context_processors.py
@@ -1,0 +1,41 @@
+import tempfile
+from pathlib import Path
+
+from django.test import override_settings
+
+from temba.context_processors import config
+from temba.tests import TembaTest
+
+
+class ConfigTest(TembaTest):
+    def test_components_dev(self):
+        with tempfile.TemporaryDirectory() as components_dir, tempfile.TemporaryDirectory() as static_root:
+            with override_settings(DEBUG=True, COMPONENTS_DIR=components_dir, STATIC_ROOT=static_root):
+                # no build output at all: stay on the dev module path rather than falling back to a
+                # compress block that hard-fails on the missing packaged bundle
+                self.assertTrue(config(None)["COMPONENTS_DEV"])
+
+                # a built packaged bundle and no watcher output: fall back to it
+                dist = Path(components_dir, "dist")
+                dist.mkdir()
+                (dist / "temba-components.js").write_text("//bundle")
+                self.assertFalse(config(None)["COMPONENTS_DEV"])
+
+                # a collected copy counts as well
+                (dist / "temba-components.js").unlink()
+                self.assertTrue(config(None)["COMPONENTS_DEV"])
+                collected = Path(static_root, "components")
+                collected.mkdir()
+                (collected / "temba-components.js").write_text("//bundle")
+                self.assertFalse(config(None)["COMPONENTS_DEV"])
+
+                # watcher output always wins, even with both packaged bundles present
+                (dist / "temba-components.js").write_text("//bundle")
+                dev_dist = Path(components_dir, "dev-dist")
+                dev_dist.mkdir()
+                (dev_dist / "temba-modules.js").write_text("//modules")
+                self.assertTrue(config(None)["COMPONENTS_DEV"])
+
+            # never outside of development
+            with override_settings(DEBUG=False, COMPONENTS_DIR=components_dir, STATIC_ROOT=static_root):
+                self.assertFalse(config(None)["COMPONENTS_DEV"])

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -165,6 +165,8 @@
   {% block body %}
     <body class="bg-gradient" id="pageBody">
       {% if COMPONENTS_DEV %}
+        {# may 404 before a first components build has produced anything — preferable to the #}
+        {# compress block below hard-failing the whole page on a missing packaged bundle #}
         <script type="module" src="{% static 'components-dev/temba-modules.js' %}"></script>
       {% else %}
         {% compress js %}


### PR DESCRIPTION
## Problem

In development, `frame.html` falls back from the live dev modules (`components/dev-dist/`) to the packaged components bundle inside a `{% compress js %}` block whenever the dev bundle doesn't exist. django-compressor resolves each file at render time even with compression disabled if any precompiler is configured, so during the window before a first components build has produced any bundle, every page load failed with:

```
compressor.exceptions.UncompressableFileError: 'components/temba-components.js' could not be found in the COMPRESS_ROOT ... or with staticfiles.
```

## Changes

* The `COMPONENTS_DEV` context var now only takes the packaged-bundle fallback when that bundle actually exists (a built `components/dist/` or a collected copy under `STATIC_ROOT`) — mirroring exactly how compressor would resolve it. Otherwise the dev module script tag is rendered, which just 404s harmlessly until a build lands and a reload picks it up.
* Removed the dead `text/less` precompiler from the base settings — no `.less` files or `text/less` templates remain in this repo. Settings modules that layer on top of these can still configure their own precompilers, which is why the render-time guard above is kept regardless.
* Dropped the `less` npm dependency and its CI install step, which existed only for that precompiler.
* Added a regression test for the context processor logic.

Production behavior is unchanged: offline compression still compresses the components bundle for cache-busted URLs (verified `collectstatic` + `compress` end-to-end).