### PR TITLE
Make code_check.py configurable so projects that build on this one can use it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           apt install -y --no-install-recommends libgdal-dev ffmpeg gettext
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install Node
         uses: actions/setup-node@v6

--- a/code_check.py
+++ b/code_check.py
@@ -3,6 +3,7 @@
 import argparse
 import subprocess
 import tempfile
+import tomllib
 
 import colorama
 
@@ -33,33 +34,46 @@ def status(line):
 if __name__ == "__main__":
     colorama.init()
 
-    status("Check for missing migrations")
-    cmd("python manage.py makemigrations --check")
+    # checks run against the project in the current directory - which needn't be this checkout, as projects that
+    # build on this one run this same script - and are configured by the [tool.code_check] section of its
+    # pyproject.toml
+    with open("pyproject.toml", "rb") as f:
+        config = tomllib.load(f)["tool"]["code_check"]
+
+    packages = " ".join(config["packages"])
+    locale_dir = config["locale"]
+    ignores = " ".join(f"--ignore='{i}'" for i in config.get("ignore", []))
+
+    if config.get("migrations", False):
+        status("Check for missing migrations")
+        cmd("python manage.py makemigrations --check")
 
     status("Check locale files are up to date")
     with tempfile.TemporaryDirectory() as backup_dir:
         # take a copy of the PO files so we can compare the regenerated ones against them, and then put them
         # back. we compare against the working copy rather than using git because git isn't usable from here
         # in CI, where the checkout isn't a safe directory for the user running the checks
-        cmd(f"cp -a locale/. {backup_dir}")
+        cmd(f"cp -a {locale_dir}/. {backup_dir}")
+
+        # run without django settings so makemessages only sees locale directories under the current directory -
+        # with settings configured, LOCALE_PATHS could pull other projects' catalogs into scope
         cmd(
-            "python manage.py makemessages -a -e haml,html,txt,py --no-location --no-wrap --ignore='env/*' "
-            "--ignore='.venv/*' --ignore='.claude/*' --ignore='fabfile.py' --ignore='media/*' "
-            "--ignore='sitestatic/*' --ignore='static/*' --ignore='node_modules/*' 2>&1"
+            f"DJANGO_SETTINGS_MODULE= django-admin makemessages -a -e haml,html,txt,py --no-location --no-wrap "
+            f"{ignores} 2>&1"
         )
-        cmd("for f in locale/*/LC_MESSAGES/django.po; do msgattrib --no-obsolete --no-wrap -o $f $f; done")
+        cmd(f"for f in {locale_dir}/*/LC_MESSAGES/django.po; do msgattrib --no-obsolete --no-wrap -o $f $f; done")
 
         # POT-Creation-Date can change without any actual message changes so ignore it. if this fails then the
         # regenerated files are left in place, ready to be committed
-        cmd(f"diff -ur -I '^\"POT-Creation-Date:' {backup_dir} locale")
+        cmd(f"diff -ur -I '^\"POT-Creation-Date:' {backup_dir} {locale_dir}")
 
         # nothing to do, so restore the originals rather than leaving a dirty working tree behind
-        cmd(f"cp -a {backup_dir}/. locale")
+        cmd(f"cp -a {backup_dir}/. {locale_dir}")
 
     status("Running ruff format")
-    cmd("ruff format --check temba")
+    cmd(f"ruff format --check {packages}")
 
     status("Running ruff")
-    cmd("ruff check temba")
+    cmd(f"ruff check {packages}")
 
     print("👍 " + colorama.Fore.GREEN + "Code looks good. Make that PR!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,12 @@ dev = [
     "djlint>=1.34.1",
 ]
 
+[tool.code_check]
+packages = ["temba"]
+locale = "locale"
+migrations = true
+ignore = ["env/*", ".venv/*", ".claude/*", "fabfile.py", "media/*", "sitestatic/*", "static/*", "node_modules/*"]
+
 [tool.ruff]
 line-length = 120
 fix = true


### PR DESCRIPTION
Projects that layer a package on top of this one need the same pre-test checks — in particular the check that locale files are up to date, whose backup/regenerate/diff/restore mechanics are subtle enough that copying the script means fixing bugs twice. This makes the script reusable: it now checks the project in the *current directory*, configured by a `[tool.code_check]` section in that project's `pyproject.toml`:

```toml
[tool.code_check]
packages = ["temba"]     # ruff targets
locale = "locale"        # directory holding */LC_MESSAGES/django.po
migrations = true        # whether to run makemigrations --check (default false)
ignore = ["env/*", ...]  # makemessages --ignore patterns
```

This repo's own invocation is unchanged (`uv run python code_check.py --debug` from the checkout root, as CI and the docs already say); a downstream project runs the same file from its own root, e.g. `uv run python ../temba/code_check.py --debug`.

One behavioral change: `makemessages` now runs via `django-admin` with `DJANGO_SETTINGS_MODULE` cleared instead of `manage.py`. Without settings it discovers locale directories purely by walking the current directory, whereas with settings configured `LOCALE_PATHS` can pull other projects' catalogs into scope — wrong for any downstream project whose settings list this package's catalogs. Verified the regenerated catalogs here are byte-identical either way (message extraction is source-driven; settings only affected directory discovery). The migrations check still uses `manage.py` and still requires a configured environment, as before.

## Testing

Ran the locale check standalone against this checkout — regenerates with no diff and restores the working tree. The config parsing and migrations gate were exercised by a full script run (which then stopped at `makemigrations` needing a database, as it always has outside the container). ruff clean.