### PR TITLE
Fix opening webhook and other router node actions in the editor

### DIFF
--- a/components/src/flow/Editor.ts
+++ b/components/src/flow/Editor.ts
@@ -3210,7 +3210,13 @@ export class Editor extends RapidElement {
       this.showUnsupportedActionDialog();
       return;
     }
-    if (!isEditableAction(requested)) {
+
+    // Find the node that contains this action
+    const nodeUuid = event.detail.nodeUuid;
+    const node = this.definition.nodes.find((n) => n.uuid === nodeUuid);
+    const nodeUI = node ? this.definition._ui.nodes[nodeUuid] : undefined;
+
+    if (!isEditableAction(requested, nodeUI?.type)) {
       return;
     }
 
@@ -3222,13 +3228,9 @@ export class Editor extends RapidElement {
         ? { x: event.detail.originX, y: event.detail.originY }
         : null;
 
-    // Find the node that contains this action
-    const nodeUuid = event.detail.nodeUuid;
-    const node = this.definition.nodes.find((n) => n.uuid === nodeUuid);
-
     if (node) {
       this.editingNode = node;
-      this.editingNodeUI = this.definition._ui.nodes[nodeUuid];
+      this.editingNodeUI = nodeUI;
     }
   }
 
@@ -3972,10 +3974,11 @@ export class Editor extends RapidElement {
     if (issue.action_uuid) {
       const action = node.actions?.find((a) => a.uuid === issue.action_uuid);
       // non-editable actions are focused on the canvas but have no dialog
-      if (isEditableAction(action)) {
+      const nodeUI = this.definition._ui.nodes[issue.node_uuid];
+      if (isEditableAction(action, nodeUI?.type)) {
         this.editingAction = action;
         this.editingNode = node;
-        this.editingNodeUI = this.definition._ui.nodes[issue.node_uuid];
+        this.editingNodeUI = nodeUI;
       }
     } else {
       this.editingNode = node;
@@ -4232,7 +4235,7 @@ export class Editor extends RapidElement {
 
     // Non-editable actions stay searchable, but there's no dialog to open
     // for them — the focus above is all we do
-    if (result.action && !isEditableAction(result.action)) {
+    if (result.action && !isEditableAction(result.action, nodeUI?.type)) {
       return;
     }
 

--- a/components/src/flow/config.ts
+++ b/components/src/flow/config.ts
@@ -71,10 +71,18 @@ export const ACTION_CONFIG: {
  * Whether an action can be opened in the editor. Some action types are
  * retained purely so actions left behind in older flow definitions still
  * render; their config declares no form, so opening the dialog for one
- * would just show an empty editor.
+ * would just show an empty editor. Actions on router nodes (e.g. the
+ * call_webhook action on a split_by_webhook node) have no action config of
+ * their own but are edited through the node's form.
  */
-export function isEditableAction(action?: { type?: string }): boolean {
-  return !!(action?.type && ACTION_CONFIG[action.type]?.form);
+export function isEditableAction(
+  action?: { type?: string },
+  nodeUiType?: string
+): boolean {
+  if (action?.type && ACTION_CONFIG[action.type]?.form) {
+    return true;
+  }
+  return !!(nodeUiType && NODE_CONFIG[nodeUiType]?.form);
 }
 
 /**

--- a/components/test/temba-flow-editor.test.ts
+++ b/components/test/temba-flow-editor.test.ts
@@ -820,12 +820,24 @@ describe('Editor', () => {
       optin: { uuid: 'optin-1', name: 'U-Report' }
     };
 
+    // call_webhook has no action config of its own — it lives on a
+    // split_by_webhook router node and is edited through the node's form
+    const WEBHOOK_ACTION = {
+      uuid: 'action-1',
+      type: 'call_webhook',
+      method: 'GET',
+      url: 'http://example.com'
+    };
+
     const unsupportedDialog = () =>
       [...document.body.querySelectorAll('temba-dialog')].find(
         (d: any) => d.header === 'Unsupported Action'
       ) as any;
 
-    const getEditor = async (action: any): Promise<Editor> => {
+    const getEditor = async (
+      action: any,
+      uiType = 'execute_actions'
+    ): Promise<Editor> => {
       const editor: Editor = await fixture(html`
         <temba-flow-editor>
           <div id="canvas"></div>
@@ -836,7 +848,7 @@ describe('Editor', () => {
         _ui: {
           nodes: {
             'node-1': {
-              type: 'execute_actions',
+              type: uiType,
               position: { left: 50, top: 50 }
             }
           }
@@ -891,6 +903,14 @@ describe('Editor', () => {
         expect(nodeEditor(editor)).to.exist;
       });
 
+      it('opens the editor for a router node action via the node form', async () => {
+        editor = await getEditor(WEBHOOK_ACTION, 'split_by_webhook');
+        await requestEdit(editor, WEBHOOK_ACTION);
+
+        expect((editor as any).editingAction).to.equal(WEBHOOK_ACTION);
+        expect(nodeEditor(editor)).to.exist;
+      });
+
       it('explains unsupported actions instead of opening the editor', async () => {
         editor = await getEditor(FORMLESS_ACTION);
         await requestEdit(editor, FORMLESS_ACTION);
@@ -916,6 +936,14 @@ describe('Editor', () => {
         expect(nodeEditor(editor)).to.exist;
       });
 
+      it('opens the editor for a router node action via the node form', async () => {
+        editor = await getEditor(WEBHOOK_ACTION, 'split_by_webhook');
+        await selectIssue(editor, WEBHOOK_ACTION);
+
+        expect((editor as any).editingAction).to.equal(WEBHOOK_ACTION);
+        expect(nodeEditor(editor)).to.exist;
+      });
+
       it('focuses unsupported actions without a dialog', async () => {
         editor = await getEditor(FORMLESS_ACTION);
         await selectIssue(editor, FORMLESS_ACTION);
@@ -932,6 +960,14 @@ describe('Editor', () => {
         await selectSearchResult(editor, EDITABLE_ACTION);
 
         expect((editor as any).editingAction).to.equal(EDITABLE_ACTION);
+        expect(nodeEditor(editor)).to.exist;
+      });
+
+      it('opens the editor for a router node action via the node form', async () => {
+        editor = await getEditor(WEBHOOK_ACTION, 'split_by_webhook');
+        await selectSearchResult(editor, WEBHOOK_ACTION);
+
+        expect((editor as any).editingAction).to.equal(WEBHOOK_ACTION);
         expect(nodeEditor(editor)).to.exist;
       });
 


### PR DESCRIPTION
## Summary

Clicking a webhook node (or any other single-action router node) in the flow editor did nothing — the editor dialog never opened. This restores editing for those nodes while keeping formless retained actions (like `request_optin`) read-only.

## Changes

- **`components/src/flow/config.ts`** — `isEditableAction()` now takes an optional node UI type and treats an action as editable when that node type's config declares a form. The guard was added when opt-in editing was removed, but it only consulted `ACTION_CONFIG` — and actions on router nodes (`call_webhook` on `split_by_webhook`, plus `call_resthook`, `transfer_airtime`, `open_ticket` and `call_llm` on their nodes) have no action config of their own; they're edited through the node's form. Since clicking such a node fires `ActionEditRequested` with its single action, the guard silently swallowed the click. `execute_actions` declares no form, so plain action lists behave as before.
- **`components/src/flow/Editor.ts`** — all three entry points that can open an action editor (canvas edit requests, selected flow issues, selected search results) now pass the containing node's UI type to the predicate; the edit-request handler looks the node up before the guard instead of after.
- **`components/test/temba-flow-editor.test.ts`** — regression tests opening a `call_webhook` action on a `split_by_webhook` node via each of the three entry points.

## Behavior examples

| Interaction | Before | After |
|---|---|---|
| Click a webhook / resthook / airtime / ticket / LLM node | nothing happens | node's editor dialog opens |
| Click a flow issue or search result pointing at one of those actions | node is focused, no dialog | node is focused and its editor opens |
| Click a retained `request_optin` action | unsupported-action dialog | unchanged |

## Test plan

- [x] Full components suite in the CI devcontainer image: 2923 passed, 0 failed
- [x] New regression tests cover all three entry points
- [x] eslint + prettier clean on changed files
- [x] Verified in the dev stack that webhook nodes open again