### PR TITLE
Use a dedicated dynamodb-local service for the default DynamoDB endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,13 @@ jobs:
       localstack:
         image: localstack/localstack:4.14
         env:
-          SERVICES: s3,dynamodb
+          SERVICES: s3
         ports:
           - 4566:4566
+      dynamodb:
+        image: amazon/dynamodb-local:3.3.1
+        ports:
+          - 8000:8000
 
     steps:
       - name: Checkout code

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -33,6 +33,7 @@ if TESTING:
 
 _db_host = "postgres"
 _valkey_host = "valkey"
+_dynamodb_host = "dynamodb"
 _localstack_host = "localstack"
 
 # -----------------------------------------------------------------------------------
@@ -43,7 +44,7 @@ AWS_ACCESS_KEY_ID = "root"
 AWS_SECRET_ACCESS_KEY = "tembatemba"
 AWS_REGION = "us-east-1"
 
-DYNAMO_ENDPOINT_URL = os.environ.get("DYNAMO_ENDPOINT_URL", f"http://{_localstack_host}:4566")
+DYNAMO_ENDPOINT_URL = f"http://{_dynamodb_host}:8000"
 DYNAMO_TABLE_PREFIX = "Test" if TESTING else "Temba"
 
 ELASTIC_ENDPOINT_URL = "http://elastic:9200"

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -43,7 +43,7 @@ AWS_ACCESS_KEY_ID = "root"
 AWS_SECRET_ACCESS_KEY = "tembatemba"
 AWS_REGION = "us-east-1"
 
-DYNAMO_ENDPOINT_URL = f"http://{_localstack_host}:4566"
+DYNAMO_ENDPOINT_URL = os.environ.get("DYNAMO_ENDPOINT_URL", f"http://{_localstack_host}:4566")
 DYNAMO_TABLE_PREFIX = "Test" if TESTING else "Temba"
 
 ELASTIC_ENDPOINT_URL = "http://elastic:9200"


### PR DESCRIPTION
Changes the default `DYNAMO_ENDPOINT_URL` from localstack's DynamoDB (`http://localstack:4566`) to a dedicated `amazon/dynamodb-local` service (`http://dynamodb:8000`), and updates CI accordingly (localstack now only provides S3 there). dynamodb-local is the same engine localstack wraps for DynamoDB, so behavior is unchanged — but it's officially maintained, lighter, and supports persistence in dev environments. Server deployments are unaffected (they override the endpoint in their own settings).